### PR TITLE
sys/uri_parser: check for uri_end instead of 0

### DIFF
--- a/sys/uri_parser/uri_parser.c
+++ b/sys/uri_parser/uri_parser.c
@@ -176,9 +176,10 @@ static char *_consume_path(uri_parser_result_t *result, char *uri,
 static int _parse_relative(uri_parser_result_t *result, char *uri,
                            char *uri_end)
 {
-    /* we expect '\0', i.e., end of string */
     uri = _consume_path(result, uri, uri_end);
-    if (uri[0] != '\0') {
+    /* uri should point to uri_end, otherwise there's something left
+     * to consume ... */
+    if (uri != uri_end) {
         return -1;
     }
 

--- a/tests/unittests/tests-uri_parser/tests-uri_parser.c
+++ b/tests/unittests/tests-uri_parser/tests-uri_parser.c
@@ -303,10 +303,31 @@ static void test_uri_parser__validate(void)
     }
 }
 
+static void test_uri_parser__unterminated_string(void)
+{
+    uri_parser_result_t ures;
+    char uri[64];
+    /* initialize with a non-null character */
+    memset(uri, 'Z', sizeof(uri));
+
+    memcpy(uri, validate_uris[0].uri, strlen(validate_uris[0].uri));
+
+    int res = uri_parser_process(&ures, uri, strlen(validate_uris[0].uri));
+
+    TEST_ASSERT_EQUAL_INT(0, res);
+    VEC_CHECK(scheme, 0, _failure_msg);
+    VEC_CHECK(userinfo, 0, _failure_msg);
+    VEC_CHECK(host, 0, _failure_msg);
+    VEC_CHECK(port, 0, _failure_msg);
+    VEC_CHECK(path, 0, _failure_msg);
+    VEC_CHECK(query, 0, _failure_msg);
+}
+
 Test *tests_uri_parser_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_uri_parser__validate),
+        new_TestFixture(test_uri_parser__unterminated_string),
     };
 
     EMB_UNIT_TESTCALLER(uri_parser_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description
~~Since we also allow the use of non-\0-terminated strings, we have to remove this check here. Otherwise, it returns `-1` for those strings, although parsing was successful.
The check was overcautious anyway.~~

I changed the diff now to check for `uri_end` instead of completely removing it.

### Testing procedure
unittests should still run

### Issues/PRs references
none