### PR TITLE
nanocoap: add const qualifier to pkt of coap_opt_get_opaque()

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -597,7 +597,7 @@ ssize_t coap_opt_get_next(const coap_pkt_t *pkt, coap_optpos_t *opt,
  * @return        -ENOENT if option not found
  * @return        -EINVAL if option cannot be parsed
  */
-ssize_t coap_opt_get_opaque(coap_pkt_t *pkt, unsigned opt_num, uint8_t **value);
+ssize_t coap_opt_get_opaque(const coap_pkt_t *pkt, unsigned opt_num, uint8_t **value);
 /**@}*/
 
 

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -206,7 +206,7 @@ static uint8_t *_parse_option(const coap_pkt_t *pkt,
     return pkt_pos;
 }
 
-ssize_t coap_opt_get_opaque(coap_pkt_t *pkt, unsigned opt_num, uint8_t **value)
+ssize_t coap_opt_get_opaque(const coap_pkt_t *pkt, unsigned opt_num, uint8_t **value)
 {
     uint8_t *start = coap_find_option(pkt, opt_num);
     if (!start) {


### PR DESCRIPTION
### Contribution description

I noticed that `coap_opt_get_opaque()` is one of the very few functions that does not have a `const` qualifier for the `pkt` parameter .. there also doesn't seem to be a reason for `pkt` to not be `const`.

For consistency reasons, this PR adds `const` to the `pkt`parameter of `coap_opt_get_opaque()`.

### Testing procedure

Compiling the gcoap example should not fail.

### Issues/PRs references

none
