### PR TITLE
Makefile.include: add $(MAKEFILEDIR) helper and use it

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -8,8 +8,11 @@ ifeq (,$(filter $(MATCH_MAKE_VERSION),$(MAKE_VERSION)))
       $(MATCH_MAKE_VERSION) or later.)
 endif
 
+# will evaluate to the absolute path of the Makefile it's evaluated in
+MAKEFILEDIR = $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
 # 'Makefile.include' directory, must be evaluated before other 'include'
-_riotbase := $(dir $(lastword $(MAKEFILE_LIST)))
+_riotbase := $(MAKEFILEDIR)
 
 # include RIOT_MAKEFILES_GLOBAL_PRE configuration files
 # allows setting user specific system wide configuration parsed before the body

--- a/cpu/kinetis/Makefile.include
+++ b/cpu/kinetis/Makefile.include
@@ -1,7 +1,7 @@
 ifeq (,$(KINETIS_SERIES))
   # Parse parameters from CPU_MODEL using the kinetis-info.mk script in the same
   # directory as this Makefile.
-  include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/kinetis-info.mk
+  include $(MAKEFILEDIR)/kinetis-info.mk
 endif
 
 # "The Vector table must be naturally aligned to a power of two whose alignment

--- a/tests/cpp_exclude/module_exclude/Makefile.include
+++ b/tests/cpp_exclude/module_exclude/Makefile.include
@@ -1,3 +1,3 @@
-# Use an immediate variable to evaluate `MAKEFILE_LIST` now
-USEMODULE_INCLUDES_module_exclude := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+# Use an immediate variable to evaluate `MAKEFILEDIR` now
+USEMODULE_INCLUDES_module_exclude := $(MAKEFILEDIR)
 USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_module_exclude)

--- a/tests/cpp_ext/module/Makefile.include
+++ b/tests/cpp_ext/module/Makefile.include
@@ -1,3 +1,3 @@
 # Use an immediate variable to evaluate `MAKEFILE_LIST` now
-USEMODULE_INCLUDES_module := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+USEMODULE_INCLUDES_module := $(MAKEFILEDIR)
 USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_module)

--- a/tests/external_module_dirs/external_module/Makefile.include
+++ b/tests/external_module_dirs/external_module/Makefile.include
@@ -1,3 +1,3 @@
 # Use an immediate variable to evaluate `MAKEFILE_LIST` now
-USEMODULE_INCLUDES_external_module := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))/include
+USEMODULE_INCLUDES_external_module := $(MAKEFILEDIR)/include
 USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_external_module)

--- a/tests/pkg_utensor/models/Makefile.include
+++ b/tests/pkg_utensor/models/Makefile.include
@@ -1,5 +1,5 @@
 # Use an immediate variable to evaluate `MAKEFILE_LIST` now
-USEMODULE_INCLUDES_models := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+USEMODULE_INCLUDES_models := $(MAKEFILEDIR)
 USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_models)
 
 CXXEXFLAGS += -Wno-unused-parameter


### PR DESCRIPTION
### Contribution description

The `$(abspath $(dir $(lastword $(MAKEFILE_LIST))))` is used to get the location of the current Makefile.

This is a useful helper especially for external modules.
It is used in several places in RIOT already, so add a special variable for it to make it more accessable.

### Testing procedure

Murdock should still be able to build everything.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
