### PR TITLE
nanocoap: Add handler for resource-based subtrees

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -274,6 +274,14 @@ typedef struct {
 } coap_resource_t;
 
 /**
+ * @brief   Type for CoAP resource subtrees
+ */
+typedef const struct {
+    const coap_resource_t *resources;   /**< ptr to resource array  */
+    const size_t resources_numof;       /**< number of entries in array */
+} coap_resource_subtree_t;
+
+/**
  * @brief   Block1 helper struct
  */
 typedef struct {
@@ -1750,6 +1758,25 @@ ssize_t coap_tree_handler(coap_pkt_t *pkt, uint8_t *resp_buf,
                           unsigned resp_buf_len,
                           const coap_resource_t *resources,
                           size_t resources_numof);
+
+/**
+ * @brief   Generic coap subtree handler
+ *
+ * This function can be used as a generic handler for resources with the
+ * @ref COAP_MATCH_SUBTREE where a new @ref coap_resource_t is to be parsed.
+ *
+ * @note The @p context must be of type @ref coap_resource_subtree_t.
+ *
+ * @param[in]   pkt             pointer to (parsed) CoAP packet
+ * @param[out]  resp_buf        buffer for response
+ * @param[in]   resp_buf_len    size of response buffer
+ * @param[in]   context         ptr to a @ref coap_resource_subtree_t instance
+ *
+ * @returns     size of the reply packet on success
+ * @returns     <0 on error
+ */
+ssize_t coap_subtree_handler(coap_pkt_t *pkt, uint8_t *resp_buf,
+                             size_t resp_buf_len, void *context);
 
 /**
  * @brief   Convert message code (request method) into a corresponding bit field

--- a/sys/include/suit/transport/coap.h
+++ b/sys/include/suit/transport/coap.h
@@ -68,29 +68,6 @@ void suit_coap_run(void);
 #ifndef DOXYGEN
 
 /**
- * @brief   Coap subtree handler
- *
- * @param[in,out]   pkt     Packet struct containing the request. Is reused for
- *                          the response
- * @param[in]       buf     Buffer to write reply to
- * @param[in]       len     Total length of the buffer associated with the
- *                          request
- * @param[in]       buf     Buffer to write reply to
- *
- * @returns     ssize_t     Size of the reply
- */
-ssize_t coap_subtree_handler(coap_pkt_t *pkt, uint8_t *buf,
-                             size_t len, void *context);
-
-/**
- * @brief   Type for CoAP resource subtrees
- */
-typedef const struct {
-    const coap_resource_t *resources;   /**< ptr to resource array  */
-    const size_t resources_numof;       /**< nr of entries in array */
-} coap_resource_subtree_t;
-
-/**
  * @brief   Reference to the coap resource subtree
  */
 extern const coap_resource_subtree_t coap_resource_subtree_suit;

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -424,6 +424,15 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
                              coap_resources_numof);
 }
 
+ssize_t coap_subtree_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
+                             void *context)
+{
+    assert(context);
+    coap_resource_subtree_t *subtree = context;
+    return coap_tree_handler(pkt, buf, len, subtree->resources,
+                             subtree->resources_numof);
+}
+
 ssize_t coap_tree_handler(coap_pkt_t *pkt, uint8_t *resp_buf,
                           unsigned resp_buf_len,
                           const coap_resource_t *resources,

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -104,14 +104,6 @@ static inline void _print_download_progress(suit_manifest_t *manifest,
 
 static kernel_pid_t _suit_coap_pid;
 
-ssize_t coap_subtree_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len,
-                             void *context)
-{
-    coap_resource_subtree_t *subtree = context;
-    return coap_tree_handler(pkt, buf, len, subtree->resources,
-                             subtree->resources_numof);
-}
-
 static void _suit_handle_url(const char *url, coap_blksize_t blksize)
 {
     LOG_INFO("suit_coap: downloading \"%s\"\n", url);


### PR DESCRIPTION
### Contribution description

This adds a coap_handler_t function that can be used to parse new
subtrees. The subtree information is included in the context pointer of
the call and must be of type coap_resource_subtree_t. This object then
contains the pointer and length of a different coap_resource_t instance.

### Testing procedure

The coap handlers in `examples/suit-update` should still work as before

### Issues/PRs references

Follow-up with more cleanups to #13687 