### PR TITLE
boards/msbiot: Use common stm32 serial/programmer settings

### DIFF
--- a/boards/msbiot/Makefile.include
+++ b/boards/msbiot/Makefile.include
@@ -1,15 +1,13 @@
 # we use shared STM32 configuration snippets
 INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 
-#define the default port depending on the host OS
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
-
-# setup serial terminal
-include $(RIOTMAKE)/tools/serial.inc.mk
+PROGRAMMER ?= openocd
 
 DEBUG_ADAPTER ?= stlink
-STLINK_VERSION ?= 2
+ifeq (openocd,$(PROGRAMMER))
+  STLINK_VERSION ?= 2
+  PORT_LINUX ?= /dev/ttyUSB0
+endif
 
-# this board uses openocd
-include $(RIOTMAKE)/tools/openocd.inc.mk
+# Setup of programmer and serial is shared between STM32 based boards
+include $(RIOTMAKE)/boards/stm32.inc.mk


### PR DESCRIPTION
### Contribution description

Replaced serial/programmer settings by common STM32 settings.

### Testing procedure

```sh
make BOARD=msbiot -C examples/default flash term
```

### Issues/PRs references

None