### PR TITLE
cpu/saml21: enable buck voltage regulator when possible

### DIFF
--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -35,6 +35,12 @@ extern "C" {
 #define CLOCK_CORECLOCK     (48000000U)
 
 /**
+ * @brief Enable the internal DC/DC converter
+ *        The board is equipped with the necessary inductor.
+ */
+#define USE_VREG_BUCK       (1)
+
+/**
  * @name    Timer peripheral configuration
  * @{
  */

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -32,6 +32,12 @@ extern "C" {
 #define CLOCK_CORECLOCK     (48000000U)
 
 /**
+ * @brief Enable the internal DC/DC converter
+ *        The board is equipped with the necessary inductor.
+ */
+#define USE_VREG_BUCK       (1)
+
+/**
  * @name    Timer peripheral configuration
  * @{
  */

--- a/cpu/saml21/periph/pm.c
+++ b/cpu/saml21/periph/pm.c
@@ -26,16 +26,19 @@
 
 void pm_set(unsigned mode)
 {
+    int deep = 0;
     uint32_t _mode;
 
     switch (mode) {
         case 0:
             DEBUG_PUTS("pm_set(): setting BACKUP mode.");
             _mode = PM_SLEEPCFG_SLEEPMODE_BACKUP;
+            deep  = 1;
             break;
         case 1:
             DEBUG_PUTS("pm_set(): setting STANDBY mode.");
             _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
+            deep  = 1;
             break;
         default: /* Falls through */
         case 2:
@@ -53,5 +56,5 @@ void pm_set(unsigned mode)
     /* make sure value has been set */
     while (PM->SLEEPCFG.bit.SLEEPMODE != _mode) {}
 
-    sam0_cortexm_sleep(0);
+    sam0_cortexm_sleep(deep);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Switch from the on-chip LDO to the on-chip buck voltage regulator when no fast internal oscillators are used.

On `saml21-xpro` with `examples/default` this gives

**before:** 750 µA
**after:** 385 µA

with a 12 MHz `CLOCK_CORECLOCK`.

### Testing procedure

Run `test/periph/pm`.
You should still be able to wake up from any sleep mode.

Also try setting `CLOCK_CORECLOCK` to 12 MHz so the buck converter is actually used.


### Issues/PRs references

split from #13441
