### PR TITLE
[PoC, RFC] Don't use `<stdio.h>` in RIOT

### DIFF
--- a/core/assert.c
+++ b/core/assert.c
@@ -13,14 +13,16 @@
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
  */
 
-#include <stdio.h>
-
 #include "assert.h"
+#include "fmt.h"
 
 #ifdef DEBUG_ASSERT_VERBOSE
 NORETURN void _assert_failure(const char *file, unsigned line)
 {
-    printf("%s:%u => ", file, line); \
+    print_str(file);
+    print_str(":");
+    print_u32_dec(line);
+    print_str(" => ");
     core_panic(PANIC_ASSERT_FAIL, assert_crash_message); \
 }
 #else

--- a/core/bitarithm.c
+++ b/core/bitarithm.c
@@ -19,8 +19,6 @@
  * @}
  */
 
-#include <stdio.h>
-
 #include "bitarithm.h"
 
 unsigned bitarithm_msb(unsigned v)

--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -24,7 +24,7 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
-#include <stdio.h>
+#include "fmt_stdio.h"
 #include "sched.h"
 #include "thread.h"
 
@@ -35,28 +35,9 @@ extern "C" {
 /**
  * @def DEBUG_PRINT
  *
- * @brief Print debug information if the calling thread stack is large enough
- *
- * Use this macro the same as `printf`. When `DEVELHELP` is defined inside an
- * implementation file, all usages of ::DEBUG_PRINT will print the given
- * information to stdout after verifying the stack is big enough. If `DEVELHELP`
- * is not set, this check is not performed. (CPU exception may occur)
+ * @brief Print debug information
  */
-#ifdef DEVELHELP
-#include "cpu_conf.h"
-#define DEBUG_PRINT(...) \
-do { \
-    if ((sched_active_thread == NULL) || \
-        (sched_active_thread->stack_size >= THREAD_EXTRA_STACKSIZE_PRINTF)) { \
-        printf(__VA_ARGS__); \
-    } \
-    else { \
-        puts("Cannot debug, stack too small. Consider using DEBUG_PUTS()."); \
-    } \
-} while (0)
-#else
-#define DEBUG_PRINT(...) printf(__VA_ARGS__)
-#endif
+#define DEBUG_PRINT(...) printf_nano(__VA_ARGS__)
 
 /**
  * @name Debugging defines

--- a/core/include/log.h
+++ b/core/include/log.h
@@ -97,12 +97,12 @@ enum {
 #ifdef MODULE_LOG
 #include "log_module.h"
 #else
-#include <stdio.h>
+#include "fmt_stdio.h"
 
 /**
- * @brief Default log_write function, just maps to printf
+ * @brief Default log_write function, just maps to printf_nano
  */
-#define log_write(level, ...) printf(__VA_ARGS__)
+#define log_write(level, ...) printf_nano(__VA_ARGS__)
 #endif
 
 #ifdef __cplusplus

--- a/core/include/native_sched.h
+++ b/core/include/native_sched.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 #ifdef BOARD_NATIVE
-#include <stdio.h>
+#include "fmt.h"
 
 /*
  * Required to use some C++11 headers with g++ on the native board.
@@ -45,7 +45,7 @@ typedef struct {
  */
 inline int sched_yield(void)
 {
-    puts("[ERROR] sched_yield called (defined in sched.h)\n");
+    print_str("[ERROR] sched_yield called (defined in sched.h)\n");
     return 0;
 }
 #else

--- a/core/msg.c
+++ b/core/msg.c
@@ -23,15 +23,18 @@
 #include <stddef.h>
 #include <inttypes.h>
 #include <assert.h>
-#include "sched.h"
-#include "msg.h"
+
+#include "cib.h"
+#include "fmt.h"
+#include "irq.h"
 #include "list.h"
+#include "msg.h"
+#include "sched.h"
 #include "thread.h"
+
 #if MODULE_CORE_THREAD_FLAGS
 #include "thread_flags.h"
 #endif
-#include "irq.h"
-#include "cib.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
@@ -405,16 +408,28 @@ void msg_queue_print(void)
     msg_t *msg_array = thread->msg_array;
     unsigned int i = msg_queue->read_count & msg_queue->mask;
 
-    printf("Message queue of thread %" PRIkernel_pid "\n", thread->pid);
-    printf("    size: %u (avail: %d)\n", msg_queue->mask + 1,
-           cib_avail(msg_queue));
+    print_str("Message queue of thread ");
+    print_u32_dec(thread->pid);
+    print_str("\n\tsize: ");
+    print_u32_dec(msg_queue->mask + 1);
+    print_str(" (avail: ");
+    print_u32_dec(cib_avail(msg_queue));
+    print_str(")\n");
 
     for (; i != (msg_queue->write_count & msg_queue->mask);
          i = (i + 1) & msg_queue->mask) {
         msg_t *m = &msg_array[i];
-        printf("    * %u: sender: %" PRIkernel_pid ", type: 0x%04" PRIu16
-               ", content: %" PRIu32 " (%p)\n", i, m->sender_pid, m->type,
-               m->content.value, m->content.ptr);
+        print_str("\t* ");
+        print_u32_dec(i);
+        print_str(": sender: ");
+        print_u32_dec(m->sender_pid);
+        print_str(", type: 0x");
+        print_u32_hex(m->type);
+        print_str(", content: ");
+        print_u32_dec(m->content.value);
+        print_str(" (0x");
+        print_u32_hex((uintptr_t)m->content.ptr);
+        print_str(")\n");
     }
 
     irq_restore(state);

--- a/core/mutex.c
+++ b/core/mutex.c
@@ -20,7 +20,6 @@
  * @}
  */
 
