### PR TITLE
nanocoap: allow coap_opt_add_string() for non-zero-terminated strings

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1047,6 +1047,27 @@ static inline ssize_t coap_opt_add_uri_query(coap_pkt_t *pkt, const char *key,
 ssize_t coap_opt_add_proxy_uri(coap_pkt_t *pkt, const char *uri);
 
 /**
+ * @brief   Encode the given array of characters as option(s) into pkt
+ *
+ * Use separator to split array of characters into multiple options.
+ *
+ * @post pkt.payload advanced to first byte after option(s)
+ * @post pkt.payload_len reduced by option(s) length
+ *
+ * @param[in,out] pkt         pkt referencing target buffer
+ * @param[in]     optnum      option number to use
+ * @param[in]     chars       array of characters to encode as option
+ * @param[in]     chars_len   length of @p chars
+ * @param[in]     separator   character used in @p string to separate parts
+ *
+ * @return        number of bytes written to buffer
+ * @return        <0 on error
+ * @return        -ENOSPC if no available options or insufficient buffer space
+ */
+ssize_t coap_opt_add_chars(coap_pkt_t *pkt, uint16_t optnum, const char *chars,
+                           size_t chars_len, char separator);
+
+/**
  * @brief   Encode the given string as option(s) into pkt
  *
  * Use separator to split string into multiple options.
@@ -1063,7 +1084,11 @@ ssize_t coap_opt_add_proxy_uri(coap_pkt_t *pkt, const char *uri);
  * @return        <0 on error
  * @return        -ENOSPC if no available options or insufficient buffer space
  */
-ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum, const char *string, char separator);
+static inline ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum,
+                                          const char *string, char separator)
+{
+    return coap_opt_add_chars(pkt, optnum, string, strlen(string), separator);
+}
 
 /**
  * @brief   Adds one or multiple Uri-Path options in the form '/path' into pkt

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -819,28 +819,31 @@ static ssize_t _add_opt_pkt(coap_pkt_t *pkt, uint16_t optnum, const uint8_t *val
     return optlen;
 }
 
-ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum, const char *string,
-                           char separator)
+ssize_t coap_opt_add_chars(coap_pkt_t *pkt, uint16_t optnum, const char *chars,
+                           size_t chars_len, char separator)
 {
-    size_t unread_len = strlen(string);
-    if (!unread_len) {
+    /* chars_len denotes the length of the chars buffer and is
+     * gradually decremented below while iterating over the buffer */
+    if (!chars_len) {
         return 0;
     }
-    char *uripos = (char *)string;
+
+    char *uripos = (char *)chars;
+    char *endpos = ((char *)chars + chars_len);
     size_t write_len = 0;
 
-    while (unread_len) {
+    while (chars_len) {
         size_t part_len;
         if (*uripos == separator) {
             uripos++;
         }
         uint8_t *part_start = (uint8_t *)uripos;
 
-        while (unread_len) {
+        while (chars_len) {
             /* must decrement separately from while loop test to ensure
              * the value remains non-negative */
-            unread_len--;
-            if ((*uripos == separator) || (*uripos == '\0')) {
+            chars_len--;
+            if ((*uripos == separator) || (uripos == endpos)) {
                 break;
             }
             uripos++;


### PR DESCRIPTION
### Contribution description
The current nanocoap API allows to add a path using the convenient `coap_opt_add_string()` function. The path is then split into multiple CoAP options. However, this function requires the path to be zero-terminated, which is quite inconvenient when dealing with buffers.

This PR adds `coap_opt_add_chars()`, which takes a character array and the length of the desired string as input. `coap_opt_add_string()` is modified to call `coap_opt_add_chars()` with `strlen()` as input.

### Testing procedure
The unittests should run for the existing `coap_opt_add_string()` test cases, and for the newly introduced `coap_opt_add_chars()` test case (at the very end of the unittest file).

### Issues/PRs references
This is a cutout of #13790