### PR TITLE
drivers/at86rf215 : Expose Configurations to Kconfig

### DIFF
--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -5,6 +5,7 @@
 # directory for more details.
 
 menu "Network Device Drivers"
+rsource "at86rf215/Kconfig"
 rsource "cc110x/Kconfig"
 rsource "mrf24j40/Kconfig"
 source "$(RIOTCPU)/nrf52/radio/nrf802154/Kconfig"

--- a/drivers/at86rf215/Kconfig
+++ b/drivers/at86rf215/Kconfig
@@ -1,0 +1,41 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_AT86RF215
+    bool "Configure AT86RF215 driver"
+    depends on MODULE_AT86RF215
+    help
+        Configure the AT86RF215 driver using Kconfig.
+
+if KCONFIG_MODULE_AT86RF215
+
+config AT86RF215_USE_CLOCK_OUTPUT
+    bool "Enable clock output"
+    help
+        Enable this to enable the clock output pin of the AT86RF215 chip.
+        This way it can be used as a clock source in place of a separate crystal.
+        You also have to enable this if you want to measure the clock frequency
+        for trimming. After proper trim value is applied this may be disabled
+        if not used otherwise.
+        By Default it is turned off to save energy.
+
+config AT86RF215_TRIM_VAL_EN
+    bool "Enable crystal oscillator trimming"
+    help
+        Enable crystal oscillator trimming.
+
+config AT86RF215_TRIM_VAL
+    int "Trim value for the crystal oscillator"
+    range 0 15
+    default 0
+    depends on AT86RF215_TRIM_VAL_EN
+    help
+        Each increment adds 300nF capacitance between the crystal oscillator pins
+        TCXO and XTAL2.Tweak the value until the measured clock output matches
+        26 MHz the best.
+        For more information Refer Table 6-25 TRIM in Datasheet
+
+endif # KCONFIG_MODULE_AT86RF215

--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -25,6 +25,7 @@
 #include "unaligned.h"
 #include "at86rf215_internal.h"
 #include "at86rf215_netdev.h"
+#include "kernel_defines.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -115,10 +116,9 @@ void at86rf215_reset(at86rf215_t *dev)
     }
 
     /* disable clock output */
-#if AT86RF215_USE_CLOCK_OUTPUT == 0
+if (!IS_ACTIVE(CONFIG_AT86RF215_USE_CLOCK_OUTPUT)){
     at86rf215_reg_write(dev, RG_RF_CLKO, 0);
-#endif
-
+}
     /* allow to configure board-specific trim */
 #ifdef AT86RF215_TRIM_VAL
     at86rf215_reg_write(dev, RG_RF_XOC, AT86RF215_TRIM_VAL | XOC_FS_MASK);

--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -120,8 +120,8 @@ if (!IS_ACTIVE(CONFIG_AT86RF215_USE_CLOCK_OUTPUT)){
     at86rf215_reg_write(dev, RG_RF_CLKO, 0);
 }
     /* allow to configure board-specific trim */
-#ifdef AT86RF215_TRIM_VAL
-    at86rf215_reg_write(dev, RG_RF_XOC, AT86RF215_TRIM_VAL | XOC_FS_MASK);
+#ifdef CONFIG_AT86RF215_TRIM_VAL
+    at86rf215_reg_write(dev, RG_RF_XOC, CONFIG_AT86RF215_TRIM_VAL | XOC_FS_MASK);
 #endif
 
     /* enable TXFE & RXFE IRQ */

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -75,7 +75,7 @@ typedef void (*at86rf215_batmon_cb_t)(void *arg);
 #define CONFIG_AT86RF215_USE_CLOCK_OUTPUT
 #endif
 
-#if defined(DOXYGEN) && !defined(AT86RF215_TRIM_VAL)
+#if defined(DOXYGEN) && !defined(CONFIG_AT86RF215_TRIM_VAL)
 /**
  * @brief   Trim value for the external crystal oscillator.
  *
@@ -88,7 +88,7 @@ typedef void (*at86rf215_batmon_cb_t)(void *arg);
  *          meter connected to the clock output pin of the AT86RF215.
  *          Tweak the value until the measured clock output matches 26 MHz the best.
  */
-#define AT86RF215_TRIM_VAL              (0)
+#define CONFIG_AT86RF215_TRIM_VAL              (0)
 #endif
 /** @} */
 

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -71,8 +71,8 @@ typedef void (*at86rf215_batmon_cb_t)(void *arg);
  *          as a clock source on the board.
  *          Otherwise it is turned off to save energy.
  */
-#ifndef AT86RF215_USE_CLOCK_OUTPUT
-#define AT86RF215_USE_CLOCK_OUTPUT      (0)
+#ifdef DOXYGEN
+#define CONFIG_AT86RF215_USE_CLOCK_OUTPUT
 #endif
 
 #if defined(DOXYGEN) && !defined(AT86RF215_TRIM_VAL)
@@ -84,7 +84,7 @@ typedef void (*at86rf215_batmon_cb_t)(void *arg);
  *
  *          Range: 0..15
  *
- *          Use in conjunction with @see AT86RF215_USE_CLOCK_OUTPUT and a frequency
+ *          Use in conjunction with @see CONFIG_AT86RF215_USE_CLOCK_OUTPUT and a frequency
  *          meter connected to the clock output pin of the AT86RF215.
  *          Tweak the value until the measured clock output matches 26 MHz the best.
  */


### PR DESCRIPTION
Contribution description

This PR exposes compile configurations in at86rf215 network device driver to Kconfig. The following macro was define to print the macros.

#define STR(x)   #x
#define SHOW_DEFINE(x) printf("%s=%s\n", #x, STR(x))

### Testing procedure

The firmware was uploaded to FIT/IoT-LAB Test Bed and following results were obtained.

#### Default State:

##### Firmware Output
gnrc_netif: netdev init failed: -19
gnrc_netif: netdev init failed: -134
main(): This is RIOT! (Version: 2020.07-devel-82-g1d30-Kconfig_at86rf215)
CONFIG_AT86RF215_USE_CLOCK_OUTPUT=0
CONFIG_AT86RF215_TRIM_VAL=CONFIG_AT86RF215_TRIM_VAL


#### Usage with CFLAGS 

/tests/driver_at86rf215/Makefile

> CFLAGS += -DCONFIG_AT86RF215_USE_CLOCK_OUTPUT=1
> CFLAGS += -DCONFIG_AT86RF215_TRIM_VAL=5

##### Firmware Output
gnrc_netif: netdev init failed: -19
gnrc_netif: netdev init failed: -134
main(): This is RIOT! (Version: 2020.07-devel-82-g1d30-Kconfig_at86rf215)
CONFIG_AT86RF215_USE_CLOCK_OUTPUT=1
CONFIG_AT86RF215_TRIM_VAL=5

#### Usage with Kconfig

/tests/at86rf215/

> make menuconfig

##### Firmware Output
gnrc_netif: netdev init failed: -19
gnrc_netif: netdev init failed: -134
main(): This is RIOT! (Version: 2020.07-devel-82-g1d30-Kconfig_at86rf215)
CONFIG_AT86RF215_USE_CLOCK_OUTPUT=1
CONFIG_AT86RF215_TRIM_VAL=15

Note : The sensor is not available hence configurability of macros were only tested.

### Issues/PRs references

#12888
@leandrolanzieri 