-#include <stdio.h>
 #include <inttypes.h>
 
 #include "mutex.h"

--- a/core/panic.c
+++ b/core/panic.c
@@ -22,7 +22,6 @@
  */
 
 #include <string.h>
-#include <stdio.h>
 
 #include "assert.h"
 #include "kernel_defines.h"

--- a/core/rmutex.c
+++ b/core/rmutex.c
@@ -21,7 +21,6 @@
  *
  */
 
-#include <stdio.h>
 #include <inttypes.h>
 
 #include "rmutex.h"

--- a/core/thread.c
+++ b/core/thread.c
@@ -19,7 +19,6 @@
  */
 
 #include <errno.h>
-#include <stdio.h>
 
 #include "assert.h"
 #include "thread.h"

--- a/cpu/atmega_common/Makefile.dep
+++ b/cpu/atmega_common/Makefile.dep
@@ -10,6 +10,9 @@ USEMODULE += atmega_common_periph
 # the atmel port uses stdio_uart
 USEMODULE += stdio_uart
 
+# used by cpu_print_last_instruction(), needed by module core_panic
+USEMODULE += fmt
+
 # expand atmega_pcint module
 ifneq (,$(filter atmega_pcint,$(USEMODULE)))
   USEMODULE += atmega_pcint0

--- a/cpu/atmega_common/avr_libc_extra/atmega_stdio.c
+++ b/cpu/atmega_common/avr_libc_extra/atmega_stdio.c
@@ -47,7 +47,4 @@ void atmega_stdio_init(void)
 
     stdout = &_uart_stdout;
     stdin = &_uart_stdin;
-
-    /* Flush stdout */
-    puts("\f");
 }

--- a/cpu/atmega_common/include/atmega_gpio.h
+++ b/cpu/atmega_common/include/atmega_gpio.h
@@ -24,7 +24,6 @@
 
 #ifndef ATMEGA_GPIO_H
 #define ATMEGA_GPIO_H
-#include <stdio.h>
 
 #include <avr/interrupt.h>
 

--- a/cpu/atmega_common/include/cpu.h
+++ b/cpu/atmega_common/include/cpu.h
@@ -30,11 +30,11 @@
 #ifndef CPU_H
 #define CPU_H
 
-#include <stdio.h>
 #include <stdint.h>
 
 #include <avr/interrupt.h>
 #include "cpu_conf.h"
+#include "fmt.h"
 #include "sched.h"
 #include "thread.h"
 /**
@@ -164,13 +164,15 @@ static inline void __attribute__((always_inline)) cpu_print_last_instruction(voi
 
     __asm__ volatile ("in __tmp_reg__, __SP_H__  \n\t"
                       "mov %0, __tmp_reg__       \n\t"
-                      : "=g" (hi));
+                      : "=r" (hi));
 
     __asm__ volatile ("in __tmp_reg__, __SP_L__  \n\t"
                       "mov %0, __tmp_reg__       \n\t"
-                      : "=g" (lo));
+                      : "=r" (lo));
     ptr = hi << 8 | lo;
-    printf("Stack Pointer: 0x%04x\n", ptr);
+    print_str("Stack Pointer: 0x");
+    print_u32_hex(ptr);
+    print_str("\n");
 }
 
 /**

--- a/cpu/atmega_common/irq_arch.c
+++ b/cpu/atmega_common/irq_arch.c
@@ -22,7 +22,6 @@
  */
 
 #include <stdint.h>
-#include <stdio.h>
 #include <stdint.h>
 #include "irq.h"
 #include "cpu.h"

--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -26,8 +26,6 @@
  * @}
  */
 
