### PR TITLE
drivers/ws281x: Fix dependencies & doc

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -794,7 +794,7 @@ ifneq (,$(filter ws281x_%,$(USEMODULE)))
 endif
 
 ifneq (,$(filter ws281x,$(USEMODULE)))
-  FEATURES_REQUIRED_ANY += arch_avr8|arch_native
+  FEATURES_REQUIRED_ANY += arch_avr8|arch_esp32|arch_native
 
   ifeq (,$(filter ws281x_%,$(USEMODULE)))
     ifneq (,$(filter arch_avr8,$(FEATURES_USED)))

--- a/drivers/include/ws281x.h
+++ b/drivers/include/ws281x.h
@@ -48,7 +48,17 @@
  *
  * ### Usage
  *
- * Add the following to your `Makefile` to use:
+ * Add the following to your `Makefile`:
+ *
+ * * Auto-selecting the backend:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Makefile
+ * USEMODULE += ws281x
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * This will automatically pull in one of the backends supported by your board.
+ * In case multiple backends apply and the automatic selection does not pick
+ * your preferred backend, you can manually pick your preferred backend as
+ * described below.
  *
  * * the ATmega backend:
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Makefile


### PR DESCRIPTION
### Contribution description

- Fixed bug in dependencies resolution: `arch_esp32` was previously missing `FEATURES_REQUIRED_ANY`
- Added info on automatic backend selection

### Testing procedure

- `make info-boards-supported -C tests/driver_ws281x` should now also list ESP32 boards
- Backends should be automagically being selected as described in the added doc. (E.g. run `make BOARD=<some_supported_board> -C tests/driver_ws281x flash term`. If that works, a backend was automagically pulled in.)

### Issues/PRs references

Follow up to https://github.com/RIOT-OS/RIOT/pull/13843