### PR TITLE
core/includes: add common macros file

### DIFF
--- a/core/doc.txt
+++ b/core/doc.txt
@@ -26,11 +26,11 @@
  * @brief       Configuration data and startup code for the kernel
  */
 
- /**
-  * @defgroup    core_sync Thread Synchronization
-  * @ingroup     core
-  * @brief       Thread synchronization mechanisms of the kernel
-  */
+/**
+ * @defgroup    core_sync Thread Synchronization
+ * @ingroup     core
+ * @brief       Thread synchronization mechanisms of the kernel
+ */
 
 /**
  * @defgroup    core_macros Common Macros

--- a/core/doc.txt
+++ b/core/doc.txt
@@ -31,3 +31,9 @@
   * @ingroup     core
   * @brief       Thread synchronization mechanisms of the kernel
   */
+
+/**
+ * @defgroup    core_macros Common Macros
+ * @ingroup     core
+ * @brief       Commonly used macros header definitions
+ */

--- a/core/include/macros/xtstr.h
+++ b/core/include/macros/xtstr.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     core_macros
+ * @{
+ *
+ * @file
+ * @brief       Macro to return string representation of x
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef MACROS_XTSTR_H
+#define MACROS_XTSTR_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @def     XTSTR
+ *
+ * @brief   A macro to return the string respresentation of x
+ */
+#ifndef XTSTR
+#define _XTSTR(x)    # x
+#define XTSTR(x)    _XTSTR(x)
+#endif /* XTSTR */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MACROS_XTSTR_H */
+/** @} */

--- a/cpu/esp_common/include/esp_common.h
+++ b/cpu/esp_common/include/esp_common.h
@@ -28,14 +28,9 @@ extern "C" {
 
 #include "log.h"
 #include "esp_common_log.h"
+#include "macros/xtstr.h"
 
 #define asm __asm__
-
-/** string representation of x */
-#ifndef XTSTR
-#define _XTSTR(x)    # x
-#define XTSTR(x)    _XTSTR(x)
-#endif /* XSTR */
 
 #if !defined(ICACHE_FLASH)
 #ifndef ICACHE_RAM_ATTR


### PR DESCRIPTION
### Contribution description

This PR wants to make common macros available, first example is `XTSTR`, `esp32` already uses it in some assembler instructions but it can also be useful for compile time error messages based on a macros value, e.g:

```c
#pragma message "The value for X is out of range, X < " XSTR(X_MAX_VALUE)
```

I'm unsure about the proper location for this kind of macros, but it somehow didn't make sense to put it in `kernel_defines.h`, it didn't seem to fit with the macros defined there, although with the current description in `kernel_defines.h`, the line between what should or should not be there is unclear to me.

### Testing procedure

- Green Murdock for esp32.

- Does the naming for the file make sense? How to limit what goes in?