### PR TITLE
cpu: always use TIMER_CHANNELS

### DIFF
--- a/boards/common/atmega/include/periph_conf_atmega_common.h
+++ b/boards/common/atmega/include/periph_conf_atmega_common.h
@@ -106,7 +106,7 @@ extern "C" {
 #ifndef TIMER_NUMOF
 #if defined(CPU_ATMEGA32U4)
     #define TIMER_NUMOF         (2U)
-    #define TIMER_CHANNELS      (3)
+    #define TIMER_CHANNEL_NUMOF (3)
 
     #define TIMER_0             MEGA_TIMER1
     #define TIMER_0_MASK        &TIMSK1
@@ -123,7 +123,7 @@ extern "C" {
     #define TIMER_1_ISRC        TIMER3_COMPC_vect
 #elif defined(CPU_ATMEGA128RFA1) || defined(CPU_ATMEGA256RFR2)
     #define TIMER_NUMOF         (3U)
-    #define TIMER_CHANNELS      (3)
+    #define TIMER_CHANNEL_NUMOF (3)
 
     #define TIMER_0             MEGA_TIMER4
     #define TIMER_0_MASK        &TIMSK4
@@ -147,7 +147,7 @@ extern "C" {
     #define TIMER_2_ISRC        TIMER1_COMPC_vect
 #elif defined(CPU_ATMEGA328P)
     #define TIMER_NUMOF         (1U)
-    #define TIMER_CHANNELS      (2)
+    #define TIMER_CHANNEL_NUMOF (2)
 
     #define TIMER_0             MEGA_TIMER1
     #define TIMER_0_MASK        &TIMSK1
@@ -156,7 +156,7 @@ extern "C" {
     #define TIMER_0_ISRB        TIMER1_COMPB_vect
 #elif defined(CPU_ATMEGA1284P)
     #define TIMER_NUMOF         (2U)
-    #define TIMER_CHANNELS      (2)
+    #define TIMER_CHANNEL_NUMOF (2)
 
     #define TIMER_0             MEGA_TIMER1
     #define TIMER_0_MASK        &TIMSK1
@@ -171,7 +171,7 @@ extern "C" {
     #define TIMER_1_ISRB        TIMER3_COMPB_vect
 #elif defined(CPU_ATMEGA2560) || defined(CPU_ATMEGA1281)
     #define TIMER_NUMOF         (2U)
-    #define TIMER_CHANNELS      (3)
+    #define TIMER_CHANNEL_NUMOF (3)
 
     #define TIMER_0             MEGA_TIMER1
     #define TIMER_0_MASK        &TIMSK1

--- a/boards/common/esp8266/include/periph_conf_common.h
+++ b/boards/common/esp8266/include/periph_conf_common.h
@@ -193,13 +193,13 @@ static const spi_conf_t spi_config[] = {
 
 /* software timer */
 #define TIMER_NUMOF         (1U)    /**< number of timer devices */
-#define TIMER_CHANNELS      (10U)   /**< number of channels per timer device */
+#define TIMER_CHANNEL_NUMOF (10U)   /**< number of channels per timer device */
 
 #else /* MODULE_ESP_SW_TIMER */
 
 /* hardware timer */
 #define TIMER_NUMOF         (1U)    /**< number of timer devices */
-#define TIMER_CHANNELS      (1U)    /**< number of channels per timer device */
+#define TIMER_CHANNEL_NUMOF (1U)    /**< number of channels per timer device */
 
 #endif /* MODULE_ESP_SW_TIMER */
 /** @} */

--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -132,7 +132,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 
 int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 {
-    if (channel >= TIMER_CHANNELS) {
+    if (channel >= TIMER_CHANNEL_NUMOF) {
         return -1;
     }
 
@@ -145,7 +145,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 
 int timer_clear(tim_t tim, int channel)
 {
-    if (channel >= TIMER_CHANNELS) {
+    if (channel >= TIMER_CHANNEL_NUMOF) {
         return -1;
     }
 

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -290,6 +290,11 @@ typedef struct {
     uint_fast8_t cfg;   /**< timer config word */
 } timer_conf_t;
 
+/**
+ * @brief   Number of maximal available timer channels
+ */
+#define TIMER_CHANNELS      (2U)
+
 #ifndef DOXYGEN
 /**
  * @name   Override resolution options

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -293,7 +293,7 @@ typedef struct {
 /**
  * @brief   Number of maximal available timer channels
  */
-#define TIMER_CHANNELS      (2U)
+#define TIMER_CHANNEL_NUMOF (2U)
 
 #ifndef DOXYGEN
 /**

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -360,6 +360,11 @@ typedef struct {
 /** @} */
 
 /**
+ * @brief   This timer implementation has three available channels
+ */
+#define TIMER_CHANNELS      (3)
+
+/**
  * @brief   UART device configuration.
  */
 #ifndef DOXYGEN

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -362,7 +362,7 @@ typedef struct {
 /**
  * @brief   This timer implementation has three available channels
  */
-#define TIMER_CHANNELS      (3)
+#define TIMER_CHANNEL_NUMOF (3)
 
 /**
  * @brief   UART device configuration.

--- a/cpu/efm32/periph/timer.c
+++ b/cpu/efm32/periph/timer.c
@@ -29,11 +29,6 @@
 #include "em_timer_utils.h"
 
 /**
- * @brief   This timer implementation has three available channels
- */
-#define CC_CHANNELS      (3U)
-
-/**
  * @brief   Timer state memory
  */
 static timer_isr_ctx_t isr_ctx[TIMER_NUMOF];
@@ -116,7 +111,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 {
     TIMER_TypeDef *tim;
 
-    if (channel < 0 || channel >= (int) CC_CHANNELS) {
+    if (channel < 0 || channel >= TIMER_CHANNELS) {
         return -1;
     }
 
@@ -158,7 +153,7 @@ void TIMER_0_ISR(void)
 {
     TIMER_TypeDef *tim = timer_config[0].timer.dev;
 
-    for (int i = 0; i < (int) CC_CHANNELS; i++) {
+    for (int i = 0; i < TIMER_CHANNELS; i++) {
         if (tim->IF & (TIMER_IF_CC0 << i)) {
             tim->CC[i].CTRL = _TIMER_CC_CTRL_MODE_OFF;
             tim->IFC = (TIMER_IFC_CC0 << i);

--- a/cpu/efm32/periph/timer.c
+++ b/cpu/efm32/periph/timer.c
@@ -111,7 +111,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 {
     TIMER_TypeDef *tim;
 
-    if (channel < 0 || channel >= TIMER_CHANNELS) {
+    if (channel < 0 || channel >= TIMER_CHANNEL_NUMOF) {
         return -1;
     }
 
@@ -153,7 +153,7 @@ void TIMER_0_ISR(void)
 {
     TIMER_TypeDef *tim = timer_config[0].timer.dev;
 
-    for (int i = 0; i < TIMER_CHANNELS; i++) {
+    for (int i = 0; i < TIMER_CHANNEL_NUMOF; i++) {
         if (tim->IF & (TIMER_IF_CC0 << i)) {
             tim->CC[i].CTRL = _TIMER_CC_CTRL_MODE_OFF;
             tim->IFC = (TIMER_IFC_CC0 << i);

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -485,12 +485,12 @@ typedef struct {
  */
 #ifdef MODULE_ESP_HW_COUNTER
 /** hardware ccount/ccompare registers are used for timer implementation */
-#define TIMER_NUMOF     (2)
-#define TIMER_CHANNELS  (1)
+#define TIMER_NUMOF         (2)
+#define TIMER_CHANNEL_NUMOF (1)
 #else
 /** hardware timer modules are used for timer implementation (default) */
-#define TIMER_NUMOF     (3)
-#define TIMER_CHANNELS  (1)
+#define TIMER_NUMOF         (3)
+#define TIMER_CHANNEL_NUMOF (1)
 #endif
 
 /** Timer used for system time */

--- a/cpu/ezr32wg/include/periph_cpu.h
+++ b/cpu/ezr32wg/include/periph_cpu.h
@@ -39,6 +39,11 @@ typedef uint32_t tim_t;
 /** @} */
 
 /**
+ * @brief   This timer implementation has three available channels
+ */
+#define TIMER_CHANNELS          (3)
+
+/**
  * @brief   Starting offset of CPU_ID
  */
 #define CPUID_ADDR          (&DEVINFO->UNIQUEL)

--- a/cpu/ezr32wg/include/periph_cpu.h
+++ b/cpu/ezr32wg/include/periph_cpu.h
@@ -41,7 +41,7 @@ typedef uint32_t tim_t;
 /**
  * @brief   This timer implementation has three available channels
  */
-#define TIMER_CHANNELS          (3)
+#define TIMER_CHANNEL_NUMOF (3)
 
 /**
  * @brief   Starting offset of CPU_ID

--- a/cpu/ezr32wg/periph/timer.c
+++ b/cpu/ezr32wg/periph/timer.c
@@ -27,11 +27,6 @@
 #include "debug.h"
 
 /**
- * @brief   This timer implementation has three available channels
- */
-#define CC_CHANNELS      (3U)
-
-/**
  * @brief   Timer state memory
  */
 static timer_isr_ctx_t isr_ctx[TIMER_NUMOF];
@@ -87,7 +82,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 {
     TIMER_TypeDef *tim;
 
-    if ((channel < 0) || (channel >= (int)CC_CHANNELS)) {
+    if ((channel < 0) || (channel >= TIMER_CHANNELS)) {
         return -1;
     }
 
@@ -99,7 +94,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 
 int timer_clear(tim_t dev, int channel)
 {
-    if ((channel < 0) || (channel >= (int)CC_CHANNELS)) {
+    if ((channel < 0) || (channel >= TIMER_CHANNELS)) {
         return -1;
     }
 
@@ -131,7 +126,7 @@ void timer_reset(tim_t dev)
 void TIMER_0_ISR(void)
 {
     TIMER_TypeDef *tim = timer_config[0].timer;
-    for (unsigned i = 0; i < CC_CHANNELS; i++) {
+    for (int i = 0; i < TIMER_CHANNELS; i++) {
         if (tim->IF & (TIMER_IF_CC0 << i)) {
             tim->CC[i].CTRL = _TIMER_CC_CTRL_MODE_OFF;
             tim->IFC = (TIMER_IFC_CC0 << i);

--- a/cpu/ezr32wg/periph/timer.c
+++ b/cpu/ezr32wg/periph/timer.c
@@ -82,7 +82,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 {
     TIMER_TypeDef *tim;
 
-    if ((channel < 0) || (channel >= TIMER_CHANNELS)) {
+    if ((channel < 0) || (channel >= TIMER_CHANNEL_NUMOF)) {
         return -1;
     }
 
@@ -94,7 +94,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 
 int timer_clear(tim_t dev, int channel)
 {
-    if ((channel < 0) || (channel >= TIMER_CHANNELS)) {
+    if ((channel < 0) || (channel >= TIMER_CHANNEL_NUMOF)) {
         return -1;
     }
 
@@ -126,7 +126,7 @@ void timer_reset(tim_t dev)
 void TIMER_0_ISR(void)
 {
     TIMER_TypeDef *tim = timer_config[0].timer;
-    for (int i = 0; i < TIMER_CHANNELS; i++) {
+    for (int i = 0; i < TIMER_CHANNEL_NUMOF; i++) {
         if (tim->IF & (TIMER_IF_CC0 << i)) {
             tim->CC[i].CTRL = _TIMER_CC_CTRL_MODE_OFF;
             tim->IFC = (TIMER_IFC_CC0 << i);

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -130,6 +130,11 @@ typedef uint16_t gpio_t;
 #define PERIPH_TIMER_PROVIDES_SET
 
 /**
+ * @brief   Number of maximal available timer channels
+ */
+#define TIMER_CHANNELS      (1U)
+
+/**
  * @brief   number of usable power modes
  */
 #define PM_NUM_MODES    (1U)

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -132,7 +132,7 @@ typedef uint16_t gpio_t;
 /**
  * @brief   Number of maximal available timer channels
  */
-#define TIMER_CHANNELS      (1U)
+#define TIMER_CHANNEL_NUMOF      (1U)
 
 /**
  * @brief   number of usable power modes

--- a/cpu/lpc1768/include/periph_cpu.h
+++ b/cpu/lpc1768/include/periph_cpu.h
@@ -66,6 +66,11 @@ typedef enum {
 #endif /* ndef DOXYGEN */
 
 /**
+ * @brief   Number of available timer channels
+ */
+#define TIMER_CHANNELS      (4U)
+
+/**
  * @brief   CPU provides own pm_off() function
  */
 #define PROVIDES_PM_LAYERED_OFF

--- a/cpu/lpc1768/include/periph_cpu.h
+++ b/cpu/lpc1768/include/periph_cpu.h
@@ -68,7 +68,7 @@ typedef enum {
 /**
  * @brief   Number of available timer channels
  */
-#define TIMER_CHANNELS      (4U)
+#define TIMER_CHANNEL_NUMOF      (4U)
 
 /**
  * @brief   CPU provides own pm_off() function

--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -126,7 +126,7 @@ typedef struct {
 /**
  * @brief   Number of available timer channels
  */
-#define TIMER_CHAN_NUMOF        (4U)
+#define TIMER_CHANNELS      (4U)
 
 /**
  * @brief   Declare needed generic SPI functions

--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -126,7 +126,7 @@ typedef struct {
 /**
  * @brief   Number of available timer channels
  */
-#define TIMER_CHANNELS      (4U)
+#define TIMER_CHANNEL_NUMOF      (4U)
 
 /**
  * @brief   Declare needed generic SPI functions

--- a/cpu/lpc2387/periph/timer.c
+++ b/cpu/lpc2387/periph/timer.c
@@ -136,7 +136,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 
 int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 {
-    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHAN_NUMOF)) {
+    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNELS)) {
         return -1;
     }
 
@@ -148,7 +148,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 
 int timer_clear(tim_t tim, int channel)
 {
-    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHAN_NUMOF)) {
+    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNELS)) {
         return -1;
     }
     get_dev(tim)->MCR &= ~(1 << (channel * 3));
@@ -172,7 +172,7 @@ void timer_stop(tim_t tim)
 
 static inline void isr_handler(lpc23xx_timer_t *dev, int tim_num)
 {
-    for (unsigned i = 0; i < TIMER_CHAN_NUMOF; i++) {
+    for (unsigned i = 0; i < TIMER_CHANNELS; i++) {
         if (dev->IR & (1 << i)) {
             dev->IR |= (1 << i);
             dev->MCR &= ~(1 << (i * 3));

--- a/cpu/lpc2387/periph/timer.c
+++ b/cpu/lpc2387/periph/timer.c
@@ -136,7 +136,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 
 int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 {
-    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNELS)) {
+    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNEL_NUMOF)) {
         return -1;
     }
 
@@ -148,7 +148,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 
 int timer_clear(tim_t tim, int channel)
 {
-    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNELS)) {
+    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNEL_NUMOF)) {
         return -1;
     }
     get_dev(tim)->MCR &= ~(1 << (channel * 3));
@@ -172,7 +172,7 @@ void timer_stop(tim_t tim)
 
 static inline void isr_handler(lpc23xx_timer_t *dev, int tim_num)
 {
-    for (unsigned i = 0; i < TIMER_CHANNELS; i++) {
+    for (unsigned i = 0; i < TIMER_CHANNEL_NUMOF; i++) {
         if (dev->IR & (1 << i)) {
             dev->IR |= (1 << i);
             dev->MCR &= ~(1 << (i * 3));

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -335,6 +335,11 @@ typedef struct {
 } tc32_conf_t;
 
 /**
+ * @brief   Number of available timer channels
+ */
+#define TIMER_CHANNELS      (2)
+
+/**
  * @brief   Set up alternate function (PMUX setting) for a PORT pin
  *
  * @param[in] pin   Pin to set the multiplexing for

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -337,7 +337,7 @@ typedef struct {
 /**
  * @brief   Number of available timer channels
  */
-#define TIMER_CHANNELS      (2)
+#define TIMER_CHANNEL_NUMOF      (2)
 
 /**
  * @brief   Set up alternate function (PMUX setting) for a PORT pin

--- a/cpu/sam3/include/periph_cpu.h
+++ b/cpu/sam3/include/periph_cpu.h
@@ -68,7 +68,7 @@ typedef uint32_t gpio_t;
 /**
  * @brief   We use 3 channels for each defined timer
  */
-#define TIMER_CHANNELS      (3)
+#define TIMER_CHANNEL_NUMOF      (3)
 
 /**
  * @brief   The RTT width is fixed to 32-bit

--- a/cpu/sam3/periph/timer.c
+++ b/cpu/sam3/periph/timer.c
@@ -124,7 +124,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 
 int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 {
-    if (channel >= TIMER_CHANNELS) {
+    if (channel >= TIMER_CHANNEL_NUMOF) {
         return -1;
     }
     (&dev(tim)->TC_CHANNEL[0].TC_RA)[channel] = value;
@@ -135,7 +135,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 
 int timer_clear(tim_t tim, int channel)
 {
-    if (channel >= TIMER_CHANNELS) {
+    if (channel >= TIMER_CHANNEL_NUMOF) {
         return -1;
     }
 
@@ -163,7 +163,7 @@ static inline void isr_handler(tim_t tim)
 {
     uint32_t status = dev(tim)->TC_CHANNEL[0].TC_SR;
 
-    for (int i = 0; i < TIMER_CHANNELS; i++) {
+    for (int i = 0; i < TIMER_CHANNEL_NUMOF; i++) {
         if (status & (TC_SR_CPAS << i)) {
             dev(tim)->TC_CHANNEL[0].TC_IDR = (TC_IDR_CPAS << i);
             isr_ctx[tim].cb(isr_ctx[tim].arg, i);

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -58,7 +58,7 @@ extern "C" {
 /**
  * @brief   All STM timers have 4 capture-compare channels
  */
-#define TIMER_CHAN          (4U)
+#define TIMER_CHANNELS      (4U)
 
 /**
  * @brief   All STM QDEC timers have 2 capture channels
@@ -364,7 +364,7 @@ typedef struct {
 typedef struct {
     TIM_TypeDef *dev;               /**< Timer used */
     uint32_t rcc_mask;              /**< bit in clock enable register */
-    pwm_chan_t chan[TIMER_CHAN];    /**< channel mapping, set to {GPIO_UNDEF, 0}
+    pwm_chan_t chan[TIMER_CHANNELS];    /**< channel mapping, set to {GPIO_UNDEF, 0}
                                      *   if not used */
     gpio_af_t af;                   /**< alternate function used */
     uint8_t bus;                    /**< APB bus */

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -58,7 +58,7 @@ extern "C" {
 /**
  * @brief   All STM timers have 4 capture-compare channels
  */
-#define TIMER_CHANNELS      (4U)
+#define TIMER_CHANNEL_NUMOF      (4U)
 
 /**
  * @brief   All STM QDEC timers have 2 capture channels
@@ -364,7 +364,7 @@ typedef struct {
 typedef struct {
     TIM_TypeDef *dev;               /**< Timer used */
     uint32_t rcc_mask;              /**< bit in clock enable register */
-    pwm_chan_t chan[TIMER_CHANNELS];    /**< channel mapping, set to {GPIO_UNDEF, 0}
+    pwm_chan_t chan[TIMER_CHANNEL_NUMOF]; /**< channel mapping, set to {GPIO_UNDEF, 0}
                                      *   if not used */
     gpio_af_t af;                   /**< alternate function used */
     uint8_t bus;                    /**< APB bus */

--- a/cpu/stm32_common/periph/pwm.c
+++ b/cpu/stm32_common/periph/pwm.c
@@ -52,13 +52,13 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
     /* reset configuration and CC channels */
     dev(pwm)->CR1 = 0;
     dev(pwm)->CR2 = 0;
-    for (unsigned i = 0; i < TIMER_CHAN; ++i) {
+    for (unsigned i = 0; i < TIMER_CHANNELS; ++i) {
         dev(pwm)->CCR[i] = 0;
     }
 
     /* configure the used pins */
     unsigned i = 0;
-    while ((i < TIMER_CHAN) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
+    while ((i < TIMER_CHANNELS) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
         gpio_init(pwm_config[pwm].chan[i].pin, GPIO_OUT);
         gpio_init_af(pwm_config[pwm].chan[i].pin, pwm_config[pwm].af);
         i++;
@@ -103,7 +103,7 @@ uint8_t pwm_channels(pwm_t pwm)
     assert(pwm < PWM_NUMOF);
 
     unsigned i = 0;
-    while ((i < TIMER_CHAN) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
+    while ((i < TIMER_CHANNELS) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
         i++;
     }
     return (uint8_t)i;
@@ -112,7 +112,7 @@ uint8_t pwm_channels(pwm_t pwm)
 void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
 {
     assert((pwm < PWM_NUMOF) &&
-           (channel < TIMER_CHAN) &&
+           (channel < TIMER_CHANNELS) &&
            (pwm_config[pwm].chan[channel].pin != GPIO_UNDEF));
 
     /* norm value to maximum possible value */

--- a/cpu/stm32_common/periph/pwm.c
+++ b/cpu/stm32_common/periph/pwm.c
@@ -52,13 +52,13 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
     /* reset configuration and CC channels */
     dev(pwm)->CR1 = 0;
     dev(pwm)->CR2 = 0;
-    for (unsigned i = 0; i < TIMER_CHANNELS; ++i) {
+    for (unsigned i = 0; i < TIMER_CHANNEL_NUMOF; ++i) {
         dev(pwm)->CCR[i] = 0;
     }
 
     /* configure the used pins */
     unsigned i = 0;
-    while ((i < TIMER_CHANNELS) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
+    while ((i < TIMER_CHANNEL_NUMOF) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
         gpio_init(pwm_config[pwm].chan[i].pin, GPIO_OUT);
         gpio_init_af(pwm_config[pwm].chan[i].pin, pwm_config[pwm].af);
         i++;
@@ -103,7 +103,7 @@ uint8_t pwm_channels(pwm_t pwm)
     assert(pwm < PWM_NUMOF);
 
     unsigned i = 0;
-    while ((i < TIMER_CHANNELS) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
+    while ((i < TIMER_CHANNEL_NUMOF) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
         i++;
     }
     return (uint8_t)i;
@@ -112,7 +112,7 @@ uint8_t pwm_channels(pwm_t pwm)
 void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
 {
     assert((pwm < PWM_NUMOF) &&
-           (channel < TIMER_CHANNELS) &&
+           (channel < TIMER_CHANNEL_NUMOF) &&
            (pwm_config[pwm].chan[channel].pin != GPIO_UNDEF));
 
     /* norm value to maximum possible value */

--- a/cpu/stm32_common/periph/timer.c
+++ b/cpu/stm32_common/periph/timer.c
@@ -70,7 +70,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 
 int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 {
-    if (channel >= (int)TIMER_CHAN) {
+    if (channel >= (int)TIMER_CHANNELS) {
         return -1;
     }
 
@@ -83,7 +83,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 
 int timer_clear(tim_t tim, int channel)
 {
-    if (channel >= (int)TIMER_CHAN) {
+    if (channel >= (int)TIMER_CHANNELS) {
         return -1;
     }
 
@@ -110,7 +110,7 @@ static inline void irq_handler(tim_t tim)
 {
     uint32_t status = (dev(tim)->SR & dev(tim)->DIER);
 
-    for (unsigned int i = 0; i < TIMER_CHAN; i++) {
+    for (unsigned int i = 0; i < TIMER_CHANNELS; i++) {
         if (status & (TIM_SR_CC1IF << i)) {
             dev(tim)->DIER &= ~(TIM_DIER_CC1IE << i);
             isr_ctx[tim].cb(isr_ctx[tim].arg, i);

--- a/cpu/stm32_common/periph/timer.c
+++ b/cpu/stm32_common/periph/timer.c
@@ -70,7 +70,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 
 int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 {
-    if (channel >= (int)TIMER_CHANNELS) {
+    if (channel >= (int)TIMER_CHANNEL_NUMOF) {
         return -1;
     }
 
@@ -83,7 +83,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 
 int timer_clear(tim_t tim, int channel)
 {
-    if (channel >= (int)TIMER_CHANNELS) {
+    if (channel >= (int)TIMER_CHANNEL_NUMOF) {
         return -1;
     }
 
@@ -110,7 +110,7 @@ static inline void irq_handler(tim_t tim)
 {
     uint32_t status = (dev(tim)->SR & dev(tim)->DIER);
 
-    for (unsigned int i = 0; i < TIMER_CHANNELS; i++) {
+    for (unsigned int i = 0; i < TIMER_CHANNEL_NUMOF; i++) {
         if (status & (TIM_SR_CC1IF << i)) {
             dev(tim)->DIER &= ~(TIM_DIER_CC1IE << i);
             isr_ctx[tim].cb(isr_ctx[tim].arg, i);

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -38,7 +38,7 @@ extern "C" {
 /**
  * @brief   All timers for the STM32F1 have 4 CC channels
  */
-#define TIMER_CHANNELS      (4U)
+#define TIMER_CHANNEL_NUMOF (4U)
 
 /**
  * @brief   All timers have a width of 16-bit

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -35,12 +35,20 @@
 
 #include <limits.h>
 
+#include "periph_conf.h"
 #include "periph_cpu.h"
 /** @todo remove dev_enums.h include once all platforms are ported to the updated periph interface */
 #include "periph/dev_enums.h"
 
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+/**
+ * @brief   The Timer implementation must define the number of channels the timer has.
+ */
+#ifndef TIMER_CHANNEL_NUMOF
+#error "Timer implementations have to provide the number of channels as CPP macro TIMER_CHANNEL_NUMOF"
 #endif
 
 /**


### PR DESCRIPTION

### Contribution description

There is currently no consistent way to define the number of available timer channels.
The majority of the existing implementations uses `TIMER_CHANNELS`, so convert the other implementations to also use this define.

### Testing procedure

Murdock should confirm the renames didn't break anything.
For new additions you can check the according `periph/timer.c`


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
