### PR TITLE
Doc: fix typo and extend ws281x documentation

### DIFF
--- a/drivers/include/ws281x.h
+++ b/drivers/include/ws281x.h
@@ -40,7 +40,7 @@
  * ## ESP32
  *
  * The ESP32 implementation is frequency independent, as frequencies above 80MHz
- * are high enough to support big banging without assembly.
+ * are high enough to support bit banging without assembly.
  *
  * ## Native/VT100
  *
@@ -48,10 +48,21 @@
  *
  * ### Usage
  *
- * Add the following to your `Makefile` to use the ATmega backend:
+ * Add the following to your `Makefile` to use:
  *
+ * * the ATmega backend:
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Makefile
  * USEMODULE += ws281x_atmega
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * * the ESP32 backend:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Makefile
+ * USEMODULE += ws281x_esp32
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * * the native/VT100 backend:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Makefile
+ * USEMODULE += ws281x_vt100
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * @{


### PR DESCRIPTION
### Contribution description

Fix small typo and add usage of ESP32 and VT100  in ws281x documentation

### Testing procedure
Running make doc and check documentation

### Issues/PRs references
None