### PR TITLE
cpu/stm: Fix broken character encoding

### DIFF
--- a/cpu/stm32f0/include/vendor/stm32f030xc.h
+++ b/cpu/stm32f0/include/vendor/stm32f030xc.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *  
   ******************************************************************************
   * @attention

--- a/cpu/stm32f0/include/vendor/stm32f072xb.h
+++ b/cpu/stm32f0/include/vendor/stm32f072xb.h
@@ -11,7 +11,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention

--- a/cpu/stm32f2/include/vendor/stm32f207xx.h
+++ b/cpu/stm32f2/include/vendor/stm32f207xx.h
@@ -6,7 +6,7 @@
   *          This file contains :
   *           - Data structures and the address mapping for all peripherals
   *           - Peripherals registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention

--- a/cpu/stm32f3/include/vendor/stm32f303xc.h
+++ b/cpu/stm32f3/include/vendor/stm32f303xc.h
@@ -7,7 +7,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention

--- a/cpu/stm32f3/include/vendor/stm32f303xe.h
+++ b/cpu/stm32f3/include/vendor/stm32f303xe.h
@@ -7,7 +7,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention

--- a/cpu/stm32f7/include/vendor/stm32f723xx.h
+++ b/cpu/stm32f7/include/vendor/stm32f723xx.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention

--- a/cpu/stm32f7/include/vendor/stm32f767xx.h
+++ b/cpu/stm32f7/include/vendor/stm32f767xx.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention

--- a/cpu/stm32l4/include/vendor/stm32l412xx.h
+++ b/cpu/stm32l4/include/vendor/stm32l412xx.h
@@ -7,7 +7,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention

--- a/cpu/stm32l4/include/vendor/stm32l433xx.h
+++ b/cpu/stm32l4/include/vendor/stm32l433xx.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention

--- a/cpu/stm32l4/include/vendor/stm32l452xx.h
+++ b/cpu/stm32l4/include/vendor/stm32l452xx.h
@@ -7,7 +7,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention

--- a/cpu/stm32l4/include/vendor/stm32l475xx.h
+++ b/cpu/stm32l4/include/vendor/stm32l475xx.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention

--- a/cpu/stm32l4/include/vendor/stm32l4r5xx.h
+++ b/cpu/stm32l4/include/vendor/stm32l4r5xx.h
@@ -7,7 +7,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While trying to analyze the RIOT project with SonarCloud as a part of the [Software Architecture course at Delft University of Technology](https://se.ewi.tudelft.nl/delftswa/2020/index.html), I ran into a few broken characters in doxygen which caused errors.
I replaced the characters with an apostrophe.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
N/A
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
N/A
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