-#include <stdio.h>
-
 #include <avr/interrupt.h>
 
 #include "cpu.h"

--- a/cpu/atmega_common/thread_arch.c
+++ b/cpu/atmega_common/thread_arch.c
@@ -22,13 +22,12 @@
  * @}
  */
 
-#include <stdio.h>
-
-#include "thread.h"
-#include "sched.h"
-#include "irq.h"
-#include "cpu.h"
 #include "board.h"
+#include "cpu.h"
+#include "fmt.h"
+#include "irq.h"
+#include "sched.h"
+#include "thread.h"
 
 static void atmega_context_save(void);
 static void atmega_context_restore(void);
@@ -179,11 +178,16 @@ void thread_stack_print(void)
     uint8_t *sp = (uint8_t *)sched_active_thread->sp;
     uint16_t size = 0;
 
-    printf("Printing current stack of thread %" PRIkernel_pid "\n", thread_getpid());
-    printf("\taddress:\tdata:\n");
+    print_str("Printing current stack of thread ");
+    print_u32_dec(thread_getpid());
+    print_str("\n\taddress:\tdata:\n");
 
     do {
-        printf("\t0x%04x:\t\t0x%04x\n", (unsigned int)sp, (unsigned int)*sp);
+        print_str("\t0x");
+        print_u32_hex((uintptr_t)sp);
+        print_str(":\t\t0x");
+        print_u32_hex(*sp);
+        print_str("\n");
         sp++;
         size++;
 
@@ -192,7 +196,9 @@ void thread_stack_print(void)
         }
     } while (found_marker == 1);
 
-    printf("stack size: %u bytes\n", size);
+    print_str("stack size: ");
+    print_u32_dec(size);
+    print_str(" bytes\n");
 }
 
 void cpu_switch_context_exit(void)

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -30,12 +30,13 @@
 #ifndef CPU_H
 #define CPU_H
 
-#include <stdio.h>
+#include <stdint.h>
 
+#include "cpu_conf.h"
+#include "fmt.h"
 #include "irq.h"
 #include "sched.h"
 #include "thread.h"
