### PR TITLE
drivers/at86rf215: return error when switching state while busy

### DIFF
--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -237,7 +237,7 @@ static void _block_while_busy(at86rf215_t *dev)
     gpio_irq_enable(dev->params.int_pin);
 }
 
-void at86rf215_block_while_busy(at86rf215_t *dev)
+static void at86rf215_block_while_busy(at86rf215_t *dev)
 {
     if (_tx_ongoing(dev)) {
         DEBUG("[at86rf215] Block while TXing\n");

--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -206,6 +206,8 @@ static bool _tx_ongoing(at86rf215_t *dev)
         return true;
     }
 
+    /* we can still fill the TX buffer and queue TX
+       when in AT86RF215_STATE_RX_SEND_ACK */
     if (dev->state == AT86RF215_STATE_TX ||
         dev->state == AT86RF215_STATE_TX_WAIT_ACK) {
         return true;

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -52,6 +52,21 @@ const netdev_driver_t at86rf215_driver = {
     .set = _set,
 };
 
+static bool _is_busy(at86rf215_t *dev)
+{
+    if (dev->flags & AT86RF215_OPT_TX_PENDING) {
+        return true;
+    }
+
+    if (dev->state == AT86RF215_STATE_TX ||
+        dev->state == AT86RF215_STATE_TX_WAIT_ACK ||
+        dev->state == AT86RF215_STATE_RX_SEND_ACK) {
+        return true;
+    }
+
+    return false;
+}
+
 /* executed in the GPIO ISR context */
 static void _irq_handler(void *arg)
 {
@@ -175,7 +190,9 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
 static int _set_state(at86rf215_t *dev, netopt_state_t state)
 {
-    at86rf215_block_while_busy(dev);
+    if (_is_busy(dev)) {
+        return -EBUSY;
+    }
 
     switch (state) {
         case NETOPT_STATE_STANDBY:

--- a/drivers/at86rf215/include/at86rf215_internal.h
+++ b/drivers/at86rf215/include/at86rf215_internal.h
@@ -374,13 +374,6 @@ void at86rf215_enable_rpc(at86rf215_t *dev);
 bool at86rf215_switch_mode(at86rf215_t *dev, uint8_t new_mode);
 
 /**
- * @brief Block while the device is busy sending
- *
- * @param[in] dev           device that might be TXing
- */
-void at86rf215_block_while_busy(at86rf215_t *dev);
-
-/**
  * @brief Checks whether the device operates in the sub-GHz band.
  *
  * @param[in] dev   device to read from


### PR DESCRIPTION
### Contribution description

Previously the function attempted to block here and manually service the ISR.
This lead to unexpected results, in particular messages queuing up in the threads message queue.

The result was that the radio would not end up in the correct state.
E.g. sending SLEEP to both interfaces while a transmission was ongoing would lead to the interfaces waking up again.

With this patch the operation will just return `-ERRNO` so the caller can try again.

### Testing procedure

Provided is a patch to `examples/gnrc_networking` that will reliably trigger the issue on master:

<details>
<summary>gnrc_networking.patch</summary>

```patch
diff --git a/examples/gnrc_networking/main.c b/examples/gnrc_networking/main.c
index 6301f4291d..93b96eb939 100644
--- a/examples/gnrc_networking/main.c
+++ b/examples/gnrc_networking/main.c
@@ -23,12 +23,47 @@
 #include "shell.h"
 #include "msg.h"

+#include "periph/pm.h"
+
+#include "net/netopt.h"
+#include "net/gnrc/netif.h"
+
 #define MAIN_QUEUE_SIZE     (8)
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];

 extern int udp_cmd(int argc, char **argv);

+extern void send(char *addr_str, char *port_str, char *data, unsigned int num,
+                 unsigned int delay);
+
+static int send_and_shutdown(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+
+    /* the address must not exist */
+    char addr[] = "fe80::2068:3123:59f5:d238%7";
+    char port[] = "1234";
+    char data[] = "Hello World!";
+
+    send(addr, port, data, 1, 0);
+
+    /* disable radio */
+    gnrc_netif_t* netif = NULL;
+    netopt_state_t state = NETOPT_STATE_SLEEP;
+    while ((netif = gnrc_netif_iter(netif))) {
+        /* retry while busy */
+        while (gnrc_netapi_set(netif->pid, NETOPT_STATE, 0, &state,
+               sizeof(netopt_state_t)) == -EBUSY);
+    }
+
+    pm_set(0);
+
+    return 0;
+}
+
 static const shell_command_t shell_commands[] = {
+    { "shutdown", "turn off the radio & shut down", send_and_shutdown },
     { "udp", "send data over UDP and listen on UDP ports", udp_cmd },
     { NULL, NULL, NULL }
 };
diff --git a/examples/gnrc_networking/udp.c b/examples/gnrc_networking/udp.c
index e8a559846e..cb80855b76 100644
--- a/examples/gnrc_networking/udp.c
+++ b/examples/gnrc_networking/udp.c
@@ -36,7 +36,7 @@ static gnrc_netreg_entry_t server = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX
                                                                KERNEL_PID_UNDEF);

-static void send(char *addr_str, char *port_str, char *data, unsigned int num,
+void send(char *addr_str, char *port_str, char *data, unsigned int num,
                  unsigned int delay)
 {
     gnrc_netif_t *netif = NULL;
```
</details>

The `shutdown` command will send a packet (with ACK request) to a non-existing address, then put the network interfaces to SLEEP and also put the main CPU to SLEEP.

Measure the power consumption.
On `master` you will find that the at86rf215 still consumes ~2.4mA after the 'shutdown' and a wake-up is triggered on both interfaces, putting them in the TRXOFF stete.

With this patch at86rf215 is properly entering (and staying) in DEEP SLEEP, consuming < 1µA.

### Issues/PRs references

Requires  #13750 to fix init after exiting DEEP SLEEP when you restart your board.
