### PR TITLE
gnrc_dhcpv6_client: fix for SLIP link-layer

### DIFF
--- a/sys/include/net/arp.h
+++ b/sys/include/net/arp.h
@@ -32,6 +32,7 @@ extern "C" {
  * @{
  */
 #define ARP_HWTYPE_ETHERNET (1U)        /**< Ethernet */
+#define ARP_HWTYPE_SERIAL   (20U)       /**< Serial Line */
 #define ARP_HWTYPE_EUI64    (27U)       /**< EUI-64 */
 /** @} */
 

--- a/sys/net/gnrc/application_layer/dhcpv6/client.c
+++ b/sys/net/gnrc/application_layer/dhcpv6/client.c
@@ -52,6 +52,11 @@ unsigned dhcpv6_client_get_duid_l2(unsigned iface, dhcpv6_duid_l2_t *duid)
     }
     else {
         switch (netif->device_type) {
+            case NETDEV_TYPE_SLIP:
+                duid->l2type = byteorder_htons(ARP_HWTYPE_SERIAL);
+                /* L2 address length is 0 */
+                res = 0;
+                break;
             case NETDEV_TYPE_ETHERNET:
             case NETDEV_TYPE_BLE:
             case NETDEV_TYPE_ESP_NOW:


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

In a point-to-point serial connection, we don't have L2 addresses.
Set the link type & packet length accordingly and we will get a prefix from KEA.


### Testing procedure

    USE_DHCPV6=1 UPLINK=slip make -C examples/gnrc_border_router


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/13832#issuecomment-610588159