### PR TITLE
cpu/stm32_common: enable EXTI interrupt for rtt [take over]

### DIFF
--- a/cpu/stm32_common/periph/rtt.c
+++ b/cpu/stm32_common/periph/rtt.c
@@ -67,6 +67,23 @@
 #endif
 #endif
 
+#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB)
+#define IMR_REG             IMR2
+#define EXTI_IMR_BIT        EXTI_IMR2_IM32
+#elif defined(CPU_FAM_STM32L0)
+#define IMR_REG             IMR
+#define EXTI_IMR_BIT        EXTI_IMR_IM29
+#else
+#define IMR_REG             IMR
+#define FTSR_REG            FTSR
+#define RTSR_REG            RTSR
+#define PR_REG              PR
+#define EXTI_FTSR_BIT       EXTI_FTSR_TR23
+#define EXTI_RTSR_BIT       EXTI_RTSR_TR23
+#define EXTI_IMR_BIT        EXTI_IMR_MR23
+#define EXTI_PR_BIT         EXTI_PR_PR23
+#endif
+
 
 /* allocate memory for overflow and alarm callbacks + args */
 static rtt_cb_t ovf_cb = NULL;
@@ -91,6 +108,15 @@ void rtt_init(void)
     LPTIM1->CFGR = PRE;
     /* enable overflow and compare interrupts */
     LPTIM1->IER = (LPTIM_IER_ARRMIE | LPTIM_IER_CMPMIE);
+    /* configure the EXTI channel, as RTT interrupts are routed through it.
+     * Needs to be configured to trigger on rising edges. */
+    EXTI->IMR_REG |= EXTI_IMR_BIT;
+#if !defined(CPU_FAM_STM32L4) && !defined(CPU_FAM_STM32L0) && \
+    !defined(CPU_FAM_STM32WB)
+    EXTI->FTSR_REG &= ~(EXTI_FTSR_BIT);
+    EXTI->RTSR_REG |= EXTI_RTSR_BIT;
+    EXTI->PR_REG |= EXTI_PR_BIT;
+#endif
     NVIC_EnableIRQ(LPTIM1_IRQn);
     /* enable timer */
     LPTIM1->CR = LPTIM_CR_ENABLE;
@@ -178,6 +204,10 @@ void isr_lptim1(void)
         }
     }
     LPTIM1->ICR = (LPTIM_ICR_ARRMCF | LPTIM_ICR_CMPMCF);
+#if !defined(CPU_FAM_STM32L4) && !defined(CPU_FAM_STM32L0) && \
+    !defined(CPU_FAM_STM32WB)
+    EXTI->PR_REG |= EXTI_PR_BIT;
+#endif
 
     cortexm_isr_end();
 }

--- a/cpu/stm32_common/stmclk_l4wb.c
+++ b/cpu/stm32_common/stmclk_l4wb.c
@@ -189,5 +189,15 @@ void stmclk_init_sysclk(void)
 
     stmclk_disable_hsi();
     irq_restore(is);
+
+#ifdef MODULE_PERIPH_RTT
+    /* Ensure LPTIM1 clock source (LSI or LSE) is correctly reset when initializing
+       the clock, this is particularly useful after waking up from deep sleep */
+#if CLOCK_LSE
+    RCC->CCIPR |= RCC_CCIPR_LPTIM1SEL_0 | RCC_CCIPR_LPTIM1SEL_1;
+#else
+    RCC->CCIPR |= RCC_CCIPR_LPTIM1SEL_0;
+#endif /* CLOCK_LSE */
+#endif /* MODULE_PERIPH_RTT */
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is take over from #11286 with the missing patches added:
- fix for Murdock
- fix for correctly reset the lptim on stm32l4/wb cpus, especially after waking-up

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- This PR was already tested in #11286 

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

closes #11286 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
