### PR TITLE
cpu/samd21: pwm: allow to use channels > 3

### DIFF
--- a/cpu/samd21/periph/pwm.c
+++ b/cpu/samd21/periph/pwm.c
@@ -167,8 +167,16 @@ void pwm_set(pwm_t dev, uint8_t channel, uint16_t value)
         (pwm_config[dev].chan[channel].pin == GPIO_UNDEF)) {
         return;
     }
-    _tcc(dev)->CC[_chan(dev, channel)].reg = value;
-    while (_tcc(dev)->SYNCBUSY.reg & (TCC_SYNCBUSY_CC0 << _chan(dev, channel))) {}
+
+    uint8_t chan = _chan(dev, channel);
+    if (chan < 4) {
+        _tcc(dev)->CC[chan].reg = value;
+        while (_tcc(dev)->SYNCBUSY.reg & (TCC_SYNCBUSY_CC0 << chan)) {}
+    } else {
+        chan -= 4;
+        _tcc(dev)->CCB[chan].reg = value;
+        while (_tcc(dev)->SYNCBUSY.reg & (TCC_SYNCBUSY_CCB0 << chan)) {}
+    }
 }
 
 void pwm_poweron(pwm_t dev)


### PR DESCRIPTION
### Contribution description

Each TCC device has 8 capture-compare channels, but RIOT will crash when accessing any channel > 3.
This is because the upper for channels are on the `CCB` set of registers.

There was also a bit of a hack in place to get the TCC ID (and from that the GCLK_ID & APBCMASK) by masking out some bits from the register address of the hardware blocks.

But TCC devices are not always adjacent in memory - this already breaks for samd21 devices that have a `TCC3` and is certainly broken for non-samd21 MCUs.

### Testing procedure

Run `tests/periph_pwm` on a samd21 board with pwm configured (e.g. `samr21-xpro`)
The `osci` test should blink the on-board LED when configured properly.

### Issues/PRs references
Needed for the PWM config of the serpente board #13654