### PR TITLE
examples/gnrc_border_router: enable sock_dns if WiFi uplink is used

### DIFF
--- a/examples/gnrc_border_router/Makefile.wifi.conf
+++ b/examples/gnrc_border_router/Makefile.wifi.conf
@@ -1,2 +1,8 @@
 CFLAGS += -DESP_WIFI_SSID=\"$(WIFI_SSID)\"
 CFLAGS += -DESP_WIFI_PASS=\"$(WIFI_PASS)\"
+
+# When using a WiFi uplink it is very likely
+# we also have DNS.
+# Enable to module to also enable advertising
+# the DNS server in the LoWPAN.
+USEMODULE += sock_dns


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

When using a WiFi uplink it is very likely we also have proper DNS set up.
So enable the `sock_dns` module by default.

This allows us to `ping6` proper hostnames instead of IP addresses.
It also enables the dissemination of DNS server information in the LoWPAN network.


### Testing procedure

```
2020-03-27 00:00:40,074 #  ping6 google.com
2020-03-27 00:00:41,179 # 12 bytes from 2a00:1450:4001:816::200e: icmp_seq=0 ttl=55 rssi=-54 dBm time=40.581 ms
2020-03-27 00:00:42,182 # 12 bytes from 2a00:1450:4001:816::200e: icmp_seq=1 ttl=55 rssi=-42 dBm time=40.901 ms
2020-03-27 00:00:43,181 # 12 bytes from 2a00:1450:4001:816::200e: icmp_seq=2 ttl=55 rssi=-50 dBm time=37.504 ms
2020-03-27 00:00:43,182 # 
2020-03-27 00:00:43,184 # --- google.com PING statistics ---
2020-03-27 00:00:43,190 # 3 packets transmitted, 3 packets received, 0% packet loss
2020-03-27 00:00:43,194 # round-trip min/avg/max = 37.504/39.662/40.901 ms
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
