### PR TITLE
pkg/fatfs: fix day_of_month value of get_fattime()

### DIFF
--- a/pkg/fatfs/fatfs_diskio/mtd/mtd_diskio.c
+++ b/pkg/fatfs/fatfs_diskio/mtd/mtd_diskio.c
@@ -213,7 +213,7 @@ DWORD get_fattime(void)
     /* bit 31:25 Year origin from 1980 (0..127) */
     uint8_t year = time.tm_year + RTC_YEAR_OFFSET - FATFS_YEAR_OFFSET;
     uint8_t month = time.tm_mon + 1;        /* bit 24:21 month (1..12) */
-    uint8_t day_of_month = time.tm_mon + 1; /* bit 20:16 day (1..31) */
+    uint8_t day_of_month = time.tm_mday;    /* bit 20:16 day (1..31) */
     uint8_t hour = time.tm_hour;            /* bit 15:11 hour (0..23) */
     uint8_t minute = time.tm_min;           /* bit 10:5 minute (0..59) */
     uint8_t second = (time.tm_sec / 2);     /* bit 4:0 second/2 (0..29) */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The function [`get_fattime`](https://github.com/RIOT-OS/RIOT/blob/master/pkg/fatfs/fatfs_diskio/mtd/mtd_diskio.c#L207) was assigning the `day_of_month` value incorrectly.  Fixed this to use the correct time struct member.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Called `get_fattime` and validated that the returned bits representing the day of the month are actually correct.
```
rtc_get_time(&time);
printf("Current RTC time %04d-%02d-%02d %02d:%02d:%02d\n",
    time.tm_year + RTC_YEAR_OFFSET,
    time.tm_mon + TEST_FATFS_RTC_MON_OFFSET,
    time.tm_mday,
    time.tm_hour,
    time.tm_min,
    time.tm_sec);
printf("get_fattime(): %lu\n", get_fattime());        
printf("get_fattime()->day_of_month: %lu\n", (get_fattime()>>FATFS_DISKIO_FATTIME_DAY_OFFS)&0x1F);
```
Adding this code to the pkg_fatfs example gave the following output with the correct number for the day of the month.

```
Current RTC time 2020-04-03 11:47:08
get_fattime(): 1350786532
get_fattime()->day_of_month: 3
```


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
N/A
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
