### PR TITLE
drivers/include/hdc1000.h : Compile Configs

### DIFF
--- a/drivers/include/hdc1000.h
+++ b/drivers/include/hdc1000.h
@@ -50,9 +50,17 @@
 extern "C"
 {
 #endif
+/**
+ * @defgroup drivers_hdc1000_config     HDC1000 Humidity and Temperature Sensor driver compile configuration
+ * @ingroup config
+ * @{
+ */
 
 /**
  * @brief   Default I2C bus address of HDC1000 devices
+ *
+ * The address value depends on the state of ADR0 and ADR1 Pin
+ * For more details refer Section 8.5.1 of datasheet
  */
 #ifndef HDC1000_I2C_ADDRESS
 #define HDC1000_I2C_ADDRESS           (0x43)
@@ -68,6 +76,7 @@ extern "C"
 #ifndef HDC1000_CONVERSION_TIME
 #define HDC1000_CONVERSION_TIME       (26000)
 #endif
+/** @} */
 
 /**
  * @brief   HDC1000 specific return values


### PR DESCRIPTION
### Contribution description

Identify Compile Time Parameters in drivers/include/hdc1000.h header and expose it,

### Testing procedure

Doxygen build works fine.

### Issues/PRs references

#10566
