### PR TITLE
Makefile.features: provide CPU as a feature

### DIFF
--- a/Makefile.features
+++ b/Makefile.features
@@ -17,3 +17,6 @@ ifeq (,$(CPU))
 endif
 
 include $(RIOTCPU)/$(CPU)/Makefile.features
+
+# Provide CPU as a feature to allow listing all boards with a CPU
+FEATURES_PROVIDED += cpu_$(CPU)


### PR DESCRIPTION
### Contribution description

I often found myself adding something like `FEATURES_PROVIDED += cpu_saml21` to a CPUs `Makefile.features` in order to list all boards with this CPU when a change to the CPU required changes to the boards using it.

I was wondering, why not add this by default?

### Testing procedure

Run e.g.

    FEATURES_REQUIRED=cpu_samd21 make -C examples/default info-boards-supported

to list all boards that belong to the samd21 family.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
