### PR TITLE
gnrc_sock: provide implementation for `sock_*_recv_buf()`

### DIFF
--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -45,6 +45,13 @@ static void _callback_put(void *arg)
 }
 #endif
 
+void sock_recv_buf_free(void *buf_ctx)
+{
+    if (buf_ctx) {
+        gnrc_pktbuf_release(buf_ctx);
+    }
+}
+
 #ifdef SOCK_HAS_ASYNC
 static void _netapi_cb(uint16_t cmd, gnrc_pktsnip_t *pkt, void *ctx)
 {

--- a/tests/gnrc_sock_ip/main.c
+++ b/tests/gnrc_sock_ip/main.c
@@ -343,6 +343,27 @@ static void test_sock_ip_recv__non_blocking(void)
     expect(_check_net());
 }
 
+static void test_sock_ip_recv_buf__success(void)
+{
+    static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR_REMOTE };
+    static const ipv6_addr_t dst_addr = { .u8 = _TEST_ADDR_LOCAL };
+    static const sock_ip_ep_t local = { .family = AF_INET6 };
+    static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR_REMOTE },
+                                         .family = AF_INET6 };
+    void *data = NULL, *ctx = NULL;
+
+    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+                               SOCK_FLAGS_REUSE_EP));
+    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+                          sizeof("ABCD"), _TEST_NETIF));
+    assert(sizeof("ABCD") == sock_ip_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT,
+                                              NULL));
+    assert(data != NULL);
+    assert(ctx != NULL);
+    sock_recv_buf_free(ctx);
+    assert(_check_net());
+}
+
 static void test_sock_ip_send__EAFNOSUPPORT(void)
 {
     static const sock_ip_ep_t remote = { .addr = { .ipv6 = _TEST_ADDR_REMOTE },
@@ -616,6 +637,7 @@ int main(void)
     CALL(test_sock_ip_recv__unsocketed_with_remote());
     CALL(test_sock_ip_recv__with_timeout());
     CALL(test_sock_ip_recv__non_blocking());
+    CALL(test_sock_ip_recv_buf__success());
     _prepare_send_checks();
     CALL(test_sock_ip_send__EAFNOSUPPORT());
     CALL(test_sock_ip_send__EINVAL_addr());


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This provides an implementation for GNRC of the zero-copy receive functions (see https://github.com/RIOT-OS/RIOT/pull/13616). As the implementation of `sock_*_recv()` now uses those functions, I only adapted the tests minimally to test the success case to acknowledge the function is there.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The following tests should still pass:

- `tests/gnrc_sock_ip`
- `tests/gnrc_sock_udp`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to #13616.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
