### PR TITLE
gnrc/ipv6: Group IPv6 related Kconfig files

### DIFF
--- a/sys/net/gnrc/Kconfig
+++ b/sys/net/gnrc/Kconfig
@@ -11,10 +11,6 @@ rsource "application_layer/dhcpv6/Kconfig"
 rsource "link_layer/lorawan/Kconfig"
 rsource "netif/Kconfig"
 rsource "network_layer/ipv6/Kconfig"
-rsource "network_layer/ipv6/blacklist/Kconfig"
-rsource "network_layer/ipv6/ext/frag/Kconfig"
-rsource "network_layer/ipv6/nib/Kconfig"
-rsource "network_layer/ipv6/whitelist/Kconfig"
 rsource "network_layer/sixlowpan/Kconfig"
 
 endmenu # GNRC Network Stack

--- a/sys/net/gnrc/network_layer/ipv6/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/Kconfig
@@ -4,6 +4,8 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 #
+menu "IPv6"
+
 menuconfig KCONFIG_MODULE_GNRC_IPV6
     bool "Configure GNRC IPv6 module"
     depends on MODULE_GNRC_IPV6
@@ -17,3 +19,10 @@ config GNRC_IPV6_MSG_QUEUE_SIZE
     default 8
 
 endif # KCONFIG_MODULE_GNRC_IPV6
+
+rsource "blacklist/Kconfig"
+rsource "ext/frag/Kconfig"
+rsource "nib/Kconfig"
+rsource "whitelist/Kconfig"
+
+endmenu # IPv6


### PR DESCRIPTION
### Contribution description
As [suggested](https://github.com/RIOT-OS/RIOT/pull/13626#discussion_r400098329) in #13626, this groups all GNRC IPv6-related `rsource` in the IPv6 Kconfig file, and creates a menu for them.

### Testing procedure
Run `make menuconfig` on a networking application, configuration options should show up inside the "IPv6" menu. To see all use `show-all` mode, by pressing `a`.

### Issues/PRs references
Proposed in #13626 