### PR TITLE
pkg/nanopb: fix for proto files with includes

### DIFF
--- a/pkg/nanopb/Makefile.gensrc
+++ b/pkg/nanopb/Makefile.gensrc
@@ -2,12 +2,19 @@ PROTOC ?= protoc
 PROTOC_GEN_NANOPB ?= $(PKGDIRBASE)/nanopb/generator/protoc-gen-nanopb
 
 PROTOBUF_FILES ?= $(wildcard *.proto)
+PROTOBUF_PATH  ?= $(CURDIR)
 GENSRC   += $(PROTOBUF_FILES:%.proto=$(BINDIR)/$(MODULE)/%.pb.c)
 GENOBJC  := $(GENSRC:%.c=%.o)
 
-ifneq (, $(PROTOBUF_FILES))
+ifneq (,$(PROTOBUF_FILES))
   INCLUDES += -I$(BINDIR)/$(MODULE)
 endif
+
+# workaround for old protoc
+PROTO_INCLUDES += -I.
+# add nanopb specific includes
+PROTO_INCLUDES += -I$(PKGDIRBASE)/nanopb/generator/proto
+PROTO_INCLUDES += -I$(PROTOBUF_PATH)
 
 $(SRC): $(GENSRC)
 
@@ -18,6 +25,6 @@ $(GENSRC): $(PROTOBUF_FILES)
 		make -C $(PKGDIRBASE)/nanopb/generator/proto && \
 		for protofile in $(PROTOBUF_FILES); do \
 			protoc --plugin=protoc-gen-nanopb=$(PROTOC_GEN_NANOPB) \
-				--nanopb_out="$$D" \
+				--nanopb_out="$$D" $(PROTO_INCLUDES) \
 				$^ \
 				; done

--- a/pkg/nanopb/doc.txt
+++ b/pkg/nanopb/doc.txt
@@ -5,4 +5,12 @@
  * @brief    Provides a protocol buffers library to RIOT
  *
  * @see      https://github.com/nanopb/nanopb
+ *
+ * # Limitations
+ *
+ * The generated headers and includes from `.proto` files not accessible outside the
+ * module in which the `.proto` file is located.
+ *
+ * You can include `.proto` files that are not in the same directory by adding the
+ * directory of the `.proto` include to `PROTOBUF_PATH`.
  */

--- a/tests/pkg_nanopb/simple.proto
+++ b/tests/pkg_nanopb/simple.proto
@@ -2,6 +2,7 @@
 // one message.
 
 syntax = "proto2";
+import "nanopb.proto";
 
 message SimpleMessage {
     required int32 lucky_number = 1;


### PR DESCRIPTION
### Contribution description

Proto files can include other proto files.
E.g. nanopb comes with a `nanopb.proto` include that contains some nanopb-specific definitions.

This patch makes it possible to include this file as well as specifying additional proto include folders.

I added the include to `simple.proto` so it gets exercised by the test.

### Testing procedure

`tests/pkg_nanopb` should still build.
Without this patch, the test application will not work when `nanopb.proto` is included. 

### Issues/PRs references

I noticed a limitation in `GENSRC` handling (unrelated to this PR): `.proto` files in modules can only be used by that module.
That is because the header file (and directory) only get generated when the module is compiled, so there is no guarantee that it's available when a different module is build. (when it's built before the module containing the proto file).
