### PR TITLE
cpu/esp32: use module newlib_nano

### DIFF
--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -5,6 +5,7 @@ include $(RIOTCPU)/esp_common/Makefile.dep
 USEMODULE += esp_idf_driver
 USEMODULE += esp_idf_esp32
 USEMODULE += esp_idf_soc
+USEMODULE += newlib_nano
 USEMODULE += pm_layered
 
 ifneq (,$(filter cpp,$(FEATURES_USED)))

--- a/tests/libc_newlib/Makefile
+++ b/tests/libc_newlib/Makefile
@@ -2,8 +2,6 @@ include ../Makefile.tests_common
 
 USEMODULE += embunit
 
-FEATURES_BLACKLIST += arch_esp32
-
 include $(RIOTBASE)/Makefile.include
 
 # Compile time tests

--- a/tests/libc_newlib/Makefile
+++ b/tests/libc_newlib/Makefile
@@ -2,6 +2,8 @@ include ../Makefile.tests_common
 
 USEMODULE += embunit
 
+FEATURES_BLACKLIST += arch_esp32
+
 include $(RIOTBASE)/Makefile.include
 
 # Compile time tests


### PR DESCRIPTION
### Contribution description

This PR fixes the compilation and execution problem of `tests/libc_newlib` for ESP32. The new toolchain version uses the `newlibc-nano`. Module `newlib_nano` has to be used therefore.

### Testing procedure

Compilation and execution of `tests/libc_newlib` should work with any ESP32 board, for example
```
make BOARD=esp32-wroom-32 -C tests/libc_newlib flash test
```

### Issues/PRs references

Depends on #13814 