### PR TITLE
at86rf2xx: implement basic mode (v2)

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -498,6 +498,8 @@ uint8_t at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state)
         old_state = at86rf2xx_get_status(dev);
     } while (old_state == AT86RF2XX_STATE_BUSY_RX_AACK ||
              old_state == AT86RF2XX_STATE_BUSY_TX_ARET ||
+             old_state == AT86RF2XX_STATE_BUSY_RX      ||
+             old_state == AT86RF2XX_STATE_BUSY_TX      ||
              old_state == AT86RF2XX_STATE_IN_PROGRESS);
 
     if (state == AT86RF2XX_STATE_FORCE_TRX_OFF) {

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -33,6 +33,7 @@
 #include <stdbool.h>
 
 #include "board.h"
+#include "kernel_defines.h"
 #include "net/netdev.h"
 #include "net/netdev/ieee802154.h"
 #include "net/gnrc/nettype.h"
@@ -206,6 +207,30 @@ extern "C" {
                                                      *   pending */
 
 /** @} */
+
+#if IS_ACTIVE(AT86RF2XX_BASIC_MODE) || defined(DOXYGEN)
+/**
+ * @brief Internal radio state equivalent to RX_ON
+ */
+#define AT86RF2XX_PHY_STATE_RX       AT86RF2XX_STATE_RX_ON
+/**
+ * @brief Internal radio state equivalent to RX_BUSY
+ */
+#define AT86RF2XX_PHY_STATE_RX_BUSY  AT86RF2XX_STATE_BUSY_RX
+/**
+ * @brief Internal radio state equivalent to TX_ON
+ */
+#define AT86RF2XX_PHY_STATE_TX       AT86RF2XX_STATE_PLL_ON
+/**
+ * @brief Internal radio state equivalent to TX_BUSY
+ */
+#define AT86RF2XX_PHY_STATE_TX_BUSY  AT86RF2XX_STATE_BUSY_TX
+#else
+#define AT86RF2XX_PHY_STATE_RX       AT86RF2XX_STATE_RX_AACK_ON
+#define AT86RF2XX_PHY_STATE_RX_BUSY  AT86RF2XX_STATE_BUSY_RX_AACK
+#define AT86RF2XX_PHY_STATE_TX       AT86RF2XX_STATE_TX_ARET_ON
+#define AT86RF2XX_PHY_STATE_TX_BUSY  AT86RF2XX_STATE_BUSY_TX_ARET
+#endif /* IS_ACTIVE(AT86RF2XX_BASIC_MODE) */
 
 #if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR implements basic mode for the AT86RF2XX radios.

In basic mode, the radio doesn't perform any kind of CSMA-CA, retransmissions and Auto ACK.
Although the Address Matching is still available, I'm not adding it because the AT86RF233 doesn't match ACK frames, which might be problematic for users of the basic mode (e.g OpenWSN)

I added CRC error report via a netdev event. The radio will release frame buffer protection when the CRC check fails. Since the extended mode doesn't trigger the TRX_END if CRC fails, this event is only available in basic mode.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
It's possible to test with one radio in extended mode (default configuration) and another radio running in Basic Mode:
`CFLAGS=-DAT86RF2XX_BASIC_MODE make flash term`

You should be able to see the retransmissions + received ACKs.

Check that the `NETDEV_EVENT_CRC_ERROR` is called (e.g with an failed assertion).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
https://github.com/RIOT-OS/RIOT/issues/8213
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
