### PR TITLE
cpu/lpc2387: gpio: Fix interrupts on PORT2

### DIFF
--- a/boards/mcb2388/include/board.h
+++ b/boards/mcb2388/include/board.h
@@ -93,6 +93,7 @@ extern "C" {
  */
 #define BTN0_PIN            GPIO_PIN(2, 10)
 #define BTN0_MODE           GPIO_IN
+#define BTN0_INT_FLANK      GPIO_FALLING
 /** @} */
 
 /**

--- a/cpu/lpc2387/periph/gpio.c
+++ b/cpu/lpc2387/periph/gpio.c
@@ -268,11 +268,10 @@ void gpio_irq_disable(gpio_t dev)
     _gpio_configure(dev, 0, 0);
 }
 
-static void test_irq(int port, unsigned long f_mask, unsigned long r_mask)
+static void test_irq(int port, unsigned long active_pins)
 {
     /* Test each bit of rising and falling masks, if set trigger interrupt
      * on corresponding device */
-    unsigned long active_pins = f_mask | r_mask;
 
     while (active_pins) {
         /* we want the position of the first one bit, so N_bits - (N_leading_zeros + 1) */
@@ -295,24 +294,18 @@ void GPIO_IRQHandler(void) __attribute__((interrupt("IRQ")));
 
 void GPIO_IRQHandler(void)
 {
+    unsigned long int_stat;
+
     if (IO_INT_STAT & BIT0) {                       /* interrupt(s) on PORT0 pending */
-        unsigned long int_stat_f = IO0_INT_STAT_F;  /* save content */
-        unsigned long int_stat_r = IO0_INT_STAT_R;  /* save content */
-
-        IO0_INT_CLR = int_stat_f;                   /* clear flags of fallen pins */
-        IO0_INT_CLR = int_stat_r;                   /* clear flags of risen pins */
-
-        test_irq(0, int_stat_f, int_stat_r);
+        int_stat = IO0_INT_STAT_F | IO0_INT_STAT_R; /* get risen & fallen pin IRQs */
+        IO0_INT_CLR = int_stat;                     /* clear IRQ flags */
+        test_irq(0, int_stat);
     }
 
     if (IO_INT_STAT & BIT2) {                       /* interrupt(s) on PORT2 pending */
-        unsigned long int_stat_f = IO2_INT_STAT_F;  /* save content */
-        unsigned long int_stat_r = IO2_INT_STAT_R;  /* save content */
-
-        IO2_INT_CLR = int_stat_f;                   /* clear flags of fallen pins */
-        IO2_INT_CLR = int_stat_r;                   /* clear flags of risen pins */
-
-        test_irq(2, int_stat_f, int_stat_r);
+        int_stat = IO2_INT_STAT_F | IO2_INT_STAT_R; /* get risen & fallen pin IRQs */
+        IO2_INT_CLR = int_stat;                     /* clear IRQ flags */
+        test_irq(2, int_stat);
     }
 
     VICVectAddr = 0;                                /* Acknowledge Interrupt */


### PR DESCRIPTION
### Contribution description

The calculation of `_state_index` is broken for `port = 2`

    _gpio_isr_map[n + (port<<1)];

Will not yield the right result. As a consequence, IRQs on Port 2
are not working.
The right thing here would be

    _gpio_isr_map[n + (port ? 32 : 0)];

But we might just re-using the `_isr_map_entry()` function.
While we are at it, also only iterate as many times as there are set interrupt bits.

### Testing procedure

Interrupts should still work.
You can verify this with the `tests/periph_gpio` test.

You will find that interrupts on Port 2 were broken on master.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
