### PR TITLE
boards/nucleo-f767zi: Fix SPI config

### DIFF
--- a/boards/nucleo-f767zi/Makefile
+++ b/boards/nucleo-f767zi/Makefile
@@ -2,3 +2,8 @@ MODULE = board
 DIRS = $(RIOTBOARD)/common/nucleo
 
 include $(RIOTBASE)/Makefile.base
+
+ifneq (,$(filter stm32_eth,$(USEMODULE)))
+  $(info Remapping MOSI of SPI_DEV(0) from PA7 to PB5 to solve pin conflict.\
+         (PA7 is also connected to the RMII_DV of the Ethernet Phy.))
+endif

--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -118,7 +118,16 @@ static const uart_conf_t uart_config[] = {
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SPI1,
+        /* PA7 is the default MOSI pin, as it is required for compatibility with
+         * Arduino(ish) shields. Sadly, it is also connected to the RMII_DV of
+         * Ethernet PHY. We work around this by remapping the MOSI to PB5 when
+         * the on-board Ethernet PHY is used.
+         */
+#ifdef MODULE_PERIPH_ETH
+        .mosi_pin = GPIO_PIN(PORT_B, 5),
+#else
         .mosi_pin = GPIO_PIN(PORT_A, 7),
+#endif
         .miso_pin = GPIO_PIN(PORT_A, 6),
         .sclk_pin = GPIO_PIN(PORT_A, 5),
         .cs_pin   = GPIO_UNDEF,


### PR DESCRIPTION
### Contribution description

This PR changes the MOSI pin for `SPI_DEV(0)` (SPI1) from PA7 to PB5.

Pin PA7 cannot be used for SPI1 (a.k.a. `SPI_DEV(0)`) while using `stm32_eth`, as that pin is connected to the Ethernet PHY as RMII_DV (unless the jumper JP6 is pulled, which is connected by default). Using PB5 instead of PA7 for MOSI resolves the pin conflict.

### Testing procedure

The `SPI_DEV(0)` should now work fine while using `stm32_eth`.

### Issues/PRs references

None