### PR TITLE
*/Makefile.dep: remove usage of DEFAULT_MODULE += stdio%

### DIFF
--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -6,9 +6,12 @@ PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-# The following configuration is dependencies specific
-# but they are resolved later
-# Hack to know now if 'nordic_softdevice_ble' is used
+# The following configuration are dependencies specific, specifically they need
+# to know if 'nordic_softdevice_ble' is used. The dependencies are not known
+# because BOARDs Makefile.include are included before Makefile.dep
+# This HACK can be removed either when Makefile.include is included after
+# Makefile.features (see #9913) or if 'nordic_softdevice_ble' is deprecated.
+-include $(APPDIR)/Makefile.board.dep
 include $(RIOTBOARD)/$(BOARD)/Makefile.dep
 
 PROGRAMMER ?= jlink

--- a/boards/feather-nrf52840/Makefile.dep
+++ b/boards/feather-nrf52840/Makefile.dep
@@ -1,7 +1,7 @@
-# Provide stdio over USB by default
-# This is a temporary solution until management of stdio is correctly
-# handled by the build system
-DEFAULT_MODULE += stdio_cdc_acm
+# Use stdio_cdc_acm unless another stdio_% is already used
+ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+  USEMODULE += stdio_cdc_acm
+endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio

--- a/boards/hamilton/Makefile.dep
+++ b/boards/hamilton/Makefile.dep
@@ -13,5 +13,7 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   #USEMODULE += apds9007
 endif
 
-# Use Segger's RTT by default for stdio on this board
-DEFAULT_MODULE += stdio_rtt
+# Use Segger's RTT unless another stdio_% is already used
+ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+  USEMODULE += stdio_rtt
+endif

--- a/boards/pinetime/Makefile.dep
+++ b/boards/pinetime/Makefile.dep
@@ -1,4 +1,7 @@
-DEFAULT_MODULE += stdio_rtt
+# Use Segger's RTT unless another stdio_% is already used
+ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+  USEMODULE += stdio_rtt
+endif
 
 ifneq (,$(filter mtd,$(USEMODULE)))
   USEMODULE += mtd_spi_nor

--- a/boards/ruuvitag/Makefile.dep
+++ b/boards/ruuvitag/Makefile.dep
@@ -4,8 +4,10 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += lis2dh12_spi
 endif
 
-# Use Segger's RTT by default for stdio on this board
-DEFAULT_MODULE += stdio_rtt
+# Use Segger's RTT unless another stdio_% is already used
+ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+  USEMODULE += stdio_rtt
+endif
 
 USEMODULE += boards_common_nrf52xxdk
 

--- a/boards/thingy52/Makefile.dep
+++ b/boards/thingy52/Makefile.dep
@@ -4,7 +4,9 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += lps22hb
 endif
 
-# Use Segger's RTT by default for stdio on this board
-DEFAULT_MODULE += stdio_rtt
+# Use Segger's RTT unless another stdio_% is already used
+ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+  USEMODULE += stdio_rtt
+endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -7,20 +7,6 @@ STDIO_MODULES = \
   stdio_uart \
   #
 
-# Since USEMODULE and DEFAULT_MODULEs are recursively expanded we need to
-# disable DEFAULT_MODULEs before any of there dependencies are evaluated,
-# otherwise the disabled MODULE will be in USEMODULE (triggering) its
-# dependencies, and then removed but leaving its dependencies
-ifneq (,$(filter $(filter-out stdio_rtt,$(STDIO_MODULES)),$(USEMODULE)))
-  # stdio_rtt cannot be used when another STDIO is loaded
-  DISABLE_MODULE += stdio_rtt
-endif
-
-ifneq (,$(filter $(filter-out stdio_cdc_acm,$(STDIO_MODULES)),$(USEMODULE)))
-  # stdio_cdc_acm cannot be used when another STDIO is loaded
-  DISABLE_MODULE += stdio_cdc_acm
-endif
-
 ifneq (,$(filter newlib,$(USEMODULE)))
   ifeq (,$(filter $(STDIO_MODULES),$(USEMODULE)))
     USEMODULE += stdio_uart


### PR DESCRIPTION
### Contribution description

This PR removes all usage of `DEFAULT_MODULE += stdio_%`. When this was added it was to make explicit an implementation choice, from all `stdio_` modules which one to use in an application.
Using `DEFAULT_MODULE` made the "preferred" choice clear, and also allowed for applications or applications requirements to change the preferred one.

This seemed like a good choice at the time because `DEFAULT_MODULE` and the issues with its recursive expansion where not properly understood. This leads to a lot of weird corner cases, comments in #13651 have been in the direction of simply removing that kind of usage. In #13785 I had included a temporal exception for `stdio_` until something like  https://github.com/RIOT-OS/RIOT/issues/13469#issuecomment-607284397_ or as a result of #13469.

But know I think this is already causing more harm than good, because its poorly understood and also causes issues in `info-boards-supported` where recursive expansion of `DEFAULT_MODULE` doesn't happen.

Maybe the declaration of `STDIO_MODULES` can be moved earlier?

PS: @miri64 and @haukepetersen had spoken against this before, but we didn't understand `DEFAULT_MODULE`s issues at the time, there gut feeling seemed to be right.

### Testing procedure

- green murdock (lets see if issues stop popping up :))

- test on `BOARD` that used to declare `DEFAULT_MODULE += stdio_%`

