### PR TITLE
drivers/at25xxx: return read/written bytes to match MTD API [backport 2020.04]

### DIFF
--- a/drivers/at25xxx/at25xxx.c
+++ b/drivers/at25xxx/at25xxx.c
@@ -113,7 +113,7 @@ static ssize_t _write_page(const at25xxx_t *dev, uint32_t pos, const void *data,
 
 int at25xxx_write(const at25xxx_t *dev, uint32_t pos, const void *data, size_t len)
 {
-    int res = 0;
+    int res = len;
     const uint8_t *d = data;
 
     if (pos + len > dev->params.size) {
@@ -164,7 +164,7 @@ int at25xxx_read(const at25xxx_t *dev, uint32_t pos, void *data, size_t len)
 
     spi_release(dev->params.spi);
 
-    return 0;
+    return len;
 }
 
 uint8_t at25xxx_read_byte(const at25xxx_t *dev, uint32_t pos)

--- a/drivers/include/at25xxx.h
+++ b/drivers/include/at25xxx.h
@@ -82,7 +82,7 @@ uint8_t at25xxx_read_byte(const at25xxx_t *dev, uint32_t pos);
  * @param[out] data     read buffer
  * @param[in] len       requested length to be read
  *
- * @return    0 on success
+ * @return    Number of bytes read
  * @return    -ERANGE if pos + len > EEPROM size
  */
 int at25xxx_read(const at25xxx_t *dev, uint32_t pos, void *data, size_t len);
@@ -104,7 +104,7 @@ void at25xxx_write_byte(const at25xxx_t *dev, uint32_t pos, uint8_t data);
  * @param[in] data      write buffer
  * @param[in] len       requested length to be written
  *
- * @return    0 on success
+ * @return    Number of bytes written
  * @return    -ERANGE if pos + len > EEPROM size
  */
 int at25xxx_write(const at25xxx_t *dev, uint32_t pos, const void *data, size_t len);

--- a/tests/driver_at25xxx/main.c
+++ b/tests/driver_at25xxx/main.c
@@ -34,12 +34,12 @@ static void test_normal_write(void)
     const char data_in_b[] = "This is a test.";
     char data_out[32];
 
-    TEST_ASSERT_EQUAL_INT(0, at25xxx_write(&dev, 0, data_in_a, sizeof(data_in_a)));
-    TEST_ASSERT_EQUAL_INT(0, at25xxx_read(&dev, 0, data_out, sizeof(data_out)));
+    TEST_ASSERT_EQUAL_INT(sizeof(data_in_a), at25xxx_write(&dev, 0, data_in_a, sizeof(data_in_a)));
+    TEST_ASSERT_EQUAL_INT(sizeof(data_out), at25xxx_read(&dev, 0, data_out, sizeof(data_out)));
     TEST_ASSERT_EQUAL_STRING(data_in_a, data_out);
 
-    TEST_ASSERT_EQUAL_INT(0, at25xxx_write(&dev, 0, data_in_b, sizeof(data_in_b)));
-    TEST_ASSERT_EQUAL_INT(0, at25xxx_read(&dev, 0, data_out, sizeof(data_out)));
+    TEST_ASSERT_EQUAL_INT(sizeof(data_in_b), at25xxx_write(&dev, 0, data_in_b, sizeof(data_in_b)));
+    TEST_ASSERT_EQUAL_INT(sizeof(data_out), at25xxx_read(&dev, 0, data_out, sizeof(data_out)));
     TEST_ASSERT_EQUAL_STRING(data_in_b, data_out);
 }
 
@@ -49,12 +49,16 @@ static void test_page_write(void)
     const char data_in_b[] = "This is a test.";
     char data_out[32];
 
-    TEST_ASSERT_EQUAL_INT(0, at25xxx_write(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_in_a, sizeof(data_in_a)));
-    TEST_ASSERT_EQUAL_INT(0, at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
+    TEST_ASSERT_EQUAL_INT(sizeof(data_in_a),
+                          at25xxx_write(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_in_a, sizeof(data_in_a)));
+    TEST_ASSERT_EQUAL_INT(sizeof(data_out),
+                          at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
     TEST_ASSERT_EQUAL_STRING(data_in_a, data_out);
 
-    TEST_ASSERT_EQUAL_INT(0, at25xxx_write(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_in_b, sizeof(data_in_b)));
-    TEST_ASSERT_EQUAL_INT(0, at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
+    TEST_ASSERT_EQUAL_INT(sizeof(data_in_b),
+                          at25xxx_write(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_in_b, sizeof(data_in_b)));
+    TEST_ASSERT_EQUAL_INT(sizeof(data_out),
+                          at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
     TEST_ASSERT_EQUAL_STRING(data_in_b, data_out);
 }
 
@@ -66,12 +70,15 @@ static void test_page_clear(void)
 
     memset(data_clr, 0, sizeof(data_clr));
 
-    TEST_ASSERT_EQUAL_INT(0, at25xxx_write(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_in_a, sizeof(data_in_a)));
-    TEST_ASSERT_EQUAL_INT(0, at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
+    TEST_ASSERT_EQUAL_INT(sizeof(data_in_a),
+                          at25xxx_write(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_in_a, sizeof(data_in_a)));
+    TEST_ASSERT_EQUAL_INT(sizeof(data_out),
+                          at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
     TEST_ASSERT_EQUAL_STRING(data_in_a, data_out);
 
     TEST_ASSERT_EQUAL_INT(0, at25xxx_clear(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, sizeof(data_out)));
-    TEST_ASSERT_EQUAL_INT(0, at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
+    TEST_ASSERT_EQUAL_INT(sizeof(data_out),
+                          at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(data_out, data_clr, sizeof(data_clr)));
 }
 


### PR DESCRIPTION
# Backport of #13886

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The MTD API expects `read()` to return the number of read bytes and `write()` to return the number of written bytes.
This also matches the behavior of `periph/eeprom.h`.

So change the driver API to match that.

### Testing procedure

`tests/driver_at25xxx` should still work.

```
2020-04-17 11:58:34,252 # AT25XXX EEPROM driver test application
2020-04-17 11:58:34,252 # 
2020-04-17 11:58:34,254 # EEPROM size: 128 kiB
2020-04-17 11:58:34,257 # EEPROM page size: 256 bytes
2020-04-17 11:58:34,259 # EEPROM address length: 24 bits
2020-04-17 11:58:34,259 # 
2020-04-17 11:58:34,302 # ...
2020-04-17 11:58:34,303 # OK (3 tests)
```


### Issues/PRs references

needed for #13877