### PR TITLE
sys/riotboot: add a warning about the size of riotboot_flashwrite_t

### DIFF
--- a/sys/include/riotboot/flashwrite.h
+++ b/sys/include/riotboot/flashwrite.h
@@ -59,6 +59,9 @@ extern "C" {
 
 /**
  * @brief   firmware update state structure
+ *
+ * @note    @ref FLASHPAGE_SIZE can be very large on some platforms, don't place
+ *          this struct on the stack or increase the thread stack size accordingly.
  */
 typedef struct {
     int target_slot;                        /**< update targets this slot     */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

On e.g. samd5x `FLASHPAGE_SIZE` is 8k (4k on kinetis, stm32w, nrf52) so placing this struct on the stack will almost always cause a stack overflow if the user is not aware of this.

### Testing procedure

Only amends the documentation.


### Issues/PRs references
I initially also wanted to make the use of `riotboot_flashwrite_t writer` in `sys/suit/transport/coap.c` `static`, but there the thread size is already set to be larger than `FLASHPAGE_SIZE`, so this is fine.