-#include "cpu_conf.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -138,7 +139,8 @@ static inline void cpu_print_last_instruction(void)
 {
     uint32_t *lr_ptr;
     __asm__ __volatile__("mov %0, lr" : "=r"(lr_ptr));
-    printf("%p\n", (void*) lr_ptr);
+    print_str("0x");
+    print_u32_hex((uintptr_t)lr_ptr);
 }
 
 /**

--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -26,6 +26,7 @@
 #include <string.h>
 
 #include "thread.h"
+#include "fmt.h"
 #include "shell.h"
 #include "shell_commands.h"
 
@@ -42,7 +43,7 @@ int main(void)
     gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
 #endif
 
-    (void) puts("Welcome to RIOT!");
+    print_str("Welcome to RIOT!\n");
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
     shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);

--- a/makefiles/defaultmodules.inc.mk
+++ b/makefiles/defaultmodules.inc.mk
@@ -1,5 +1,7 @@
 DEFAULT_MODULE += board cpu core core_init core_msg core_panic sys
 
+DEFAULT_MODULE += fmt
+
 DEFAULT_MODULE += auto_init
 
 # Initialize all used peripherals by default

--- a/makefiles/defaultmodules.inc.mk
+++ b/makefiles/defaultmodules.inc.mk
@@ -1,6 +1,6 @@
 DEFAULT_MODULE += board cpu core core_init core_msg core_panic sys
 
-DEFAULT_MODULE += fmt
+DEFAULT_MODULE += fmt fmt_stdio
 
 DEFAULT_MODULE += auto_init
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -8,6 +8,10 @@ ifneq (,$(filter eepreg,$(USEMODULE)))
   FEATURES_REQUIRED += periph_eeprom
 endif
 
+ifneq (,$(filter phydat,$(USEMODULE)))
+  USEMODULE += fmt_table
+endif
+
 ifneq (,$(filter shell,$(USEMODULE)))
   USEMODULE += fmt_table
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -12,6 +12,10 @@ ifneq (,$(filter phydat,$(USEMODULE)))
   USEMODULE += fmt_table
 endif
 
+ifneq (,$(filter ps,$(USEMODULE)))
+  USEMODULE += fmt_table
+endif
+
 ifneq (,$(filter shell,$(USEMODULE)))
   USEMODULE += fmt_table
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -8,6 +8,10 @@ ifneq (,$(filter eepreg,$(USEMODULE)))
   FEATURES_REQUIRED += periph_eeprom
 endif
 
+ifneq (,$(filter shell,$(USEMODULE)))
+  USEMODULE += fmt_table
+endif
+
 ifneq (,$(filter fmt_table,$(USEMODULE)))
   USEMODULE += fmt
 endif

--- a/sys/fmt/Makefile
+++ b/sys/fmt/Makefile
@@ -1,5 +1,5 @@
 # exclude submodule sources from *.c wildcard source selection
-SRC := $(filter-out table.c,$(wildcard *.c))
+SRC := fmt.c
 
 # enable submodules
 SUBMODULES := 1

--- a/sys/fmt/stdio.c
+++ b/sys/fmt/stdio.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_fmt_stdio
+ * @{
+ *
+ * @file
+ * @brief       Implementation of the stdio compatibility functions
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+#include <assert.h>
+#include <stdarg.h>
+#include <stdint.h>
+
+#include "fmt.h"
+#include "kernel_defines.h"
+
+static int handle_format_error(const char *format)
+{
+    /* The best for the user would be to just skip that value and continue
+     * formatting the rest of the expression. However, as we don't know the size
+     * of the variadic argument, we cannot pop it from the argument stack. Thus,
+     * we cannot access subsequent arguments and sadly just have to give up
+     * here.
+     */
+    print_str("???");
+
+    if (IS_USED(DEVELHELP)) {
+        print_str("\nUnsupported format string was: \"");
+        print_str(format);
+        print_str("\"\n");
+    }
+
+    return 0;
+}
+
+int printf_nano(const char *format, ...)
+{
+    va_list args;
+    va_start(args, format);
+
+    /* When devel help is enabled, the format string is printed verbatim when
+     * parsing it failed. Thus, we need to back up the original value of format
+     */
+    const char *format_orig = format;
+
+    while (*format) {
+        if (*format == '%') {
+            /* Handle format specifier */
+            format++;
+
+            /* "%%" just prints a percent char */
+            if (*format == '%') {
+                print(format, 1);
+                continue;
+            }
+
+            /* We don't want to support advanced stuff like aligned output
+             * (e.g. "%-30s" or "%08x") in a nano version of printf. But at
+             * least skipping the alignment specification is trivial and results
+             * in content-wise correct output with incorrect alignment, which
+             * is better than just giving up.
+             */
+            if (*format == '-') {
+                format++;
+            }
+            while ((*format >= '0') && (*format <= '9')) {
+                format++;
+            }
+            /* Printing e.g. `short int` is done with `%hd`, `signed char` with
+             * `%hhd`. However, the C standard requires integer variables in
+             * a variadic function to be promoted to at least `int`. Thus, we
+             * can just ignore these type specifiers. This will fall into the
+             * common `int` sized format specifier handling code, which is just
+             * what we want.
+             */
+            while (*format == 'h') {
+                format++;
+            }
+            switch (*format) {
+                /* Handle formatting strings (%s) */
+                case 's':
+                    {
+                        const char *str = va_arg(args, char *);
+                        print_str(str);
+                    }
+                    break;
+                /* Handle formatting `int` sized numbers, either `signed int`
+                 * (%d or %i), `unsigned int` (%u) or hexadecimal output of the
+                 * binary representation of the `int` sized value.
+                 * Note: If `int` is of smaller width than `int32_t` (e.g. on
+                 * AVR), it will be implicitly promoted to `int32_t`. So no
+                 * casting is needed in any case.
+                 */
+                case 'i':
+                case 'd':
+                    {
+                        int num = va_arg(args, int);
+                        print_s32_dec(num);
+                    }
+                    break;
+                case 'u':
+                    {
+                        unsigned num = va_arg(args, unsigned);
+                        print_u32_dec(num);
+                    }
+                    break;
+                case 'x':
+                    {
+                        unsigned num = va_arg(args, unsigned);
+                        print_u32_hex(num);
+                    }
+                    break;
+                /* Handle formatting pointers (%p) */
+                case 'p':
+                    {
+                        /* `uintptr_t` is an unsigned integer with the same
+                         * width as a pointer. Just what we need to get the
+                         * numeric value of a pointer.
+                         * An `uintptr_t` can be implicitly promoted to
+                         * `uint32_t` for platforms (e.g. AVR) where pointers
+                         * are 16 bit rather than 32 bit.
+                         */
+                        uintptr_t ptr = (uintptr_t)va_arg(args, void *);
+                        print_u32_hex(ptr);
+                    }
+                    break;
+                /* Handle formatting `long` sized integers such as
+                 * `signed long` (%ld or %li), `unsigned long` (%lu), or
+                 * hexadecimal representation of the binary contents of a `long`
+                 * sized integer (`%lx`).
+                 * Note: On all supported platforms `long` is 32 bit wide.
+                 */
+                case 'l':
+                    format++;
+                    switch (*format) {
+                        case 'i':
+                        case 'd':
+                            {
+                                long num = va_arg(args, long);
+                                print_s32_dec(num);
+                            }
+                            break;
+                        case 'u':
+                            {
+                                unsigned long num = va_arg(args, unsigned long);
+                                print_u32_dec(num);
+                            }
+                            break;
+                        case 'x':
+                            {
+                                unsigned long num = va_arg(args, unsigned long);
+                                print_u32_hex(num);
+                            }
+                            break;
+                        default:
+                            /* Either illegal or unsupported format specifier */
+                            return handle_format_error(format_orig);
+                    }
+                    break;
+                default:
+                    /* Either illegal or unsupported format specifier */
+                    return handle_format_error(format_orig);
+            }
+        }
+        else {
+            print(format, 1);
+        }
+        format++;
+    }
+
+    /* The correct behavior is to return the number of printed chars. But a
+     * nano version of printf does not need to provide such exotic features.
+     * However, returning the correct type for ABI compatibility is nice.
+     */
+    return 0;
+}

