### PR TITLE
usbus: add Device Firmware Upgrade (DFU) support

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -995,6 +995,12 @@ ifneq (,$(filter usbus_cdc_ecm,$(USEMODULE)))
   USEMODULE += luid
 endif
 
+ifneq (,$(filter usbus_dfu,$(USEMODULE)))
+  USEMODULE += usbus
+  USEMODULE += xtimer
+  FEATURES_REQUIRED += periph_flashpage
+endif
+
 ifneq (,$(filter uuid,$(USEMODULE)))
   USEMODULE += hashes
   USEMODULE += random

--- a/sys/auto_init/usb/auto_init_usb.c
+++ b/sys/auto_init/usb/auto_init_usb.c
@@ -35,7 +35,6 @@ usbus_cdcecm_device_t cdcecm;
 #endif
 #ifdef MODULE_USBUS_DFU
 #include "usb/dfu.h"
-usbus_dfu_device_t dfu;
 #endif
 
 static char _stack[USBUS_STACKSIZE];
@@ -61,6 +60,7 @@ void auto_init_usb(void)
 #endif
 
 #ifdef MODULE_USBUS_DFU
+    static usbus_dfu_device_t dfu;
     usbus_dfu_init(&usbus, &dfu, USBUS_APP_MODE);
 #endif
 

--- a/sys/auto_init/usb/auto_init_usb.c
+++ b/sys/auto_init/usb/auto_init_usb.c
@@ -33,6 +33,10 @@ usbus_cdcecm_device_t cdcecm;
 #ifdef MODULE_USBUS_CDC_ACM
 #include "usb/usbus/cdc/acm.h"
 #endif
+#ifdef MODULE_USBUS_DFU
+#include "usb/dfu.h"
+usbus_dfu_device_t dfu;
+#endif
 
 static char _stack[USBUS_STACKSIZE];
 static usbus_t usbus;
@@ -54,6 +58,10 @@ void auto_init_usb(void)
 
 #ifdef MODULE_USBUS_CDC_ECM
     usbus_cdcecm_init(&usbus, &cdcecm);
+#endif
+
+#ifdef MODULE_USBUS_DFU
+    usbus_dfu_init(&usbus, &dfu, USBUS_APP_MODE);
 #endif
 
     /* Finally initialize USBUS thread */

