### PR TITLE
boards/esp32-heltec-lora32-v2: enable sx1276 by default

### DIFF
--- a/boards/esp32-heltec-lora32-v2/Makefile.dep
+++ b/boards/esp32-heltec-lora32-v2/Makefile.dep
@@ -1,1 +1,5 @@
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += sx1276
+endif
+
 include $(RIOTBOARD)/common/esp32/Makefile.dep


### PR DESCRIPTION
### Contribution description

Now that #12994 is merged we can enable `sx1276` in addition to `esp_wifi` by default.

### Testing procedure

    make -C examples/gnrc_networking BOARD=esp32-heltec-lora32-v2 flash term

both network Interfaces (`esp_now` and LoRA) should be available. 

### Issues/PRs references

follow-up on #11265