--- a/sys/fmt/table.c
+++ b/sys/fmt/table.c
@@ -27,48 +27,74 @@
 
 #include "fmt.h"
 
-static const char fmt_table_spaces[16] = "                ";
-
-/**
- * @brief Prints @p fill_size bytes of the given pattern, repeating the
- *        pattern if needed
- * @param pat       Pattern to print
- * @param pat_size  Size of the pattern in bytes
- * @param fill_size Number of bytes to print (if bigger than @p pat_size, the
- *                  pattern will be repeated)
- *
- * E.g. `print_pattern("ab", 2, 5);` will print `ababa` to the console.
- * This can be used to fill table columns with spaces, draw lines, etc.
- */
-static void print_pattern(const char *pat, size_t pat_size, size_t fill_size)
-{
-    while (fill_size > pat_size) {
-        print(pat, pat_size);
-    }
-
-    print(pat, fill_size);
-}
-
-void print_col_u32_dec(uint32_t number, size_t width)
+void print_u32_dec_fill(uint32_t number, size_t width, char fill)
 {
     char sbuf[10]; /* "4294967295" */
     size_t slen;
 
     slen = fmt_u32_dec(sbuf, number);
-    if (width > slen) {
-        print_pattern(fmt_table_spaces, sizeof(fmt_table_spaces), width - slen);
+    while (width > slen) {
+        print(&fill, 1);
+        width--;
     }
     print(sbuf, slen);
 }
 
-void print_col_s32_dec(int32_t number, size_t width)
+void print_u32_dec_fill_right(uint32_t number, size_t width, char fill)
+{
+    char sbuf[10]; /* "4294967295" */
+    size_t slen;
+
+    slen = fmt_u32_dec(sbuf, number);
+    print(sbuf, slen);
+    while (width > slen) {
+        print(&fill, 1);
+        width--;
+    }
+}
+
+void print_s32_dec_fill(int32_t number, size_t width, char fill)
 {
     char sbuf[11]; /* "-2147483648" */
     size_t slen;
 
     slen = fmt_s32_dec(sbuf, number);
-    if (width > slen) {
-        print_pattern(fmt_table_spaces, sizeof(fmt_table_spaces), width - slen);
+    while (width > slen) {
+        print(&fill, 1);
+        width--;
     }
     print(sbuf, slen);
+}
+
+void print_s32_dec_fill_right(int32_t number, size_t width, char fill)
+{
+    char sbuf[11]; /* "-2147483648" */
+    size_t slen;
+
+    slen = fmt_s32_dec(sbuf, number);
+    print(sbuf, slen);
+    while (width > slen) {
+        print(&fill, 1);
+        width--;
+    }
+}
+
+void print_str_fill(const char *str, size_t width, char fill)
+{
+    size_t slen = strlen(str);
+    while (width > slen) {
+        print(&fill, 1);
+        width--;
+    }
+    print(str, slen);
+}
+
+void print_str_fill_right(const char *str, size_t width, char fill)
+{
+    size_t slen = strlen(str);
+    print(str, slen);
+    while (width > slen) {
+        print(&fill, 1);
+        width--;
+    }
 }

--- a/sys/include/fmt_stdio.h
+++ b/sys/include/fmt_stdio.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_fmt_stdio   Partial compatibility with stdio.h
+ * @ingroup     sys_fmt
+ * @brief       Provides functions to easily replace users of stdio.h
+ *
+ * @{
+ *
+ * @file
+ * @brief       APIs provied by @ref sys_fmt_stdio
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef FMT_STDIO_H
+#define FMT_STDIO_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Print the output specified by the given format
+ *
+ * @param   format      String to print while processing format specifiers
+ * @param   ...         Additional data to print as given by format specifiers
+ *
+ * Supported Format Specifiers
+ * ===========================
+ *
+ * - `%s`: String (`char` array terminated by a zero byte)
+ * - `%p`: Pointer address (hexadecimal without leading `0x`)
+ * - `%[<LENGTH_SPECIFIER>]x`: Integer (printed hexadecimal)
+ * - `%[<LENGTH_SPECIFIER>]d`: Signed integer of given length
+ * - `%[<LENGTH_SPECIFIER>]i`: Signed integer of given length
+ * - `%[<LENGTH_SPECIFIER>]u`: Unsigned integer of given length
+ *
+ * Supported Length Specifiers
+ * ===========================
+ * - Empty (e.g. `%d`): `int` / `unsigned int`
+ * - `l` (e.g. `%ld`): `long int` / `unsigned long int`
+ * - `h` (e.g. `%hd`): `short int` / `unsigned short int`
+ * - `hh` (e.g. `%hhd`): `signed char` / `unsigned char`
+ *
+ * Limitations
+ * ===========
+ *
+ * All other format specifiers and length are (intentionally) not supported.
+ * Unlike the real `printf()`, the length of the printed string is
+ * (intentionally) not returned. All additional format and length specifiers as
+ * well as the return value are rarely useful, but increase ROM size.
+ */
+void printf_nano(const char *format, ...);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* FMT_STDIO_H */

--- a/sys/include/fmt_table.h
+++ b/sys/include/fmt_table.h
@@ -35,18 +35,114 @@ extern "C" {
 #endif
 
 /**
- * @brief Print a table column with the given number as decimal
- * @param number    Number to print in the column
- * @param width     Width of the column
+ * @brief   Print the given number and fill the output on the left to reach the
+ *          given width
+ *
+ * @param   number      Number to print
+ * @param   width       Number of characters to print
+ * @param   fill        Character used to fill up (if needed) the output
  */
-void print_col_u32_dec(uint32_t number, size_t width);
+void print_u32_dec_fill(uint32_t number, size_t width, char fill);
 
 /**
- * @brief Print a table column with the given number as decimal
- * @param number    Number to print in the column
- * @param width     Width of the column
+ * @brief   Print the given number and fill the output on the right to reach the
+ *          given width
+ *
+ * @param   number      Number to print
+ * @param   width       Number of characters to print
+ * @param   fill        Character used to fill up (if needed) the output
  */
-void print_col_s32_dec(int32_t number, size_t width);
+void print_u32_dec_fill_right(uint32_t number, size_t width, char fill);
+
+/**
+ * @brief   Print the given number and fill the output on the left to reach the
+ *          given width
+ *
+ * @param   number      Number to print
+ * @param   width       Number of characters to print
+ * @param   fill        Character used to fill up (if needed) the output
+ */
+void print_s32_dec_fill(int32_t number, size_t width, char fill);
+
+/**
+ * @brief   Print the given number and fill the output on the right to reach the
+ *          given width
+ *
+ * @param   number      Number to print
+ * @param   width       Number of characters to print
+ * @param   fill        Character used to fill up (if needed) the output
+ */
+void print_s32_dec_fill_right(int32_t number, size_t width, char fill);
+
+/**
+ * @brief   Print the given zero terminated string and fill the output on the
+ *          left with the char @p fill to print @p width chars in total
+ *
+ * @param   str         String to print (terminated by a zero byte)
+ * @param   width       Number of chars to print
+ * @param   fill        Character to fill the output with
+ */
+void print_str_fill(const char *str, size_t width, char fill);
+
+/**
+ * @brief   Print the given zero terminated string and fill the output on the
+ *          right with the char @p fill to print @p width chars in total
+ *
+ * @param   str         String to print (terminated by a zero byte)
+ * @param   width       Number of chars to print
+ * @param   fill        Character to fill the output with
+ */
+void print_str_fill_right(const char *str, size_t width, char fill);
+
+/**
+ * @brief   Print a table column with the given number as decimal
+ *
+ * @param   number    Number to print in the column
+ * @param   width     Width of the column
+ */
+static inline void print_col_u32_dec(uint32_t number, size_t width)
+{
+    print_u32_dec_fill(number, width, ' ');
+}
+
+/**
+ * @brief   Print a table column with the given number as decimal
+ *
+ * @param   number    Number to print in the column
+ * @param   width     Width of the column
+ */
+static inline void print_col_s32_dec(int32_t number, size_t width)
+{
+    print_s32_dec_fill(number, width, ' ');
+}
+
+/**
+ * @brief   Print the given numbers and add leading zeros when needed
+ *
+ * @param   number      Number to print
+ * @param   width       Number of characters to print
+ */
+static inline void print_u32_dec_zeros(uint32_t number, size_t width)
+{
+    print_u32_dec_fill(number, width, '0');
+}
+
+/**
+ * @brief   Print the given numbers and add leading zeros when needed
+ *
+ * @param   number      Number to print
+ * @param   width       Number of characters to print
+ */
+static inline void print_s32_dec_zeros(int32_t number, size_t width)
+{
+    if (number < 0) {
+        const char minus[1] = "-";
+        print(minus, 1);
+        width--;
+        number = -number;
+    }
+    print_u32_dec_zeros((uint32_t)number, width);
+}
 
 #ifdef __cplusplus
 }

--- a/sys/shell/commands/sc_rtc.c
+++ b/sys/shell/commands/sc_rtc.c
@@ -20,18 +20,19 @@
  * @}
  */
 
-#include <stdio.h>
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
 
+#include "fmt.h"
+#include "fmt_table.h"
 #include "periph/rtc.h"
 
 static void _alarm_handler(void *arg)
 {
     (void) arg;
 
-    puts("The alarm rang");
+    print_str("The alarm rang\n");
 }
 
 static int dow(int year, int month, int day)
@@ -74,10 +75,18 @@ static int _parse_time(char **argv, struct tm *time)
 
 static int _print_time(struct tm *time)
 {
-    printf("%04i-%02i-%02i %02i:%02i:%02i\n",
-            time->tm_year + 1900, time->tm_mon + 1, time->tm_mday,
-            time->tm_hour, time->tm_min, time->tm_sec
-          );
+    print_u32_dec_zeros(time->tm_year + 1900, 4);
+    print_str("-");
+    print_u32_dec_zeros(time->tm_mon, 2);
+    print_str("-");
+    print_u32_dec_zeros(time->tm_mday, 2);
+    print_str(" ");
+    print_u32_dec_zeros(time->tm_hour, 2);
+    print_str(":");
+    print_u32_dec_zeros(time->tm_min, 2);
+    print_str(":");
+    print_u32_dec_zeros(time->tm_sec, 2);
+    print_str("\n");
     return 0;
 }
 
@@ -89,7 +98,7 @@ static int _rtc_getalarm(void)
         return 0;
     }
     else {
-        puts("rtc: error getting alarm");
+        print_str("rtc: error getting alarm\n");
         return 1;
     }
 }
