### PR TITLE
cpu/cortexm: cleanup dependencies

### DIFF
--- a/cpu/cc2538/Makefile.dep
+++ b/cpu/cc2538/Makefile.dep
@@ -8,3 +8,5 @@ ifneq (,$(filter periph_rtc,$(USEMODULE)))
 endif
 
 USEMODULE += pm_layered
+
+include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/cc26xx_cc13xx/Makefile.dep
+++ b/cpu/cc26xx_cc13xx/Makefile.dep
@@ -1,1 +1,3 @@
 USEMODULE += periph_common cc26xx_cc13xx_periph
+
+include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/cortexm_common/Makefile.dep
+++ b/cpu/cortexm_common/Makefile.dep
@@ -1,0 +1,14 @@
+# Tell the build system that the CPU depends on the Cortex-M common files:
+USEMODULE += cortexm_common
+
+# include common periph code
+USEMODULE += cortexm_common_periph
+
+# all cortex MCU's use newlib as libc
+USEMODULE += newlib
+
+# use the nano-specs of Newlib when available
+USEMODULE += newlib_nano
+
+# Export the peripheral drivers to be linked into the final binary:
+USEMODULE += periph

--- a/cpu/cortexm_common/Makefile.dep
+++ b/cpu/cortexm_common/Makefile.dep
@@ -12,3 +12,9 @@ USEMODULE += newlib_nano
 
 # Export the peripheral drivers to be linked into the final binary:
 USEMODULE += periph
+
+# Use Hardware FPU by default if present
+FEATURES_OPTIONAL += cortexm_fpu
+ifneq (,$(filter cortexm_fpu,$(FEATURES_USED)))
+  DEFAULT_MODULE += cortexm_fpu
+endif

--- a/cpu/cortexm_common/Makefile.features
+++ b/cpu/cortexm_common/Makefile.features
@@ -5,3 +5,8 @@ FEATURES_PROVIDED += periph_pm
 FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += cpu_check_address
 FEATURES_PROVIDED += ssp
+
+# cortex-m4f and cortex-m7 provide FPU support
+ifneq (,$(filter $(CPU_ARCH),cortex-m4f cortex-m7))
+  FEATURES_PROVIDED += cortexm_fpu
+endif

--- a/cpu/efm32/Makefile.dep
+++ b/cpu/efm32/Makefile.dep
@@ -19,3 +19,5 @@ endif
 
 # include CPU family module
 USEMODULE += cpu_$(CPU_FAM)
+
+include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/ezr32wg/Makefile.dep
+++ b/cpu/ezr32wg/Makefile.dep
@@ -1,2 +1,1 @@
-include $(RIOTCPU)/nrf5x_common/Makefile.dep
 include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/kinetis/Makefile.dep
+++ b/cpu/kinetis/Makefile.dep
@@ -4,3 +4,5 @@ endif
 ifneq (,$(filter periph_i2c,$(USEMODULE)))
   USEMODULE += core_thread_flags
 endif
+
+include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/lm4f120/Makefile.dep
+++ b/cpu/lm4f120/Makefile.dep
@@ -1,2 +1,1 @@
-include $(RIOTCPU)/nrf5x_common/Makefile.dep
 include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/lpc1768/Makefile.dep
+++ b/cpu/lpc1768/Makefile.dep
@@ -1,1 +1,3 @@
 USEMODULE += pm_layered
+
+include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/nrf52/Makefile.dep
+++ b/cpu/nrf52/Makefile.dep
@@ -6,3 +6,4 @@ ifneq (,$(filter nrf802154,$(USEMODULE)))
 endif
 
 include $(RIOTCPU)/nrf5x_common/Makefile.dep
+include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/sam0_common/Makefile.dep
+++ b/cpu/sam0_common/Makefile.dep
@@ -7,3 +7,5 @@ USEMODULE += pm_layered
 
 # include sam0 common periph drivers
 USEMODULE += sam0_common_periph
+
+include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/sam3/Makefile.dep
+++ b/cpu/sam3/Makefile.dep
@@ -1,2 +1,1 @@
-include $(RIOTCPU)/nrf5x_common/Makefile.dep
 include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/stm32_common/Makefile.dep
+++ b/cpu/stm32_common/Makefile.dep
@@ -7,3 +7,5 @@ USEMODULE += stm32_common stm32_common_periph
 ifneq (,$(filter periph_usbdev,$(FEATURES_USED)))
   USEMODULE += xtimer
 endif
