### PR TITLE
drivers/cc110x : Expose Configurations to Kconfig 

### DIFF
--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -5,6 +5,7 @@
 # directory for more details.
 
 menu "Network Device Drivers"
+rsource "cc110x/Kconfig"
 rsource "mrf24j40/Kconfig"
 source "$(RIOTCPU)/nrf52/radio/nrf802154/Kconfig"
 endmenu # Network Device Drivers

--- a/drivers/cc110x/Kconfig
+++ b/drivers/cc110x/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_CC110X
+    bool "Configure CC110X driver"
+    depends on MODULE_CC110X
+    help
+        Configure the CC110X driver using Kconfig.
+
+if KCONFIG_MODULE_CC110X
+
+config CC110X_DEFAULT_CHANNEL
+    int "Configure default channel"
+    range 0 7
+    default 0
+    help
+        Set the default channel for transmission from the allowed
+        maximum of 8 (0-7) Channels.
+        Default channel is 0.
+
+endif # KCONFIG_MODULE_CC110X

--- a/drivers/cc110x/cc110x_netdev.c
+++ b/drivers/cc110x/cc110x_netdev.c
@@ -348,7 +348,7 @@ static int cc110x_init(netdev_t *netdev)
      * cc110x_full_calibration
      */
     retval = cc110x_apply_config(dev, dev->params.config, dev->params.channels,
-                                 CC110X_DEFAULT_CHANNEL);
+                                 CONFIG_CC110X_DEFAULT_CHANNEL);
     if (retval) {
         gpio_irq_disable(dev->params.gdo0);
         gpio_irq_disable(dev->params.gdo2);

--- a/drivers/include/cc110x.h
+++ b/drivers/include/cc110x.h
@@ -248,8 +248,8 @@ extern "C" {
 /**
  * @brief The default channel to set up after initializing the device
  */
-#ifndef CC110X_DEFAULT_CHANNEL
-#define CC110X_DEFAULT_CHANNEL      (0U)
+#ifndef CONFIG_CC110X_DEFAULT_CHANNEL
+#define CONFIG_CC110X_DEFAULT_CHANNEL      (0U)
 #endif
 /** @} */
 

--- a/makefiles/default-radio-settings.inc.mk
+++ b/makefiles/default-radio-settings.inc.mk
@@ -2,7 +2,7 @@
 ifndef CONFIG_KCONFIG_MODULE_IEEE802154
   ifneq (,$(DEFAULT_CHANNEL))
     ifneq (,$(filter cc110x,$(USEMODULE)))        # radio is cc110x sub-GHz
-      CFLAGS += -DCC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
+      CFLAGS += -DCONFIG_CC110X_DEFAULT_CHANNEL=$(DEFAULT_CHANNEL)
     endif
 
     ifneq (,$(filter at86rf212b,$(USEMODULE)))    # radio is IEEE 802.15.4 sub-GHz


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in CC110X Network Device driver to Kconfig.

### Testing procedure

The firmware was uploaded to FIT/IoT-LAB Test Bed and following results were obtained.

#### Default State:

##### Firmware Output

magnrc_netif: netdev init failed: -134
rc_netif: netdev init failed: -134
07-devel-97-g01a8c6-Kconfig_cc110x)
CONFIG_CC110X_DEFAULT_CHANNEL=(0U)
cc110x driver test application
..................

#### Usage with CFLAGS 

/tests/driver_ads101x/Makefile

> CFLAGS += -DCONFIG_CC110X_DEFAULT_CHANNEL=3

##### Firmware Output

magnrc_netif: netdev init failed: -134
rc_netif: netdev init failed: -134
07-devel-97-g01a8c6-Kconfig_cc110x)
CONFIG_CC110X_DEFAULT_CHANNEL=3
cc110x driver test application
..................

#### Usage with Kconfig

/tests/cc110x/

> make menuconfig

##### Firmware Output

magnrc_netif: netdev init failed: -134
rc_netif: netdev init failed: -134
07-devel-97-g01a8c6-Kconfig_cc110x)
CONFIG_CC110X_DEFAULT_CHANNEL=7
cc110x driver test application
..................

Note : The network device is not available fro interfacing hence configurability of macros were only tested.

### Issues/PRs references

#12888
@leandrolanzieri 
