### PR TITLE
cpu/samd5x: work around errata when (re-)initializing DFLL

### DIFF
--- a/cpu/samd5x/cpu.c
+++ b/cpu/samd5x/cpu.c
@@ -64,9 +64,14 @@ static void dfll_init(void)
 #endif
     ;
 
-    OSCCTRL->DFLLCTRLB.reg = reg;
-    OSCCTRL->DFLLCTRLA.reg = OSCCTRL_DFLLCTRLA_ENABLE;
+    /* workaround for Errata 2.8.3 DFLLVAL.FINE Value When DFLL48M Re-enabled */
+    OSCCTRL->DFLLMUL.reg   = 0;   /* Write new DFLLMULL configuration */
+    OSCCTRL->DFLLCTRLB.reg = 0;   /* Select Open loop configuration */
+    OSCCTRL->DFLLCTRLA.bit.ENABLE = 1; /* Enable DFLL */
+    OSCCTRL->DFLLVAL.reg   = OSCCTRL->DFLLVAL.reg; /* Reload DFLLVAL register */
+    OSCCTRL->DFLLCTRLB.reg = reg; /* Write final DFLL configuration */
 
+    OSCCTRL->DFLLCTRLA.reg = OSCCTRL_DFLLCTRLA_ENABLE;
     while (!OSCCTRL->STATUS.bit.DFLLRDY) {}
 }
 
@@ -152,8 +157,12 @@ void cpu_pm_cb_enter(int deep)
 
 void cpu_pm_cb_leave(int deep)
 {
-    (void) deep;
     /* will be called after wake-up */
+
+    if (deep) {
+        /* DFLL needs to be re-initialized to work around errata 2.8.3 */
+        dfll_init();
+    }
 }
 
 /**


### PR DESCRIPTION


### Contribution description

When a previously disabled DFLL gets enabled again, the frequency will be incorrect.
Follow the procedure outlined in the errata sheet, section 2.8.3 to work around the issue.

This fixes wake from standby.


### Testing procedure

Run `tests/periph_pm` on `same54-xpro`:

    unblock_rtc 2 5

The CPU should wake-up and UART output should work again after 5s.
This is broken on `master`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
