### PR TITLE
makefiles: default-channel.inc.mk -> Supporting Sam R30 Xpro working on frequency=868MHz when sending UDP packet

### DIFF
--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -19,23 +19,7 @@ ifndef CONFIG_KCONFIG_MODULE_IEEE802154
       endif
     endif 
   endif
+  ifneq (,$(DEFAULT_PAN_ID))
+    CFLAGS += -DCONFIG_IEEE802154_DEFAULT_PANID=$(DEFAULT_PAN_ID)
+  endif
 endif
-# # Set a custom channel if needed
-# ifndef CONFIG_KCONFIG_MODULE_IEEE802154
-#   ifneq (,$(DEFAULT_CHANNEL))
-#     ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
-#       CFLAGS += -DCONFIG_CC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-#     endif
-
-#     ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
-#       CFLAGS += -DCONFIG_IEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
-#     else                                          # radio is IEEE 802.15.4 2.4 GHz
-#       CFLAGS += -DCONFIG_IEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-#     endif
-#   endif
-
-#   # Set a custom PAN ID if needed
-#   ifneq (,$(DEFAULT_PAN_ID))
-#     CFLAGS += -DCONFIG_IEEE802154_DEFAULT_PANID=$(DEFAULT_PAN_ID)
-#   endif
-# endif

--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -1,5 +1,5 @@
 ifneq (EU,$(ISM))
-  # Default seeting which working on US (Channel 26 for 2.4 GHz, Channel 5/Page 2 for sub-GHz)
+  # Default setting for US ISM band (Channel 26 for 2.4 GHz, Channel 5/Page 2 for sub-GHz)
   ifneq (,$(DEFAULT_CHANNEL))
     ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
       CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)

--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -2,22 +2,23 @@
 # with FBAND=868 changes channel/page setting only if transceiver is at86rf212b
 ifndef CONFIG_KCONFIG_MODULE_IEEE802154
   ifeq (868, $(FBAND))
-    # radio is at86rf212b sub GHz at FBAND=868MHz (channel = 0 / page = 0）
-    ifneq (,$(filter at86rf212b,$(USEMODULE)))     
+    # radio is at86rf212b sub GHz at FBAND=868MHz (channel = 0 / page = 0)
+    ifneq (,$(filter at86rf212b,$(USEMODULE)))
       CFLAGS += -DCONFIG_IEEE802154_DEFAULT_SUBGHZ_CHANNEL=0
-      CFLAGS += -DCONFIG_IEEE802154_DEFAULT_SUBGHZ_PAGE=0
+      CFLAGS += -DCONFIG_IEEE802154_DEFAULT_SUBGHZ_PAGE=2
     # if not using samr30-xpro radio is the same as default IEEE 802.15.4 2.4 GHz
-    else                                        # radio is IEEE 802.15.4 2.4 GHz
-      GHZ_CHANNEL ?= 26                                        
+    else
+    # radio is IEEE 802.15.4 2.4 GHz
+      GHZ_CHANNEL ?= 26
       CFLAGS += -DCONFIG_IEEE802154_DEFAULT_CHANNEL=$(GHZ_CHANNEL)
     endif
   # Applying default setting if FBAND is 915MHz (Channel = 26 for 2.4 GHz, Channel = 5/Page = 2 for sub-GHz)
-  else                                          
+  else
     ifneq (,$(DEFAULT_CHANNEL))
-      ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
+      ifneq (,$(filter cc110x,$(USEMODULE)))# radio is cc110x sub-GHz
         CFLAGS += -DCONFIG_CC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
       endif
-    endif 
+    endif
   endif
   ifneq (,$(DEFAULT_PAN_ID))
     CFLAGS += -DCONFIG_IEEE802154_DEFAULT_PANID=$(DEFAULT_PAN_ID)

