### PR TITLE
periph/timer: add timer_set_periodic()

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1050,6 +1050,10 @@ ifneq (,$(filter periph_gpio_irq,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
 endif
 
+ifneq (,$(filter periph_timer_periodic,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_timer
+endif
+
 ifneq (,$(filter devfs_hwrng,$(USEMODULE)))
   FEATURES_REQUIRED += periph_hwrng
 endif

--- a/cpu/atmega_common/Makefile.features
+++ b/cpu/atmega_common/Makefile.features
@@ -5,6 +5,7 @@ FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_eeprom
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pm
+FEATURES_PROVIDED += periph_timer_periodic
 FEATURES_PROVIDED += periph_wdt
 FEATURES_PROVIDED += puf_sram
 

--- a/cpu/lpc2387/Makefile.features
+++ b/cpu/lpc2387/Makefile.features
@@ -2,5 +2,6 @@
 FEATURES_PROVIDED += backup_ram
 FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
+FEATURES_PROVIDED += periph_timer_periodic
 
 -include $(RIOTCPU)/arm7_common/Makefile.features

--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -126,7 +126,7 @@ typedef struct {
 /**
  * @brief   Number of available timer channels
  */
-#define TIMER_CHAN_NUMOF        (4U)
+#define TIMER_CHANNELS      (4U)
 
 /**
  * @brief   Declare needed generic SPI functions

--- a/cpu/lpc2387/periph/timer.c
+++ b/cpu/lpc2387/periph/timer.c
@@ -139,7 +139,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 
 int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 {
-    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHAN_NUMOF)) {
+    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNELS)) {
         return -1;
     }
 
@@ -151,7 +151,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 
 int timer_clear(tim_t tim, int channel)
 {
-    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHAN_NUMOF)) {
+    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNELS)) {
         return -1;
     }
     get_dev(tim)->MCR &= ~(1 << (channel * 3));
@@ -175,7 +175,7 @@ void timer_stop(tim_t tim)
 
 static inline void isr_handler(lpc23xx_timer_t *dev, int tim_num)
 {
-    for (unsigned i = 0; i < TIMER_CHAN_NUMOF; i++) {
+    for (unsigned i = 0; i < TIMER_CHANNELS; i++) {
         if (dev->IR & (1 << i)) {
             dev->IR |= (1 << i);
             dev->MCR &= ~(1 << (i * 3));

--- a/cpu/lpc2387/periph/timer.c
+++ b/cpu/lpc2387/periph/timer.c
@@ -38,6 +38,23 @@
  */
 static timer_isr_ctx_t isr_ctx[TIMER_NUMOF];
 
+static uint32_t _oneshot;
+
+static inline void set_oneshot(tim_t tim, int chan)
+{
+    _oneshot |= (1 << chan) << (TIMER_CHANNELS * tim);
+}
+
+static inline void clear_oneshot(tim_t tim, int chan)
+{
+    _oneshot &= ~((1 << chan) << (TIMER_CHANNELS * tim));
+}
+
+static inline bool is_oneshot(tim_t tim, int chan)
+{
+    return _oneshot & ((1 << chan) << (TIMER_CHANNELS * tim));
+}
+
 /**
  * @brief   Forward declarations for interrupt functions
  * @{
@@ -144,8 +161,42 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
     }
 
     lpc23xx_timer_t *dev = get_dev(tim);
+
+    set_oneshot(tim, channel);
+
     dev->MR[channel] = value;
+    /* Match Interrupt */
     dev->MCR |= (1 << (channel * 3));
+    return 0;
+}
+
+int timer_set_periodic(tim_t tim, int channel, unsigned int value, uint8_t flags)
+{
+    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNELS)) {
+        return -1;
+    }
+
+    lpc23xx_timer_t *dev = get_dev(tim);
+
+    if (flags & TIM_FLAG_RESET_ON_SET) {
+        /* reset the timer */
+        dev->TCR = 2;
+        /* start the timer */
+        /* cppcheck-suppress redundantAssignment
+         * (reason: TCR is volatile control register.
+                    Bit 2 will put the timer into Reset
+                    Bit 1 will control if the timer is running) */
+        dev->TCR = 1;
+    }
+
+    clear_oneshot(tim, channel);
+
+    uint8_t cfg = (flags & TIM_FLAG_RESET_ON_MATCH)
+                ? 0x3   /* Match Interrupt & Reset on Match */
+                : 0x1;  /* Match Interrupt */
+
+    dev->MR[channel] = value;
+    dev->MCR |= (cfg << (channel * 3));
     return 0;
 }
 
@@ -173,15 +224,28 @@ void timer_stop(tim_t tim)
     get_dev(tim)->TCR = 0;
 }
 
+static inline void chan_handler(lpc23xx_timer_t *dev, unsigned tim_num, unsigned chan_num)
+{
+    const uint32_t mask = (1 << chan_num);
+
+    if ((dev->IR & mask) == 0) {
+        return;
+    }
+
+    dev->IR |= mask;
+    if (is_oneshot(tim_num, chan_num)) {
+        dev->MCR &= ~(1 << (chan_num * 3));
+    }
+
+    isr_ctx[tim_num].cb(isr_ctx[tim_num].arg, chan_num);
+}
+
 static inline void isr_handler(lpc23xx_timer_t *dev, int tim_num)
 {
-    for (unsigned i = 0; i < TIMER_CHANNELS; i++) {
-        if (dev->IR & (1 << i)) {
-            dev->IR |= (1 << i);
-            dev->MCR &= ~(1 << (i * 3));
-            isr_ctx[tim_num].cb(isr_ctx[tim_num].arg, i);
-        }
+    for (unsigned i = 0; i < TIMER_CHANNELS; ++i) {
+        chan_handler(dev, tim_num, i);
     }
+
     /* we must not forget to acknowledge the handling of the interrupt */
     VICVectAddr = 0;
 }

--- a/cpu/sam0_common/Makefile.dep
+++ b/cpu/sam0_common/Makefile.dep
@@ -5,6 +5,9 @@ endif
 # All SAM0 based CPUs provide PM
 USEMODULE += pm_layered
 
+# the timer implements timer_set_periodic()
+FEATURES_PROVIDED += periph_timer_periodic
+
 # include sam0 common periph drivers
 USEMODULE += sam0_common_periph
 

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -344,6 +344,11 @@ typedef struct {
 } tc32_conf_t;
 
 /**
+ * @brief   Number of available timer channels
+ */
+#define TIMER_CHANNELS      (2)
+
+/**
  * @brief   Set up alternate function (PMUX setting) for a PORT pin
  *
  * @param[in] pin   Pin to set the multiplexing for

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -34,6 +34,7 @@
 #define PERIPH_TIMER_H
 
 #include <limits.h>
+#include <stdint.h>
 
 #include "periph_cpu.h"
 /** @todo remove dev_enums.h include once all platforms are ported to the updated periph interface */
@@ -67,6 +68,26 @@ extern "C" {
  */
 #ifndef HAVE_TIMER_T
 typedef unsigned int tim_t;
+#endif
+
+/**
+ * @brief   Reset the timer when the set() function is called
+ *
+ * When set, calling the timer_set_periodic() function resets the timer count value.
+ */
+#ifndef TIM_FLAG_RESET_ON_SET
+#define TIM_FLAG_RESET_ON_SET   (0x01)
+#endif
+
+/**
+ * @brief   Reset the timer on match
+ *
+ * When set, a match on this channel will reset the timer count value.
+ * When set on multiple channels, only the channel with the lowest match value
+ * will be reached.
+ */
+#ifndef TIM_FLAG_RESET_ON_MATCH
+#define TIM_FLAG_RESET_ON_MATCH (0x02)
 #endif
 
 /**
@@ -137,6 +158,21 @@ int timer_set(tim_t dev, int channel, unsigned int timeout);
  * @return                  -1 on error
  */
 int timer_set_absolute(tim_t dev, int channel, unsigned int value);
+
+/**
+ * @brief Set an absolute timeout value for the given channel of the given timer
+ *        The timeout will be called periodically for each iteration
+ *
+ * @param[in] dev           the timer device to set
+ * @param[in] channel       the channel to set
+ * @param[in] value         the absolute compare value when the callback will be
+ *                          triggered
+ * @param[in] flags         options
+ *
+ * @return                  0 on success
+ * @return                  -1 on error
+ */
+int timer_set_periodic(tim_t dev, int channel, unsigned int value, uint8_t flags);
 
 /**
  * @brief Clear the given channel of the given timer device

--- a/tests/periph_timer_periodic/Makefile
+++ b/tests/periph_timer_periodic/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_timer_periodic
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_timer_periodic/main.c
+++ b/tests/periph_timer_periodic/main.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2020 Beuth Hochschule für Technik Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Periodic timer test application
+ *
+ * @author      Benjamin Valentin <benpicco@beuth-hochschule.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+
+#include "board.h"
+#include "test_utils/expect.h"
+
+#include "mutex.h"
+#include "periph/timer.h"
+#include "xtimer.h"
+
+/* We use the timer used for xtimer with the frequency used by xtimer here
+ * to make sure we have a known valid timer configuration.
+ *
+ * DO NOT USE any low-level timer functions demonstrated here when xtimer
+ * is used with that timer!
+ * Configure a separate timer, XTIMER_DEV is usually 'owned' by xtimer, but
+ * as xtimer is not used in this test, we can use it and the fact that every board
+ * provides a configuration for it.
+ */
+#define TIMER_CYCL  XTIMER_DEV
+#define CYCLE_MS    100UL
+#define CYCLES_MAX   10
+
+static unsigned count[TIMER_CHANNELS];
+
+static void cb(void *arg, int chan)
+{
+    unsigned c = count[chan]++;
+
+    printf("[%d] tick\n", chan);
+
+    if (c > CYCLES_MAX) {
+        timer_stop(TIMER_CYCL);
+        mutex_unlock(arg);
+    }
+}
+
+static const char* _print_ok(int chan, bool *succeeded)
+{
+    if (chan == 0 && count[chan] > 0) {
+        return "OK";
+    }
+
+    if (chan > 0 && count[chan] == 0) {
+        return "OK";
+    }
+
+    *succeeded = false;
+    return "ERROR";
+}
+
+int main(void)
+{
+    mutex_t lock = MUTEX_INIT_LOCKED;
+    const unsigned long timer_hz = XTIMER_HZ;
+    const unsigned steps = (CYCLE_MS * timer_hz) / 1000;
+
+    printf("\nRunning Timer %d at %lu Hz.\n", TIMER_CYCL, timer_hz);
+    printf("One counter cycle is %u ticks or %lu ms\n", steps, CYCLE_MS);
+    puts("Will print 'tick' every cycle.\n");
+
+    expect(timer_init(TIMER_CYCL, timer_hz, cb, &lock) == 0);
+
+    puts("TEST START");
+
+    /* Only the first channel should trigger and reset the counter */
+    /* If subsequent channels trigger this is an error. */
+    timer_set_periodic(TIMER_CYCL, 1, 2 * steps, TIM_FLAG_RESET_ON_SET);
+    timer_set_periodic(TIMER_CYCL, 0, steps, TIM_FLAG_RESET_ON_MATCH);
+
+    mutex_lock(&lock);
+
+    puts("\nCycles:");
+
+    bool succeeded = true;
+    for (unsigned i = 0; i < TIMER_CHANNELS; ++i) {
+        printf("channel %u = %02u\t[%s]\n", i, count[i], _print_ok(i, &succeeded));
+    }
+
+    if (succeeded) {
+        puts("TEST SUCCEEDED");
+    } else {
+        puts("TEST FAILED");
+    }
+
+    return 0;
+}

--- a/tests/periph_timer_periodic/tests/01-run.py
+++ b/tests/periph_timer_periodic/tests/01-run.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2020 Benjamin Valentin <benpicco@beuth-hochschule.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+import time
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact('TEST START')
+    start = time.time()
+    child.expect_exact('TEST SUCCEEDED')
+    end = time.time()
+    # test should run 10 cycles with 100ms each
+    assert (end - start) > 1
+    assert (end - start) < 1.5
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

All hardware timers have a continuous mode where they will restart counting once they reached the max value or the value of a capture compare channel.

So far, timers in RIOT have only implemented a one-shot mote where an alarm will only trigger once.

There are however applications where periodic events are needed and the accuracy of a software solution does not suffice / incurs unnecessary overhead, e.g. feeding audio samples to a DAC.

Since all hardware supports this feature, it's rather straightforward to export.
I only implemented it for `atmega_common`, `sam0_common`, and `lpc2387` so far and thus added a new `periph_timer_periodic` feature to test for this.

However, all timer implementations should be capable of this.

### Testing procedure

A test application is provided in `tests/periph_timer_periodic`.

It will check if periodic events are occurring and if the timer gets properly reset on reaching the first compare channel.

#### Testing status

- [x] [ATmega implementation](https://github.com/RIOT-OS/RIOT/pull/13902#pullrequestreview-419824664), [ATmega regression test](https://github.com/RIOT-OS/RIOT/pull/13902#issuecomment-635241162)
- [x] [LPC2387 implementation](https://github.com/RIOT-OS/RIOT/pull/13902#pullrequestreview-419824664), [LPC2387 regression test](https://github.com/RIOT-OS/RIOT/pull/13902#issuecomment-635241162)
- [x] [SAM0 implementation](https://github.com/RIOT-OS/RIOT/pull/13902#issuecomment-635295144), [SAM0 regression test](https://github.com/RIOT-OS/RIOT/pull/13902#issuecomment-635293284)

### Issues/PRs references

Needs #13901 for being able to set the timer frequency on sam0.
Includes parts of #13900