### PR TITLE
tests/periph_pm: introduce set_rtc

### DIFF
--- a/tests/periph_pm/main.c
+++ b/tests/periph_pm/main.c
@@ -112,7 +112,6 @@ static int cmd_unblock_rtc(int argc, char **argv)
 
     rtc_get_time(&time);
     time.tm_sec += duration;
-    mktime(&time);
     rtc_set_alarm(&time, cb_rtc, (void *)mode);
 
     pm_unblock(mode);

--- a/tests/periph_pm/main.c
+++ b/tests/periph_pm/main.c
@@ -86,6 +86,11 @@ static void cb_rtc(void *arg)
     pm_block(level);
 }
 
+static void cb_rtc_puts(void *arg)
+{
+    puts(arg);
+}
+
 static int cmd_unblock_rtc(int argc, char **argv)
 {
     if (check_mode_duration(argc, argv) != 0) {
@@ -118,6 +123,33 @@ static int cmd_unblock_rtc(int argc, char **argv)
 
     return 0;
 }
+
+static int cmd_set_rtc(int argc, char **argv)
+{
+    if (check_mode_duration(argc, argv) != 0) {
+        return 1;
+    }
+
+    int mode = parse_mode(argv[1]);
+    int duration = parse_duration(argv[2]);
+
+    if (mode < 0 || duration < 0) {
+        return 1;
+    }
+
+    printf("Setting power mode %d for %d seconds.\n", mode, duration);
+    fflush(stdout);
+
+    struct tm time;
+
+    rtc_get_time(&time);
+    time.tm_sec += duration;
+    rtc_set_alarm(&time, cb_rtc_puts, "The alarm rang");
+
+    pm_set(mode);
+
+    return 0;
+}
 #endif /* MODULE_PERIPH_RTC */
 #endif /* MODULE_PM_LAYERED */
 
@@ -134,6 +166,7 @@ static void btn_cb(void *ctx)
  */
 static const shell_command_t shell_commands[] = {
 #if defined MODULE_PM_LAYERED && defined MODULE_PERIPH_RTC
+    { "set_rtc", "temporary set power mode", cmd_set_rtc },
     { "unblock_rtc", "temporarily unblock power mode", cmd_unblock_rtc },
 #endif
     { NULL, NULL, NULL }


### PR DESCRIPTION

### Contribution description

The `unblock_rtc` function is a bit clunky to use because it does not directly cause entering a set power mode, but just unblocks the power mode.
One has to manually unblock higher power modes for the CPU to enter the lower power mode.

If the higher power modes do not support shell input, the system is stuck here.

This introduces a new `set_rtc` function that works just like `unblock_rtc`, but uses `pm_set()` instead of `pm_unblock()`.

### Testing procedure

Run `set_rtc 0 5` to unblock the lowest power mode for 5s.
The system will probably reset after 5s.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
