### PR TITLE
mtd: Change API to return 0 on success

### DIFF
--- a/cpu/esp_common/periph/flash.c
+++ b/cpu/esp_common/periph/flash.c
@@ -508,7 +508,7 @@ static int _flash_read  (mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t siz
     /* size must be within the flash address space */
     CHECK_PARAM_RET (_flash_beg + addr + size <= _flash_end, -EOVERFLOW);
 
-    return (spi_flash_read(_flash_beg + addr, buff, size) == ESP_OK) ? (int)size : -EIO;
+    return (spi_flash_read(_flash_beg + addr, buff, size) == ESP_OK) ? 0 : -EIO;
 }
 
 static int _flash_write (mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
@@ -525,7 +525,7 @@ static int _flash_write (mtd_dev_t *dev, const void *buff, uint32_t addr, uint32
     CHECK_PARAM_RET (size <= _flashchip->page_size, -EOVERFLOW);
     CHECK_PARAM_RET ((addr % _flashchip->page_size) + size <= _flashchip->page_size, -EOVERFLOW);
 
-    return (spi_flash_write(_flash_beg + addr, buff, size) == ESP_OK) ? (int)size : -EIO;
+    return (spi_flash_write(_flash_beg + addr, buff, size) == ESP_OK) ? 0 : -EIO;
 }
 
 static int _flash_erase (mtd_dev_t *dev, uint32_t addr, uint32_t size)

--- a/cpu/native/mtd/mtd_native.c
+++ b/cpu/native/mtd/mtd_native.c
@@ -69,10 +69,10 @@ static int _read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
         return -EIO;
     }
     real_fseek(f, addr, SEEK_SET);
-    size = real_fread(buff, 1, size, f);
+    size_t nread = real_fread(buff, 1, size, f);
     real_fclose(f);
 
-    return size;
+    return (nread == size) ? 0 : -EIO;
 }
 
 static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
@@ -101,7 +101,7 @@ static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size
     }
     real_fclose(f);
 
-    return size;
+    return 0;
 }
 
 static int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)

