### PR TITLE
shell_commands/rtc: Fix off by one when checking for clearalarm command

### DIFF
--- a/sys/shell/commands/sc_rtc.c
+++ b/sys/shell/commands/sc_rtc.c
@@ -161,7 +161,7 @@ int _rtc_handler(int argc, char **argv)
     else if (strncmp(argv[1], "poweroff", 8) == 0) {
         rtc_poweroff();
     }
-    else if (strncmp(argv[1], "clearalarm", 8) == 0) {
+    else if (strncmp(argv[1], "clearalarm", 10) == 0) {
         rtc_clear_alarm();
     }
     else if (strncmp(argv[1], "getalarm", 8) == 0) {


### PR DESCRIPTION
### Contribution description

Fises an off by one with strncmp usage.


### Testing procedure

I haven't tested this change. This issue has been found in an automated way, so I am only proposing a fix. Please, close this issue if it is irrelevant.