--- a/sys/include/usb/dfu.h
+++ b/sys/include/usb/dfu.h
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2020 Dylan Laduranty
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @defgroup    usb_dfu   DFU - USB Device Firmware Upgrade
+ * @ingroup     usb
+ * @brief       Generic USB DFU defines and helpers
+ *
+ * @{
+ *
+ * @file
+ * @brief       Definition for USB DFU interfaces
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ */
+
+#ifndef USB_DFU_H
+#define USB_DFU_H
+
+#include <stdint.h>
+
+#include "usb.h"
+#include "usb/descriptor.h"
+#include "usb/usbus.h"
+#include "usb/usbus/control.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define USB_IF_DESCRIPTOR_DFU           0x21   /**< USB DFU type descriptor */
+#define USB_DFU_VERSION_BCD             0x0110 /**< USB DFU version in BCD */
+
+/**
+ * @name    Default USB detach timeout for DFU descriptor
+ * @{
+ */
+#ifndef USB_DFU_DETACH_TIMEOUT_MS
+#define USB_DFU_DETACH_TIMEOUT_MS 255
+#endif
+/** @} */
+
+/**
+ * @name    Default USB transfer size for DFU descriptor
+ * @{
+ */
+#ifndef USB_DFU_TRANSFER_SIZE
+#define USB_DFU_TRANSFER_SIZE FLASHPAGE_SIZE
+#endif
+/** @} */
+
+/**
+ * @name USB DFU interface attribute bit flags
+ * @{
+ */
+#define USB_DFU_CAN_DOWNLOAD            0x01    /**<  USB DFU download capability flag */
+#define USB_DFU_CAN_UPLOAD              0x02    /**<  USB DFU upload capability flag */
+#define USB_DFU_MANIFEST_TOLERANT       0x04    /**<  USB DFU manifest tolerant capability flag */
+#define USB_DFU_WILL_DETACH             0x08    /**<  USB DFU detach capability flag */
+/** @} */
+
+/**
+ * @name USB DFU interface type
+ * @{
+ */
+#define USB_DFU_INTERFACE               0xFE /**< Application Specific Interface */
+/** @} */
+/**
+ * @name USB DFU subclass types
+ * @anchor usb_dfu_subtype
+ * @{
+ */
+#define USB_DFU_SUBCLASS_DFU            0x01 /**< DFU subclass */
+/** @} */
+
+/**
+ * @name USB DFU protocol types
+ * @{
+ */
+#define USB_DFU_PROTOCOL_RUNTIME_MODE   0x01 /**< Runtime mode */
+#define USB_DFU_PROTOCOL_DFU_MODE       0x02 /**< DFU mode */
+/** @} */
+
+/**
+ * @name USB DFU setup request
+ * @{
+ */
+#define DFU_DETACH      0x00        /**< DFU detach request */
+#define DFU_DOWNLOAD    0x01        /**< DFU download request */
+#define DFU_UPLOAD      0x02        /**< DFU upload request */
+#define DFU_GET_STATUS  0x03        /**< DFU get status request */
+#define DFU_CLR_STATUS  0x04        /**< DFU clear status request */
+#define DFU_GET_STATE   0x05        /**< DFU get state request */
+#define DFU_ABORT       0x06        /**< DFU abort operation request */
+/** @} */
+
+/**
+ * @name USBUS DFU startup mode to be used with @ref usbus_dfu_init
+ * @{
+ */
+typedef enum {
+    USBUS_APP_MODE,         /**< USBUS DFU application mode selection */
+    USBUS_DFU_MODE          /**< USBUS DFU runtime mode selection */
+} usbus_dfu_startup_mode_t;
+/** @} */
+
+/**
+ * @name USBUS DFU internal state machine
+ * @{
+ */
+typedef enum {
+    USBUS_DFU_STATE_APP_IDLE,               /**< DFU application idle */
+    USBUS_DFU_STATE_APP_DETACH,             /**< DFU application detach (reboot to DFU mode) */
+    USBUS_DFU_STATE_DFU_IDLE,               /**< DFU runtime mode idle */
+    USBUS_DFU_STATE_DFU_DL_SYNC,            /**< DFU download synchronization */
+    USBUS_DFU_STATE_DFU_DL_BUSY,            /**< DFU download busy */
+    USBUS_DFU_STATE_DFU_DL_IDLE,            /**< DFU download idle */
+    USBUS_DFU_STATE_DFU_MANIFEST_SYNC,      /**< DFU manifest synchronization */
+    USBUS_DFU_STATE_DFU_MANIFEST,           /**< DFU manifest mode */
+    USBUS_DFU_STATE_DFU_MANIFEST_WAIT_RST,  /**< DFU manifest wait for CPU reset */
+    USBUS_DFU_STATE_DFU_UP_IDLE,            /**< DFU upload idle */
+    USBUS_DFU_STATE_DFU_ERROR               /**< DFU internal error */
+} usbus_dfu_state_t;
+/** @} */
+/**
+ * @brief USB DFU interface descriptor
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t length;              /**< Descriptor length */
+    uint8_t type;                /**< Descriptor type */
+    uint8_t attribute;           /**< Descriptor attributes flags */
+    uint16_t detach_timeout;     /**< Descriptor detach timeout (ms) */
+    uint16_t xfer_size;          /**< Descriptor transfer size */
+    uint16_t bcd_dfu;            /**< Descriptor bcd version */
+} usb_desc_if_dfu_t;
+
+/**
+ * @brief USB DFU get_status control request packet
+ */
+typedef struct __attribute__((packed))  {
+    uint8_t status;             /**< DFU status response */
+    uint32_t timeout : 24;      /**< DFU timeout (ms) response */
+    uint8_t state;              /**< DFU internal state machine */
+    uint8_t string;             /**< DFU string */
+} dfu_get_status_pkt_t;
+
+/**
+ * @brief USBUS DFU device interface context
+ */
+typedef struct usbus_dfu_device {
+    usbus_handler_t handler_ctrl;           /**< Control interface handler */
+    usbus_interface_t iface;                /**< Control interface */
+    usbus_descr_gen_t dfu_descr;            /**< DFU descriptor generator */
+    usbus_t *usbus;                         /**< Ptr to the USBUS context */
+    unsigned mode;                          /**< 0 - APP mode, 1 DFU mode */
+} usbus_dfu_device_t;
+
+/**
+ * @brief DFU initialization function
+ *
+ * @param   usbus   USBUS thread to use
+ * @param   handler DFU device struct
+ * @param   mode    DFU start mode (0 runtime mode / 1 dfu mode)
+ */
+void usbus_dfu_init(usbus_t *usbus, usbus_dfu_device_t *handler, usbus_dfu_startup_mode_t mode);
+
+/**
+ * @brief DFU control request handler
+ *
+ * @param   usbus   USBUS thread to use
+ * @param   handler DFU device struct
+ */
+void dfu_control_req(usbus_t *usbus, usbus_control_handler_t *handler);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* USB_DFU_H */
+/** @} */