--- a/drivers/at25xxx/at25xxx.c
+++ b/drivers/at25xxx/at25xxx.c
@@ -113,7 +113,7 @@ static ssize_t _write_page(const at25xxx_t *dev, uint32_t pos, const void *data,
 
 int at25xxx_write(const at25xxx_t *dev, uint32_t pos, const void *data, size_t len)
 {
-    int res = len;
+    int res = 0;
     const uint8_t *d = data;
 
     if (pos + len > dev->params.size) {
@@ -164,7 +164,7 @@ int at25xxx_read(const at25xxx_t *dev, uint32_t pos, void *data, size_t len)
 
     spi_release(dev->params.spi);
 
-    return len;
+    return 0;
 }
 
 uint8_t at25xxx_read_byte(const at25xxx_t *dev, uint32_t pos)

--- a/drivers/include/at25xxx.h
+++ b/drivers/include/at25xxx.h
@@ -82,7 +82,7 @@ uint8_t at25xxx_read_byte(const at25xxx_t *dev, uint32_t pos);
  * @param[out] data     read buffer
  * @param[in] len       requested length to be read
  *
- * @return    Number of bytes read
+ * @return    0 on success
  * @return    -ERANGE if pos + len > EEPROM size
  */
 int at25xxx_read(const at25xxx_t *dev, uint32_t pos, void *data, size_t len);
@@ -104,7 +104,7 @@ void at25xxx_write_byte(const at25xxx_t *dev, uint32_t pos, uint8_t data);
  * @param[in] data      write buffer
  * @param[in] len       requested length to be written
  *
- * @return    Number of bytes written
+ * @return    0 on success
  * @return    -ERANGE if pos + len > EEPROM size
  */
 int at25xxx_write(const at25xxx_t *dev, uint32_t pos, const void *data, size_t len);

--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -93,7 +93,7 @@ struct mtd_desc {
      * @param[in]  addr     Starting address
      * @param[in]  size     Number of bytes
      *
-     * @return the number of bytes actually read
+     * @return 0 on success
      * @return < 0 value on error
      */
     int (*read)(mtd_dev_t *dev,
@@ -112,7 +112,7 @@ struct mtd_desc {
      * @param[in] addr      Starting address
      * @param[in] size      Number of bytes
      *
-     * @return the number of bytes actually written
+     * @return 0 on success
      * @return < 0 value on error
      */
     int (*write)(mtd_dev_t *dev,
@@ -167,7 +167,7 @@ int mtd_init(mtd_dev_t *mtd);
  * @param[in]  addr  the start address to read from
  * @param[in]  count the number of bytes to read
  *
- * @return the number of byte actually read
+ * @return 0 on success
  * @return < 0 if an error occurred
  * @return -ENODEV if @p mtd is not a valid device
  * @return -ENOTSUP if operation is not supported on @p mtd
@@ -188,7 +188,7 @@ int mtd_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t count);
  * @param[in]  addr  the start address to write to
  * @param[in]  count the number of bytes to write
  *
- * @return the number of byte actually written
+ * @return 0 on success
  * @return < 0 if an error occurred
  * @return -ENODEV if @p mtd is not a valid device
  * @return -ENOTSUP if operation is not supported on @p mtd

--- a/drivers/mtd/mtd-vfs.c
+++ b/drivers/mtd/mtd-vfs.c
@@ -100,12 +100,12 @@ static ssize_t mtd_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes)
         nbytes = size - src;
     }
     int res = mtd_read(mtd, dest, src, nbytes);
-    if (res < 0) {
-        return res;
+    if (res != 0) {
+        return -EIO;
     }
     /* Advance file position */
-    filp->pos += res;
-    return res;
+    filp->pos += nbytes;
+    return nbytes;
 }
 
 static ssize_t mtd_vfs_write(vfs_file_t *filp, const void *src, size_t nbytes)
@@ -124,12 +124,12 @@ static ssize_t mtd_vfs_write(vfs_file_t *filp, const void *src, size_t nbytes)
         nbytes = size - dest;
     }
     int res = mtd_write(mtd, src, dest, nbytes);
-    if (res < 0) {
-        return res;
+    if (res != 0) {
+        return -EIO;
     }
     /* Advance file position */
-    filp->pos += res;
-    return res;
+    filp->pos += nbytes;
+    return nbytes;
 }
 
 /** @} */

--- a/drivers/mtd_flashpage/mtd_flashpage.c
+++ b/drivers/mtd_flashpage/mtd_flashpage.c
@@ -54,7 +54,7 @@ static int _read(mtd_dev_t *dev, void *buf, uint32_t addr, uint32_t size)
 
     memcpy(buf, (void *)dst_addr, size);
 
-    return size;
+    return 0;
 }
 
 static int _write(mtd_dev_t *dev, const void *buf, uint32_t addr, uint32_t size)
@@ -82,7 +82,7 @@ static int _write(mtd_dev_t *dev, const void *buf, uint32_t addr, uint32_t size)
 
     flashpage_write_raw((void *)dst_addr, buf, size);
 
-    return size;
+    return 0;
 }
 
 int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)

--- a/drivers/mtd_sdcard/mtd_sdcard.c
+++ b/drivers/mtd_sdcard/mtd_sdcard.c
@@ -69,12 +69,12 @@ static int mtd_sdcard_read(mtd_dev_t *dev, void *buff, uint32_t addr,
     DEBUG("mtd_sdcard_read: addr:%" PRIu32 " size:%" PRIu32 "\n", addr, size);
     mtd_sdcard_t *mtd_sd = (mtd_sdcard_t*)dev;
     sd_rw_response_t err;
-    int res = sdcard_spi_read_blocks(mtd_sd->sd_card, addr / SD_HC_BLOCK_SIZE,
-                                     buff, SD_HC_BLOCK_SIZE,
-                                     size / SD_HC_BLOCK_SIZE, &err);
+    sdcard_spi_read_blocks(mtd_sd->sd_card, addr / SD_HC_BLOCK_SIZE,
+                           buff, SD_HC_BLOCK_SIZE,
+                           size / SD_HC_BLOCK_SIZE, &err);
 
     if (err == SD_RW_OK) {
-        return res * SD_HC_BLOCK_SIZE;
+        return 0;
     }
     return -EIO;
 }
@@ -85,12 +85,12 @@ static int mtd_sdcard_write(mtd_dev_t *dev, const void *buff, uint32_t addr,
     DEBUG("mtd_sdcard_write: addr:%" PRIu32 " size:%" PRIu32 "\n", addr, size);
     mtd_sdcard_t *mtd_sd = (mtd_sdcard_t*)dev;
     sd_rw_response_t err;
-    int res = sdcard_spi_write_blocks(mtd_sd->sd_card, addr / SD_HC_BLOCK_SIZE,
-                                      buff, SD_HC_BLOCK_SIZE,
-                                      size / SD_HC_BLOCK_SIZE, &err);
+    sdcard_spi_write_blocks(mtd_sd->sd_card, addr / SD_HC_BLOCK_SIZE,
+                            buff, SD_HC_BLOCK_SIZE,
+                            size / SD_HC_BLOCK_SIZE, &err);
 
     if (err == SD_RW_OK) {
-        return res * SD_HC_BLOCK_SIZE;
+        return 0;
     }
     return -EIO;
 }

