### PR TITLE
tests/unittests/uri_parse: use less confusing assert message 

### DIFF
--- a/tests/unittests/tests-uri_parser/tests-uri_parser.c
+++ b/tests/unittests/tests-uri_parser/tests-uri_parser.c
@@ -24,7 +24,7 @@
     { .uri = u, .scheme = s, .userinfo = us, .host = h, .port = po,     \
       .path = pa, .query = q, .expected = e}
 
-#define VEC_CHECK(comp)                                                 \
+#define VEC_CHECK(comp, i)                                              \
     do {                                                                \
         if (ures.comp == NULL) {                                        \
             TEST_ASSERT(validate_uris[i].comp[0] == '\0');              \
@@ -281,12 +281,12 @@ static void test_uri_parser__validate(void)
         int res = uri_parser_process_string(&ures, validate_uris[i].uri);
         TEST_ASSERT_EQUAL_INT(validate_uris[i].expected, res);
         if (res == 0) {
-            VEC_CHECK(scheme);
-            VEC_CHECK(userinfo);
-            VEC_CHECK(host);
-            VEC_CHECK(port);
-            VEC_CHECK(path);
-            VEC_CHECK(query);
+            VEC_CHECK(scheme, i);
+            VEC_CHECK(userinfo, i);
+            VEC_CHECK(host, i);
+            VEC_CHECK(port, i);
+            VEC_CHECK(path, i);
+            VEC_CHECK(query, i);
         }
     }
 }

--- a/tests/unittests/tests-uri_parser/tests-uri_parser.c
+++ b/tests/unittests/tests-uri_parser/tests-uri_parser.c
@@ -32,10 +32,11 @@
         else {                                                          \
             TEST_ASSERT_EQUAL_INT(strlen(validate_uris[i].comp),        \
                                   ures.comp##_len);                     \
-            TEST_ASSERT_EQUAL_INT(0,                                    \
-                                  memcmp(ures.comp,                     \
-                                         validate_uris[i].comp,         \
-                                         strlen(validate_uris[i].comp))); \
+            TEST_ASSERT_MESSAGE(0 ==                                    \
+                                  strncmp(ures.comp,                    \
+                                          validate_uris[i].comp,        \
+                                          strlen(validate_uris[i].comp)), \
+                                "Unexpected " # comp " member");        \
         }                                                               \
     } while (0)
 

--- a/tests/unittests/tests-uri_parser/tests-uri_parser.c
+++ b/tests/unittests/tests-uri_parser/tests-uri_parser.c
@@ -24,21 +24,30 @@
     { .uri = u, .scheme = s, .userinfo = us, .host = h, .port = po,     \
       .path = pa, .query = q, .expected = e}
 
-#define VEC_CHECK(comp, i)                                              \
-    do {                                                                \
-        if (ures.comp == NULL) {                                        \
-            TEST_ASSERT(validate_uris[i].comp[0] == '\0');              \
-        }                                                               \
-        else {                                                          \
-            TEST_ASSERT_EQUAL_INT(strlen(validate_uris[i].comp),        \
-                                  ures.comp##_len);                     \
-            TEST_ASSERT_MESSAGE(0 ==                                    \
-                                  strncmp(ures.comp,                    \
-                                          validate_uris[i].comp,        \
-                                          strlen(validate_uris[i].comp)), \
-                                "Unexpected " # comp " member");        \
-        }                                                               \
+#define VEC_CHECK(comp, i, vec_msg)                                         \
+    do {                                                                    \
+        if (ures.comp == NULL) {                                            \
+            TEST_ASSERT(validate_uris[i].comp[0] == '\0');                  \
+        }                                                                   \
+        else {                                                              \
+            TEST_ASSERT_EQUAL_INT(strlen(validate_uris[i].comp),            \
+                                  ures.comp##_len);                         \
+            vec_msg[0] = '\0';                                              \
+            stdimpl_strcat(vec_msg, "Unexpected " # comp " member \"");     \
+            stdimpl_strcat(vec_msg, validate_uris[i].comp);                 \
+            stdimpl_strcat(vec_msg, "\" for \"");                           \
+            stdimpl_strcat(vec_msg, validate_uris[i].uri);                  \
+            stdimpl_strcat(vec_msg, "\"");                                  \
+            TEST_ASSERT_MESSAGE(0 ==                                        \
+                                  strncmp(ures.comp,                        \
+                                          validate_uris[i].comp,            \
+                                          strlen(validate_uris[i].comp)),   \
+                                vec_msg);                                   \
+        }                                                                   \
     } while (0)
+
+#define VEC_MSG_LEN (sizeof("Unexpected userinfo member \"\" for \"\"") + \
+                     64U + 8U)
 
 typedef struct {
     char uri[64];
@@ -275,6 +284,8 @@ static const validate_t validate_uris[26] = {
         0),
 };
 
+static char _failure_msg[VEC_MSG_LEN];
+
 static void test_uri_parser__validate(void)
 {
     uri_parser_result_t ures;
@@ -282,12 +293,12 @@ static void test_uri_parser__validate(void)
         int res = uri_parser_process_string(&ures, validate_uris[i].uri);
         TEST_ASSERT_EQUAL_INT(validate_uris[i].expected, res);
         if (res == 0) {
-            VEC_CHECK(scheme, i);
-            VEC_CHECK(userinfo, i);
-            VEC_CHECK(host, i);
-            VEC_CHECK(port, i);
-            VEC_CHECK(path, i);
-            VEC_CHECK(query, i);
+            VEC_CHECK(scheme, i, _failure_msg);
+            VEC_CHECK(userinfo, i, _failure_msg);
+            VEC_CHECK(host, i, _failure_msg);
+            VEC_CHECK(port, i, _failure_msg);
+            VEC_CHECK(path, i, _failure_msg);
+            VEC_CHECK(query, i, _failure_msg);
         }
     }
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Some minor tweaks to the tests of `uri_parse`:

- use `strncmp()` instead of `memcmp()` to compare strings
- use `TEST_ASSERT_MESSAGE()` to print a less confusing output message on error
- add index as parameter for the `VEC_CHECK()` macro (otherwise it is unusable outside the `for`-loop.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```sh
make -C tests/unittests tests-uri_parse test
```

should still pass. When changing one of the expected value strings by one character e.g.

```diff
diff --git a/tests/unittests/tests-uri_parser/tests-uri_parser.c b/tests/unittests/tests-uri_parser/tests-uri_parser.c
index 247996a37..d8632dde9 100644
--- a/tests/unittests/tests-uri_parser/tests-uri_parser.c
+++ b/tests/unittests/tests-uri_parser/tests-uri_parser.c
@@ -244,7 +244,7 @@ static const validate_t validate_uris[26] = {
     VEC("telnet://192.0.2.16:80/",
         "telnet",
         "",
-        "192.0.2.16",
+        "192.0.2.14",
         "80",
         "/",
         "",
```

one now gets

```
uri_parser_tests.test_uri_parser__validate (tests/unittests/tests-uri_parser/tests-uri_parser.c 287) Unexpected host member
```

instead of

```
uri_parser_tests.test_uri_parser__validate (tests/unittests/tests-uri_parser/tests-uri_parser.c 286) exp 0 was 1
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #13758
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
