### PR TITLE
cpu/esp32: use conditional expansion for INCLUDES and esp_eth

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -19,8 +19,6 @@ ifneq (,$(filter esp_eth,$(USEMODULE)))
   USEMODULE += netdev_eth
   USEMODULE += netopt
   USEMODULE += xtimer
-  INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/ethernet
-  INCLUDES += -I$(ESP32_SDK_DIR)/components/ethernet/include
 endif
 
 ifneq (,$(filter esp_wifi_any,$(USEMODULE)))

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -48,6 +48,9 @@ INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/esp32/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/soc/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)
 
+INCLUDES += $(if $(filter esp_eth,$(USEMODULE)),-I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/ethernet)
+INCLUDES += $(if $(filter esp_eth,$(USEMODULE)),-I$(ESP32_SDK_DIR)/components/ethernet/include)
+
 CFLAGS += -DSDK_NOT_USED -DCONFIG_FREERTOS_UNICORE=1 -DESP_PLATFORM
 CFLAGS += -DLOG_TAG_IN_BRACKETS
 


### PR DESCRIPTION
### Contribution description

This PR is a very small cleanup of `cpu/esp32/Makefile.dep`. Instead of setting the `INCLUDES` for `esp_eth` in `cpu/esp32/Makefile.dep`, conditional expansion is used in `cpu/esp32/Makefile.include`.

### Testing procedure

Compilation of `examples/gnrc_networking` for board `esp32-olimex-evb` should succeed in Murdock.
```
make BOARD=esp32-olimex-evb -C examples/gnrc_networking
```
`esp_eth` is used as `netdev_default` for this board.

### Issues/PRs references