--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -432,7 +432,7 @@ static int mtd_spi_nor_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t 
     mtd_spi_cmd_addr_read(dev, dev->params->opcode->read, addr_be, dest, size);
     mtd_spi_release(dev);
 
-    return size;
+    return 0;
 }
 
 static int mtd_spi_nor_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t size)
@@ -470,7 +470,7 @@ static int mtd_spi_nor_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uin
     wait_for_write_complete(dev, 0);
 
     mtd_spi_release(dev);
-    return size;
+    return 0;
 }
 
 static int mtd_spi_nor_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size)

--- a/pkg/fatfs/fatfs_diskio/mtd/mtd_diskio.c
+++ b/pkg/fatfs/fatfs_diskio/mtd/mtd_diskio.c
@@ -95,16 +95,16 @@ DRESULT disk_read(BYTE pdrv, BYTE *buff, DWORD sector, UINT count)
         return RES_PARERR;
     }
 
+    uint32_t nread = count * fatfs_mtd_devs[pdrv]->page_size;
     int res = mtd_read(fatfs_mtd_devs[pdrv], buff,
                        sector * fatfs_mtd_devs[pdrv]->page_size,
-                       count * fatfs_mtd_devs[pdrv]->page_size);
+                       nread);
 
-    if (res >= 0) {
-        uint32_t r_sect = ((unsigned)res) / fatfs_mtd_devs[pdrv]->page_size;
-        return ((r_sect == count) ? RES_OK : RES_ERROR);
+    if (res != 0) {
+        return RES_ERROR;
     }
-
-    return RES_ERROR;
+    assert((nread / fatfs_mtd_devs[pdrv]->page_size) == count);
+    return RES_OK;
 }
 
 /**
@@ -135,16 +135,16 @@ DRESULT disk_write(BYTE pdrv, const BYTE *buff, DWORD sector, UINT count)
         return RES_ERROR; /* erase failed! */
     }
 
+    uint32_t nwrite = count * fatfs_mtd_devs[pdrv]->page_size;
     res = mtd_write(fatfs_mtd_devs[pdrv], buff,
                     sector * fatfs_mtd_devs[pdrv]->page_size,
-                    count * fatfs_mtd_devs[pdrv]->page_size);
+                    nwrite);
 
