### PR TITLE
Kconfig: Add CPU and Board common symbols

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -13,6 +13,8 @@ osource "$(KCONFIG_GENERATED_DEPENDENCIES)"
 orsource "$(RIOTBOARD)/$(BOARD)/Kconfig"
 orsource "$(RIOTCPU)/$(CPU)/Kconfig"
 
+rsource "$(RIOTBOARD)/Kconfig"
+
 # The application may declare new symbols as well
 osource "$(APPDIR)/Kconfig"
 

--- a/Kconfig
+++ b/Kconfig
@@ -14,6 +14,7 @@ orsource "$(RIOTBOARD)/$(BOARD)/Kconfig"
 orsource "$(RIOTCPU)/$(CPU)/Kconfig"
 
 rsource "$(RIOTBOARD)/Kconfig"
+rsource "$(RIOTCPU)/Kconfig"
 
 # The application may declare new symbols as well
 osource "$(APPDIR)/Kconfig"

--- a/Kconfig
+++ b/Kconfig
@@ -9,6 +9,8 @@ mainmenu "RIOT Configuration"
 # For now, get used modules as macros from this file (see kconfig.mk)
 osource "$(KCONFIG_GENERATED_DEPENDENCIES)"
 
+# Load first board configurations, which might override CPU's
+orsource "$(RIOTBOARD)/$(BOARD)/Kconfig"
 orsource "$(RIOTCPU)/$(CPU)/Kconfig"
 
 # The application may declare new symbols as well

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+config BOARD
+    string
+    help
+        Name of the currently selected board.

--- a/cpu/Kconfig
+++ b/cpu/Kconfig
@@ -1,0 +1,48 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+#   +-----------+
+#   | CPU_MODEL |
+#   +-----------+
+#        || selects
+#        \/
+#  +------------+
+#  | CPU_SERIES |
+#  +------------+
+#        || selects
+#        \/
+#  +------------+
+#  | CPU_FAMILY |
+#  +------------+
+#        || selects
+#        \/
+#   +----------+
+#   | CPU_ARCH |
+#   +----------+
+config CPU
+    string
+    help
+        Name of the currently selected CPU.
+
+config CPU_MODEL
+    string
+    help
+        Model of the currently selected CPU.
+
+config CPU_SERIES
+    string
+    help
+        Series of the currently selected CPU.
+
+config CPU_FAMILY
+    string
+    help
+        Family of the currently selected CPU.
+
+config CPU_ARCH
+    string
+    help
+        Architecture of the currently selected CPU.

--- a/examples/usbus_minimal/Makefile
+++ b/examples/usbus_minimal/Makefile
@@ -24,6 +24,9 @@ USB_PID ?= $(DEFAULT_PID)
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
+# Do not run Kconfig by default
+SHOULD_RUN_KCONFIG ?=
+
 include $(RIOTBASE)/Makefile.include
 
 # Set USB VID/PID via CFLAGS if not being set via Kconfig

--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -30,6 +30,11 @@ KCONFIG_USER_CONFIG = $(APPDIR)/user.config
 # one that is used to generate the 'riotconf.h' header
 KCONFIG_MERGED_CONFIG = $(GENERATED_DIR)/merged.config
 
+# This is the output of the generated configuration. It always mirrors the
+# content of KCONFIG_GENERATED_AUTOCONF_HEADER_C, and it is used to load
+# configuration symbols to the build system.
+KCONFIG_OUT_CONFIG = $(GENERATED_DIR)/out.config
+
 # Include configuration symbols if available, only when not cleaning. This
 # allows to check for Kconfig symbols in makefiles.
 # Make tries to 'remake' all included files
@@ -39,7 +44,7 @@ KCONFIG_MERGED_CONFIG = $(GENERATED_DIR)/merged.config
 # This has the side effect of requiring a Kconfig user to run 'clean' on a
 # separate call (e.g. 'make clean && make all'), to get the symbols correctly.
 ifneq ($(CLEAN),clean)
-  -include $(KCONFIG_MERGED_CONFIG)
+  -include $(KCONFIG_OUT_CONFIG)
 endif
 
 # Flag that indicates that the configuration has been edited
@@ -116,6 +121,9 @@ $(KCONFIG_MERGED_CONFIG): $(MERGECONFIG) $(KCONFIG_GENERATED_DEPENDENCIES) FORCE
 
 # Build a header file with all the Kconfig configurations. genconfig will avoid
 # any unnecessary rewrites of the header file if no configurations changed.
-$(KCONFIG_GENERATED_AUTOCONF_HEADER_C): $(KCONFIG_GENERATED_DEPENDENCIES) $(GENCONFIG) $(KCONFIG_MERGED_CONFIG) FORCE
-	$(Q)KCONFIG_CONFIG=$(KCONFIG_MERGED_CONFIG) $(GENCONFIG) --header-path $@ $(KCONFIG)
+$(KCONFIG_OUT_CONFIG) $(KCONFIG_GENERATED_AUTOCONF_HEADER_C) &: $(KCONFIG_GENERATED_DEPENDENCIES) $(GENCONFIG) $(KCONFIG_MERGED_CONFIG) FORCE
+	$(Q) \
+	KCONFIG_CONFIG=$(KCONFIG_MERGED_CONFIG) $(GENCONFIG) \
+	  --config-out=$(KCONFIG_OUT_CONFIG) \
+	  --header-path $(KCONFIG_GENERATED_AUTOCONF_HEADER_C) $(KCONFIG)
 endif


### PR DESCRIPTION
### Contribution description
This adds the definitions of common symbols to Kconfig which should be defined for every board/cpu combination, which would somehow mirror the variables we are currently defining in `Makefile.features` files:
- `BOARD`
- `CPU`
- `CPU_MODEL`
- `CPU_SERIES`
- `CPU_FAMILY`
- `CPU_ARCH`

Now the main `Kconfig` file will also search for symbols on the currently selected `BOARD` and `CPU`.

Also, this changes the file which is included in the build system to one that is generated every time (`out.config`).

This was originally part of #13404, @jia200x suggested to split it. 

### Testing procedure
With any board selected, run `make menuconfig`. Using the search function (`/`) you should be able to find these hidden symbols. Check that they are displayed correctly.

**Edit**: As this also changes the Makefile to use `out.config`, make sure that `tests/kconfig` still works as expected.

### Issues/PRs references
#13404 