--- a/sys/usb/usbus/Makefile
+++ b/sys/usb/usbus/Makefile
@@ -7,4 +7,7 @@ endif
 ifneq (,$(filter usbus_cdc_acm,$(USEMODULE)))
     DIRS += cdc/acm
 endif
+ifneq (,$(filter usbus_dfu,$(USEMODULE)))
+    DIRS += dfu/
+endif
 include $(RIOTBASE)/Makefile.base

--- a/sys/usb/usbus/dfu/Makefile
+++ b/sys/usb/usbus/dfu/Makefile
@@ -1,0 +1,3 @@
+MODULE = usbus_dfu
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/usb/usbus/dfu/dfu.c
+++ b/sys/usb/usbus/dfu/dfu.c
@@ -1,0 +1,255 @@
+/*
+ * Copyright (C) 2020 Dylan Laduranty
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup usb_dfu
+ * @{
+ * @file USBUS implementation for device firmware upgrade
+ *
+ * @note This feature is currently experimental as it needs a proper riotboot
+ * or another bootloader implementation to be fully functional
+ *
+ *
+ * @author  Dylan Laduranty <dylan.laduranty@mesotic.com>
+ * @}
+ */
+
+#define USB_H_USER_IS_RIOT_INTERNAL
+
+#include "usb/dfu.h"
+#include "usb/descriptor.h"
+#include "usb/usbus.h"
+#include "usb/usbus/control.h"
+#include "xtimer.h"
+
+#include "periph/flashpage.h"
+#include "periph/pm.h"
+
+#include <string.h>
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+static void _event_handler(usbus_t *usbus, usbus_handler_t *handler,
+                          usbus_event_usb_t event);
+static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
+                            usbus_control_request_state_t state,
+                            usb_setup_t *setup);
+static void _transfer_handler(usbus_t *usbus, usbus_handler_t *handler,
+                              usbdev_ep_t *ep, usbus_event_transfer_t event);
+static void _init(usbus_t *usbus, usbus_handler_t *handler);
+
+static usbus_dfu_state_t dfu_state;
+static uint32_t offset = 0;
+static uint8_t page_mem[FLASHPAGE_SIZE];
+/* TODO: properly integrate this part to riotboot */
+static usbus_dfu_device_t dfu2;
+static char _stack[USBUS_STACKSIZE];
+static usbus_t usbus2;
+
+static size_t _gen_dfu_descriptor(usbus_t *usbus, void *arg)
+{
+    usb_desc_if_dfu_t if_desc;
+    (void) arg;
+
+    /* functional dfu descriptor */
+    if_desc.length = sizeof(usb_desc_if_dfu_t);
+    if_desc.type = USB_IF_DESCRIPTOR_DFU;
+    if_desc.attribute = USB_DFU_WILL_DETACH | USB_DFU_CAN_DOWNLOAD;
+    if_desc.detach_timeout = USB_DFU_DETACH_TIMEOUT_MS;
+    if_desc.xfer_size = USB_DFU_TRANSFER_SIZE;
+    if_desc.bcd_dfu = USB_DFU_VERSION_BCD;
+
+    usbus_control_slicer_put_bytes(usbus, (uint8_t *)&if_desc, sizeof(if_desc));
+    return sizeof(usb_desc_if_dfu_t);
+}
+
+
+static const usbus_handler_driver_t dfu_driver = {
+    .init = _init,
+    .event_handler = _event_handler,
+    .transfer_handler = _transfer_handler,
+    .control_handler = _control_handler,
+};
+
+/* Descriptors */
+static const usbus_descr_gen_funcs_t _dfu_descriptor = {
+    .fmt_post_descriptor = _gen_dfu_descriptor,
+    .fmt_pre_descriptor = NULL,
+    .len = {
+        .fixed_len = sizeof(usb_desc_if_dfu_t),
+    },
+    .len_type = USBUS_DESCR_LEN_FIXED,
+};
+
+static void _flashpage(void) {
+    static int page_cpt = 0;
+    /* reset offset value for next transfer */
+    offset = 0;
+    /* Erase page content */
+    flashpage_write(page_cpt, NULL);
+    /* Write buffer into flash */
+    int ret = flashpage_write_and_verify(page_cpt, page_mem);
+    page_cpt++;
+    if (ret != FLASHPAGE_OK) {
+         /* TODO: Set DFU status variable accordingly */
+         return;
+    }
+    /* Clear buffer for next transfer */
+    memset(page_mem, 0, sizeof(page_mem));
+}
+void usbus_dfu_init(usbus_t *usbus, usbus_dfu_device_t *handler, usbus_dfu_startup_mode_t mode)
+{
+    DEBUG_PUTS("DFU: initializations");
+    assert(usbus);
+    assert(handler);
+    memset(handler, 0, sizeof(usbus_dfu_device_t));
+    handler->usbus = usbus;
+    handler->handler_ctrl.driver = &dfu_driver;
+    handler->mode = mode;
+    dfu_state = (handler->mode) ? USBUS_DFU_STATE_DFU_IDLE : USBUS_DFU_STATE_APP_IDLE;
+    usbus_register_event_handler(usbus, (usbus_handler_t *)handler);
+}
+
+static void _init(usbus_t *usbus, usbus_handler_t *handler)
+{
+    usbus_dfu_device_t *dfu = (usbus_dfu_device_t*) handler;
+
+    /* Set up descriptor generators */
+    dfu->dfu_descr.next = NULL;
+    dfu->dfu_descr.funcs = &_dfu_descriptor;
+    dfu->dfu_descr.arg = dfu;
+
+    /* Configure Interface 0 as control interface */
+    dfu->iface.class = USB_DFU_INTERFACE;
+    dfu->iface.subclass = USB_DFU_SUBCLASS_DFU;
+
+    dfu->iface.protocol = ((dfu->mode) ? USB_DFU_PROTOCOL_DFU_MODE :
+                                USB_DFU_PROTOCOL_RUNTIME_MODE);
+
+    dfu->iface.descr_gen = &dfu->dfu_descr;
+    dfu->iface.handler = handler;
+    dfu->iface.alts = NULL;
+
+    /* Add interfaces to the stack */
+    usbus_add_interface(usbus, &dfu->iface);
+    usbus_handler_set_flag(handler, USBUS_HANDLER_FLAG_RESET);
+}
+
+static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
+                          usbus_control_request_state_t state,
+                          usb_setup_t *setup)
+{
+    (void)usbus;
+    (void)state;
+    (void)handler;
+    (void)setup;
+
+    return 1;
+}
+
+
+static void _transfer_handler(usbus_t *usbus, usbus_handler_t *handler,
+                             usbdev_ep_t *ep, usbus_event_transfer_t event)
+{
+    (void)event;
+    (void)usbus;
+    (void)handler;
+    (void)ep;
+}
+
+void dfu_control_req(usbus_t *usbus, usbus_control_handler_t *handler)
+{
+    usb_setup_t *pkt = &handler->setup;
+    usbopt_enable_t enable = USBOPT_DISABLE;
+
+    DEBUG("DFU control request:%d\n", pkt->request);
+    switch(pkt->request) {
+        case DFU_DETACH:
+            /* Detach USB bus */
+            usbdev_set(usbus->dev, USBOPT_ATTACH, &enable, sizeof(usbopt_enable_t));
+            /* EXPERIMENTAL: Start a new usbus instance with a single interface */
+            /* TODO: properly integrate this part to riotboot */
+            usbus_init(&usbus2, usbdev_get_ctx(0));
+            usbus_dfu_init(&usbus2, &dfu2, USBUS_DFU_MODE);
+            usbus_create(_stack, USBUS_STACKSIZE, USBUS_PRIO, USBUS_TNAME, &usbus2);
+            break;
+        case DFU_DOWNLOAD:
+            /* Host indicates end of firmware download */
+            if (pkt->length == 0) {
+                /* Set DFU to manifest sync */
+                dfu_state = USBUS_DFU_STATE_DFU_MANIFEST_SYNC;
+                /* Flash pending buffer */
+                if (offset) {
+                    _flashpage();
+                }
+            }
+            else if (dfu_state != USBUS_DFU_STATE_DFU_DL_SYNC) {
+                dfu_state = USBUS_DFU_STATE_DFU_DL_SYNC;
+            }
+            else {
+                /* Retrieve firmware data */
+                size_t len = 0;
+                usbdev_ep_get(handler->out, USBOPT_EP_AVAILABLE,
+                              &len, sizeof(size_t));
+
+                memcpy(&page_mem[handler->received_len + offset - len],
+                       handler->out->buf, len);
+
+                if (handler->received_len == pkt->length) {
+                    /* Received a whole page, flash it */
+                    if (handler->received_len + offset == FLASHPAGE_SIZE) {
+                        /* DFU 1.1 doesn't support firmware addressing */
+                        _flashpage();
+                    }
+                    else if (handler->received_len + offset < FLASHPAGE_SIZE){
+                        /* If the transferred block is smaller than a flashpage
+                           size, then we wait a new block to fill the buffer.
+                           Block size is determined by the host despite the
+                           given value during USB enumeration */
+                           offset += handler->received_len;
+                    }
+                }
+            }
+            break;
+        case DFU_GET_STATUS:
+        {
+            dfu_get_status_pkt_t buf;
+            if (dfu_state == USBUS_DFU_STATE_DFU_DL_SYNC) {
+                dfu_state = USBUS_DFU_STATE_DFU_DL_IDLE;
+            }
+            else if (dfu_state == USBUS_DFU_STATE_DFU_MANIFEST_SYNC) {
+                pm_reboot();
+            }
+
+            memset(&buf, 0, sizeof(buf));
+            buf.status = 0;
+            buf.timeout = USB_DFU_DETACH_TIMEOUT_MS;
+            buf.state = dfu_state;
+            /* Send answer to host */
+            usbus_control_slicer_put_bytes(usbus, (uint8_t*)&buf, sizeof(buf));
+            break;
+        }
+        case DFU_CLR_STATUS:
+            DEBUG("CLRSTATUS To be implemented\n");
+            break;
+        default:
+            DEBUG("Unhandled DFU control request:%d\n", pkt->request);
+    }
+}
+static void _event_handler(usbus_t *usbus, usbus_handler_t *handler,
+                          usbus_event_usb_t event)
+{
+    (void) usbus;
+    (void) handler;
+    switch (event) {
+        default:
+            DEBUG("Unhandled event :0x%x\n", event);
+            break;
+    }
+}

