### PR TITLE
Added a new flashing parameter for generic cheap St-link and bluepill(-128kib) boards.

### DIFF
--- a/boards/common/blxxxpill/Makefile.include
+++ b/boards/common/blxxxpill/Makefile.include
@@ -7,6 +7,22 @@ ifeq (dfu-util,$(PROGRAMMER))
 
   # Leave some space at the beginning of the flash for the bootloader
   ROM_OFFSET ?= 0x2000
+
+  # If using STM32duino bootloader, this change is necessary.
+  # Bootloader available at
+  # github.com/rogerclarkmelbourne/STM32duino-bootloader/tree/master/binaries
+  ifeq (stm32duino,$(BOOTLOADER))
+    FFLAGS_OPTS ?= -R
+    FFLAGS ?= --device $(DFU_USB_ID) \
+              --alt $(DFU_ALT) \
+              --download $(FLASHFILE) \
+              $(FFLAGS_OPTS)
+
+    # Flashing may be easier if using a software USB reset.
+    # Future updates may provide USB support for stm32f1 which benefits
+    # from this software reset.
+  endif
+
 else ifeq (openocd,$(PROGRAMMER))
   STLINK_VERSION ?= 2
 endif

--- a/boards/common/blxxxpill/dist/openocd-128kib.cfg
+++ b/boards/common/blxxxpill/dist/openocd-128kib.cfg
@@ -9,9 +9,20 @@ set STOP_WATCHDOG 1
 # STlink Debug clock frequency
 set CLOCK_FREQ 4000
 
+# Some revisions of the Bluepills use a CS32F103C8T6 rather than the STM32Fx
+# MCU, which has a different CPUTAPID than the official STM32F103C8T6. As of
+# 2020-04-09, no upstream support in OpenOCD has been merged. You can uncomment
+# the following line as a workaround until your OpenOCD supports this option:
+#set CPUTAPID 0x2ba01477
+
+# Set the default reset option in cases where "SRST=none" is not used for make
+if { ![info exists SRST_OPT] } {
+   set SRST_OPT srst_only
+}
+
 # use hardware reset, connect under reset
 # connect_assert_srst needed if low power mode application running (WFI...)
-reset_config srst_only srst_nogate connect_assert_srst
+reset_config $SRST_OPT srst_nogate connect_assert_srst
 set CONNECT_UNDER_RESET 1
 
 # brutally overwriting detected flash size with 128KiB (OpenOCD > 0.10.0)

--- a/boards/common/blxxxpill/dist/openocd.cfg
+++ b/boards/common/blxxxpill/dist/openocd.cfg
@@ -9,9 +9,20 @@ set STOP_WATCHDOG 1
 # STlink Debug clock frequency
 set CLOCK_FREQ 4000
 
+# Some revisions of the Bluepills use a CS32F103C8T6 rather than the STM32Fx
+# MCU, which has a different CPUTAPID than the official STM32F103C8T6. As of
+# 2020-04-09, no upstream support in OpenOCD has been merged. You can uncomment
+# the following line as a workaround until your OpenOCD supports this option:
+#set CPUTAPID 0x2ba01477
+
+# Set the default reset option in cases where "SRST=none" is not used for make
+if { ![info exists SRST_OPT] } {
+   set SRST_OPT srst_only
+}
+
 # use hardware reset, connect under reset
 # connect_assert_srst needed if low power mode application running (WFI...)
-reset_config srst_only srst_nogate connect_assert_srst
+reset_config $SRST_OPT srst_nogate connect_assert_srst
 set CONNECT_UNDER_RESET 1
 
 source [find target/stm32f1x.cfg]

--- a/makefiles/tools/openocd-adapters/stlink.inc.mk
+++ b/makefiles/tools/openocd-adapters/stlink.inc.mk
@@ -11,6 +11,16 @@ ifneq (,$(DEBUG_ADAPTER_ID))
   OPENOCD_ADAPTER_INIT += -c 'hla_serial $(DEBUG_ADAPTER_ID)'
 endif
 
