### PR TITLE
drivers/dose.h : Expose Configurations to Kconfig 

### DIFF
--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -6,6 +6,7 @@
 
 menu "Network Device Drivers"
 rsource "cc110x/Kconfig"
+rsource "dose/Kconfig"
 rsource "mrf24j40/Kconfig"
 source "$(RIOTCPU)/nrf52/radio/nrf802154/Kconfig"
 endmenu # Network Device Drivers

--- a/drivers/dose/Kconfig
+++ b/drivers/dose/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_DOSE
+    bool "Configure DOSE driver"
+    depends on MODULE_DOSE
+    help
+        Configure the Differentially Operated Serial Ethernet (DOSE)
+        driver using Kconfig.
+
+if KCONFIG_MODULE_DOSE
+
+config DOSE_TIMEOUT_USEC
+    int "Transaction timeout in microseconds [us]"
+    default 5000
+    help
+        Timeout, in microseconds, to bring the driver back into idle state if
+        the remote side died within a transaction.
+
+endif # KCONFIG_MODULE_DOSE

--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -568,7 +568,7 @@ void dose_setup(dose_t *ctx, const dose_params_t *params)
      * We have to ensure it is above the XTIMER_BACKOFF. Otherwise state
      * transitions are triggered from another state transition setting up the
      * timeout. */
-    ctx->timeout_base = DOSE_TIMEOUT_USEC;
+    ctx->timeout_base = CONFIG_DOSE_TIMEOUT_USEC;
     if (ctx->timeout_base < xtimer_usec_from_ticks(min_timeout)) {
         ctx->timeout_base = xtimer_usec_from_ticks(min_timeout);
     }

--- a/drivers/include/dose.h
+++ b/drivers/include/dose.h
@@ -134,8 +134,8 @@ typedef enum {
  *
  *  Fallback to idle if the remote side died within a transaction.
  */
-#ifndef DOSE_TIMEOUT_USEC
-#define DOSE_TIMEOUT_USEC        (5000)
+#ifndef CONFIG_DOSE_TIMEOUT_USEC
+#define CONFIG_DOSE_TIMEOUT_USEC        (5000)
 #endif
 /** @} */
 


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in Dose network driver to Kconfig.

### Testing procedure

The firmware was uploaded to FIT/IoT-LAB Test Bed and following results were obtained. 

New macro was introduced in main.c for testing.

```
#define STR(x)   #x
#define SHOW_DEFINE(x) printf("%s=%s\n", #x, STR(x))
```

#### Default State:

##### Firmware Output
main(): This is RIOT! (Version: 2020.07-devel-97-ga0d15-Kconfig_dose)
CONFIG_DOSE_TIMEOUT_USEC=(5000)

#### Usage with CFLAGS 

/tests/driver_dose/Makefile

> CFLAGS += -DCONFIG_DOSE_TIMEOUT_USEC=6500


##### Firmware Output
main(): This is RIOT! (Version: 2020.07-devel-97-ga0d15-Kconfig_dose)
CONFIG_DOSE_TIMEOUT_USEC=6500

#### Usage with Kconfig

/tests/driver_dose/

> make menuconfig

##### Firmware Output
main(): This is RIOT! (Version: 2020.07-devel-97-ga0d15-Kconfig_dose)
CONFIG_DOSE_TIMEOUT_USEC=10000

Note : The sensor is not available hence configurability of macros were only tested.

### Issues/PRs references

#12888
@leandrolanzieri 
