### PR TITLE
boards/mcb2388: misc enhancements

### DIFF
--- a/boards/mcb2388/Makefile.dep
+++ b/boards/mcb2388/Makefile.dep
@@ -1,3 +1,4 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_adc
   USEMODULE += saul_gpio
 endif

--- a/boards/mcb2388/include/adc_params.h
+++ b/boards/mcb2388/include/adc_params.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 Beuth Hochschule für Technik Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_mcb2388
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped ADC
+ *
+ * @author    Benjamin Valentin <benpicco@beuth-hochschule.de>
+ */
+
+#ifndef ADC_PARAMS_H
+#define ADC_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    ADC configuration
+ */
+static const  saul_adc_params_t saul_adc_params[] =
+{
+    {
+        .name = "POT1",
+        .line = ADC_LINE(0),
+        .res  = ADC_RES_10BIT,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_PARAMS_H */
+/** @} */

--- a/boards/mcb2388/include/board.h
+++ b/boards/mcb2388/include/board.h
@@ -93,6 +93,7 @@ extern "C" {
  */
 #define BTN0_PIN            GPIO_PIN(2, 10)
 #define BTN0_MODE           GPIO_IN
+#define BTN0_INT_FLANK      GPIO_FALLING
 /** @} */
 
 /**

--- a/boards/mcb2388/include/board.h
+++ b/boards/mcb2388/include/board.h
@@ -26,13 +26,6 @@ extern "C" {
 #endif
 
 /**
- * @name    xtimer tuning values
- * @{
- */
-#define XTIMER_OVERHEAD     7
-/** @} */
-
-/**
  * @name    LED pin definitions and handlers
  * @{
  */

--- a/boards/mcb2388/include/periph_conf.h
+++ b/boards/mcb2388/include/periph_conf.h
@@ -41,7 +41,7 @@ extern "C" {
  * @name    Timer configuration, select a number from 1 to 4
  * @{
  */
-#define TIMER_NUMOF         (1U)
+#define TIMER_NUMOF         (4U)
 /** @} */
 
 /**

--- a/boards/mcb2388/include/periph_conf.h
+++ b/boards/mcb2388/include/periph_conf.h
@@ -20,6 +20,7 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "kernel_defines.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -83,9 +84,18 @@ static const spi_conf_t spi_config[] = {
         .pinsel_msk_miso = (BIT14 | BIT15), /* P1.23 */
         .pinsel_msk_clk  = (BIT8  | BIT9),  /* P1.20 */
     },
+    {
+        .dev = SPI1,
+        .pinsel_mosi = 0,
+        .pinsel_miso = 0,
+        .pinsel_clk  = 0,
+        .pinsel_msk_mosi = (BIT19), /* P0.9 */
+        .pinsel_msk_miso = (BIT17), /* P0.8 */
+        .pinsel_msk_clk  = (BIT15), /* P0.7 */
+    },
 };
 
-#define SPI_NUMOF           (1)
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
 /** @} */
 
 /**


### PR DESCRIPTION

### Contribution description

This adds some small enhancements to `boards/mcb2388`.

- add SAUL config for the ADC/potentiometer
- add configuration for SPI1
- add definition of the button flank
- enable all 4 timers

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
