### PR TITLE
cc26x2_cc13x2: trim device registers on `cpu_init`.

### DIFF
--- a/cpu/cc26x2_cc13x2/aux.c
+++ b/cpu/cc26x2_cc13x2/aux.c
@@ -1,0 +1,91 @@
+
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+/**
+ * @ingroup         cpu_cc26x2_cc13x2
+ * @{
+ *
+ * @file
+ * @brief           CC26x2, CC13x2 AUX functions
+ * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
+ * @}
+ */
+
+#include <assert.h>
+#include "cpu.h"
+
+/**
+ * @brief   Order of operation modes
+ *
+ * This is to calculate which mode follows the other, to change step-by-step
+ * the mode.
+ *
+ * @{
+ */
+#define OPMODE_PDA_ORDER  (0)
+#define OPMODE_A_ORDER    (1)
+#define OPMODE_LP_ORDER   (2)
+#define OPMODE_PDLP_ORDER (3)
+/** @} */
+
+/** Array to map an operation mode to it's order when changing it */
+static const uint8_t _opmode_to_order[4] = {
+    OPMODE_A_ORDER,
+    OPMODE_LP_ORDER,
+    OPMODE_PDA_ORDER,
+    OPMODE_PDLP_ORDER
+};
+/** Array to map an order to an operation mode, used to get the next operation
+ * mode. This is because we need to change the operation in ordered steps */
+static const uint8_t _order_to_opmode[4] = {
+    AUX_SYSIF_OPMODEREQ_REQ_PDA,
+    AUX_SYSIF_OPMODEREQ_REQ_A,
+    AUX_SYSIF_OPMODEREQ_REQ_LP,
+    AUX_SYSIF_OPMODEREQ_REQ_PDLP
+};
+
+void aux_sysif_opmode_change(uint32_t target_opmode)
+{
+    assert((target_opmode == AUX_SYSIF_OPMODEREQ_REQ_PDLP) ||
+           (target_opmode == AUX_SYSIF_OPMODEREQ_REQ_PDA)  ||
+           (target_opmode == AUX_SYSIF_OPMODEREQ_REQ_LP)   ||
+           (target_opmode == AUX_SYSIF_OPMODEREQ_REQ_A));
+
+    uint32_t current_opmode;
+    uint32_t next_mode;
+
+    /* Change AUX operation mode following hardware rules, operation mode
+     * change needs to be done in order, and one step at a time:
+     *
+     * PDA -> A -> LP -> PDLP
+     */
+    do {
+        current_opmode = AUX_SYSIF->OPMODEREQ;
+
+        /* Wait for change ACK */
+        while (current_opmode != AUX_SYSIF->OPMODEACK) {}
+
+        if (current_opmode == target_opmode) {
+            break;
+        }
+
+        /* At this point we aren't in the mode we want, now we calculate which
+         * mode follows this and make the change to that mode, this is repeated
+         * in this loop until we get to the desired mode */
+        uint32_t current_order = _opmode_to_order[current_opmode];
+        if (current_order < _opmode_to_order[target_opmode]) {
+            next_mode = _order_to_opmode[current_order + 1];
+        }
+        else {
+            next_mode = _order_to_opmode[current_order - 1];
+        }
+
+        /* Request next mode */
+        AUX_SYSIF->OPMODEREQ = next_mode;
+    } while (current_opmode != target_opmode);
+}

--- a/cpu/cc26x2_cc13x2/cpu.c
+++ b/cpu/cc26x2_cc13x2/cpu.c
@@ -33,6 +33,9 @@ void cpu_init(void)
     /* initialize the Cortex-M core */
     cortexm_init();
 
+    /* trim device */
+    setup_trim_device();
+
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
     stdio_init();
 

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_aux.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_aux.h
@@ -417,6 +417,35 @@ typedef struct {
 } adi_4_aux_regs_t;
 
 /**
+ * @brief   ADI_4_AUX registers using masked 8-bit access
+ */
+typedef struct {
+    reg8_m8_t MUX0; /**< Multiplexer 0 */
+    reg8_m8_t MUX1; /**< Multiplexer 1 */
+    reg8_m8_t MUX2; /**< Multiplexer 2 */
+    reg8_m8_t MUX3; /**< Multiplexer 3 */
+    reg8_m8_t ISRC; /**< Current Source */
+    reg8_m8_t COMP; /**< Comparator */
+    reg8_m8_t MUX4; /**< Multiplexer 4 */
+    reg8_m8_t ADC0; /**< ADC Control 0 */
+    reg8_m8_t ADC1; /**< ADC Control 1 */
+    reg8_m8_t ADCREF0; /**< ADC Reference 0 */
+    reg8_m8_t ADCREF1; /**< ADC Reference 1 */
+    reg8_m8_t __reserved1[0x3]; /**< Reserved */
+    reg8_m8_t LPMBIAS; /**< Internal */
+} adi_4_aux_regs_m8_t;
+
+/**
+ * @brief   ADI_4_AUX register values
+ * @{
+ */
+#define ADI_4_AUX_COMP_LPM_BIAS_WIDTH_TRIM_m 0x00000038
+#define ADI_4_AUX_COMP_LPM_BIAS_WIDTH_TRIM_s 3
+#define ADI_4_AUX_LPMBIAS_LPM_TRIM_IOUT_m    0x0000003F
+#define ADI_4_AUX_LPMBIAS_LPM_TRIM_IOUT_s    0
+/** @} */
+
+/**
  * @ingroup cpu_specific_peripheral_memory_map
  * @{
  */
@@ -424,12 +453,20 @@ typedef struct {
  * @brief   ADI_4_AUX base address
  */
 #define ADI_4_AUX_BASE       (PERIPH_BASE + 0xCB000)
+/**
+ * @brief   ADI_4_AUX base address for masked 8-bit access
+ */
+#define ADI_4_AUX_BASE_M8    (ADI_4_AUX_BASE + ADI_MASK8B)
 /** @} */
 
 /**
  * @brief   ADI_4_AUX register bank
  */
 #define ADI_4_AUX            ((adi_4_aux_regs_t *) (ADI_4_AUX_BASE))
+/**
+ * @brief   ADI_4_AUX register bank
+ */
+#define ADI_4_AUX_M8         ((adi_4_aux_regs_m8_t *) (ADI_4_AUX_BASE_M8))
 
 /**
  * @brief   Semamphore used for ADDI

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_aux.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_aux.h
@@ -217,6 +217,17 @@ typedef struct {
     reg32_t SWPWRPROF; /**< Software Power Profiler */
 } aux_sysif_regs_t;
 
+
+/**
+ * @brief   AUX_SYSIF register values
+ * @{
+ */
+#define AUX_SYSIF_OPMODEREQ_REQ_PDLP 0x00000003
+#define AUX_SYSIF_OPMODEREQ_REQ_PDA  0x00000002
+#define AUX_SYSIF_OPMODEREQ_REQ_LP   0x00000001
+#define AUX_SYSIF_OPMODEREQ_REQ_A    0x00000000
+/** @} */
+
 /**
  * @ingroup cpu_specific_peripheral_memory_map
  * @{
@@ -231,6 +242,21 @@ typedef struct {
  * @brief   AUX_SYSIF register bank
  */
 #define AUX_SYSIF            ((aux_sysif_regs_t *) (AUX_SYSIF_BASE))