--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -1,4 +1,4 @@
-# Frequency Band (FBAND) vairable can pass like: make BOARD=samr30-xpro FBAND=868 flash term
+# Frequency Band (FBAND) variable can pass like: make BOARD=samr30-xpro FBAND=868 flash term
 # with FBAND=868 changes channel/page setting only if transceiver is at86rf212b 
 ifeq (868, $(FBAND))
   ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz

--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -1,9 +1,6 @@
 # Frequency Band (FBAND) variable can pass like: make BOARD=samr30-xpro FBAND=868 flash term
-# with FBAND=868 changes channel/page setting only if transceiver is at86rf212b 
+# with FBAND=868 changes channel/page setting only if transceiver is at86rf212b
 ifeq (868, $(FBAND))
-  ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
-    CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-  endif
   # radio is at86rf212b sub GHz at FBAND=868MHz (channel = 0 / page = 0）
   ifneq (,$(filter at86rf212b,$(USEMODULE)))     
     FBAND_CHANNEL ?= 0

--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -1,26 +1,30 @@
-# ISM = 868Mhz Channel & Page Switch for EU area
-ifeq (868,$(ISM))
-  ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
-    EU_CHANNEL ?= 0
-    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(UK_CHANNEL)
-    EU_PAGE ?= 0
-    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_PAGE=$(UK_PAGE)
-    # As Issues/PRS reference #13526 has already sloved, we don't need change the SPI_CLK anaymore
-    # SCLK := SPI_CLK_1MHZ
-    # CFLAGS += -DAT86RF2XX_PARAM_SPI_CLK=$(SCLK)
+ifneq (EU,$(ISM))
+  # Default seeting which working on US (Channel 26 for 2.4 GHz, Channel 5/Page 2 for sub-GHz)
+  ifneq (,$(DEFAULT_CHANNEL))
+    ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
+      CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+    endif
+    ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
+      CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
+    else                                          # radio is IEEE 802.15.4 2.4 GHz
+      CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+    endif
   endif
-endif
-ifneq (,$(DEFAULT_CHANNEL))
+else      # Switching to ISM-EU if ISM=EU when make (sub-GHz channel = 0 / sub-GHz page = 0)
   ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
     CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
   endif
-  ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
-    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
+  ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio sub-GHz channel = 0 / sub-GHz page = 0
+    EU_CHANNEL ?= 0
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(EU_CHANNEL)
+    EU_PAGE ?= 0
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_PAGE=$(EU_PAGE)
   else                                          # radio is IEEE 802.15.4 2.4 GHz
     CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
   endif
 endif
-  # Set a custom PAN ID if needed
+
+# Set a custom PAN ID if needed
 ifneq (,$(DEFAULT_PAN_ID))
   CFLAGS += -DIEEE802154_DEFAULT_PANID=$(DEFAULT_PAN_ID)
 endif

--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -1,17 +1,26 @@
-# Set a custom channel if needed
+# ISM = 868Mhz Channel & Page Switch for EU area
+ifeq (868,$(ISM))
+  ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
+    EU_CHANNEL ?= 0
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(UK_CHANNEL)
+    EU_PAGE ?= 0
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_PAGE=$(UK_PAGE)
+    # As Issues/PRS reference #13526 has already sloved, we don't need change the SPI_CLK anaymore
+    # SCLK := SPI_CLK_1MHZ
+    # CFLAGS += -DAT86RF2XX_PARAM_SPI_CLK=$(SCLK)
+  endif
+endif
 ifneq (,$(DEFAULT_CHANNEL))
   ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
     CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
   endif
-
   ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
     CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
   else                                          # radio is IEEE 802.15.4 2.4 GHz
     CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
   endif
 endif
-
-# Set a custom PAN ID if needed
+  # Set a custom PAN ID if needed
 ifneq (,$(DEFAULT_PAN_ID))
   CFLAGS += -DIEEE802154_DEFAULT_PANID=$(DEFAULT_PAN_ID)
 endif

