### PR TITLE
boards/blxxxpill: improve adc

### DIFF
--- a/boards/common/blxxxpill/include/periph_conf.h
+++ b/boards/common/blxxxpill/include/periph_conf.h
@@ -66,8 +66,6 @@ extern "C" {
 #define ADC_CONFIG {                                     \
     { .dev = 0, .pin = GPIO_PIN(PORT_A, 0), .chan = 0 }, \
     { .dev = 0, .pin = GPIO_PIN(PORT_A, 1), .chan = 1 }, \
-    { .dev = 0, .pin = GPIO_PIN(PORT_A, 2), .chan = 2 }, \
-    { .dev = 0, .pin = GPIO_PIN(PORT_A, 3), .chan = 3 }, \
     { .dev = 0, .pin = GPIO_PIN(PORT_A, 4), .chan = 4 }, \
     { .dev = 0, .pin = GPIO_PIN(PORT_A, 5), .chan = 5 }, \
     { .dev = 0, .pin = GPIO_PIN(PORT_A, 6), .chan = 6 }, \
@@ -80,7 +78,7 @@ extern "C" {
     { .dev = 0, .pin = GPIO_UNDEF, .chan = 17 },         \
 }
 
-#define ADC_NUMOF           12
+#define ADC_NUMOF           10
 /** @} */
 
 /**

--- a/boards/common/blxxxpill/include/periph_conf.h
+++ b/boards/common/blxxxpill/include/periph_conf.h
@@ -74,9 +74,13 @@ extern "C" {
     { .dev = 0, .pin = GPIO_PIN(PORT_A, 7), .chan = 7 }, \
     { .dev = 0, .pin = GPIO_PIN(PORT_B, 0), .chan = 8 }, \
     { .dev = 0, .pin = GPIO_PIN(PORT_B, 1), .chan = 9 }, \
+    /* ADC Temperature channel */                        \
+    { .dev = 0, .pin = GPIO_UNDEF, .chan = 16 },         \
+    /* ADC VREF channel */                               \
+    { .dev = 0, .pin = GPIO_UNDEF, .chan = 17 },         \
 }
 
-#define ADC_NUMOF           10
+#define ADC_NUMOF           12
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description
This PR add two adc lines for blxxxpill boards. So it is possible to get the internal temperature and voltage reference values from the adc and calculate the physical values in your own applications.
It also moves the turn on/off command of the adc to reduce the current if the device is in sleep mode (from 950µA to 115µA in my own application).

### Testing procedure
Tested on `BOARD=bluepill` with `tests/periph_adc` but have to change the resolution of the adc to 12bit. Also tested with my own application.

### Issues/PRs references
Can't find any direct references
