### PR TITLE
net/gcoap: add canonical uri query function names

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -929,7 +929,7 @@ ssize_t gcoap_encode_link(const coap_resource_t *resource, char *buf,
  * The Uri-Query options will be added in the order those calls.
  *
  * @deprecated  Will not be available after the 2020.10 release. Use
- * coap_opt_add_uquery() instead.
+ * coap_opt_add_uri_query() instead.
  *
  * @param[out] pdu      The package that is being build
  * @param[in]  key      Key to add to the query string

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -976,6 +976,44 @@ ssize_t coap_opt_add_opaque(coap_pkt_t *pkt, uint16_t optnum, const uint8_t *val
 /**
  * @brief   Adds a single Uri-Query option in the form 'key=value' into pkt
  *
+ * @note Use this only for null-terminated string. See @ref coap_opt_add_uri_query2()
+ *       for non null-terminated string.
+ *
+ * @param[in,out] pkt         Packet being built
+ * @param[in]     key         Key to add to the query string
+ * @param[in]     val         Value to assign to @p key (may be NULL)
+ *
+ * @pre     ((pkt != NULL) && (key != NULL))
+ *
+ * @return        number of bytes written to pkt buffer
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or pkt full
+ */
+ssize_t coap_opt_add_uri_query(coap_pkt_t *pkt, const char *key, const char *val);
+
+/**
+ * @brief   Adds a single Uri-Query option in the form 'key=value' into pkt
+ *
+ *
+ * @param[in,out] pkt         Packet being built
+ * @param[in]     key         Key to add to the query string
+ * @param[in]     key_len     Length of @p key
+ * @param[in]     val         Value to assign to @p key (may be NULL)
+ * @param[in]     val_len     Length of @p val. 0 if @p val is NULL
+ *
+ * @pre     ((pkt != NULL) && (key != NULL) && (key_len > 0)
+ *              && ((val_len == 0) || ((val != NULL) && (val_len > 0))))
+ *
+ * @return        number of bytes written to pkt buffer
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or pkt full
+ */
+ssize_t coap_opt_add_uri_query2(coap_pkt_t *pkt, const char *key, size_t key_len,
+                                const char *val, size_t val_len);
+
+/**
+ * @brief   Adds a single Uri-Query option in the form 'key=value' into pkt
+ *
  * @note Use this only for null-terminated string. See @ref coap_opt_add_uquery2()
  *       for non null-terminated string.
  *

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -81,6 +81,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <string.h>
 #include <unistd.h>
 
 #ifdef RIOT_VERSION
@@ -976,24 +977,6 @@ ssize_t coap_opt_add_opaque(coap_pkt_t *pkt, uint16_t optnum, const uint8_t *val
 /**
  * @brief   Adds a single Uri-Query option in the form 'key=value' into pkt
  *
- * @note Use this only for null-terminated string. See @ref coap_opt_add_uri_query2()
- *       for non null-terminated string.
- *
- * @param[in,out] pkt         Packet being built
- * @param[in]     key         Key to add to the query string
- * @param[in]     val         Value to assign to @p key (may be NULL)
- *
- * @pre     ((pkt != NULL) && (key != NULL))
- *
- * @return        number of bytes written to pkt buffer
- * @return        <0 on error
- * @return        -ENOSPC if no available options or pkt full
- */
-ssize_t coap_opt_add_uri_query(coap_pkt_t *pkt, const char *key, const char *val);
-
-/**
- * @brief   Adds a single Uri-Query option in the form 'key=value' into pkt
- *
  *
  * @param[in,out] pkt         Packet being built
  * @param[in]     key         Key to add to the query string
@@ -1014,6 +997,28 @@ ssize_t coap_opt_add_uri_query2(coap_pkt_t *pkt, const char *key, size_t key_len
 /**
  * @brief   Adds a single Uri-Query option in the form 'key=value' into pkt
  *
+ * @note Use this only for null-terminated string. See @ref coap_opt_add_uri_query2()
+ *       for non null-terminated string.
+ *
+ * @param[in,out] pkt         Packet being built
+ * @param[in]     key         Key to add to the query string
+ * @param[in]     val         Value to assign to @p key (may be NULL)
+ *
+ * @pre     ((pkt != NULL) && (key != NULL))
+ *
+ * @return        number of bytes written to pkt buffer
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or pkt full
+ */
+static inline ssize_t coap_opt_add_uri_query(coap_pkt_t *pkt, const char *key,
+                                             const char *val)
+{
+    return coap_opt_add_uri_query2(pkt, key, strlen(key), val, val ? strlen(val) : 0);
+}
+
+/**
+ * @brief   Adds a single Uri-Query option in the form 'key=value' into pkt
+ *
  * @note Use this only for null-terminated string. See @ref coap_opt_add_uquery2()
  *       for non null-terminated string.
  *
@@ -1027,7 +1032,10 @@ ssize_t coap_opt_add_uri_query2(coap_pkt_t *pkt, const char *key, size_t key_len
  * @return        <0 on error
  * @return        -ENOSPC if no available options or pkt full
  */
-ssize_t coap_opt_add_uquery(coap_pkt_t *pkt, const char *key, const char *val);
+static inline ssize_t coap_opt_add_uquery(coap_pkt_t *pkt, const char *key, const char *val)
+{
+    return coap_opt_add_uri_query(pkt, key, val);
+}
 
 /**
  * @brief   Adds a single Uri-Query option in the form 'key=value' into pkt
@@ -1046,8 +1054,11 @@ ssize_t coap_opt_add_uquery(coap_pkt_t *pkt, const char *key, const char *val);
  * @return        <0 on error
  * @return        -ENOSPC if no available options or pkt full
  */
-ssize_t coap_opt_add_uquery2(coap_pkt_t *pkt, const char *key, size_t key_len,
-                             const char *val, size_t val_len);
+static inline ssize_t coap_opt_add_uquery2(coap_pkt_t *pkt, const char *key, size_t key_len,
+                                           const char *val, size_t val_len)
+{
+    return coap_opt_add_uri_query2(pkt, key, key_len, val, val_len);
+}
 
 /**
  * @brief   Adds a single Proxy-URI option into @p pkt

--- a/sys/net/application_layer/cord/common/cord_common.c
+++ b/sys/net/application_layer/cord/common/cord_common.c
@@ -57,7 +57,7 @@ void cord_common_init(void)
 int cord_common_add_qstring(coap_pkt_t *pkt)
 {
     /* extend the url with some query string options */
-    int res = coap_opt_add_uquery(pkt, "ep", cord_common_ep);
+    int res = coap_opt_add_uri_query(pkt, "ep", cord_common_ep);
     if (res < 0) {
         return res;
     }
@@ -66,7 +66,7 @@ int cord_common_add_qstring(coap_pkt_t *pkt)
 #if CORD_LT
     char lt[11];
     lt[fmt_u32_dec(lt, CORD_LT)] = '\0';
-    res = coap_opt_add_uquery(pkt, "lt", lt);
+    res = coap_opt_add_uri_query(pkt, "lt", lt);
     if (res < 0) {
         return res;
     }
@@ -74,7 +74,7 @@ int cord_common_add_qstring(coap_pkt_t *pkt)
 
     /* [optional] set the domain parameter */
 #ifdef CORD_D
-    res = coap_opt_add_uquery(pkt, "d", CORD_D);
+    res = coap_opt_add_uri_query(pkt, "d", CORD_D);
     if (res < 0) {
         return res;
     }

--- a/sys/net/application_layer/cord/ep/cord_ep.c
+++ b/sys/net/application_layer/cord/ep/cord_ep.c
@@ -221,7 +221,7 @@ static int _discover_internal(const sock_udp_ep_t *remote,
         return CORD_EP_ERR;
     }
     coap_hdr_set_type(pkt.hdr, COAP_TYPE_CON);
-    coap_opt_add_uquery(&pkt, "rt", "core.rd");
+    coap_opt_add_uri_query(&pkt, "rt", "core.rd");
     size_t pkt_len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
     res = gcoap_req_send(buf, pkt_len, remote, _on_discover, NULL);
     if (res < 0) {

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -854,13 +854,8 @@ ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum, const char *string
     return write_len;
 }
 
-ssize_t coap_opt_add_uquery(coap_pkt_t *pkt, const char *key, const char *val)
-{
-    return coap_opt_add_uquery2(pkt, key, strlen(key), val, val ? strlen(val) : 0);
-}
-
-ssize_t coap_opt_add_uquery2(coap_pkt_t *pkt, const char *key, size_t key_len,
-                             const char *val, size_t val_len)
+ssize_t coap_opt_add_uri_query2(coap_pkt_t *pkt, const char *key, size_t key_len,
+                                const char *val, size_t val_len)
 {
     assert(pkt);
     assert(key);

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -318,9 +318,9 @@ static void test_nanocoap__get_multi_query(void)
 
     uint8_t *query_pos = &pkt.payload[0];
     /* first opt header is 2 bytes long */
-    ssize_t optlen = coap_opt_add_uquery(&pkt, key1, val1);
+    ssize_t optlen = coap_opt_add_uri_query(&pkt, key1, val1);
     TEST_ASSERT_EQUAL_INT(8, optlen);
-    optlen = coap_opt_add_uquery(&pkt, key2, NULL);
+    optlen = coap_opt_add_uri_query(&pkt, key2, NULL);
     TEST_ASSERT_EQUAL_INT(2, optlen);
 
     char query[20] = {0};
@@ -335,9 +335,9 @@ static void test_nanocoap__get_multi_query(void)
     TEST_ASSERT_EQUAL_STRING((char *)qs, &query[1]);
 }
 /*
- * Builds on get_multi_query test, to use coap_opt_add_uquery2().
+ * Builds on get_multi_query test, to use coap_opt_add_uri_query2().
  */
-static void test_nanocoap__add_uquery2(void)
+static void test_nanocoap__add_uri_query2(void)
 {
     uint8_t buf[_BUF_SIZE];
     coap_pkt_t pkt;
@@ -362,7 +362,7 @@ static void test_nanocoap__add_uquery2(void)
 
     /* includes key and value */
     char query[20] = {0};
-    len = coap_opt_add_uquery2(&pkt, keys, key1_len, vals, val1_len);
+    len = coap_opt_add_uri_query2(&pkt, keys, key1_len, vals, val1_len);
     TEST_ASSERT_EQUAL_INT(query1_opt_len, len);
     coap_get_uri_query(&pkt, (uint8_t *)&query[0]);
     /* skip initial '&' from coap_get_uri_query() */
@@ -370,7 +370,7 @@ static void test_nanocoap__add_uquery2(void)
 
     /* includes key only */
     memset(query, 0, 20);
-    len = coap_opt_add_uquery2(&pkt, &keys[2], key2_len, NULL, 0);
+    len = coap_opt_add_uri_query2(&pkt, &keys[2], key2_len, NULL, 0);
     TEST_ASSERT_EQUAL_INT(query2_opt_len, len);
     coap_get_uri_query(&pkt, (uint8_t *)&query[0]);
     /* skip initial '&' from coap_get_uri_query() */
@@ -378,7 +378,7 @@ static void test_nanocoap__add_uquery2(void)
 
     /* includes key only; value not NULL but zero length */
     memset(query, 0, 20);
-    len = coap_opt_add_uquery2(&pkt, &keys[2], key2_len, &vals[3], 0);
+    len = coap_opt_add_uri_query2(&pkt, &keys[2], key2_len, &vals[3], 0);
     TEST_ASSERT_EQUAL_INT(query3_opt_len, len);
     coap_get_uri_query(&pkt, (uint8_t *)&query[0]);
     /* skip initial '&' from coap_get_uri_query() */
@@ -391,7 +391,7 @@ static void test_nanocoap__add_uquery2(void)
 
     /* includes key only; value NULL and length > 0 */
     memset(query, 0, 20);
-    len = coap_opt_add_uquery2(&pkt, &keys[2], key2_len, NULL, 1);
+    len = coap_opt_add_uri_query2(&pkt, &keys[2], key2_len, NULL, 1);
     TEST_ASSERT_EQUAL_INT(query4_opt_len, len);
     coap_get_uri_query(&pkt, (uint8_t *)&query[0]);
     /* skip initial '&' from coap_get_uri_query() */
@@ -726,7 +726,7 @@ Test *tests_nanocoap_tests(void)
         new_TestFixture(test_nanocoap__get_path_too_long),
         new_TestFixture(test_nanocoap__get_query),
         new_TestFixture(test_nanocoap__get_multi_query),
-        new_TestFixture(test_nanocoap__add_uquery2),
+        new_TestFixture(test_nanocoap__add_uri_query2),
         new_TestFixture(test_nanocoap__option_add_buffer_max),
         new_TestFixture(test_nanocoap__options_get_opaque),
         new_TestFixture(test_nanocoap__options_iterate),


### PR DESCRIPTION
### Contribution description
gcoap has been a great education for me in the development of an API. To prove that I am learning, this PR fixes a recent mistake in function names. ;-)  #13213 and #13022 introduced functions to add a Uri-Query option with the Packet API. I named these functions `coap_opt_add_uquery() and coap_opt_add_uquery2()`. (Let's call them `coap_opt_add_uqueryX()`.) In retrospect, I should have chosen `coap_opt_add_uri_queryX()`. This PR creates the new function names and migrates existing uses of the functions.

One of the principles of API design to me is ease of use. This principle does include minimizing keystrokes, as in the original implementation of these functions. But I realize now that the longer name has more advantages:
* It is consistent with other functions to add a specific option, like `coap_opt_put_uri_query()` and `coap_get_uri_query()`.
* It uses the canonical name of the option from RFC 7252, which will help if we add similar functions for the Location-Query option.

Together I think these advantages make it easier for an API user when writing an application. They will be less likely to get confused and resort to the documentation.

I think it is OK also to have shorthand names for functions, but I think the API should include a default function based on the name of the option from the RFC.

### Testing procedure
* review module documentation
* run nanocoap tests
* run cord_ep example
* [edit] run nanocoap_server example since it failed in automated build

### Issues/PRs references
See other PRs above.