### PR TITLE
Makefile.base: pass NPROC to module builds

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -27,7 +27,7 @@ all: $(BINDIR)/$(MODULE).a ..nothing
 clean:: $(DIRS:%=CLEAN--%)
 
 $(DIRS:%=ALL--%):
-	$(QQ)"$(MAKE)" -C $(@:ALL--%=%)
+	$(QQ)"$(MAKE)" -j $(NPROC) -C $(@:ALL--%=%)
 
 $(DIRS:%=CLEAN--%):
 	$(QQ)"$(MAKE)" -C $(@:CLEAN--%=%) clean


### PR DESCRIPTION
### Contribution description
Is there a reason why we do not pass `-j` down to the sub make processes? On my local machine this greatly enhances build times .. let's see how murdock reacts.

### Testing procedure
-

### Issues/PRs references
-