### PR TITLE
pkg/fs: set VFS params by fs, not by the application

### DIFF
--- a/examples/filesystem/Makefile
+++ b/examples/filesystem/Makefile
@@ -38,14 +38,4 @@ USEMODULE += littlefs
 USEMODULE += constfs
 # USEMODULE += devfs
 
-# Set file systems specific variables
-ifneq (,$(filter littlefs, $(USEMODULE)))
-    CFLAGS += -DVFS_FILE_BUFFER_SIZE=56 -DVFS_DIR_BUFFER_SIZE=44
-else ifneq (,$(filter spiffs, $(USEMODULE)))
-    SPIFFS_NB_FD ?= 8
-    CFLAGS += '-DSPIFFS_FS_FD_SPACE_SIZE=(32 * $(SPIFFS_NB_FD))'
-else ifneq (,$(filter fatfs_vfs, $(USEMODULE)))
-    CFLAGS += -DVFS_FILE_BUFFER_SIZE=72 -DVFS_DIR_BUFFER_SIZE=44
-endif
-
 include $(RIOTBASE)/Makefile.include

--- a/pkg/fatfs/Makefile.include
+++ b/pkg/fatfs/Makefile.include
@@ -3,7 +3,6 @@ INCLUDES += -I$(RIOTPKG)/fatfs/fatfs_diskio/mtd/include
 
 DIRS += $(RIOTBASE)/pkg/fatfs/fatfs_diskio/mtd
 
-
 ifneq (,$(filter fatfs_vfs,$(USEMODULE)))
   DIRS += $(RIOTBASE)/pkg/fatfs/fatfs_vfs
 endif
@@ -18,3 +17,6 @@ endif
 ifeq ($(OS),Darwin)
   CFLAGS += -Wno-empty-body
 endif
+
+# Set vfs file and dir buffer sizes
+CFLAGS += -DVFS_FILE_BUFFER_SIZE=72 -DVFS_DIR_BUFFER_SIZE=44

--- a/pkg/fatfs/Makefile.include
+++ b/pkg/fatfs/Makefile.include
@@ -3,6 +3,7 @@ INCLUDES += -I$(RIOTPKG)/fatfs/fatfs_diskio/mtd/include
 
 DIRS += $(RIOTBASE)/pkg/fatfs/fatfs_diskio/mtd
 
+
 ifneq (,$(filter fatfs_vfs,$(USEMODULE)))
   DIRS += $(RIOTBASE)/pkg/fatfs/fatfs_vfs
 endif
@@ -17,6 +18,3 @@ endif
 ifeq ($(OS),Darwin)
   CFLAGS += -Wno-empty-body
 endif
-
-# Set vfs file and dir buffer sizes
-CFLAGS += -DVFS_FILE_BUFFER_SIZE=72 -DVFS_DIR_BUFFER_SIZE=44

--- a/pkg/littlefs/Makefile.include
+++ b/pkg/littlefs/Makefile.include
@@ -4,7 +4,5 @@ ifneq (,$(filter littlefs_fs,$(USEMODULE)))
   DIRS += $(RIOTBASE)/pkg/littlefs/fs
 endif
 
-# Set vfs file and dir buffer sizes
-CFLAGS += -DVFS_FILE_BUFFER_SIZE=56 -DVFS_DIR_BUFFER_SIZE=44
 # Reduce LFS_NAME_MAX to 31 (as VFS_NAME_MAX default)
 CFLAGS += -DLFS_NAME_MAX=31

--- a/pkg/littlefs/Makefile.include
+++ b/pkg/littlefs/Makefile.include
@@ -3,3 +3,8 @@ INCLUDES += -I$(PKGDIRBASE)/littlefs
 ifneq (,$(filter littlefs_fs,$(USEMODULE)))
   DIRS += $(RIOTBASE)/pkg/littlefs/fs
 endif
+
+# Set vfs file and dir buffer sizes
+CFLAGS += -DVFS_FILE_BUFFER_SIZE=56 -DVFS_DIR_BUFFER_SIZE=44
+# Reduce LFS_NAME_MAX to 31 (as VFS_NAME_MAX default)
+CFLAGS += -DLFS_NAME_MAX=31

