### PR TITLE
tests/xtimer_now32_overflow: simplify

### DIFF
--- a/tests/xtimer_now32_overflow/Makefile
+++ b/tests/xtimer_now32_overflow/Makefile
@@ -1,6 +1,5 @@
 include ../Makefile.tests_common
 
-USEMODULE += fmt
 USEMODULE += xtimer
 
 DISABLE_MODULE += auto_init_xtimer

--- a/tests/xtimer_now32_overflow/main.c
+++ b/tests/xtimer_now32_overflow/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Freie Universität Berlin
+ * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -7,85 +7,53 @@
  */
 
 /**
+ * @ingroup     tests
  * @{
  *
  * @file
- * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ * @brief       timer test application
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
  */
 
 #include <stdio.h>
 
-#include "fmt.h"
-#include "kernel_defines.h"
-#include "msg.h"
-#include "test_utils/expect.h"
-#include "thread.h"
 #include "xtimer.h"
 
-#define MAIN_MSG_QUEUE_SIZE     (4U)
-#define TIMERS_NUMOF            (3U)
-
-msg_t _main_msg_queue[MAIN_MSG_QUEUE_SIZE];
-static const uint64_t _timers_offsets[TIMERS_NUMOF] = {
-    /* MUST ASCEND */
-    1 * US_PER_SEC,
-    2 * US_PER_SEC,
-    3 * US_PER_SEC,
-};
+static void _callback(void *arg)
+{
+    (void)arg;
+}
 
 int main(void)
 {
-    xtimer_t timers[TIMERS_NUMOF];
-    msg_t msgs[TIMERS_NUMOF];
-    uint64_t start;
+    xtimer_t t1 = { .callback=_callback };
+    xtimer_t t2 = { .callback=_callback };
 
-    expect(ARRAY_SIZE(_timers_offsets) == TIMERS_NUMOF);
-    msg_init_queue(_main_msg_queue, MAIN_MSG_QUEUE_SIZE);
-    /* ensure that xtimer_now64() is greater than UINT32_MAX */
-    _xtimer_current_time = (2LLU << 32U);
+    /* ensure that xtimer_now64() is greater than UINT32_MAX
+     * and the upper 32bit of xtimer_now64() equal 1 */
+    _xtimer_current_time = (1LLU << 32U);
     xtimer_init();
-    print_str("Setting ");
-    print_u32_dec(TIMERS_NUMOF);
-    print_str(" timers:\n");
-    for (unsigned i = 0; i < TIMERS_NUMOF; i++) {
-        msgs[i].content.value = i;
-        print_str(" #");
-        print_u32_dec(i);
-        print_str(" in ");
-        print_u64_dec(_timers_offsets[i]);
-        print_str(" usec\n");
-    }
-    print_str("now=");
-    start = xtimer_now64().ticks64;
-    print_u64_dec(start);
-    print_str("\n");
-    expect(start > UINT32_MAX);
-    /* set timers after all were printed for better timing */
-    for (unsigned i = 0; i < TIMERS_NUMOF; i++) {
-        xtimer_set_msg64(&timers[i], _timers_offsets[i], &msgs[i],
-                         thread_getpid());
-        expect(timers[i].long_start_time > 0);
-    }
-    while (1) {
-        msg_t msg;
 
-        msg_receive(&msg);
-        print_str("#");
-        print_u32_dec(msg.content.value);
-        print_str(":now=");
-        print_u64_dec((uint64_t)xtimer_now64().ticks64);
-        print_str("\n");
-        for (unsigned i = 0; i <= msg.content.value; i++) {
-            /* all fired timers expired */
-            expect(timers[i].long_start_time == 0);
-        }
-        for (unsigned i = (msg.content.value + 1); i <= TIMERS_NUMOF; i++) {
-            /* upper half of remaing_timers' start_time stays above 0 as it is
-             * based on xtimer_now64() during the timer's callback execution */
-            expect(timers[i].long_start_time > 0);
-        }
+    /* set to 100s (far in the future) */
+    xtimer_set(&t1, 100000000LU);
+    xtimer_set(&t2, 100000000LU);
+
+    /* sleep 1 ms (uses a third xtimer internally).
+     * shooting this timer did set all following short timer's to have a
+     * long_start_time of 0.  The timer_callback main loop would correct the
+     * timer_list_head, but not the following.
+     */
+    xtimer_usleep(1000);
+
+    if (t2.long_start_time == 1) {
+        puts("[SUCCESS]");
     }
+    else {
+        puts("[FAILED]");
+    }
+
     return 0;
 }
-
-/** @} */

--- a/tests/xtimer_now32_overflow/tests/01-run.py
+++ b/tests/xtimer_now32_overflow/tests/01-run.py
@@ -1,47 +1,17 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2018 Freie Universität Berlin
+# Copyright (C) 2020 Freie Universität Berlin
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
 import sys
-import time
 from testrunner import run
 
 
-def _get_largest_timeout_difference(timeouts):
-    next_timeout = min(timeouts)
-    # get largest difference between all timeouts
-    timeout = max(a - b for a in timeouts for b in timeouts)
-    # check if smallest timeout (difference to 0) is the largest difference
-    if timeout < next_timeout:
-        timeout = next_timeout
-    return timeout
-
-
 def testfunc(child):
-    timers = {}
-    child.expect(r"Setting (\d+) timers:")
-    timers_numof = int(child.match.group(1))
-    for i in range(timers_numof):
-        child.expect(r" #(\d+) in (\d+) usec")
-        assert i == int(child.match.group(1))
-        timers[i] = int(child.match.group(2))
-    assert timers_numof == len(timers)
-    check_time = int(time.time())
-    child.expect(r"now=(\d+)")
-    offset = int(child.match.group(1))
-    # get largest possible timeout for expects below
-    timeout = _get_largest_timeout_difference(timers.values()) / (10**6) + 1
-    for i in range(timers_numof):
-        child.expect(r"#(\d):now=(\d+)", timeout=timeout)
-        t = int(child.match.group(1))
-        now = int(child.match.group(2))
-        assert (int(time.time()) - check_time) >= (timers[t] / 10**6)
-        expected = timers[t] + offset
-        assert expected <= now
+    child.expect_exact("[SUCCESS]")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Vastly simplifies and speeds up the regression test added in #13850.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Test should succeed on master. To see that it would fail, revert 212fe157863695dd526be6320ddc84ce6ff5d392.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#13850

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
