### PR TITLE
gnrc_ipv6_nib: only route to prefix list entry if on-link

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -619,7 +619,9 @@ int _nib_get_route(const ipv6_addr_t *dst, gnrc_pktsnip_t *pkt,
           (void *)pkt);
     _nib_offl_entry_t *offl = _nib_offl_get_match(dst);
 
-    if (offl == NULL) {
+    if ((offl == NULL) ||
+        /* give default route precedence over off-link PLEs */
+        ((offl->mode == _PL) && !(offl->flags & _PFX_ON_LINK))) {
         _nib_dr_entry_t *router = _nib_drl_get_dr();
 
         if ((router == NULL) && (offl == NULL)) {

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -58,7 +58,12 @@ int gnrc_ipv6_nib_pl_set(unsigned iface,
         return 0;
     }
     gnrc_netif_acquire(netif);
-    if (!gnrc_netif_is_6ln(netif) &&
+    /* prefixes within a 6Lo-ND-performing network are typically off-link, the
+     * border router however should configure the prefix as on-link to only do
+     * address resolution towards the LoWPAN and not the upstream interface
+     * See https://github.com/RIOT-OS/RIOT/pull/10627 and follow-ups
+     */
+    if ((!gnrc_netif_is_6ln(netif) || gnrc_netif_is_6lbr(netif)) &&
         ((idx = gnrc_netif_ipv6_addr_match(netif, pfx)) >= 0) &&
         (ipv6_addr_match_prefix(&netif->ipv6.addrs[idx], pfx) >= pfx_len)) {
         dst->flags |= _PFX_ON_LINK;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

In 06aa65e1ba9788fd645a698290cf0339f42ba2ca (#10627) a new behavior was introduced in IPv6 route resolution to try address resolution only at interfaces that have the prefix of the address to be resolved configured in the prefix list. This however only makes sense, if the prefix configured is [on-link], otherwise there is small likelihood of the address to be resolved being on that link.

For the error case presented for 06aa65e (circular routing at the border router) this made sense, owever within a 6LoWPAN, due to the prefix being valid for the entire mesh, this leads to the nodes always trying classic address resolution for in-network addresses instead of just routing to the default  route. Classic address resolution however fails, as 6LoWPAN hosts typically [don't join the solicited-node multicast address of their unicast addresses][6LN-iface-init], resulting in in-network addresses not being reachable.

As such, to prevent both error cases

- the fallback to address resolution by prefix list must only be used when the prefix is on-link,
- the prefix configured by DHCPv6/UHCP at the 6LoWPAN border router must be configured as on-link, but
- the prefix must not be advertised as on-link within the 6LoWPAN to still be [in line with RFC 6775][RFC-6775-forbidden]

With this change these cases are covered.

[on-link]: https://tools.ietf.org/html/rfc4861#page-6
[RFC 6775]: https://tools.ietf.org/html/rfc6775
[6LN-iface-init]: https://tools.ietf.org/html/rfc6775#section-5.2
[RFC-6775-forbidden]: https://tools.ietf.org/html/rfc6775#section-6.1


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The testing procedure for https://github.com/RIOT-OS/RIOT/pull/10627 should still work.
Pinging another node from within a LoWPAN should also still work e.g.

```
   6LBR
  /   \
6LN   6LN
 ^     ^
 |     + pinged node
 + pinging node
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to / reverts partly https://github.com/RIOT-OS/RIOT/pull/10627
Found by trying to reproduce https://github.com/RIOT-OS/RIOT/pull/13485#issuecomment-603480280
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
