### PR TITLE
boards/common/cc2538/include: re-order timer config

### DIFF
--- a/boards/common/cc2538/include/cfg_timer_default.h
+++ b/boards/common/cc2538/include/cfg_timer_default.h
@@ -42,12 +42,12 @@ static const timer_conf_t timer_config[] = {
         .cfg = GPTMCFG_16_BIT_TIMER, /* required for XTIMER */
     },
     {
-        .chn = 1,
-        .cfg = GPTMCFG_32_BIT_TIMER,
-    },
-    {
         .chn = 2,
         .cfg = GPTMCFG_16_BIT_TIMER,
+    },
+    {
+        .chn = 1,
+        .cfg = GPTMCFG_32_BIT_TIMER,
     },
     {
         .chn = 1,


### PR DESCRIPTION
### Contribution description

This PR re-orders the timers in `cfg_timer_default.h` by grouping timer with the same configuration together. This change is more for convenience than anything else, but it does make sense to use a configurable speed timer since some applications defualt to `TIMER_DEV(1)` to avoid `xtimer` collisions.

### Testing procedure

This is more of a convenience change, but `tests/periph_timer` still works and `tests/bench_timers` does not fail to initialize anymore:

- `tests/bench_timers` 

```
2020-03-30 18:05:31,602 # main(): This is RIOT! (Version: 2020.04-devel-1712-g84376-pr_cc2538_timer_order)
2020-03-30 18:05:31,602 # 
2020-03-30 18:05:31,618 # Statistical benchmark for timers
2020-03-30 18:05:31,620 # Running timer test with seed 123 using Tiny Mersenne Twister PRNG.
2020-03-30 18:05:31,621 # TEST_MIN = 16
2020-03-30 18:05:31,621 # TEST_MAX = 128
2020-03-30 18:05:31,622 # TEST_MIN_REL = 0
2020-03-30 18:05:31,623 # TEST_MAX_REL = 112
2020-03-30 18:05:31,623 # TEST_NUM = 113
2020-03-30 18:05:31,632 # log2(TEST_NUM - 1) = 6
2020-03-30 18:05:31,633 # state vector elements per variant = 7
2020-03-30 18:05:31,634 # number of variants = 8
2020-03-30 18:05:31,635 # sizeof(state) = 32 bytes
2020-03-30 18:05:31,636 # state vector total memory usage = 1792 bytes
2020-03-30 18:05:31,648 # TIM_TEST_DEV = 0, TIM_TEST_FREQ = 1000000, TIM_TEST_CHAN = 0
```

- `tests/periph_timer` still works

```
2020-03-30 19:36:48,185 # main(): This is RIOT! (Version: 2020.04-devel-1712-g84376-pr_cc2538_timer_order)
2020-03-30 19:36:48,186 # 
2020-03-30 19:36:48,186 # Test for peripheral TIMERs
2020-03-30 19:36:48,186 # 
2020-03-30 19:36:48,187 # Available timers: 4
2020-03-30 19:36:48,187 # 
2020-03-30 19:36:48,187 # Testing TIMER_0:
2020-03-30 19:36:48,188 # prescaled value : 0
2020-03-30 19:36:48,189 # TIMER_0: initialization successful
2020-03-30 19:36:48,200 # TIMER_0: stopped
2020-03-30 19:36:48,201 # TIMER_0: set channel 0 to 5000
2020-03-30 19:36:48,201 # TIMER_0: set channel 1 to 10000
2020-03-30 19:36:48,201 # TIMER_0: starting
2020-03-30 19:36:48,202 # TIMER_0: channel 0 fired at SW count      279 - init:      279
2020-03-30 19:36:48,217 # TIMER_0: channel 1 fired at SW count      586 - diff:      307
2020-03-30 19:36:48,217 # 
2020-03-30 19:36:48,217 # Testing TIMER_1:
2020-03-30 19:36:48,218 # prescaled value : 0
2020-03-30 19:36:48,218 # TIMER_1: initialization successful
2020-03-30 19:36:48,218 # TIMER_1: stopped
2020-03-30 19:36:48,219 # TIMER_1: set channel 0 to 5000
2020-03-30 19:36:48,232 # TIMER_1: set channel 1 to 10000
2020-03-30 19:36:48,234 # TIMER_1: starting
2020-03-30 19:36:48,235 # TIMER_1: channel 0 fired at SW count      279 - init:      279
2020-03-30 19:36:48,235 # TIMER_1: channel 1 fired at SW count      586 - diff:      307
2020-03-30 19:36:48,235 # 
2020-03-30 19:36:48,236 # Testing TIMER_2:
2020-03-30 19:36:48,248 # TIMER_2: initialization successful
2020-03-30 19:36:48,249 # TIMER_2: stopped
2020-03-30 19:36:48,250 # TIMER_2: set channel 0 to 5000
2020-03-30 19:36:48,251 # TIMER_2: starting
2020-03-30 19:36:48,252 # TIMER_2: channel 0 fired at SW count      294 - init:      294
2020-03-30 19:36:48,252 # 
2020-03-30 19:36:48,252 # Testing TIMER_3:
2020-03-30 19:36:48,265 # TIMER_3: initialization successful
2020-03-30 19:36:48,265 # TIMER_3: stopped
2020-03-30 19:36:48,266 # TIMER_3: set channel 0 to 5000
2020-03-30 19:36:48,266 # TIMER_3: starting
2020-03-30 19:36:48,268 # TIMER_3: channel 0 fired at SW count      294 - init:      294
2020-03-30 19:36:48,269 # 
2020-03-30 19:36:48,270 # TEST SUCCEEDED
```

### Issues/PRs references

