### PR TITLE
gnrc_sixlowpan_iphc: zero IPv6 header before decompressing into it

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -158,6 +158,9 @@ static size_t _iphc_ipv6_decode(const uint8_t *iphc_hdr,
         payload_offset++;
     }
 
+    /* bits of the uncompressed address might not be written in decompression,
+     * so zero the whole header first */
+    memset(ipv6_hdr, 0, sizeof(*ipv6_hdr));
     ipv6_hdr_set_version(ipv6_hdr);
 
     switch (iphc_hdr[IPHC1_IDX] & SIXLOWPAN_IPHC1_TF) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
With 6LoWPAN IPHC, if a compressed prefix is smaller than 64 bit some of the bits within the uncompressed addresses won't be written ever. This zeros the whole target IPv6 header region before decompressing into it. This way wildly set bits do not sneak into 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Merge #13712 and run the border router application with a prefix of a length lesser than 64. Add a `gnrc_networking` app to your network. On master, in some instances the address will stay tentative and if you sniff the WPAN you will see, that the `gnrc_networking` node will send `Destination unreachable` messages on the NA containing something like the following copy of an IPv6 header:

```
Internet Control Message Protocol v6
    Type: Destination Unreachable (1)
    Code: 3 (Address unreachable)
    Checksum: 0x2524 [correct]
    [Checksum Status: Good]
    Reserved: 00000000
    Internet Protocol Version 6, Src: 2001:db8::840c:77ec:2333:6278, Dst: 2001:db8:0:3:589d:9386:2208:6578
        0110 .... = Version: 6
        .... 0000 0000 .... .... .... .... .... = Traffic Class: 0x00 (DSCP: CS0, ECN: Not-ECT)
        .... .... .... 0000 0000 0000 0000 0000 = Flow Label: 0x00000
        Payload Length: 40
        Next Header: ICMPv6 (58)
        Hop Limit: 254
        Source: 2001:db8::840c:77ec:2333:6278
        Destination: 2001:db8:0:3:589d:9386:2208:6578
    Internet Control Message Protocol v6
```

vs. original NA

```
Internet Protocol Version 6, Src: 2001:db8::840c:77ec:2333:6278, Dst: 2001:db8::589d:9386:2208:6578
    0110 .... = Version: 6
    .... 0000 0000 .... .... .... .... .... = Traffic Class: 0x00 (DSCP: CS0, ECN: Not-ECT)
    .... .... .... 0000 0000 0000 0000 0000 = Flow Label: 0x00000
    Payload Length: 40
    Next Header: ICMPv6 (58)
    Hop Limit: 255
    Source: 2001:db8::840c:77ec:2333:6278
    Destination: 2001:db8::589d:9386:2208:6578
```

With this patch this random 3 (or 1 or 2) will disappear in the copied headers addresses and the auto-configured global address will become valid reliably.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes https://github.com/RIOT-OS/RIOT/pull/13485#issuecomment-603480280.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