--- a/pkg/littlefs2/Makefile.include
+++ b/pkg/littlefs2/Makefile.include
@@ -2,7 +2,5 @@ INCLUDES += -I$(PKGDIRBASE)/littlefs2
 
 DIRS += $(RIOTBASE)/pkg/littlefs2/fs
 
-# Set vfs file and dir buffer sizes
-CFLAGS += -DVFS_FILE_BUFFER_SIZE=84 -DVFS_DIR_BUFFER_SIZE=52
 # Reduce LFS_NAME_MAX to 31 (as VFS_NAME_MAX default)
 CFLAGS += -DLFS_NAME_MAX=31

--- a/pkg/littlefs2/Makefile.include
+++ b/pkg/littlefs2/Makefile.include
@@ -1,3 +1,8 @@
 INCLUDES += -I$(PKGDIRBASE)/littlefs2
 
 DIRS += $(RIOTBASE)/pkg/littlefs2/fs
+
+# Set vfs file and dir buffer sizes
+CFLAGS += -DVFS_FILE_BUFFER_SIZE=84 -DVFS_DIR_BUFFER_SIZE=52
+# Reduce LFS_NAME_MAX to 31 (as VFS_NAME_MAX default)
+CFLAGS += -DLFS_NAME_MAX=31

--- a/pkg/spiffs/Makefile.include
+++ b/pkg/spiffs/Makefile.include
@@ -4,3 +4,6 @@ INCLUDES += -I$(PKGDIRBASE)/spiffs/src/
 ifneq (,$(filter spiffs_fs,$(USEMODULE)))
   DIRS += $(RIOTBASE)/pkg/spiffs/fs
 endif
+
+SPIFFS_NB_FD ?= 8
+CFLAGS += '-DSPIFFS_FS_FD_SPACE_SIZE=(32 * $(SPIFFS_NB_FD))'

--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -79,6 +79,70 @@ extern "C" {
 /* #define restrict */
 #endif
 
+/**
+ * @brief   MAX functions for internal use
+ * @{
+ */
+#ifndef _MAX
+#define _MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
+#ifndef MAX4
+#define MAX4(a, b, c, d) _MAX(_MAX((a), (b)), _MAX((c),(d)))
+#endif
+/** @} */
+
+/**
+ * @brief   VFS parameters for FAT
+ * @{
+ */
+#ifdef MODULE_FATFS_VFS
+#define FATFS_VFS_DIR_BUFFER_SIZE       (44)
+#define FATFS_VFS_FILE_BUFFER_SIZE      (72)
+#else
+#define FATFS_VFS_DIR_BUFFER_SIZE       (1)
+#define FATFS_VFS_FILE_BUFFER_SIZE      (1)
+#endif
+/** @} */
+
+/**
+ * @brief   VFS parameters for littlefs
+ * @{
+ */
+#ifdef MODULE_LITTLEFS
+#define LITTLEFS_VFS_DIR_BUFFER_SIZE    (44)
+#define LITTLEFS_VFS_FILE_BUFFER_SIZE   (56)
+#else
+#define LITTLEFS_VFS_DIR_BUFFER_SIZE    (1)
+#define LITTLEFS_VFS_FILE_BUFFER_SIZE   (1)
+#endif
+/** @} */
+
+/**
+ * @brief   VFS parameters for littlefs2
+ * @{
+ */
+#ifdef MODULE_LITTLEFS2
+#define LITTLEFS2_VFS_DIR_BUFFER_SIZE   (52)
+#define LITTLEFS2_VFS_FILE_BUFFER_SIZE  (84)
+#else
+#define LITTLEFS2_VFS_DIR_BUFFER_SIZE   (1)
+#define LITTLEFS2_VFS_FILE_BUFFER_SIZE  (1)
+#endif
+/** @} */
+
+/**
+ * @brief   VFS parameters for spiffs
+ * @{
+ */
+#ifdef MODULE_SPIFFS
+#define SPIFFS_VFS_DIR_BUFFER_SIZE      (12)
+#define SPIFFS_VFS_FILE_BUFFER_SIZE     (1)
+#else
+#define SPIFFS_VFS_DIR_BUFFER_SIZE      (1)
+#define SPIFFS_VFS_FILE_BUFFER_SIZE     (1)
+#endif
+/** @} */
+
 #ifndef VFS_MAX_OPEN_FILES
 /**
  * @brief Maximum number of simultaneous open files
@@ -114,7 +178,11 @@ extern "C" {
  * @attention Put the check in the public header file (.h), do not put the check in the
  * implementation (.c) file.
  */
-#define VFS_DIR_BUFFER_SIZE (12)
+#define VFS_DIR_BUFFER_SIZE MAX4(FATFS_VFS_DIR_BUFFER_SIZE,     \
+                                 LITTLEFS_VFS_DIR_BUFFER_SIZE,  \
+                                 LITTLEFS2_VFS_DIR_BUFFER_SIZE, \
+                                 SPIFFS_VFS_DIR_BUFFER_SIZE     \
+                                )
 #endif
 
 #ifndef VFS_FILE_BUFFER_SIZE
