### PR TITLE
drivers/include/ads101x.h: Tagged Compile Time Parameters

### DIFF
--- a/drivers/include/ads101x.h
+++ b/drivers/include/ads101x.h
@@ -39,13 +39,20 @@ extern "C" {
 #include "periph/gpio.h"
 
 /**
- * @brief   ADS101x/111x default address
+ * @defgroup drivers_ads101x_config    ADS101 driver compile configuration
+ * @ingroup config
+ * @{
+ */
+
+/**
+ * @brief   Set ADS101x/111x default I2C address
  *
  * Address pin tied to: GND (0x48), Vcc (0x49), SDA (0x50), SCL (0x51)
  */
 #ifndef ADS101X_I2C_ADDRESS
 #define ADS101X_I2C_ADDRESS    (0x48)
 #endif
+/** @} */
 
 /**
  * @brief   Named return values


### PR DESCRIPTION
### Contribution description

Identify Compile Time Parameters in drivers/include/ads101x.h header and expose it.


### Testing procedure

Doxygen build works fine.


### Issues/PRs references

#10566