### PR TITLE
bootloaders/riotboot: use stdio_null

### DIFF
--- a/bootloaders/riotboot/Makefile
+++ b/bootloaders/riotboot/Makefile
@@ -16,7 +16,9 @@ CFLAGS += -DRIOTBOOT
 CFLAGS += -DNDEBUG -DLOG_LEVEL=LOG_NONE
 DISABLE_MODULE += core_init core_msg core_panic
 DISABLE_MODULE += auto_init
-DISABLE_MODULE += stdio_cdc_acm
+
+# avoid using stdio
+USEMODULE += stdio_null
 
 # Include riotboot flash partition functionality
 USEMODULE += riotboot_slot


### PR DESCRIPTION
### Contribution description

Instead of disablin `stdio_` modules force `stdio_null` to be used just as `tests/minimal`

### Testing procedure

- green murdock

- `tests/riotboot` should still work

`BOARD=usb-kw41z make -C tests/riotboot flash test`
```
Current slot=0
> curslothdr
 curslothdr
Image magic_number: 0x544f4952
Image Version: 0x5e7a4dc9
Image start address: 0x00001100
Header chksum: 0xd20e5ae5

> getslotaddr 0
 getslotaddr 0
Slot 0 address=0x00001100
> dumpaddrs
 dumpaddrs
slot 0: metadata: 0x1000 image: 0x00001100
slot 1: metadata: 0x40800 image: 0x00040900
> TEST PASSED
```

### Issues/PRs references

Expands on #13674.
