### PR TITLE
dist/tools/*/start_network.sh: ensure TUN/TAP interface

### DIFF
--- a/dist/tools/ethos/start_network.sh
+++ b/dist/tools/ethos/start_network.sh
@@ -42,6 +42,7 @@ PORT=$1
 TAP=$2
 PREFIX=$3
 BAUDRATE=115200
+START_ETHOS=1
 
 [ -z "${PORT}" -o -z "${TAP}" -o -z "${PREFIX}" ] && {
     echo "usage: $0 [-e|--ethos-only] <serial-port> <tap-device> <prefix> " \

--- a/dist/tools/sliptty/start_network.sh
+++ b/dist/tools/sliptty/start_network.sh
@@ -6,6 +6,7 @@ TUN=sl0
 TUN_GLB="fdea:dbee:f::1/64"
 UHCPD_PID=
 CREATED_IFACE=0
+START_SLIP=1
 
 SUDO=${SUDO:-sudo}
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Previously, when the creation of the TUN/TAP interface failed in one of the `start_network.sh` scripts, the script will fail with a cryptic error like

>     dist/tools/ethos/start_network.sh: 68: [: -eq: unexpected operator

This fix ensures, that the value of this variable checked is always set such that in the error case, `ethos`/`sliptty` won't start.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Ask @benpicco. I was not able to reproduce it.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See https://github.com/RIOT-OS/RIOT/pull/13734#issuecomment-608382327
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
