### PR TITLE
Add fuzzing application for gcoap

### DIFF
--- a/fuzzing/gcoap/Makefile
+++ b/fuzzing/gcoap/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.fuzzing_common
+
+USEMODULE += gnrc_ipv6
+USEMODULE += gcoap
+
+include $(RIOTBASE)/Makefile.include

--- a/fuzzing/gcoap/input/confirmable-get.dat
+++ b/fuzzing/gcoap/input/confirmable-get.dat
@@ -1,0 +1,1 @@
+@¹'=fe80::8813:2ff:fec1:98ef%tap0‹.well-knowncore

--- a/fuzzing/gcoap/input/confirmable-post.dat
+++ b/fuzzing/gcoap/input/confirmable-post.dat
@@ -1,0 +1,1 @@
+@¹'=fe80::8813:2ff:fec1:98ef%tap0„riotvalueÿfoo

--- a/fuzzing/gcoap/input/non-confirmable-get.dat
+++ b/fuzzing/gcoap/input/non-confirmable-get.dat
@@ -1,0 +1,1 @@
+P¹'=fe80::8813:2ff:fec1:98ef%tap0„riotboard

--- a/fuzzing/gcoap/main.c
+++ b/fuzzing/gcoap/main.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2019 Sören Tempel <tempel@uni-bremen.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <err.h>
+#include <stdlib.h>
+
+#include "thread.h"
+#include "fuzzing.h"
+#include "kernel_types.h"
+
+#include "net/gcoap.h"
+#include "net/gnrc/udp.h"
+#include "net/gnrc/pkt.h"
+#include "net/ipv6/addr.h"
+#include "net/gnrc/nettype.h"
+#include "net/gnrc/ipv6/hdr.h"
+
+static uint32_t demux = COAP_PORT;
+static gnrc_nettype_t ntype = GNRC_NETTYPE_UDP;
+
+void initialize(void)
+{
+    if (fuzzing_init(NULL, 0)) {
+        errx(EXIT_FAILURE, "fuzzing_init failed");
+    }
+
+    gcoap_init();
+}
+
+int main(void)
+{
+    gnrc_pktsnip_t *ipkt, *upkt, *cpkt;
+
+    initialize();
+    if (!(ipkt = gnrc_ipv6_hdr_build(NULL, NULL, &ipv6_addr_loopback))) {
+        errx(EXIT_FAILURE, "gnrc_ipv6_hdr_build failed");
+    }
+    if (!(upkt = gnrc_udp_hdr_build(ipkt, 2342, COAP_PORT))) {
+        errx(EXIT_FAILURE, "gnrc_udp_hdr_build failed");
+    }
+
+    if (!(cpkt = gnrc_pktbuf_add(upkt, NULL, 0, GNRC_NETTYPE_UNDEF))) {
+        errx(EXIT_FAILURE, "gnrc_pktbuf_add failed");
+    }
+    if (fuzzing_read_packet(STDIN_FILENO, cpkt)) {
+        errx(EXIT_FAILURE, "fuzzing_read_packet failed");
+    }
+
+    if (!gnrc_netapi_dispatch_receive(ntype, demux, cpkt)) {
+        errx(EXIT_FAILURE, "couldn't find any subscriber");
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c
+++ b/sys/net/gnrc/pktbuf_malloc/gnrc_pktbuf_malloc.c
@@ -54,6 +54,10 @@ static inline void *_malloc(size_t size)
 static inline void _free(void *ptr)
 {
     if (ptr != NULL) {
+        /* The fuzzing module is only enabled when building a fuzzing
+         * application from the fuzzing/ subdirectory. If _free is
+         * called on the crafted fuzzing packet, the setup assumes that
+         * input processing has completed and the application terminates. */
 #if defined(MODULE_FUZZING) && !defined(MODULE_GNRC_SOCK)
         if (ptr == gnrc_pktbuf_fuzzptr) {
            exit(EXIT_SUCCESS);

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -31,6 +31,7 @@
 
 #ifdef MODULE_FUZZING
 extern gnrc_pktsnip_t *gnrc_pktbuf_fuzzptr;
+gnrc_pktsnip_t *gnrc_sock_prevpkt = NULL;
 #endif
 
 #ifdef MODULE_XTIMER
@@ -93,8 +94,7 @@ ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
     msg_t msg;
 
 #ifdef MODULE_FUZZING
-    static gnrc_pktsnip_t *prevpkt;
-    if (prevpkt && prevpkt == gnrc_pktbuf_fuzzptr) {
+    if (gnrc_sock_prevpkt && gnrc_sock_prevpkt == gnrc_pktbuf_fuzzptr) {
         exit(EXIT_SUCCESS);
     }
 #endif
@@ -159,7 +159,7 @@ ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
     }
 #endif
 #ifdef MODULE_FUZZING
-    prevpkt = pkt;
+    gnrc_sock_prevpkt = pkt;
 #endif
 
     return 0;

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -93,6 +93,13 @@ ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
     gnrc_pktsnip_t *pkt, *netif;
     msg_t msg;
 
+    /* The fuzzing module is only enabled when building a fuzzing
+     * application from the fuzzing/ subdirectory. When using gnrc_sock
+     * the fuzzer assumes that gnrc_sock_recv is called in a loop. If it
+     * is called again and the previous return value was the special
+     * crafted fuzzing packet, the fuzzing application terminates.
+     *
+     * sock_async_event has its on fuzzing termination condition. */
 #if defined(MODULE_FUZZING) && !defined(MODULE_SOCK_ASYNC_EVENT)
     if (gnrc_sock_prevpkt && gnrc_sock_prevpkt == gnrc_pktbuf_fuzzptr) {
         exit(EXIT_SUCCESS);

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -93,7 +93,7 @@ ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
     gnrc_pktsnip_t *pkt, *netif;
     msg_t msg;
 
-#ifdef MODULE_FUZZING
+#if defined(MODULE_FUZZING) && !defined(MODULE_SOCK_ASYNC_EVENT)
     if (gnrc_sock_prevpkt && gnrc_sock_prevpkt == gnrc_pktbuf_fuzzptr) {
         exit(EXIT_SUCCESS);
     }

--- a/sys/net/sock/async/event/sock_async_event.c
+++ b/sys/net/sock/async/event/sock_async_event.c
@@ -16,6 +16,11 @@
 #include "irq.h"
 #include "net/sock/async/event.h"
 
+#ifdef MODULE_FUZZING
+extern gnrc_pktsnip_t *gnrc_pktbuf_fuzzptr;
+extern gnrc_pktsnip_t *gnrc_sock_prevpkt;
+#endif
+
 static void _event_handler(event_t *ev)
 {
     sock_event_t *event = (sock_event_t *)ev;
@@ -36,6 +41,12 @@ static inline void _cb(void *sock, sock_async_flags_t type, void *arg,
     ctx->event.cb_arg = arg;
     ctx->event.type |= type;
     event_post(ctx->queue, &ctx->event.super);
+
+#ifdef MODULE_FUZZING
+    if (gnrc_sock_prevpkt && gnrc_sock_prevpkt == gnrc_pktbuf_fuzzptr) {
+        exit(EXIT_SUCCESS);
+    }
+#endif
 }
 
 static void _set_ctx(sock_async_ctx_t *ctx, event_queue_t *ev_queue)

--- a/sys/net/sock/async/event/sock_async_event.c
+++ b/sys/net/sock/async/event/sock_async_event.c
@@ -42,6 +42,11 @@ static inline void _cb(void *sock, sock_async_flags_t type, void *arg,
     ctx->event.type |= type;
     event_post(ctx->queue, &ctx->event.super);
 
+    /* The fuzzing module is only enabled when building a fuzzing
+     * application from the fuzzing/ subdirectory. The fuzzing setup
+     * assumes that gnrc_sock_recv is called by the event callback. If
+     * the value returned by gnrc_sock_recv was the fuzzing packet, the
+     * fuzzing application is terminated as input processing finished. */
 #ifdef MODULE_FUZZING
     if (gnrc_sock_prevpkt && gnrc_sock_prevpkt == gnrc_pktbuf_fuzzptr) {
         exit(EXIT_SUCCESS);


### PR DESCRIPTION
### Contribution description

Based on #13157, this PR adds a fuzzing application for the `gcoap` module. Since it's initial implementation in 2019 the `gcoap` module switched to using `sock_async_event`. For this reason, this PR also includes an implementation of a fuzzing termination condition for `sock_async_event`. After the callback has been invoked, the code checks if the previous packet returned by `gnrc_sock_recv` was the fuzzing packet, if so the fuzzing application is terminated.

### Testing procedure

One function tested extensively by this fuzzing application is `coap_parse()`. As such, this fuzzing application would have been capable of finding #10753. To test this, remove the following code from the `coap_parse()` function:

https://github.com/RIOT-OS/RIOT/blob/b6be8af81c3f7f38b00340d6441d08a34431d865/sys/net/application_layer/nanocoap/nanocoap.c#L111-L114

Afterwards run:

    $ make -C fuzzing/gcoap all-asan
    $ make -C fuzzing/gcoap fuzz

AFL should discover a crash, in the modified code branch, within a few minutes.

### Issues/PRs references

* #13157 
* #10753