### PR TITLE
Makefile.dep: add auto_init_usbus as usbus DEFAULT_MODULE

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -901,6 +901,7 @@ ifneq (,$(filter tlsf-malloc,$(USEMODULE)))
 endif
 
 ifneq (,$(filter usbus,$(USEMODULE)))
+  DEFAULT_MODULE += auto_init_usbus
   FEATURES_REQUIRED += periph_usbdev
   USEMODULE += core_thread_flags
   USEMODULE += event

--- a/boards/common/samd21-arduino-bootloader/Makefile.dep
+++ b/boards/common/samd21-arduino-bootloader/Makefile.dep
@@ -3,9 +3,6 @@
 # handled by the build system
 DEFAULT_MODULE += stdio_cdc_acm
 
-# Default auto-initialization of usbus for stdio other USB
-USEMODULE += auto_init_usbus
-
 # This boards requires support for Arduino bootloader.
 USEMODULE += usb_board_reset
 USEMODULE += boards_common_samd21-arduino-bootloader

--- a/tests/usbus_cdc_acm_stdio/Makefile
+++ b/tests/usbus_cdc_acm_stdio/Makefile
@@ -1,7 +1,6 @@
 BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
-USEMODULE += auto_init_usbus
 USEMODULE += stdio_cdc_acm
 USEMODULE += shell
 USEMODULE += shell_commands

--- a/tests/usbus_cdc_ecm/Makefile
+++ b/tests/usbus_cdc_ecm/Makefile
@@ -2,7 +2,6 @@ BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
 USEMODULE += auto_init_gnrc_netif
-USEMODULE += auto_init_usbus
 USEMODULE += gnrc_ipv6_router_default
 USEMODULE += gnrc_icmpv6_echo
 USEMODULE += usbus_cdc_ecm


### PR DESCRIPTION
### Contribution description

This PR adds `auto_init_usbus` as a default module when `usbus` is used.

### Testing procedure

No change in `USEMODULES`:

- `boards_common_samd21-arduino-bootloader` users:

```
BOARD=arduino-mkrfox1200 make -C examples/hello-world/ info-debug-variable-USEMODULE --no-print-directory | grep auto_init_usbus
auto_init auto_init_usbus board boards_common_arduino-mkr boards_common_samd21-arduino-bootloader core core_init core_msg core_panic core_thread_flags cortexm_common cortexm_common_periph cpu event isrpipe newlib newlib_nano newlib_syscalls_default periph periph_common periph_gpio periph_init periph_init_common periph_init_gpio periph_init_init periph_init_pm periph_init_usbdev periph_pm periph_usbdev pm_layered sam0_common_periph stdio_cdc_acm sys tsrb usb_board_reset usbus usbus_cdc_acm
```

- ` tests/usbus_cdc_ecm/`
```
make -C tests/usbus_cdc_ecm/ info-debug-variable-USEMODULE --no-print-directory | grep auto_init_usbus
auto_init auto_init_gnrc_ipv6 auto_init_gnrc_ipv6_nib auto_init_gnrc_netif auto_init_gnrc_pktbuf auto_init_random auto_init_usbus auto_init_xtimer board core core_init core_msg core_panic core_thread_flags cortexm_common cortexm_common_periph cpu div event evtimer fmt gnrc gnrc_icmpv6 gnrc_icmpv6_echo gnrc_ipv6 gnrc_ipv6_hdr gnrc_ipv6_nib gnrc_ipv6_nib_router gnrc_ipv6_router gnrc_ipv6_router_default gnrc_ndp gnrc_netapi gnrc_netif gnrc_netif_ethernet gnrc_netif_hdr gnrc_netif_init_devs gnrc_netreg gnrc_pkt gnrc_pktbuf gnrc_pktbuf_static icmpv6 inet_csum iolist ipv6_addr ipv6_hdr isrpipe l2util luid netdev_eth netif newlib newlib_nano newlib_syscalls_default periph periph_common periph_cpuid periph_gpio periph_init periph_init_common periph_init_cpuid periph_init_gpio periph_init_init periph_init_pm periph_init_timer periph_init_uart periph_init_usbdev periph_pm periph_timer periph_uart periph_usbdev pm_layered prng prng_tinymt32 ps random sam0_common_periph shell shell_commands stdin stdio_uart stdio_uart_rx sys tinymt32 tsrb usbus usbus_cdc_ecm xtimer
```

-  `tests/usbus_cdc_acm_stdio/`

```
make -C tests/usbus_cdc_acm_stdio/ info-debug-variable-USEMODULE --no-print-directory | grep auto_init_usbus
auto_init auto_init_usbus board core core_init core_msg core_panic core_thread_flags cortexm_common cortexm_common_periph cpu event isrpipe newlib newlib_nano newlib_syscalls_default periph periph_common periph_gpio periph_init periph_init_common periph_init_gpio periph_init_init periph_init_pm periph_init_usbdev periph_pm periph_usbdev pm_layered ps sam0_common_periph shell shell_commands stdin stdio_cdc_acm sys tsrb usbus usbus_cdc_acm
```

- can be disabled if requires

```
DISABLE_MODULE=auto_init_usbus make -C tests/usbus_cdc_acm_stdio/ info-debug-variable-USEMODULE --no-print-directory | grep auto_init_usbus
#empty

```
