### PR TITLE
sys/btree: Initial include of a self-balancing binary search tree module

### DIFF
--- a/sys/btree/Makefile
+++ b/sys/btree/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/btree/btree.c
+++ b/sys/btree/btree.c
@@ -1,0 +1,320 @@
+/*
+ * Copyright (C) 2020 Inria
+ * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup sys_btree2
+ * @{
+ * @file
+ * @brief   Function implementations for btree structures
+ *
+ * @author  Koen Zandberg <koen@bergzand.net>
+ * @}
+ */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "btree.h"
+
+static void _path_helper(btree_node_t *node, size_t depth, void *ctx)
+{
+    (void)node;
+    size_t *max_depth = ctx;
+    if (*max_depth < depth) {
+        *max_depth = depth;
+    }
+}
+
+static size_t _max_path(btree_node_t *node)
+{
+    size_t len = 0;
+    btree_t start = {.start = node};
+    btree_traverse(&start, _path_helper, &len);
+    return len;
+}
+
+/**
+ * @brief find the node with a matching key
+ *
+ * @param   node    parent node
+ */
+static btree_node_t *_find_key(btree_node_t *cur_node, btree_node_t **parent, uint32_t key)
+{
+    while (cur_node) {
+        if (cur_node->key > key) {
+            *parent = cur_node;
+            cur_node = cur_node->left;
+        }
+        else if (cur_node->key < key) {
+            *parent = cur_node;
+            cur_node = cur_node->right;
+        }
+        else {
+            break;
+        }
+    }
+    return cur_node;
+}
+
+static size_t _find_distance(btree_node_t *parent, btree_node_t *child)
+{
+    size_t depth = 0;
+    while (child && (parent != child)) {
+        depth++;
+        child = child->parent;
+    }
+    return depth;
+}
+
+static btree_node_t *_find_min(btree_node_t *node)
+{
+    btree_node_t *min = NULL;
+    _find_key(node, &min, 0);
+    return min;
+}
+
+static btree_node_t *_find_max(btree_node_t *node)
+{
+    btree_node_t *max = NULL;
+    _find_key(node, &max, UINT32_MAX);
+    return max;
+}
+
+static void _replace_ref(btree_node_t *parent, btree_node_t *child, btree_node_t *new)
+{
+    if (parent->left == child) {
+        parent->left = new;
+    }
+    else {
+        parent->right = new;
+    }
+}
+
+static void _update_parent_ref(btree_node_t *node, btree_node_t *parent)
+{
+    if (node) {
+        node->parent = parent;
+    }
+}
+
+static void _start_rotate(btree_t *btree, btree_node_t *root, btree_node_t *pivot)
+{
+    if (root->parent) {
+        _replace_ref(root->parent, root, pivot);
+    }
+    else {
+        btree->start = pivot;
+    }
+    _update_parent_ref(pivot, root->parent);
+    root->parent = pivot;
+}
+
+static void _rotate_left(btree_t *btree, btree_node_t *root, btree_node_t *pivot)
+{
+    _start_rotate(btree, root, pivot);
+    _update_parent_ref(pivot->left, root);
+    root->right = pivot->left;
+    pivot->left = root;
+}
+
+static void _rotate_right(btree_t *btree, btree_node_t *root, btree_node_t *pivot)
+{
+    _start_rotate(btree, root, pivot);
+    _update_parent_ref(pivot->right, root);
+    root->left = pivot->right;
+    pivot->right = root;
+}
+
+static void _balance(btree_t *btree, btree_node_t *node)
+{
+    int child_balance = 0;
+    while (node) {
+        /* Determine max length of the other branch */
+        /* TODO: reuse the result from the previous loop */
+        int balance = _max_path(node->right) - _max_path(node->left);
+        if (balance > 1) {
+            /* right/left case */
+            if (child_balance < 0) {
+                /* Tranform to right/right case */
+                _rotate_right(btree, node->right,
+                              node->right->left);
+            }
+            /* right/right case */
+            _rotate_left(btree, node, node->right);
+            node = node->right;
+            child_balance = 0;
+        }
+        else if (balance < -1) {
+            /* left/right case */
+            if (child_balance > 0) {
+                /* Tranform to left/left case */
+                _rotate_left(btree, node->left, node->left->right);
+            }
+            /* left/left case */
+            _rotate_right(btree, node, node->left);
+            node = node->left;
+            child_balance = 0;
+        }
+        else {
+            child_balance = balance;
+            node = node->parent;
+        }
+    }
+}
+
+btree_node_t *btree_find_key(btree_t *btree, uint32_t key)
+{
+    btree_node_t *_tmp;
+    return _find_key(btree->start, &_tmp, key);
+}
+
+int btree_insert(btree_t *btree, btree_node_t *new, uint32_t key)
+{
+    new->left = NULL;
+    new->right = NULL;
+    new->key = key;
+
+    if (_find_key(btree->start, &new->parent, key) != NULL) {
+        return BTREE_ERROR_NODE_EXISTS;
+    }
+
+    btree_node_t *p = new->parent;
+
+    if (!p) {
+        btree->start = new;
+        return BTREE_OK;
+    }
+
+    if (p->key > key) {
+        p->left = new;
+    }
+    else {
+        p->right = new;
+    }
+
+    /* Only balance if the rank changes */
+    if (!(p->left && p->right)) {
+        _balance(btree, p);
+    }
+
+    return BTREE_OK;
+}
+
+btree_node_t *btree_remove(btree_t *btree, uint32_t key)
+{
+    btree_node_t *balance_start;
+    btree_node_t *d = _find_key(btree->start, &balance_start, key);
+
+    if (d == NULL) {
+        /* Key not found */
+        return NULL;
+    }
+
+    btree_node_t *left = _find_min(d->left);
+    btree_node_t *right = _find_max(d->right);
+
+    size_t left_len = _find_distance(d, left) + _max_path(left);
+    size_t right_len = _find_distance(d, right) + _max_path(right);
+
+    btree_node_t *replacement = left_len > right_len ? left : right;
+
+    if (d->parent) {
+        _replace_ref(d->parent, d, replacement);
+    }
+    else {
+        btree->start = replacement;
+    }
+
+    if (replacement) {
+        btree_node_t *p_replacement = replacement->parent;
+        replacement->parent = d->parent;
+
+        /* The replacement node can, by definition, only have one child node */
+        btree_node_t *dangling = replacement->left ? replacement->left : replacement->right;
+
+        /* Overwrite the node acting as the deleted nodes replacement with it's
+         * child node */
+        _replace_ref(p_replacement, replacement, dangling);
+        /* Overwrite the replacements children with the deleted nodes children */
+        replacement->left = d->left;
+        replacement->right = d->right;
+        _update_parent_ref(replacement->right, replacement);
+        _update_parent_ref(replacement->left, replacement);
+
+        balance_start = p_replacement;
+    }
+
+    _balance(btree, balance_start);
+
+    return d;
+}
+
+void btree_traverse(btree_t *btree, btree_cb_t cb, void *ctx)
+{
+    btree_node_t *node = btree->start;
+    if (!node) {
+        return;
+    }
+
+    btree_node_t *parent = node->parent;
+    btree_node_t *prev_node = parent;
+
+    size_t depth = 0;
+
+    /* Look Ma, no recursion! */
+    while (node != parent) {
+        btree_node_t *next = NULL;
+
+        do {
+            if (prev_node == node->parent) {
+                depth++;
+                next = node->left;
+                if (next) {
+                    break;
+                }
+            }
+            if ((prev_node == node->parent) || (prev_node == node->left)) {
+                cb(node, depth, ctx);
+                next = node->right;
+                if (next) {
+                    break;
+                }
+            }
+            depth--;
+            next = node->parent;
+        } while (0);
+
+        prev_node = node;
+        node = next;
+    }
+}
+
+size_t btree_max_depth(btree_t *btree)
+{
+    if (btree->start) {
+        return _max_path(btree->start);
+    }
+    return 0;
+}
+
+static void _dump(btree_node_t *node, size_t level, char *prefix)
+{
+    if (node) {
+       _dump(node->right, level + 2, "┌─r");
+       printf("%*s%s: %"PRIu32"\n", level, "", prefix, node->key);
+       _dump(node->left, level + 2, "└─l");
+    }
+}
+
+void btree_dump(btree_t *btree)
+{
+   _dump(btree->start, 0, "O");
+}