+
+/**
+ * @brief   AUX_SYSIF functions
+ * @{
+ */
+/**
+ * @brief    Changes the AUX operational mode
+ *
+ * @note Only this function should be used to change the operational mode,
+ * because it needs to be done in order.
+ *
+ * @param[in] target_opmode The opmode we want to change to.
+ */
+void aux_sysif_opmode_change(uint32_t target_opmode);
+/** @} */
 
 /**
  * @brief   AUX_TIMER01 registers

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_fcfg.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_fcfg.h
@@ -127,6 +127,17 @@ typedef struct {
 } fcfg_regs_t;
 
 /**
+ * @brief   FCFG1 register values
+ * @{
+ */
+#define FCFG1_DAC_BIAS_CNF_LPM_TRIM_IOUT_m       0x0003F000
+#define FCFG1_DAC_BIAS_CNF_LPM_TRIM_IOUT_s       12
+#define FCFG1_DAC_BIAS_CNF_LPM_BIAS_WIDTH_TRIM_m 0x00000E00
+#define FCFG1_DAC_BIAS_CNF_LPM_BIAS_WIDTH_TRIM_s 9
+#define FCFG1_DAC_BIAS_CNF_LPM_BIAS_BACKUP_EN    0x00000100
+/** @} */
+
+/**
  * @ingroup cpu_specific_peripheral_memory_map
  * @{
  */

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
@@ -48,6 +48,30 @@ typedef struct {
 } ddi0_osc_regs_t;
 
 /**
+ * @brief   DDI_0_OSC registers with masked 16-bit access
+ */
+typedef struct {
+    reg32_m16_t CTL0; /**< Control 0 */
+    reg32_m16_t CTL1; /**< Control 1 */
+    reg32_m16_t RADCEXTCFG; /**< RADC External Configuration */
+    reg32_m16_t AMPCOMPCTL; /**< Amplitude Compensation Control */
+    reg32_m16_t AMPCOMPTH1; /**< Amplitude Compensation Threshold 1 */
+    reg32_m16_t AMPCOMPTH2; /**< Amplitude Compensation Threshold 2 */
+    reg32_m16_t ANABYPASSVAL1; /**< Analog Bypass Values 1 */
+    reg32_m16_t ANABYPASSVAL2; /**< Internal */
+    reg32_m16_t ATESTCTL; /**< Analog Test Control */
+    reg32_m16_t ADCDOUBLERNANOAMPCTL; /**< ADC Doubler Nanoamp Control */
+    reg32_m16_t XOSCHFCTL; /**< XOSCHF Control */
+    reg32_m16_t LFOSCCTL; /**< Low Frequency Oscillator Control */
+    reg32_m16_t RCOSCHFCTL; /**< RCOSCHF Control */
+    reg32_m16_t RCOSCMFCTL; /**< RCOSC_MF Control */
+    reg32_m16_t __reserved1; /**< Reserved */
+    reg32_m16_t STAT0; /**< Status 0 */
+    reg32_m16_t STAT1; /**< Status 1 */
+    reg32_m16_t STAT2; /**< Status 2 */
+} ddi0_osc_regs_m16_t;
+
+/**
  * @brief   DDI_0_OSC register values
  * @{
  */
