### PR TITLE
nanocoap_sock: extend with blockwise get request

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -223,6 +223,19 @@ extern "C" {
 #define COAP_BLOCKWISE_SZX_MAX  (7)
 /** @} */
 
+/**
+ * @brief Coap block-wise-transfer size values
+ */
+typedef enum {
+    COAP_BLOCKSIZE_16   = 0, /**< 16 byte block size    */
+    COAP_BLOCKSIZE_32   = 1, /**< 32 byte block size    */
+    COAP_BLOCKSIZE_64   = 2, /**< 64 byte block size    */
+    COAP_BLOCKSIZE_128  = 3, /**< 128 byte block size   */
+    COAP_BLOCKSIZE_256  = 4, /**< 256 byte block size   */
+    COAP_BLOCKSIZE_512  = 5, /**< 512 byte block size   */
+    COAP_BLOCKSIZE_1024 = 6, /**< 1024 byte block size  */
+} coap_blocksize_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -199,7 +199,7 @@ ssize_t nanocoap_get(sock_udp_ep_t *remote, const char *path, uint8_t *buf,
  * @returns     <0 on error
  */
 int nanocoap_get_blockwise(sock_udp_ep_t *remote, const char *path,
-                           uint8_t *buf, size_t len, coap_blockwise_t size,
+                           uint8_t *buf, size_t len, coap_blocksize_t size,
                            coap_blockwise_cb_t callback, void *arg);
 
 /**

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -139,6 +139,21 @@
 extern "C" {
 #endif
 
+
+/**
+ * @brief   Coap blockwise request callback descriptor
+ *
+ * @param[in] arg      Pointer to be passed as arguments to the callback
+ * @param[in] offset   Offset of received data
+ * @param[in] buf      Pointer to the received data
+ * @param[in] len      Length of the received data
+ * @param[in] more     -1 for no option, 0 for last block, 1 for more blocks
+ *
+ * @returns    0       on success
+ * @returns   -1       on error
+ */
+typedef int (*coap_blockwise_cb_t)(coap_pkt_t *pkt, void *arg);
+
 /**
  * @brief   Start a nanocoap server instance
  *
@@ -166,6 +181,26 @@ int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize);
  */
 ssize_t nanocoap_get(sock_udp_ep_t *remote, const char *path, uint8_t *buf,
                      size_t len);
+
+/**
+ * @brief   Simple synchronous blockwise CoAP get request
+ *
+ * @p callback is called for every valid received blockwise answer
+ *
+ * @param[in]   remote   remote UDP endpoint
+ * @param[in]   path     remote path
+ * @param[in]   buf      buffer to use for the packet
+ * @param[in]   len      length of @p buffer
+ * @param[in]   size     CoAP blockwise size to use for requests
+ * @param[in]   callback function to call on valid response received
+ * @param[in]   arg      context to pass to @p callback
+ *
+ * @returns     length of response payload on success
+ * @returns     <0 on error
+ */
+int nanocoap_get_blockwise(sock_udp_ep_t *remote, const char *path,
+                           uint8_t *buf, size_t len, coap_blockwise_t size,
+                           coap_blockwise_cb_t callback, void *arg);
 
 /**
  * @brief   Simple synchronous CoAP request

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -30,11 +30,29 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+static inline uint32_t deadline_from_interval(int32_t interval)
+{
+    assert(interval >= 0);
+    return xtimer_now_usec() + (uint32_t)interval;
+}
+
+static inline uint32_t deadline_left(uint32_t deadline)
+{
+    int32_t left = (int32_t)(deadline - xtimer_now_usec());
+
+    if (left < 0) {
+        left = 0;
+    }
+    return left;
+}
+
 ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local, sock_udp_ep_t *remote, size_t len)
 {
     ssize_t res;
     size_t pdu_len = (pkt->payload - (uint8_t *)pkt->hdr) + pkt->payload_len;
     uint8_t *buf = (uint8_t*)pkt->hdr;
+    uint32_t id = coap_get_id(pkt);
+
     sock_udp_t sock;
 
     if (!remote->port) {
@@ -46,29 +64,41 @@ ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local, sock_udp_ep_t *r
         return res;
     }
 
+    res = -EAGAIN;
+
     /* TODO: timeout random between between ACK_TIMEOUT and (ACK_TIMEOUT *
      * ACK_RANDOM_FACTOR) */
     uint32_t timeout = COAP_ACK_TIMEOUT * US_PER_SEC;
-    unsigned tries_left = COAP_MAX_RETRANSMIT + 1;  /* add 1 for initial transmit */
-    while (tries_left) {
+    uint32_t deadline = deadline_from_interval(timeout);
 
-        res = sock_udp_send(&sock, buf, pdu_len, NULL);
-        if (res <= 0) {
-            DEBUG("nanocoap: error sending coap request, %d\n", (int)res);
-            break;
+    /* add 1 for initial transmit */
+    unsigned tries_left = COAP_MAX_RETRANSMIT + 1;
+
+    while (tries_left) {
+        if (res == -EAGAIN) {
+            res = sock_udp_send(&sock, buf, pdu_len, NULL);
+            if (res <= 0) {
+                DEBUG("nanocoap: error sending coap request, %d\n", (int)res);
+                break;
+            }
         }
 
-        res = sock_udp_recv(&sock, buf, len, timeout, NULL);
+        res = sock_udp_recv(&sock, buf, len, deadline_left(deadline), NULL);
         if (res <= 0) {
             if (res == -ETIMEDOUT) {
                 DEBUG("nanocoap: timeout\n");
 
-                timeout *= 2;
                 tries_left--;
                 if (!tries_left) {
                     DEBUG("nanocoap: maximum retries reached\n");
+                    break;
                 }
-                continue;
+                else {
+                    timeout *= 2;
+                    deadline = deadline_from_interval(timeout);
+                    res = -EAGAIN;
+                    continue;
+                }
             }
             DEBUG("nanocoap: error receiving coap response, %d\n", (int)res);
             break;
@@ -78,6 +108,11 @@ ssize_t nanocoap_request(coap_pkt_t *pkt, sock_udp_ep_t *local, sock_udp_ep_t *r
                 DEBUG("nanocoap: error parsing packet\n");
                 res = -EBADMSG;
             }
+            else if (coap_get_id(pkt) != id) {
+                res = -EBADMSG;
+                continue;
+            }
+
             break;
         }
     }

--- a/tests/nanocoap_cli/main.c
+++ b/tests/nanocoap_cli/main.c
@@ -30,11 +30,13 @@
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
 extern int nanotest_client_cmd(int argc, char **argv);
+extern int nanotest_client_get_cmd(int argc, char **argv);
 extern int nanotest_server_cmd(int argc, char **argv);
 static int _list_all_inet6(int argc, char **argv);
 
 static const shell_command_t shell_commands[] = {
     { "client", "CoAP client", nanotest_client_cmd },
+    { "get", "CoAP client simple get", nanotest_client_get_cmd },
     { "server", "CoAP server", nanotest_server_cmd },
     { "inet6", "IPv6 addresses", _list_all_inet6 },
     { NULL, NULL, NULL }


### PR DESCRIPTION
### Contribution description

This PR extends the existing `nanocoap_sock` code with an additional function to request a resource using separate block2 requests. A callback must be supplied and is called for every 
received block. The full `coap_pkt_t` is passed to the callback to allow for flexible parsing of the packet in the handler and to not have to pass every block2 property as separate argument.

### Testing procedure

`tests/nanocoap_cli` is extended to include a separate command that uses the new get function. This can be used to test the functionality, for example by starting a separate instance running the server and requesting `/.well-known/core`.

### Issues/PRs references

depends on #13707, A follow-up will be provided soon to simplify a lot of the SUIT CoAP transport code.