-    if (res >= 0) {
-        uint32_t w_sect = ((unsigned)res) / fatfs_mtd_devs[pdrv]->page_size;
-        return ((w_sect == count) ? RES_OK : RES_ERROR);
+    if (res != 0) {
+        return RES_ERROR;
     }
-
-    return RES_ERROR;
+    assert((nwrite / fatfs_mtd_devs[pdrv]->page_size) == count);
+    return RES_OK;
 }
 
 /**

--- a/pkg/littlefs/fs/littlefs_fs.c
+++ b/pkg/littlefs/fs/littlefs_fs.c
@@ -72,12 +72,7 @@ static int _dev_read(const struct lfs_config *c, lfs_block_t block,
     DEBUG("lfs_read: c=%p, block=%" PRIu32 ", off=%" PRIu32 ", buf=%p, size=%" PRIu32 "\n",
           (void *)c, block, off, buffer, size);
 
-    int ret = mtd_read(mtd, buffer, ((fs->base_addr + block) * c->block_size) + off, size);
-    if (ret >= 0) {
-        return 0;
-    }
-
-    return ret;
+    return mtd_read(mtd, buffer, ((fs->base_addr + block) * c->block_size) + off, size);
 }
 
 static int _dev_write(const struct lfs_config *c, lfs_block_t block,
@@ -94,11 +89,8 @@ static int _dev_write(const struct lfs_config *c, lfs_block_t block,
     for (const uint8_t *part = buf; part < buf + size; part += c->prog_size,
          addr += c->prog_size) {
         int ret = mtd_write(mtd, part, addr, c->prog_size);
-        if (ret < 0) {
+        if (ret != 0) {
             return ret;
-        }
-        else if ((unsigned)ret != c->prog_size) {
-            return -EIO;
         }
     }
 

--- a/pkg/littlefs2/fs/littlefs2_fs.c
+++ b/pkg/littlefs2/fs/littlefs2_fs.c
@@ -72,12 +72,7 @@ static int _dev_read(const struct lfs_config *c, lfs_block_t block,
     DEBUG("lfs_read: c=%p, block=%" PRIu32 ", off=%" PRIu32 ", buf=%p, size=%" PRIu32 "\n",
           (void *)c, block, off, buffer, size);
 
-    int ret = mtd_read(mtd, buffer, ((fs->base_addr + block) * c->block_size) + off, size);
-    if (ret >= 0) {
-        return 0;
-    }
-
-    return ret;
+    return mtd_read(mtd, buffer, ((fs->base_addr + block) * c->block_size) + off, size);
 }
 
 static int _dev_write(const struct lfs_config *c, lfs_block_t block,
@@ -94,11 +89,8 @@ static int _dev_write(const struct lfs_config *c, lfs_block_t block,
     for (const uint8_t *part = buf; part < buf + size; part += c->prog_size,
          addr += c->prog_size) {
         int ret = mtd_write(mtd, part, addr, c->prog_size);
-        if (ret < 0) {
+        if (ret != 0) {
             return ret;
-        }
-        else if ((unsigned)ret != c->prog_size) {
-            return -EIO;
         }
     }
 

--- a/pkg/spiffs/fs/spiffs_fs.c
+++ b/pkg/spiffs/fs/spiffs_fs.c
@@ -39,12 +39,7 @@ static int32_t _dev_read(struct spiffs_t *fs, u32_t addr, u32_t size, u8_t *dst)
 
     DEBUG("spiffs: read: from addr 0x%" PRIx32 " size 0x%" PRIx32 "\n", addr, size);
 
-    if (mtd_read(dev, dst, addr, size) > 0) {
-        return 0;
-    }
-    else {
-        return -EIO;
-    }
+    return mtd_read(dev, dst, addr, size);
 }
 
 static int32_t _dev_write(struct spiffs_t *fs, u32_t addr, u32_t size, const u8_t *src)
@@ -53,12 +48,7 @@ static int32_t _dev_write(struct spiffs_t *fs, u32_t addr, u32_t size, const u8_
 
     DEBUG("spiffs: write: from addr 0x%" PRIx32 " size 0x%" PRIx32 "\n", addr, size);
 
-    if (mtd_write(dev, src, addr, size) > 0) {
-        return 0;
-    }
-    else {
-        return -EIO;
-    }
+    return mtd_write(dev, src, addr, size);
 }
 
 static int32_t _dev_erase(struct spiffs_t *fs, u32_t addr, u32_t size)
@@ -77,24 +67,14 @@ static int32_t _dev_read(u32_t addr, u32_t size, u8_t *dst)
 {
     DEBUG("spiffs: read: from addr 0x%" PRIx32 " size 0x%" PRIx32 "\n", addr, size);
 
-    if (mtd_read(SPIFFS_MTD_DEV, dst, addr, size) > 0) {
-        return 0;
-    }
-    else {
-        return -EIO;
-    }
+    return mtd_read(SPIFFS_MTD_DEV, dst, addr, size);
 }
 
 static int32_t _dev_write(u32_t addr, u32_t size, const u8_t *src)
 {
     DEBUG("spiffs: write: from addr 0x%" PRIx32 " size 0x%" PRIx32 "\n", addr, size);
 
-    if (mtd_write(SPIFFS_MTD_DEV, src, addr, size) > 0) {
-        return 0;
-    }
-    else {
-        return -EIO;
-    }
+    return mtd_write(SPIFFS_MTD_DEV, src, addr, size);
 }
 
 static int32_t _dev_erase(u32_t addr, u32_t size)

--- a/tests/driver_at25xxx/main.c
+++ b/tests/driver_at25xxx/main.c
@@ -34,12 +34,12 @@ static void test_normal_write(void)
     const char data_in_b[] = "This is a test.";
     char data_out[32];
 
-    TEST_ASSERT_EQUAL_INT(sizeof(data_in_a), at25xxx_write(&dev, 0, data_in_a, sizeof(data_in_a)));
-    TEST_ASSERT_EQUAL_INT(sizeof(data_out), at25xxx_read(&dev, 0, data_out, sizeof(data_out)));
+    TEST_ASSERT_EQUAL_INT(0, at25xxx_write(&dev, 0, data_in_a, sizeof(data_in_a)));
+    TEST_ASSERT_EQUAL_INT(0, at25xxx_read(&dev, 0, data_out, sizeof(data_out)));
     TEST_ASSERT_EQUAL_STRING(data_in_a, data_out);
 
-    TEST_ASSERT_EQUAL_INT(sizeof(data_in_b), at25xxx_write(&dev, 0, data_in_b, sizeof(data_in_b)));
-    TEST_ASSERT_EQUAL_INT(sizeof(data_out), at25xxx_read(&dev, 0, data_out, sizeof(data_out)));
+    TEST_ASSERT_EQUAL_INT(0, at25xxx_write(&dev, 0, data_in_b, sizeof(data_in_b)));
+    TEST_ASSERT_EQUAL_INT(0, at25xxx_read(&dev, 0, data_out, sizeof(data_out)));
     TEST_ASSERT_EQUAL_STRING(data_in_b, data_out);
 }
 
@@ -49,16 +49,12 @@ static void test_page_write(void)
     const char data_in_b[] = "This is a test.";
     char data_out[32];
 
-    TEST_ASSERT_EQUAL_INT(sizeof(data_in_a),
-                          at25xxx_write(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_in_a, sizeof(data_in_a)));
-    TEST_ASSERT_EQUAL_INT(sizeof(data_out),
-                          at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
+    TEST_ASSERT_EQUAL_INT(0, at25xxx_write(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_in_a, sizeof(data_in_a)));
+    TEST_ASSERT_EQUAL_INT(0, at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
     TEST_ASSERT_EQUAL_STRING(data_in_a, data_out);
 
-    TEST_ASSERT_EQUAL_INT(sizeof(data_in_b),
-                          at25xxx_write(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_in_b, sizeof(data_in_b)));
-    TEST_ASSERT_EQUAL_INT(sizeof(data_out),
-                          at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
+    TEST_ASSERT_EQUAL_INT(0, at25xxx_write(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_in_b, sizeof(data_in_b)));
+    TEST_ASSERT_EQUAL_INT(0, at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
     TEST_ASSERT_EQUAL_STRING(data_in_b, data_out);
 }
 
@@ -70,15 +66,12 @@ static void test_page_clear(void)
 
     memset(data_clr, 0, sizeof(data_clr));
 
-    TEST_ASSERT_EQUAL_INT(sizeof(data_in_a),
-                          at25xxx_write(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_in_a, sizeof(data_in_a)));
-    TEST_ASSERT_EQUAL_INT(sizeof(data_out),
-                          at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
+    TEST_ASSERT_EQUAL_INT(0, at25xxx_write(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_in_a, sizeof(data_in_a)));
+    TEST_ASSERT_EQUAL_INT(0, at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
     TEST_ASSERT_EQUAL_STRING(data_in_a, data_out);
 
     TEST_ASSERT_EQUAL_INT(0, at25xxx_clear(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, sizeof(data_out)));
-    TEST_ASSERT_EQUAL_INT(sizeof(data_out),
-                          at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
+    TEST_ASSERT_EQUAL_INT(0, at25xxx_read(&dev, AT25XXX_PARAM_PAGE_SIZE - 5, data_out, sizeof(data_out)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(data_out, data_clr, sizeof(data_clr)));
 }
 

--- a/tests/mtd_at25xxx/main.c
+++ b/tests/mtd_at25xxx/main.c
@@ -68,7 +68,7 @@ static void test_mtd_write_erase(void)
     memset(buf_read, 0, sizeof(buf_read));
 
     int ret = mtd_write(dev, buf, TEST_ADDRESS, sizeof(buf));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
 
     ret = mtd_erase(dev, TEST_ADDRESS, dev->pages_per_sector * dev->page_size);
     TEST_ASSERT_EQUAL_INT(0, ret);
@@ -76,7 +76,7 @@ static void test_mtd_write_erase(void)
     uint8_t expected[sizeof(buf_read)];
     memset(expected, 0, sizeof(expected));
     ret = mtd_read(dev, buf_read, TEST_ADDRESS, sizeof(buf_read));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf_read), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
     TEST_ASSERT_EQUAL_INT(0, memcmp(expected, buf_read, sizeof(buf_read)));
 }
 
@@ -90,10 +90,10 @@ static void test_mtd_write_read(void)
 
     /* Basic write / read */
     int ret = mtd_write(dev, buf, TEST_ADDRESS, sizeof(buf));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
 
     ret = mtd_read(dev, buf_read, TEST_ADDRESS, sizeof(buf_read));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf_read), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
     TEST_ASSERT_EQUAL_INT(0, memcmp(buf, buf_read, sizeof(buf)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(buf_empty, buf_read + sizeof(buf), sizeof(buf_empty)));
 

--- a/tests/mtd_flashpage/main.c
+++ b/tests/mtd_flashpage/main.c
@@ -98,7 +98,7 @@ static void test_mtd_write_erase(void)
     memset(buf_read, 0, sizeof(buf_read));
 
     int ret = mtd_write(dev, buf, TEST_ADDRESS1, sizeof(buf));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
 
     ret = mtd_erase(dev, TEST_ADDRESS1, dev->pages_per_sector * dev->page_size);
     TEST_ASSERT_EQUAL_INT(0, ret);
@@ -110,7 +110,7 @@ static void test_mtd_write_erase(void)
     memset(expected, 0xff, sizeof(expected));
 #endif
     ret = mtd_read(dev, buf_read, TEST_ADDRESS1, sizeof(buf_read));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf_read), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
     TEST_ASSERT_EQUAL_INT(0, memcmp(expected, buf_read, sizeof(buf_read)));
 }
 
