### PR TITLE
boards/cc1312-launchpad: fix typo + reword

### DIFF
--- a/boards/cc1312-launchpad/include/periph_conf.h
+++ b/boards/cc1312-launchpad/include/periph_conf.h
@@ -70,7 +70,7 @@ static const timer_conf_t timer_config[] = {
 /**
  * @name    UART configuration
  *
- * The used LAUNCHXL-CC1312R board has available a single UART device throught
+ * The used LAUNCHXL-CC1312R board has a single UART device available through
  * the debugger, so all we need to configure are the RX and TX pins.
  *
  * Optionally we can enable hardware flow control, by setting UART_HW_FLOW_CTRL


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a small typo in the cc1312_launchpad periph_conf header file. It also rewords slightly the sentence.

This was discovered by chance when running the static-test locally to check another PR.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just read :)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
