### PR TITLE
pkg/littlefs2: bump version to 2.2

### DIFF
--- a/pkg/littlefs2/Makefile
+++ b/pkg/littlefs2/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=littlefs2
 PKG_URL=https://github.com/ARMmbed/littlefs.git
-# v2.1.4
-PKG_VERSION=ce2c01f098f4d2b9479de5a796c3bb531f1fe14c
+# v2.2.0
+PKG_VERSION=a049f1318eecbe502549f9d74a41951985fb956f
 PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
### Contribution description

Update to the [new minor release](https://github.com/ARMmbed/littlefs/tree/v2.2.0).

### Testing procedure

`tests/pkg_littlefs2` should still work. (Murdock will run the test)

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
