### PR TITLE
drivers/rtt_rtc: fix of the second alignment problem

### DIFF
--- a/drivers/rtt_rtc/rtt_rtc.c
+++ b/drivers/rtt_rtc/rtt_rtc.c
@@ -36,7 +36,7 @@
 
 #define _RTT(n)         ((n) & RTT_MAX_VALUE)
 
-#define RTT_SECOND_MAX  (RTT_MAX_VALUE/RTT_FREQUENCY)
+#define RTT_SECOND_MAX  ((RTT_MAX_VALUE/RTT_FREQUENCY) - 1)
 
 #define TICKS(x)        (    (x) * RTT_SECOND)
 #define SECONDS(x)      (_RTT(x) / RTT_SECOND)


### PR DESCRIPTION
### Contribution description

This PR fixes an alignment problem in the computation of `rtc_now`. To avoid that `SECONDS(now)` gives the same value in two subsequent RTT cycles, the difference `2^32 - TICKS(RTT_SECOND_MAX)` has to be larger than one second, i.e., larger than `TICKS(1)`. This is only guaranteed if `RTT_SECOND_MAX` is `(RTT_MAX_VALUE/RTT_FREQUENCY) - 1` instead of `(RTT_MAX_VALUE/RTT_FREQUENCY)`.

### Problem Description

Let's suppose we have a 32 bit microsecond counter. In that case, `RTT_SECOND_MAX` would be 4294. The remainder from full seconds to the full range of the counter would then be `2^32 - TICKS(4294) = 967296` or 0.967296 seconds. If the fractional part of `now` can be greater than this remainder, `SECONDS(now - last_alarm)` can become 0 here https://github.com/RIOT-OS/RIOT/blob/623381f9d3c403b8814a8ec7bb8fe305a933d053/drivers/rtt_rtc/rtt_rtc.c#L61-L64 For example, if  `now` is 1,990,000 (1.99 seconds), `last_alarm` will become 1,000,000 and the alarm would be set to 1,990,000 + 4,294,000,000, i.e., to 1,022,704. When the alarm is triggered, `_rtc_now()` is called to update `rtc_now`:
```c
    rtc_now + SECONDS(now - last_alarm);
```
Since `last_alarm` is 1,000,000 and the `now` is 1,022,704, the result will be the former value of `rtc_now`.

### Testing procedure

Flash any board which uses `rtt_rtc` to provide feature `periph_rtc`.
```
make BOARD=... -C tests/shell flash term
```
Set the time with `rtc settime` and let the RTC run for a couple of hours.

### Issues/PRs references
