### PR TITLE
tinydtls_sock_dtls: remove duplicate dtls_handle_message

### DIFF
--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -410,10 +410,6 @@ ssize_t sock_dtls_recv(sock_dtls_t *sock, sock_dtls_session_t *remote,
             timeout = (time_passed > timeout) ? 0: timeout - time_passed;
         }
 
-        _ep_to_session(&remote->ep, &remote->dtls_session);
-        res = dtls_handle_message(sock->dtls_ctx, &remote->dtls_session,
-                                  (uint8_t *)data, res);
-
         if (sock->buf != NULL) {
             return _copy_buffer(sock, data, max_len);
         }


### PR DESCRIPTION
### Contribution description

In aa3cbacceb51d22c1d0ef4e2655756dee33349c5 the `dtls_handle_message` call is moved to before timeout calculation but the old call after timeout calculation is not removed. It seems to have no apparent effect so I missed it when testing.

### Testing procedure

Test that the dtls-sock example application still works as usual (start server/client, send message to server/client).