### PR TITLE
gnrc_netif: document new *_create() out parameter as such

### DIFF
--- a/cpu/esp_common/esp-now/esp_now_gnrc.h
+++ b/cpu/esp_common/esp-now/esp_now_gnrc.h
@@ -27,7 +27,7 @@ extern "C" {
 /**
  * @brief   Creates the ESP-NOW network interface
  * @see     gnrc_netif_create
- * @param   [in]    netif       The interface. May not be `NULL`.
+ * @param   [out]   netif       The interface. May not be `NULL`.
  * @param   [in]    stack       The stack for the network interface's thread.
  * @param   [in]    stacksize   Size of stack.
  * @param   [in]    priority    Priority for the network interface's thread.

--- a/drivers/include/cc1xxx_common.h
+++ b/drivers/include/cc1xxx_common.h
@@ -115,7 +115,7 @@ typedef struct netdev_radio_rx_info cc1xxx_rx_info_t;
 /**
  * @brief   Creates a CC110x/CC1200 network interface
  *
- * @param[in] netif     The interface. May not be `NULL`.
+ * @param[out] netif    The interface. May not be `NULL`.
  * @param[in] stack     The stack for the network interface's thread.
  * @param[in] stacksize Size of @p stack.
  * @param[in] priority  Priority for the network interface's thread.

--- a/drivers/xbee/include/gnrc_netif_xbee.h
+++ b/drivers/xbee/include/gnrc_netif_xbee.h
@@ -27,7 +27,7 @@ extern "C" {
 /**
  * @brief   Creates an Xbee network interface
  *
- * @param[in] netif     The interface. May not be `NULL`.
+ * @param[out] netif    The interface. May not be `NULL`.
  * @param[in] stack     The stack for the network interface's thread.
  * @param[in] stacksize Size of @p stack.
  * @param[in] priority  Priority for the network interface's thread.

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -354,7 +354,7 @@ extern "C" {
 /**
  * @brief   Creates an IEEE 802.15.4 GoMacH network interface
  *
- * @param[in] netif     The interface. May not be `NULL`.
+ * @param[out] netif    The interface. May not be `NULL`.
  * @param[in] stack     The stack for the GoMacH network interface's thread.
  * @param[in] stacksize Size of @p stack.
  * @param[in] priority  Priority for the GoMacH network interface's thread.

--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -300,7 +300,7 @@ extern "C" {
 /**
  * @brief   Creates an IEEE 802.15.4 LWMAC network interface
  *
- * @param[in] netif     The interface. May not be `NULL`.
+ * @param[out] netif    The interface. May not be `NULL`.
  * @param[in] stack     The stack for the LWMAC network interface's thread.
  * @param[in] stacksize Size of @p stack.
  * @param[in] priority  Priority for the LWMAC network interface's thread.

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -246,7 +246,7 @@ void gnrc_netif_init_devs(void);
 /**
  * @brief   Creates a network interface
  *
- * @param[in] netif     The interface. May not be `NULL`.
+ * @param[out] netif    The interface. May not be `NULL`.
  * @param[in] stack     The stack for the network interface's thread.
  * @param[in] stacksize Size of @p stack.
  * @param[in] priority  Priority for the network interface's thread.

--- a/sys/include/net/gnrc/netif/ethernet.h
+++ b/sys/include/net/gnrc/netif/ethernet.h
@@ -27,7 +27,7 @@ extern "C" {
 /**
  * @brief   Creates an Ethernet network interface
  *
- * @param[in] netif     The interface. May not be `NULL`.
+ * @param[out] netif    The interface. May not be `NULL`.
  * @param[in] stack     The stack for the network interface's thread.
  * @param[in] stacksize Size of @p stack.
  * @param[in] priority  Priority for the network interface's thread.

--- a/sys/include/net/gnrc/netif/ieee802154.h
+++ b/sys/include/net/gnrc/netif/ieee802154.h
@@ -27,7 +27,7 @@ extern "C" {
 /**
  * @brief   Creates an IEEE 802.15.4 network interface
  *
- * @param[in] netif     The interface. May not be `NULL`.
+ * @param[out] netif    The interface. May not be `NULL`.
  * @param[in] stack     The stack for the network interface's thread.
  * @param[in] stacksize Size of @p stack.
  * @param[in] priority  Priority for the network interface's thread.

--- a/sys/include/net/gnrc/netif/lorawan_base.h
+++ b/sys/include/net/gnrc/netif/lorawan_base.h
@@ -27,7 +27,7 @@ extern "C" {
 /**
  * @brief   Creates a raw network interface
  *
- * @param[in] netif     The interface. May not be `NULL`.
+ * @param[out] netif    The interface. May not be `NULL`.
  * @param[in] stack     The stack for the network interface's thread.
  * @param[in] stacksize Size of @p stack.
  * @param[in] priority  Priority for the network interface's thread.

--- a/sys/include/net/gnrc/netif/raw.h
+++ b/sys/include/net/gnrc/netif/raw.h
@@ -28,7 +28,7 @@ extern "C" {
 /**
  * @brief   Creates a raw network interface
  *
- * @param[in] netif     The interface. May not be `NULL`.
+ * @param[out] netif    The interface. May not be `NULL`.
  * @param[in] stack     The stack for the network interface's thread.
  * @param[in] stacksize Size of @p stack.
  * @param[in] priority  Priority for the network interface's thread.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
See https://github.com/RIOT-OS/RIOT/pull/12994#issuecomment-604432139
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```
make doc
```

should still succeed and all create functions of `gnrc_netif_*_create()` should now be marked as out parameter.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up to https://github.com/RIOT-OS/RIOT/pull/12994
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
