### PR TITLE
boards: add support for the Waveshare nRF52840 Eval Kit

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -70,6 +70,7 @@ slwstk6220a
 stm32f723e-disco
 stm32mp157c-dk2
 waspmote-pro
+waveshare-nrf52840-eval-kit
 weact-f401ce
 z1
 "}

--- a/boards/waveshare-nrf52840-eval-kit/Kconfig
+++ b/boards/waveshare-nrf52840-eval-kit/Kconfig
@@ -1,0 +1,31 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "waveshare-nrf52840-eval-kit" if BOARD_WAVESHARE_NRF52840_EVAL_KIT
+
+config BOARD_WAVESHARE_NRF52840_EVAL_KIT
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52840XXAA
+    select HAS_ARDUINO
+    select HAS_ARDUINO_PWM
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+
+    select HAVE_SAUL_GPIO
+    select HAVE_SDCARD_SPI
+    select HAVE_MTD_SDCARD
+
+    select MODULE_FATFS_VFS if MODULE_VFS_DEFAULT
+    select MODULE_MTD if MODULE_VFS_DEFAULT
+    select MODULE_SDCARD_SPI if MODULE_MTD
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/waveshare-nrf52840-eval-kit/Makefile
+++ b/boards/waveshare-nrf52840-eval-kit/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/waveshare-nrf52840-eval-kit/Makefile.dep
+++ b/boards/waveshare-nrf52840-eval-kit/Makefile.dep
@@ -1,1 +1,5 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/waveshare-nrf52840-eval-kit/Makefile.dep
+++ b/boards/waveshare-nrf52840-eval-kit/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/waveshare-nrf52840-eval-kit/Makefile.dep
+++ b/boards/waveshare-nrf52840-eval-kit/Makefile.dep
@@ -2,4 +2,14 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
+ifneq (,$(filter mtd,$(USEMODULE)))
+  USEMODULE += mtd_sdcard
+endif
+
+# default to using fatfs on SD card
+ifneq (,$(filter vfs_default,$(USEMODULE)))
+  USEMODULE += fatfs_vfs
+  USEMODULE += mtd
+endif
+
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/waveshare-nrf52840-eval-kit/Makefile.features
+++ b/boards/waveshare-nrf52840-eval-kit/Makefile.features
@@ -10,5 +10,5 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 
 # Other features
-FEATURES_PROVIDED += radio_nrf802154
-
+FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += arduino_pwm

--- a/boards/waveshare-nrf52840-eval-kit/Makefile.features
+++ b/boards/waveshare-nrf52840-eval-kit/Makefile.features
@@ -1,0 +1,14 @@
+CPU_MODEL = nrf52840xxaa
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features
+
+# MCU peripherals
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# Other features
+FEATURES_PROVIDED += radio_nrf802154
+

--- a/boards/waveshare-nrf52840-eval-kit/Makefile.include
+++ b/boards/waveshare-nrf52840-eval-kit/Makefile.include
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/waveshare-nrf52840-eval-kit/board.c
+++ b/boards/waveshare-nrf52840-eval-kit/board.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2022 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_waveshare_nrf52840_eval_kit
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for Waveshare nRF52840 Eval Kit
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#if defined(MODULE_MTD_SDCARD)
+
+#include "board.h"
+#include "kernel_defines.h"
+
+#include "mtd_sdcard.h"
+#include "sdcard_spi.h"
+#include "sdcard_spi_params.h"
+
+#if defined(MODULE_FATFS_VFS)
+#include "fs/fatfs.h"
+#include "vfs_default.h"
+#endif
+
+/* this is provided by the sdcard_spi driver see drivers/sdcard_spi/sdcard_spi.c */
+extern sdcard_spi_t sdcard_spi_devs[ARRAY_SIZE(sdcard_spi_params)];
+
+mtd_sdcard_t mtd_sdcard_dev = {
+    .base = {
+        .driver = &mtd_sdcard_driver,
+    },
+    .sd_card = &sdcard_spi_devs[0],
+    .params = &sdcard_spi_params[0]
+};
+
+mtd_dev_t *mtd0 = (mtd_dev_t *)&mtd_sdcard_dev;
+
+#if IS_USED(MODULE_FATFS_VFS)
+VFS_AUTO_MOUNT(fatfs, VFS_MTD(mtd_sdcard_dev), VFS_DEFAULT_SD(0), 0);
+#endif /* MODULE_FATFS_VFS */
+
+#endif /* MODULE_MTD_SDCARD */
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/** @} */