@@ -137,7 +205,11 @@ extern "C" {
  * @attention Put the check in the public header file (.h), do not put the check in the
  * implementation (.c) file.
  */
-#define VFS_FILE_BUFFER_SIZE (1)
+#define VFS_FILE_BUFFER_SIZE MAX4(FATFS_VFS_FILE_BUFFER_SIZE,    \
+                                  LITTLEFS_VFS_FILE_BUFFER_SIZE, \
+                                  LITTLEFS2_VFS_FILE_BUFFER_SIZE,\
+                                  SPIFFS_VFS_FILE_BUFFER_SIZE    \
+                                 )
 #endif
 
 #ifndef VFS_NAME_MAX

--- a/tests/pkg_fatfs_vfs/Makefile
+++ b/tests/pkg_fatfs_vfs/Makefile
@@ -3,8 +3,6 @@ include ../Makefile.tests_common
 USEMODULE += fatfs_vfs
 FEATURES_OPTIONAL += periph_rtc
 
-CFLAGS += -DVFS_FILE_BUFFER_SIZE=72 -DVFS_DIR_BUFFER_SIZE=44
-
 FATFS_IMAGE_FILE_SIZE_MIB ?= 128
 
 ifeq ($(BOARD),native)

--- a/tests/pkg_littlefs/Makefile
+++ b/tests/pkg_littlefs/Makefile
@@ -8,11 +8,6 @@ BOARD_BLACKLIST := chronos \
                    wsn430-v1_4 \
                    z1 \
 
-# Set vfs file and dir buffer sizes
-CFLAGS += -DVFS_FILE_BUFFER_SIZE=56 -DVFS_DIR_BUFFER_SIZE=44
-# Reduce LFS_NAME_MAX to 31 (as VFS_NAME_MAX default)
-CFLAGS += -DLFS_NAME_MAX=31
-
 USEMODULE += littlefs
 USEMODULE += embunit
 

--- a/tests/pkg_littlefs2/Makefile
+++ b/tests/pkg_littlefs2/Makefile
@@ -1,10 +1,5 @@
 include ../Makefile.tests_common
 
-# Set vfs file and dir buffer sizes
-CFLAGS += -DVFS_FILE_BUFFER_SIZE=84 -DVFS_DIR_BUFFER_SIZE=52
-# Reduce LFS_NAME_MAX to 31 (as VFS_NAME_MAX default)
-CFLAGS += -DLFS_NAME_MAX=31
-
 USEPKG += littlefs2
 USEMODULE += embunit
 

--- a/tests/pkg_spiffs/tests/01-run.py
+++ b/tests/pkg_spiffs/tests/01-run.py
@@ -11,4 +11,4 @@ from testrunner import run_check_unittests
 
 
 if __name__ == "__main__":
-    sys.exit(run_check_unittests())
+    sys.exit(run_check_unittests(timeout=90))


### PR DESCRIPTION
### Contribution description

It should not be the responsibility of the application to set the correct VFS parameters for the filesystem used.
Copy & pasting those parameters between apps in bad practice and leads to unexpected crashes if the user forgets to copy those parameters over.


### Testing procedure

- [x] `tests/pkg_fatfs_vfs`
- [x] `tests/pkg_spiffs`
- [x] `tests/pkg_littlefs`
- [x] `tests/pkg_littlefs2`

should still work.
(Murdock will take care of testing of `spiffs`, `littlefs`, & `littlefs2`. I manually ran a test of `fatfs_vfs` and can confirm it's also still working.)

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
