### PR TITLE
USB VID/PID: allow for boards to define default custom VID/PID

### DIFF
--- a/boards/serpente/Makefile.include
+++ b/boards/serpente/Makefile.include
@@ -1,9 +1,6 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-CONFIG_USB_VID=0x239A
-CONFIG_USB_PID=0x0057
-
 CFLAGS += -DBOOTLOADER_UF2
 
 # setup serial terminal

--- a/boards/serpente/include/board.h
+++ b/boards/serpente/include/board.h
@@ -83,6 +83,14 @@ extern mtd_dev_t *mtd0;
 /** @} */
 
 /**
+ * @name USB configuration
+ * @{
+ */
+#define INTERNAL_PERIPHERAL_VID         (0x239A)
+#define INTERNAL_PERIPHERAL_PID         (0x0057)
+/** @} */
+
+/**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);

--- a/sys/include/usb.h
+++ b/sys/include/usb.h
@@ -24,17 +24,31 @@
 extern "C" {
 #endif
 
+#include "board.h"
+
 /**
  * @defgroup usb_conf USB peripheral compile time configurations
  * @ingroup config
  * @{
  */
 
+/* These can be overridden by boards that should come up with their board
+ * supplier VID/PID pair. Boards should only override this if the RIOT built-in
+ * peripherals are compatible with whatever is usually shipped with that pair
+ * */
+#ifndef INTERNAL_PERIPHERAL_VID
+/** Reserved for RIOT standard peripherals as per http://pid.codes/1209/7D00/ */
+#define INTERNAL_PERIPHERAL_VID (0x1209)
+#endif
+#ifndef INTERNAL_PERIPHERAL_PID
+/** Reserved for RIOT standard peripherals as per http://pid.codes/1209/7D00/ */
+#define INTERNAL_PERIPHERAL_PID (0x7D00)
+#endif
+
 #if !(defined(CONFIG_USB_VID) && defined(CONFIG_USB_PID))
 #ifdef USB_H_USER_IS_RIOT_INTERNAL
-/* Reserved for RIOT standard peripherals as per http://pid.codes/1209/7D00/ */
-#define CONFIG_USB_VID (0x1209)
-#define CONFIG_USB_PID (0x7D00)
+#define CONFIG_USB_VID INTERNAL_PERIPHERAL_VID
+#define CONFIG_USB_PID INTERNAL_PERIPHERAL_PID
 #else
 #error Please configure your vendor and product IDs. For development, you may \
     set CONFIG_USB_VID=0x1209 CONFIG_USB_PID=0x7D01.


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

For boards that have terminals in their shipped configurations it makes sense to reuse those VID/PIDs when providing a terminal in RIOT as well.

That affects the builtin-peripherals IDs and not the custom specified ones.

Taken from https://github.com/RIOT-OS/RIOT/pull/13652#issuecomment-608378808

### Testing procedure

Set `RIOT_INTERNALPERIPHERAL_VID` and `RIOT_INTERNALPERIPHERAL_PID` for a board.
RIOT should use those IDs now and not spit out warnings when those IDs are used for stdio over USB.

### Issues/PRs references

alternative to #13652
