### PR TITLE
cpu/stm32_common: make RTT_FREQUENCY configurable

### DIFF
--- a/boards/common/stm32/include/cfg_rtt_default.h
+++ b/boards/common/stm32/include/cfg_rtt_default.h
@@ -31,8 +31,15 @@ extern "C" {
  * On the STM32Lx platforms, we always utilize the LPTIM1.
  * @{
  */
-#define RTT_FREQUENCY       (1024U)             /* 32768 / 2^n */
-#define RTT_MAX_VALUE       (0x0000ffff)        /* 16-bit timer */
+#define RTT_CLOCK_FREQUENCY (32768U)                    /* in Hz */
+
+#define RTT_MAX_VALUE       (0x0000ffff)                /* 16-bit timer */
+#define RTT_MAX_FREQUENCY   (RTT_CLOCK_FREQUENCY)       /* 32768Hz at @32768Hz */
+#define RTT_MIN_FREQUENCY   (RTT_CLOCK_FREQUENCY / 128) /* 256Hz at @32768Hz */
+
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (RTT_MAX_FREQUENCY)   /* in Hz */
+#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f413zh/include/periph_conf.h
+++ b/boards/nucleo-f413zh/include/periph_conf.h
@@ -24,6 +24,7 @@
 #include "periph_cpu.h"
 #include "f4/cfg_clock_100_8_1.h"
 #include "cfg_i2c1_pb8_pb9.h"
+#include "cfg_rtt_default.h"
 #include "cfg_timer_tim5.h"
 #include "cfg_usb_otg_fs.h"
 
@@ -217,8 +218,9 @@ static const spi_conf_t spi_config[] = {
  * @name    RTT configuration
  * @{
  */
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (4096)
-#define RTT_MAX_VALUE       (0xffff)
+#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/tests/periph_rtt/Makefile
+++ b/tests/periph_rtt/Makefile
@@ -6,3 +6,11 @@ FEATURES_REQUIRED = periph_rtt
 DISABLE_MODULE += periph_init_rtt
 
 include $(RIOTBASE)/Makefile.include
+
+# Put board specific dependencies here
+ifneq (,$(filter-out stm32f1,$(filter stm32%,$(CPU))))
+  # all stm32% but stm32f1 RTT are based on a 16 bit LPTIM, if using the default
+  # 32768KHz configuration TICKS_TO_WAIT will overflow
+  RTT_FREQUENCY ?= 1024
+  CFLAGS += -DRTT_FREQUENCY=$(RTT_FREQUENCY)
+endif


### PR DESCRIPTION
### Contribution description

This PR is split from https://github.com/RIOT-OS/RIOT/pull/13874. It unifies `rtt` configuration for `stm32%` and make the `RTT_FREQUENCY` configurable.

As in #13874 max and min values for the RTT are documented.

I also had to set `RTT_FREQUENCY ` for `stm32%` board to avoid `TICKS_TO_WAIT` overflowing, I kept the previous value for it.

### Testing procedure

- `tests/periph_rtt` should still pass on `stm32%` boards with different frequencies

`BOARD=b-l072z-lrwan1make -C tests/periph_rtt flash test --no-print-directory -j3`
```
main(): This is RIOT! (Version: 2020.07-devel-110-g66faf-pr_stm32_rtt)

RIOT RTT low-level driver test
This test will display 'Hello' every 5 seconds

Initializing the RTT driver
RTT now: 0
Setting initial alarm to now + 5 s (5120)
Done setting up the RTT, wait for many Hellos
Hello
Hello
Hello
Hello
Hello
```

`CFLAGS+=-DRTT_FREQUENCY=2048 BOARD=iotlab-m3 make -C tests/periph_rtt clean flash test --no-print-directory -j3`

```
main(): This is RIOT! (Version: 2020.07-devel-110-g66faf-pr_stm32_rtt)

RIOT RTT low-level driver test
This test will display 'Hello' every 5 seconds

Initializing the RTT driver
RTT now: 0
Setting initial alarm to now + 5 s (10240)
Done setting up the RTT, wait for many Hellos
Hello
Hello
Hello
Hello
Hello
```

### Issues/PRs references

Split from https://github.com/RIOT-OS/RIOT/pull/13874