--- a/sys/btree/btree.c
+++ b/sys/btree/btree.c
@@ -210,7 +210,7 @@ int btree_insert(btree_t *btree, btree_node_t *new, uint32_t key)
 
 btree_node_t *btree_remove(btree_t *btree, uint32_t key)
 {
-    btree_node_t *balance_start;
+    btree_node_t *balance_start = NULL;
     btree_node_t *d = _find_key(btree->start, &balance_start, key);
 
     if (d == NULL) {

--- a/sys/include/btree.h
+++ b/sys/include/btree.h
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2020 Inria
+ * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_btree Binary tree
+ * @ingroup     sys
+ * @brief       Self-balancing sorted binary tree
+ *
+ * This module provides a minimal self-balancing sorted binary tree
+ * implementation. It can be used to implement key-value stores and other
+ * key-based structures.
+ *
+ * The binary search tree provided here is optimized for fast key lookups.
+ * Insertions and deletions are slow and should be avoided when possible. Both
+ * insertions and deletions trigger the relative slow balancing algorithm to
+ * keep the tree into an relative optimal shape for search operations.
+ *
+ * The btree_node_t structs stores the required internal references and a key.
+ * It is up to the implementor to inherit from the struct and add the required
+ * data that must be associated with the key.
+ *
+ * example:
+ *
+ * ```
+ * typedef struct {
+ *     btree_node_t node;
+ *     uint32_t value;
+ * } keyval_entry_t;
+ * ```
+ *
+ * Inserting a keyval entry can be done with:
+ *
+ * ```
+ * static keyval_entry_t entry = { .value = 5 };
+ * if (btree_insert(btree, &entry.node, 12) < 0) {
+ *     LOG_ERROR("Key already exists in tree\n");
+ * }
+ * ```
+ * Note that the btree does not copy the inserted object. The object must be
+ * kept in memory while it is used in the tree.
+ *
+ * Retrieving the pair is then as simple as:
+ *
+ * ```
+ * keyval_entry_t *entry = (keyval_entry_t*)btree_find_key(btree, 12);
+ * if (entry) {
+ *     _handle_entry(entry);
+ * }
+ * ```
+ *
+ * Removing the entry from the btree can done with:
+ *
+ * ```
+ * keyval_entry_t *entry = (keyval_entry_t*)btree_remove(btree, 12);
+ * if (entry) {
+ *     _deallocate_entry(entry);
+ * }
+ * ```
+ *
+ * The removal function returns the removed entry or NULL when no entry was
+ * removed. The returned entry can safely be reinserted or can be deallocated by
+ * an external memory allocator.
+ *
+ * Allocating entry nodes is the responsibility of the application. If all nodes
+ * are equal in allocated size the @ref sys_memarray module can be used for dynamic
+ * allocation of entry nodes.
+ *
+ * @{
+ *
+ * @file
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+#ifndef BTREE_H
+#define BTREE_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    BTREE_OK = 0,                   /**< No error */
+
+    /**
+     * @brief Node could not be inserted because the key already exists in the
+     *        tree
+     */
+    BTREE_ERROR_NODE_EXISTS = -1,
+};
+
+/**
+ * @brief Forward declaration for the btree node struct
+ */
+typedef struct btree_node btree_node_t;
+
+/**
+ * @brief btree node
+ */
+struct btree_node {
+    struct btree_node *left;    /**< Lower value reference  */
+    struct btree_node *right;   /**< Higher value reference */
+    struct btree_node *parent;  /**< Parent node reference  */
+    uint32_t key;               /**< Key of this node       */
+};
+
+/**
+ * @brief btree reference
+ */
+typedef struct {
+    btree_node_t *start; /**< Root node reference */
+} btree_t;
+
+/**
+ * @brief retrieve the key of a node
+ *
+ * @param       Node    The node to retrieve the key from
+ *
+ * @returns             The key of the node
+ */
+static inline uint32_t btree_node_key(btree_node_t *node) {
+    return node->key;
+}
+
+/**
+ * @brief Callback function for tree traversal
+ *
+ * @param   node    Current node
+ * @param   depth   Depth of the current node
+ * @param   ctx     Pointer to the supplied traversal context
+ */
+typedef void (*btree_cb_t)(btree_node_t *node, size_t depth, void *ctx);
+
+/**
+ * @brief Traverse the full tree, visiting every node exactly once in ascending
+ *        order.
+ *
+ * @param   btree   Tree to traverse
+ * @param   cb      Callback to call for every node
+ * @param   ctx     Context to pass to every callback
+ */
+void btree_traverse(btree_t *btree, btree_cb_t cb, void *ctx);
+
+/**
+ * @brief Find a node with a specified key
+ *
+ * @param   btree   Tree to search
+ * @param   key     Key to find
+ *
+ * @returns         The node with the requested key
+ * @returns         NULL if no node was found
+ */
+btree_node_t *btree_find_key(btree_t *btree, uint32_t key);
+
+/**
+ * @brief Insert a new node into the tree
+ *
+ * @param   btree   Tree to insert into
+ * @param   New     Preallocated node to insert
+ * @param   key     Key to insert
+ */
+int btree_insert(btree_t *btree, btree_node_t *new, uint32_t key);
+
+/**
+ * @brief Remove a node from the tree
+ *
+ * @param   btree   Tree to remove from
+ * @param   key     Key to remove from the tree
+ *
+ * @returns         A reference to the deleted node
+ * @returns         NULL if no node to delete was found
+ */
+btree_node_t *btree_remove(btree_t *btree, uint32_t key);
+
+/**
+ * @brief Auxiliary function to retrieve the depth of the tree
+ *
+ * @param   btree   tree to find the max depth for
+ *
+ * @returns         Depth of the tree
+ */
+size_t btree_max_depth(btree_t *btree);
+
+/**
+ * @brief Auxiliary function to dump a print of the tree to stdio
+ *
+ * @param   btree   tree to print
+ */
+void btree_dump(btree_t *btree);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* UUID_H */
+/** @} */

--- a/sys/include/btree.h
+++ b/sys/include/btree.h
@@ -142,6 +142,9 @@ typedef void (*btree_cb_t)(btree_node_t *node, size_t depth, void *ctx);
  * @brief Traverse the full tree, visiting every node exactly once in ascending
  *        order.
  *
+ * @warning     Modifying the btree during the traverse is not supported and
+ *              consistency of the tree can't be guaranteed.
+ *
  * @param   btree   Tree to traverse
  * @param   cb      Callback to call for every node
  * @param   ctx     Context to pass to every callback

--- a/tests/btree/Makefile
+++ b/tests/btree/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += embunit
+USEMODULE += btree
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/btree/main.c
+++ b/tests/btree/main.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2020 Inria
+ * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Tests btree implementation
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+#include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <string.h>
+#include "btree.h"
+#include "embUnit.h"
+
+static btree_t _btree;
+static btree_node_t _nodes[15];
+
+static const uint32_t _keys[] = {
+    8, 3, 10, 1, 6, 14, 0, 2
+};
+
+static uint32_t prev_key = 0;
+
+static void _btree_node_print(btree_node_t *node, size_t depth, void *ctx)
+{
+    (void)ctx;
+    (void)depth;
+    TEST_ASSERT_EQUAL_INT(prev_key + 1, node->key);
+    prev_key = node->key;
+}
+
+static void tests_btree_empty(void)
+{
+    btree_t tree = {.start = NULL};
+    btree_traverse(&tree, _btree_node_print, NULL);
+    TEST_ASSERT(NULL == btree_remove(&tree, 0));
+    TEST_ASSERT(NULL == btree_find_key(&tree, 0));
+}
+
+static void tests_btree_construct(void)
+{
+
+    for (size_t i = 0; i < ARRAY_SIZE(_nodes); i++) {
+        /* Worst case insertions */
+        btree_insert(&_btree, &_nodes[i], i + 1);
+    }
+
+    TEST_ASSERT_EQUAL_INT(4, btree_max_depth(&_btree));
+
+    btree_traverse(&_btree, _btree_node_print, NULL);
+}
+
+static void tests_btree_lookup(void)
+{
+    for (size_t i = 0; i < ARRAY_SIZE(_nodes); i++) {
+        btree_node_t *n = btree_find_key(&_btree, i + 1);
+        TEST_ASSERT(n);
+        TEST_ASSERT_EQUAL_INT(i + 1, n->key);
+    }
+
+    TEST_ASSERT_EQUAL_INT(14, btree_remove(&_btree, 14)->key);
+    TEST_ASSERT_EQUAL_INT(15, btree_remove(&_btree, 15)->key);
+    TEST_ASSERT_EQUAL_INT(13, btree_remove(&_btree, 13)->key);
+}
+
+static void tests_btree_remove(void)
+{
+    memset(&_btree, 0, sizeof(_btree));
+    memset(_nodes, 0, sizeof(_nodes));
+
+    for (size_t i = 0; i < ARRAY_SIZE(_keys); i++) {
+        btree_insert(&_btree, &_nodes[i], _keys[i]);
+    }
+    TEST_ASSERT_EQUAL_INT(6, btree_remove(&_btree, 6)->key);
+    TEST_ASSERT_EQUAL_INT(14, btree_remove(&_btree, 14)->key);
+    TEST_ASSERT_EQUAL_INT(BTREE_OK, btree_insert(&_btree,
+                                                 &_nodes[ARRAY_SIZE(_keys) + 1],
+                                                 14));
+}
+
+static void tests_btree_remove2(void)
+{
+    memset(&_btree, 0, sizeof(_btree));
+    memset(_nodes, 0, sizeof(_nodes));
+
+    for (size_t i = 0; i < 3; i++) {
+        btree_insert(&_btree, &_nodes[i], _keys[i]);
+    }
+
+    btree_remove(&_btree, 0);
+}
+
+Test *tests_btree(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(tests_btree_empty),
+        new_TestFixture(tests_btree_construct),
+        new_TestFixture(tests_btree_lookup),
+        new_TestFixture(tests_btree_remove),
+        new_TestFixture(tests_btree_remove2),
+    };
+
+    EMB_UNIT_TESTCALLER(btree_tests, NULL, NULL, fixtures);
+    return (Test*)&btree_tests;
+}
+
+int main(void)
+{
+    TESTS_START();
+    TESTS_RUN(tests_btree());
+    TESTS_END();
+
+    return 0;
+}

--- a/tests/btree/tests/01-run.py
+++ b/tests/btree/tests/01-run.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+# Copyright (C) 2016 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+
+from testrunner import run_check_unittests
+
+
+if __name__ == "__main__":
+    sys.exit(run_check_unittests())


### PR DESCRIPTION
### Contribution description

This PR adds a simple binary search tree module to RIOT. It is optimized for low flash footprint and fast key lookups. Without the auxiliary debug functions the flash footprint is approx 600 bytes on a samr21-xpro.

### Testing procedure

A test is supplied. Please also read the accompanied docs and check whether the module usage is clear.

### Issues/PRs references

None