@@ -129,10 +129,10 @@ static void test_mtd_write_read(void)
 
     /* Basic write / read */
     int ret = mtd_write(dev, buf, TEST_ADDRESS1, sizeof(buf));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
 
     ret = mtd_read(dev, buf_read, TEST_ADDRESS1, sizeof(buf_read));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf_read), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
     TEST_ASSERT_EQUAL_INT(0, memcmp(buf, buf_read, sizeof(buf)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(buf_empty, buf_read + sizeof(buf), sizeof(buf_empty)));
 

--- a/tests/mtd_mapper/main.c
+++ b/tests/mtd_mapper/main.c
@@ -62,7 +62,7 @@ static int _read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
     }
     memcpy(buff, _dummy_memory + addr, size);
 
-    return size;
+    return 0;
 }
 
 static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr,
@@ -78,7 +78,7 @@ static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr,
     }
     memcpy(_dummy_memory + addr, buff, size);
 
-    return size;
+    return 0;
 }
 
 static int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)

--- a/tests/pkg_littlefs/main.c
+++ b/tests/pkg_littlefs/main.c
@@ -56,7 +56,7 @@ static int _read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
     }
     memcpy(buff, dummy_memory + addr, size);
 
-    return size;
+    return 0;
 }
 
 static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
@@ -71,7 +71,7 @@ static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size
     }
     memcpy(dummy_memory + addr, buff, size);
 
