### PR TITLE
boards/samd21-bootloader*: small cleanup

### DIFF
--- a/boards/common/arduino-mkr/Makefile.dep
+++ b/boards/common/arduino-mkr/Makefile.dep
@@ -4,7 +4,7 @@ endif
 
 # use arduino-bootloader only if no other stdio_% other than stdio_cdc_acm
 # is requested
-ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_%,$(USEMODULE))))
+ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_% slipdev_stdio,$(USEMODULE))))
   USEMODULE += boards_common_samd21-arduino-bootloader
 endif
 

--- a/boards/common/samd21-arduino-bootloader/reset.c
+++ b/boards/common/samd21-arduino-bootloader/reset.c
@@ -19,7 +19,7 @@
  * @}
  */
 
-#ifdef MODULE_BOARDS_COMMON_SAMD21_ARDUINO_BOOTLOADER
+#ifdef MODULE_USB_BOARD_RESET
 
 #define USB_H_USER_IS_RIOT_INTERNAL
 
@@ -45,4 +45,4 @@ void usb_board_reset_in_bootloader(void)
 }
 #else
 typedef int dont_be_pedantic;
-#endif /* MODULE_BOARDS_COMMON_SAMD21_ARDUINO_BOOTLOADER */
+#endif /* MODULE_USB_BOARD_RESET */

--- a/boards/common/sodaq/Makefile.dep
+++ b/boards/common/sodaq/Makefile.dep
@@ -4,7 +4,7 @@ endif
 
 # use arduino-bootloader only if no other stdio_% other than stdio_cdc_acm
 # is requested
-ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_%,$(USEMODULE))))
+ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_% slipdev_stdio,$(USEMODULE))))
   USEMODULE += boards_common_samd21-arduino-bootloader
 endif
 

--- a/boards/feather-m0/Makefile.dep
+++ b/boards/feather-m0/Makefile.dep
@@ -4,7 +4,7 @@ endif
 
 # use arduino-bootloader only if no other stdio_% other than stdio_cdc_acm
 # is requested
-ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_%,$(USEMODULE))))
+ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_% slipdev_stdio,$(USEMODULE))))
   USEMODULE += boards_common_samd21-arduino-bootloader
 endif
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a follow-up of #13664 and #13791 for samd21 boards that are using the arduino bootloader:
- exclude the bootloader module also when slipdev_stdio is used
- exclude the reset.c build when usb-board-reset is loaded instead of samd21-arduino-bootloader. This is more consistent I think. I skipped that initially when reviewing #13664

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- The code for managing the arduino bootloader is correctly built by default:

<details><summary>feather-m0</summary>

```
$ make BOARD=feather-m0 -C examples/hello-world
make: Entering directory '/work/riot/RIOT/examples/hello-world'
Building application "hello-world" for "feather-m0" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/feather-m0
"make" -C /work/riot/RIOT/boards/common/samd21-arduino-bootloader
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/auto_init/usb
"make" -C /work/riot/RIOT/sys/event
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/usb/usbus
"make" -C /work/riot/RIOT/sys/usb/usbus/cdc/acm
"make" -C /work/riot/RIOT/sys/usb_board_reset
   text	   data	    bss	    dec	    hex	filename
  15316	    132	   5868	  21316	   5344	/work/riot/RIOT/examples/hello-world/bin/feather-m0/hello-world.elf
```

</details>

- The bootloader is correctly removed from build when another stdio module is used, for example stdio_null:

<details><summary>feather-m0</summary>

```
$ USEMODULE=stdio_null make BOARD=feather-m0 -C examples/hello-world
make: Entering directory '/work/riot/RIOT/examples/hello-world'
Building application "hello-world" for "feather-m0" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/feather-m0
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_null
   text	   data	    bss	    dec	    hex	filename
   7748	    112	   2544	  10404	   28a4	/work/riot/RIOT/examples/hello-world/bin/feather-m0/hello-world.elf
```

</details>

- Same when the slipdev_stdio module is used:

<details><summary>feather-m0</summary>

```
$ USEMODULE=slipdev_stdio make BOARD=feather-m0 -C examples/hello-world
make: Entering directory '/work/riot/RIOT/examples/hello-world'
Building application "hello-world" for "feather-m0" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/feather-m0
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/slipdev
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
   9184	    132	   2620	  11936	   2ea0	/work/riot/RIOT/examples/hello-world/bin/feather-m0/hello-world.elf
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #13664 and #13791

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
