### PR TITLE
gnrc_netif: fix highlander function

### DIFF
--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -284,7 +284,11 @@ unsigned gnrc_netif_numof(void);
  */
 static inline bool gnrc_netif_highlander(void)
 {
-    return IS_ACTIVE(GNRC_NETIF_SINGLE);
+    if (IS_ACTIVE(GNRC_NETIF_SINGLE)) {
+        return true;
+    } else {
+        return gnrc_netif_numof() == 1;
+    }
 }
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes the `gnrc_netif_highlander` function to provide the correct values when GNRC_NETIF_SINGLE is not defined. There are cases where GNRC_NETIF_SINGLE=0 but there's only one interface, which was not covered by the upstream implementation.

This fixes the issue described in https://github.com/RIOT-OS/RIOT/pull/12994#issuecomment-604950107
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
- Using any GNRC example, add this snippet somewhere:
```c
assert((gnrc_netif_numof() != 1 && gnrc_netif_single() == false) || (gnrc_netif_numof() == 1 && gnrc_netif_single() == true));
```
It should pass for both cases of GNRC_NETIF_SINGLE when there's only one interface. It should also pass when GNRC_NETIF_SINGLE=0 and there's more than one interface.

- You should be able to ping now via the link local address if there's only one interface, for both cases of GNRC_NETIF_SINGLE
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes https://github.com/RIOT-OS/RIOT/pull/12994#issuecomment-604950107
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