@@ -100,7 +109,7 @@ static int _rtc_setalarm(char **argv)
 
     if (_parse_time(argv, &now) == 0) {
         if (rtc_set_alarm(&now, _alarm_handler, NULL) == -1) {
-            puts("rtc: error setting alarm");
+            print_str("rtc: error setting alarm\n");
             return 1;
         }
         return 0;
@@ -116,7 +125,7 @@ static int _rtc_gettime(void)
         return 0;
     }
     else {
-        puts("rtc: error getting time");
+        print_str("rtc: error getting time\n");
         return 1;
     }
 }
@@ -127,7 +136,7 @@ static int _rtc_settime(char **argv)
 
     if (_parse_time(argv, &now) == 0) {
         if (rtc_set_time(&now) == -1) {
-            puts("rtc: error setting time");
+            print_str("rtc: error setting time\n");
             return 1;
         }
         return 0;
@@ -137,15 +146,17 @@ static int _rtc_settime(char **argv)
 
 static int _rtc_usage(void)
 {
-    puts("usage: rtc <command> [arguments]");
-    puts("commands:");
-    puts("\tpoweron\t\tpower the interface on");
-    puts("\tpoweroff\tpower the interface off");
-    puts("\tclearalarm\tdeactivate the current alarm");
-    puts("\tgetalarm\tprint the currently alarm time");
-    puts("\tsetalarm YYYY-MM-DD HH:MM:SS\n\t\t\tset an alarm for the specified time");
-    puts("\tgettime\t\tprint the current time");
-    puts("\tsettime YYYY-MM-DD HH:MM:SS\n\t\t\tset the current time");
+    print_str(
+        "usage: rtc <command> [arguments]\n"
+        "commands:\n"
+        "\tpoweron\t\tpower the interface on\n"
+        "\tpoweroff\tpower the interface off\n"
+        "\tclearalarm\tdeactivate the current alarm\n"
+        "\tgetalarm\tprint the currently alarm time\n"
+        "\tsetalarm YYYY-MM-DD HH:MM:SS\n\t\t\tset an alarm for the specified time\n"
+        "\tgettime\t\tprint the current time\n"
+        "\tsettime YYYY-MM-DD HH:MM:SS\n\t\t\tset the current time\n"
+    );
     return 0;
 }
 
@@ -177,7 +188,9 @@ int _rtc_handler(int argc, char **argv)
         _rtc_settime(argv + 2);
     }
     else {
-        printf("unknown command or missing parameters: %s\n\n", argv[1]);
+        print_str("unknown command or missing parameters: ");
+        print_str(argv[1]);
+        print_str("\n\n");
         _rtc_usage();
         return 1;
     }

