### PR TITLE
boards: define the interrupt flank for BTN0 for ESP32 Heltec Lora32 V2

### DIFF
--- a/boards/esp32-heltec-lora32-v2/include/board.h
+++ b/boards/esp32-heltec-lora32-v2/include/board.h
@@ -56,6 +56,13 @@
 #define BTN0_MODE       GPIO_IN
 
 /**
+ * @brief   Default interrupt flank definition for the button GPIO
+ */
+#ifndef BTN0_INT_FLANK
+#define BTN0_INT_FLANK  GPIO_FALLING
+#endif
+
+/**
  * @brief   Definition for compatibility with previous versions
  */
 #define BUTTON0_PIN     BTN0_PIN


### PR DESCRIPTION
### Contribution description

With PR #13655, a default GPIO interrupt flank was introduced for test applications. Since PR #11265 with Heltec WiFi LoRa 32 V2 board definition was provided before but merged after PR #13655, it didn't contain contain this definition.

This PR defines `GPIO_FALLING` as default interrupt flank for `BTN0`.

### Testing procedure

If a Heltec WiFi LoRa 32 V2 board is at hand, use `tests/periph_pm` to test. This test application defines `GPIO_RISING` as default interrupt flank if it is not overriden by the board definition.
```
make BOARD=esp32-heltec-lora32-v2 -C tests/periph_pm flash term
```
With the current master the button interrupt is generated when the button is released since the GPIO for `BTN` is pulled up. With this PR the button interrupt is generated when the button is pressed.

### Issues/PRs references

Provides the default interrupt definition for PR #13655.