### PR TITLE
examples/gnrc_border_router: allow to configure more than one ZEP device

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -87,6 +87,8 @@ ifeq (,$(filter native,$(BOARD)))
     include $(CURDIR)/Makefile.wifi.conf
   endif
 else
+  # The number of native (emulated) ZigBee/6LoWPAN devices
+  ZEP_DEVICES ?= 1
   include $(CURDIR)/Makefile.native.conf
 endif
 

--- a/examples/gnrc_border_router/Makefile.native.conf
+++ b/examples/gnrc_border_router/Makefile.native.conf
@@ -1,6 +1,14 @@
 # native has a TAP interface towards the host, just add parameters for
 # `socket_zep`
-TERMFLAGS += -z [::1]:17754
+ZEP_PORT_BASE ?= 17754
+ZEP_PORT_MAX := $(shell expr $(ZEP_PORT_BASE) + $(ZEP_DEVICES) - 1)
+
+CFLAGS += -DSOCKET_ZEP_MAX=$(ZEP_DEVICES)
+CFLAGS += -DDHCPV6_CLIENT_PFX_LEASE_MAX=$(ZEP_DEVICES)
+CFLAGS += -DASYNC_READ_NUMOF=$(shell expr $(ZEP_DEVICES) + 1)
+
+# -z [::1]:$PORT for each ZEP device
+TERMFLAGS += $(patsubst %,-z [::1]:%, $(shell seq $(ZEP_PORT_BASE) $(ZEP_PORT_MAX)))
 
 ifneq (1,$(USE_DHCPV6))
   # We don't need to start ethos so just start the UHCPD daemon in the


### PR DESCRIPTION
Native supports multiple ZEP devices, so add a config option for it to `gnrc_border_router`.

This allows for easier testing of border routers with multiple interfaces.

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run

    sudo dist/tools/tapsetup/tapsetup
    make -C examples/gnrc_border_router BOARD=native ZEP_DEVICES=2 all term

You should now have a naive border router with multiple 6LoWPAN interfaces

```
Iface  8  HWaddr: C5:6C  Channel: 26  NID: 0x23
          Long HWaddr: 00:5A:45:50:0A:00:C5:6C 
          L2-PDU:102 MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::25a:4550:a00:c56c  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff00:c56c
          
Iface  7  HWaddr: 45:5B  Channel: 26  NID: 0x23
          Long HWaddr: 00:5A:45:50:0A:00:45:5B 
          L2-PDU:102 MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::25a:4550:a00:455b  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff00:455b
          
Iface  6  HWaddr: E6:0E:EF:4B:27:89 
          L2-PDU:1500 MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::e40e:efff:fe4b:2789  scope: link  VAL
          inet6 addr: fe80::2  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff4b:2789
          inet6 group: ff02::1:ff00:2
```

### Issues/PRs references

Makes it easier to reproduce #13806