### PR TITLE
sys/net/dhcpv6: fix requesting multiple prefixes

### DIFF
--- a/sys/net/application_layer/dhcpv6/client.c
+++ b/sys/net/application_layer/dhcpv6/client.c
@@ -155,6 +155,7 @@ void dhcpv6_client_req_ia_pd(unsigned netif, unsigned pfx_len)
             lease->parent.ia_id.info.netif = netif;
             lease->parent.ia_id.info.type = DHCPV6_OPT_IA_PD;
             lease->pfx_len = pfx_len;
+            break;
         }
     }
 }
@@ -662,7 +663,6 @@ static bool _parse_reply(uint8_t *rep, size_t len)
                                     lease->pfx_len, valid, pref
                                 );
                         }
-                        return true;
                     }
                 }
                 break;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

There were two subtle bugs that prevented the DHCPv6 client to request
multiple prefixes for different interfaces.

 - `dhcpv6_client_req_ia_pd()` would fill up *all* leases with the same interface
 - `_parse_reply()` would return after parsing the first answer

With this patch, `gnrc_border_router` gets a prefix on both interfaces of the at86rf215.



### Testing procedure

To reproduce, run the `gnrc_border_router` on a board with two 6LoWPAN interfaces using `ethos` with DHCPv6 as an uplink:

    CFLAGS=-DDHCPV6_CLIENT_PFX_LEASE_MAX=2 USE_DHCPV6=1 BOARD=openmote-b make -C examples/gnrc_border_router flash term

You should see that both interfaces receive a prefix from the DHCP server.

```
net.ipv6.conf.tap0.forwarding = 1
net.ipv6.conf.tap0.accept_ra = 0
----> ethos: sending hello.
----> ethos: activating serial pass through.
----> ethos: hello reply received
DHCPv6 client: send SOLICIT
DHCPv6 client: resend SOLICIT
2020-04-03 17:00:25.781 INFO  [kea-dhcp6.dhcp6/8423] DHCP6_STARTING Kea DHCPv6 server version 1.5.0 starting
DHCPv6 client: resend SOLICIT
DHCPv6 client: received ADVERTISE
DHCPv6 client: scheduling REQUEST
DHCPv6 client: send REQUEST
DHCPv6 client: resend REQUEST
DHCPv6 client: received REPLY
ia_id: got 190007 (expect 190007)
DHCPv6 client: scheduling RENEW in 10000 sec
DHCPv6 client: scheduling REBIND in 20000 sec
ia_id: got 190007 (expect 190006)
ia_id: got 190007 (expect 0)
ia_id: got 190006 (expect 190007)
ia_id: got 190006 (expect 190006)
DHCPv6 client: scheduling RENEW in 10000 sec
DHCPv6 client: scheduling REBIND in 20000 sec
ia_id: got 190006 (expect 0)

Iface  8  HWaddr: 02:5F:61:15:22:DD 
          L2-PDU:1500 MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::5f:61ff:fe15:22dd  scope: link  VAL
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff15:22dd
          inet6 group: ff02::1:ff00:2
          
Iface  7  HWaddr: 01:55  Channel: 26  Page: 0  NID: 0x23
          Long HWaddr: 1A:F9:8F:5F:30:5D:05:8C 
           TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
          AUTOACK  ACK_REQ  CSMA  L2-PDU:102 MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::18f9:8f5f:305d:58c  scope: link  VAL
          inet6 addr: 2001:db8:0:10:18f9:8f5f:305d:58c  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff5d:58c
          
Iface  6  HWaddr: 01:57  Channel: 0  Page: 2  NID: 0x23
          Long HWaddr: 1A:F9:8F:5F:30:5D:05:8E 
           TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
          AUTOACK  ACK_REQ  CSMA  L2-PDU:102 MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::18f9:8f5f:305d:58e  scope: link  VAL
          inet6 addr: 2001:db8:0:11:18f9:8f5f:305d:58e  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff5d:58e
```

### Issues/PRs references

requires #13609 for simple testing.