### PR TITLE
net/coap: add macro to generate custom option number

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -47,6 +47,22 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief   Generate a custom CoAP option number
+ *
+ * @param[in]  num      Custom number, will be the base for the CoAP option number.
+ * @param[in]  crit     Set to 1 if the option is critical, that is the option is
+ *                      mandatory.
+ * @param[in]  safe     Set to 1 if the option is safe to forward.
+ * @param[in]  cKey     If the option is safe to forward, set to 1 if the Option is
+ *                      a cache key.
+ */
+#define COAP_OPT_CUSTOM(num, crit, safe, cKey) ( \
+                        ((crit) ? (1) : (0))   | \
+                        ((safe) ? (0) : (2))   | \
+                        ((cKey) ? (0) : (0x1c))| \
+                        ((num) << 11)          )
+
+/**
  * @name    Message types -- confirmable, non-confirmable, etc.
  * @{
  */


### PR DESCRIPTION
### Contribution description

From the CoAP specification [1]

>    […] An Option number is constructed with a bit
>    mask to indicate if an option is Critical or Elective, Unsafe or
>    Safe-to-Forward, and, in the case of Safe-to-Forward, to provide a
>    Cache-Key indication as shown by the following figure.  In the
>    following text, the bit mask is expressed as a single byte that is
>    applied to the least significant byte of the option number in
>    unsigned integer representation.  When bit 7 (the least significant
>    bit) is 1, an option is Critical (and likewise Elective when 0).
>    When bit 6 is 1, an option is Unsafe (and likewise Safe-to-Forward
>    when 0).  When bit 6 is 0, i.e., the option is not Unsafe, it is not
>    a Cache-Key (NoCacheKey) if and only if bits 3-5 are all set to 1;
>    all other bit combinations mean that it indeed is a Cache-Key.  These
>    classes of options are explained in the next sections.
> 
>                        0   1   2   3   4   5   6   7
>                      +---+---+---+---+---+---+---+---+
>                      |           | NoCacheKey| U | C |
>                      +---+---+---+---+---+---+---+---+
> 

The Option is moved into the space above 2048 which seems to be the least restrictive [2] even though it is not explicitly listed as custom option space.

Or maybe I'm misunderstanding CoAP and the user is not supposed to define custom options.
My use case was that I wanted to encode a custom node ID as an Option.

 [1] https://tools.ietf.org/html/rfc7252#section-5.4.6
 [2] https://tools.ietf.org/html/rfc7252#section-12.2

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
