### PR TITLE
cpu/samd5x: don't run DFLL on-demand

### DIFF
--- a/cpu/samd5x/cpu.c
+++ b/cpu/samd5x/cpu.c
@@ -235,6 +235,5 @@ void cpu_init(void)
 
     /* set ONDEMAND bit after all clocks have been configured */
     /* This is to avoid setting the source for the main clock to ONDEMAND before using it. */
-    OSCCTRL->DFLLCTRLA.reg |= OSCCTRL_DFLLCTRLA_ONDEMAND;
     OSCCTRL->Dpll[0].DPLLCTRLA.reg |= OSCCTRL_DPLLCTRLA_ONDEMAND;
 }


### PR DESCRIPTION



<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The DFLL on samd5x has a hardware bug that requires a special re-enabling sequence when it is disabled and then re-enabled again.

When running the clock on-demand, the hardware handles the disabling and re-enabling so that sequence does not get executed.



### Testing procedure

To reproduce, run `tests/periph_uart` on `same54-xpro`.

Without this patch the test will get seemingly stuck on `sleep_test()`.
(In fact it keeps running, but the DFLL has the wrong frequency so the UART baudrate is wrong).

In this test, on `same54-xpro` only UART0 is sourced from DFLL.
So if the UART is disabled the DFLL will be turned off as well.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
