### PR TITLE
nanocoap: add convenience function for adding path elements

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1047,6 +1047,25 @@ ssize_t coap_opt_add_proxy_uri(coap_pkt_t *pkt, const char *uri);
 ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum, const char *string, char separator);
 
 /**
+ * @brief   Adds one or multiple Uri-Path options in the form '/path' into pkt
+ *
+ * @note Use this only for null-terminated strings.
+ *
+ * @param[in,out] pkt         Packet being built
+ * @param[in]     path        Resource (sub)path
+ *
+ * @pre     ((pkt != NULL) && (path != NULL))
+ *
+ * @return        number of bytes written to pkt buffer
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or pkt full
+ */
+static inline ssize_t coap_opt_add_uri_path(coap_pkt_t *pkt, const char *path)
+{
+    return coap_opt_add_string(pkt, COAP_OPT_URI_PATH, path, '/');
+}
+
+/**
  * @brief   Finalizes options as required and prepares for payload
  *
  * @post pkt.payload advanced to first available byte after options

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -659,7 +659,7 @@ int gcoap_req_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
 
     coap_pkt_init(pdu, buf, len - CONFIG_GCOAP_REQ_OPTIONS_BUF, res);
     if (path != NULL) {
-        res = coap_opt_add_string(pdu, COAP_OPT_URI_PATH, path, '/');
+        res = coap_opt_add_uri_path(pdu, path);
     }
     return (res > 0) ? 0 : res;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Add a convenience function to make adding additional sub-path options easier.

The user might not want to construct the entire path at once (it will be split up internally anyway), e.g. when adding additional resource options.

### Testing procedure

Nothing to test

### Issues/PRs references

