### PR TITLE
boards/samr3x-xpro: add riotboot feature

### DIFF
--- a/boards/samr30-xpro/Makefile.features
+++ b/boards/samr30-xpro/Makefile.features
@@ -9,3 +9,6 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot

--- a/boards/samr34-xpro/Makefile.features
+++ b/boards/samr34-xpro/Makefile.features
@@ -10,3 +10,6 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds the riotboot feature to samr30-xpro and samr34-xpro boards.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Check `tests/riotboot` application on the samr30-xpro and samr34-xpro boards:

<details><summary>samr30-xpro (using iot-lab, so can't use `test` since the offset is not (yet) supported when flashing with iot-lab cli tools)</summary>

```
$ make BOARD=samr30-xpro -C tests/riotboot riotboot/flash-combined-slot0 IOTLAB_NODE=auto-ssh term
make: Entering directory '/work/riot/RIOT/tests/riotboot'
"make" -C /work/riot/RIOT/boards/samr30-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/saml21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/saml21/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/stdio_null
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
"make" -C /work/riot/RIOT/boards/samr30-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/saml21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/saml21/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
creating /work/riot/RIOT/tests/riotboot/bin/samr30-xpro/tests_riotboot-slot0.1586881959.riot.bin...
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,samr30,1 --flash /work/riot/RIOT/tests/riotboot/bin/samr30-xpro/tests_riotboot-slot0-combined.bin | grep 0
0
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:samr30-1.saclay.iot-lab.info:20000'
��

shell: command not found: �
> help
help
Command              Description
---------------------------------------
curslotnr            Print current slot number
curslothdr           Print current slot header
getslotaddr          Print address of requested slot
dumpaddrs            Prints all slot data in header
reboot               Reboot the node
version              Prints current RIOT_VERSION
> reboot
reboot
main(): This is RIOT! (Version: 2020.07-devel-45-g72266-pr/boards/samr3x-riotboot)
Hello riotboot!
You are running RIOT on a(n) samr30-xpro board.
This board features a(n) saml21 MCU.
riotboot_test: running from slot 0
Image magic_number: 0x544f4952
Image Version: 0x5e95e5a7
Image start address: 0x00001100
Header chksum: 0x31daf2de

> ^CConnection to saclay.iot-lab.info closed.
```

</details>

<details><summary>samr34-xpro</summary>

```
$ make BOARD=samr34-xpro -C tests/riotboot flash test
make: Entering directory '/work/riot/RIOT/tests/riotboot'
Building application "tests_riotboot" for "samr34-xpro" with MCU "saml21".

"make" -C /work/riot/RIOT/boards/samr34-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/saml21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/saml21/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/boards/samr34-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/saml21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/saml21/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/checksum
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/riotboot
"make" -C /work/riot/RIOT/sys/stdio_null
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/samr34-xpro/tests_riotboot-slot0.1586882214.riot.bin...
   text	   data	    bss	    dec	    hex	filename
  12504	    136	   2616	  15256	   3b98	/work/riot/RIOT/tests/riotboot/bin/samr34-xpro/tests_riotboot.elf
/work/riot/RIOT/dist/tools/edbg/edbg  --target samr34 --verbose --file /work/riot/RIOT/tests/riotboot/bin/samr34-xpro/tests_riotboot-slot0-extended.bin --verify || /work/riot/RIOT/dist/tools/edbg/edbg  --target samr34 --verbose --file /work/riot/RIOT/tests/riotboot/bin/samr34-xpro/tests_riotboot-slot0-extended.bin --verify --program
Debugger: ATMEL EDBG CMSIS-DAP ATML3167041800000808 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM R34J18B (Rev C)
Verification...
at address 0x4 expected 0xb1, read 0x2d
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML3167041800000808 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM R34J18B (Rev C)
Programming............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................ done.
Verification............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................ done.


/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
�
shell: command not found: �> 
> curslotnr
 curslotnr
Current slot=0
> curslothdr
 curslothdr
Image magic_number: 0x544f4952
Image Version: 0x5e95e6a6
compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/samr34-xpro/tests_riotboot-slot1.1586882215.riot.bin...
/work/riot/RIOT/dist/tools/edbg/edbg --offset 133120 --target samr34 --verbose --file /work/riot/RIOT/tests/riotboot/bin/samr34-xpro/tests_riotboot-slot1.1586882215.riot.bin --verify || /work/riot/RIOT/dist/tools/edbg/edbg --offset 133120 --target samr34 --verbose --file /work/riot/RIOT/tests/riotboot/bin/samr34-xpro/tests_riotboot-slot1.1586882215.riot.bin --verify --program
Debugger: ATMEL EDBG CMSIS-DAP ATML3167041800000808 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM R34J18B (Rev C)
Verification...
at address 0x20800 expected 0x52, read 0x00
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML3167041800000808 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM R34J18B (Rev C)
Programming...................................................... done.
Verification...................................................... done.
Image start address: 0x00001100
Header chksum: 0x35d6f3dd

> curslotnr
 main(): This is RIOT! (Version: 2020.07-devel-45-g72266-pr/boards/samr3x-riotboot)
Hello riotboot!
You are running RIOT on a(n) samr34-xpro board.
This board features a(n) saml21 MCU.
riotboot_test: running from slot 1
Image magic_number: 0x544f4952
Image Version: 0x5e95e6a7
Image start address: 0x00020900
Header chksum: 0x25dcebe0

>  curslotnr
Current slot=1
> curslothdr
 curslothdr
Image magic_number: 0x544f4952
Image Version: 0x5e95e6a7
Image start address: 0x00020900
Header chksum: 0x25dcebe0

> getslotaddr 0
 getslotaddr 0
Slot 0 address=0x00001100
> dumpaddrs
 dumpaddrs
slot 0: metadata: 0x1000 image: 0x00001100
slot 1: metadata: 0x20800 image: 0x00020900
> compiling /work/riot/RIOT/dist/tools/riotboot_gen_hdr/bin/genhdr...
make: Nothing to be done for 'all'.
creating /work/riot/RIOT/tests/riotboot/bin/samr34-xpro/tests_riotboot-slot0.1586882216.riot.bin...
/work/riot/RIOT/dist/tools/edbg/edbg --offset 0x1000 --target samr34 --verbose --file /work/riot/RIOT/tests/riotboot/bin/samr34-xpro/tests_riotboot-slot0.1586882216.riot.bin --verify || /work/riot/RIOT/dist/tools/edbg/edbg --offset 0x1000 --target samr34 --verbose --file /work/riot/RIOT/tests/riotboot/bin/samr34-xpro/tests_riotboot-slot0.1586882216.riot.bin --verify --program
Debugger: ATMEL EDBG CMSIS-DAP ATML3167041800000808 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM R34J18B (Rev C)
Verification...
at address 0x1004 expected 0xa8, read 0xa6
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML3167041800000808 03.25.01B6 (S)
Clock frequency: 16.0 MHz
Target: SAM R34J18B (Rev C)
Programming...................................................... done.
Verification...................................................... done.
 main(): This is RIOT! (Version: 2020.07-devel-45-g72266-pr/boards/samr3x-riotboot)
Hello riotboot!
You are running RIOT on a(n) samr34-xpro board.
This board features a(n) saml21 MCU.
riotboot_test: running from slot 0
Image magic_number: 0x544f4952
Image Version: 0x5e95e6a8
Image start address: 0x00001100
Header chksum: 0x35def3df

> curslotnr
 curslotnr
Current slot=0
> curslothdr
 curslothdr
Image magic_number: 0x544f4952
Image Version: 0x5e95e6a8
Image start address: 0x00001100
Header chksum: 0x35def3df

> getslotaddr 0
 getslotaddr 0
Slot 0 address=0x00001100
> dumpaddrs
 dumpaddrs
slot 0: metadata: 0x1000 image: 0x00001100
slot 1: metadata: 0x20800 image: 0x00020900
> TEST PASSED

make: Leaving directory '/work/riot/RIOT/tests/riotboot'

```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Cut out from #13842

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
