### PR TITLE
New feature: supporting Sam R30 Xpro working on frequency=868MHz when sending UDP packet

### DIFF
--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -1,5 +1,5 @@
 ifneq (EU,$(ISM))
-  # Default seeting which working on US (Channel 26 for 2.4 GHz, Channel 5/Page 2 for sub-GHz)
+  # Default setting for US ISM band (Channel 26 for 2.4 GHz, Channel 5/Page 2 for sub-GHz)
   ifneq (,$(DEFAULT_CHANNEL))
     ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
       CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)

--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -1,26 +1,30 @@
-# ISM = 868Mhz Channel & Page Switch for EU area
-ifeq (868,$(ISM))
-  ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
-    EU_CHANNEL ?= 0
-    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(UK_CHANNEL)
-    EU_PAGE ?= 0
-    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_PAGE=$(UK_PAGE)
-    # As Issues/PRS reference #13526 has already sloved, we don't need change the SPI_CLK anaymore
-    # SCLK := SPI_CLK_1MHZ
-    # CFLAGS += -DAT86RF2XX_PARAM_SPI_CLK=$(SCLK)
+ifneq (EU,$(ISM))
+  # Default seeting which working on US (Channel 26 for 2.4 GHz, Channel 5/Page 2 for sub-GHz)
+  ifneq (,$(DEFAULT_CHANNEL))
+    ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
+      CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+    endif
+    ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
+      CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
+    else                                          # radio is IEEE 802.15.4 2.4 GHz
+      CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+    endif
   endif
-endif
-ifneq (,$(DEFAULT_CHANNEL))
+else      # Switching to ISM-EU if ISM=EU when make (sub-GHz channel = 0 / sub-GHz page = 0)
   ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
     CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
   endif
-  ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
-    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
+  ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio sub-GHz channel = 0 / sub-GHz page = 0
+    EU_CHANNEL ?= 0
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(EU_CHANNEL)
+    EU_PAGE ?= 0
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_PAGE=$(EU_PAGE)
   else                                          # radio is IEEE 802.15.4 2.4 GHz
     CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
   endif
 endif
-  # Set a custom PAN ID if needed
+
+# Set a custom PAN ID if needed
 ifneq (,$(DEFAULT_PAN_ID))
   CFLAGS += -DIEEE802154_DEFAULT_PANID=$(DEFAULT_PAN_ID)
 endif

--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -1,17 +1,26 @@
-# Set a custom channel if needed
+# ISM = 868Mhz Channel & Page Switch for EU area
+ifeq (868,$(ISM))
+  ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
+    EU_CHANNEL ?= 0
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(UK_CHANNEL)
+    EU_PAGE ?= 0
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_PAGE=$(UK_PAGE)
+    # As Issues/PRS reference #13526 has already sloved, we don't need change the SPI_CLK anaymore
+    # SCLK := SPI_CLK_1MHZ
+    # CFLAGS += -DAT86RF2XX_PARAM_SPI_CLK=$(SCLK)
+  endif
+endif
 ifneq (,$(DEFAULT_CHANNEL))
   ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
     CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
   endif
-
   ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
     CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
   else                                          # radio is IEEE 802.15.4 2.4 GHz
     CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
   endif
 endif
-
-# Set a custom PAN ID if needed
+  # Set a custom PAN ID if needed
 ifneq (,$(DEFAULT_PAN_ID))
   CFLAGS += -DIEEE802154_DEFAULT_PANID=$(DEFAULT_PAN_ID)
 endif

--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -1,3 +1,4 @@
+# vairable can pass like: make BOARD=samr30-xpro ISM=EU flash term
 ifneq (EU,$(ISM))
   # Default setting for US ISM band (Channel 26 for 2.4 GHz, Channel 5/Page 2 for sub-GHz)
   ifneq (,$(DEFAULT_CHANNEL))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
New feature: Enable Channel/Page easy selection of the EU ISM 868MHz frequency band for the SAM R30 Xpro. Easily, ISM vairable can pass like:
 `make  BOARD=samr30-xpro ISM=EU flash term`
it willchange the default channel and page number into 0. This has been tested by sending UPD packets between two samr30-xpro. Check page: 387 of [IEEE 802.15.4-2015](https://ieeexplore.ieee.org/document/7460875) for more details about Channel/Page numbering. 

If you don't need to work on 868MHz, just make the board flash and nothing will change. The setting will still as same as 915MHz if no ISM value set:
`make  BOARD=samr30-xpro flash term`

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
1.Checking the UDP sending feature:
using tests/gnrc_udp by passing the ISM variable as shown below:
`make BOARD=samr30-xpro ISM=EU flash term`
This has been tested by sending UPD packets between two samr30-xpro", see result shown below:
![0403_1](https://user-images.githubusercontent.com/50105190/78407045-d3ddf000-75fb-11ea-8ed4-8e700aa2d6fa.jpg)
![image](https://user-images.githubusercontent.com/50105190/78407468-cf660700-75fc-11ea-9f90-87cb313ec13c.png)

2. Also using radio checker to observe the working frequence, in my test, all packet is sending in the central frequence of 868.3MHz

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Thanks to the work of #13537, this time don't need to update SPI_CLK setting. 