### PR TITLE
drivers/fxos8700 :  Expose Configurations to Kconfig

### DIFF
--- a/boards/hamilton/include/board.h
+++ b/boards/hamilton/include/board.h
@@ -75,7 +75,7 @@ extern "C" {
 
 /**
  * @name FXOS8700 configuration
- * Note that another fxos8700 operation option, FXOS8700_USE_ACC_RAW_VALUES,
+ * Note that another fxos8700 operation option, CONFIG_FXOS8700_USE_ACC_RAW_VALUES,
  * need to be set according to the application purposes
  * @{
  */

--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -19,6 +19,7 @@ endmenu # Network Device Drivers
 
 menu "Sensor Device Drivers"
 rsource "ads101x/Kconfig"
+rsource "fxos8700/Kconfig"
 rsource "hdc1000/Kconfig"
 rsource "mag3110/Kconfig"
 rsource "mma8x5x/Kconfig"

--- a/drivers/fxos8700/Kconfig
+++ b/drivers/fxos8700/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_FXOS8700
+    bool "Configure FXOS8700 driver"
+    depends on MODULE_FXOS8700
+    help
+        Configure the FXOS8700 driver using Kconfig.
+
+if KCONFIG_MODULE_FXOS8700
+
+config FXOS8700_USE_ACC_RAW_VALUES
+    bool "Enable raw ADC readings"
+    help
+        Enable this to return raw ADC readings.
+        By default measurements are converted to mg.
+
+endif # KCONFIG_MODULE_FXOS8700

--- a/drivers/fxos8700/fxos8700.c
+++ b/drivers/fxos8700/fxos8700.c
@@ -18,6 +18,7 @@
 #include "periph/i2c.h"
 #include "xtimer.h"
 #include "fxos8700.h"
+#include "kernel_defines.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -161,34 +162,35 @@ int fxos8700_read(const fxos8700_t* dev, fxos8700_measurement_t* acc,
 
     /* Read accelerometer */
     if (acc) {
-#if FXOS8700_USE_ACC_RAW_VALUES
-        acc->x = (int16_t) ((data[0] << 8) | data[1]) >> 2;
-        acc->y = (int16_t) ((data[2] << 8) | data[3]) >> 2;
-        acc->z = (int16_t) ((data[4] << 8) | data[5]) >> 2;
-#else
-        int32_t acc_raw_x = (int16_t) ((data[0] << 8) | data[1]) >> 2;
-        int32_t acc_raw_y = (int16_t) ((data[2] << 8) | data[3]) >> 2;
-        int32_t acc_raw_z = (int16_t) ((data[4] << 8) | data[5]) >> 2;
-        switch(dev->p.acc_range) {
-            case FXOS8700_REG_XYZ_DATA_CFG_FS__2G:
-                acc->x = (int16_t) ((acc_raw_x * 244) / 100);
-                acc->y = (int16_t) ((acc_raw_y * 244) / 100);
-                acc->z = (int16_t) ((acc_raw_z * 244) / 100);
-                break;
-            case FXOS8700_REG_XYZ_DATA_CFG_FS__4G:
-                acc->x = (int16_t) ((acc_raw_x * 488) / 1000);
-                acc->y = (int16_t) ((acc_raw_y * 488) / 1000);
-                acc->z = (int16_t) ((acc_raw_z * 488) / 1000);
-                break;
-            case FXOS8700_REG_XYZ_DATA_CFG_FS__8G:
-                acc->x = (int16_t) ((acc_raw_x * 976) / 1000);
-                acc->y = (int16_t) ((acc_raw_y * 976) / 1000);
-                acc->z = (int16_t) ((acc_raw_z * 976) / 1000);
-                break;
-            default:
-                return FXOS8700_NODEV;
+        if (IS_ACTIVE(CONFIG_FXOS8700_USE_ACC_RAW_VALUES)) {
+            acc->x = (int16_t) ((data[0] << 8) | data[1]) >> 2;
+            acc->y = (int16_t) ((data[2] << 8) | data[3]) >> 2;
+            acc->z = (int16_t) ((data[4] << 8) | data[5]) >> 2;
         }
-#endif
+        else {
+            int32_t acc_raw_x = (int16_t) ((data[0] << 8) | data[1]) >> 2;
+            int32_t acc_raw_y = (int16_t) ((data[2] << 8) | data[3]) >> 2;
+            int32_t acc_raw_z = (int16_t) ((data[4] << 8) | data[5]) >> 2;
+            switch(dev->p.acc_range) {
+                case FXOS8700_REG_XYZ_DATA_CFG_FS__2G:
+                    acc->x = (int16_t) ((acc_raw_x * 244) / 100);
+                    acc->y = (int16_t) ((acc_raw_y * 244) / 100);
+                    acc->z = (int16_t) ((acc_raw_z * 244) / 100);
+                    break;
+                case FXOS8700_REG_XYZ_DATA_CFG_FS__4G:
+                    acc->x = (int16_t) ((acc_raw_x * 488) / 1000);
+                    acc->y = (int16_t) ((acc_raw_y * 488) / 1000);
+                    acc->z = (int16_t) ((acc_raw_z * 488) / 1000);
+                    break;
+                case FXOS8700_REG_XYZ_DATA_CFG_FS__8G:
+                    acc->x = (int16_t) ((acc_raw_x * 976) / 1000);
+                    acc->y = (int16_t) ((acc_raw_y * 976) / 1000);
+                    acc->z = (int16_t) ((acc_raw_z * 976) / 1000);
+                    break;
+                default:
+                    return FXOS8700_NODEV;
+             }
+         }
     }
     /* Read magnetometer */
     if (mag) {

--- a/drivers/fxos8700/fxos8700_saul.c
+++ b/drivers/fxos8700/fxos8700_saul.c
@@ -22,6 +22,7 @@
 
 #include "saul.h"
 #include "fxos8700.h"
+#include "kernel_defines.h"
 
 static int read_mag(const void *dev, phydat_t *res)
 {
@@ -42,17 +43,19 @@ static int read_acc(const void *dev, phydat_t *res)
         /* Read failure */
         return -ECANCELED;
     }
-#if FXOS8700_USE_ACC_RAW_VALUES
-    res->unit = UNIT_NONE;
-    res->scale = 0;
-#else
-    res->unit = UNIT_G;
-    if (((fxos8700_t *)dev)->p.acc_range == FXOS8700_REG_XYZ_DATA_CFG_FS__2G) {
-        res->scale = -4;
-    } else {
-        res->scale = -3;
+    if (IS_ACTIVE(CONFIG_FXOS8700_USE_ACC_RAW_VALUES)) {
+        res->unit = UNIT_NONE;
+        res->scale = 0;
     }
-#endif
+    else {
+        res->unit = UNIT_G;
+        if (((fxos8700_t *)dev)->p.acc_range == FXOS8700_REG_XYZ_DATA_CFG_FS__2G) {
+            res->scale = -4;
+        }
+        else {
+            res->scale = -3;
+        }
+    }
     return 3;
 }
 

--- a/drivers/include/fxos8700.h
+++ b/drivers/include/fxos8700.h
@@ -44,11 +44,11 @@ extern "C" {
 /**
  * @brief   Default raw value mode for accelerator
  *
- * If set to 0, measurements will be converted to mg.
- * If set to 1, raw adc readings will be returned.
+ * Set this to 1 to return raw ADC readings. Otherwise measurements
+ * will be converted to mg.
  */
-#ifndef FXOS8700_USE_ACC_RAW_VALUES
-#define FXOS8700_USE_ACC_RAW_VALUES (0)
+#ifdef DOXYGEN
+#define CONFIG_FXOS8700_USE_ACC_RAW_VALUES
 #endif
 /** @} */
 


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in fxos8700 sensor driver to Kconfig.

### Testing procedure

The firmware was uploaded to FIT/IoT-LAB Test Bed and following results were obtained. 

New macro was introduced in main.c for testing.

```
#define STR(x)   #x
#define SHOW_DEFINE(x) printf("%s=%s\n", #x, STR(x))
```

#### Default State:

##### Firmware Output
main(): This is RIOT! (Version: 2020.07-devel-119-g0c64e-Kconfig_fxos8700)
CONFIG_FXOS8700_USE_ACC_RAW_VALUES=(0)
FXOS8700 driver test application

#### Usage with CFLAGS 

/tests/driver_fxos8700/Makefile

> CFLAGS += -DCONFIG_FXOS8700_USE_ACC_RAW_VALUES=1


##### Firmware Output
main(): This is RIOT! (Version: 2020.07-devel-119-g0c64e-Kconfig_fxos8700)
CONFIG_FXOS8700_USE_ACC_RAW_VALUES=1
FXOS8700 driver test application

#### Usage with Kconfig

/tests/driver_fxos8700/

> make menuconfig

##### Firmware Output
main(): This is RIOT! (Version: 2020.07-devel-119-g0c64e-Kconfig_fxos8700)
CONFIG_FXOS8700_USE_ACC_RAW_VALUES=1
FXOS8700 driver test application

Note : The sensor is not available hence configurability of macros were only tested.

### Issues/PRs references

#12888
@leandrolanzieri 
