### PR TITLE
drivers: Add compile configurations groups and add parameters

### DIFF
--- a/cpu/nrf52/include/nrf802154.h
+++ b/cpu/nrf52/include/nrf802154.h
@@ -45,7 +45,7 @@ extern "C" {
 /**
  * @defgroup drivers_nrf52_802154_conf  nrf802154 driver compile configuration
  * @ingroup drivers_nrf52_802154
- * @ingroup config
+ * @ingroup config_drivers_netdev
  * @{
  */
 

--- a/drivers/adcxx1c/include/adcxx1c_params.h
+++ b/drivers/adcxx1c/include/adcxx1c_params.h
@@ -29,9 +29,9 @@ extern "C" {
 #endif
 
 /**
- * @defgroup drivers_adcxx1c_conf   ADCXX1C driver compile configurations
+ * @defgroup drivers_adcxx1c_config   ADCXX1C driver compile configurations
  * @ingroup drivers_adcxx1c
- * @ingroup config
+ * @ingroup config_drivers_sensors
  * @{
  */
 

--- a/drivers/doc.txt
+++ b/drivers/doc.txt
@@ -72,3 +72,47 @@
  * @brief       Drivers for different kinds of devices that do not match any
  *              other category
  */
+
+/**
+ * @defgroup    config_drivers_netdev Network Device Configurations
+ * @ingroup     config
+ * @brief       Compile time configurations for external network devices
+ */
+
+/**
+ * @defgroup    config_drivers_sensors Sensor Device Configurations
+ * @ingroup     config
+ * @brief       Compile time configurations for Sensors
+ */
+
+/**
+ * @defgroup    config_drivers_actuators Actuator Device Configurations
+ * @ingroup     config
+ * @brief       Compile time configurations for actuating devices
+ */
+
+/**
+ * @defgroup    config_drivers_storage Storage Device Configurations
+ * @ingroup     config
+ * @brief       Compile time configurations for storage devices
+ */
+
+ /**
+ * @defgroup    config_drivers_display Display Device Configurations
+ * @ingroup     config
+ * @brief       Compile time configurations for display devices
+ */
+
+/**
+ * @defgroup    config_drivers_soft_periph Soft Peripheral Configurations
+ * @ingroup     config
+ * @brief       Compile time configurations for Software emulated
+ *              @ref drivers_periph for UART, SPI, etc
+ */
+
+/**
+ * @defgroup    config_drivers_misc Miscellaneous Device Configurations
+ * @ingroup     config
+ * @brief       Compile time configurations for different kinds of
+ *              devices that do not match any other category
+ */

--- a/drivers/include/ads101x.h
+++ b/drivers/include/ads101x.h
@@ -40,7 +40,7 @@ extern "C" {
 
 /**
  * @defgroup drivers_ads101x_config    ADS101 driver compile configuration
- * @ingroup config
+ * @ingroup config_drivers_sensors
  * @{
  */
 

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -47,10 +47,9 @@ extern "C" {
 
 /**
  * @defgroup drivers_at_config     AT driver compile configuration
- * @ingroup config
+ * @ingroup config_drivers_misc
  * @{
  */
-
 /**
  * @brief End of line character to send after the AT command.
  */

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -63,7 +63,7 @@ typedef void (*at86rf215_batmon_cb_t)(void *arg);
 
 /**
  * @defgroup drivers_at86rf215_config     AT86RF215 driver compile configuration
- * @ingroup config
+ * @ingroup config_drivers_netdev
  * @{
  */
 /**

--- a/drivers/include/dose.h
+++ b/drivers/include/dose.h
@@ -126,10 +126,9 @@ typedef enum {
 
 /**
  * @defgroup drivers_dose_config    Differentially Operated Serial Ethernet (DOSE) driver compile configuration
- * @ingroup config
+ * @ingroup config_drivers_netdev
  * @{
  */
-
 /**
  * @brief Timeout that brings the driver back into idle state.
  *

--- a/drivers/include/ds1307.h
+++ b/drivers/include/ds1307.h
@@ -40,7 +40,7 @@ extern "C" {
 
 /**
  * @defgroup drivers_ds1307_config   DS1307 RTC driver compile configuration
- * @ingroup config
+ * @ingroup config_drivers_sensors
  * @{
  */
 

--- a/drivers/include/ethos.h
+++ b/drivers/include/ethos.h
@@ -28,20 +28,34 @@
 #include "net/netdev.h"
 #include "tsrb.h"
 #include "mutex.h"
+#include "kernel_defines.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* if using ethos + stdio, use STDIO_UART values unless overridden */
-#ifdef MODULE_STDIO_ETHOS
+#if IS_USED(MODULE_STDIO_ETHOS) || defined(DOXYGEN)
 #include "stdio_uart.h"
+/**
+ * @defgroup drivers_ethos_config     Ethernet-over-serial driver driver compile configuration
+ * @ingroup config_drivers_netdev
+ * @{
+ */
+/**
+ * @brief Set the default UART Interface.
+ */
 #ifndef ETHOS_UART
 #define ETHOS_UART     STDIO_UART_DEV
 #endif
+
+/**
+ * @brief Set the default baudrate.
+ */
 #ifndef ETHOS_BAUDRATE
 #define ETHOS_BAUDRATE STDIO_UART_BAUDRATE
 #endif
+/** @} */
 #endif
 
 /**

--- a/drivers/include/fxos8700.h
+++ b/drivers/include/fxos8700.h
@@ -38,10 +38,9 @@ extern "C" {
 
 /**
  * @defgroup drivers_fxos8700_config     FXOS8700 accelerometer/magnetometer driver compile configuration
- * @ingroup config
+ * @ingroup config_drivers_sensors
  * @{
  */
-
 /**
  * @brief   Default raw value mode for accelerator
  *
@@ -52,6 +51,7 @@ extern "C" {
 #define FXOS8700_USE_ACC_RAW_VALUES (0)
 #endif
 /** @} */
+
 /**
  * @brief   FXOS8700 specific return values
  */

--- a/drivers/include/hdc1000.h
+++ b/drivers/include/hdc1000.h
@@ -52,7 +52,15 @@ extern "C"
 #endif
 
 /**
+ * @defgroup drivers_hdc1000_config     HDC1000 Humidity and Temperature Sensor driver compile configuration
+ * @ingroup config_drivers_sensors
+ * @{
+ */
+/**
  * @brief   Default I2C bus address of HDC1000 devices
+ *
+ * The address value depends on the state of ADR0 and ADR1 Pins
+ * For more details refer Section 8.5.1 of datasheet
  */
 #ifndef HDC1000_I2C_ADDRESS
 #define HDC1000_I2C_ADDRESS           (0x43)
@@ -68,6 +76,7 @@ extern "C"
 #ifndef HDC1000_CONVERSION_TIME
 #define HDC1000_CONVERSION_TIME       (26000)
 #endif
+/** @} */
 
 /**
  * @brief   HDC1000 specific return values

--- a/drivers/include/ili9341.h
+++ b/drivers/include/ili9341.h
@@ -44,43 +44,48 @@
 extern "C" {
 #endif
 
-#ifndef ILI9341_GVDD
 /**
- * @brief ili9341 gvdd level.
+ * @defgroup drivers_ili9341_config     ILI9341 display driver compile configuration
+ * @ingroup config_drivers_display
+ * @{
+ */
+/**
+ * @brief ILI9341 gvdd level.
  *
  * Default GVDD voltage of 4.8V
  */
+#ifndef ILI9341_GVDD
 #define ILI9341_GVDD    4800
+#endif
 
-#endif /* ILI9341_GVDD */
-
-#ifndef ILI9341_VCOMH
 /**
- * @brief ili9341 VCOMH voltage level.
+ * @brief ILI9341 VCOMH voltage level.
  *
  * Default VCOMH voltage of 4.25V
  */
+#ifndef ILI9341_VCOMH
 #define ILI9341_VCOMH   4250
+#endif
 
-#endif /* ILI9341_VCOMH */
-
-#ifndef ILI9341_VCOML
 /**
- * @brief ili9341 VCOML voltage level.
+ * @brief ILI9341 VCOML voltage level.
  *
  * Default VCOMH voltage of -2V
  */
+#ifndef ILI9341_VCOML
 #define ILI9341_VCOML   -2000
+#endif
 
-#endif /* ILI9341_VCOML */
-
-#ifndef ILI9341_LE_MODE
 /**
- * @brief Compile time switch to change the driver to convert little endian
- *        colors to big endian.
+ * @brief Convert little endian colors to big endian.
+ *
+ * Compile time switch to change the driver to convert little endian
+ * colors to big endian.
  */
+#ifndef ILI9341_LE_MODE
 #define ILI9341_LE_MODE     (0)
 #endif
+/** @} */
 
 /**
  * @brief   Device initialization parameters

--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -43,9 +43,12 @@ extern "C" {
 #define KW2XRF_MAX_PKT_LENGTH           (IEEE802154_FRAME_LEN_MAX)
 
 /**
- * @name    Default channel used after initialization
- *
+ * @defgroup drivers_kw2xrf_config     CR20A and KW2xD radio driver compile configuration
+ * @ingroup config_drivers_netdev
  * @{
+ */
+/**
+ * @brief Default channel used after initialization.
  */
 #ifndef KW2XRF_DEFAULT_CHANNEL
 #define KW2XRF_DEFAULT_CHANNEL          (CONFIG_IEEE802154_DEFAULT_CHANNEL)

--- a/drivers/include/kw41zrf.h
+++ b/drivers/include/kw41zrf.h
@@ -39,29 +39,26 @@ extern "C" {
 #define KW41ZRF_MAX_PKT_LENGTH           (IEEE802154_FRAME_LEN_MAX)
 
 /**
- * @brief   Default channel used after initialization
- *
+ * @defgroup drivers_kw41zrf_config     KW41Z, KW21Z in-cpu transceiver driver compile configuration
+ * @ingroup config_drivers_netdev
  * @{
+ */
+/**
+ * @brief   Default channel used after initialization
  */
 #ifndef KW41ZRF_DEFAULT_CHANNEL
 #define KW41ZRF_DEFAULT_CHANNEL          (CONFIG_IEEE802154_DEFAULT_CHANNEL)
 #endif
-/** @} */
 
 /**
  * @brief   Default CCA threshold
- *
- * @{
  */
 #ifndef KW41ZRF_DEFAULT_CCA_THRESHOLD
 #define KW41ZRF_DEFAULT_CCA_THRESHOLD    (-60)
 #endif
-/** @} */
 
 /**
  * @brief   Default LQI compensation
- *
- * @{
  */
 #ifndef KW41ZRF_DEFAULT_LQI_COMPENSATION
 #define KW41ZRF_DEFAULT_LQI_COMPENSATION (102)

--- a/drivers/include/mag3110.h
+++ b/drivers/include/mag3110.h
@@ -54,9 +54,21 @@ enum {
     MAG3110_ERROR_CNF,          /**< Device configuration failed */
 };
 
+/**
+ * @defgroup drivers_mag3110_config     MAG3110 Magnetometer driver compile configuration
+ * @ingroup config_drivers_sensors
+ * @{
+ */
+/**
+ * @brief Magnetometer default address
+ *
+ * The address depends on part number of MAG3110.
+ * For more information on SerialBus Address, refer Table 1 in Technical datasheet(MAG3110).
+ */
 #ifndef MAG3110_I2C_ADDRESS
-#define MAG3110_I2C_ADDRESS             0x0E /**< Magnetometer Default Address */
+#define MAG3110_I2C_ADDRESS             0x0E
 #endif
+/** @} */
 
 /**
  * @name    Output data rate macros

--- a/drivers/include/mma8x5x.h
+++ b/drivers/include/mma8x5x.h
@@ -40,9 +40,21 @@
 extern "C" {
 #endif
 
+/**
+ * @defgroup drivers_mma8x5x_config     MMA8x5x Accelerometer driver compile configuration
+ * @ingroup config_drivers_sensors
+ * @{
+ */
+/**
+ * @brief   Accelerometer Default Address
+ *
+ * The address value depends on the state of SA0 Address Pin in the case of MMA845x series.
+ * For more details refer Table 1 in datasheet (MMA8451Q/MMA8452Q/MMA8453Q)
+ */
 #ifndef MMA8X5X_I2C_ADDRESS
-#define MMA8X5X_I2C_ADDRESS           0x1D /**< Accelerometer Default Address */
+#define MMA8X5X_I2C_ADDRESS           0x1D
 #endif
+/** @} */
 
 /**
  * @brief   Devices supported by this driver

--- a/drivers/include/motor_driver.h
+++ b/drivers/include/motor_driver.h
@@ -92,11 +92,17 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup drivers_motor_driver_config     Motor_Driver driver compile configuration
+ * @ingroup config_drivers_actuators
+ * @{
+ */
+/**
  * @brief Maximum number of motors by motor driver
  */
 #ifndef MOTOR_DRIVER_MAX
 #define MOTOR_DRIVER_MAX    (2)
-#endif /* MOTOR_DRIVER_MAX */
+#endif
+/** @} */
 
 /**
  * @brief Macro to return motor driver id

--- a/drivers/include/mpl3115a2.h
+++ b/drivers/include/mpl3115a2.h
@@ -74,14 +74,20 @@ enum {
 #define MPL3115A2_OS_RATIO_DEFAULT  MPL3115A2_OS_RATIO_16 /**< Default Ratio */
 /** @} */
 
-#ifndef MPL3115A2_CONVERSION_TIME
+/**
+ * @defgroup drivers_mpl3115a2_config     MPL3115A2 Pressure Sensor driver compile configuration
+ * @ingroup config_drivers_sensors
+ * @{
+ */
 /**
  * @brief   Maximum Conversion Time in microseconds [us]
  *
  * @note    Conversion time is: ((oversampling ratio * 4) + 2) * 1000 us
  */
+#ifndef MPL3115A2_CONVERSION_TIME
 #define MPL3115A2_CONVERSION_TIME   (514000UL)
 #endif
+/** @} */
 
 /**
  * @brief   Configuration parameters

--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -118,7 +118,7 @@ extern "C" {
 /**
  * @defgroup drivers_mrf24j40_config     mrf24j40 driver compile configuration
  * @ingroup drivers_mrf24j40
- * @ingroup config
+ * @ingroup config_drivers_netdev
  * @{
  */
 

--- a/drivers/include/mtd_sdcard.h
+++ b/drivers/include/mtd_sdcard.h
@@ -43,16 +43,23 @@ typedef struct {
     const sdcard_spi_params_t *params; /**< params for sdcard_spi init */
 } mtd_sdcard_t;
 
-
 /**
- * @brief   sdcards handle sector erase internally so it's possible to directly
- *          write to the card without erasing the sector first.
- *          Attention: an erase call will therefore NOT touch the content,
- *                     so disable this feature to ensure overriding the data.
+ * @defgroup drivers_mtd_sdcard_config     SDCard driver compile configuration
+ * @ingroup config_drivers_storage
+ * @{
+ */
+/**
+ * @brief   Enable Skip SDCard Erase
+ * @note    SDCards handle sector erase internally so it's
+ * possible to directly write to the card without erasing
+ * the sector first.
+ * Attention: an erase call will therefore NOT touch the content,
+ * so disable this feature to ensure overriding the data.
  */
 #ifndef MTD_SDCARD_SKIP_ERASE
 #define MTD_SDCARD_SKIP_ERASE (1)
 #endif
+/** @} */
 
 /**
  * @brief   sdcard device operations table for mtd

--- a/drivers/include/opt3001.h
+++ b/drivers/include/opt3001.h
@@ -49,14 +49,6 @@
 extern "C" {
 #endif
 
-/**
- * @brief   OPT3001 Default Address
- *
- * If set to 0x44 the corresponding ADDR PIN is GND.
- */
-#ifndef OPT3001_I2C_ADDRESS
-#define OPT3001_I2C_ADDRESS   (0x45)
-#endif
 
 /**
  * @name    Conversion time
@@ -67,6 +59,21 @@ extern "C" {
 /** @} */
 
 /**
+ * @defgroup drivers_opt3001_config    OPT3001 Ambient Light Sensor driver compile configuration
+ * @ingroup config_drivers_sensors
+ * @{
+ */
+/**
+ * @brief   OPT3001 Default Address
+ *
+ * If set to 0x45 the ADDR PIN should be connected to VDD.
+ * For more information on SerialBus Address, refer section 7.3.4.1 in datasheet.
+ */
+#ifndef OPT3001_I2C_ADDRESS
+#define OPT3001_I2C_ADDRESS   (0x45)
+#endif
+
+/**
  * @brief   OPT3001 Default conversion time
  *
  * If set to 0x0000, the conversion time will be 100ms.
@@ -75,6 +82,7 @@ extern "C" {
 #ifndef OPT3001_CONVERSION_TIME
 #define OPT3001_CONVERSION_TIME   OPT3001_CONVERSION_TIME_800_MS
 #endif
+/** @} */
 
 /**
  * @brief   Parameters needed for device initialization

--- a/drivers/include/pir.h
+++ b/drivers/include/pir.h
@@ -62,11 +62,17 @@ typedef struct {
 } pir_t;
 
 /**
- * @brief   value to configure sensitivity of sensore
+ * @defgroup drivers_pir_config     PIR Motion Sensor driver compile configuration
+ * @ingroup config_drivers_sensors
+ * @{
+ */
+/**
+ * @brief   Sensitivity of sensor
  */
 #ifndef PIR_MSG_T_STATUS_START
 #define PIR_MSG_T_STATUS_START 150
 #endif
+/** @} */
 
 /**
  * @brief   event type for a PIR sensor

--- a/drivers/include/pn532.h
+++ b/drivers/include/pn532.h
@@ -73,15 +73,21 @@ typedef struct {
 } pn532_t;
 
 /**
+ * @defgroup drivers_pn532_config     PN532 NFC Radio driver compile configuration
+ * @ingroup config_drivers_netdev
+ * @{
+ */
+/**
  * @brief   Internal buffer size
  *
- * A small buffer size is enough for most applications, however if large NDEF
+ * @note A small buffer size is enough for most applications, however if large NDEF
  * files are to be written this size shall be increased. Otherwise the files
  * can be written in chunks.
  */
 #ifndef PN532_BUFFER_LEN
 #define PN532_BUFFER_LEN     (64)
 #endif
+/** @} */
 
 /**
  * @name    Helpers to extract firmware information from word

--- a/drivers/include/rn2xx3.h
+++ b/drivers/include/rn2xx3.h
@@ -57,11 +57,17 @@ extern "C" {
 #define RN2XX3_SLEEP_MIN                (100U)
 
 /**
+ * @defgroup drivers_rn2xx3_config     RN2483/RN2903 Radio driver compile configuration
+ * @ingroup config_drivers_netdev
+ * @{
+ */
+/**
  * @brief   Default sleep duration (in ms)
  */
 #ifndef RN2XX3_DEFAULT_SLEEP
 #define RN2XX3_DEFAULT_SLEEP            (5000U)
 #endif
+/** @} */
 
 #if defined(MODULE_RN2903)
 #define RN2XX3_FREQ_BAND                (915U)

--- a/drivers/include/slipdev.h
+++ b/drivers/include/slipdev.h
@@ -33,6 +33,11 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup drivers_slipdev_config     SLIP Network driver compile configuration
+ * @ingroup config_drivers_netdev
+ * @{
+ */
+/**
  * @brief   UART buffer size used for TX and RX buffers
  *
  * Reduce this value if your expected traffic does not include full IPv6 MTU
@@ -43,6 +48,7 @@ extern "C" {
 #ifndef SLIPDEV_BUFSIZE
 #define SLIPDEV_BUFSIZE (2048U)
 #endif
+/** @} */
 
 /**
  * @name    Device state definitions

--- a/drivers/include/soft_spi.h
+++ b/drivers/include/soft_spi.h
@@ -37,6 +37,11 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup drivers_softspi_config      Software SPI driver compile configuration
+ * @ingroup config_drivers_soft_periph
+ * @{
+ */
+/**
  * @brief   Default SPI device access macro
  */
 #ifndef SOFT_SPI_DEV
@@ -56,6 +61,7 @@ extern "C" {
 #ifndef SOFT_SPI_CS_UNDEF
 #define SOFT_SPI_CS_UNDEF    (GPIO_UNDEF)
 #endif
+/** @} */
 
 /**
  * @brief   Default type for SPI devices

--- a/drivers/include/sps30.h
+++ b/drivers/include/sps30.h
@@ -128,6 +128,11 @@ typedef enum {
 #define SPS30_DEFAULT_ACI_S  (604800UL)
 
 /**
+ * @defgroup drivers_SPS30_config     SPS30 PM Sensor driver compile configuration
+ * @ingroup config_drivers_sensors
+ * @{
+ */
+/**
  * @brief     Maximum number of automatic retries on communication errors
  *
  * @details   If no delays happen between individual requests to the sensor, it
@@ -142,6 +147,7 @@ typedef enum {
 #ifndef SPS30_ERROR_RETRY
 #define SPS30_ERROR_RETRY    (500U)
 #endif
+/** @} */
 
 /**
  * @brief       Initialize SPS30 sensor driver.

--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -96,12 +96,11 @@ extern "C" {
 
 /**
  * @defgroup drivers_sx127x_config     Semtech SX1272 and SX1276 driver compile configuration
- * @ingroup config
+ * @ingroup config_drivers_netdev
  * @{
  */
-
 /**
- * @brief GPIO mode of DIOx Pins.
+ * @brief   GPIO mode of DIOx Pins.
  */
 #ifndef SX127X_DIO_PULL_MODE
 #define SX127X_DIO_PULL_MODE             (GPIO_IN_PD)

--- a/drivers/include/tcs37727.h
+++ b/drivers/include/tcs37727.h
@@ -40,9 +40,18 @@ extern "C"
 #define TCS37727_I2C_ADDRESS    0x29    /**< Default Device Address */
 #endif
 
+/**
+ * @defgroup drivers_tcs37727_config     TCS37727 RGB Light Sensor driver compile configuration
+ * @ingroup config_drivers_sensors
+ * @{
+ */
+/**
+ * @brief   Default RGBC integration time.
+ */
 #ifndef TCS37727_ATIME_DEFAULT
-#define TCS37727_ATIME_DEFAULT  200000  /**< Default RGBC integration time */
+#define TCS37727_ATIME_DEFAULT  200000
 #endif
+/** @} */
 
 /**
  * @brief   Struct for storing TCS37727 sensor data

--- a/drivers/include/tmp00x.h
+++ b/drivers/include/tmp00x.h
@@ -93,7 +93,15 @@ extern "C"
 #define ADDR                        (dev->p.addr) /**< ADDR */
 
 /**
- * @brief   TMP00X Default Address
+ * @defgroup drivers_tmp00x_config     TMP006/TMP007 Infrared Thermopile Sensor driver compile configuration
+ * @ingroup config_drivers_sensors
+ * @{
+ */
+/**
+ * @brief   Default Address
+ *
+ * I2C Address depends on the state of ADR0 and ADR1 Pins
+ * For more information, please refer to section 7.3.6.2 of TMP007 datasheet (SBOS685B).
  */
 #ifndef TMP00X_I2C_ADDRESS
 #define TMP00X_I2C_ADDRESS         (0x40)
@@ -127,6 +135,7 @@ extern "C"
 #ifndef TMP00X_USE_RAW_VALUES
 #define TMP00X_USE_RAW_VALUES (0)
 #endif
+/** @} */
 
 /**
  * @name    Conversion rate and AVG sampling configuration


### PR DESCRIPTION
### Contribution description

1. Create Subgroups in drivers/doc.txt

Identify Compile Time Parameters in  the following drivers 

2. drivers/include/hdc1000.h
3. drivers/include/ili9341.h
4. drivers/include/kw2xrf.h
5. drivers/include/kw41zrf.h
6. drivers/include/mag3110.h
7. drivers/include/motor_driver.h
8. drivers/include/mpl3115a2.h
9. drivers/include/mtd_sdcard.h
10. drivers/include/opt3001.h
11. drivers/include/pir.h
12. drivers/include/pn532.h
13. drivers/include/rn2xx3.h
14. drivers/include/slipdev.h
15. drivers/include/soft_spi.h
16. drivers/include/sps30.h
17. drivers/include/tcs37727.h
18. drivers/include/tmp00x.h

29.drivers/include/mma8x5x.h

Add to subgroups :

19. drivers/include/mrf24j40.h : Add to config_drivers_netdev group
20. drivers/include/sx127x.h : Add to config_drivers_netdev group 
21. drivers/adcxx1c/include/adcxx1c_params.h : Add to config_drivers_sensors group
22. drivers/include/at.h : Add to config_drivers_misc group
23. drivers/include/at86rf215.h : Add to config_drivers_netdev group
24. cpu/nrf52/include/nrf802154.h : Add to config_drivers_netdev group
25. drivers/include/dose.h : Add to config_drivers_netdev group 
26. drivers/include/ds1307.h : Add to config_drivers_sensors group
27. drivers/include/fxos8700.h : Add to config_drivers_sensors group
28. drivers/include/ads101x.h : Add to config_drivers_sensors group

Skipped the following Parameters 

1. drivers/include/ds1307.h-> I2C Address remains constant.
2. drivers/include/hts221.h-> I2C Address remains constant.
3. ~~drivers/include/mma8x5x.h -> I2C Address remains constant.~~
4. drivers/include/mpl3115a2.h  -> I2C Address remains constant.
5. drivers/include/tcs37727.h -> I2C Address remains constant. 
6. drivers/include/tmp00x.h - > Skipped calibration constant

### Testing procedure

Doxygen build works fine.

### Issues/PRs references

#10566 