### PR TITLE
riotboot: forward BOARDSDIR

### DIFF
--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -78,8 +78,9 @@ riotboot: $(SLOT_RIOT_BINS)
 riotboot/flash-bootloader: riotboot/bootloader/flash
 riotboot/bootloader/%:
 	$(Q)/usr/bin/env -i \
-		QUIET=$(QUIET)\
-		PATH=$(PATH) BOARD=$(BOARD) DEBUG_ADAPTER_ID=$(DEBUG_ADAPTER_ID)\
+		QUIET=$(QUIET) PATH=$(PATH)\
+		BOARDSDIR=$(BOARDSDIR) BOARD=$(BOARD)\
+		DEBUG_ADAPTER_ID=$(DEBUG_ADAPTER_ID)\
 			$(MAKE) --no-print-directory -C $(RIOTBOOT_DIR) $*
 
 # Generate a binary file from the bootloader which fills all the


### PR DESCRIPTION
### Contribution description

Tiny fix to allow to build riotboot bootloader and slots for external boards.
