### PR TITLE
drivers/hdc1000 : Expose Configurations to Kconfig

### DIFF
--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -8,3 +8,7 @@ menu "Network Device Drivers"
 rsource "mrf24j40/Kconfig"
 source "$(RIOTCPU)/nrf52/radio/nrf802154/Kconfig"
 endmenu # Network Device Drivers
+
+menu "Sensor Device Drivers"
+rsource "hdc1000/Kconfig"
+endmenu # Sensor Device Drivers

--- a/drivers/hdc1000/Kconfig
+++ b/drivers/hdc1000/Kconfig
@@ -1,0 +1,32 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_HDC1000
+    bool "Configure HDC1000 driver"
+    depends on MODULE_HDC1000
+    help
+        Configure the HDC1000 driver using Kconfig.
+
+if KCONFIG_MODULE_HDC1000
+
+config HDC1000_I2C_ADDRESS
+    hex "I2C default address"
+    range 0x40 0x43
+    default 0x43
+    help
+        HDC1000 allows for up to 4 devices on single bus. The value depends on
+        the state of ADR1 and ADR0 pins.
+        For more information refer to the section 8.5.1 in the Datasheet (SNAS643C).
+
+config HDC1000_CONVERSION_TIME
+    int "Conversion time in microseconds [us]"
+    default 26000
+    help
+        This time value is chosen twice as large as needed for two 14-bit
+        conversions (worst case) to allow for timer imprecision:
+        (convert temp + convert hum) * 2 -> (6.5ms + 6.5ms) * 2 := 26ms.
+
+endif # KCONFIG_MODULE_HDC1000

--- a/drivers/hdc1000/hdc1000.c
+++ b/drivers/hdc1000/hdc1000.c
@@ -130,7 +130,7 @@ int hdc1000_read(const hdc1000_t *dev, int16_t *temp, int16_t *hum)
     if (hdc1000_trigger_conversion(dev) != HDC1000_OK) {
         return HDC1000_BUSERR;
     }
-    xtimer_usleep(HDC1000_CONVERSION_TIME);
+    xtimer_usleep(CONFIG_HDC1000_CONVERSION_TIME);
     return hdc1000_get_results(dev, temp, hum);
 }
 

--- a/drivers/hdc1000/include/hdc1000_params.h
+++ b/drivers/hdc1000/include/hdc1000_params.h
@@ -35,7 +35,7 @@ extern "C" {
 #define HDC1000_PARAM_I2C            I2C_DEV(0)
 #endif
 #ifndef HDC1000_PARAM_ADDR
-#define HDC1000_PARAM_ADDR           (HDC1000_I2C_ADDRESS)
+#define HDC1000_PARAM_ADDR           (CONFIG_HDC1000_I2C_ADDRESS)
 #endif
 #ifndef HDC1000_PARAM_RES
 #define HDC1000_PARAM_RES            HDC1000_14BIT

--- a/drivers/include/hdc1000.h
+++ b/drivers/include/hdc1000.h
@@ -21,7 +21,7 @@
  * simplified `hdc1000_read()` function, or the conversion can be triggered
  * manually using the `hdc1000_trigger_conversion()` and `hdc1000_get_results()`
  * functions sequentially. If using the second method, on must wait at least
- * `HDC1000_CONVERSION_TIME` between triggering the conversion and reading the
+ * `CONFIG_HDC1000_CONVERSION_TIME` between triggering the conversion and reading the
  * results.
  *
  * @note        The driver does currently not support using the devices heating
@@ -62,8 +62,8 @@ extern "C"
  * The address value depends on the state of ADR0 and ADR1 Pins
  * For more details refer Section 8.5.1 of datasheet
  */
-#ifndef HDC1000_I2C_ADDRESS
-#define HDC1000_I2C_ADDRESS           (0x43)
+#ifndef CONFIG_HDC1000_I2C_ADDRESS
+#define CONFIG_HDC1000_I2C_ADDRESS           (0x43)
 #endif
 
 /**
@@ -73,8 +73,8 @@ extern "C"
  *          conversions (worst case) to allow for timer imprecision:
  *          (convert temp + convert hum) * 2 -> (6.5ms + 6.5ms) * 2 := 26ms.
  */
-#ifndef HDC1000_CONVERSION_TIME
-#define HDC1000_CONVERSION_TIME       (26000)
+#ifndef CONFIG_HDC1000_CONVERSION_TIME
+#define CONFIG_HDC1000_CONVERSION_TIME       (26000)
 #endif
 /** @} */
 
@@ -129,7 +129,7 @@ int hdc1000_init(hdc1000_t *dev, const hdc1000_params_t *params);
  * @brief   Trigger a new conversion
  *
  * After the conversion is triggered, one has to wait
- * @ref HDC1000_CONVERSION_TIME us until the results can be read using
+ * @ref CONFIG_HDC1000_CONVERSION_TIME us until the results can be read using
  * @ref hdc1000_get_results().
  *
  * @param[in]  dev          device descriptor of sensor


### PR DESCRIPTION


### Contribution description

This PR exposes compile configurations in HDC1000 sensor driver to Kconfig.


### Testing procedure

The firmware was uploaded to FIT/IoT-LAB Test Bed and following results were obtained.

#### Default State:

main(): This is RIOT! (Version: 2020.07-devel-46-g4e42a-tests_hdc1000)
CONFIG_HDC1000_CONVERSION_TIME=(26000)
CONFIG_HDC1000_I2C_ADDRESS=(0x43)
HDC1000 Temperature and Humidity Sensor driver test application

Initializing HDC1000 sensor at I2C_DEV(0)... [Failed]

#### Usage with CFLAGS 

/tests/driver_hdc1000/Makefile

> CFLAGS += -DCONFIG_HDC1000_I2C_ADDRESS=0x42
> CFLAGS += -DCONFIG_HDC1000_CONVERSION_TIME=14000

##### Output
main(): This is RIOT! (Version: 2020.07-devel-46-g4e42a-tests_hdc1000)

CONFIG_HDC1000_CONVERSION_TIME=14000
CONFIG_HDC1000_I2C_ADDRESS=0x42

HDC1000 Temperature and Humidity Sensor driver test application

Initializing HDC1000 sensor at I2C_DEV(0)... [Failed]

#### Usage with Kconfig

/tests/driver_hdc1000/

> make menuconfig

main(): This is RIOT! (Version: 2020.07-devel-46-g4e42a-tests_hdc1000)
CONFIG_HDC1000_CONVERSION_TIME=13000
CONFIG_HDC1000_I2C_ADDRESS=0x40
HDC1000 Temperature and Humidity Sensor driver test application

Initializing HDC1000 sensor at I2C_DEV(0)... [Failed]

Note : The sensor is not available hence configurability of macros were only tested.
### Issues/PRs references

#12888
@leandrolanzieri 