--- a/sys/usb/usbus/usbus_control.c
+++ b/sys/usb/usbus/usbus_control.c
@@ -263,12 +263,14 @@ static void _recv_setup(usbus_t *usbus, usbus_control_handler_t *handler)
     DEBUG("usbus_control: Received setup %x %x @ %d\n", pkt->type,
           pkt->request, pkt->length);
 
+#ifdef MODULE_USBUS_DFU
     if (pkt->type & USB_SETUP_REQUEST_TYPE_CLASS) {
         if (pkt->type & USB_SETUP_REQUEST_RECIPIENT_INTERFACE) {
             dfu_control_req(usbus, handler);
             res = 1;
         }
     }
+#endif
 
     uint8_t destination = pkt->type & USB_SETUP_REQUEST_RECIPIENT_MASK;
 

--- a/tests/usbus_dfu/Makefile
+++ b/tests/usbus_dfu/Makefile
@@ -1,0 +1,31 @@
+BOARD ?= same54-xpro
+include ../Makefile.tests_common
+
+USEMODULE += usbus_dfu
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+FEATURES_REQUIRED += riotboot
+
+# Include modules to test the bootloader
+USEMODULE += riotboot_slot
+# USB device vendor and product ID
+# pid.codes test VID/PID, not globally unique
+DEFAULT_VID = 1209
+DEFAULT_PID = 7D00
+USB_VID ?= $(DEFAULT_VID)
+USB_PID ?= $(DEFAULT_PID)
+
+CFLAGS += -DCONFIG_USB_VID=0x$(USB_VID) -DCONFIG_USB_PID=0x$(USB_PID)
+
+include $(RIOTBASE)/Makefile.include
+
+.PHONY: usb_id_check
+usb_id_check:
+	@if [ $(USB_VID) = $(DEFAULT_VID) -o $(USB_PID) = $(DEFAULT_PID) ] ; then \
+		$(COLOR_ECHO) "$(COLOR_RED)Private testing pid.codes USB VID/PID used!, do not use it outside of test environments!$(COLOR_RESET)" 1>&2 ; \
+		$(COLOR_ECHO) "$(COLOR_RED)MUST NOT be used on any device redistributed, sold or manufactured, VID/PID is not unique!$(COLOR_RESET)" 1>&2 ; \
+	fi
+
+all: | usb_id_check