@@ -71,16 +95,30 @@ typedef struct {
  * @ingroup cpu_cc26x2_cc13x2_peripheral_memory_map
  * @{
  */
+#define DDI_DIR              0x00000000
+#define DDI_SET              0x00000080
+#define DDI_CLR              0x00000100
+#define DDI_MASK4B           0x00000200
+#define DDI_MASK8B           0x00000300
+#define DDI_MASK16B          0x00000400
 /**
  * @brief   DDI0_OSC base address
  */
 #define DDI0_OSC_BASE        (PERIPH_BASE + 0xCA000)
+/**
+ * @brief   DDI0_OSC 16-bit masked access base address
+ */
+#define DDI0_OSC_BASE_M16    (DDI0_OSC_BASE + DDI_MASK16B)
 /** @} */
 
 /**
  * @brief   DDI_0_OSC register bank
  */
 #define DDI_0_OSC            ((ddi0_osc_regs_t *) (DDI0_OSC_BASE))
+/**
+ * @brief   DDI_0_OSC 16-bit masked access register bank
+ */
+#define DDI_0_OSC_M16        ((ddi0_osc_regs_m16_t *) (DDI0_OSC_BASE_M16))
 
 /**
 * AON_PMCTL registers

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
@@ -23,57 +23,64 @@
 extern "C" {
 #endif
 
-
 /**
- * DDI_0_OSC registers
+ * @brief   DDI_0_OSC registers
  */
 typedef struct {
-    reg32_t CTL0; /**< control 0 */
-    reg32_t CTL1; /**< control 1 */
-    reg32_t RADCEXTCFG; /**< RADC external config */
-    reg32_t AMPCOMPCTL; /**< amplitude compensation control */
-    reg32_t AMPCOMPTH1; /**< amplitude compensation threshold 1 */
-    reg32_t AMPCOMPTH2; /**< amplitude compensation threshold 2 */
-    reg32_t ANABYPASSVAL1; /**< analog bypass values 1 */
-    reg32_t ANABYPASSVAL2; /**< analog bypass values 2 */
-    reg32_t ATESTCTL; /**< analog test control */
-    reg32_t ADCDOUBLERNANOAMPCTL; /**< ADC doubler nanoamp control */
-    reg32_t XOSCHFCTL; /**< XOSCHF control */
-    reg32_t LFOSCCTL; /**< low frequency oscillator control */
-    reg32_t RCOSCHFCTL; /**< RCOSCHF control */
-    reg32_t RCOSCHMCTL; /**< RCOSCHM control */
-    reg32_t STAT0; /**< status 0 */
-    reg32_t STAT1; /**< status 1 */
-    reg32_t STAT2; /**< status 2 */
+    reg32_t CTL0; /**< Control 0 */
+    reg32_t CTL1; /**< Control 1 */
+    reg32_t RADCEXTCFG; /**< RADC External Configuration */
+    reg32_t AMPCOMPCTL; /**< Amplitude Compensation Control */
+    reg32_t AMPCOMPTH1; /**< Amplitude Compensation Threshold 1 */
+    reg32_t AMPCOMPTH2; /**< Amplitude Compensation Threshold 2 */
+    reg32_t ANABYPASSVAL1; /**< Analog Bypass Values 1 */
+    reg32_t ANABYPASSVAL2; /**< Internal */
+    reg32_t ATESTCTL; /**< Analog Test Control */
+    reg32_t ADCDOUBLERNANOAMPCTL; /**< ADC Doubler Nanoamp Control */
+    reg32_t XOSCHFCTL; /**< XOSCHF Control */
+    reg32_t LFOSCCTL; /**< Low Frequency Oscillator Control */
+    reg32_t RCOSCHFCTL; /**< RCOSCHF Control */
+    reg32_t RCOSCMFCTL; /**< RCOSC_MF Control */
+    reg32_t __reserved1; /**< Reserved */
+    reg32_t STAT0; /**< Status 0 */
+    reg32_t STAT1; /**< Status 1 */
+    reg32_t STAT2; /**< Status 2 */
 } ddi0_osc_regs_t;
 
 /**
  * @brief   DDI_0_OSC register values
  * @{
  */
-#define DDI_0_OSC_CTL0_SCLK_HF_SRC_SEL              0x00000001
-#define DDI_0_OSC_CTL0_SCLK_LF_SRC_SEL              0x0000000C
-#define DDI_0_OSC_CTL0_ACLK_TDC_SRC_SEL             0x00000180
-#define DDI_0_OSC_CTL0_CLK_LOSS_EN                  0x00000200 /* enable clock loss detection */
-#define DDI_0_OSC_CTL0_XOSC_LF_DIG_BYPASS           0x00000400 /* bypass XOSC_LF and use digital input clock from AON foor xosx_lf (precuations in datasheet) */
-#define DDI_0_OSC_CTL0_XOSC_HF_POWER_MODE           0x00000800
-#define DDI_0_OSC_CTL0_RCOSC_LF_TRIMMED             0x00001000
-#define DDI_0_OSC_CTL0_HPOSC_MODE_EN                0x00004000
-#define DDI_0_OSC_CTL0_DCDC_SRC_SEL                 0x01000000
-#define DDI_0_OSC_CTL0_DOUBLER_RESET_DURATION       0x02000000
-#define DDI_0_OSC_CTL0_DOUBLER_START_DURATION       0x0C000000
-#define DDI_0_OSC_CTL0_BYPASS_RCOSC_LF_CLK_QUAL     0x10000000
-#define DDI_0_OSC_CTL0_BYPASS_XOSC_LF_CLK_QUAL      0x20000000
-#define DDI_0_OSC_CTL0_XTAL_IS_24M                  0x80000000
+#define DDI_0_OSC_CTL0_SCLK_HF_SRC_SEL          0x00000001
+#define DDI_0_OSC_CTL0_SCLK_LF_SRC_SEL          0x0000000C
+#define DDI_0_OSC_CTL0_ACLK_TDC_SRC_SEL         0x00000180
+#define DDI_0_OSC_CTL0_CLK_LOSS_EN              0x00000200
+#define DDI_0_OSC_CTL0_XOSC_LF_DIG_BYPASS       0x00000400
+#define DDI_0_OSC_CTL0_XOSC_HF_POWER_MODE       0x00000800
+#define DDI_0_OSC_CTL0_RCOSC_LF_TRIMMED         0x00001000
+#define DDI_0_OSC_CTL0_HPOSC_MODE_EN            0x00004000
+#define DDI_0_OSC_CTL0_DCDC_SRC_SEL             0x01000000
+#define DDI_0_OSC_CTL0_DOUBLER_RESET_DURATION   0x02000000
+#define DDI_0_OSC_CTL0_DOUBLER_START_DURATION   0x0C000000
+#define DDI_0_OSC_CTL0_BYPASS_RCOSC_LF_CLK_QUAL 0x10000000
+#define DDI_0_OSC_CTL0_BYPASS_XOSC_LF_CLK_QUAL  0x20000000
+#define DDI_0_OSC_CTL0_XTAL_IS_24M              0x80000000
 /** @} */
 
-/** @ingroup cpu_cc26x2_cc13x2_peripheral_memory_map
-  * @{
-  */
-#define DDI0_OSC_BASE       0x400CA000 /**< DDI0_OSC base address */
-/*@}*/
+/**
+ * @ingroup cpu_cc26x2_cc13x2_peripheral_memory_map
+ * @{
+ */
+/**
+ * @brief   DDI0_OSC base address
+ */
+#define DDI0_OSC_BASE        (PERIPH_BASE + 0xCA000)
+/** @} */
 
-#define DDI_0_OSC ((ddi0_osc_regs_t *) (DDI0_OSC_BASE)) /**< DDI_0_OSC register bank */
+/**
+ * @brief   DDI_0_OSC register bank
+ */
+#define DDI_0_OSC            ((ddi0_osc_regs_t *) (DDI0_OSC_BASE))
 
 /**
 * AON_PMCTL registers

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
@@ -83,7 +83,7 @@ typedef struct {
 #define DDI_0_OSC_CTL0_XOSC_HF_POWER_MODE       0x00000800
 #define DDI_0_OSC_CTL0_RCOSC_LF_TRIMMED         0x00001000
 #define DDI_0_OSC_CTL0_HPOSC_MODE_EN            0x00004000
-#define DDI_0_OSC_CTL0_DCDC_SRC_SEL             0x01000000
+#define DDI_0_OSC_CTL0_CLK_DCDC_SRC_SEL_m       0x01000000
 #define DDI_0_OSC_CTL0_DOUBLER_RESET_DURATION   0x02000000
 #define DDI_0_OSC_CTL0_DOUBLER_START_DURATION   0x0C000000
 #define DDI_0_OSC_CTL0_BYPASS_RCOSC_LF_CLK_QUAL 0x10000000
@@ -121,13 +121,13 @@ typedef struct {
 #define DDI_0_OSC_M16        ((ddi0_osc_regs_m16_t *) (DDI0_OSC_BASE_M16))
 
 /**
-* AON_PMCTL registers
-*/
+ * @brief    AON_PMCTL registers
+ */
 typedef struct {
-   reg32_t __reserved1; /**< meh */
+   reg32_t __reserved1; /**< Reserved */
    reg32_t AUXSCECLK; /**< AUX SCE management */
    reg32_t RAMCFG; /**< RAM configuration */
-   reg32_t __reserved2; /**< meh */
+   reg32_t __reserved2; /**< Reserved */
    reg32_t PWRCTL; /**< Power management control */
    reg32_t PWRSTAT; /**< Power status */
    reg32_t SHUTDOWN; /**< Shutdown control */
@@ -136,18 +136,41 @@ typedef struct {
    reg32_t OSCCFG; /**< Oscillator configuration */
    reg32_t RESETCTL; /**< Reset control */
    reg32_t SLEEPCTL; /**< Reset control */
-   reg32_t __reserved3; /**< meh */
+   reg32_t __reserved3; /**< Reserved */
    reg32_t JTAGCFG; /**< JTAG configuration */
+   reg32_t __reserved4; /**< Reserved */
    reg32_t JTAGUSERCODE; /**< JTAG USERCODE */
 } aon_pmctl_regs_t;
 
-/** @ingroup cpu_specific_peripheral_memory_map
+/**
+ * @brief   AON_PMTCTL register values
  * @{
  */
-#define AON_PMCTL_BASE       0x40090000 /**< AON_PMCTL base address */
-/*@}*/
+#define AON_PMCTL_SLEEPCTL_IO_PAD_SLEEP_DIS 0x00000001
+#define AON_PMCTL_RESETCTL_BOOT_DET_1_CLR_m 0x02000000
+#define AON_PMCTL_RESETCTL_BOOT_DET_0_CLR_m 0x01000000
+#define AON_PMCTL_RESETCTL_BOOT_DET_1_SET_m 0x00020000
+#define AON_PMCTL_RESETCTL_BOOT_DET_0_SET_m 0x00010000
+#define AON_PMCTL_RESETCTL_BOOT_DET_1_m     0x00002000
+#define AON_PMCTL_RESETCTL_BOOT_DET_0_m     0x00001000
+#define AON_PMCTL_RESETCTL_BOOT_DET_0_s     12
+#define AON_PMCTL_RESETCTL_MCU_WARM_RESET_m 0x00000010
+/** @} */
 
-#define AON_PMCTL ((aon_pmctl_regs_t *) (AON_PMCTL_BASE)) /**< AON_PMCTL register bank */
+/**
+ * @ingroup cpu_specific_peripheral_memory_map
+ * @{
+ */
+/**
+ * @brief   AON_PMCTL base address
+ */
+#define AON_PMCTL_BASE       (PERIPH_BASE + 0x90000)
+/** @} */
+
+/**
+ * @brief   AON_PMCTL register bank
+ */
+#define AON_PMCTL            ((aon_pmctl_regs_t *) (AON_PMCTL_BASE))
 
 /**
  * AON_RTC registers

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_setup.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_setup.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_cc26x2_cc13x2
+ * @{
+ *
+ * @file
+ * @brief           CC26x2/CC13x2 Device setup functions
+ */
+
+#ifndef CC26X2_CC13X2_SETUP_H
+#define CC26X2_CC13X2_SETUP_H
+
+#include <cc26xx_cc13xx.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Setup API address
+ */
+#define ROM_API_SETUP ((uint32_t *) (ROM_API_TABLE[28]))
+
+/**
+ * @brief   Setup API ROM functions
+ * @{
+ */
+#define rom_setup_after_cold_reset_wakeup_from_shutdown_cfg1 \
+    ((void (*)(uint32_t mode_conf))ROM_API_SETUP[0])
+
+#define rom_setup_after_cold_reset_wakeup_from_shutdown_cfg2 \
+    ((void (*)(uint32_t rev, uint32_t mode_conf))ROM_API_SETUP[1])
+
+#define rom_setup_after_cold_reset_wakeup_from_shutdown_cfg3 \
+    ((void (*)(uint32_t mode_conf))ROM_API_SETUP[2])
+
+#define rom_setup_get_trim_for_adc_sh_mode_en \
+    ((uint32_t (*)(uint32_t rev))ROM_API_SETUP[3])
+
+#define rom_setup_get_trim_for_adc_sh_vbuf_en \
+    ((uint32_t (*)(uint32_t rev))ROM_API_SETUP[4])
+
+#define rom_setup_get_trim_for_ampcomp_ctrl \
+    ((uint32_t (*)(uint32_t rev))ROM_API_SETUP[5])
+
+#define rom_setup_get_trim_for_ampcomp_th1 \
+    ((uint32_t (*)(void))ROM_API_SETUP[6])
+
+#define rom_setup_get_trim_for_ampcomp_th2 \
+    ((uint32_t (*)(void))ROM_API_SETUP[7])
+
+#define rom_setup_get_trim_for_anabypass_value1 \
+    ((uint32_t (*)(uint32_t mode_conf))ROM_API_SETUP[8])
+
+#define rom_setup_get_trim_for_dblr_loop_filter_reset_voltage \
+    ((uint32_t (*)(uint32_t rev))ROM_API_SETUP[9])
+
+#define rom_setup_get_trim_for_radc_ext_cfg \
+    ((uint32_t (*)(uint32_t rev))ROM_API_SETUP[10])
+
+#define rom_setup_get_trim_for_rc_osc_lf_ibias_trim \
+    ((uint32_t (*)(uint32_t rev))ROM_API_SETUP[11])
+
+#define rom_setup_get_trim_for_rc_osc_lf_rtune_ctune_trim \
+    ((uint32_t (*)(void))ROM_API_SETUP[12])
+
+#define rom_setup_get_trim_for_xosc_hf_ctl \
+    ((uint32_t (*)(uint32_t rev))ROM_API_SETUP[13])
+
+#define rom_setup_get_trim_for_xosc_hf_fast_start \
+    ((uint32_t (*)(void))ROM_API_SETUP[14])
+
+#define rom_setup_get_trim_for_xosc_hf_ibiastherm \
+    ((uint32_t (*)(void))ROM_API_SETUP[15])
+
+#define rom_setup_get_trim_for_xosc_lf_regulator_and_cmirrwr_ratio \
+    ((uint32_t (*)(uint32_t rev))ROM_API_SETUP[16])
+
+#define rom_setup_set_aon_rtc_sub_sec_inc \
+    ((void (*)(uint32_t subsecinc))ROM_API_SETUP[17])
+
+#define rom_setup_set_cache_mode_according_to_ccfg_setting \
+    ((void (*)(void))ROM_API_SETUP[18])
+
+#define rom_setup_step_vddr_trim_to \
+    ((void (*)(uint32_t tocode))ROM_API_SETUP[19])
+/** @} */
+
+/**
+ * @brief   Performs the necessary trim of the device which is not done in ROM
+ *          boot code.
+ *
+ * The following is handled by this function:
+ *
+ * - Checks if the driverlib variant used by the application is supported by the
+ *   device. Execution is halted in case of unsupported driverlib variant.
+ * - Configures VIMS cache mode based on setting in CCFG.
+ * - Configures functionalities like DCDC and XOSC dependent on startup modes
+ *   like cold reset, wakeup from shutdown and wakeup from from powerdown.
+ * - Configures VIMS power domain control.
+ * - Configures optimal wait time for flash FSM in cases where flash pump wakes
+ *   up from sleep.
+ *
+ * @note It does no damage to execute this function again. It only consumes
+ * time.
+ */
+void setup_trim_device(void);
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* CC26X2_CC13X2_SETUP_H */
+/** @} */

--- a/cpu/cc26x2_cc13x2/include/cpu_conf.h
+++ b/cpu/cc26x2_cc13x2/include/cpu_conf.h
@@ -27,6 +27,7 @@
 #include "cc26x2_cc13x2_aux.h"
 #include "cc26x2_cc13x2_fcfg.h"
 #include "cc26x2_cc13x2_prcm.h"
+#include "cc26x2_cc13x2_setup.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/cc26x2_cc13x2/setup.c
+++ b/cpu/cc26x2_cc13x2/setup.c
@@ -1,0 +1,198 @@
+
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+/**
+ * @ingroup         cpu_cc26x2_cc13x2
+ * @{
+ *
+ * @file
+ * @brief           CC26x2, CC13x2 Functions to setup the device
+ *
+ * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
+ * @}
+ */
+
+#include "cpu.h"
+
+/**
+ * @brief   Optimal wait time in cases where flash pump wakes up from sleep.
+ */
+#define FPAC1_OPTIMAL_PSLEEPTDIS (0x139)
+
+/**
+ * @brief   Trims to be applied when coming from PIN_RESET.
+ */
+__attribute__ ((weak)) void trim_after_cold_reset(void)
+{
+    /* Currently no specific trim for Cold Reset */
+}
+
+/**
+ * @brief   Trims to be applied when coming from POWER_DOWN (also called when
+ *          coming from SHUTDOWN and PIN_RESET).
+ */
+__attribute__ ((weak)) void trim_after_cold_reset_wakeup_from_shutdown_wakeup_from_powerdown(void)
+{
+    /* Currently no specific trim for Powerdown */
+}
+
+/**
+ * @brief   Trims to be applied when coming from SHUTDOWN (also called when
+ *          coming from PIN_RESET).
+ *
+ * @param[in] fcfg_rev FCFG1 revision
+ */
+void trim_after_cold_reset_wakeup_from_shutdown(uint32_t fcfg_rev)
+{
+    uint32_t ccfg_mode_conf_reg;
+
+    /* Check in CCFG for alternative DCDC setting */
+    if ((CCFG->SIZE_AND_DIS_FLAGS & CCFG_SIZE_AND_DIS_FLAGS_DIS_ALT_DCDC_SETTING) == 0) {
+        /* ADI_3_REFSYS:DCDCCTL5[3]  (=DITHER_EN) = CCFG_MODE_CONF_1[19]   (=ALT_DCDC_DITHER_EN)
+         * ADI_3_REFSYS:DCDCCTL5[2:0](=IPEAK    ) = CCFG_MODE_CONF_1[18:16](=ALT_DCDC_IPEAK    )
+         *
+         * Using a single 4-bit masked write since layout is equal for both
+         * source and destination
+         */
+        ADI3_M4->DCDCCTL5.LOW = 0xF0 | (CCFG->MODE_CONF_1 >>
+                                CCFG_MODE_CONF_1_ALT_DCDC_IPEAK_s);
+    }
+
+    /* Force DCDC to use RCOSC before starting up XOSC.
+     * Clock loss detector does not use XOSC until SCLK_HF actually switches
+     * and thus DCDC is not protected from clock loss on XOSC in that time frame.
+     * The force must be released when the switch to XOSC has happened. */
+    DDI_0_OSC_M16->CTL0.HIGH = DDI_0_OSC_CTL0_CLK_DCDC_SRC_SEL_m |
+                               (DDI_0_OSC_CTL0_CLK_DCDC_SRC_SEL_m >> 16);
+    /* Dummy read to ensure that the write has propagated */
+    DDI_0_OSC->CTL0;
+
+    /* Read the MODE_CONF register in CCFG */
+    ccfg_mode_conf_reg = CCFG->MODE_CONF;
+
+    /* First part of trim done after cold reset and wakeup from shutdown:
+     *
+     * - Adjust the VDDR_TRIM_SLEEP value.
+     * - Configure DCDC.
+     */
+    rom_setup_after_cold_reset_wakeup_from_shutdown_cfg1(ccfg_mode_conf_reg);
+
+    /* Addition to the CC1352 boost mode for HWREV >= 2.0
+     * The combination VDDR_EXT_LOAD=0 and VDDS_BOD_LEVEL=1 is defined to select
+     * boost mode */
+    if (((ccfg_mode_conf_reg & CCFG_MODE_CONF_VDDR_EXT_LOAD) == 0) &&
+        ((ccfg_mode_conf_reg & CCFG_MODE_CONF_VDDS_BOD_LEVEL) != 0)) {
+        ADI3->DCDCCTL3 = ADI_3_REFSYS_DCDCCTL3_VDDR_BOOST_COMP_BOOST;
+    }
+
+    /* Second part of trim done after cold reset and wakeup from shutdown:
+     *
+     * - Configure XOSC.
+     */
+    rom_setup_after_cold_reset_wakeup_from_shutdown_cfg2(fcfg_rev, ccfg_mode_conf_reg);
+
+    {
+        uint32_t trim_reg;
+        uint32_t trim_value;
+
+        /* Propagate the LPM_BIAS trim */
+        trim_reg = FCFG->DAC_BIAS_CNF;
+        trim_value = (trim_reg & FCFG1_DAC_BIAS_CNF_LPM_TRIM_IOUT_m) >>
+                     FCFG1_DAC_BIAS_CNF_LPM_TRIM_IOUT_s;
+        ADI_4_AUX->LPMBIAS = (trim_value << ADI_4_AUX_LPMBIAS_LPM_TRIM_IOUT_s) &
+                              ADI_4_AUX_LPMBIAS_LPM_TRIM_IOUT_m;
+
+        /* Set LPM_BIAS_BACKUP_EN according to FCFG1 configuration */
+        if (trim_reg & FCFG1_DAC_BIAS_CNF_LPM_BIAS_BACKUP_EN) {
+            ADI3_SET->AUX_DEBUG = ADI_3_REFSYS_AUX_DEBUG_LPM_BIAS_BACKUP_EN;
+        }
+        else {
+            ADI3_CLR->AUX_DEBUG = ADI_3_REFSYS_AUX_DEBUG_LPM_BIAS_BACKUP_EN;
+        }
+
+        /* Set LPM_BIAS_WIDTH_TRIM according to FCFG1 configuration */
+        {
+            uint32_t width_trim = (trim_reg & FCFG1_DAC_BIAS_CNF_LPM_BIAS_WIDTH_TRIM_m) >>
+                                  FCFG1_DAC_BIAS_CNF_LPM_BIAS_WIDTH_TRIM_s;
+            /* Set LPM_BIAS_WIDTH_TRIM = 3
+             * Set mask (bits to be written) in [15:8]
+             * Set value (in correct bit pos) in [7:0]
+             */
+            ADI_4_AUX_M8->COMP = (ADI_4_AUX_COMP_LPM_BIAS_WIDTH_TRIM_m << 8) |
+                                 (width_trim << ADI_4_AUX_COMP_LPM_BIAS_WIDTH_TRIM_s);
+        }
+    }
+
+    /* Third part of trim done after cold reset and wakeup from shutdown:
+     *
+     * - Configure HPOSC.
+     * - Setup the LF clock.
+     */
+    rom_setup_after_cold_reset_wakeup_from_shutdown_cfg3(ccfg_mode_conf_reg);
+
+    /* Set AUX into power down active mode */
+    aux_sysif_opmode_change(AUX_SYSIF_OPMODEREQ_REQ_PDA);
+
+    /* Disable EFUSE clock */
+    FLASH->CFG |= FLASH_CFG_DIS_EFUSECLK;
+}
+
+void setup_trim_device(void)
+{
+    /* Get factory configuration revision, treat undefined revision as 0 */
+    uint32_t fcfg_rev = FCFG->FCFG1_REVISION;
+    if (fcfg_rev == 0xFFFFFFFF) {
+        fcfg_rev = 0;
+    }
+
+    /* Enable standby in flash bank */
+    FLASH->CFG &= ~FLASH_CFG_DIS_STANDBY;
+
+    if (!(AON_IOC->IOCLATCH & AON_IOC_IOCLATCH_EN)) {
+        trim_after_cold_reset_wakeup_from_shutdown_wakeup_from_powerdown();
+    }
+    else if (!(AON_PMCTL->SLEEPCTL & AON_PMCTL_SLEEPCTL_IO_PAD_SLEEP_DIS)) {
+        trim_after_cold_reset_wakeup_from_shutdown(fcfg_rev);
+        trim_after_cold_reset_wakeup_from_shutdown_wakeup_from_powerdown();
+    }
+    else {
+        trim_after_cold_reset();
+        trim_after_cold_reset_wakeup_from_shutdown(fcfg_rev);
+        trim_after_cold_reset_wakeup_from_shutdown_wakeup_from_powerdown();
+    }
+
+    /* Set VIMS power domain */
+    PRCM->PDCTL1VIMS = 0;
+
+    /* Configure optimal wait time for flash FSM in cases where flash pump
+     * wakes up from sleep */
+    FLASH->FPAC1 = (FLASH->FPAC1 & ~FLASH_FPAC1_PSLEEPTDIS_m) |
+                   (FPAC1_OPTIMAL_PSLEEPTDIS << FLASH_FPAC1_PSLEEPTDIS_s);
+
+    /* Set BOOT_DET bits in AON_PMCTL to 3 if already found to be 1.
+     * Note: The BOOT_DET_x_CLR/SET bits must be manually cleared */
+    uint32_t boot_det_m = AON_PMCTL_RESETCTL_BOOT_DET_1_m |
+                          AON_PMCTL_RESETCTL_BOOT_DET_0_m;
+    uint32_t boot_det = (AON_PMCTL->RESETCTL & boot_det_m) >>
+                        AON_PMCTL_RESETCTL_BOOT_DET_0_s;
+    if (boot_det == 1) {
+        uint32_t aon_sys_resetctl = AON_PMCTL->RESETCTL &
+                                    ~(AON_PMCTL_RESETCTL_BOOT_DET_1_CLR_m |
+                                      AON_PMCTL_RESETCTL_BOOT_DET_0_CLR_m |
+                                      AON_PMCTL_RESETCTL_BOOT_DET_1_SET_m |
+                                      AON_PMCTL_RESETCTL_BOOT_DET_0_SET_m |
+                                      AON_PMCTL_RESETCTL_MCU_WARM_RESET_m);
+        AON_PMCTL->RESETCTL = aon_sys_resetctl |
+                              AON_PMCTL_RESETCTL_BOOT_DET_1_SET_m;
+        AON_PMCTL->RESETCTL = aon_sys_resetctl;
+    }
+
+    /* Make sure there are no ongoing VIMS mode change when leaving (There
+     * should typically be no wait time here, but need to be sure) */
+    while (VIMS->STAT & VIMS_STAT_MODE_CHANGING) {}
+}

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx.h
@@ -27,7 +27,29 @@ extern "C" {
 #endif
 
 typedef volatile uint8_t reg8_t;
+typedef volatile uint16_t reg16_t;
 typedef volatile uint32_t reg32_t;
+
+/**
+ * @brief   Masked 8-bit register
+ */
+typedef struct {
+    reg8_t LOW; /**< Low 4-bit half */
+    reg8_t HIGH; /**< High 4-bit half */
+} reg8_m4_t;
+
+/**
+ * @brief   Masked 8-bit register
+ */
+typedef reg16_t reg8_m8_t;
+
+/**
+ * @brief   Masked 32-bit register
+ */
+typedef struct {
+    reg32_t LOW; /**< Low 16-bit half */
+    reg32_t HIGH; /**< High 16-bit half */
+} reg32_m16_t;
 
 /** @addtogroup CC13x2_cmsis CMSIS Definitions */
 /*@{*/

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx.h
@@ -146,6 +146,18 @@ typedef enum IRQn
 #define PERIPH_BASE_NONBUF 0x60000000 /**< Peripheral base address (nonbuf) */
 /*@}*/
 
+/**
+ * @brief   ADI master instruction offsets
+ * @{
+ */
+#define ADI_DIR            0x00000000
+#define ADI_SET            0x00000010
+#define ADI_CLR            0x00000020
+#define ADI_MASK4B         0x00000040
+#define ADI_MASK8B         0x00000060
+#define ADI_MASK16B        0x00000080
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx.h
@@ -144,6 +144,8 @@ typedef enum IRQn
 #define FLASH_BASE         0x00000000 /**< FLASH base address */
 #define PERIPH_BASE        0x40000000 /**< Peripheral base address */
 #define PERIPH_BASE_NONBUF 0x60000000 /**< Peripheral base address (nonbuf) */
+#define ROM_API_TABLE      ((uint32_t *) 0x10000180) /**< ROM API table */
+
 /*@}*/
 
 /**

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_adi.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_adi.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_cc26xx_cc13xx_definitions
+ * @{
+ *
+ * @file
+ * @brief           CC26xx/CC13xx MCU I/O register definitions
+ *
+ * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef CC26XX_CC13XX_ADI_H
+#define CC26XX_CC13XX_ADI_H
+
+#include "cc26xx_cc13xx.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   ADI_3_REFSYS registers
+ */
+typedef struct {
+    reg8_t __reserved1; /**< Reserved */
+    reg8_t ATESTCTL1; /**< Internal */
+    reg8_t REFSYSCTL0; /**< Internal */
+    reg8_t REFSYSCTL1; /**< Internal */
+    reg8_t REFSYSCTL2; /**< Internal */
+    reg8_t REFSYSCTL3; /**< Internal */
+    reg8_t DCDCCTL0; /**< DCDC Control 0 */
+    reg8_t DCDCCTL1; /**< DCDC Control 1 */
+    reg8_t DCDCCTL2; /**< DCDC Control 2 */
+    reg8_t DCDCCTL3; /**< Internal */
+    reg8_t DCDCCTL4; /**< Internal */
+    reg8_t DCDCCTL5; /**< Internal */
+#ifdef CPU_VARIANT_X2
+    reg8_t AUX_DEBUG; /**< RECHARGE_CONTROL_1 */
+    reg8_t CTL_RECHARGE_CMP0; /**< Recharge Comparator Control Byte 0 */
+    reg8_t CTL_RECHARGE_CMP1; /**< Recharge Comparator Control Byte 1 */
+#endif
+} adi_3_refsys_regs_t;
+
+/**
+ * @brief   ADI_3_REFSYS registers
+ */
+typedef struct {
+    reg8_m4_t __reserved1; /**< Reserved */
+    reg8_m4_t ATESTCTL1; /**< Internal */
+    reg8_m4_t REFSYSCTL0; /**< Internal */
+    reg8_m4_t REFSYSCTL1; /**< Internal */
+    reg8_m4_t REFSYSCTL2; /**< Internal */
+    reg8_m4_t REFSYSCTL3; /**< Internal */
+    reg8_m4_t DCDCCTL0; /**< DCDC Control 0 */
+    reg8_m4_t DCDCCTL1; /**< DCDC Control 1 */
+    reg8_m4_t DCDCCTL2; /**< DCDC Control 2 */
+    reg8_m4_t DCDCCTL3; /**< Internal */
+    reg8_m4_t DCDCCTL4; /**< Internal */
+    reg8_m4_t DCDCCTL5; /**< Internal */
+#ifdef CPU_VARIANT_X2
+    reg8_m4_t AUX_DEBUG; /**< RECHARGE_CONTROL_1 */
+    reg8_m4_t CTL_RECHARGE_CMP0; /**< Recharge Comparator Control Byte 0 */
+    reg8_m4_t CTL_RECHARGE_CMP1; /**< Recharge Comparator Control Byte 1 */
+#endif
+} adi_3_refsys_regs_m4_t;
+
+/**
+ * @brief   ADI3 register values
+ * @{
+ */
+#define ADI_3_REFSYS_DCDCCTL3_VDDR_BOOST_COMP_BOOST 0x00000002
+#define ADI_3_REFSYS_AUX_DEBUG_LPM_BIAS_BACKUP_EN   0x00000040
+/** @} */
+
+/**
+ * @ingroup cpu_specific_peripheral_memory_map
+ * @{
+ */
+/**
+ * @brief   ADI3 base address
+ */
+#define ADI_3_REFSYS_BASE    (PERIPH_BASE + 0x86200)
+/**
+ * @brief   ADI3 base address for SET instruction
+ */
+#define ADI_3_REFSYS_BASE_SET (ADI_3_REFSYS_BASE + ADI_SET)
+/**
+ * @brief   ADI3 base address for CLR instruction
+ */
+#define ADI_3_REFSYS_BASE_CLR (ADI_3_REFSYS_BASE + ADI_CLR)
+/**
+ * @brief   ADI3 base address for 4-bit masked access
+ */
+#define ADI_3_REFSYS_BASE_M4 (ADI_3_REFSYS_BASE + ADI_MASK4B)
+/** @} */
+
+/**
+ * @brief   ADI3 register bank
+ */
+#define ADI3                 ((adi_3_refsys_regs_t *) (ADI_3_REFSYS_BASE))
+/**
+ * @brief   ADI3 register bank for SET instruction
+ */
+#define ADI3_SET             ((adi_3_refsys_regs_t *) (ADI_3_REFSYS_BASE_SET))
+/**
+ * @brief   ADI3 register bank for CLR instruction
+ */
+#define ADI3_CLR             ((adi_3_refsys_regs_t *) (ADI_3_REFSYS_BASE_CLR))
+/**
+ * @brief   ADI3 register bank for 4-bit masked access
+ */
+#define ADI3_M4              ((adi_3_refsys_regs_m4_t *) (ADI_3_REFSYS_BASE_M4))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CC26XX_CC13XX_ADI_H */
+/** @} */

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_ccfg.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_ccfg.h
@@ -54,7 +54,11 @@ typedef struct {
  * @brief   CCFG register values
  * @{
  */
-#define CCFG_SIZE_AND_DIS_FLAGS_DIS_GPRAM 0x00000004
+#define CCFG_MODE_CONF_1_ALT_DCDC_IPEAK_s            16
+#define CCFG_MODE_CONF_VDDR_EXT_LOAD                 0x02000000
+#define CCFG_MODE_CONF_VDDS_BOD_LEVEL                0x01000000
+#define CCFG_SIZE_AND_DIS_FLAGS_DIS_GPRAM            0x00000004
+#define CCFG_SIZE_AND_DIS_FLAGS_DIS_ALT_DCDC_SETTING 0x00000002
 /** @} */
 
 /**

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_ioc.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_ioc.h
@@ -142,30 +142,42 @@ typedef struct {
 #define IOCFG_HYST_ENABLE               0x40000000
 /** @} */
 
+/**
+ * @brief   AON_IOC registers
+ */
+typedef struct {
+    reg32_t IOSTRMIN; /**< IO Drive Strength Minimum */
+    reg32_t IOSTRMED; /**< IO Drive Strength Medium */
+    reg32_t IOSTRMAX; /**< IO Drive Strength Maximum */
+    reg32_t IOCLATCH; /**< IO Latch Control */
+    reg32_t CLK32KCTL; /**< SCLK_LF External Output Control */
+#ifdef CPU_VARIANT_X2
+    reg32_t TCKCTL; /**< TCK IO Pin Control */
+#endif
+} aon_ioc_regs_t;
 
-/** @ingroup cpu_specific_peripheral_memory_map
+/**
+ * @brief   AON_IOC register values
  * @{
  */
-#define AON_IOC_BASE            (PERIPH_BASE + 0x94000) /**< always-on-IOC base address */
+#define AON_IOC_IOCLATCH_EN   0x00000001
+#define AON_IOC_CLK32KCTL_OEN 0x00000001
 /** @} */
 
 /**
- * AON registers
+ * @ingroup cpu_specific_peripheral_memory_map
+ * @{
  */
-typedef struct {
-    reg32_t IOSTRMIN; /**< IO drive strength minimum */
-    reg32_t IOSTRMED; /**< IO drive strength medium */
-    reg32_t IOSTRMAX; /**< IO drive strength maximum */
-    reg32_t IOCLATCH; /**< IO latch control */
-    reg32_t CLK32KCTL; /**< SCLK_LF external output control */
-} aon_regs_t;
+/**
+ * @brief   AON_IOC base address
+ */
+#define AON_IOC_BASE         (PERIPH_BASE + 0x94000)
+/** @} */
 
-#define AON                     ((aon_regs_t *) (AON_IOC_BASE)) /**< AON register bank */
-
-#define IOCLATCH_EN             0x00000001 /**< IO controlled by GPIO or peripheral; kept in AON otherwise */
-
-#define CLK32KCTL_OEN           0x00000001 /**< don't output SCLK_LF on DIOs with PORT_ID AON_CLK32K */
-
+/**
+ * @brief   AON_IOC register bank
+ */
+#define AON_IOC              ((aon_ioc_regs_t *) (AON_IOC_BASE))
 
 #ifdef __cplusplus
 }

--- a/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_vims.h
+++ b/cpu/cc26xx_cc13xx/include/cc26xx_cc13xx_vims.h
@@ -25,16 +25,16 @@ extern "C" {
  * @brief   FLASH registers
  */
 typedef struct {
-    reg32_t __reserved1[7]; /**< meh */
+    reg32_t __reserved1[7]; /**< Reserved */
     reg32_t STAT; /**< FMC and efuse status */
-    reg32_t CTL; /**< config */
-    reg32_t __reserved2; /**< meh */
+    reg32_t __reserved2; /**< Reserved */
+    reg32_t CFG; /**< Config */
     reg32_t SYSCODE_START; /**< syscode start address offset config */
     reg32_t FLASH_SIZE; /**< flash size config */
-    reg32_t __reserved3[3]; /**< meh */
+    reg32_t __reserved3[3]; /**< Reserved */
     reg32_t FWLOCK; /**< firmware lock */
     reg32_t FWFLAG; /**< firmware flags */
-    reg32_t __reserved4[0x3EF]; /**< meh */
+    reg32_t __reserved4[0x3EF]; /**< Reserved */
     reg32_t EFUSE; /**< efuse instruction */
     reg32_t EFUSEADDR; /**< efuse address */
     reg32_t DATAUPPER; /**< efuse data - upper */
@@ -55,13 +55,13 @@ typedef struct {
     reg32_t TWOBIT; /**< two-bit error status */
     reg32_t SELFTESTCYC; /**< self-test cycles */
     reg32_t SELFTESTSIGN; /**< self-test signature */
-    reg32_t __reserved5[0x3ec]; /**< meh */
+    reg32_t __reserved5[0x3ec]; /**< Reserved */
     reg32_t FRDCTL; /**< FMC read control */
     reg32_t FSPRD; /**< FMC read margin control */
     reg32_t FEDACCTL1; /**< FMC error correction control 1 */
-    reg32_t __reserved6[4]; /**< meh */
+    reg32_t __reserved6[4]; /**< Reserved */
     reg32_t FEDACSTAT; /**< FMC error status */
-    reg32_t __reserved7[4]; /**< meh */
+    reg32_t __reserved7[4]; /**< Reserved */
     reg32_t FBPROT; /**< FMC bank protection */
     reg32_t FBSE; /**< FMC sector enable */
     reg32_t FBBUSY; /**< FMC bank busy */
@@ -72,9 +72,9 @@ typedef struct {
     reg32_t FPAC2; /**< FMC pump access control 2 */
     reg32_t FMAC; /**< FMC module access control */
     reg32_t FMSTAT; /**< FMC module status */
-    reg32_t __reserved8[3]; /**< meh */
+    reg32_t __reserved8[3]; /**< Reserved */
     reg32_t FLOCK; /**< FMC flash lock */
-    reg32_t __reserved9[6]; /**< meh */
+    reg32_t __reserved9[6]; /**< Reserved */
     reg32_t FVREADCT; /**< FMC VREADCT trim */
     reg32_t FVHVCT1; /**< FMC VHVCT1 trim */
     reg32_t FVHVCT2; /**< FMC VHVCT2 trim */
@@ -86,13 +86,13 @@ typedef struct {
     reg32_t FEFUSESTAT; /**< FMC efuse status */
     reg32_t FEFUSEDATA; /**< FMC efuse data */
     reg32_t FSEQPMP; /**< FMC sequential pump information */
-    reg32_t __reserved10[21]; /**< meh */
+    reg32_t __reserved10[21]; /**< Reserved */
     reg32_t FBSTROBES; /**< FMC bank signal strobe */
     reg32_t FPSTROBES; /**< FMC pump signal strobe */
     reg32_t FBMODE; /**< FMC bank and pump mode */
     reg32_t FTCR; /**< FMC test command control */
     reg32_t FADDR; /**< FMC bank address */
-    reg32_t __reserved11[2]; /**< meh */
+    reg32_t __reserved11[2]; /**< Reserved */
     reg32_t FTCTL; /**< FMC test control */
     reg32_t FWPWRITE0; /**< FMC flash wide programming write data 0 */
     reg32_t FWPWRITE1; /**< FMC flash wide programming write data 1 */
@@ -104,7 +104,7 @@ typedef struct {
     reg32_t FWPWRITE7; /**< FMC flash wide programming write data 7 */
     reg32_t FWPWRITE_ECC; /**< FMC flash wide programming ECC */
     reg32_t FSWSTAT; /**< FMC software interface status */
-    reg32_t __reserved12[0x2E]; /**< meh */
+    reg32_t __reserved12[0x2E]; /**< Reserved */
     reg32_t FSM_GLBCTL; /**< FMC FSM global control */
     reg32_t FSM_STATE; /**< FMC FSM state status */
     reg32_t FSM_STAT; /**< FMC FSM status */
@@ -119,10 +119,10 @@ typedef struct {
     reg32_t FSM_ERA_OH; /**< FMC FSM erase operation hold */
     reg32_t FSM_SAV_PPUL; /**< FMC FSM saved program pulses */
     reg32_t FSM_PE_VH; /**< FMC FSM program/erase verify hold */
-    reg32_t __reserved13[2]; /**< meh */
+    reg32_t __reserved13[2]; /**< Reserved */
     reg32_t FSM_PRG_PW; /**< FMC FSM program pulse width */
     reg32_t FSM_ERA_PW; /**< FMC FSM erase pulse width */
-    reg32_t __reserved14[3]; /**< meh */
+    reg32_t __reserved14[3]; /**< Reserved */
     reg32_t FSM_SAV_ERA_PUL; /**< FMC FSM saved erased pulses */
     reg32_t FSM_TIMER; /**< FMC FSM timer */
     reg32_t FSM_MODE; /**< FMC FSM MODE */
@@ -135,32 +135,32 @@ typedef struct {
     reg32_t FSM_EC_STEP_HEIGHT; /**< FMC FSM EC step height */
     reg32_t FSM_ST_MACHINE; /**< FMC FSM ST MACHINE */
     reg32_t FSM_FLES; /**< FMC FSM FLES memory control bits */
-    reg32_t __reserved15; /**< meh */
+    reg32_t __reserved15; /**< Reserved */
     reg32_t FSM_WR_ENA; /**< FMC FSM register write enable */
     reg32_t FSM_ACC_PP; /**< FMC FSM accumulate program pulses */
     reg32_t FSM_ACC_EP; /**< FMC FSM accumulate erase pulses */
-    reg32_t __reserved16[3]; /**< meh */
+    reg32_t __reserved16[3]; /**< Reserved */
     reg32_t FSM_ADDR; /**< FMC FSM address */
     reg32_t FSM_SECTOR; /**< FMC sectors erased */
     reg32_t FMC_REV_ID; /**< FMC revision identification */
     reg32_t FSM_ERR_ADDR; /**< FSM error address */
     reg32_t FSM_PGM_MAXPUL; /**< FMC FSM maximum program pulse */
     reg32_t FSM_EXECUTE; /**< FMC FSM command execute */
-    reg32_t __reserved17[2]; /**< meh */
+    reg32_t __reserved17[2]; /**< Reserved */
     reg32_t FSM_SECTOR1; /**< FMC FSM sector erased 1 */
     reg32_t FSM_SECTOR2; /**< FMC FSM sector erased 2 */
-    reg32_t __reserved18[6]; /**< meh */
+    reg32_t __reserved18[6]; /**< Reserved */
     reg32_t FSM_BSLE0; /**< FMC FSM bank sector lock erase 0 */
     reg32_t FSM_BSLE1; /**< FMC FSM bank sector lock erase 1 */
-    reg32_t __reserved19[2]; /**< meh */
+    reg32_t __reserved19[2]; /**< Reserved */
     reg32_t FSM_BSLP0; /**< FMC FSM bank sector lock program 0 */
     reg32_t FSM_BSLP1; /**< FMC FSM bank sector lock program 1 */
     reg32_t FSM_PGM_128; /**< Enable 128-bit programming. CC26x2_CC13x2 only */
-    reg32_t __reserved20[0x41]; /**< meh */
+    reg32_t __reserved20[0x41]; /**< Reserved */
     reg32_t FCFG_BANK; /**< FMC flash configuration bank */
     reg32_t FCFG_WRAPPER; /**< FMC flash wrapper configuration */
     reg32_t FCFG_BNK_TYPE; /**< FMC flash bank type */
-    reg32_t __reserved21; /**< meh */
+    reg32_t __reserved21; /**< Reserved */
     reg32_t FCFG_B0_START; /**< FMC flash bank 0 starting address */
     reg32_t FCFG_B1_START; /**< FMC flash bank 1 starting address */
     reg32_t FCFG_B2_START; /**< FMC flash bank 2 starting address */
@@ -171,6 +171,16 @@ typedef struct {
     reg32_t FCFG_B7_START; /**< FMC flash bank 7 starting address */
     reg32_t FCFG_B0_SSIZE0; /**< FMC flash bank 0 sector size */
 } flash_regs_t;
+
+/**
+ * @brief   FLASH register values
+ * @{
+ */
+#define FLASH_CFG_DIS_STANDBY    0x00000002
+#define FLASH_CFG_DIS_EFUSECLK   0x00000020
+#define FLASH_FPAC1_PSLEEPTDIS_m 0x0FFF0000
+#define FLASH_FPAC1_PSLEEPTDIS_s 16
+/** @} */
 
 /**
  * @ingroup cpu_specific_peripheral_memory_map
@@ -214,32 +224,34 @@ typedef struct {
  * @brief   VIMS register values
  * @{
  */
-#define VIMS_CTL_STATS_CLR                  0x80000000
-#define VIMS_CTL_STATS_CLR_m                0x80000000
+#define VIMS_CTL_STATS_CLR       0x80000000
+#define VIMS_CTL_STATS_CLR_m     0x80000000
 
-#define VIMS_CTL_STATS_EN                   0x40000000
-#define VIMS_CTL_STATS_EN_m                 0x40000000
+#define VIMS_CTL_STATS_EN        0x40000000
+#define VIMS_CTL_STATS_EN_m      0x40000000
 
-#define VIMS_CTL_DYN_CG_EN                  0x20000000
-#define VIMS_CTL_DYN_CG_EN_m                0x20000000
+#define VIMS_CTL_DYN_CG_EN       0x20000000
+#define VIMS_CTL_DYN_CG_EN_m     0x20000000
 
-#define VIMS_CTL_IDCODE_LB_DIS              0x00000020
-#define VIMS_CTL_IDCODE_LB_DIS_m            0x00000020
+#define VIMS_CTL_IDCODE_LB_DIS   0x00000020
+#define VIMS_CTL_IDCODE_LB_DIS_m 0x00000020
 
-#define VIMS_CTL_SYSBUS_LB_DIS              0x00000010
-#define VIMS_CTL_SYSBUS_LB_DIS_m            0x00000010
+#define VIMS_CTL_SYSBUS_LB_DIS   0x00000010
+#define VIMS_CTL_SYSBUS_LB_DIS_m 0x00000010
 
-#define VIMS_CTL_ARB_CFG                    0x00000008
-#define VIMS_CTL_ARB_CFG_m                  0x00000008
+#define VIMS_CTL_ARB_CFG         0x00000008
+#define VIMS_CTL_ARB_CFG_m       0x00000008
 
-#define VIMS_CTL_PREF_EN                    0x00000004
-#define VIMS_CTL_PREF_EN_m                  0x00000004
+#define VIMS_CTL_PREF_EN         0x00000004
+#define VIMS_CTL_PREF_EN_m       0x00000004
 
-#define VIMS_CTL_MODE_GPRAM                 0x00000000
-#define VIMS_CTL_MODE_CACHE                 0x00000001
-#define VIMS_CTL_MODE_SPLIT                 0x00000002
-#define VIMS_CTL_MODE_OFF                   0x00000003
-#define VIMS_CTL_MODE_m                     0x00000003
+#define VIMS_CTL_MODE_GPRAM      0x00000000
+#define VIMS_CTL_MODE_CACHE      0x00000001
+#define VIMS_CTL_MODE_SPLIT      0x00000002
+#define VIMS_CTL_MODE_OFF        0x00000003
+#define VIMS_CTL_MODE_m          0x00000003
+
+#define VIMS_STAT_MODE_CHANGING  0x00000008
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/cc26xx_cc13xx/include/cpu_conf_cc26xx_cc13xx.h
+++ b/cpu/cc26xx_cc13xx/include/cpu_conf_cc26xx_cc13xx.h
@@ -24,6 +24,7 @@
 
 #include "cc26xx_cc13xx.h"
 
+#include "cc26xx_cc13xx_adi.h"
 #include "cc26xx_cc13xx_ccfg.h"
 #include "cc26xx_cc13xx_gpio.h"
 #include "cc26xx_cc13xx_gpt.h"


### PR DESCRIPTION
### Contribution description

This is a very stripped-down port from the TI SDK of the
`SetupTrimDevice` function which _must_ be called on CPU initialization.

It sets configurations from the CCFG (Customer Configuration Area), most
of the code is already implemented in the ROM and we use that API.

More importantly, these ROM functions aren't present on `cc26x0` devices
and must be implemented manually on these to just implement
`SetupTrimDevice`, so I opted out on writing a more general
implementation as the code for that is quite big and the review effort
for that kind of code is simply too much (more than writing it IMHO), it
also happens that I don't have one of these to test.

This function is important because it allows us to change the `SCLK_HF`
clock source to the external HF XOSC, without this, the MCU simply halts
when performing the switch due to a bad state on the MCU registers.

Also this function sets some `FLASH` registers to a working state, so we
can write in the future a MTD driver for it.

There's room for improvement in this port, mainly refactorings, but as
documentation is scarse I tried to do a one-to-one port without changing
the logic too much, even some variables don't make sense, or some code
blocks. Unbelievably, it's much worse on the TI SDK, of course we have
the opportunity to change that on RIOT :wink:.

Feel free to criticize the code, as I personally think that can be improved,
but I need some opinions though.

### Testing procedure

- Green travis/murdock.
- Any test/example should run as normal, there isn't a change in the functionality.

### Issues/PRs references

Needed for #13295.
Fixes one item on #13635.
