### PR TITLE
cpu: mips_pic32_common: Implement GPIO IRQ

### DIFF
--- a/boards/6lowpan-clicker/Makefile.features
+++ b/boards/6lowpan-clicker/Makefile.features
@@ -2,6 +2,5 @@ CPU = mips_pic32mx
 CPU_MODEL = p32mx470f512h
 
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/6lowpan-clicker/include/board.h
+++ b/boards/6lowpan-clicker/include/board.h
@@ -59,6 +59,17 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    Button pin configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(PORT_E, 7)
+#define BTN0_MODE           GPIO_IN
+
+#define BTN1_PIN            GPIO_PIN(PORT_B, 0)
+#define BTN1_MODE           GPIO_IN
+/** @} */
+
+/**
  * @brief   Board level initialization
  */
 void board_init(void);

--- a/boards/6lowpan-clicker/include/gpio_params.h
+++ b/boards/6lowpan-clicker/include/gpio_params.h
@@ -41,6 +41,16 @@ static const saul_gpio_params_t saul_gpio_params[] =
         .pin = LED2_PIN,
         .mode = GPIO_OUT,
     },
+    {
+        .name  = "T1",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+    },
+    {
+        .name  = "T2",
+        .pin   = BTN1_PIN,
+        .mode  = BTN1_MODE,
+    },
 };
 
 #ifdef __cplusplus

--- a/boards/pic32-wifire/Makefile.features
+++ b/boards/pic32-wifire/Makefile.features
@@ -2,6 +2,5 @@ CPU = mips_pic32mz
 CPU_MODEL = p32mz2048efg100
 
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/pic32-wifire/include/board.h
+++ b/boards/pic32-wifire/include/board.h
@@ -70,6 +70,17 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    Button pin configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(PORT_A, 5)
+#define BTN0_MODE           GPIO_IN
+
+#define BTN1_PIN            GPIO_PIN(PORT_A, 4)
+#define BTN1_MODE           GPIO_IN
+/** @} */
+
+/**
  * @brief   Board level initialization
  */
 void board_init(void);

--- a/boards/pic32-wifire/include/gpio_params.h
+++ b/boards/pic32-wifire/include/gpio_params.h
@@ -51,6 +51,16 @@ static const saul_gpio_params_t saul_gpio_params[] =
         .pin = LED4_PIN,
         .mode = GPIO_OUT,
     },
+    {
+        .name  = "BTN1",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+    },
+    {
+        .name  = "BTN2",
+        .pin   = BTN1_PIN,
+        .mode  = BTN1_MODE,
+    },
 };
 
 #ifdef __cplusplus

--- a/cpu/mips_pic32_common/Makefile.features
+++ b/cpu/mips_pic32_common/Makefile.features
@@ -1,3 +1,4 @@
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 
 -include $(RIOTCPU)/mips32r2_common/Makefile.features


### PR DESCRIPTION
### Contribution description

This PR implements `periph_gpio_irq` for PIC32 devices. It also updates the SAUL configuration on the pic32-clicker and pic32-wifire.
Note that the implementation differs slightly between PIC32MX and PIC32MZ. While implementing this feature, it appeared that the PIC32MX is only able to trigger interrupts on any edge. This means that it will probably be less reliable than on the PIC32MZ.  

### Testing procedure

Build and flash `test/buttons` on a pic32-clicker or pic32-wifire. On a pic32-wifire, pushing a button pulls the line to 3V3, while on pic32-clicker, pushing a button pulls down the line.

### Issues/PRs references

None