--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -1,32 +1,41 @@
 # Frequency Band (FBAND) variable can pass like: make BOARD=samr30-xpro FBAND=868 flash term
 # with FBAND=868 changes channel/page setting only if transceiver is at86rf212b
-ifeq (868, $(FBAND))
-  # radio is at86rf212b sub GHz at FBAND=868MHz (channel = 0 / page = 0）
-  ifneq (,$(filter at86rf212b,$(USEMODULE)))     
-    FBAND_CHANNEL ?= 0
-    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(FBAND_CHANNEL)
-    FBAND_PAGE ?= 0
-    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_PAGE=$(FBAND_PAGE)
-  # if not using samr30-xpro radio is the same as default IEEE 802.15.4 2.4 GHz
-  else                                        # radio is IEEE 802.15.4 2.4 GHz
-    GHZ_CHANNEL ?= 26                                        
-    CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(GHZ_CHANNEL)
-  endif
-# Applying default setting if FBAND is 915MHz (Channel = 26 for 2.4 GHz, Channel = 5/Page = 2 for sub-GHz)
-else                                          
-  ifneq (,$(DEFAULT_CHANNEL))
-    ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
-      CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+ifndef CONFIG_KCONFIG_MODULE_IEEE802154
+  ifeq (868, $(FBAND))
+    # radio is at86rf212b sub GHz at FBAND=868MHz (channel = 0 / page = 0）
+    ifneq (,$(filter at86rf212b,$(USEMODULE)))     
+      CFLAGS += -DCONFIG_IEEE802154_DEFAULT_SUBGHZ_CHANNEL=0
+      CFLAGS += -DCONFIG_IEEE802154_DEFAULT_SUBGHZ_PAGE=0
+    # if not using samr30-xpro radio is the same as default IEEE 802.15.4 2.4 GHz
+    else                                        # radio is IEEE 802.15.4 2.4 GHz
+      GHZ_CHANNEL ?= 26                                        
+      CFLAGS += -DCONFIG_IEEE802154_DEFAULT_CHANNEL=$(GHZ_CHANNEL)
     endif
-    ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
-      CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
-    else                                          # radio is IEEE 802.15.4 2.4 GHz
-      CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-    endif
+  # Applying default setting if FBAND is 915MHz (Channel = 26 for 2.4 GHz, Channel = 5/Page = 2 for sub-GHz)
+  else                                          
+    ifneq (,$(DEFAULT_CHANNEL))
+      ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
+        CFLAGS += -DCONFIG_CC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+      endif
+    endif 
   endif
 endif
+# # Set a custom channel if needed
+# ifndef CONFIG_KCONFIG_MODULE_IEEE802154
+#   ifneq (,$(DEFAULT_CHANNEL))
+#     ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
+#       CFLAGS += -DCONFIG_CC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+#     endif
 
-# Set a custom PAN ID if needed
-ifneq (,$(DEFAULT_PAN_ID))
-  CFLAGS += -DIEEE802154_DEFAULT_PANID=$(DEFAULT_PAN_ID)
-endif
+#     ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz
+#       CFLAGS += -DCONFIG_IEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(DEFAULT_CHANNEL)
+#     else                                          # radio is IEEE 802.15.4 2.4 GHz
+#       CFLAGS += -DCONFIG_IEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+#     endif
+#   endif
+
+#   # Set a custom PAN ID if needed
+#   ifneq (,$(DEFAULT_PAN_ID))
+#     CFLAGS += -DCONFIG_IEEE802154_DEFAULT_PANID=$(DEFAULT_PAN_ID)
+#   endif
+# endif