--- a/tests/usbus_dfu/Makefile.ci
+++ b/tests/usbus_dfu/Makefile.ci
@@ -1,0 +1,3 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    stm32f030f4-demo \
+    #

--- a/tests/usbus_dfu/README.md
+++ b/tests/usbus_dfu/README.md
@@ -1,0 +1,25 @@
+Expected result
+===============
+
+Use the network related shell commands to verify the network link between the
+board under test and the host computer. Ping to the link local address from and
+to the host computer must work.
+
+On the host computer, using tools such as `ethtool` must show the USB CDC ECM
+interface as link detected:
+
+```
+# ethtool enp0s20u9u4
+Settings for enp0s20u9u4:
+        Current message level: 0x00000007 (7)
+                               drv probe link
+        Link detected: yes
+```
+
+Background
+==========
+
+This test application can be used to verify the USBUS CDC ECM implementation.
+Assuming drivers available, the board under test should show up on the host
+computer as an USB network interface. Drivers are available for both Linux and
+macOS.

--- a/tests/usbus_dfu/README.md
+++ b/tests/usbus_dfu/README.md
@@ -1,25 +1,28 @@
-Expected result
-===============
+# Dependencies
 
-Use the network related shell commands to verify the network link between the
-board under test and the host computer. Ping to the link local address from and
-to the host computer must work.
+Install dfu-util package.
+* On Ubuntu based system:
+        apt-get install dfu-util
 
