### PR TITLE
test/usbus: disable auto_init_usbus

### DIFF
--- a/tests/usbus/Makefile
+++ b/tests/usbus/Makefile
@@ -3,6 +3,8 @@ USEMODULE += embunit
 USEMODULE += usbus
 FEATURES_PROVIDED += periph_usbdev
 
+DISABLE_MODULE += auto_init_usbus
+
 # USB device vendor and product ID
 DEFAULT_VID = 1209
 DEFAULT_PID = 7D00


### PR DESCRIPTION
### Contribution description

Cleanup from #13703. `tests/usbus` did not use or need (actually causes a hard-fault since its a mock test) `auto_init_usbus`, but #13703 added it as `DEFAULT` and I forgot to remove it.

### Testing procedure

- Murdock should be green now.

- Run on any board and it should work again


`BOARD=samr21-xpro make -C tests/usbus flash test`
```
READY
s
START
main(): This is RIOT! (Version: 2020.04-devel-1629-gab5deca-HEAD)
.
OK (1 tests)
```
