### PR TITLE
drivers/include/cc110x.h : Tagged compile config

### DIFF
--- a/drivers/include/cc110x.h
+++ b/drivers/include/cc110x.h
@@ -240,12 +240,18 @@ extern "C" {
 #define CC110X_DEFAULT_PROTOCOL         (GNRC_NETTYPE_UNDEF)
 #endif
 
-#ifndef CC110X_DEFAULT_CHANNEL
+/**
+ * @defgroup drivers_cc110x_config CC1100/CC1100e/CC1101 Sub-GHz transceiver driver compile configuration
+ * @ingroup config_drivers_netdev
+ * @{
+ */
 /**
  * @brief The default channel to set up after initializing the device
  */
+#ifndef CC110X_DEFAULT_CHANNEL
 #define CC110X_DEFAULT_CHANNEL      (0U)
 #endif
+/** @} */
 
 /**
  * @brief   The state of the CC1100/CC1101 transceiver


### PR DESCRIPTION
### Contribution description

Identify Compile Time Parameters in drivers/include/cc110x.h header and expose it,

### Testing procedure

Doxygen build works fine.

### Issues/PRs references
~~Depends on #13784~~
Part of #10566