### PR TITLE
tests/libc_newlib: blacklist esp32 boards temporarily

### DIFF
--- a/tests/libc_newlib/Makefile
+++ b/tests/libc_newlib/Makefile
@@ -2,6 +2,8 @@ include ../Makefile.tests_common
 
 USEMODULE += embunit
 
+FEATURES_BLACKLIST += arch_esp32
+
 include $(RIOTBASE)/Makefile.include
 
 # Compile time tests


### PR DESCRIPTION
### Contribution description

ESP32 boards must be blacklisted for `tests/libc_newlib` to avoid CI compilation errors until the toolchain is updated on all nodes. This change has to be reverted by merging PR #13812 once all nodes are update.

### Testing procedure

Compilation in Murdock has to succeed.

### Issues/PRs references
