### PR TITLE
unittests/tests-rtt_rtc: blacklist test on esp32

### DIFF
--- a/tests/unittests/tests-rtt_rtc/Makefile.include
+++ b/tests/unittests/tests-rtt_rtc/Makefile.include
@@ -6,3 +6,7 @@ CFLAGS += -DMOCK_RTT_MAX_VALUE=0xFFFF
 # mulle always enables periph_rtt.
 # This clashes with mock_rtt.
 BOARD_BLACKLIST := mulle
+
+# esp32 enables periph_rtc by default.
+# This clashes with rtt_rtc,
+FEATURES_BLACKLIST += arch_esp32


### PR DESCRIPTION
### Contribution description

The PM implementation of the esp32 relies on the RTC peripheral.
`pm_layered` is enabled by default.

The result is that in `tests-rtt_rtc` the functions of the real RTC will be called.
Since the real RTC is not controlled by the mock RTT from the test, all tests will fail.

This does ~~two things~~:

 - ~~make `pm_layered` a `DEFAULT_MODULE` on esp32 so it can be disabled.~~
 - ~~disable `pm_layered` for `unittests/tests-rtt_rtc`.~~
 - blacklist the `rtt_rtc` test on esp32.

~~While this blanket disables `pm_layered` for all architectures, I think for the unit tests this shouldn't be a problem.~~ *I was wrong*


### Testing procedure

Murdock should confirm all tests are successful now.

### Issues/PRs references

introduces by #13416
