### PR TITLE
gnrc_ipv6_nib: have two default routers with gnrc_rpl

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -248,7 +248,11 @@ extern "C" {
  *              default routers
  */
 #ifndef CONFIG_GNRC_IPV6_NIB_DEFAULT_ROUTER_NUMOF
+#if IS_USED(MODULE_GNRC_RPL)
+#define CONFIG_GNRC_IPV6_NIB_DEFAULT_ROUTER_NUMOF    (2)
+#else
 #define CONFIG_GNRC_IPV6_NIB_DEFAULT_ROUTER_NUMOF    (1)
+#endif
 #endif
 
 /**

--- a/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/nib/Kconfig
@@ -94,6 +94,7 @@ config GNRC_IPV6_NIB_L2ADDR_MAX_LEN
 
 config GNRC_IPV6_NIB_DEFAULT_ROUTER_NUMOF
     int "Number of default routers in the default router list"
+    default 2 if MODULE_GNRC_RPL
     default 1
     help
         @attention This number has direct influence on the maximum number of


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
RPL might pick a different parent then the advertising upstream router, so having another entry available in the default router list can prevent potential battles for the default route between RPL and NDP.

The route added by RPL is already marked as the primary route to pick, so no need for any adoption there.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Best way to test this is to have 3 nodes and restart so long until `nib route` shows more than one default route. The RPL parent (use `rpl` to check) should be marked as the primary default routes (with an `*`) and all traffic should be routed over it.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None (also as far as I can judge not related to the until now unreported bug faced when running long-term RPL applications).
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
