### PR TITLE
tests: buttons: Fix build failure if BTN0_PIN is not declared

### DIFF
--- a/tests/buttons/main.c
+++ b/tests/buttons/main.c
@@ -41,7 +41,7 @@
 #define BTN3_INT_FLANK  GPIO_FALLING
 #endif
 
-#ifdef BTN0_PIN /* assuming that first button is always BTN0 */
+#if defined (BTN0_PIN) || defined (BTN1_PIN) || defined (BTN2_PIN) || defined (BTN3_PIN)
 static void cb(void *arg)
 {
     printf("Pressed BTN%d\n", (int)arg);


### PR DESCRIPTION
### Contribution description

While implementing gpio_irq peripheral for PIC32 devices, I encountered a build failure for `tests/buttons` because `BTN0_PIN` was not defined although `BTN1_PIN` and BTN2_PIN` were defined (I used these numbers to match what can be found in the schematics and on the board silkscreen).

### Testing procedure

Build and run `tests/buttons`.

### Issues/PRs references

None