### PR TITLE
netdev: add netdev_register() to keep track of netdev IDs 

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -69,6 +69,11 @@ ifneq (,$(filter gnrc_mac,$(USEMODULE)))
   endif
 endif
 
+# Don't register netdevs if there is only a single one  of them
+ifeq (,$(filter gnrc_netif_single,$(USEMODULE)))
+  USEMODULE += netdev_register
+endif
+
 ifneq (,$(filter gnrc_gomach,$(USEMODULE)))
   USEMODULE += gnrc_netif
   USEMODULE += gnrc_nettype_gomach

--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -30,22 +30,24 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static void _setup_interface(at86rf215_t *dev, const at86rf215_params_t *params)
+static void _setup_interface(at86rf215_t *dev, const at86rf215_params_t *params, uint8_t index)
 {
     netdev_t *netdev = (netdev_t *)dev;
 
     netdev->driver = &at86rf215_driver;
     dev->params = *params;
     dev->state = AT86RF215_STATE_OFF;
+
+    netdev_register(netdev, NETDEV_AT86RF215, index);
 }
 
-void at86rf215_setup(at86rf215_t *dev_09, at86rf215_t *dev_24, const at86rf215_params_t *params)
+void at86rf215_setup(at86rf215_t *dev_09, at86rf215_t *dev_24, const at86rf215_params_t *params, uint8_t index)
 {
     /* configure the sub-GHz interface */
     if (dev_09) {
         dev_09->RF = &RF09_regs;
         dev_09->BBC = &BBC0_regs;
-        _setup_interface(dev_09, params);
+        _setup_interface(dev_09, params, 2 * index);
         dev_09->sibling = dev_24;
     }
 
@@ -53,7 +55,7 @@ void at86rf215_setup(at86rf215_t *dev_09, at86rf215_t *dev_24, const at86rf215_p
     if (dev_24) {
         dev_24->RF = &RF24_regs;
         dev_24->BBC = &BBC1_regs;
-        _setup_interface(dev_24, params);
+        _setup_interface(dev_24, params, 2 * index + 1);
         dev_24->sibling = dev_09;
     }
 }

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -37,7 +37,7 @@
 #include "debug.h"
 
 
-void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params)
+void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params, uint8_t index)
 {
     netdev_t *netdev = (netdev_t *)dev;
 
@@ -56,6 +56,8 @@ void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params)
     /* initialize device descriptor */
     dev->params = *params;
 #endif
+
+    netdev_register(netdev, NETDEV_AT86RF2XX, index);
 }
 
 static void at86rf2xx_disable_clock_output(at86rf2xx_t *dev)

--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -49,7 +49,6 @@ static int _send(netdev_t *dev, const iolist_t *iolist);
 static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len);
 static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t len);
 static int _init(netdev_t *dev);
