### PR TITLE
testrunner: use SIGKILL only as last resort

### DIFF
--- a/dist/pythonlibs/testrunner/spawn.py
+++ b/dist/pythonlibs/testrunner/spawn.py
@@ -89,11 +89,19 @@ def setup_child(timeout=10, spawnclass=pexpect.spawnu, env=None, logfile=None):
 
 
 def teardown_child(child):
+    pid = child.pid
     try:
-        os.killpg(os.getpgid(child.pid), signal.SIGKILL)
+        os.killpg(os.getpgid(pid), signal.SIGTERM)
     except ProcessLookupError:
         print("Process already stopped")
-
+    else:
+        time.sleep(1)
+        # kill still lingering processes
+        try:
+            os.killpg(os.getpgid(pid), signal.SIGKILL)
+        except ProcessLookupError:
+            # This is what we actually wanted
+            pass
     child.close()
 
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When the child has a clean-up step (closing files, killing sub-processes, deleting operational files, etc.), this currently is not executed by the test, as the `testrunner` just does a hard `SIGKILL` for the child's PPID. This change makes this a `SIGTERM` and only uses `SIGKILL` if there are still processes lingering around a second after the `SIGTERM` was issued.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Use e.g. `dist/tools/ethos/start_network.sh` where just `dist/tools/ethos/ethos` is used:

```diff
diff --git a/tests/emcute/Makefile b/tests/emcute/Makefile
index bde386ca99..93af8bde72 100644
--- a/tests/emcute/Makefile
+++ b/tests/emcute/Makefile
@@ -11,8 +11,8 @@ else
   ETHOS_BAUDRATE ?= 115200
   CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE)
   TERMDEPS += ethos
-  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/ethos
-  TERMFLAGS ?= $(TAP) $(PORT) $(ETHOS_BAUDRATE)
+  TERMPROG ?= sudo $(RIOTTOOLS)/ethos/start_network.sh
+  TERMFLAGS ?= -e $(PORT) $(TAP) "2001:db8::/64" $(ETHOS_BAUDRATE)
 endif
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_ipv6_default
```

and run the test, e.g.

```sh
BOARD=samr21-xpro make -C tests/emcute/ flash
sudo BOARD=samr21-xpro make -C tests/emcute/ test
```

With this fix, the `tap0` interface created by `start_network.sh` will be deleted, without it, it will not (check with `ip link`). Also check native (which sometimes leaves lingering processes):

```sh
sudo dist/tools/tapsetup/tapsetup
BOARD=native make -C tests/emcute/ flash
sudo BOARD=native make -C tests/emcute/ test
sudo dist/tools/tapsetup/tapsetup -d
```

 No process using the `tap0` interface is still lingering (check e.g. with `ps -ef | grep -e ethos -e "tap0"`).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
