### PR TITLE
sys/ztimer: add power management for ztimer clocks

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -374,16 +374,6 @@ int ztimer_msg_receive_timeout(ztimer_clock_t *clock, msg_t *msg,
  /* created with dist/tools/define2u16.py */
 #define MSG_ZTIMER 0xc83e   /**< msg type used by ztimer_msg_receive_timeout */
 
-/*
- * @brief ztimer_now() for extending timers
- *
- * @internal
- *
- * @param[in]   clock          ztimer clock to operate on
- * @return  Current count on the clock @p clock
- */
-ztimer_now_t _ztimer_now_extend(ztimer_clock_t *clock);
-
 /**
  * @brief ztimer_now() for extending timers
  *

--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -224,6 +224,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Disables interaction with pm_layered for a clock
+ */
+#define ZTIMER_CLOCK_NO_REQUIRED_PM_MODE (UINT8_MAX)
+
+/**
  * @brief ztimer_base_t forward declaration
  */
 typedef struct ztimer_base ztimer_base_t;
@@ -296,6 +301,9 @@ struct ztimer_clock {
     uint32_t max_value;             /**< maximum relative timer value       */
     uint32_t lower_last;            /**< timer value at last now() call     */
     ztimer_now_t checkpoint;        /**< cumulated time at last now() call  */
+#endif
+#if MODULE_PM_LAYERED || DOXYGEN
+    uint8_t required_pm_mode;       /**< min. pm mode required for the clock to run */
 #endif
 };
 

--- a/sys/ztimer/auto_init.c
+++ b/sys/ztimer/auto_init.c
@@ -86,6 +86,14 @@
 #define CONFIG_ZTIMER_USEC_WIDTH (32)
 #endif
 
+#ifndef CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE
+#define CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE ZTIMER_CLOCK_NO_REQUIRED_PM_MODE
+#endif
+
+#ifndef CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE
+#define CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE ZTIMER_CLOCK_NO_REQUIRED_PM_MODE
+#endif
+
 #if MODULE_ZTIMER_USEC
 #  if CONFIG_ZTIMER_USEC_TYPE_PERIPH_TIMER
 static ztimer_periph_timer_t _ztimer_periph_timer_usec = { .min = CONFIG_ZTIMER_USEC_MIN };
@@ -160,6 +168,11 @@ void ztimer_init(void)
             CONFIG_ZTIMER_USEC_ADJUST);
     ZTIMER_USEC->adjust = CONFIG_ZTIMER_USEC_ADJUST;
 #  endif
+#  ifdef MODULE_PM_LAYERED
+    LOG_DEBUG("ztimer_init(): ZTIMER_USEC setting required_pm_mode to %i\n",
+            CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE);
+    ZTIMER_USEC->required_pm_mode = CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE;
+#  endif
 #endif
 
 #ifdef ZTIMER_RTT_INIT
@@ -179,6 +192,11 @@ void ztimer_init(void)
     LOG_DEBUG("ztimer_init(): ZTIMER_MSEC setting adjust value to %i\n",
             CONFIG_ZTIMER_MSEC_ADJUST);
     ZTIMER_MSEC->adjust = CONFIG_ZTIMER_MSEC_ADJUST;
+#  endif
+#  ifdef MODULE_PM_LAYERED
+    LOG_DEBUG("ztimer_init(): ZTIMER_MSEC setting required_pm_mode to %i\n",
+            CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE);
+    ZTIMER_MSEC->required_pm_mode = CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE;
 #  endif
 #endif
 }


### PR DESCRIPTION
### Contribution description

This is a follow-up of #13585. After some discussion with @kaspar030 I came up with an implementation of his approach.

The basic idea / assumptions behind this PR:

* On some platforms, the power consumption can be reduced dramatically by disabling high frequency hardware timers. Those timers are used by the `ZTIMER_USEC` clock.
* The high frequency timers require a certain pm mode to be active. Lower pm modes deactivate those timers.
* ztimer knows if any `ztimer_t` is running on the `ZTIMER_USEC` clock.
* ztimer blocks that certain pm mode, if a `ztimer_t` requires the `ZTIMER_USEC` clock and unblocks it if no `ztimer_t` is running on `ZTIMER_USEC`.

### Testing procedure

*I'll describe the testing procedure later if the over-all architecture is considered acceptable*

### Issues/PRs references

Closes #13585
Closes #13580