### PR TITLE
cpu/cc2538: Prevent underflow of the RX FIFO

### DIFF
--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -66,6 +66,8 @@ extern "C" {
 #define CC2538_CORR_VAL_MAX         (110U)
 #define CC2538_CORR_VAL_MASK        (0x7F)
 
+#define CC2538_CRC_BIT_MASK         (0x80)
+
 #define CC2538_RSSI_OFFSET          (-73)  /**< Signal strength offset value */
 #define CC2538_RF_SENSITIVITY       (-97)  /**< dBm typical, normal conditions */
 

--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -310,8 +310,17 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
         /* Make sure pkt_len is sane */
         if (pkt_len > CC2538_RF_MAX_DATA_LEN) {
+            DEBUG_PRINT("cc2538_rf: pkt_len > CC2538_RF_MAX_DATA_LEN\n");
             RFCORE_SFR_RFST = ISFLUSHRX;
             return -EOVERFLOW;
+        }
+
+        /* Make sure pkt_len is not too short.
+         * There are at least 2 bytes (FCS). */
+        if (pkt_len < IEEE802154_FCS_LEN) {
+            DEBUG_PRINT("cc2538_rf: pkt_len < IEEE802154_FCS_LEN\n");
+            RFCORE_SFR_RFST = ISFLUSHRX;
+            return -ENODATA;
         }
 
         /* CRC check */

--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -347,7 +347,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
         return -ENODATA;
     }
 
-    if (info != NULL && RFCORE->XREG_RSSISTATbits.RSSI_VALID) {
+    if (info != NULL) {
         netdev_ieee802154_rx_info_t *radio_info = info;
 
         RFCORE_ASSERT(rssi_val > CC2538_RF_SENSITIVITY);

--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -371,7 +371,13 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
                           (CC2538_CORR_VAL_MAX - CC2538_CORR_VAL_MIN);
     }
 
-    RFCORE_SFR_RFST = ISFLUSHRX;
+    /* Check for overflow of the rx fifo */
+    if (RFCORE->XREG_FSMSTAT1bits.FIFOP != 0 &&
+        RFCORE->XREG_FSMSTAT1bits.FIFO == 0)
+    {
+        DEBUG_PRINT("cc2538_rf: RXFIFO Overflow\n");
+        RFCORE_SFR_RFST = ISFLUSHRX;
+    }
 
     return pkt_len;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The implementation of receiving packets for CC2538 can lead to underflows of the RX FIFO when running the gnrc_border_router and gnrc_networking examples.

```
RFCORE_ASSERT(RFCORE_XREG_RXFIFOCNT > 0) failed at line 77 in rfcore_read_byte()!
  RFCORE_SFR_RFERRF = 0x00
RFCORE_ASSERT(NOT(flags & RXUNDERF)) failed at line 40 in isr_rfcoreerr()!
  RFCORE_SFR_RFERRF = 0x00
RFCORE_ASSERT(RFCORE_XREG_RXFIFOCNT > 0) failed at line 77 in rfcore_read_byte()!
  RFCORE_SFR_RFERRF = 0x00
RFCORE_ASSERT(NOT(flags & RXUNDERF)) failed at line 40 in isr_rfcoreerr()!
  RFCORE_SFR_RFERRF = 0x00
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR makes the following changes:

1. Checks that FIFOP is set indicating that the last byte of a new frame has been received [Section 23.10.1]
2. Moves the CRC check later in receive. This was because the look ahead check could be inconsistent, where the original CRC check passed but an assert on the CRC bit in `crc_corr_val` later failed.
3. Only flush the RX FIFO if it has overflowed [Section 23.10.2]. This prevents discarding partial frames that haven't finishing being received and fit into the RX FIFO.

References are to the manual available at: https://www.ti.com/lit/ug/swru191f/swru191f.pdf

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Tested on 4 Zolertia RE Mote Rev. Bs, with one running gnrc_border_router (with RPL enabled) and the other three running gnrc_networking. Without the patch RXUNDERF and other asserts will be printed. With the patch these asserts will not be triggered.



### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Fixes original issue identified in #7020 .
