### PR TITLE
nanocoap: export coap_opt_get_uint()

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -447,6 +447,20 @@ static inline void coap_hdr_set_type(coap_hdr_t *hdr, unsigned type)
 unsigned coap_get_content_type(coap_pkt_t *pkt);
 
 /**
+ * @brief   Get a uint32 option value
+ *
+ * @param[in]   pkt         packet to read from
+ * @param[in]   optnum      absolute option number
+ * @param[out]  value       the parsed option value
+ *
+ * @return      0 if the option was found and the value was parsed correctly
+ * @return      -ENOENT if the option was not found in @p pkt
+ * @return      -ENOSPC if option length is greater than 4 octets
+ * @return      -EBADMSG if option value is invalid
+ */
+int coap_opt_get_uint(const coap_pkt_t *pkt, uint16_t optnum, uint32_t *value);
+
+/**
  * @brief   Read a full option as null terminated string into the target buffer
  *
  * This function is for reading and concatenating string based, multi-part CoAP

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -42,7 +42,6 @@
 /** @} */
 
 static int _decode_value(unsigned val, uint8_t **pkt_pos_ptr, uint8_t *pkt_end);
-int coap_get_option_uint(coap_pkt_t *pkt, unsigned opt_num, uint32_t *target);
 static uint32_t _decode_uint(uint8_t *pkt_pos, unsigned nbytes);
 static size_t _encode_uint(uint32_t *val);
 
@@ -135,7 +134,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     }
 
 #ifdef MODULE_GCOAP
-    if (coap_get_option_uint(pkt, COAP_OPT_OBSERVE, &pkt->observe_value) != 0) {
+    if (coap_opt_get_uint(pkt, COAP_OPT_OBSERVE, &pkt->observe_value) != 0) {
         pkt->observe_value = UINT32_MAX;
     }
 #endif
@@ -224,7 +223,7 @@ ssize_t coap_opt_get_opaque(const coap_pkt_t *pkt, unsigned opt_num, uint8_t **v
     return len;
 }
 
-int coap_get_option_uint(coap_pkt_t *pkt, unsigned opt_num, uint32_t *target)
+int coap_opt_get_uint(const coap_pkt_t *pkt, uint16_t opt_num, uint32_t *target)
 {
     assert(target);
 
@@ -246,7 +245,7 @@ int coap_get_option_uint(coap_pkt_t *pkt, unsigned opt_num, uint32_t *target)
             return -EBADMSG;
         }
     }
-    return -1;
+    return -ENOENT;
 }
 
 uint8_t *coap_iterate_option(const coap_pkt_t *pkt, uint8_t **optpos,


### PR DESCRIPTION
### Contribution description
This PR exports the `coap_opt_get_uint()` function (similar to the already existing public `coap_opt_add_uint()` function). Currently, it is a hidden function in `nanocoap.c`.

### Testing procedure
--

### Issues/PRs references
This PR is a cut-out of #13889 since it is unrelated to the actual cache implementation.