### PR TITLE
net/gcoap: add context struct for request handler

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -60,8 +60,15 @@
  *
  * ### Creating a response ###
  *
- * An application resource includes a callback function, a coap_handler_t. After
- * reading the request, the callback must use functions provided by gcoap to
+ * An application resource includes a coap_handler_t callback function, which
+ * is called to notify the application of an incoming request. This function
+ * includes a coap_pkt_t parsed representation of the incoming message, as
+ * well as the raw message buffer. The callback also includes a context
+ * parameter as a generic void pointer. gcoap sets this parameter to a
+ * gcoap_req_ctx_t, which includes the remote endpoint and the application
+ * resource for the request.
+ *
+ * After reading the request, the callback must use functions provided by gcoap to
  * format the response, as described below. The callback *must* read the request
  * thoroughly before calling the functions, because the response buffer likely
  * reuses the request buffer. See `examples/gcoap/gcoap_cli.c` for a simple
@@ -712,6 +719,14 @@ typedef struct {
     uint8_t token[GCOAP_TOKENLEN_MAX];  /**< Client token for notifications */
     unsigned token_len;                 /**< Actual length of token attribute */
 } gcoap_observe_memo_t;
+
+/**
+ * @brief   Context data about an incoming request, for application handler
+ */
+typedef struct {
+    sock_udp_ep_t *remote;              /**< Endpoint that sent request */
+    const coap_resource_t *resource;    /**< Resource for request */
+} gcoap_req_ctx_t;
 
 /**
  * @brief   Initializes the gcoap thread and device

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -352,7 +352,11 @@ static size_t _handle_req(coap_pkt_t *pdu, uint8_t *buf, size_t len,
         return -1;
     }
 
-    ssize_t pdu_len = resource->handler(pdu, buf, len, resource->context);
+    gcoap_req_ctx_t req_ctx;
+    req_ctx.remote = remote;
+    req_ctx.resource = resource;
+
+    ssize_t pdu_len = resource->handler(pdu, buf, len, &req_ctx);
     if (pdu_len < 0) {
         pdu_len = gcoap_response(pdu, buf, len,
                                  COAP_CODE_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
### Contribution description
The nanocoap request handler callback, [coap_handler_t](https://github.com/RIOT-OS/RIOT/blob/abd399b9343e1b13b0393e978b78e882f86a658c/sys/include/net/nanocoap.h#L209), limits context data to the user context parameter from the resource for the request. However, an application may need more context information. For example, #13621 adds a reference to the remote endpoint for the request in the coap_pkt_t struct. As I pointed out in a [comment](https://github.com/RIOT-OS/RIOT/pull/13621#issuecomment-599478765), addition of the remote reference in this struct is not a great fit. 

So, the PR here proposes addition of a `gcoap_req_ctx_t` struct that is passed to the application as the void pointer for the request callback. This struct holds the remote endpoint from #13621 as well as the application resource for the request, which provides access to the resource's user context attribute. This approach solves the original problem and provides a mechanism for passing more context data to the handler in the future as needed.

On the down side, it is possible that existing gcoap applications already use the user context parameter, and will break with this update. I think this risk is acceptable because the nature of the context parameter in the callback has not been explicitly stated in the gcoap or nanocoap documentation. This PR also updates the gcoap documentation to describe the contents of the context parameter.

### Testing procedure
The gcoap example does not use the context parameter, but you can modify it to do so in one of the request handlers with code like:
```
   printf("Resource path: %s\n", ((gcoap_req_ctx_t *)ctx)->resource->path);
```

Also review the documentation update in the first paragraph of the _Creating a response_ section.

### Issues/PRs references
Alternative to #13621
