### PR TITLE
boards/common/nrf52: allow ST-LINKV2 as programmer

### DIFF
--- a/boards/common/nrf52/dist/openocd.cfg
+++ b/boards/common/nrf52/dist/openocd.cfg
@@ -1,3 +1,6 @@
-transport select swd
+# if stlink adapter is used, the transport protocol is already set by the configuration
+if { [string first "transport select hla_swd" $::env(OPENOCD_ADAPTER_INIT)] == -1} {
+    transport select swd
+}
 
 source [find target/nrf52.cfg]

--- a/boards/common/nrf52/doc.txt
+++ b/boards/common/nrf52/doc.txt
@@ -25,4 +25,9 @@ To flash the board with OpenOCD, use the `PROGRAMMER` variable:
     PROGRAMMER=openocd make BOARD=<nrf52 board> -C examples/hello-world flash
 ```
 
+It is also possible to use the SWD interface of a ST-LINK/V2 in-circuit
+debugger/programmer with OpenOCD to flash a nrf52 board:
+```
+    PROGRAMMER=openocd DEBUG_ADAPTER=stlink make BOARD=<nrf52 board> -C examples/hello-world flash
+```
 */


### PR DESCRIPTION
### Contribution description

The PR povides a small change in the OpenOCD configuration for nRF52 boards, which allows to use the SWD interface of a ST-LINKV2 in-circuit debugger/programmer to flash nRF52 boards that do not have an on-board programmer.

### Testing procedure

Use a ST-LINKV2, connect any nRF52 board and flash any program:
```
PROGRAMMER=openocd DEBUG_ADAPTER=stlink \
make BOARD=<nrf52 board> -C examples/hello-world flash
```
For example, to use the ST-LINKV2 of a STM32 nucleo-64/144 board, the nRF52 board has to be connected as follows:
```
nrf52 VCC     ----  nucleo-64/144 SWD (1) - Vref
nrf52 SWDCLK  ----  nucleo-64/144 SWD (2) - SWCLK
nrf52 GND     ----  nucleo-64/144 SWD (3) - GND
nrf52 SWDIO   ----  nucleo-64/144 SWD (4) - SWDIO
```
To use the ST-LINKV2 adapter, the nRF52 board has to be connected as follows:
```
nrf52 VCC     ----  ST-LINKV2 JTAG/SWD (1) - VAPP
nrf52 SWDIO   ----  ST-LINKV2 JTAG/SWD (7) - SWDIO
nrf52 SWDCLK  ----  ST-LINKV2 JTAG/SWD (9) - SWCLK
nrf52 GND     ----  ST-LINKV2 JTAG/SWD (8) - GND
```

### Issues/PRs references