### PR TITLE
gnrc_uhcp, gnrc_dhcpv6_client_6lbr: disable Router Advertisements on upstream interface

### DIFF
--- a/sys/net/gnrc/application_layer/dhcpv6/client_6lbr.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client_6lbr.c
@@ -20,6 +20,7 @@
 #include "net/dhcpv6/client.h"
 #include "net/ipv6/addr.h"
 #include "net/gnrc.h"
+#include "net/gnrc/ipv6/nib.h"
 #include "net/gnrc/ipv6/nib/ft.h"
 #include "net/gnrc/netif/internal.h"
 
@@ -85,6 +86,15 @@ static void _configure_upstream_netif(gnrc_netif_t *upstream_netif)
         addr.u8[15] = 2;
         gnrc_netif_ipv6_addr_add(upstream_netif, &addr, 64, 0);
     }
+
+    /* Disable router advertisements on upstream interface. With this, the border
+     * router
+     * 1. Does not confuse the upstream router to add the border router to its
+     *    default router list and
+     * 2. Solicits upstream Router Advertisements quicker to auto-configure its
+     *    upstream global address.
+     */
+    gnrc_ipv6_nib_change_rtr_adv_iface(upstream_netif, false);
 }
 
 /**

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -43,6 +43,15 @@ static void set_interface_roles(void)
             gnrc_netapi_set(dev, NETOPT_IPV6_ADDR, 64 << 8, &addr, sizeof(addr));
             ipv6_addr_from_str(&addr, "fe80::1");
             gnrc_ipv6_nib_ft_add(&defroute, IPV6_ADDR_BIT_LEN, &addr, dev, 0);
+
+            /* Disable router advertisements on upstream interface. With this, the border
+             * router
+             * 1. Does not confuse the upstream router to add the border router to its
+             *    default router list and
+             * 2. Solicits upstream Router Advertisements quicker to auto-configure its
+             *    upstream global address.
+             */
+            gnrc_ipv6_nib_change_rtr_adv_iface(netif, false);
         }
         else if ((!gnrc_wireless_interface) && (is_wired != 1)) {
             gnrc_wireless_interface = dev;


### PR DESCRIPTION
### Contribution description

We don't want to advertise ourselves as a router to the upstream router.
This also has the side effect the the node / border router will not request a prefix from the upstream router, so it can take very long to obtain a valid prefix on an interface with `RTR_AVD` enabled.

### Testing procedure

Run `examples/gnrc_border_router` on a network were a router is advertised on the upstream interface (either by running `radvd` manually or by connecting to a WiFi network where routes are advertised).

You should immediately get a global address on the upstream interface.

Previously this would take several minutes.

### Issues/PRs references
#13668 if you want to use `radvd` locally