```
BOARD=arduino-mkrfox1200 make -C tests/xtimer_usleep flash
make: Entering directory '/home/francisco/workspace/RIOT2/tests/xtimer_usleep'
Building application "tests_xtimer_usleep" for "arduino-mkrfox1200" with MCU "samd21".

"make" -C /home/francisco/workspace/RIOT2/boards/arduino-mkrfox1200
"make" -C /home/francisco/workspace/RIOT2/boards/common/arduino-mkr
"make" -C /home/francisco/workspace/RIOT2/boards/common/samd21-arduino-bootloader
"make" -C /home/francisco/workspace/RIOT2/core
"make" -C /home/francisco/workspace/RIOT2/cpu/samd21
"make" -C /home/francisco/workspace/RIOT2/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT2/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT2/cpu/sam0_common
"make" -C /home/francisco/workspace/RIOT2/cpu/sam0_common/periph
"make" -C /home/francisco/workspace/RIOT2/cpu/samd21/periph
"make" -C /home/francisco/workspace/RIOT2/drivers
"make" -C /home/francisco/workspace/RIOT2/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT2/sys
"make" -C /home/francisco/workspace/RIOT2/sys/auto_init
"make" -C /home/francisco/workspace/RIOT2/sys/auto_init/usb
"make" -C /home/francisco/workspace/RIOT2/sys/div
"make" -C /home/francisco/workspace/RIOT2/sys/event
"make" -C /home/francisco/workspace/RIOT2/sys/isrpipe
"make" -C /home/francisco/workspace/RIOT2/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT2/sys/pm_layered
"make" -C /home/francisco/workspace/RIOT2/sys/test_utils/interactive_sync
"make" -C /home/francisco/workspace/RIOT2/sys/tsrb
"make" -C /home/francisco/workspace/RIOT2/sys/usb/usbus
"make" -C /home/francisco/workspace/RIOT2/sys/usb/usbus/cdc/acm
"make" -C /home/francisco/workspace/RIOT2/sys/usb_board_reset
"make" -C /home/francisco/workspace/RIOT2/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  17580	    132	   5908	  23620	   5c44	/home/francisco/workspace/RIOT2/tests/xtimer_usleep/bin/arduino-mkrfox1200/tests_xtimer_usleep.elf
stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
sleep 1
/home/francisco/workspace/RIOT2/dist/tools/bossa-1.9/bossac -p /dev/ttyACM0 -o 0x2000 -e -i -w -v -b -R /home/francisco/workspace/RIOT2/tests/xtimer_usleep/bin/arduino-mkrfox1200/tests_xtimer_usleep.bin
Device       : ATSAMD21x18
Version      : v2.0 [Arduino:XYZ] Mar 10 2017 12:20:17
Address      : 0x0
Pages        : 4096
Page Size    : 64 bytes
Total Size   : 256KB
Planes       : 1
Lock Regions : 16
Locked       : none
Security     : false
BOD          : true
BOR          : true
Erase flash

Done in 0.840 seconds
Write 17712 bytes to flash (277 pages)
[==============================] 100% (277/277 pages)
Done in 0.101 seconds
Verify 17712 bytes of flash
[==============================] 100% (277/277 pages)
Verify successful
Done in 0.179 seconds
Set boot flash true

```

The "default" is still excluded when needed to be.

```
BOARD=arduino-mkrfox1200 make -C examples/gnrc_border_router/ info-debug-variable-USEMODULE | grep stdio
auto_init auto_init_gnrc_ipv6 auto_init_gnrc_ipv6_nib auto_init_gnrc_netif auto_init_gnrc_pktbuf auto_init_gnrc_sixlowpan auto_init_gnrc_udp auto_init_gnrc_uhcpc auto_init_random auto_init_xtimer board boards_common_arduino-mkr core core_init core_mbox core_msg core_panic cortexm_common cortexm_common_periph cpu div ethos evtimer fmt gnrc gnrc_icmpv6 gnrc_icmpv6_echo gnrc_ipv6 gnrc_ipv6_hdr gnrc_ipv6_nib gnrc_ipv6_nib_6lbr gnrc_ipv6_nib_6ln gnrc_ipv6_nib_6lr gnrc_ipv6_nib_router gnrc_ipv6_router gnrc_ipv6_router_default gnrc_ndp gnrc_netapi gnrc_netapi_mbox gnrc_netdev_default gnrc_netif gnrc_netif_ethernet gnrc_netif_hdr gnrc_netif_init_devs gnrc_netreg gnrc_pkt gnrc_pktbuf gnrc_pktbuf_static gnrc_sixlowpan gnrc_sixlowpan_border_router_default gnrc_sixlowpan_ctx gnrc_sixlowpan_frag gnrc_sixlowpan_frag_fb gnrc_sixlowpan_frag_rb gnrc_sixlowpan_iphc gnrc_sixlowpan_iphc_nhc gnrc_sixlowpan_nd gnrc_sixlowpan_router gnrc_sock gnrc_sock_udp gnrc_udp gnrc_uhcpc icmpv6 inet_csum iolist ipv6_addr ipv6_hdr isrpipe l2util luid netdev_default netdev_eth netif newlib newlib_nano newlib_syscalls_default periph periph_common periph_cpuid periph_gpio periph_init periph_init_cpuid periph_init_gpio periph_init_pm periph_init_timer periph_init_uart periph_pm periph_timer periph_uart pm_layered posix_headers posix_inet prng prng_tinymt32 ps random sam0_common_periph shell shell_commands sixlowpan sock sock_udp stdin stdio_ethos stdio_uart stdio_uart_rx sys tinymt32 tsrb udp uhcpc xtimer

```

### Issues/PRs references

Related to #13651 #13469
Introduced in  #12724