### PR TITLE
cpu/samd5x: disable RTC on init to prevent undefined RTC state

### DIFF
--- a/cpu/samd5x/cpu.c
+++ b/cpu/samd5x/cpu.c
@@ -149,6 +149,14 @@ uint32_t sam0_gclk_freq(uint8_t id)
  */
 void cpu_init(void)
 {
+    /* Disable the RTC module to prevent synchronization issues during CPU init
+       if the RTC was running from a previous boot (e.g wakeup from backup) */
+    if (RTC->MODE2.CTRLA.bit.ENABLE) {
+        while (RTC->MODE2.SYNCBUSY.reg) {}
+        RTC->MODE2.CTRLA.bit.ENABLE = 0;
+        while (RTC->MODE2.SYNCBUSY.reg) {}
+    }
+
     /* initialize the Cortex-M core */
     cortexm_init();
 


### PR DESCRIPTION
### Contribution description

When changing the clock configuration while the RTC is running, the RTC may end up in an undefined state that leaves it unresponsive.

To stay persistent across reboots/hibernate the RTC is not reset to, so it will not be reset on init.
Instead, disable the RTC while configuring the clocks, `rtc_init()` will take care of re-enabling it.

@dylad introduced this workaround for saml21, samd5x needs it too.

### Testing procedure

To reproduce, set the `CLOCK_CORECLOCK` of a samd5x board (e.g. `same54-xpro`) to 48 MHz.
Run any RTC application. The CPU will be stuck in `_wait_syncbusy()` after a reboot.
This patch will fix this. (You will need to power-cycle the board if the RTC has entered the stuck state as it will never be reset.)

### Issues/PRs references

Same approach as in #10075
