### PR TITLE
sys/base64: Implement Base 64 Encoding with URL and Filename Safe Alphabet

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -42,6 +42,10 @@ ifneq (,$(filter auto_init_saul,$(USEMODULE)))
   USEMODULE += saul_init_devs
 endif
 
+ifneq (,$(filter base64url,$(USEMODULE)))
+  USEMODULE += base64
+endif
+
 ifneq (,$(filter csma_sender,$(USEMODULE)))
   USEMODULE += random
   USEMODULE += xtimer

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -1,5 +1,6 @@
 PSEUDOMODULES += at_urc
 PSEUDOMODULES += at24c%
+PSEUDOMODULES += base64url
 PSEUDOMODULES += can_mbox
 PSEUDOMODULES += can_pm
 PSEUDOMODULES += can_raw

--- a/sys/include/base64.h
+++ b/sys/include/base64.h
@@ -77,6 +77,32 @@ int base64_encode(const void *data_in, size_t data_in_size,
                   unsigned char *base64_out, size_t *base64_out_size);
 
 /**
+ * @brief           Encodes a given datum to base64 with URL and Filename Safe Alphabet
+ *                  and save the result to the given destination.
+ *
+ * @see             [RFC 4648, section 5](https://tools.ietf.org/html/rfc4648#section-5)
+ *
+ * @note            Requires the use of the `base64url` module.
+ *
+ * @param[in]       data_in           pointer to the datum to encode
+ * @param[in]       data_in_size      the size of `data_in`
+ * @param[out]      base64_out        pointer to store the encoded base64 string
+ * @param[in,out]   base64_out_size   pointer to the variable containing the size of `base64_out.`
+                                      This value is overwritten with the estimated size used for
+                                      the encoded base64 string on BASE64_ERROR_BUFFER_OUT_SIZE.
+                                      This value is overwritten with the actual used size for the
+                                      encoded base64 string on BASE64_SUCCESS.
+
+ * @returns BASE64_SUCCESS on success,
+            BASE64_ERROR_BUFFER_OUT_SIZE on insufficient size for encoding to `base64_out`,
+            BASE64_ERROR_BUFFER_OUT if `base64_out` equals NULL
+                                    but the `base64_out_size` is sufficient,
+            BASE64_ERROR_DATA_IN if `data_in` equals NULL.
+ */
+int base64url_encode(const void *data_in, size_t data_in_size,
+                     unsigned char *base64_out, size_t *base64_out_size);
+
+/**
  * @brief           Decodes a given base64 string and save the result to the given destination.
  * @param[out]      base64_in        pointer to store the encoded base64 string
  * @param[in]       base64_in_size   pointer to the variable containing the size of `base64_out.`

--- a/tests/unittests/tests-base64/Makefile.include
+++ b/tests/unittests/tests-base64/Makefile.include
@@ -1,1 +1,1 @@
-USEMODULE += base64
+USEMODULE += base64url

--- a/tests/unittests/tests-base64/tests-base64.c
+++ b/tests/unittests/tests-base64/tests-base64.c
@@ -11,6 +11,7 @@
 #if (TEST_BASE64_SHOW_OUTPUT == 1)
 #include <stdio.h>
 #endif
+#include <stdint.h>
 #include <string.h>
 #include "embUnit.h"
 #include "tests-base64.h"
@@ -409,6 +410,79 @@ static void test_base64_10_decode_empty(void)
     TEST_ASSERT_EQUAL_INT(0, base64_out_size);
 }
 
+static void test_base64_11_urlsafe_encode_int(void)
+{
+    uint32_t data_in = 4345;
+    unsigned char expected_encoding[] = "-RAAAA==";
+
+    size_t base64_out_size = 0;
+    unsigned char base64_out[ strlen((char *)expected_encoding) ];
+
+    /*
+    * @Note:
+    * The first encoding attempt fails, but reveals the required out size.
+    *
+    * This size is a lower bound estimation,
+    * thus it can require few more bytes then the actual used size for the output.
+    */
+    int ret = base64url_encode((void *)&data_in, sizeof(data_in), NULL, &base64_out_size);
+
+    TEST_ASSERT_EQUAL_INT(BASE64_ERROR_BUFFER_OUT_SIZE, ret);
+
+    ret = base64url_encode((void *)&data_in, sizeof(data_in), base64_out, &base64_out_size);
+
+    TEST_ASSERT_EQUAL_INT(BASE64_SUCCESS, ret);
+
+    for (int i = 0; i < (int)base64_out_size; ++i) {
+        TEST_ASSERT_MESSAGE(base64_out[i] == expected_encoding[i], \
+                            "encoding failed!(produced unexpected output)");
+    }
+
+#if (TEST_BASE64_SHOW_OUTPUT == 1)
+    puts("Test 11 Encoded:");
+
+    for (int i = 0; i < (int)base64_out_size; ++i) {
+        printf("%c", base64_out[i]);
+    }
+
+    printf("\nFrom:\n%x\n", data_in);
+#endif
+}
+
+static void test_base64_12_urlsafe_decode_int(void)
+{
+    unsigned char encoded_base64[] = "_____wAA==";
+    unsigned char expected[]       = {0xFF, 0xFF, 0xFF, 0xFF, 0x0, 0x0};
+
+    size_t base64_size = strlen((char *)encoded_base64);
+
+    size_t data_out_size = 0;
+    unsigned char data_out[ sizeof(expected) ];
+
+    int ret = base64_decode(encoded_base64, base64_size, NULL, &data_out_size);
+    TEST_ASSERT_EQUAL_INT(BASE64_ERROR_BUFFER_OUT_SIZE, ret);
+
+    ret = base64_decode(encoded_base64, base64_size, NULL, &data_out_size);
+    TEST_ASSERT_EQUAL_INT(BASE64_ERROR_BUFFER_OUT, ret);
+
+    ret = base64_decode(encoded_base64, base64_size, data_out, &data_out_size);
+    TEST_ASSERT_EQUAL_INT(BASE64_SUCCESS, ret);
+
+    for (int i = 0; i < (int)data_out_size; ++i) {
+        TEST_ASSERT_MESSAGE(data_out[i] == expected[i], \
+                            "decoding failed!(produced unexpected output)");
+    }
+
+#if (TEST_BASE64_SHOW_OUTPUT == 1)
+    puts("Test 11 Decoded:");
+
+    for (int i = 0; i < (int)data_out_size; ++i) {
+        printf("%x", data_out[i]);
+    }
+
+    printf("\nFrom:\n%x\n", (char *)encoded_base64);
+#endif
+}
 
 Test *tests_base64_tests(void)
 {
@@ -424,6 +498,8 @@ Test *tests_base64_tests(void)
         new_TestFixture(test_base64_09_encode_size_determination),
         new_TestFixture(test_base64_10_encode_empty),
         new_TestFixture(test_base64_10_decode_empty),
+        new_TestFixture(test_base64_11_urlsafe_encode_int),
+        new_TestFixture(test_base64_12_urlsafe_decode_int),
     };
 
     EMB_UNIT_TESTCALLER(base64_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

RFC4648 specifies an alternate alphabet for base64 encoding / decoding where '+' and '/' are exchanged for '-' and '_' to make the resulting string safe to use in filenames and URLs.

This adds a `base64url_encode()` function that uses the alternate alphabet.

The `base64_decode()` function is extended to accept both alphabets.

### Testing procedure

Run 

    make -C tests/unittests tests-base64

### Issues/PRs references

https://tools.ietf.org/html/rfc4648#page-7