### PR TITLE
dist/tools: add sliptty to host-tools

### DIFF
--- a/dist/tools/Makefile
+++ b/dist/tools/Makefile
@@ -1,4 +1,4 @@
-HOST_TOOLS=ethos uhcpd
+HOST_TOOLS=ethos uhcpd sliptty
 
 .PHONY: all $(HOST_TOOLS)
 

--- a/examples/gnrc_border_router/Makefile.slip.conf
+++ b/examples/gnrc_border_router/Makefile.slip.conf
@@ -9,6 +9,6 @@ ifeq (1,$(USE_DHCPV6))
 endif
 
 # Configure terminal parameters
-TERMDEPS += sliptty
+TERMDEPS += host-tools
 TERMPROG ?= sudo sh $(RIOTTOOLS)/sliptty/start_network.sh
 TERMFLAGS ?= $(FLAGS_EXTRAS) $(IPV6_PREFIX) $(PORT) $(SLIP_BAUDRATE)


### PR DESCRIPTION
### Contribution description

The `host-tools` target was only build with `UPLINK=ethos`, not when slip was used.

As a result, `uhcp` would not get build, resulting in an error message like

    dist/tools/sliptty/start_network.sh: 4: cd: can't cd to dist/tools/sliptty/../uhcpd/bin

Add `host-tools` to `TERMDEPS` like it's done in `Makefile.ethos.conf` to fix this. 

(If you did build with `UPLINK=ethos` before, you would not see this, as the `uhcp` binary got created there already)

### Testing procedure

    rm -r dist/tools/uhcpd/bin
    make -C examples/gnrc_border_router UPLINK=slip flash term

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