-    return size;
+    return 0;
 }
 
 static int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)

--- a/tests/pkg_littlefs2/main.c
+++ b/tests/pkg_littlefs2/main.c
@@ -56,7 +56,7 @@ static int _read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
     }
     memcpy(buff, dummy_memory + addr, size);
 
-    return size;
+    return 0;
 }
 
 static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
@@ -71,7 +71,7 @@ static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size
     }
     memcpy(dummy_memory + addr, buff, size);
 
-    return size;
+    return 0;
 }
 
 static int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)

--- a/tests/pkg_spiffs/main.c
+++ b/tests/pkg_spiffs/main.c
@@ -54,7 +54,7 @@ static int _read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
     }
     memcpy(buff, dummy_memory + addr, size);
 
-    return size;
+    return 0;
 }
 
 static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
@@ -69,7 +69,7 @@ static int _write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size
     }
     memcpy(dummy_memory + addr, buff, size);
 
-    return size;
+    return 0;
 }
 
 static int _erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
@@ -400,34 +400,34 @@ static void tests_spiffs_partition(void)
     /* if SPIFFS_USE_MAGIC is used, a magic word is written in each sector */
     uint8_t buf[4];
     const uint8_t buf_erased[4] = {0xff, 0xff, 0xff, 0xff};
-    int nread;
+    int ret;
     res = 0;
     for (size_t i = 0; i < _dev->page_size * _dev->pages_per_sector; i += sizeof(buf)) {
-        nread = mtd_read(_dev, buf, _dev->page_size * _dev->pages_per_sector + i, sizeof(buf));
-        TEST_ASSERT_EQUAL_INT(sizeof(buf), nread);
+        ret = mtd_read(_dev, buf, _dev->page_size * _dev->pages_per_sector + i, sizeof(buf));
+        TEST_ASSERT_EQUAL_INT(0, ret);
         res |= memcmp(buf, buf_erased, sizeof(buf));
     }
     TEST_ASSERT(res != 0);
     res = 0;
     for (size_t i = 0; i < _dev->page_size * _dev->pages_per_sector; i += sizeof(buf)) {
-        nread = mtd_read(_dev, buf, (2 * _dev->page_size * _dev->pages_per_sector) + i, sizeof(buf));
-        TEST_ASSERT_EQUAL_INT(sizeof(buf), nread);
+        ret = mtd_read(_dev, buf, (2 * _dev->page_size * _dev->pages_per_sector) + i, sizeof(buf));
+        TEST_ASSERT_EQUAL_INT(0, ret);
         res |= memcmp(buf, buf_erased, sizeof(buf));
     }
     TEST_ASSERT(res != 0);
     /* Check previous sector (must be erased) */
     res = 0;
     for (size_t i = 0; i < _dev->page_size * _dev->pages_per_sector; i += sizeof(buf)) {
-        nread = mtd_read(_dev, buf, i, sizeof(buf));
-        TEST_ASSERT_EQUAL_INT(sizeof(buf), nread);
+        ret = mtd_read(_dev, buf, i, sizeof(buf));
+        TEST_ASSERT_EQUAL_INT(0, ret);
         res |= memcmp(buf, buf_erased, sizeof(buf));
     }
     TEST_ASSERT(res == 0);
     /* Check next sector (must be erased) */
     res = 0;
     for (size_t i = 0; i < _dev->page_size * _dev->pages_per_sector; i += sizeof(buf)) {
-        nread = mtd_read(_dev, buf, (3 * _dev->page_size * _dev->pages_per_sector) + i, sizeof(buf));
-        TEST_ASSERT_EQUAL_INT(sizeof(buf), nread);
+        ret = mtd_read(_dev, buf, (3 * _dev->page_size * _dev->pages_per_sector) + i, sizeof(buf));
+        TEST_ASSERT_EQUAL_INT(0, ret);
         res |= memcmp(buf, buf_erased, sizeof(buf));
     }
     TEST_ASSERT(res == 0);

