### PR TITLE
I2C Address Cleanup and Documentation

### DIFF
--- a/drivers/include/bmx055.h
+++ b/drivers/include/bmx055.h
@@ -36,12 +36,39 @@ extern "C" {
 #endif
 
 /**
- * @name   The sensors default I2C addresses
+ * @defgroup drivers_bmx055_config     BMX055 sensor driver compile configuration
+ * @ingroup config_drivers_sensors
  * @{
  */
+/**
+ * @brief Magnetometer default address
+ *
+ * The address depends on part number of SDO1, SDO2 and CSB3.
+ * For more information on SerialBus Address, refer section 11.2 in datasheet.
+ */
+#ifndef BMX055_MAG_ADDR_DEFAULT
 #define BMX055_MAG_ADDR_DEFAULT  (0x10U)
+#endif
+
+/**
+ * @brief Accelerometer default address
+ *
+ * The address depends on part number of SDO1, SDO2 and CSB3.
+ * For more information on SerialBus Address, refer section 11.2 in datasheet.
+ */
+#ifndef BMX055_ACC_ADDR_DEFAULT
 #define BMX055_ACC_ADDR_DEFAULT  (0x18U)
+#endif
+
+/**
+ * @brief Gyroscope default address
+ *
+ * The address depends on part number of SDO1, SDO2 and CSB3.
+ * For more information on SerialBus Address, refer section 11.2 in datasheet.
+ */
+#ifndef BMX055_GYRO_ADDR_DEFAULT
 #define BMX055_GYRO_ADDR_DEFAULT (0x68U)
+#endif
 /** @} */
 
 /**

--- a/drivers/include/ds1307.h
+++ b/drivers/include/ds1307.h
@@ -34,9 +34,7 @@ extern "C" {
 /**
  * @brief   I2C address of DS1307 RTC
  */
-#ifndef DS1307_I2C_ADDRESS
 #define DS1307_I2C_ADDRESS      (0x68)
-#endif
 
 /**
  * @defgroup drivers_ds1307_config   DS1307 RTC driver compile configuration

--- a/drivers/include/hts221.h
+++ b/drivers/include/hts221.h
@@ -36,9 +36,7 @@ extern "C" {
 /**
  * @brief   Default I2C bus address (7 Bit) of HTS221 devices
  */
-#ifndef HTS221_I2C_ADDRESS
 #define HTS221_I2C_ADDRESS           (0x5F)
-#endif
 
 /**
  * @brief   Parameters needed for device initialization

--- a/drivers/include/isl29020.h
+++ b/drivers/include/isl29020.h
@@ -31,10 +31,23 @@
 extern "C" {
 #endif
 
- /**
-  * @brief   The sensors default I2C address
-  */
+/**
+ * @defgroup drivers_isl29020_config     ISL29020 light sensor driver compile configuration
+ * @ingroup config_drivers_sensors
+ * @{
+ */
+/**
+ * @brief Default address
+ *
+ * The address depends on the status of A0 Pin.
+ * Default address corresponds to A0 connected to GND.
+ * For more information on SerialBus Address, refer Section I2C
+ * Interface on Page 3 of datasheet.
+ */
+#ifndef ISL29020_DEFAULT_ADDRESS
 #define ISL29020_DEFAULT_ADDRESS        0x44
+#endif
+/** @} */
 
 /**
  * @brief   Possible modes for the ISL29020 sensor

--- a/drivers/include/l3g4200d.h
+++ b/drivers/include/l3g4200d.h
@@ -37,9 +37,22 @@
 #endif
 
 /**
- * @brief   The sensors default I2C address
+ * @defgroup drivers_l3g4200d_config     L3G4200D gyroscope driver compile configuration
+ * @ingroup config_drivers_sensors
+ * @{
  */
+/**
+ * @brief Default address
+ *
+ * The address depends on the status of SDO Pin.
+ * Default address corresponds to SD0 connected to GND.
+ * For more information on SerialBus Address, refer Section 5.1.1
+ * I2C Operation on datasheet.
+ */
+#ifndef L3G4200D_DEFAULT_ADDRESS
 #define L3G4200D_DEFAULT_ADDRESS        0x68
+#endif
+/** @} */
 
 /**
  * @brief   Result vector for gyro measurement

--- a/drivers/include/lpsxxx.h
+++ b/drivers/include/lpsxxx.h
@@ -37,12 +37,21 @@ extern "C" {
 #include "periph/i2c.h"
 
 /**
+ * @defgroup drivers_lpsxxx_config     LPS331AP/LPS25HB/LPS22HB driver compile configuration
+ * @ingroup config_drivers_sensors
+ * @{
+ */
+/**
  * @brief   The sensors default I2C address
  *
  * Default address corresponds to SDO/SA0 pad connected to ground. If SDO/SA0
  * pad is connected to power supply, I2C address is 0x5C.
+ * Refer to 'I2C Operation' section on the datasheet
  */
+#ifndef LPSXXX_DEFAULT_ADDRESS
 #define LPSXXX_DEFAULT_ADDRESS  (0x5d)
+#endif
+/** @} */
 
 /**
  * @brief   Return codes

--- a/drivers/include/mpl3115a2.h
+++ b/drivers/include/mpl3115a2.h
@@ -50,12 +50,10 @@ enum {
     MPL3115A2_ERROR_CNF,        /**< Device configuration failed */
 };
 