--- a/boards/waveshare-nrf52840-eval-kit/doc.txt
+++ b/boards/waveshare-nrf52840-eval-kit/doc.txt
@@ -1,0 +1,162 @@
+/**
+@defgroup   boards_waveshare_nrf52840_eval_kit Waveshare nRF52840 Eval Kit
+@ingroup    boards
+@brief      Support for the Waveshare nRF52840 Eval Kit
+@author     Gunar Schorcht <gunar@schorcht.net>
+
+## Overview
+
+The [Waveshare nRF52840 Eval Kit]
+(https://www.waveshare.com/NRF52840-Eval-Kit.htm) is an evaluation board
+for the nRF52840 SoC with the following on-board components:
+
+1. Arduino headers for connecting Arduino shields
+2. Raspberry Pi GPIO header for connecting Raspberry Pi HATs
+3. USB TO UART interface
+4. USB port of nRF52840
+5. 4PIN SWD debugging interface for connecting ARM Debugger to program / debug
+6. 3.3V/5V power input/output provides power output OR powered from external
+   power supply
+7. Waveshare Core52840: nRF52840 core module
+8. CP2102: USB TO UART converter
+9. Buzzer
+10. RT9193-33: 3.3V voltage regulator
+11. Optical sensor
+12. RESET and USER KEY
+13. 4 User LEDs
+14. Power switch: USB powered - OFF - Battery powered
+15. NFC antenna connector
+16. TF card slot
+17. CR2032 battery holder
+
+![Waveshare nRF52840 Eval Kit]
+(https://www.waveshare.com/img/devkit/accBoard/NRF52840-Eval-Kit/NRF52840-Eval-Kit-intro.jpg)
+
+Using the onboard Arduino and Raspberry Pi compatible headers, both Arduino
+shields and Raspberry Pi HATs can be used at the same time.
+
+## Hardware:
+
+| MCU        | NRF52840                             |
+|:---------- |:------------------------------------ |
+| Family     | ARM Cortex-M4                        |
+| Vendor     | Nordic Semiconductor                 |
+| RAM        | 256 kByte                            |
+| Flash      | 1 MByte                              |
+| Frequency  | 64 MHz                               |
+| FPU        | yes                                  |
+| GPIOs      | 48                                   |
+| Timers     | 5 x 32-bit counter                   |
+| RTC        | 3 x Real Time Counter                |
+| ADCs       | 1 x 12-bit 200 ksps with 8 channels  |
+| UARTs      | 2                                    |
+| SPIs       | 1 x QSPI, 3 x SPI master/slave       |
+| I2Cs       | 2                                    |
+| I2S        | 1                                    |
+| PWM        | 4 * 4 Channels                       |
+| Crypto     | AES-128, SHA1/2, RSA, Chacha20/Poly1305, ECC |
+| Radio      | 2.4 GHz transceiver, Bluetooth 5, IEEE 802.15.4 |
+| Vcc        | 1.7V - 5.5V              |
+| Datasheet  | [Datasheet](https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52840) |
+| Reference Manual | [Reference Manual](https://infocenter.nordicsemi.com/pdf/nRF52840_PS_v1.1.pdf) |
+| Board Manual | [Board Manual](https://www.waveshare.com/w/upload/7/71/NRF52840_Eval_Kit_User_Manual_EN.pdf) |
+| Board Schematic | [Board Schematic](https://www.waveshare.com/w/upload/f/f2/NRF52840-Eval-Kit-Schematic.pdf) |
+
+## Pin Layout / Configuration
+
+The following table shows the connection of the on-board components with the
+MCU pins. All these connections are jumpered and can be removed.
+
+| MCU Pin | MCU Peripheral | RIOT Peripheral | Board Function | Arduino Header | Rasperry Pi (*) |
+|:------|:-----------|:--------------------|:----------------------|:-----------|:-----------|
+| P0.02 | ADC        | ADC_LINE(0)         |                       | AREF       |            |
+| P0.03 | ADC        | ADC_LINE(1)         |                       | A0         | P26 (32)   |
+| P0.04 | ADC        | ADC_LINE(2)         |                       | A1         | P27 (36)   |
+| P0.05 | ADC        | ADC_LINE(3)         | Optical sensor (LDR)  |            | P7 (7)     |
+| P0.06 | UARTE0 RX  | UART_DEV(0) RX      | UART RX               |            | P21 (29)   |
+| P0.07 | UARTE0 CTS | UART_DEV(0) CTS     | UART CTS              |            | P6 (22)    |
+| P0.08 | UARTE0 TX  | UART_DEV(0) TX      | UART TX               |            | P3 (15)    |
+| P0.09 |            |                     | NFC Antenna Connector |            | P1 (12)    |
+| P0.10 |            |                     | NFC Antenna Connector |            | P25 (37)   |
+| P0.11 |            | BTN0                | Button KEY1           |            | P2 (13)    |
+| P0.12 |            | SPI_DEV(1) CS       | SD Card CS            |            | CIE1 (26)  |
+| P0.13 | PWM        | PWM_DEV(1).0 / LED1 | LED1                  |            | P24 (35)   |
+| P0.14 |            | PWM_DEV(1).1 / LED2 | LED2                  |            | P23 (33)   |
+| P0.15 |            | PWM_DEV(2).0        | Buzzer                |            | P22 (31)   |
+| P0.16 |            | PWM_DEV(1).3 / LED4 | LED4                  |            | ID_SD (27) |
+| P0.17 | SPI1 SCK   | SPI_DEV(1) SCK      | SD Card SCLK          |            | SCLK (23)  |
+| P0.18 |            | BTN1                | Button RESET          |            |            |
+| P0.19 |            |                     |                       |            | TXD0 (8)   |
+| P0.20 | SPI1 MISO  | SPI_DEV(1) MISO     | SD Card MISO          |            | MISO (21)  |
+| P0.21 |            |                     |                       |            | RXD0 (10)  |
+| P0.22 | I2C0 SCL   | I2C_DEV(1) SCL      |                       |            | SCL (5)    |
+| P0.23 |            |                     |                       |            | CIE0 (24)  |
+| P0.24 | SPI1 MOSI  | SPI_DEV(1) MOSI     | SD Card MOSI          |            | MOSI (19)  |
+| P0.25 | UARTE0 RTS | UART_DEV(0) RTS     | UART RTS              |            | P0 (11)    |
+| P0.26 | I2C1 SDA   | I2C_DEV(0) SDA      | I2C SDA               | SDA        |            |
+| P0.27 | I2C1 SCL   | I2C_DEV(0) SCL      | I2C SCL               | SCL        |            |
+| P0.28 | ADC        | ADC_LINE(4)         |                       | A2         | P28 (38)   |
+| P0.29 | ADC        | ADC_LINE(5)         |                       | A3         | P29 (40)   |
+| P0.30 | ADC        | ADC_LINE(6)         |                       | A4         |            |
+| P0.31 | ADC        | ADC_LINE(7)         |                       | A5         |            |
+| P1.00 | I2C0 SDA   | I2C_DEV(1) SDA      |                       |            | SDA (3)    |
+| P1.01 | UARTE1 RX  | UART_DEV(1) RX      |                       | D0 / RX    |            |
+| P1.02 | UARTE1 TX  | UART_DEV(1) TX      |                       | D1 / TX    |            |
+| P1.03 |            |                     |                       | D2         |            |
+| P1.04 |            | PWM_DEV(0).0        |                       | D3 / PWM   |            |
+| P1.05 |            |                     |                       | D4         |            |
+| P1.06 |            | PWM_DEV(0).1        |                       | D5 / PWM   |            |
+| P1.07 |            | PWM_DEV(0).2        |                       | D6 / PWM   |            |
+| P1.08 |            |                     |                       | D7         |            |
+| P1.09 |            | PWM_DEV(1).2 / LED3 | LED3                  |            | ID_SC (28) |
+| P1.10 |            |                     |                       | D8         |            |
+| P1.11 |            | PWM_DEV(0).3        |                       | D9 / PWM   |            |
+| P1.12 |            |                     |                       | D10 / SS   |            |
+| P1.13 | SPI0 MOSI  | SPI_DEV(0) MOSI     |                       | D11 / MOSI |            |
+| P1.14 | SPI0 MISO  | SPI_DEV(0) MISO     |                       | D12 / MISO |            |
+| P1.15 | SPI0 SCK   | SPI_DEV(0)SCK       |                       | D13 / SCK  |            |
+
+**(*)** Raspberry Pi header pins are given by the labels as used on the board.
+These labels correspond to the pins and names as used by the 'WiringPi'
+library. For detailed information on how these numbers are mapped to the GPIOs
+of the BCM SoCs, see [this document](https://pinout.xyz/pinout/wiringpi).
+The numbers in the brackets are the pin numbers of the 40-pin header.
+
+## Flash the board
+
+See the `Flashing` section in @ref boards_common_nrf52.
+
+The easiest way is to use a Segger J-Link and connect it to the SWD header of
+the board as follows:
+
+- Segger J-Link Pin 7 with SWD Header pin `DIN`
+- Segger J-Link Pin 9 with SWD Header pin `CLK`
+
+## Accessing STDIO via UART
+
+The `stdio` is directly accessible via the on-board CP2102 USB to UART bridge.
+On a Linux host, this interface is mapped to `/dev/ttyUSB<n>` where `<n>` is
+the index of the UART interface which is 0 by default.
+
+Use the `term` target to connect to the board serial port using `/dev/ttyUSB0`:
+```
+    make BOARD=waveshare-nrf52840-eval-kit -C examples/hello-world term
+```
+If the UART interface index of board's USB to UART bridge is not 0, use
+the following command to connect to the board serial port:
+```
+    make BOARD=waveshare-nrf52840-eval-kit -C examples/hello-world PORT=/dev/ttyUSB<n> term
+```
+
+## RESET Pin Configuration
+
+On nRF52840 boards, the RESET pin is not configured out-of-the box.
+This means, that simply nothing happens if the RESET button is pressed. To
+change this, RIOT provides a little tool in `dist/tools/nrf52_resetpin_cfg`:
+```
+RESET_PIN='GPIO_PIN\(0,18\)' make BOARD=waveshare-nrf52840-eval-kit -C dist/tools/nrf52_resetpin_cfg/ flash
+```
+Simply compile, flash, and run that tool on your board, and the reset pin should
+work for the time being.
+
+ */

