### PR TITLE
gnrc_ipv6_nib: fix border router with DNS & Context Compression

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.c
@@ -172,7 +172,7 @@ static gnrc_pktsnip_t *_build_ext_opts(gnrc_netif_t *netif,
             ((ctx = gnrc_sixlowpan_ctx_lookup_id(i)) != NULL)) {
             gnrc_pktsnip_t *sixco = gnrc_sixlowpan_nd_opt_6ctx_build(
                                             ctx->prefix_len, ctx->flags_id,
-                                            ctx->ltime, &ctx->prefix, NULL);
+                                            ctx->ltime, &ctx->prefix, ext_opts);
             if (sixco == NULL) {
                 DEBUG("nib: No space left in packet buffer. Not adding 6LO\n");
                 return NULL;


### PR DESCRIPTION
### Contribution description

There were two subtle bugs that broke the border router when used with a WiFi uplink:

 - Adding a compression context to the router advertisement would overwrite the DNS server information
 - the index calculation in `gnrc_ipv6_nib` was broken, so the right prefix never got advertised.

### Testing procedure

Run `examples/gnrc_border_router` on a network that provides a DNS server via router advertisements and a global prefix.
Any WiFi network with a IPv6 enabled upstream router that supports DHCPv6 IA_PD will do.

### Issues/PRs references