-On the host computer, using tools such as `ethtool` must show the USB CDC ECM
-interface as link detected:
+# Expected result
 
-```
-# ethtool enp0s20u9u4
-Settings for enp0s20u9u4:
-        Current message level: 0x00000007 (7)
-                               drv probe link
-        Link detected: yes
-```
+Build the RIOT firmware you want to flash.
+Build and flash the riotboot bootloader
+        make -C tests/riotboot riotboot/flash-bootloader
+Build and flash the DFU test application onto SLOT1 (avoid SLOT0 for now)
+        APP_VER=2 make -C tests/usbus_dfu riotboot/flash-slot1
+Finally use dfu-util to flash your firmware (use a .bin file)
+        dfu-util  -a 0 -R -D /path/to/your/firmware.bin
 
-Background
-==========
+Please not that it will erase the riotboot bootloader, this is known limitation
+as this feature is still experimental as long as DFU is not properly integrated
+to riotboot or any other bootloader
 
-This test application can be used to verify the USBUS CDC ECM implementation.
-Assuming drivers available, the board under test should show up on the host
-computer as an USB network interface. Drivers are available for both Linux and
-macOS.
+# Background
+
+This test application can be used to verify the USBUS Device Firmware Upgrade
+(DFU) implementation.
+Assuming dfu-util package is installed on your system, the board under test
+should show up on the host computer with a runtime DFU interface. dfu-util will
+detect the device and will switch it to DFU mode. After flashing, the board will
+be reset to run the newly flashed firmware.

