### PR TITLE
boards: pic32*: Add GPIO SAUL configuration

### DIFF
--- a/boards/pic32-clicker/Makefile.dep
+++ b/boards/pic32-clicker/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/pic32-clicker/include/gpio_params.h
+++ b/boards/pic32-clicker/include/gpio_params.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Francois Berder
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_pic32-wifire
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Francois Berder <fberder@outlook.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   GPIO configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LD1",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LD2",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/pic32-wifire/Makefile.dep
+++ b/boards/pic32-wifire/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/pic32-wifire/include/gpio_params.h
+++ b/boards/pic32-wifire/include/gpio_params.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Francois Berder
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_pic32-wifire
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Francois Berder <fberder@outlook.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   GPIO configuration
+ */
+static const saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LD1",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LD2",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LD3",
+        .pin = LED3_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .name = "LD4",
+        .pin = LED4_PIN,
+        .mode = GPIO_OUT,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */


### PR DESCRIPTION
### Contribution description

This PR adds GPIO SAUL configuration for pic32-wifire and pic32-clicker boards.

### Testing procedure

Compile `examples/default` and flash it on a pic32-clicker/pic32-wifire. If you type `saul write 0 1`, a LED should turn on. `saul write 0 0` to turn if off.

### Issues/PRs references

None.