### PR TITLE
nanocoap: add payload helper functions

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -78,6 +78,7 @@
 #define NET_NANOCOAP_H
 
 #include <assert.h>
+#include <errno.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -1510,6 +1511,21 @@ static inline void coap_payload_advance_bytes(coap_pkt_t *pkt, size_t len)
  * @returns      < 0 on error
  */
 ssize_t coap_payload_put_bytes(coap_pkt_t *pkt, const void *data, size_t len);
+
+/**
+ * @brief Add a single character to the payload data of the CoAP request
+ *
+ * This function is used to add single characters to a CoAP payload data. It
+ * checks whether the character can be added to the buffer and ignores if the
+ * payload area is already exhausted.
+ *
+ * @param[out]   pkt        pkt to add payload to
+ * @param[in]    c          character to write
+ *
+ * @returns      number of payload bytes added on success (always one)
+ * @returns      < 0 on error
+ */
+ssize_t coap_payload_put_char(coap_pkt_t *pkt, char c);
 
 /**
  * @brief   Create CoAP reply (convenience function)

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1470,6 +1470,48 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len);
 void coap_pkt_init(coap_pkt_t *pkt, uint8_t *buf, size_t len, size_t header_len);
 
 /**
+ * @brief   Advance the payload pointer.
+ *
+ * @pre     You added @p len bytes of data to `pkt->payload`.
+ *
+ * You can add payload to a CoAP request by writing data directly to
+ * `pkt->payload`.
+ * This convenience function takes care of advancing the payload pointer
+ * afterwards.
+ *
+ * @param[out]   pkt        pkt to which payload was added
+ * @param[in]    len        length of payload
+ */
+static inline void coap_payload_advance_bytes(coap_pkt_t *pkt, size_t len)
+{
+    pkt->payload += len;
+    pkt->payload_len -= len;
+}
+
+/**
+ * @brief   Add payload data to the CoAP request.
+ *
+ * @pre     @ref coap_opt_finish must have been called before with
+ *               the @ref COAP_OPT_FINISH_PAYLOAD option.
+ *
+ * The function copies @p data into the payload buffer of @p pkt and
+ * advances the payload pointer.
+ *
+ * This is just a convenience function, you can also directly write
+ * to `pkt->payload` if you have a function that outputs payload to
+ * a buffer.
+ * In this case you should instead call @ref coap_payload_advance_bytes.
+ *
+ * @param[out]   pkt        pkt to add payload to
+ * @param[in]    data       payload data
+ * @param[in]    len        length of payload
+ *
+ * @returns      number of payload bytes added on success
+ * @returns      < 0 on error
+ */
+ssize_t coap_payload_put_bytes(coap_pkt_t *pkt, const void *data, size_t len);
+
+/**
  * @brief   Create CoAP reply (convenience function)
  *
  * This is a simple wrapper that allows for building CoAP replies for simple

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -934,6 +934,18 @@ ssize_t coap_payload_put_bytes(coap_pkt_t *pkt, const void *data, size_t len)
     return len;
 }
 
+ssize_t coap_payload_put_char(coap_pkt_t *pkt, char c)
+{
+    if (pkt->payload_len < 1) {
+        return -ENOSPC;
+    }
+
+    *pkt->payload++ = c;
+    pkt->payload_len--;
+
+    return 1;
+}
+
 void coap_block_object_init(coap_block1_t *block, size_t blknum, size_t blksize,
                             int more)
 {

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -922,6 +922,18 @@ ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags)
     return pkt->payload - (uint8_t *)pkt->hdr;
 }
 
+ssize_t coap_payload_put_bytes(coap_pkt_t *pkt, const void *data, size_t len)
+{
+    if (pkt->payload_len < len) {
+        return -ENOSPC;
+    }
+
+    memcpy(pkt->payload, data, len);
+    coap_payload_advance_bytes(pkt, len);
+
+    return len;
+}
+
 void coap_block_object_init(coap_block1_t *block, size_t blknum, size_t blksize,
                             int more)
 {


### PR DESCRIPTION
### Contribution description

This adds two functions `coap_payload_add()` and `coap_payload_advance()`.

 - `coap_payload_add()` will add n bytes to the payload buffer and advance
    payload pointer accordingly.

```C
    const char hello[] = "Hello CoAP!";
    coap_payload_add(pkt, hello, sizeof(hello));
```

 - `coap_payload_advance()` will advance the payload buffer after data
    has been added to it.

```C
    int len = snprintf(pkt->payload, pkt->payload_len, "%s %s!", "Hello", "CoAP");
    coap_payload_advance(pkt, len);
```

I considered adding an additional parameter to keep track of the total request size
(returned size from coap_opt_finish() incremented by each added payload fragment),
but decided against it to keep consistency with the existing API.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->



<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
