### PR TITLE
tests: use start_network instead of `ethos` directly

### DIFF
--- a/tests/emcute/Makefile
+++ b/tests/emcute/Makefile
@@ -11,8 +11,8 @@ else
   ETHOS_BAUDRATE ?= 115200
   CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE)
   TERMDEPS += ethos
-  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/ethos
-  TERMFLAGS ?= $(TAP) $(PORT) $(ETHOS_BAUDRATE)
+  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/start_network.sh
+  TERMFLAGS ?= -e $(PORT) $(TAP) "2001:db8::/64" $(ETHOS_BAUDRATE)
 endif
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_ipv6_default

--- a/tests/gnrc_dhcpv6_client/Makefile
+++ b/tests/gnrc_dhcpv6_client/Makefile
@@ -20,8 +20,8 @@ else
   IFACE ?= tap0
   ETHOS_BAUDRATE ?= 115200
   CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE)
-  TERMPROG ?= sudo sh $(RIOTBASE)/dist/tools/ethos/ethos
-  TERMFLAGS ?= $(IFACE) $(PORT) $(ETHOS_BAUDRATE)
+  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/start_network.sh
+  TERMFLAGS ?= -e $(PORT) $(TAP) "2001:db8::/64" $(ETHOS_BAUDRATE)
   TERMDEPS += ethos
 endif
 USEMODULE += auto_init_gnrc_netif

--- a/tests/gnrc_dhcpv6_client_6lbr/Makefile
+++ b/tests/gnrc_dhcpv6_client_6lbr/Makefile
@@ -19,8 +19,8 @@ else
   ETHOS_BAUDRATE ?= 115200
   CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE)
   TERMDEPS += ethos
-  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/ethos
-  TERMFLAGS ?= $(TAP) $(PORT) $(ETHOS_BAUDRATE)
+  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/start_network.sh
+  TERMFLAGS ?= -e $(PORT) $(TAP) "2001:db8::/64" $(ETHOS_BAUDRATE)
   STATIC_ROUTES ?= 1
 endif
 

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -11,8 +11,8 @@ else
   ETHOS_BAUDRATE ?= 115200
   CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE)
   TERMDEPS += ethos
-  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/ethos
-  TERMFLAGS ?= $(TAP) $(PORT) $(ETHOS_BAUDRATE)
+  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/start_network.sh
+  TERMFLAGS ?= -e $(PORT) $(TAP) "2001:db8::/64" $(ETHOS_BAUDRATE)
 endif
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for IPv6

--- a/tests/gnrc_ipv6_ext_frag/Makefile
+++ b/tests/gnrc_ipv6_ext_frag/Makefile
@@ -13,8 +13,8 @@ else
   ETHOS_BAUDRATE ?= 115200
   CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE)
   TERMDEPS += ethos
-  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/ethos
-  TERMFLAGS ?= $(TAP) $(PORT) $(ETHOS_BAUDRATE)
+  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/start_network.sh
+  TERMFLAGS ?= -e $(PORT) $(TAP) "2001:db8::/64" $(ETHOS_BAUDRATE)
 endif
 USEMODULE += auto_init_gnrc_netif
 # add dummy interface to test forwarding to smaller MTU

--- a/tests/gnrc_rpl_srh/Makefile
+++ b/tests/gnrc_rpl_srh/Makefile
@@ -13,8 +13,8 @@ else
   ETHOS_BAUDRATE ?= 115200
   CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE)
   TERMDEPS += ethos
-  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/ethos
-  TERMFLAGS ?= $(TAP) $(PORT) $(ETHOS_BAUDRATE)
+  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/start_network.sh
+  TERMFLAGS ?= -e $(PORT) $(TAP) "2001:db8::/64" $(ETHOS_BAUDRATE)
 endif
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for IPv6

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -15,8 +15,8 @@ else
   ETHOS_BAUDRATE ?= 115200
   CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE)
   TERMDEPS += ethos
-  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/ethos
-  TERMFLAGS ?= $(TAP) $(PORT) $(ETHOS_BAUDRATE)
+  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/start_network.sh
+  TERMFLAGS ?= -e $(PORT) $(TAP) "2001:db8::/64" $(ETHOS_BAUDRATE)
 endif
 USEMODULE += auto_init_gnrc_netif
 

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -22,8 +22,8 @@ else
   ETHOS_BAUDRATE ?= 115200
   CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE)
   TERMDEPS += ethos
-  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/ethos
-  TERMFLAGS ?= $(TAP) $(PORT) $(ETHOS_BAUDRATE)
+  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/start_network.sh
+  TERMFLAGS ?= -e $(PORT) $(TAP) "2001:db8::/64" $(ETHOS_BAUDRATE)
 endif
 
 USEMODULE += auto_init_gnrc_netif


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
On some platforms (e.g. Arch Linux or newer Ubuntu versions) the TAP interface does not come up once connected and must be set up manually. This is already done in the `start_network.sh` script so let's just use that instead of pure `ethos`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The tests in question should still work for boards supporting `ethos`:

```
cd tests/${TEST}
export BOARD=samr21-xpro
make flash
sudo make test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See https://github.com/RIOT-OS/RIOT/pull/13734#issuecomment-608378911
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