-void dose_setup(dose_t *ctx, const dose_params_t *params);
 
 static uint16_t crc16_update(uint16_t crc, uint8_t octet)
 {
@@ -540,7 +539,7 @@ static const netdev_driver_t netdev_driver_dose = {
     .set = _set
 };
 
-void dose_setup(dose_t *ctx, const dose_params_t *params)
+void dose_setup(dose_t *ctx, const dose_params_t *params, uint8_t index)
 {
     static const xtimer_ticks32_t min_timeout = {.ticks32 = XTIMER_BACKOFF};
 
@@ -556,6 +555,8 @@ void dose_setup(dose_t *ctx, const dose_params_t *params)
         gpio_init_int(ctx->sense_pin, GPIO_IN, GPIO_FALLING, _isr_gpio, (void *) ctx);
         gpio_irq_disable(ctx->sense_pin);
     }
+
+    netdev_register(&ctx->netdev, NETDEV_DOSE, index);
 
     assert(sizeof(ctx->mac_addr.uint8) == ETHERNET_ADDR_LEN);
     luid_get_eui48(&ctx->mac_addr);

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -292,8 +292,10 @@ typedef struct at86rf215 {
  * @param[out] dev_09       sub-GHz device descriptor
  * @param[out] dev_24       2.4 GHz device descriptor
  * @param[in]  params       parameters for device initialization
+ * @param[in]  index        index of @p params in a global parameter struct array.
+ *                          If initialized manually, pass a unique identifier instead.
  */
-void at86rf215_setup(at86rf215_t *dev_09, at86rf215_t *dev_24, const at86rf215_params_t *params);
+void at86rf215_setup(at86rf215_t *dev_09, at86rf215_t *dev_24, const at86rf215_params_t *params, uint8_t index);
 
 /**
  * @brief   Trigger a hardware reset and configure radio with default values.

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -389,7 +389,7 @@ uint8_t at86rf2xx_get_phy_mode(at86rf2xx_t *dev);
  *
  * @param[in] dev           device to read from
  *
- * @return                  the currenty set rate mode
+ * @return                  the currently set rate mode
  */
 uint8_t at86rf2xx_get_rate(at86rf2xx_t *dev);
 

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -294,8 +294,10 @@ typedef struct {
  *
  * @param[out] dev          device descriptor
  * @param[in]  params       parameters for device initialization
+ * @param[in]  index        index of @p params in a global parameter struct array.
+ *                          If initialized manually, pass a unique identifier instead.
  */
-void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params);
+void at86rf2xx_setup(at86rf2xx_t *dev, const at86rf2xx_params_t *params, uint8_t index);
 
 /**
  * @brief   Trigger a hardware reset and configure radio with default values

--- a/drivers/include/dose.h
+++ b/drivers/include/dose.h
@@ -175,8 +175,10 @@ typedef struct {
  * @brief   Setup a DOSE based device state
  * @param[out]  dev         Handle of the device to initialize
  * @param[in]   params      Parameters for device initialization
+ * @param[in]   index       Index of @p params in a global parameter struct array.
+ *                          If initialized manually, pass a unique identifier instead.
  */
-void dose_setup(dose_t *dev, const dose_params_t *params);
+void dose_setup(dose_t *dev, const dose_params_t *params, uint8_t index);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -280,6 +280,7 @@ typedef enum {
     NETDEV_ANY = 0,         /**< Will match any device type */
     NETDEV_AT86RF215,
     NETDEV_AT86RF2XX,
+    NETDEV_DOSE,
     /* add more if needed */
 } netdev_type_t;
 /** @} */

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -199,6 +199,7 @@ extern "C" {
 
 #include "iolist.h"
 #include "net/netopt.h"
+#include "kernel_defines.h"
 
 #ifdef MODULE_L2FILTER
 #include "net/l2filter.h"
@@ -272,6 +273,18 @@ typedef struct netdev netdev_t;
 typedef void (*netdev_event_cb_t)(netdev_t *dev, netdev_event_t event);
 
 /**
+ * @brief   Driver types for netdev.
+ * @{
+ */
+typedef enum {
+    NETDEV_ANY = 0,         /**< Will match any device type */
+    NETDEV_AT86RF215,
+    NETDEV_AT86RF2XX,
+    /* add more if needed */
+} netdev_type_t;
+/** @} */
+
+/**
  * @brief Structure to hold driver state
  *
  * Supposed to be extended by driver implementations.
@@ -290,7 +303,31 @@ struct netdev {
 #ifdef MODULE_L2FILTER
     l2filter_t filter[CONFIG_L2FILTER_LISTSIZE];   /**< link layer address filters */
 #endif
+#ifdef MODULE_NETDEV_REGISTER
+    netdev_type_t type;                     /**< driver type used for netdev */
+    uint8_t index;                          /**< instance number of the device */
+#endif
 };
+
+/**
+ * @brief Register a device with netdev.
+ *        Must by called by the driver's setup function.
+ *
+ * @param[out] dev          the new netdev
+ * @param[in]  type         the driver used for the netdev
+ * @param[in]  index        the index in the config struct
+ */
+static inline void netdev_register(struct netdev *dev, netdev_type_t type, uint8_t index)
+{
+#ifdef MODULE_NETDEV_REGISTER
+    dev->type  = type;
+    dev->index = index;
+#else
+    (void) dev;
+    (void) type;
+    (void) index;
+#endif
+}
 
 /**
  * @brief Structure to hold driver interface -> function mapping

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -73,6 +73,7 @@ PSEUDOMODULES += mpu_noexec_ram
 PSEUDOMODULES += nanocoap_%
 PSEUDOMODULES += netdev_default
 PSEUDOMODULES += netdev_ieee802154_%
+PSEUDOMODULES += netdev_register
 PSEUDOMODULES += netstats
 PSEUDOMODULES += netstats_l2
 PSEUDOMODULES += netstats_ipv6

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -200,7 +200,7 @@ void lwip_bootstrap(void)
     }
 #elif defined(MODULE_AT86RF2XX)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
-        at86rf2xx_setup(&at86rf2xx_devs[i], &at86rf2xx_params[i]);
+        at86rf2xx_setup(&at86rf2xx_devs[i], &at86rf2xx_params[i], i);
         if (netif_add(&netif[i], &at86rf2xx_devs[i], lwip_netdev_init,
                       tcpip_6lowpan_input) == NULL) {
             DEBUG("Could not add at86rf2xx device\n");

--- a/pkg/openthread/contrib/openthread.c
+++ b/pkg/openthread/contrib/openthread.c
@@ -64,7 +64,7 @@ void openthread_bootstrap(void)
 
     /* setup netdev modules */
 #ifdef MODULE_AT86RF2XX
-    at86rf2xx_setup(&at86rf2xx_dev, &at86rf2xx_params[0]);
+    at86rf2xx_setup(&at86rf2xx_dev, &at86rf2xx_params[0], 0);
     netdev_t *netdev = (netdev_t *) &at86rf2xx_dev;
 #endif
 #ifdef MODULE_KW41ZRF

--- a/pkg/openwsn/contrib/openwsn.c
+++ b/pkg/openwsn/contrib/openwsn.c
@@ -71,7 +71,7 @@ int openwsn_bootstrap(void)
 
 #ifdef MODULE_AT86RF2XX
     netdev_t *netdev = (netdev_t *)&at86rf2xx_dev.netdev.netdev;
-    at86rf2xx_setup(&at86rf2xx_dev, &at86rf2xx_params[0]);
+    at86rf2xx_setup(&at86rf2xx_dev, &at86rf2xx_params[0], 0);
     (void) netdev;
 #endif
 

--- a/sys/net/gnrc/netif/init_devs/auto_init_at86rf215.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_at86rf215.c
@@ -79,8 +79,7 @@ static inline void _setup_netif(gnrc_netif_t *netif, void* netdev, void* stack,
 void auto_init_at86rf215(void)
 {
     unsigned i = 0;
-    unsigned j = 0;
-    while (j < AT86RF215_NUM) {
+    for (unsigned j = 0; j < AT86RF215_NUM; ++j) {
 
         at86rf215_t *dev_09 = NULL;
         at86rf215_t *dev_24 = NULL;
@@ -103,7 +102,7 @@ void auto_init_at86rf215(void)
             ++i;
         }
 
-        at86rf215_setup(dev_09, dev_24, &at86rf215_params[j++]);
+        at86rf215_setup(dev_09, dev_24, &at86rf215_params[j], j);
 
         /* setup sub-GHz interface */
         _setup_netif(netif_09, dev_09, stack_09, AT86RF215_MAC_PRIO_SUBGHZ);

--- a/sys/net/gnrc/netif/init_devs/auto_init_at86rf2xx.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_at86rf2xx.c
@@ -51,7 +51,7 @@ void auto_init_at86rf2xx(void)
     for (unsigned i = 0; i < AT86RF2XX_NUM; i++) {
         LOG_DEBUG("[auto_init_netif] initializing at86rf2xx #%u\n", i);
 
-        at86rf2xx_setup(&at86rf2xx_devs[i], &at86rf2xx_params[i]);
+        at86rf2xx_setup(&at86rf2xx_devs[i], &at86rf2xx_params[i], i);
 #if defined(MODULE_GNRC_GOMACH)
         gnrc_netif_gomach_create(&_netif[i], _at86rf2xx_stacks[i],
                                  AT86RF2XX_MAC_STACKSIZE,

--- a/sys/net/gnrc/netif/init_devs/auto_init_dose.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_dose.c
@@ -44,7 +44,7 @@ void auto_init_dose(void)
     for (unsigned i = 0; i < DOSE_NUM; i++) {
         LOG_DEBUG("[auto_init_netif] initializing dose #%d.\n", i);
 
-        dose_setup(&dose[i], &dose_params[i]);
+        dose_setup(&dose[i], &dose_params[i], i);
         gnrc_netif_ethernet_create(&_netif[i], _netdev_eth_stack[i], DOSE_MAC_STACKSIZE,
                                    DOSE_MAC_PRIO, "dose", (netdev_t *)&dose[i]);
     }

--- a/tests/driver_at86rf2xx/main.c
+++ b/tests/driver_at86rf2xx/main.c
@@ -96,7 +96,7 @@ int main(void)
         netdev_t *dev = (netdev_t *)(&devs[i]);
 
         printf("Initializing AT86RF2xx radio at SPI_%d\n", p->spi);
-        at86rf2xx_setup(&devs[i], p);
+        at86rf2xx_setup(&devs[i], p, i);
         dev->event_callback = _event_cb;
         if (dev->driver->init(dev) < 0) {
             continue;

--- a/tests/driver_at86rf2xx_aes/main.c
+++ b/tests/driver_at86rf2xx_aes/main.c
@@ -141,7 +141,7 @@ int main(void)
 {
     at86rf2xx_t dev;
     bool success = true;
-    at86rf2xx_setup(&dev, &at86rf2xx_params[0]);
+    at86rf2xx_setup(&dev, &at86rf2xx_params[0], 0);
     dev.netdev.netdev.event_callback = _event_cb;
     if (dev.netdev.netdev.driver->init(&dev.netdev.netdev) != 0) {
         return EXIT_FAILURE;


### PR DESCRIPTION
### Contribution description

This introduces the new `type` and `index` field to the `netdev` struct.
The `type` field is unique for each driver type and thus driver configuration struct. The `index` is the index of the device in the driver configuration struct.

For this the driver needs to call `netdev_register()` on setup.
Only a few drivers have been converted yet as an example.

This creates a unique and stable identifier for network devices that only depends on the board configuration.

With this we can continue (can be split off to a separate PR) to implement an EUI -> device mapping for boards that provide MAC addresses.

As a third step we can also extend `luid_get_euiXX` to use `luid_custom` for the fall-back case.
This will allow for stable addresses across driver resets and can be easily implemented as a follow-up to this.

### Testing procedure

This is just adding IDs without using them, nothing to test.

### Issues/PRs references
required for #14634