### PR TITLE
Makefile: remove usage of SUBMODULES_NOFORCE

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -43,10 +43,8 @@ ifeq (1, $(SUBMODULES))
   # for each $(BASE_MODULE)_<name> in USEMODULE, add <name>.c to SRC
   SRC += $(wildcard $(patsubst $(BASE_MODULE)_%,%.c,$(filter $(BASE_MODULE)_%,$(USEMODULE))))
 
-  # don't fail if a selected *.c file does not exist
-  ifeq (1, $(SUBMODULES_NOFORCE))
-    SRC := $(filter $(SRC), $(wildcard *.c))
-  endif
+  # remove duplicates
+  SRC := $(sort $(SRC))
 endif
 
 # By default consider C++ files has a .cpp extension

--- a/makefiles/periph.mk
+++ b/makefiles/periph.mk
@@ -3,9 +3,6 @@ MODULE ?= periph
 # enable submodules
 SUBMODULES := 1
 
-# don't fail if requested submodule does not have corresponding *.c file
-SUBMODULES_NOFORCE := 1
-
 # in case of e.g., <cpu>_periph_common, use periph_* as submodule prefix
 BASE_MODULE := periph
 

--- a/pkg/wolfssl/Makefile.wolfcrypt
+++ b/pkg/wolfssl/Makefile.wolfcrypt
@@ -2,9 +2,6 @@ MODULE = wolfcrypt
 
 SUBMODULES += 1
 
-# Do not fail for module that do not have a file
-SUBMODULES_NOFORCE = 1
-
 NO_AUTO_SRC = 1
 
 #-------------------------------------------------------------#

--- a/pkg/wolfssl/Makefile.wolfssl
+++ b/pkg/wolfssl/Makefile.wolfssl
@@ -2,7 +2,5 @@ MODULE = wolfssl
 
 NO_AUTO_SRC = 1
 SUBMODULES += 1
-SUBMODULES_NOFORCE = 1
-
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/event/Makefile
+++ b/sys/event/Makefile
@@ -1,6 +1,5 @@
 SRC := event.c
 
 SUBMODULES := 1
-SUBMODULES_NOFORCE := 1
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/ztimer/Makefile
+++ b/sys/ztimer/Makefile
@@ -10,9 +10,6 @@ SRC := core.c util.c
 # enable submodules
 SUBMODULES := 1
 
-# "ztimer_extend" does not have corresponding .c
-SUBMODULES_NOFORCE := 1
-
 # disable obsolete warning
 CFLAGS += -Wno-missing-field-initializers
 


### PR DESCRIPTION
### Contribution description

With #10970 only existing *.c files well be added to SRC when using
the SUBMODULES mechanism, so SUBMODULES_NOFORCE (used to filter out
non existing source files) is now redundant so remove the usage.

### Testing procedure

- Green murdock.

### Issues/PRs references

#10970