### PR TITLE
sys/shell: fix ifconfig command for NETOPT_LINK

### DIFF
--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -494,9 +494,10 @@ static void _netif_list(netif_t *iface)
         printf(" CR: %s ", _netopt_coding_rate_str[u8]);
     }
 #endif
-    res = netif_get_opt(iface, NETOPT_LINK, 0, &u8, sizeof(u8));
+    netopt_enable_t link;
+    res = netif_get_opt(iface, NETOPT_LINK, 0, &link, sizeof(netopt_enable_t));
     if (res >= 0) {
-        printf(" Link: %s ", (netopt_enable_t)u8 ? "up" : "down" );
+        printf(" Link: %s ", (link == NETOPT_ENABLE) ? "up" : "down" );
     }
     line_thresh = _newline(0U, line_thresh);
     res = netif_get_opt(iface, NETOPT_ADDRESS_LONG, 0, hwaddr, sizeof(hwaddr));


### PR DESCRIPTION
### Contribution description

This PR fixes a problem with handling of `NETOPT_LINK` in `ifconfig` command.

According to the documentation of [`netopt_t`](https://doc.riot-os.org/group__net__netopt.html#gga19e30424c1ab107c9c84dc0cb29d9906a747aff887ecf7b682571a2ed4add9e5d), the type of `NETOPT_LINK` is `netopt_enable_t`. Using `uint8_t` to get the information whether the link is up or down, and its casting to `netopt_enable_t` causes a crash on systems where the enumeration type is not just one byte.

### Testing procedure

`ifconfig` command should still work.

### Issues/PRs references
