### PR TITLE
cpu/stm32f1: add unified rtt configuration

### DIFF
--- a/boards/common/iotlab/include/periph_conf_common.h
+++ b/boards/common/iotlab/include/periph_conf_common.h
@@ -153,14 +153,9 @@ static const uart_conf_t uart_config[] = {
  * @name    Real time counter configuration
  * @{
  */
-#define RTT_IRQ_PRIO        1
-
-#define RTT_DEV             RTC
-#define RTT_IRQ             RTC_IRQn
-#define RTT_ISR             isr_rtc
-#define RTT_MAX_VALUE       (0xffffffff)
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (1)             /* in Hz */
-#define RTT_PRESCALER       (0x7fff)        /* run with 1 Hz */
+#endif
 /** @} */
 
 /**

--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -153,14 +153,9 @@ static const spi_conf_t spi_config[] = {
  * @name    Real time counter configuration
  * @{
  */
-#define RTT_IRQ_PRIO        1
-
-#define RTT_DEV             RTC
-#define RTT_IRQ             RTC_IRQn
-#define RTT_ISR             isr_rtc
-#define RTT_MAX_VALUE       (0xffffffff)
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (1)             /* in Hz */
-#define RTT_PRESCALER       (0x7fff)        /* run with 1 Hz */
+#endif
 /** @} */
 
 /**

--- a/boards/nucleo-f103rb/include/periph_conf.h
+++ b/boards/nucleo-f103rb/include/periph_conf.h
@@ -123,14 +123,9 @@ static const uart_conf_t uart_config[] = {
  * @name    Real time counter configuration
  * @{
  */
-#define RTT_IRQ_PRIO        1
-
-#define RTT_DEV             RTC
-#define RTT_IRQ             RTC_IRQn
-#define RTT_ISR             isr_rtc
-#define RTT_MAX_VALUE       (0xffffffff)
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (16384)      /* in Hz */
-#define RTT_PRESCALER       (0x1)        /* run with ~16 kHz Hz */
+#endif
 /** @} */
 
 /**

--- a/boards/olimexino-stm32/include/periph_conf.h
+++ b/boards/olimexino-stm32/include/periph_conf.h
@@ -197,14 +197,9 @@ static const uart_conf_t uart_config[] = {
  * @name    Real time counter configuration
  * @{
  */
-#define RTT_IRQ_PRIO        1
-
-#define RTT_DEV             RTC
-#define RTT_IRQ             RTC_IRQn
-#define RTT_ISR             isr_rtc
-#define RTT_MAX_VALUE       (0xffffffff)
-#define RTT_FREQUENCY       (16384)         /* in Hz */
-#define RTT_PRESCALER       (0x1)           /* run with ~16 kHz Hz */
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (16384)      /* in Hz */
+#endif
 /** @} */
 
 /**

--- a/cpu/stm32f1/include/periph_cpu.h
+++ b/cpu/stm32f1/include/periph_cpu.h
@@ -133,6 +133,23 @@ typedef struct {
     uint8_t chan;           /**< CPU ADC channel connected to the pin */
 } adc_conf_t;
 
+/**
+ * @name    Real time counter configuration
+ * @{
+ */
+#define RTT_IRQ_PRIO        1
+
+#define RTT_DEV             RTC
+#define RTT_IRQ             RTC_IRQn
+#define RTT_ISR             isr_rtc
+
+#define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_CLOCK_FREQUENCY (32768U)                  /* in Hz */
+#define RTT_MIN_FREQUENCY   (1U)                      /* in Hz */
+/* RTC frequency of 32kHz is not recommended, see RM0008 Rev 20, p490 */
+#define RTT_MAX_FREQUENCY   (RTT_CLOCK_FREQUENCY / 2) /* in Hz */
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32f1/periph/rtt.c
+++ b/cpu/stm32f1/periph/rtt.c
@@ -26,6 +26,8 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+#define RTT_PRESCALER        ((RTT_CLOCK_FREQUENCY / RTT_FREQUENCY) - 1 )
+
 #define RTT_FLAG_RTOFF       ((uint16_t)0x0020)  /**< RTC Operation OFF flag */
 #define RTT_FLAG_RSF         ((uint16_t)0x0008)  /**< Registers Synchronized flag */
 #define RTT_FLAG_OW          ((uint16_t)0x0004)  /**< Overflow flag */


### PR DESCRIPTION
### Contribution description

This PR is split from https://github.com/RIOT-OS/RIOT/pull/13874. It unifies `rtt` configuration for `stm32f1` and make the `RTT_FREQYENCY` configurable.

As in #13874 max and min values for the RTT are documented.

### Testing procedure

- `tests/periph_rtt` should still pass on `stm32f1` boards with different frequencies


`BOARD=iotlab-m3 make -C tests/periph_rtt flash test --no-print-directory -j3`
```
main(): This is RIOT! (Version: 2020.07-devel-56-g42700-pr_rtt_enhancement)

RIOT RTT low-level driver test
This test will display 'Hello' every 5 seconds

Initializing the RTT driver
RTT now: 0
Setting initial alarm to now + 5 s (81920)
Done setting up the RTT, wait for many Hellos
Hello
Hello
Hello
Hello
Hello
```

`CFLAGS+=-DRTT_FREQUENCY=1 BOARD=iotlab-m3 make -C tests/periph_rtt clean flash test --no-print-directory -j3`

```
main(): This is RIOT! (Version: 2020.07-devel-56-g42700-pr_rtt_enhancement)

RIOT RTT low-level driver test
This test will display 'Hello' every 5 seconds

Initializing the RTT driver
RTT now: 0
Setting initial alarm to now + 5 s (5)
Done setting up the RTT, wait for many Hellos
Hello
Hello
Hello
Hello
Hello
```

### Issues/PRs references

Split from https://github.com/RIOT-OS/RIOT/pull/13874