### PR TITLE
cpu/sam0_common: fix handling of PM_NUM_MODES

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -96,17 +96,6 @@ enum {
  */
 #define GPIO_MODE(pr, ie, pe)   (pr | (ie << 1) | (pe << 2))
 
-/**
- * @name    Power mode configuration
- * @{
- */
-#ifdef CPU_SAML1X
-#define PM_NUM_MODES        (2)
-#else
-#define PM_NUM_MODES        (3)
-#endif
-/** @} */
-
 #ifndef DOXYGEN
 /**
  * @brief   Override GPIO modes

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -29,6 +29,13 @@ extern "C" {
 #endif
 
 /**
+ * @name    Power mode configuration
+ * @{
+ */
+#define PM_NUM_MODES        (3)
+/** @} */
+
+/**
  * @brief   Override the default initial PM blocker
  * @todo   Idle modes are enabled by default, deep sleep mode blocked
  */

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -44,6 +44,13 @@ extern "C" {
 #define SAM0_DPLL_FREQ_MAX_HZ   (200000000U)
 
 /**
+ * @name    Power mode configuration
+ * @{
+ */
+#define PM_NUM_MODES        (3)
+/** @} */
+
+/**
  * @name   SAMD5x GCLK definitions
  * @{
  */

--- a/cpu/saml1x/include/periph_cpu.h
+++ b/cpu/saml1x/include/periph_cpu.h
@@ -27,6 +27,13 @@ extern "C" {
 #endif
 
 /**
+ * @name    Power mode configuration
+ * @{
+ */
+#define PM_NUM_MODES        (1)
+/** @} */
+
+/**
  * @brief   Override the default initial PM blocker
  * @todo   Idle modes are enabled by default, deep sleep mode blocked
  */

--- a/cpu/saml1x/periph/pm.c
+++ b/cpu/saml1x/periph/pm.c
@@ -26,26 +26,24 @@
 
 void pm_set(unsigned mode)
 {
-    if (mode < PM_NUM_MODES) {
-        uint32_t _mode;
+    uint32_t _mode;
 
-        switch (mode) {
-            case 0:
-                DEBUG_PUTS("pm_set(): setting STANDBY mode.");
-                _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
-                break;
-            default: /* Falls through */
-            case 1:
-                DEBUG_PUTS("pm_set(): setting IDLE mode.");
-                _mode = PM_SLEEPCFG_SLEEPMODE_IDLE;
-                break;
-        }
-
-        /* write sleep configuration */
-        PM->SLEEPCFG.bit.SLEEPMODE = _mode;
-        /* make sure value has been set */
-        while (PM->SLEEPCFG.bit.SLEEPMODE != _mode) {}
+    switch (mode) {
+        case 0:
+            DEBUG_PUTS("pm_set(): setting STANDBY mode.");
+            _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
+            break;
+        default: /* Falls through */
+        case 1:
+            DEBUG_PUTS("pm_set(): setting IDLE mode.");
+            _mode = PM_SLEEPCFG_SLEEPMODE_IDLE;
+            break;
     }
+
+    /* write sleep configuration */
+    PM->SLEEPCFG.bit.SLEEPMODE = _mode;
+    /* make sure value has been set */
+    while (PM->SLEEPCFG.bit.SLEEPMODE != _mode) {}
 
     sam0_cortexm_sleep(0);
 }

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -32,6 +32,13 @@ extern "C" {
 #define CPU_BACKUP_RAM_NOT_RETAINED (1)
 
 /**
+ * @name    Power mode configuration
+ * @{
+ */
+#define PM_NUM_MODES        (2)
+/** @} */
+
+/**
  * @name   SAML21 GCLK definitions
  * @{
  */

--- a/cpu/saml21/periph/pm.c
+++ b/cpu/saml21/periph/pm.c
@@ -26,34 +26,32 @@
 
 void pm_set(unsigned mode)
 {
-    if (mode < PM_NUM_MODES) {
-        uint32_t _mode;
+    uint32_t _mode;
 
-        switch (mode) {
-            case 0:
-                DEBUG_PUTS("pm_set(): setting BACKUP mode.");
-                _mode = PM_SLEEPCFG_SLEEPMODE_BACKUP;
-                break;
-            case 1:
-                DEBUG_PUTS("pm_set(): setting STANDBY mode.");
-                _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
-                break;
-            default: /* Falls through */
-            case 2:
-                DEBUG_PUTS("pm_set(): setting IDLE mode.");
+    switch (mode) {
+        case 0:
+            DEBUG_PUTS("pm_set(): setting BACKUP mode.");
+            _mode = PM_SLEEPCFG_SLEEPMODE_BACKUP;
+            break;
+        case 1:
+            DEBUG_PUTS("pm_set(): setting STANDBY mode.");
+            _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
+            break;
+        default: /* Falls through */
+        case 2:
+            DEBUG_PUTS("pm_set(): setting IDLE mode.");
 #if !defined(PM_SLEEPCFG_SLEEPMODE_IDLE2)
-                _mode = PM_SLEEPCFG_SLEEPMODE_IDLE;
+            _mode = PM_SLEEPCFG_SLEEPMODE_IDLE;
 #else
-                _mode = PM_SLEEPCFG_SLEEPMODE_IDLE2;
+            _mode = PM_SLEEPCFG_SLEEPMODE_IDLE2;
 #endif
-                break;
-        }
-
-        /* write sleep configuration */
-        PM->SLEEPCFG.bit.SLEEPMODE = _mode;
-        /* make sure value has been set */
-        while (PM->SLEEPCFG.bit.SLEEPMODE != _mode) {}
+            break;
     }
+
+    /* write sleep configuration */
+    PM->SLEEPCFG.bit.SLEEPMODE = _mode;
+    /* make sure value has been set */
+    while (PM->SLEEPCFG.bit.SLEEPMODE != _mode) {}
 
     sam0_cortexm_sleep(0);
 }


### PR DESCRIPTION
### Contribution description

From the [documentation](https://riot-os.org/api/group__sys__pm__layered.html):

 - CPUs define up to 4 power modes (from zero, the lowest power mode,
   to `PM_NUM_MODES-1`, the highest)
 - **there is an implicit extra idle mode (which has the number `PM_NUM_MODES`)**

The sam0 family did get this wrong.
It wasn't so bad for samd21 and samd5x as the default case in `pm.c` would still catch, but due to the range check on `saml21` and `saml1x` the `SLEEPMODE` register would never get written on idle, causing the CPU to never leave the previous sleep mode.

Another side effect was that the CPU never entered idle mode.
With this patch, IDLE consumption drops from 750µA to 368µA on saml21.

### Testing procedure

Run `tests/periph_pm` on e.g. `saml21-xpro`:

    unblock_rtc 1 5

You will find that on `master`, saml1x and saml21 are not able to wake from STANDBY (`mode 1`).
With this patch the board should wake up again after 5s.


### Issues/PRs references

split off #13475
