### PR TITLE
sliptty/start_network.sh: don't default to DHCPv6

### DIFF
--- a/dist/tools/sliptty/start_network.sh
+++ b/dist/tools/sliptty/start_network.sh
@@ -118,7 +118,7 @@ usage() {
 trap "cleanup" INT QUIT TERM EXIT
 
 SLIP_ONLY=0
-USE_DHCPV6=1
+USE_DHCPV6=0
 
 while getopts dehI: opt; do
     case ${opt} in


### PR DESCRIPTION

### Contribution description

DHCPv6 is enabled by the `-d` option.
It should not be enabled in absence of this option.

### Testing procedure

    make -C examples/gnrc_border_router UPLINK=slip term

should use the default `uhcp` but `start_network.sh` will default to DHCPv6 (with no way to disable it)

This PR fixes this.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
