### PR TITLE
boards: pic32*: Update documentation

### DIFF
--- a/boards/pic32-clicker/doc.txt
+++ b/boards/pic32-clicker/doc.txt
@@ -60,7 +60,7 @@ found in the [manual](https://download.mikroe.com/documents/starter-boards/click
 | Low-level driver | GPIO            | partly    | gpio_irq not supported |
 |                  | ADC             | no        |                        |
 |                  | PWM             | no        |                        |
-|                  | UART            | partly    | only TX                |
+|                  | UART            | yes       |                        |
 |                  | I2C             | no        |                        |
 |                  | SPI             | no        |                        |
 |                  | USB             | no        |                        |

--- a/boards/pic32-wifire/doc.txt
+++ b/boards/pic32-wifire/doc.txt
@@ -61,7 +61,7 @@ Additional documents:
 | Low-level driver | GPIO              | partly    | gpio_irq not supported |
 |                  | ADC               | no        |                        |
 |                  | PWM               | no        |                        |
-|                  | UART              | partly    | only TX                |
+|                  | UART              | yes       |                        |
 |                  | I2C               | no        |                        |
 |                  | SPI               | no        |                        |
 |                  | USB               | no        |                        |


### PR DESCRIPTION
## Contribution description

Given that pull request #13094 is now merged, pic32-clicker and pic32-wifire boards have a complete UART driver implementation. This PR simply reflects this change in the documentation.

### Testing procedure

None

### Issues/PRs references

See https://github.com/RIOT-OS/RIOT/pull/13094