### PR TITLE
cpu/esp32: fix GPIO32 and GPIO 33 as I2C pins

### DIFF
--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -228,6 +228,7 @@ static void IRAM system_clk_init (void)
     rtc_select_slow_clk(RTC_SLOW_FREQ_32K_XTAL);
 #else
     /* set SLOW_CLK to internal low power clock of 150 kHz */
+    rtc_clk_32k_enable(false);
     rtc_select_slow_clk(RTC_SLOW_FREQ_RTC);
 #endif
 

--- a/cpu/esp_common/periph/i2c_sw.c
+++ b/cpu/esp_common/periph/i2c_sw.c
@@ -54,8 +54,8 @@
 #define I2C_CLOCK_STRETCH 200
 
 /* gpio access macros */
-#define GPIO_SET(l,h,b) if (b < 32) GPIO.l =  BIT(b); else GPIO.h.val =  BIT(32-b)
-#define GPIO_GET(l,h,b) ((b < 32) ? GPIO.l & BIT(b) : GPIO.h.val & BIT(32-b))
+#define GPIO_SET(l,h,b) if (b < 32) GPIO.l =  BIT(b); else GPIO.h.val =  BIT(b-32)
+#define GPIO_GET(l,h,b) ((b < 32) ? GPIO.l & BIT(b) : GPIO.h.val & BIT(b-32))
 
 #else /* MCU_ESP32 */
 


### PR DESCRIPTION
### Contribution description

This PR fixes the problem that GPIO32 and GPIO33 can't be used as I2C pins.

GPIO32 and GPIO33 are RTC GPIOs that have a special function and are intended to be used to connect an external 32.768 kHz as RTC clock. The are also used as bootstraping pins to start the 32.768 kHz XTAL if it is connected to these GPIOs.

If the 32.768 kHz XTAL is not connected, these pins can be used digital IO. However, the 32.678 kHz XTAL has to be disabled explicitly in this case.

Furthermore, the handling of GPIOs greater than GPIO31 had to be fixed in I2C software implementation.

### Testing procedure

Flash `tests/periph_i2c` to any ESP32 board without 32.678 kHz XTAL, for example:
```
CFLAGS='-DI2C0_SCL=GPIO33 -DI2C0_SDA=GPIO32' \
make BOARD=esp32-wroom-32 -C tests/periph_i2c PORT=/dev/ttyUSB2 flash term
```
Use commands 
```
i2c_acquire 0
i2c_write_byte 0 33 34 0
```
and observe the signals at GPIO32 and GPIO33 with a logic analyzer.

### Issues/PRs references
