### PR TITLE
dist/tools/tapsetup: fix deletion when UPLINK unset

### DIFF
--- a/dist/tools/tapsetup/tapsetup
+++ b/dist/tools/tapsetup/tapsetup
@@ -92,7 +92,7 @@ delete_bridge() {
             kldunload if_bridge || exit 1 ;;
         Linux)
             for IF in $(ls /sys/class/net/${BRNAME}/brif); do
-                if [ ${IF} != ${UPLINK} ]; then
+                if [ "${IF}" != "${UPLINK}" ]; then
                     ip link delete "${IF}"
                 fi
             done


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When trying to delete a previously created bridge with `tapsetup`, two error messages will be shown.

```
deleting tapbr0
dist/tools/tapsetup/tapsetup: line 95: [: tap0: unary operator expected
dist/tools/tapsetup/tapsetup: line 95: [: tap1: unary operator expected
```

and both tap interfaces will still exist. This PR fixes that regression introduced in #13662.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Create a bridge without an uplink interface and immediately destroy it afterwards. All interfaces should be removed:

```
$ sudo dist/tools/tapsetup/tapsetup -t riot -b riotbr
creating riotbr
creating riot0
creating riot1
$ ip link | grep riot
24: riotbr: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
25: riot0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel master riotbr state DOWN mode DEFAULT group default qlen 1000
26: riot1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel master riotbr state DOWN mode DEFAULT group default qlen 1000
$ sudo dist/tools/tapsetup/tapsetup -d -t riot -b riotbr
deleting riotbr
$ ip link | grep riot
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes regression introduced in #13662.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
