### PR TITLE
tests: add arduino-nano to Makefile.ci

### DIFF
--- a/tests/driver_dose/Makefile.ci
+++ b/tests/driver_dose/Makefile.ci
@@ -2,6 +2,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-leonardo \
     arduino-mega2560 \
+    arduino-nano \
     arduino-uno \
     atmega328p \
     i-nucleo-lrwan1 \

--- a/tests/driver_mrf24j40/Makefile.ci
+++ b/tests/driver_mrf24j40/Makefile.ci
@@ -2,6 +2,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-leonardo \
     arduino-mega2560 \
+    arduino-nano \
     arduino-uno \
     atmega328p \
     i-nucleo-lrwan1 \

--- a/tests/driver_netdev_common/Makefile.ci
+++ b/tests/driver_netdev_common/Makefile.ci
@@ -2,6 +2,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-leonardo \
     arduino-mega2560 \
+    arduino-nano \
     arduino-uno \
     atmega328p \
     i-nucleo-lrwan1 \

--- a/tests/driver_w5100/Makefile.ci
+++ b/tests/driver_w5100/Makefile.ci
@@ -2,6 +2,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-leonardo \
     arduino-mega2560 \
+    arduino-nano \
     arduino-uno \
     atmega328p \
     i-nucleo-lrwan1 \


### PR DESCRIPTION
#13671 # Contribution description

Somehow `arduino-nano` is sometimes skipped by Murdock, so the original Makefile.ci was missing that entry.


### Testing procedure

Murdock should skip the board for those tests.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/13691#issuecomment-607117424