### PR TITLE
boards/nucleo-l476rg: enable LSE by default

### DIFF
--- a/boards/nucleo-l476rg/include/periph_conf.h
+++ b/boards/nucleo-l476rg/include/periph_conf.h
@@ -45,7 +45,7 @@ extern "C" {
  * This defaults to 0 because hardware revision 'MB1136 C-01' of the nucleo-64
  * board disconnects LSE by default. You may safely set this to 1 on revisions
  * newer than 'MB1136 C-01' */
-#define CLOCK_LSE           (0)
+#define CLOCK_LSE           (1)
 #endif
 
 /* 0: enable MSI only if HSE isn't available


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR enables the LSE clock by default on the nucleo-l476rg board. I noticed that it could be enabled while testing #11286.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `tests/periph_rtt` and `tests/periph_rtc` on this board. One can verify that the accuracy is much better with this PR than on master:

- `tests/periph_rtc`:

<details><summary>master</summary>

```
make BOARD=nucleo-l476rg -C tests/periph_rtc flash term --no-print-directory 
Building application "tests_periph_rtc" for "nucleo-l476rg" with MCU "stm32l4".

"make" -C /work/riot/RIOT/boards/nucleo-l476rg
"make" -C /work/riot/RIOT/boards/common/nucleo
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32l4
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32_common
"make" -C /work/riot/RIOT/cpu/stm32_common/periph
"make" -C /work/riot/RIOT/cpu/stm32l4/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  12132	    132	   2692	  14956	   3a6c	/work/riot/RIOT/tests/periph_rtc/bin/nucleo-l476rg/tests_periph_rtc.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/periph_rtc/bin/nucleo-l476rg/tests_periph_rtc.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01047-g09ac9ab1 (2020-02-05-08:53)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 500 kHz
Info : STLINK V2J28M18 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.248453
Info : stm32l4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : Listening on port 41097 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l4x.cpu       hla_target little stm32l4x.cpu       reset

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x080004d0 msp: 0x20000200
Info : device idcode = 0x10076415 (STM32L47/L48xx - Rev: 4)
Info : flash size = 1024kbytes
Info : flash mode : dual-bank
Warn : Adding extra erase range, 0x08002fe8 .. 0x08002fff
auto erase enabled
wrote 12264 bytes from file /work/riot/RIOT/tests/periph_rtc/bin/nucleo-l476rg/tests_periph_rtc.elf in 0.762443s (15.708 KiB/s)

verified 12264 bytes in 0.522025s (22.943 KiB/s)

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
2020-03-25 11:13:15,010 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
s
2020-03-25 11:14:12,972 # START
2020-03-25 11:14:12,978 # main(): This is RIOT! (Version: 2020.04-devel-1603-g12b47)
2020-03-25 11:14:12,978 # 
2020-03-25 11:14:12,980 # RIOT RTC low-level driver test
2020-03-25 11:14:12,986 # This test will display 'Alarm!' every 2 seconds for 4 times
2020-03-25 11:14:12,989 #   Setting clock to   2020-02-28 23:59:57
2020-03-25 11:14:12,993 # Clock value is now   2020-02-28 23:59:57
2020-03-25 11:14:12,997 #   Setting alarm to   2020-02-28 23:59:59
2020-03-25 11:14:13,000 #    Alarm is set to   2020-02-28 23:59:59
2020-03-25 11:14:13,000 # 
2020-03-25 11:14:14,951 # Alarm!
2020-03-25 11:14:16,904 # Alarm!
2020-03-25 11:14:18,858 # Alarm!
2020-03-25 11:14:20,812 # Alarm!
2020-03-25 11:14:24,604 # Exiting Pyterm
```

</details>

<details><summary>this PR</summary>

```
make BOARD=nucleo-l476rg -C tests/periph_rtc flash term --no-print-directory 
Building application "tests_periph_rtc" for "nucleo-l476rg" with MCU "stm32l4".

"make" -C /work/riot/RIOT/boards/nucleo-l476rg
"make" -C /work/riot/RIOT/boards/common/nucleo
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32l4
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32_common
"make" -C /work/riot/RIOT/cpu/stm32_common/periph
"make" -C /work/riot/RIOT/cpu/stm32l4/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  12160	    132	   2692	  14984	   3a88	/work/riot/RIOT/tests/periph_rtc/bin/nucleo-l476rg/tests_periph_rtc.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/periph_rtc/bin/nucleo-l476rg/tests_periph_rtc.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01047-g09ac9ab1 (2020-02-05-08:53)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 500 kHz
Info : STLINK V2J28M18 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.253193
Info : stm32l4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : Listening on port 46139 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l4x.cpu       hla_target little stm32l4x.cpu       reset

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x080004d0 msp: 0x20000200
Info : device idcode = 0x10076415 (STM32L47/L48xx - Rev: 4)
Info : flash size = 1024kbytes
Info : flash mode : dual-bank
Info : Padding image section 1 at 0x08003004 with 4 bytes (bank write end alignment)
Warn : Adding extra erase range, 0x08003008 .. 0x080037ff
auto erase enabled
wrote 12296 bytes from file /work/riot/RIOT/tests/periph_rtc/bin/nucleo-l476rg/tests_periph_rtc.elf in 0.781971s (15.356 KiB/s)

verified 12292 bytes in 0.518734s (23.141 KiB/s)

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
2020-03-25 11:07:20,114 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
s
2020-03-25 11:09:31,741 # START
2020-03-25 11:09:31,749 # main(): This is RIOT! (Version: 2020.04-devel-1604-gf75ba2-pr/boards/nucleo-l476rg-lse)
2020-03-25 11:09:31,749 # 
2020-03-25 11:09:31,752 # RIOT RTC low-level driver test
2020-03-25 11:09:31,757 # This test will display 'Alarm!' every 2 seconds for 4 times
2020-03-25 11:09:31,761 #   Setting clock to   2020-02-28 23:59:57
2020-03-25 11:09:31,764 # Clock value is now   2020-02-28 23:59:57
2020-03-25 11:09:31,768 #   Setting alarm to   2020-02-28 23:59:59
2020-03-25 11:09:31,772 #    Alarm is set to   2020-02-28 23:59:59
2020-03-25 11:09:31,772 # 
2020-03-25 11:09:33,769 # Alarm!
2020-03-25 11:09:35,770 # Alarm!
2020-03-25 11:09:37,770 # Alarm!
2020-03-25 11:09:39,771 # Alarm!
2020-03-25 11:09:44,610 # Exiting Pyterm
```

</details>

- `tests/periph_rtt`:

<details><summary>master</summary>

```
make BOARD=nucleo-l476rg -C tests/periph_rtt flash term --no-print-directory 
Building application "tests_periph_rtt" for "nucleo-l476rg" with MCU "stm32l4".

"make" -C /work/riot/RIOT/boards/nucleo-l476rg
"make" -C /work/riot/RIOT/boards/common/nucleo
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32l4
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32_common
"make" -C /work/riot/RIOT/cpu/stm32_common/periph
"make" -C /work/riot/RIOT/cpu/stm32l4/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  10400	    132	   2664	  13196	   338c	/work/riot/RIOT/tests/periph_rtt/bin/nucleo-l476rg/tests_periph_rtt.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/periph_rtt/bin/nucleo-l476rg/tests_periph_rtt.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01047-g09ac9ab1 (2020-02-05-08:53)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 500 kHz
Info : STLINK V2J28M18 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.246873
Info : stm32l4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : Listening on port 39597 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l4x.cpu       hla_target little stm32l4x.cpu       reset

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x080004d0 msp: 0x20000200
Info : device idcode = 0x10076415 (STM32L47/L48xx - Rev: 4)
Info : flash size = 1024kbytes
Info : flash mode : dual-bank
Info : Padding image section 1 at 0x08002924 with 4 bytes (bank write end alignment)
Warn : Adding extra erase range, 0x08002928 .. 0x08002fff
auto erase enabled
wrote 10536 bytes from file /work/riot/RIOT/tests/periph_rtt/bin/nucleo-l476rg/tests_periph_rtt.elf in 0.686593s (14.986 KiB/s)

verified 10532 bytes in 0.474385s (21.681 KiB/s)

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
2020-03-25 11:15:08,810 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
s
2020-03-25 11:15:25,882 # START
2020-03-25 11:15:25,887 # main(): This is RIOT! (Version: 2020.04-devel-1603-g12b47)
2020-03-25 11:15:25,888 # 
2020-03-25 11:15:25,890 # RIOT RTT low-level driver test
2020-03-25 11:15:25,894 # This test will display 'Hello' every 5 seconds
2020-03-25 11:15:25,895 # 
2020-03-25 11:15:25,896 # Initializing the RTT driver
2020-03-25 11:15:25,902 # RTT now: 0
2020-03-25 11:15:25,905 # Setting initial alarm to now + 5 s (5120)
2020-03-25 11:15:25,912 # Done setting up the RTT, wait for many Hellos
2020-03-25 11:15:31,017 # Hello
2020-03-25 11:15:36,126 # Hello
2020-03-25 11:15:41,235 # Hello
2020-03-25 11:15:46,343 # Hello
2020-03-25 11:15:51,452 # Hello
2020-03-25 11:15:52,138 # Exiting Pyterm
```

</details>

<details><summary>this PR</summary>

```
make BOARD=nucleo-l476rg -C tests/periph_rtt flash term --no-print-directory 
Building application "tests_periph_rtt" for "nucleo-l476rg" with MCU "stm32l4".

"make" -C /work/riot/RIOT/boards/nucleo-l476rg
"make" -C /work/riot/RIOT/boards/common/nucleo
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32l4
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32_common
"make" -C /work/riot/RIOT/cpu/stm32_common/periph
"make" -C /work/riot/RIOT/cpu/stm32l4/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  10476	    132	   2664	  13272	   33d8	/work/riot/RIOT/tests/periph_rtt/bin/nucleo-l476rg/tests_periph_rtt.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/periph_rtt/bin/nucleo-l476rg/tests_periph_rtt.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01047-g09ac9ab1 (2020-02-05-08:53)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 500 kHz
Info : STLINK V2J28M18 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.250033
Info : stm32l4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : Listening on port 40207 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l4x.cpu       hla_target little stm32l4x.cpu       reset

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x080004d0 msp: 0x20000200
Info : device idcode = 0x10076415 (STM32L47/L48xx - Rev: 4)
Info : flash size = 1024kbytes
Info : flash mode : dual-bank
Warn : Adding extra erase range, 0x08002970 .. 0x08002fff
auto erase enabled
wrote 10608 bytes from file /work/riot/RIOT/tests/periph_rtt/bin/nucleo-l476rg/tests_periph_rtt.elf in 0.684222s (15.140 KiB/s)

verified 10608 bytes in 0.467952s (22.138 KiB/s)

Info : Unable to match requested speed 500 kHz, using 480 kHz
Info : Unable to match requested speed 500 kHz, using 480 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
2020-03-25 11:10:30,331 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
s
2020-03-25 11:11:05,098 # START
2020-03-25 11:11:05,106 # main(): This is RIOT! (Version: 2020.04-devel-1604-gf75ba2-pr/boards/nucleo-l476rg-lse)
2020-03-25 11:11:05,106 # 
2020-03-25 11:11:05,109 # RIOT RTT low-level driver test
2020-03-25 11:11:05,113 # This test will display 'Hello' every 5 seconds
2020-03-25 11:11:05,113 # 
2020-03-25 11:11:05,115 # Initializing the RTT driver
2020-03-25 11:11:05,121 # RTT now: 0
2020-03-25 11:11:05,124 # Setting initial alarm to now + 5 s (5120)
2020-03-25 11:11:05,131 # Done setting up the RTT, wait for many Hellos
2020-03-25 11:11:10,127 # Hello
2020-03-25 11:11:15,127 # Hello
2020-03-25 11:11:20,127 # Hello
2020-03-25 11:11:25,127 # Hello
2020-03-25 11:11:30,127 # Hello
2020-03-25 11:11:31,868 # Exiting Pyterm
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed that improvement while reviewing #11286 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
