### PR TITLE
drivers/include/ds1307.h : Compile Configs

### DIFF
--- a/drivers/include/ds1307.h
+++ b/drivers/include/ds1307.h
@@ -39,11 +39,18 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup drivers_ds1307_config   DS1307 RTC driver compile configuration
+ * @ingroup config
+ * @{
+ */
+
+/**
  * @brief   Maximum I2C bus speed to use with the device
  */
 #ifndef DS1307_I2C_MAX_CLK
 #define DS1307_I2C_MAX_CLK      (I2C_SPEED_FAST)
 #endif
+/** @} */
 
 /**
  * @brief   Maximum size in byte of on-chip NVRAM


### PR DESCRIPTION
### Contribution description

Identify Compile Time Parameters in drivers/include/ds1307.h header and expose it.

Note : Skipped the following since its not configurable. Device's address on I2C bus is hard coded as it does not have address pins.

#define DS1307_I2C_ADDRESS      (0x68)

### Testing procedure

Doxygen build works fine.

### Issues/PRs references

#10566