+
+include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -33,17 +33,6 @@ LINKFLAGS += -T$(LINKER_SCRIPT) -Wl,--fatal-warnings
 LINKFLAGS += $(CFLAGS_CPU) $(CFLAGS_DBG) $(CFLAGS_OPT) -static -lgcc -nostartfiles
 LINKFLAGS += -Wl,--gc-sections
 
-# Tell the build system that the CPU depends on the Cortex-M common files:
-USEMODULE += cortexm_common
-# Export the peripheral drivers to be linked into the final binary:
-USEMODULE += periph
-# include common periph code
-USEMODULE += cortexm_common_periph
-
-# all cortex MCU's use newlib as libc
-USEMODULE += newlib
-
-
 # extract version inside the first parentheses
 ARM_GCC_VERSION = $(shell $(TARGET_ARCH)-gcc --version | sed -n '1 s/[^(]*(\([^\)]*\)).*/\1/p')
 
@@ -125,9 +114,6 @@ endif
 
 # CPU depends on the cortex-m common module, so include it:
 include $(RIOTCPU)/cortexm_common/Makefile.include
-
-# use the nano-specs of Newlib when available
-USEMODULE += newlib_nano
 
 # Avoid overriding the default rule:
 all:

--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -60,24 +60,18 @@ endif # BUILD_IN_DOCKER
 CFLAGS += -DCPU_MODEL_$(call uppercase_and_underscore,$(CPU_MODEL))
 CFLAGS += -DCPU_ARCH_$(call uppercase_and_underscore,$(CPU_ARCH))
 
-# set the compiler specific CPU and FPU options
-ifneq (,$(filter $(CPU_ARCH),cortex-m4f cortex-m7))
-  ifneq (,$(filter cortexm_fpu,$(DISABLE_MODULE)))
-    CFLAGS_FPU ?= -mfloat-abi=soft
+# Add corresponding FPU CFLAGS
+# clang assumes there is an FPU, no CFLAGS necessary
+ifneq (llvm, $(TOOLCHAIN))
+  ifeq ($(CPU_ARCH),cortex-m7)
+    _CORTEX_HW_FPU_CFLAGS = -mfloat-abi=hard -mfpu=fpv5-sp-d16
   else
-    USEMODULE += cortexm_fpu
-    # clang assumes there is an FPU
-    ifneq (llvm,$(TOOLCHAIN))
-      ifeq ($(CPU_ARCH),cortex-m7)
-        CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv5-sp-d16
-      else
-        CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
-      endif
-    endif
+    _CORTEX_HW_FPU_CFLAGS = -mfloat-abi=hard -mfpu=fpv4-sp-d16
   endif
-else
-  CFLAGS_FPU ?= -mfloat-abi=soft
 endif
+# Add soft or hard FPU CFLAGS depending on the module
+# NOTE: This can be turned into normal conditional syntax once #9913 is fixed
+CFLAGS_FPU ?= $(if $(filter cortexm_fpu,$(USEMODULE)),$(_CORTEX_HW_FPU_CFLAGS),-mfloat-abi=soft)
 
 ifeq ($(CPU_ARCH),cortex-m4f)
   MCPU = cortex-m4


### PR DESCRIPTION
### Contribution description
This PR does some cleanup of dependencies that were added/resolved in `cortexm.inc.mk`. I added a architecture-specific `Makefile.dep` which is included by CPUs.

It also changes the way `CFLAGS_FPU` is handled, so we can now define `cortexm_fpu` as a default module on architectures that support it.

### Testing procedure
- Check that dependency resolution still yields the same list of modules and CFLAGS
- Check that FPU is handled correctly: Test with cortex-m7 (e.g. `nucleo-f746zg`), cortex-m4f (e.g. `nucleo-l452re`) and some architecture that provides no FPU (e.g. `samr21-xpro`):
  
  - If FPU is supported, the feature `cortexm_fpu` should be there
  - If FPU is supported `-mfloat-abi=hard` and the correspondent `-mfpu` (depending on the architecture) should be present.
  - If FPU is supported it should be possible to disable it by adding `DISABLE_MODULE=cortexm_fpu`.
  - If FPU is not supported (or disabled) `mfloat-abi=soft` should be present.


### Issues/PRs references
Part of #9913 