--- a/sys/shell/commands/sc_sys.c
+++ b/sys/shell/commands/sc_sys.c
@@ -18,8 +18,7 @@
  * @}
  */
 
-#include <stdio.h>
-
+#include "fmt.h"
 #include "periph/pm.h"
 
 int _reboot_handler(int argc, char **argv)
@@ -37,7 +36,7 @@ int _version_handler(int argc, char **argv)
     (void) argc;
     (void) argv;
 
-    puts(RIOT_VERSION);
+    print_str(RIOT_VERSION "\n");
 
     return 0;
 }


### PR DESCRIPTION
### Disclaimer

This PR contains a bunch of commits that would be better split into separate PR. But this PR is not indented to be merged nor to be reviewed in-depth, but rather to demonstrate the feasibility of an idea. If the general idea is accepted to be worth pursuing, this PR will be split up into multiple PRs to allow efficient reviewing.

***BEWARE:*** This is almost completely untested.

### Contribution description

This PR replaces the use of `<stdio.h>` within some portions of RIOT with `sys/fmt`:

- Internal RIOT stuff uses the `print_...()` family of functions directly
- `DEBUG()` and `LOG_DEBUG()`/`LOG_INFO()`/... cannot simply be replaced, as the API is closely coupled to `printf()`
    - A `printf_nano()` function is added as module `fmt_stdio`. This function implements a small subset of the `printf()` format specifiers using the `print_...` functions.
    - This `printf_nano()` should be enough for our debugging and logging requirements and is used by default for `DEBUG()` and `LOG_...()` by default

