### PR TITLE
sliptty/start_network.sh: fix with DHCPv6

### DIFF
--- a/dist/tools/sliptty/start_network.sh
+++ b/dist/tools/sliptty/start_network.sh
@@ -107,7 +107,7 @@ start_uhcpd() {
 
 start_dhcpd() {
     DHCPD_PIDFILE=$(mktemp)
-    ${DHCPD} -d -p ${DHCPD_PIDFILE} ${TAP} ${PREFIX} 2> /dev/null
+    ${DHCPD} -d -p ${DHCPD_PIDFILE} ${TUN} ${PREFIX} 2> /dev/null
 }
 
 usage() {


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The `start_network.sh` script creates a `${TUN}` interface, so the `${TAP}` variable will always be empty.

This means `start_dhcpd()` will always fail as the DHCPv6 script is lacking an interface.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