--- a/boards/waveshare-nrf52840-eval-kit/include/arduino_board.h
+++ b/boards/waveshare-nrf52840-eval-kit/include/arduino_board.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C)  2016 Freie Universität Berlin
+ *                2016 Inria
+ *                2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_waveshare_nrf52840_eval_kit
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Arduino API
+ *
+ * @author      Hauke Petersen  <hauke.petersen@fu-berlin.de>
+ * @author      Alexandre Abadie  <alexandre.abadie@inria.fr>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+#include "periph/pwm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The on-board LED is connected to Arduino pin 20 on this board
+ */
+#define ARDUINO_LED         (20)
+
+/**
+ * @brief   Look-up table for the Arduino's digital pins
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3,
+    ARDUINO_PIN_4,
+    ARDUINO_PIN_5,
+    ARDUINO_PIN_6,
+    ARDUINO_PIN_7,
+    ARDUINO_PIN_8,
+    ARDUINO_PIN_9,
+    ARDUINO_PIN_10,
+    ARDUINO_PIN_11,
+    ARDUINO_PIN_12,
+    ARDUINO_PIN_13,
+    ARDUINO_PIN_A0,
+    ARDUINO_PIN_A1,
+    ARDUINO_PIN_A2,
+    ARDUINO_PIN_A3,
+    ARDUINO_PIN_A4,
+    ARDUINO_PIN_A5,
+    ARDUINO_PIN_20,
+    ARDUINO_PIN_21,
+    ARDUINO_PIN_22,
+    ARDUINO_PIN_23
+};
+
+/**
+ * @brief   Look-up table for the Arduino's analog pins
+ */
+static const adc_t arduino_analog_map[] = {
+    ARDUINO_A0,
+    ARDUINO_A1,
+    ARDUINO_A2,
+    ARDUINO_A3,
+    ARDUINO_A4,
+    ARDUINO_A5,
+};
+
+/**
+ * @brief   PWM frequency
+ */
+#define ARDUINO_PWM_FREQU       (15625U)
+
+/**
+ * @brief   List of PWM GPIO mappings
+ */
+static const arduino_pwm_t arduino_pwm_list[] = {
+    { .pin = 3, .dev = PWM_DEV(0), .chan = 0 },
+    { .pin = 5, .dev = PWM_DEV(0), .chan = 1 },
+    { .pin = 6, .dev = PWM_DEV(0), .chan = 2 },
+    { .pin = 9, .dev = PWM_DEV(0), .chan = 3 },
+    { .pin = 20, .dev = PWM_DEV(1), .chan = 0 },
+    { .pin = 21, .dev = PWM_DEV(1), .chan = 1 },
+    { .pin = 22, .dev = PWM_DEV(1), .chan = 2 },
+    { .pin = 23, .dev = PWM_DEV(1), .chan = 3 },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/waveshare-nrf52840-eval-kit/include/arduino_pinmap.h
+++ b/boards/waveshare-nrf52840-eval-kit/include/arduino_pinmap.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C)  2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_waveshare_nrf52840_eval_kit
+ * @{
+ *
+ * @file
+ * @brief       Mapping from MCU pins to Arduino pins
+ *
+ * You can use the defines in this file for simplified interaction with the
+ * Arduino specific pin numbers.
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Mapping of MCU pins to Arduino pins
+ * @{
+ */
+#define ARDUINO_PIN_0           GPIO_PIN(1, 1)
+#define ARDUINO_PIN_1           GPIO_PIN(1, 2)
+#define ARDUINO_PIN_2           GPIO_PIN(1, 3)
+#define ARDUINO_PIN_3           GPIO_PIN(1, 4)
+#define ARDUINO_PIN_4           GPIO_PIN(1, 5)
+#define ARDUINO_PIN_5           GPIO_PIN(1, 6)
+#define ARDUINO_PIN_6           GPIO_PIN(1, 7)
+#define ARDUINO_PIN_7           GPIO_PIN(1, 8)
+#define ARDUINO_PIN_8           GPIO_PIN(1, 10)
+#define ARDUINO_PIN_9           GPIO_PIN(1, 11)
+#define ARDUINO_PIN_10          GPIO_PIN(1, 12)
+#define ARDUINO_PIN_11          GPIO_PIN(1, 13)
+#define ARDUINO_PIN_12          GPIO_PIN(1, 14)
+#define ARDUINO_PIN_13          GPIO_PIN(1, 15)
+#define ARDUINO_PIN_A0          GPIO_PIN(0, 3)
+#define ARDUINO_PIN_A1          GPIO_PIN(0, 4)
+#define ARDUINO_PIN_A2          GPIO_PIN(0, 28)
+#define ARDUINO_PIN_A3          GPIO_PIN(0, 29)
+#define ARDUINO_PIN_A4          GPIO_PIN(0, 30)
+#define ARDUINO_PIN_A5          GPIO_PIN(0, 31)
+#define ARDUINO_PIN_20          GPIO_PIN(0, 13)
+#define ARDUINO_PIN_21          GPIO_PIN(0, 14)
+#define ARDUINO_PIN_22          GPIO_PIN(1, 9)
+#define ARDUINO_PIN_23          GPIO_PIN(0, 16)
+/** @} */
+
+/**
+ * @name    Mapping of Arduino analog pins to RIOT ADC lines
+ * @{
+ */
+#define ARDUINO_A0              ADC_LINE(1)
+#define ARDUINO_A1              ADC_LINE(2)
+#define ARDUINO_A2              ADC_LINE(4)
+#define ARDUINO_A3              ADC_LINE(5)
+#define ARDUINO_A4              ADC_LINE(6)
+#define ARDUINO_A5              ADC_LINE(7)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/waveshare-nrf52840-eval-kit/include/board.h
+++ b/boards/waveshare-nrf52840-eval-kit/include/board.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_waveshare_nrf52840_eval_kit
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the Waveshare nRF52840 Eval Kit
+ *
+ * @author     Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 13)
+#define LED1_PIN            GPIO_PIN(0, 14)
+#define LED2_PIN            GPIO_PIN(1, 9)
+#define LED3_PIN            GPIO_PIN(0, 16)
+
+#define LED0_PORT           (NRF_P0)
+#define LED1_PORT           (NRF_P0)
+#define LED2_PORT           (NRF_P1)
+#define LED3_PORT           (NRF_P0)
+
+#define LED0_MASK           (1 << 13)
+#define LED1_MASK           (1 << 14)
+#define LED2_MASK           (1 << 9)
+#define LED3_MASK           (1 << 16)
+
+#define LED0_ON             (LED0_PORT->OUTCLR = LED0_MASK)
+#define LED0_OFF            (LED0_PORT->OUTSET = LED0_MASK)
+#define LED0_TOGGLE         (LED0_PORT->OUT   ^= LED0_MASK)
+
+#define LED1_ON             (LED1_PORT->OUTCLR = LED1_MASK)
+#define LED1_OFF            (LED1_PORT->OUTSET = LED1_MASK)
+#define LED1_TOGGLE         (LED1_PORT->OUT   ^= LED1_MASK)
+
+#define LED2_ON             (LED2_PORT->OUTCLR = LED2_MASK)
+#define LED2_OFF            (LED2_PORT->OUTSET = LED2_MASK)
+#define LED2_TOGGLE         (LED2_PORT->OUT   ^= LED2_MASK)
+
+#define LED3_ON             (LED3_PORT->OUTCLR = LED3_MASK)
+#define LED3_OFF            (LED3_PORT->OUTSET = LED3_MASK)
+#define LED3_TOGGLE         (LED3_PORT->OUT   ^= LED3_MASK)
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(0, 11)
+#define BTN0_MODE           GPIO_IN_PU
+#define BTN1_PIN            GPIO_PIN(0, 18)
+#define BTN1_MODE           GPIO_IN_PU
+/** @} */
+
+/**
+ * @name    SD Card configuration
+ * @{
+ */
+#define SDCARD_SPI_PARAM_SPI         SPI_DEV(1)
+#define SDCARD_SPI_PARAM_CS          GPIO_PIN(0, 12)
+#define SDCARD_SPI_PARAM_CLK         GPIO_PIN(0, 17)
+#define SDCARD_SPI_PARAM_MOSI        GPIO_PIN(0, 24)
+#define SDCARD_SPI_PARAM_MISO        GPIO_PIN(0, 20)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/waveshare-nrf52840-eval-kit/include/gpio_params.h
+++ b/boards/waveshare-nrf52840-eval-kit/include/gpio_params.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_waveshare_nrf52840_eval_kit
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LED 1",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED 2",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED 3",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED 4",
+        .pin   = LED3_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "KEY1",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name  = "RESET",
+        .pin   = BTN1_PIN,
+        .mode  = BTN1_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/waveshare-nrf52840-eval-kit/include/periph_conf.h
+++ b/boards/waveshare-nrf52840-eval-kit/include/periph_conf.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2018 Inria
+ *               2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_waveshare_nrf52840_eval_kit
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the Waveshare nRF52840 Eval Kit
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Enable the internal DC/DC converter
+ */
+#define NRF5X_ENABLE_DCDC
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = NRF_TWIM1,
+        .scl = GPIO_PIN(0, 27),
+        .sda = GPIO_PIN(0, 26),
+        .speed = I2C_SPEED_NORMAL
+    },
+    {
+        .dev = NRF_TWIM0,
+        .scl = GPIO_PIN(0, 22),
+        .sda = GPIO_PIN(1, 0),
+        .speed = I2C_SPEED_NORMAL
+    }
+
+};
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @name   PWM configuration
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    {
+        .dev = NRF_PWM0,
+        .pin = {
+                   GPIO_PIN(1, 4),
+                   GPIO_PIN(1, 6),
+                   GPIO_PIN(1, 7),
+                   GPIO_PIN(1, 11)
+               }
+    },
+    {
+        .dev = NRF_PWM1,
+        .pin = {
+                   GPIO_PIN(0, 13),
+                   GPIO_PIN(0, 14),
+                   GPIO_PIN(1, 9),
+                   GPIO_PIN(0, 16)
+               }
+    },
+    {
+        .dev = NRF_PWM2,
+        .pin = {
+                   GPIO_PIN(0, 15),
+                   GPIO_UNDEF,
+                   GPIO_UNDEF,
+                   GPIO_UNDEF
+               }
+    }
+};
+
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPIM0,
+        .sclk = GPIO_PIN(1, 15),
+        .mosi = GPIO_PIN(1, 13),
+        .miso = GPIO_PIN(1, 14),
+    },
+    {
+        .dev  = NRF_SPIM1,
+        .sclk = GPIO_PIN(0, 17),
+        .mosi = GPIO_PIN(0, 24),
+        .miso = GPIO_PIN(0, 20),
+    }
+};
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    { /* Mapped to USB virtual COM port */
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0, 8),
+        .tx_pin     = GPIO_PIN(0, 6),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin    = GPIO_PIN(0, 25),
+        .cts_pin    = GPIO_PIN(0, 7),
+#endif
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+    { /* Mapped to Arduino D0/D1 pins */
+        .dev        = NRF_UARTE1,
+        .rx_pin     = GPIO_PIN(1, 1),
+        .tx_pin     = GPIO_PIN(1, 2),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin    = GPIO_UNDEF,
+        .cts_pin    = GPIO_UNDEF,
+#endif
+        .irqn       = UARTE1_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+#define UART_1_ISR          (isr_uarte1)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/dist/tools/doccheck/exclude_patterns
+++ b/dist/tools/doccheck/exclude_patterns
@@ -14966,3 +14966,13 @@ pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMB
 pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMBLE_AUTOADV_FILTER_POLICY \(macro definition\) of file nimble_autoadv_params\.h is not documented\.
 pkg/nimble/autoadv/include/nimble_autoadv_params\.h:[0-9]+: warning: Member NIMBLE_AUTOADV_PARAMS \(macro definition\) of file nimble_autoadv_params\.h is not documented\.
 cpu/esp32/include/periph_cpu_esp32\.h:[0-9]+: warning: Member GPIO[0-9]+ \(macro definition\) of file periph_cpu_esp32\.h is not documented.
+boards/waveshare\-nrf52840\-eval\-kit/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_PIN_[A0-9]+ \(macro definition\) of file arduino_pinmap\.h is not documented.
+boards/waveshare\-nrf52840\-eval\-kit/include/arduino_pinmap\.h:[0-9]+: warning: Member ARDUINO_[A0-9]+ \(macro definition\) of file arduino_pinmap\.h is not documented.
+boards/waveshare\-nrf52840\-eval\-kit/include/board\.h:[0-9]+: warning: Member LED0_PIN \(macro definition\) of file board\.h is not documented.
+boards/waveshare\-nrf52840\-eval\-kit/include/board\.h:[0-9]+: warning: Member LED[A-Z0-9_]+ \(macro definition\) of file board\.h is not documented.
+boards/waveshare\-nrf52840\-eval\-kit/include/board\.h:[0-9]+: warning: Member BTN[A-Z0-9_]+ \(macro definition\) of file board\.h is not documented.
+boards/waveshare\-nrf52840\-eval\-kit/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARAM_[A-Z]+ \(macro definition\) of file board\.h is not documented.
+boards/waveshare\-nrf52840\-eval\-kit/include/board\.h:[0-9]+: warning: Member SDCARD_SPI_PARAM_[A-Z]+ \(macro definition\) of file board\.h is not documented.
+boards/waveshare\-nrf52840\-eval\-kit/include/periph_conf\.h:[0-9]+: warning: Member UART_[A-Z0-9_]+ \(macro definition\) of file periph_conf\.h is not documented.
+boards/waveshare\-nrf52840\-eval\-kit/include/periph_conf\.h:[0-9]+: warning: Member [A-Z0-9_]+NUMOF \(macro definition\) of file periph_conf\.h is not documented.
+boards/waveshare\-nrf52840\-eval\-kit/include/periph_conf\.h:[0-9]+: warning: Member [a-z0-9_]+config\[\] \(variable\) of file periph_conf\.h is not documented.


### PR DESCRIPTION
### Contribution description

This PR adds the support for the [Waveshare nRF52840 Eval Kit](https://www.waveshare.com/wiki/NRF52840_Eval_Kit).

The main on-board components of the Waveshare nRF52840 Eval Kit are:
- Arduino headers for connecting Arduino shields
- Raspberry Pi GPIO header for connecting Raspberry Pi HATs
- USB to UART bridge
- Optical sensor (LDR)
- 2 user keys RESET and KEY
- 4 User LEDs
- TF card slot
- CR2032 battery holder

The board definition include SAUL support as well Arduino support including Arduino PWM. The follwing peripherals and on-board components were tested:

- [x] ADC tested with `tests/periph_adc` / `tests/sys_arduino_analog`
- [x] GPIO tested with `tests/periph_gpio`
- [x] PWM tested with `tests/periph_pwm` / `tests/sys_arduino_analog`
- [x] UART tested with  `tests/periph_uart`
- [x] I2C tested with `tests/driver_sht3x`
- [x] SPI tested with `tests/driver_bme680`
- [x] SD card tested with `tests/driver_sdcard_spi`
- [x] Arduino compatibility tested with `tests/sys_arduino_analog`
- [x] Bluetooth connectivity
- [x] IEEE 802.15.4 connectivity tested with `examples/gnrc_networking` and driver `nrf802154`

[UPDATE] ~Commit https://github.com/RIOT-OS/RIOT/commit/84db9c269736e9a33d3a8c49489130dc583ccc0f can be dropped once PR #13858 is merged.~

### Testing procedure

### Issues/PRs references

~Depends on PR #14480~