--- a/tests/usbus_dfu/main.c
+++ b/tests/usbus_dfu/main.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Dylan Laduranty
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the USBUS DFU interface
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "msg.h"
+
+#define MAIN_QUEUE_SIZE     (8U)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+int main(void)
+{
+    /* we need a message queue for the thread running the shell in order to
+     * receive potentially fast incoming networking packets */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+    puts("Test application for the experimental USBUS DFU interface\n");
+
+    /* start shell */
+    puts("Starting the shell now...");
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    /* should be never reached */
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

This PR implements an experimental DFU (Device Firmware Upgrade) over USB.
This features is marked as experimental because it lacks a proper integration
into a bootloader (I guess riotboot will be the designated candidate).
The idea here is to ease the review process by only provide the USBUS DFU part
with a working (and a bit hacky?) test application. The situation is not ideal but it will
be improve in a followup PR: A proper integration to riotboot (I am already
working on it).

This PR has been tested using dfu-utils and the DFU implementation follow the
DFU 1.1 standard and thus, is not compatible with DfuSe.

MCU must support periph_flashpage driver (so STM32F4 will not work AFAIK).

DFU capable devices must export a specific interface and only use the control
endpoints (endpoints 0). Once the device receives the dedicated control command,
the device will jump into bootloader mode and will start a detach/attach sequence
on the bus. When the device reattach it will only export the DFU interface.

After flashing, MCU will reboot and start the newly flashed firmware.
This firmware will be flashed at the beginning of the ROM and will
erase riotboot (like a one shot programming).

I tested this PR on SAME54-XPRO with a Linux host machine.
But it would be good to also test on STM32 and NRF52.

### Testing procedure

build any test app you want like tests/leds or tests/shell without flashing it.
```
make BOARD=same54-xpro -C tests/leds
```
build and flash riotboot bootloader
```
make BOARD=same54-xpro  -C tests/riotboot riotboot/flash-bootloader
```
build and flash the provided dfu test app in riotboot SLOT 1 (mandatory !)
```
APP_VER=2 BOARD=same54-xpro make -C tests/usbus_dfu riotboot/flash-slot1
```

DFU should start if the USB device is plugged to your computer
lsusb -v -d 1209:

Install dfu-util on your system

Once dfu-util is installed on your machine, flash through DFU the first firmware you build at the beginning
dfu-util will load the binary and the board will reset to the newly flash application.
sudo dfu-util  -a 0 -R -D ~/path_to_bin/tests_leds.bin

### Issues/PRs references
None