### PR TITLE
cpu/esp: fix type for NETOPT_LINK for esp_wifi/esp_eth

### DIFF
--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -281,7 +281,7 @@ static int _esp_eth_get(netdev_t *netdev, netopt_t opt, void *val, size_t max_le
             esp_eth_get_mac((uint8_t *)val);
             return ETHERNET_ADDR_LEN;
         case NETOPT_LINK_CONNECTED:
-            assert(max_len == 1);
+            assert(max_len == sizeof(netopt_enable_t));
             *((netopt_enable_t *)val) = (dev->link_up) ? NETOPT_ENABLE
                                                        : NETOPT_DISABLE;
             return sizeof(netopt_enable_t);

--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -280,7 +280,7 @@ static int _esp_eth_get(netdev_t *netdev, netopt_t opt, void *val, size_t max_le
             assert(max_len >= ETHERNET_ADDR_LEN);
             esp_eth_get_mac((uint8_t *)val);
             return ETHERNET_ADDR_LEN;
-        case NETOPT_LINK_CONNECTED:
+        case NETOPT_LINK:
             assert(max_len == sizeof(netopt_enable_t));
             *((netopt_enable_t *)val) = (dev->link_up) ? NETOPT_ENABLE
                                                        : NETOPT_DISABLE;

--- a/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
@@ -639,7 +639,7 @@ static int _esp_wifi_get(netdev_t *netdev, netopt_t opt, void *val, size_t max_l
             assert(max_len >= ETHERNET_ADDR_LEN);
             esp_wifi_get_mac(ESP_MAC_WIFI_STA,(uint8_t *)val);
             return ETHERNET_ADDR_LEN;
-        case NETOPT_LINK_CONNECTED:
+        case NETOPT_LINK:
             assert(max_len == sizeof(netopt_enable_t));
             *((netopt_enable_t *)val) = (dev->connected) ? NETOPT_ENABLE
                                                          : NETOPT_DISABLE;

--- a/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
@@ -640,10 +640,10 @@ static int _esp_wifi_get(netdev_t *netdev, netopt_t opt, void *val, size_t max_l
             esp_wifi_get_mac(ESP_MAC_WIFI_STA,(uint8_t *)val);
             return ETHERNET_ADDR_LEN;
         case NETOPT_LINK_CONNECTED:
-            assert(max_len == 1);
+            assert(max_len == sizeof(netopt_enable_t));
             *((netopt_enable_t *)val) = (dev->connected) ? NETOPT_ENABLE
                                                          : NETOPT_DISABLE;
-            return 1;
+            return sizeof(netopt_enable_t);
         default:
             return netdev_eth_get(netdev, opt, val, max_len);
     }


### PR DESCRIPTION
### Contribution description

This PR is a very small fix but important fix. It fixes the handling of `netopt_enabled_t` in `netdev::get` for `NETOPT_LINK_CONNECTED`. The bug was exposed by the fix of the `netopt_enabled_t` handling in the `ifconfig` command with PR #13752.

Since `NETOPT_LINK_CONNECTED` is declared as deprecated, it is renamed to `NETOP_LINK` with this PR as a separate commit.

### Testing procedure

Flash any networking application to any ESP32 board, for example
```
make BOARD=esp32-wroom-32 -C examples/gnrc_networking flash term
```
and use the `ifconfig` command. With current master, the command leads to a crash because of the assertion, with this PR it succeeds.

### Issues/PRs reference

Introduced with # #13752.