### PR TITLE
sys/touch_dev: add generic API for touch device

### DIFF
--- a/drivers/include/stmpe811.h
+++ b/drivers/include/stmpe811.h
@@ -25,6 +25,10 @@
 #include "periph/gpio.h"
 #include "periph/i2c.h"
 
+#ifdef MODULE_TOUCH_DEV
+#include "touch_dev.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -77,9 +81,12 @@ typedef struct {
  * @brief   Device descriptor for the STMPE811 sensor
  */
 typedef struct {
-    stmpe811_params_t params;       /**< Device parameters */
-    uint16_t prev_x;                /**< Previous X coordinate */
-    uint16_t prev_y;                /**< Previous Y coordinate */
+#ifdef MODULE_TOUCH_DEV
+    touch_dev_t *dev;                   /**< Pointer to the generic touch device */
+#endif
+    stmpe811_params_t params;           /**< Device parameters */
+    uint16_t prev_x;                    /**< Previous X coordinate */
+    uint16_t prev_y;                    /**< Previous Y coordinate */
 } stmpe811_t;
 
 /**

--- a/drivers/include/touch_dev.h
+++ b/drivers/include/touch_dev.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_touch_dev Touch device generic API
+ * @ingroup     drivers_misc
+ * @brief       Define the generic API of a touch device
+ * @experimental This API is experimental and in an early state - expect
+ *               changes!
+ * @{
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef TOUCH_DEV_H
+#define TOUCH_DEV_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/**
+ * @brief   Forward declaration for touch device struct
+ */
+typedef struct touch_dev touch_dev_t;
+
+/**
+ * @brief   Touch coordinates
+ */
+typedef struct {
+    uint16_t x;     /**< X coordinate */
+    uint16_t y;     /**< Y coordinate */
+} touch_t;
+
+/**
+ * @brief   Generic type for a touch driver
+ */
+typedef struct {
+
+    /**
+     * @brief   Get the height of the touch device
+     *
+     * @param[in] dev       Pointer to the touch device
+     *
+     * @return              Height in points
+     */
+    uint16_t (*height)(const touch_dev_t *dev);
+
+    /**
+     * @brief   Get the width of the touch device
+     *
+     * @param[in] dev       Pointer to the touch device
+     *
+     * @return              Width in points
+     */
+    uint16_t (*width)(const touch_dev_t *dev);
+
+    /**
+     * @brief   Get the current touches on the touch device
+     *
+     * If @p touches is NULL, this function only returns the number of touches.
+     *
+     * @param[in] dev       Pointer to the touch device
+     * @param[out] touches  The array of touches
+     * @param[in] len       The touches array len
+     * @return              number of touch positions, 0 means no touch
+     */
+    uint8_t (*touches)(const touch_dev_t *dev, touch_t *touches, size_t len);
+} touch_dev_driver_t;
+
+/**
+ * @brief   Generic type for a touch device
+ */
+struct touch_dev {
+    const touch_dev_driver_t *driver;    /**< Pointer to driver of the touch device */
+};
+
+/**
+ * @brief   Get the height of the touch device
+ *
+ * @param[in] dev       Pointer to the touch device
+ *
+ * @return              Height in points
+ */
+uint16_t touch_dev_height(const touch_dev_t *dev);
+
+/**
+ * @brief   Get the width of the touch device
+ *
+ * @param[in] dev       Pointer to the touch device
+ *
+ * @return              Width in points
+ */
+uint16_t touch_dev_width(const touch_dev_t *dev);
+
+/**
+ * @brief   Get the current touches on the touch device
+ *
+ * If @p touches is NULL, this function only returns the number of touches.
+ *
+ * @param[in] dev       Pointer to the touch device
+ * @param[out] touches  The array of touches
+ * @param[in] len       The touches array len
+ * @return              number of touch positions, 0 means no touch
+ */
+uint8_t touch_dev_touches(const touch_dev_t *dev, touch_t *touches, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TOUCH_DEV_H */
+/** @} */

--- a/drivers/stmpe811/include/stmpe811_touch_dev.h
+++ b/drivers/stmpe811/include/stmpe811_touch_dev.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_stmpe811
+ * @{
+ *
+ * @file
+ * @brief       Definition of the driver for the touch_dev generic interface
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef STMPE811_TOUCH_DEV_H
+#define STMPE811_TOUCH_DEV_H
+
+#include "touch_dev.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Reference to the touch device driver struct
+ */
+extern const touch_dev_driver_t stmpe811_touch_dev_driver;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STMPE811_TOUCH_DEV_H */

--- a/drivers/stmpe811/stmpe811_touch_dev.c
+++ b/drivers/stmpe811/stmpe811_touch_dev.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_stmpe811
+ * @{
+ *
+ * @file
+ * @brief       Driver adaption to touch_dev generic interface
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @}
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <errno.h>
+#include <assert.h>
+
+#include "kernel_defines.h"
+
+#include "stmpe811.h"
+#include "stmpe811_touch_dev.h"
+
+uint16_t _stmpe811_height(const touch_dev_t *touch_dev)
+{
+    const stmpe811_t *dev = (const stmpe811_t *)touch_dev;
+    assert(dev);
+
+    return dev->params.ymax;
+}
+
+uint16_t _stmpe811_width(const touch_dev_t *touch_dev)
+{
+    const stmpe811_t *dev = (const stmpe811_t *)touch_dev;
+    assert(dev);
+
+    return dev->params.xmax;
+}
+
+uint8_t _stmpe811_touches(const touch_dev_t *touch_dev, touch_t *touches, size_t len)
+{
+    (void)len;
+
+    stmpe811_t *dev = (stmpe811_t *)touch_dev;
+    assert(dev);
+
+    stmpe811_touch_state_t state;
+    stmpe811_read_touch_state(dev, &state);
+    uint8_t ret = (state == STMPE811_TOUCH_STATE_PRESSED);
+
+    if (ret && touches != NULL) {
+        stmpe811_touch_position_t pos;
+        stmpe811_read_touch_position(dev, &pos);
+        touches[0].x = pos.x;
+        touches[0].y = pos.y;
+    }
+
+    return ret;
+}
+
+const touch_dev_driver_t stmpe811_touch_dev_driver = {
+    .height     = _stmpe811_height,
+    .width      = _stmpe811_width,
+    .touches    = _stmpe811_touches,
+};

--- a/drivers/touch_dev/Makefile
+++ b/drivers/touch_dev/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/touch_dev/touch_dev.c
+++ b/drivers/touch_dev/touch_dev.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_touch_dev
+ * @{
+ *
+ * @file
+ * @brief       Helper functions for generic API of touch device
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <inttypes.h>
+#include <stdbool.h>
+
+#include "touch_dev.h"
+
+uint16_t touch_dev_height(const touch_dev_t *dev)
+{
+    assert(dev);
+
+    return dev->driver->height(dev);
+}
+
+uint16_t touch_dev_width(const touch_dev_t *dev)
+{
+    assert(dev);
+
+    return dev->driver->width(dev);
+}
+
+uint8_t touch_dev_touches(const touch_dev_t *dev, touch_t *touches, size_t len)
+{
+    assert(dev);
+
+    return dev->driver->touches(dev, touches, len);
+}

--- a/tests/touch_dev/Makefile
+++ b/tests/touch_dev/Makefile
@@ -1,0 +1,10 @@
+BOARD ?= stm32f429i-disc1
+include ../Makefile.tests_common
+
+DISABLE_MODULE += test_utils_interactive_sync
+
+USEMODULE += stmpe811
+USEMODULE += touch_dev
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/touch_dev/main.c
+++ b/tests/touch_dev/main.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Generic touch device test application
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <assert.h>
+#include <stdbool.h>
+
+#include "xtimer.h"
+
+#include "touch_dev.h"
+
+#include "stmpe811.h"
+#include "stmpe811_params.h"
+#include "stmpe811_touch_dev.h"
+
+#include "test_utils/expect.h"
+
+static stmpe811_t stmpe811;
+
+static void _touch_event_cb(void *arg)
+{
+    (void)arg;
+    puts("Pressed!");
+}
+
+int main(void)
+{
+    stmpe811_init(&stmpe811, &stmpe811_params[0], _touch_event_cb, NULL);
+
+    touch_dev_t *dev = (touch_dev_t *)&stmpe811;
+    dev->driver = &stmpe811_touch_dev_driver;
+
+    uint16_t xmax = touch_dev_width(dev);
+    uint16_t ymax = touch_dev_height(dev);
+
+    expect(xmax == stmpe811.params.xmax);
+    expect(ymax == stmpe811.params.ymax);
+
+    uint8_t last_touches = touch_dev_touches(dev, NULL, 1);
+
+    while (1) {
+        touch_t touches[1];
+        uint8_t current_touches = touch_dev_touches(dev, touches, 1);
+
+        if (current_touches != last_touches) {
+            if (current_touches == 0) {
+                puts("Released!");
+            }
+            last_touches = current_touches;
+        }
+
+        /* Display touch position if pressed */
+        if (current_touches == 1) {
+            printf("X: %i, Y:%i\n", touches[0].x, touches[0].y);
+        }
+
+        xtimer_usleep(10 * US_PER_MS);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR introduces a new generic API for handling touch device like the stmpe811 one.

For the moment, only single touch position is handled but maybe the current design could support multi touch devices.

The API could maybe be extended to support gestures (see #13214).

I'm planning to open a follow-up PR that extends the lvgl integration with this API.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

There is a test application provided that should work as is on `stm32f429i-disc1`:

<details><summary>make -C tests/touch_dev flash term --no-print-directory</summary>

```
Building application "tests_touch_dev" for "stm32f429i-disc1" with MCU "stm32f4".

"make" -C /work/riot/RIOT/boards/stm32f429i-disc1
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32f4
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32_common
"make" -C /work/riot/RIOT/cpu/stm32_common/periph
"make" -C /work/riot/RIOT/cpu/stm32f4/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/stmpe811
"make" -C /work/riot/RIOT/drivers/touch_dev
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  12896	    112	   2748	  15756	   3d8c	/work/riot/RIOT/tests/touch_dev/bin/stm32f429i-disc1/tests_touch_dev.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/touch_dev/bin/stm32f429i-disc1/tests_touch_dev.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01047-g09ac9ab1 (2020-02-05-08:53)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : clock speed 2000 kHz
Info : STLINK V2J25M14 (API v2) VID:PID 0483:374B
Info : Target voltage: 2.852356
Error: jtag status contains invalid mode value - communication failure
Polling target stm32f4x.cpu failed, trying to reexamine
Examination failed, GDB will be halted. Polling again in 100ms
Info : Previous state query failed, trying to reconnect
Error: jtag status contains invalid mode value - communication failure
Polling target stm32f4x.cpu failed, trying to reexamine
Examination failed, GDB will be halted. Polling again in 300ms
Info : Listening on port 35245 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f4x.cpu       hla_target little stm32f4x.cpu       unknown

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Error: mem2array: Read @ 0xe0042004, w=4, cnt=1, failed
Error executing event examine-end on target stm32f4x.cpu:
/usr/local/bin/../share/openocd/scripts/mem_helper.tcl:6: Error: 
in procedure 'ocd_process_reset' 
in procedure 'ocd_process_reset_inner' called at file "embedded:startup.tcl", line 270
in procedure 'mmw' called at file "/usr/local/bin/../share/openocd/scripts/target/stm32f4x.cfg", line 79
in procedure 'mrw' called at file "/usr/local/bin/../share/openocd/scripts/mem_helper.tcl", line 36
at file "/usr/local/bin/../share/openocd/scripts/mem_helper.tcl", line 6
Info : Previous state query failed, trying to reconnect
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08000524 msp: 0x20000200
Polling target stm32f4x.cpu failed, trying to reexamine
Info : stm32f4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : device id = 0x20016419
Info : flash size = 2048 kbytes
Info : Dual Bank 2048 kiB STM32F42x/43x/469/479 found
auto erase enabled
wrote 16384 bytes from file /work/riot/RIOT/tests/touch_dev/bin/stm32f429i-disc1/tests_touch_dev.elf in 0.677064s (23.631 KiB/s)

verified 13008 bytes in 0.165338s (76.831 KiB/s)

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
2020-04-16 10:33:31,122 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2020-04-16 10:33:54,058 # Pressed!
2020-04-16 10:33:54,059 # X: 99, Y:160
2020-04-16 10:33:54,076 # X: 98, Y:161
2020-04-16 10:33:54,088 # X: 99, Y:161
2020-04-16 10:33:54,100 # X: 100, Y:160
2020-04-16 10:33:54,112 # X: 100, Y:160
2020-04-16 10:33:54,124 # Released!
2020-04-16 10:33:54,166 # Pressed!
2020-04-16 10:33:54,172 # X: 98, Y:156
2020-04-16 10:33:54,184 # X: 98, Y:156
2020-04-16 10:33:54,196 # X: 98, Y:156
2020-04-16 10:33:54,208 # X: 98, Y:157
2020-04-16 10:33:54,226 # X: 98, Y:157
2020-04-16 10:33:54,238 # X: 98, Y:156
2020-04-16 10:33:54,250 # X: 98, Y:156
2020-04-16 10:33:54,262 # X: 98, Y:155
2020-04-16 10:33:54,274 # Pressed!
2020-04-16 10:33:54,275 # X: 97, Y:153
2020-04-16 10:33:54,286 # Released!
2020-04-16 10:33:57,244 # Pressed!
2020-04-16 10:33:57,250 # X: 140, Y:153
2020-04-16 10:33:57,268 # X: 140, Y:154
2020-04-16 10:33:57,274 # X: 140, Y:153
2020-04-16 10:33:57,286 # X: 141, Y:153
2020-04-16 10:33:57,303 # X: 141, Y:153
2020-04-16 10:33:57,316 # X: 142, Y:153
2020-04-16 10:33:57,328 # X: 142, Y:153
2020-04-16 10:33:57,340 # X: 143, Y:153
2020-04-16 10:33:57,352 # X: 144, Y:153
2020-04-16 10:33:57,369 # X: 144, Y:152
2020-04-16 10:33:57,382 # X: 145, Y:152
2020-04-16 10:33:57,394 # X: 145, Y:152
2020-04-16 10:33:57,406 # X: 145, Y:152
2020-04-16 10:33:57,418 # X: 145, Y:152
2020-04-16 10:33:57,435 # X: 145, Y:152
2020-04-16 10:33:57,448 # X: 146, Y:152
2020-04-16 10:33:57,460 # X: 147, Y:152
2020-04-16 10:33:57,472 # X: 147, Y:152
2020-04-16 10:33:57,484 # X: 147, Y:152
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
