### PR TITLE
examples/gnrc_border_router: add sock_dns as a comment

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -36,6 +36,11 @@ USEMODULE += ps
 # configure the node as a RPL DODAG root when receiving a prefix.
 #USEMODULE += gnrc_rpl
 
+# Optionally include DNS support. This includes resolution of names at an
+# upstream DNS server and the handling of RDNSS options in Router Advertisements
+# to auto-configure that upstream DNS server.
+#USEMODULE += sock_dns
+
 # When using a WiFi uplink we should use DHCPv6
 ifeq (wifi,$(UPLINK))
   USE_DHCPV6 ?= 1


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Less feature-creepy alternative to https://github.com/RIOT-OS/RIOT/pull/13732

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Uncomment the given line and compile. When the upstream router advertisement daemon is configured to send RDNSS options, DNS requests will be send to that server if e.g.

```
ping6 google.com
```

is typed.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Alternative to https://github.com/RIOT-OS/RIOT/pull/13732

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