+
+# Some stlink clones cannot signal reset properly,
+# In this case, use SRST=none
+ifneq (,$(SRST))
+  #Change the adapter init to it
+  # Use STLINK_VERSION to select which stlink version is used
+  OPENOCD_ADAPTER_INIT += \
+    -c 'set SRST_OPT $(SRST)'
+endif
+
 # if no openocd specific configuration file, check for default locations:
 # 1. Using the default dist/openocd.cfg (automatically set by openocd.sh)
 # 2. Using the common cpu specific config file


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
It is now possible to use a new flashing parameter BOOTLOADER=stm32duino for those cheap generic bluepill(-128kib) boards (stm32F1x) while keeping backward compatibility.

It fixes the 'make flash' using clone stlink-v2 (use SRST=none). It also fixes flashing when using "PROGRAMMER=dfu-util", if your device already has the bootloader ([stm32duino](https://github.com/rogerclarkmelbourne/STM32duino-bootloader/tree/master/binaries)) installed somehow (like using Serial connection).

This PR changes:
- RIOT/boards/common/blxxxpill

### Bugs fixed when flashing generic STM32 bluepill boards with stlink-v2
* Openocd does not recognize the chip ID:
```
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01157-gd6541a81-dirty (2020-04-02-13:58)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 1000 kHz
Info : STLINK V2J29S7 (API v2) VID:PID 0483:3748
Info : Target voltage: 3.164062
Warn : UNEXPECTED idcode: 0x2ba01477
Error: expected 1 of 1: 0x1ba01477
```
**Solution:** Added new .cfg for generic board with
`set CPUTAPID 0x2ba01477`

* Openocd cannot halt the device:
```
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01157-gd6541a81-dirty (2020-04-02-13:58)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 1000 kHz
Info : STLINK V2J29S7 (API v2) VID:PID 0483:3748
Info : Target voltage: 3.151562
Info : STM32F103C8Tx.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : Listening on port 35283 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* STM32F103C8Tx.cpu  hla_target little STM32F103C8Tx.cpu  running

Error: timed out while waiting for target halted
TARGET: STM32F103C8Tx.cpu - Not halted
/home/vini/temp-projects/RIOT/tests/leds/../../Makefile.include:667: recipe for target 'flash' failed
make: *** [flash] Error 1
```
**Solution:** Changed reset_config line in the new .cfg for generic board
from
`reset_config srst_only srst_nogate connect_assert_srst`
to
`reset_config none srst_nogate connect_assert_srst`

### Bugs fixed when flashing generic STM32 bluepill boards with stm32duino bootloader
```
dfu-util: Invalid DFU suffix signature
dfu-util: A valid DFU suffix will be required in a future dfu-util release!!!
Opening DFU capable USB device...
ID 1eaf:0003
Run-time device DFU version 0110
Claiming USB DFU Interface...
Setting Alternate Setting #2 ...
Determining device status: state = dfuIDLE, status = 0
dfuIDLE, continuing
DFU mode device DFU version 0110
Device returned transfer size 1024
dfu-util: Could not read name, sscanf returned 0
dfu-util: Failed to parse memory layout
/home/user/RIOT/tests/leds/../../Makefile.include:667: recipe for target 'flash' failed
make: *** [flash] Error 74
```
**Solution:** Changed blxxxpil makefile for generic board
```
FFLAGS_OPTS ?= -R
FFLAGS ?= --device $(DFU_USB_ID) \
        --alt $(DFU_ALT) \
        --download $(FLASHFILE) \
        $(FFLAGS_OPTS)
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure
If you are trying to flash for it, just add "BOOTLOADER=stm32duino" or "SRST=none" before "make flash".
`BOARD=bluepill SRST=none make clean all flash`
`BOARD=bluepill PROGRAMMER=dfu-util BOOTLOADER=stm32duino make clean all flash`

In case of dfu-util programmer, you need to synchronize pushing the reset button before flashing it. 

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Maybe solves issue  #11030
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
