### PR TITLE
tests: fix for `GNRC_NETIF_SINGLE`

### DIFF
--- a/tests/emcute/Makefile
+++ b/tests/emcute/Makefile
@@ -25,6 +25,8 @@ USEMODULE += sock_util
 
 CFLAGS += -DEMCUTE_TOPIC_MAXLEN="249"   # 256 - 7
 CFLAGS += -DSTDIO_UART_RX_BUFSIZE="512" # Adapt to SHELL_BUFSIZE in app
+CFLAGS += -DGNRC_NETIF_SINGLE           # Only one interface used and it makes
+                                        # shell commands easier
 
 # The test requires some setup and to be run as root
 # So it cannot currently be run

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -4,6 +4,9 @@ RIOTBASE ?= $(CURDIR)/../..
 
 export TAP ?= tap0
 
+CFLAGS += -DGNRC_NETIF_SINGLE           # Only one interface used and it makes
+                                        # shell commands easier
+
 USEMODULE += sock_dns
 USEMODULE += gnrc_sock_udp
 USEMODULE += gnrc_ipv6_default

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -15,6 +15,8 @@ TEST_ON_CI_BLACKLIST += all
 CFLAGS += -DSHELL_NO_ECHO
 CFLAGS += -DGNRC_TCP_MSL=$(MSL_US)
 CFLAGS += -DGNRC_TCP_CONNECTION_TIMEOUT_DURATION=$(TIMEOUT_US)
+CFLAGS += -DGNRC_NETIF_SINGLE           # Only one interface used and it makes
+                                        # shell commands easier
 
 ifeq (native,$(BOARD))
   TERMFLAGS ?= $(TAP)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Some of the tests requiring `sudo` do not work anymore since #12994. This fixes them.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
All of these tests should now pass (with `sudo`):
```
tests/emcute
tests/gnrc_dhcpv6_client
tests/gnrc_dhcpv6_client_6lbr
tests/gnrc_ipv6_ext
tests/gnrc_ipv6_ext_frag
tests/gnrc_sock_dns
tests/gnrc_tcp
```

`tests/gnrc_rpl_srh` seems to have a problem with its sniffer, which I am currently investigating.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #12994.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
