### PR TITLE
 sock: amend API to iterate over stack-internal buffer chunks

### DIFF
--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -245,19 +245,6 @@ struct _sock_tl_ep {
     uint16_t port;          /**< transport layer port (in host byte order) */
 };
 
-/**
- * @brief   Releases the stack-internal buffer space provided by the
- *          `sock_*_recv_buf()` functions.
- *
- * @see
- *  - @ref sock_dtls_recv_buf()
- *  - @ref sock_ip_recv_buf()
- *  - @ref sock_udp_recv_buf()
- *
- * @param[in] buf_ctx   Stack-internal buffer context to release.
- */
-void sock_recv_buf_free(void *buf_ctx);
-
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -615,9 +615,11 @@ ssize_t sock_dtls_recv(sock_dtls_t *sock, sock_dtls_session_t *remote,
  *                      Cannot be NULL.
  * @param[out] data     Pointer to a stack-internal buffer space containing the
  *                      received data.
- * @param[out] buf_ctx  Stack-internal buffer context. Must be used to release
- *                      the buffer space using @ref sock_recv_buf_free() after
- *                      the data in @p data was handled.
+ * @param[in,out] buf_ctx   Stack-internal buffer context. If it points to a
+ *                      `NULL` pointer, the stack returns a new buffer space for
+ *                      a new packet. If it does not point to a `NULL` pointer,
+ *                      an existing context is assumed to get a next segment in
+ *                      a buffer.
  * @param[in] timeout   Receive timeout in microseconds.
  *                      If 0 and no data is available, the function returns
  *                      immediately.
@@ -626,7 +628,13 @@ ssize_t sock_dtls_recv(sock_dtls_t *sock, sock_dtls_session_t *remote,
  *
  * @note Function may block if data is not available and @p timeout != 0
  *
- * @return The number of bytes received on success
+ * @note    Function blocks if no packet is currently waiting.
+ *
+ * @return  The number of bytes received on success. May not be the complete
+ *          payload. Continue calling with the returned @p buf_ctx to get more
+ *          buffers until result is 0 or an error.
+ * @return  0, if no received data is available, but everything is in order.
+ *          If @p buf_ctx was provided, it was released.
  * @return  -EADDRNOTAVAIL, if the local endpoint of @p sock is not set.
  * @return  -EAGAIN, if @p timeout is `0` and no data is available.
  * @return  -EINVAL, if @p remote is invalid or @p sock is not properly

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -626,6 +626,10 @@ ssize_t sock_dtls_recv(sock_dtls_t *sock, sock_dtls_session_t *remote,
  *                      May be SOCK_NO_TIMEOUT to wait until data
  *                      is available.
  *
+ * @experimental    This function is quite new, not implemented for all stacks
+ *                  yet, and may be subject to sudden API changes. Do not use in
+ *                  production if this is unacceptable.
+ *
  * @note Function may block if data is not available and @p timeout != 0
  *
  * @note    Function blocks if no packet is currently waiting.

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -448,6 +448,10 @@ ssize_t sock_ip_recv(sock_ip_t *sock, void *data, size_t max_len,
  * @param[out] remote   Remote end point of the received data.
  *                      May be NULL, if it is not required by the application.
  *
+ * @experimental    This function is quite new, not implemented for all stacks
+ *                  yet, and may be subject to sudden API changes. Do not use in
+ *                  production if this is unacceptable.
+ *
  * @note    Function blocks if no packet is currently waiting.
  *
  * @return  The number of bytes received on success. May not be the complete

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -435,9 +435,11 @@ ssize_t sock_ip_recv(sock_ip_t *sock, void *data, size_t max_len,
  * @param[in] sock      A raw IPv4/IPv6 sock object.
  * @param[out] data     Pointer to a stack-internal buffer space containing the
  *                      received data.
- * @param[out] buf_ctx  Stack-internal buffer context. Must be used to release
- *                      the buffer space using @ref sock_recv_buf_free() after
- *                      the data in @p data was handled.
+ * @param[in,out] buf_ctx  Stack-internal buffer context. If it points to a
+ *                      `NULL` pointer, the stack returns a new buffer space
+ *                      for a new packet. If it does not point to a `NULL`
+ *                      pointer, an existing context is assumed to get a next
+ *                      segment in a buffer.
  * @param[in] timeout   Timeout for receive in microseconds.
  *                      If 0 and no data is available, the function returns
  *                      immediately.
@@ -448,8 +450,11 @@ ssize_t sock_ip_recv(sock_ip_t *sock, void *data, size_t max_len,
  *
  * @note    Function blocks if no packet is currently waiting.
  *
- * @return  The number of bytes received on success.
+ * @return  The number of bytes received on success. May not be the complete
+ *          payload. Continue calling with the returned `buf_ctx` to get more
+ *          buffers until result is 0 or an error.
  * @return  0, if no received data is available, but everything is in order.
+ *          If @p buf_ctx was provided, it was released.
  * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
  * @return  -EAGAIN, if @p timeout is `0` and no data is available.
  * @return  -EINVAL, if @p remote is invalid or @p sock is not properly

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -435,6 +435,10 @@ ssize_t sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len,
  * @param[out] remote   Remote end point of the received data.
  *                      May be `NULL`, if it is not required by the application.
  *
+ * @experimental    This function is quite new, not implemented for all stacks
+ *                  yet, and may be subject to sudden API changes. Do not use in
+ *                  production if this is unacceptable.
+ *
  * @note    Function blocks if no packet is currently waiting.
  *
  * @return  The number of bytes received on success. May not be the complete

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -422,9 +422,11 @@ ssize_t sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len,
  * @param[in] sock      A UDP sock object.
  * @param[out] data     Pointer to a stack-internal buffer space containing the
  *                      received data.
- * @param[out] buf_ctx  Stack-internal buffer context. Must be used to release
- *                      the buffer space using @ref sock_recv_buf_free() after
- *                      the data in @p data was handled.
+ * @param[in,out] buf_ctx  Stack-internal buffer context. If it points to a
+ *                      `NULL` pointer, the stack returns a new buffer space
+ *                      for a new packet. If it does not point to a `NULL`
+ *                      pointer, an existing context is assumed to get a next
+ *                      segment in a buffer.
  * @param[in] timeout   Timeout for receive in microseconds.
  *                      If 0 and no data is available, the function returns
  *                      immediately.
@@ -435,8 +437,11 @@ ssize_t sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len,
  *
  * @note    Function blocks if no packet is currently waiting.
  *
- * @return  The number of bytes received on success.
+ * @return  The number of bytes received on success. May not be the complete
+ *          payload. Continue calling with the returned `buf_ctx` to get more
+ *          buffers until result is 0 or an error.
  * @return  0, if no received data is available, but everything is in order.
+ *          If @p buf_ctx was provided, it was released.
  * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
  * @return  -EAGAIN, if @p timeout is `0` and no data is available.
  * @return  -EINVAL, if @p remote is invalid or @p sock is not properly

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -45,13 +45,6 @@ static void _callback_put(void *arg)
 }
 #endif
 
-void sock_recv_buf_free(void *buf_ctx)
-{
-    if (buf_ctx) {
-        gnrc_pktbuf_release(buf_ctx);
-    }
-}
-
 #ifdef SOCK_HAS_ASYNC
 static void _netapi_cb(uint16_t cmd, gnrc_pktsnip_t *pkt, void *ctx)
 {

--- a/tests/gnrc_sock_ip/main.c
+++ b/tests/gnrc_sock_ip/main.c
@@ -360,7 +360,9 @@ static void test_sock_ip_recv_buf__success(void)
                                               NULL));
     assert(data != NULL);
     assert(ctx != NULL);
-    sock_recv_buf_free(ctx);
+    assert(0 == sock_ip_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
+    assert(data == NULL);
+    assert(ctx == NULL);
     assert(_check_net());
 }
 

--- a/tests/gnrc_sock_udp/main.c
+++ b/tests/gnrc_sock_udp/main.c
@@ -441,7 +441,9 @@ static void test_sock_udp_recv_buf__success(void)
                                                SOCK_NO_TIMEOUT, NULL));
     assert(data != NULL);
     assert(ctx != NULL);
-    sock_recv_buf_free(ctx);
+    assert(0 == sock_udp_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
+    assert(data == NULL);
+    assert(ctx == NULL);
     assert(_check_net());
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
With lwIP we have a chunked UDP payload, so just providing the stack-internal buffer is not possible. To be able to iterate over such a chunked payload, this change allows the `sock_*_recv_buf()` functions to use the internal buffer context as an iteration state. Since the newly required handling of the context requires an iteration anyways, `sock_recv_buf_free()` becomes unnecessary.

As this function is still experimental (I piggy-backed the badge for that) this API change only should require 1 ACK.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Read the doc and

```sh
for test in tests/gnrc_sock_{ip,udp}; do
    make -C ${test} flash test
done
```

should still pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Needed for #13701.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