--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -1,6 +1,22 @@
-# ISM vairable can pass like: make BOARD=samr30-xpro ISM=EU flash term
-ifneq (EU,$(ISM))
-  # Default setting for US ISM band (Channel 26 for 2.4 GHz, Channel 5/Page 2 for sub-GHz)
+# Frequency Band (FBAND) vairable can pass like: make BOARD=samr30-xpro FBAND=868 flash term
+# with FBAND=868 changes channel/page setting only if transceiver is at86rf212b 
+ifeq (868, $(FBAND))
+  ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
+    CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+  endif
+  # radio is at86rf212b sub GHz at FBAND=868MHz (channel = 0 / page = 0）
+  ifneq (,$(filter at86rf212b,$(USEMODULE)))     
+    FBAND_CHANNEL ?= 0
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(FBAND_CHANNEL)
+    FBAND_PAGE ?= 0
+    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_PAGE=$(FBAND_PAGE)
+  # if not using samr30-xpro radio is the same as default IEEE 802.15.4 2.4 GHz
+  else                                        # radio is IEEE 802.15.4 2.4 GHz
+    GHZ_CHANNEL ?= 26                                        
+    CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(GHZ_CHANNEL)
+  endif
+# Applying default setting if FBAND is 915MHz (Channel = 26 for 2.4 GHz, Channel = 5/Page = 2 for sub-GHz)
+else                                          
   ifneq (,$(DEFAULT_CHANNEL))
     ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
       CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
@@ -10,18 +26,6 @@ ifneq (EU,$(ISM))
     else                                          # radio is IEEE 802.15.4 2.4 GHz
       CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
     endif
-  endif
-else      # Switching to ISM-EU if ISM=EU when make (sub-GHz channel = 0 / sub-GHz page = 0)
-  ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
-    CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
-  endif
-  ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio sub-GHz channel = 0 / sub-GHz page = 0
-    EU_CHANNEL ?= 0
-    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_CHANNEL=$(EU_CHANNEL)
-    EU_PAGE ?= 0
-    CFLAGS += -DIEEE802154_DEFAULT_SUBGHZ_PAGE=$(EU_PAGE)
-  else                                          # radio is IEEE 802.15.4 2.4 GHz
-    CFLAGS += -DIEEE802154_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
   endif
 endif
 

--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -1,3 +1,4 @@
+# vairable can pass like: make BOARD=samr30-xpro ISM=EU flash term
 ifneq (EU,$(ISM))
   # Default setting for US ISM band (Channel 26 for 2.4 GHz, Channel 5/Page 2 for sub-GHz)
   ifneq (,$(DEFAULT_CHANNEL))

--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -1,4 +1,4 @@
-# vairable can pass like: make BOARD=samr30-xpro ISM=EU flash term
+# ISM vairable can pass like: make BOARD=samr30-xpro ISM=EU flash term
 ifneq (EU,$(ISM))
   # Default setting for US ISM band (Channel 26 for 2.4 GHz, Channel 5/Page 2 for sub-GHz)
   ifneq (,$(DEFAULT_CHANNEL))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
New feature: Enable easier Channel/Page selection on the samr30-xpro.
Allows setting of the ISM 868MHz frequency band (e.g. for EU). 
Use the FBAND variable like:
`make BOARD=samr30-xpro FBAND=EU flash term`
will change the default channel and page number into 0. This has been tested by sending UDP packets between two samr30-xpro. Check page: 387 of [IEEE 802.15.4-2015](https://ieeexplore.ieee.org/document/7460875) for more details about Channel/Page numbering.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
1.Checked UDP with:
tests/gnrc_udp by passing the FBAND variable as shown below:
make BOARD=samr30-xpro ISM=EU flash term
This has been tested by sending UPD packets between two samr30-xpro", see result shown below:
![0403_1](https://user-images.githubusercontent.com/50105190/78430852-e2b0bb00-766c-11ea-9401-c1e20cb0da98.jpg)
![image](https://user-images.githubusercontent.com/50105190/78430983-eba18c80-766c-11ea-98b7-93af706ef636.png)
2.Also using radio checker to observe the working frequence, in my test, all packet is sending in the central frequence of 868.3MHz

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Thanks to the work of #13537, this time we don't need to change SPI_CLK into 1MHz to make it work. 