--- a/tests/unittests/tests-mtd/tests-mtd.c
+++ b/tests/unittests/tests-mtd/tests-mtd.c
@@ -59,7 +59,7 @@ static int read(mtd_dev_t *dev, void *buff, uint32_t addr, uint32_t size)
     }
     memcpy(buff, dummy_memory + addr, size);
 
-    return size;
+    return 0;
 }
 
 static int write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
@@ -74,7 +74,7 @@ static int write(mtd_dev_t *dev, const void *buff, uint32_t addr, uint32_t size)
     }
     memcpy(dummy_memory + addr, buff, size);
 
-    return size;
+    return 0;
 }
 
 static int erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
@@ -165,7 +165,7 @@ static void test_mtd_write_erase(void)
     memset(buf_read, 0, sizeof(buf_read));
 
     int ret = mtd_write(dev, buf, sizeof(buf_empty), sizeof(buf));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
 
     ret = mtd_erase(dev, 0, dev->pages_per_sector * dev->page_size);
     TEST_ASSERT_EQUAL_INT(0, ret);
@@ -173,7 +173,7 @@ static void test_mtd_write_erase(void)
     uint8_t expected[sizeof(buf_read)];
     memset(expected, 0xff, sizeof(expected));
     ret = mtd_read(dev, buf_read, 0, sizeof(buf_read));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf_read), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
     TEST_ASSERT_EQUAL_INT(0, memcmp(expected, buf_read, sizeof(buf_read)));
 
 }
