### PR TITLE
gnrc_ipv6_nib: only add prefix of same interface to ABR

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_abr.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_abr.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 
 #include "net/gnrc/ipv6/nib/abr.h"
+#include "net/gnrc/netif.h"
 
 #include "_nib-6ln.h"
 #include "_nib-internal.h"
@@ -26,15 +27,23 @@ int gnrc_ipv6_nib_abr_add(const ipv6_addr_t *addr)
 {
     _nib_abr_entry_t *abr;
     _nib_offl_entry_t *offl = NULL;
+    gnrc_netif_t *netif = gnrc_netif_get_by_ipv6_addr(addr);
 
+    assert(netif != NULL);
     _nib_acquire();
     if ((abr = _nib_abr_add(addr)) == NULL) {
         _nib_release();
         return -ENOMEM;
     }
     abr->valid_until = 0U;
+    /* Associate all existing prefixes in the prefix list of the border router's
+     * downstream interface to the authoritative border router so they are
+     * advertised in a Router Advertisement with the Authoritative Border Router
+     * Option (ABRO) in a respective Prefix Information Option (PIO)
+     * (see https://tools.ietf.org/html/rfc6775#section-8.1.1). */
     while ((offl = _nib_offl_iter(offl))) {
-        if (offl->mode & _PL) {
+        if ((offl->mode & _PL) &&
+            (_nib_onl_get_if(offl->next_hop) == (unsigned)netif->pid)) {
             _nib_abr_add_pfx(abr, offl);
         }
     }


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
It doesn't make sense for an Authoritative Border Router to manage a prefix that does not belong to the border router's downstream interface.

The border router already [just advertises the prefixes assigned to that prefix](https://github.com/RIOT-OS/RIOT/blob/ad81a88bf0a2f5fabf9faa39b861fbc13922e6b4/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c#L184-L190). However, if the ABR is deleted for whatever reason (e.g. with `nib abr del <addr>`) other prefixes might be deleted unintentionally.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Have a border router that configures (e.g. via RADVD) a global address to its upstream interface and a downstream prefix via DHCPv6 or UHCP. Without this fix `nib abr del <addr>` might remove the prefix of the upstream interface (if it was configured before the downstream prefix; check with `nib prefix` if the global address stays). With it, the prefix of the upstream interface stays untouched.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
