### PR TITLE
cpu/lpc2387: fix check for max number of timers

### DIFF
--- a/cpu/lpc2387/periph/timer.c
+++ b/cpu/lpc2387/periph/timer.c
@@ -29,7 +29,7 @@
  * @brief   Check the board config to make sure we do not exceed max number of
  *          timers
  */
-#if TIMER_NUMOF > 3
+#if TIMER_NUMOF > 4
 #error "ERROR in timer configuration: too many timers defined"
 #endif
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The CPU has 4 hardware timers.
Configuration for all 4 timers exists, but the compile-time range check has an off-by-one error, causing the last timer to remain inaccessible.


### Testing procedure

https://github.com/RIOT-OS/RIOT/blob/master/cpu/lpc2387/periph/timer.c#L67
https://github.com/RIOT-OS/RIOT/blob/master/cpu/lpc2387/periph/timer.c#L101

I also configured the timer on `mcb2388` and it's working fine just like the other three timers.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
