### PR TITLE
net/gcoap: add CoAP ping request

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -302,7 +302,7 @@ static size_t _send(uint8_t *buf, size_t len, char *addr_str, char *port_str)
 int gcoap_cli_cmd(int argc, char **argv)
 {
     /* Ordered like the RFC method code numbers, but off by 1. GET is code 0. */
-    char *method_codes[] = {"get", "post", "put"};
+    char *method_codes[] = {"ping", "get", "post", "put"};
     uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE];
     coap_pkt_t pdu;
     size_t len;
@@ -351,7 +351,7 @@ int gcoap_cli_cmd(int argc, char **argv)
         return 1;
     }
 
-    /* if not 'info' and 'proxy', must be a method code */
+    /* if not 'info' and 'proxy', must be a method code or ping */
     int code_pos = -1;
     for (size_t i = 0; i < ARRAY_SIZE(method_codes); i++) {
         if (strcmp(argv[1], method_codes[i]) == 0) {
@@ -363,32 +363,33 @@ int gcoap_cli_cmd(int argc, char **argv)
     }
 
     /* parse options */
-    int apos          = 2;               /* position of address argument */
-    unsigned msg_type = COAP_TYPE_NON;
+    int apos = 2;       /* position of address argument */
+    /* ping must be confirmable */
+    unsigned msg_type = (!code_pos ? COAP_TYPE_CON : COAP_TYPE_NON);
     if (argc > apos && strcmp(argv[apos], "-c") == 0) {
         msg_type = COAP_TYPE_CON;
         apos++;
     }
 
-    /*
-     * "get" (code_pos 0) must have exactly apos + 3 arguments
-     * while "post" (code_pos 1) and "put" (code_pos 2) and must have exactly
-     * apos + 4 arguments
-     */
-    if (((argc == apos + 3) && (code_pos == 0)) ||
-        ((argc == apos + 4) && (code_pos != 0))) {
+    if (((argc == apos + 2) && (code_pos == 0)) ||    /* ping */
+        ((argc == apos + 3) && (code_pos == 1)) ||    /* get */
+        ((argc == apos + 4) && (code_pos > 1))) {     /* post or put */
 
-        char *uri = argv[apos+2];
-        int uri_len = strlen(argv[apos+2]);
+        char *uri = NULL;
+        int uri_len = 0;
+        if (code_pos) {
+            uri = argv[apos+2];
+            uri_len = strlen(argv[apos+2]);
+        }
 
         if (_proxied) {
             uri_len = snprintf(proxy_uri, 64, "coap://[%s]:%s%s", argv[apos], argv[apos+1], uri);
             uri = proxy_uri;
 
-            gcoap_req_init(&pdu, &buf[0], CONFIG_GCOAP_PDU_BUF_SIZE, code_pos+1, NULL);
+            gcoap_req_init(&pdu, &buf[0], CONFIG_GCOAP_PDU_BUF_SIZE, code_pos, NULL);
         }
         else{
-            gcoap_req_init(&pdu, &buf[0], CONFIG_GCOAP_PDU_BUF_SIZE, code_pos+1, uri);
+            gcoap_req_init(&pdu, &buf[0], CONFIG_GCOAP_PDU_BUF_SIZE, code_pos, uri);
         }
         coap_hdr_set_type(pdu.hdr, msg_type);
 
@@ -450,13 +451,14 @@ int gcoap_cli_cmd(int argc, char **argv)
     else {
         printf("usage: %s <get|post|put> [-c] <addr>[%%iface] <port> <path> [data]\n",
                argv[0]);
+        printf("       %s ping <addr>[%%iface] <port>\n", argv[0]);
         printf("Options\n");
         printf("    -c  Send confirmably (defaults to non-confirmable)\n");
         return 1;
     }
 
     end:
-    printf("usage: %s <get|post|put|proxy|info>\n", argv[0]);
+    printf("usage: %s <get|post|put|ping|proxy|info>\n", argv[0]);
     return 1;
 }
 

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -734,10 +734,14 @@ void gcoap_register_listener(gcoap_listener_t *listener);
 /**
  * @brief   Initializes a CoAP request PDU on a buffer.
  *
+ * If @p code is COAP_CODE_EMPTY, prepares a complete "CoAP ping" 4 byte empty
+ * message request, ready to send.
+ *
  * @param[out] pdu      Request metadata
  * @param[out] buf      Buffer containing the PDU
  * @param[in] len       Length of the buffer
- * @param[in] code      Request code, one of COAP_METHOD_XXX
+ * @param[in] code      Request code, one of COAP_METHOD_XXX or COAP_CODE_EMPTY
+ *                      to ping
  * @param[in] path      Resource path, may be NULL
  *
  * @pre @p path must start with `/` if not NULL

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -70,6 +70,15 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     pkt->payload = NULL;
     pkt->payload_len = 0;
 
+    if (len < sizeof(coap_hdr_t)) {
+        DEBUG("msg too short\n");
+        return -EBADMSG;
+    }
+    else if ((coap_get_code_raw(pkt) == 0) && (len > sizeof(coap_hdr_t))) {
+        DEBUG("empty msg too long\n");
+        return -EBADMSG;
+    }
+
     /* token value (tkl bytes) */
     if (coap_get_token_len(pkt)) {
         pkt->token = pkt_pos;

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -204,6 +204,28 @@ static void test_gcoap__client_get_path_defer(void)
 }
 
 /*
+ * Validate client CoAP ping empty message request.
+ */
+static void test_gcoap__client_ping(void)
+{
+    uint8_t buf[CONFIG_GCOAP_PDU_BUF_SIZE];
+    coap_pkt_t pdu;
+    int res;
+
+    res = gcoap_req_init(&pdu, buf, CONFIG_GCOAP_PDU_BUF_SIZE, COAP_CODE_EMPTY,
+                         NULL);
+
+    TEST_ASSERT_EQUAL_INT(0, res);
+    TEST_ASSERT_EQUAL_INT(COAP_CODE_EMPTY, coap_get_code(&pdu));
+    TEST_ASSERT_EQUAL_INT(COAP_TYPE_CON, coap_get_type(&pdu));
+    TEST_ASSERT_EQUAL_INT(0, coap_get_token_len(&pdu));
+
+    /* confirm length */
+    res = coap_opt_finish(&pdu, COAP_OPT_FINISH_NONE);
+    TEST_ASSERT_EQUAL_INT(4, res);
+}
+
+/*
  * Helper for server_get tests below.
  * Request from libcoap example for gcoap_cli /cli/stats resource
  * Include 2-byte token and Uri-Host option.
@@ -371,6 +393,7 @@ Test *tests_gcoap_tests(void)
         new_TestFixture(test_gcoap__client_put_req),
         new_TestFixture(test_gcoap__client_put_req_overfill),
         new_TestFixture(test_gcoap__client_get_path_defer),
+        new_TestFixture(test_gcoap__client_ping),
         new_TestFixture(test_gcoap__server_get_req),
         new_TestFixture(test_gcoap__server_get_resp),
         new_TestFixture(test_gcoap__server_con_req),


### PR DESCRIPTION
### Contribution description
Presently gcoap supports use of a piggybacked ACK response to a confirmable request. However, #13637 illustrated the need to support separate confirmable responses, as also identified in the tracking issue #7192. A prerequisite for this support is the ability to handle empty messages, which is the format for the immediate ACK response. This PR takes the first step toward empty message support by addition of handling for CoAP ping requests.

Specifically, this PR allows creation of a ping request (empty CON with code 0.00) and generation of a reset response (empty RST also with code 0.00). This PR does _not_ include handling for the reset response because that requires empty message support for request/response correlation, which will follow in a separate PR.

| Commit | Description |
| ---------- | --------------- |
| 2d3eb1a | Validate empty message length in nanocoap, including unit test |
| f5a85e2 | Add handling for a ping request in gcoap. Update debug msg if receive an empty ACK or RST. |
| 6eae4de | Extend `gcoap_req_init()` to generate ping request if code is 0.00, including unit test |
| c267633 | Add 'coap ping' sub-command to gcoap example |

### Testing procedure

- Run nanocoap and gcoap unit tests
- Set up two native terminals or boards with gcoap example. Turn on debug in gcoap.c or use Wireshark to watch exchange. Use CLI 'coap ping' command to send a ping request. Notice receiver responds with reset message, but sender doesn't recognize it. Sender times out after the expected retries.
- Also verify regular request/response handling still works with this setup.
- Review doc for `gcoap_req_init()`

### Issues/PRs references
See above.