-#ifndef MPL3115A2_I2C_ADDRESS
 /**
  * @brief   MPL3115A2 Default Address
  */
 #define MPL3115A2_I2C_ADDRESS   (0x60)
-#endif
 
 /**
  * @name    Oversample Ratio configuration

--- a/drivers/include/tcs37727.h
+++ b/drivers/include/tcs37727.h
@@ -36,9 +36,10 @@ extern "C"
 {
 #endif
 
-#ifndef TCS37727_I2C_ADDRESS
-#define TCS37727_I2C_ADDRESS    0x29    /**< Default Device Address */
-#endif
+/**
+ * @brief   Default Device Address
+ */
+#define TCS37727_I2C_ADDRESS    0x29
 
 /**
  * @defgroup drivers_tcs37727_config     TCS37727 RGB Light Sensor driver compile configuration


### PR DESCRIPTION
### Contribution description

Make changes to expose I2C Address configurable and remove #ifndef wherever unnecessary

1. drivers/include/bmx055.h  -> define #ifndef (Refer Section 11.2 in[Datasheet](https://www.mouser.com/datasheet/2/621/BST-BMX055-DS000-01v2-371988.pdf) )
2. drivers/include/ds1307.h -> Remove ifndef for I2C  as address remains constant ( Refer Page 12 of 14 in [Datasheet](https://datasheets.maximintegrated.com/en/ds/DS1307.pdf) )
3. drivers/include/hts221.h -> Remove ifndef for I2C as address remains constant ( Refer Section 5.1.1 I2C Operation in [Datasheet](https://www.st.com/en/mems-and-sensors/hts221.html) )
4. drivers/include/isl29020.h -> Add ifndef for I2C Addressing ( Refer Section I2C interface in Page 3 of 11 in [Datasheet](https://media.digikey.com/pdf/Data%20Sheets/Renesas/isl29020_DS.pdf) )
5. drivers/include/l3g4200d.h -> Add ifndef for I2C Addressing  ( Refer Section 5.1.1 I2C Operation in [Datasheet](http://www.kontest.ru/datasheet/STMICR0ELECTR0NICS/L3G4200D.pdf) )
6. drivers/include/lpsxxx.h -> Add ifndef for I2C Addressing ( Refer 5.2.1 I2C operation in [Datasheet](https://files.amperka.ru/datasheets/LPS331AP-barometer.pdf) )
7. ~~drivers/include/mma8x5x.h : Remove ifndef for I2C as address remains constant  ( Refer Table 11 in [Datasheet](https://www.nxp.com/docs/en/data-sheet/MMA8653FC.pdf))~~ Refer #13784
8. drivers/include/mpl3115a2.h : Remove ifndef for I2C as address remains constant  ( Refer Row I2C Address in Table 6 in [Datasheet](https://www.nxp.com/docs/en/data-sheet/MPL3115A2.pdf) )
9. drivers/include/tcs37727.h : Remove ifndef for I2C as address remains constant ( Refer Figure 54 in [Datasheet](https://ams.com/documents/20143/36005/TCS3772_DS000175_3-00.pdf/8689a345-f46b-d3f0-f839-eb8d38ead80d) )



Expose Compile Parameters to Doxygen 

1. drivers/include/bmx055.h  - > Add to sensors group
2. drivers/include/isl29020.h -> Add to sensors group
3. drivers/include/l3g4200d.h -> Add to sensors group
4. drivers/include/lpsxxx.h -> Add to sensors group
5. ~~drivers/include/mma8x5x.h -> Add brief~~ Refer #13784
6. drivers/include/tcs37727.h -> Add brief

### Testing procedure

Doxygen Build works fine. 

### Issues/PRs references
~~Depends on #13784~~
Part of #10566