#### Why?

##### Code Size

With master:
```
make BOARD=bluepill BUILD_IN_DOCKER=1 -C examples/default/
[...]
   text	   data	    bss	    dec	    hex	filename
  18292	    132	   2672	  21096	   5268	/data/riotbuild/riotbase/examples/default/bin/bluepill/default.elf
```
With this PR:
```
make BOARD=bluepill BUILD_IN_DOCKER=1 -C examples/default/
[...]
   text	   data	    bss	    dec	    hex	filename
  13924	    128	   2652	  16704	   4140	/data/riotbuild/riotbase/examples/default/bin/bluepill/default.elf
```

Note: There is likely still some room for further improvement. This PR is just a quickly written proof of concept.

#### Stack Requirements

The newlibs implementation of `<stdio.h>` uses **significant** amounts of stack.

- This resulted in a stack check added to `DEBUG()` to prevent stack overflows. With a lightweight alternative like the `printf_nano()` provided here should often without having to increase the stack size of driver threads or at least with increasing the stack only a little
- In crash handler for ARM Cortex M boards `printf()` is used, which results in significant stack allocation for that handler. Using `print_...()` provided by `fmt.h` should result reducing that stack. (***BUT:*** This has not been done in this PR, as the actual stack requirements need to be evaluated with care, as different compilers might produce binaries with different stack requirements.)

#### Huge Complexity of the API in `<stdio.h>`

- There have been [numerous](https://www.openwall.com/lists/musl/2019/03/14/4) [bugs](https://www.freebsd.org/security/advisories/FreeBSD-SA-14:27.stdio.asc) [in](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2012-3406) [various](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-0689) [stdio](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-1391) [implementations](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2008-0965). Most of those are due to the inherent complexity.
- There have been even more bugs in applications using `<stdio.h>`
- There are various aspects that are either unspecified or implementation defined behavior, opening up a lot of pitfalls to fall in

#### MISRA C Compliance

- [MISRA C: "`<stdio.h>` should not be used in production code"](https://rules.sonarsource.com/c/RSPEC-988)
    - The reasoning is very much the same as above
- Companies tent to care a lot about MISRA C compliance. Having everything `core`, `sys`, and `drivers` would allow users to decide for themselves if they want to follow this MISRA C rule.

### Testing procedure

Doesn't apply (yet). Detailed testing descriptions will be provided for the individual PRs split out of this, if the general approach is agreed upon.

### Issues/PRs references

- This would mitigate most of the ROM overhead introduced by switching to newlib for MSP-430 in https://github.com/RIOT-OS/RIOT/pull/12457
- A subset of the goal (reducing ROM size) overlap with the goals of the PR adding support for piclibc https://github.com/RIOT-OS/RIOT/pull/12305