### PR TITLE
cpu/esp_common: Use python3 instead python

### DIFF
--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -105,7 +105,7 @@ PREFFLAGS += printf "phy_init, data, phy, 0xf000, 0x1000\n" >> $(BINDIR)/partiti
 PREFFLAGS += printf "factory, app, factory, 0x10000, " >> $(BINDIR)/partitions.csv;
 PREFFLAGS += ls -l $(FLASHFILE).bin | awk '{ print $$5 }' >> $(BINDIR)/partitions.csv;
 
-PREFFLAGS += python $(RIOTTOOLS)/esptool/gen_esp32part.py
+PREFFLAGS += python3 $(RIOTTOOLS)/esptool/gen_esp32part.py
 PREFFLAGS += --verify $(BINDIR)/partitions.csv $(BINDIR)/partitions.bin
 FLASHDEPS += preflash
 


### PR DESCRIPTION
### Contribution description

Python2 is now unmaintained and more and more distros are kicking it out of their repos. Thus, it is better to use `python3` instead.

### Testing procedure

`make BOARD=<SOME_ESP8266_OR_ESP32_BOARD> -C some/app flash` should still work

### Issues/PRs references

None