@@ -187,19 +187,19 @@ static void test_mtd_write_read(void)
 
     /* Basic write / read */
     int ret = mtd_write(dev, buf, 0, sizeof(buf));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
 
     ret = mtd_read(dev, buf_read, 0, sizeof(buf_read));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf_read), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
     TEST_ASSERT_EQUAL_INT(0, memcmp(buf, buf_read, sizeof(buf)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(buf_empty, buf_read + sizeof(buf), sizeof(buf_empty)));
 
     /* Unaligned write / read */
     ret = mtd_write(dev, buf, dev->page_size + sizeof(buf_empty), sizeof(buf));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
 
     ret = mtd_read(dev, buf_read, dev->page_size, sizeof(buf_read));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf_read), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
     TEST_ASSERT_EQUAL_INT(0, memcmp(buf_empty, buf_read, sizeof(buf_empty)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(buf, buf_read + sizeof(buf_empty), sizeof(buf)));
 
@@ -224,12 +224,12 @@ static void test_mtd_write_read(void)
     ret = mtd_erase(dev, 0, dev->page_size * dev->pages_per_sector);
     TEST_ASSERT_EQUAL_INT(0, ret);
     ret = mtd_write(dev, buf_page, 0, dev->page_size);
-    TEST_ASSERT_EQUAL_INT(dev->page_size, ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
     ret = mtd_write(dev, buf_page, dev->page_size, dev->page_size);
-    TEST_ASSERT_EQUAL_INT(dev->page_size, ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
     memset(buf_page, 0, sizeof(buf_page));
     ret = mtd_read(dev, buf_page, 0, sizeof(buf_page));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf_page), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
     TEST_ASSERT_EQUAL_INT(1, buf_page[0]);
     TEST_ASSERT_EQUAL_INT(1, buf_page[sizeof(buf_page) - 1]);
 
@@ -254,12 +254,12 @@ static void test_mtd_write_read_flash(void)
 
     /* Basic write / read */
     int ret = mtd_write(dev, buf1, 0, sizeof(buf1));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf1), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
     ret = mtd_write(dev, buf2, 0, sizeof(buf2));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf2), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
 
     ret = mtd_read(dev, buf_read, 0, sizeof(buf_read));
-    TEST_ASSERT_EQUAL_INT(sizeof(buf_read), ret);
+    TEST_ASSERT_EQUAL_INT(0, ret);
     TEST_ASSERT_EQUAL_INT(0, memcmp(buf_expected, buf_read, sizeof(buf_expected)));
     TEST_ASSERT_EQUAL_INT(0, memcmp(buf_empty, buf_read + sizeof(buf_expected), sizeof(buf_empty)));
 }


### PR DESCRIPTION
Returning the number of bytes written/read could return a negative integer
because a uint32_t is expected for the length in read()/write() operations.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
MTD drivers returned the number of bytes read/written as a plain integer but this could overflow because a uint32_t is expected as a function parameter, being the length to read/write.
So this PR changes the return value to be 0 on a successful read/write operation.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
```
cd tests/mtd_flashpage
make BOARD=bluepill PORT=/dev/ttyUSB0 flash term

2020-04-17 17:47:00,291 # Help: Press s to start test, r to print it is ready
s
2020-04-17 17:47:02,154 # START
2020-04-17 17:47:02,162 # main(): This is RIOT! (Version: 2020.04-devel-2062-gb4655-mtd-do-not-return-length-on-success)
2020-04-17 17:47:02,627 # ....
2020-04-17 17:47:02,627 # OK (4 tests)

cd tests/mtd_mapper
make BOARD=bluepill PORT=/dev/ttyUSB0 flash term
2020-04-17 17:48:19,200 # �Help: Press s to start test, r to print it is ready
s
2020-04-17 17:48:21,032 # START
2020-04-17 17:48:21,040 # main(): This is RIOT! (Version: 2020.04-devel-2062-gb4655-mtd-do-not-return-length-on-success)
2020-04-17 17:48:21,047 # ....
2020-04-17 17:48:21,048 # OK (4 tests)

cd tests/pkg_spiffs
make BOARD=nucleo-f767zi flash term

2020-04-17 19:01:04,472 # START
2020-04-17 19:01:04,480 # main(): This is RIOT! (Version: 2020.04-devel-2062-gb4655-mtd-do-not-return-length-on-success)
2020-04-17 19:01:04,503 # .........
2020-04-17 19:01:04,504 # OK (9 tests)

cd examples/filesystem
make BOARD=nucleo-f767zi flash term

> vfs r /const/hello-world
2020-04-17 19:04:17,346 #  vfs r /const/hello-world
2020-04-17 19:04:17,352 # 00000000: 4865 6c6c 6f20 576f 726c 6421 0a00       Hello World!..
2020-04-17 19:04:17,354 # -- EOF --

cd tests/unittests/
make tests-vfs BOARD=nucleo-f767zi flash term

2020-04-17 19:06:21,916 # main(): This is �main(): This is RIOT! (Version: 2020.04-devel-2062-gb4655-mtd-do-not-return-length-on-success)
2020-04-17 19:06:21,920 # Help: Press s to start test, r to print it is ready
s
2020-04-17 19:06:23,240 # START
2020-04-17 19:06:23,245 # .......................................
2020-04-17 19:06:23,247 # OK (39 tests)
```

### Issues/PRs references
Came up in #13877

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
