### PR TITLE
drivers/mag3110 : Expose Configurations to Kconfig

### DIFF
--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -15,5 +15,6 @@ endmenu # Network Device Drivers
 menu "Sensor Device Drivers"
 rsource "ads101x/Kconfig"
 rsource "hdc1000/Kconfig"
+rsource "mag3110/Kconfig"
 rsource "mma8x5x/Kconfig"
 endmenu # Sensor Device Drivers

--- a/drivers/include/mag3110.h
+++ b/drivers/include/mag3110.h
@@ -65,8 +65,8 @@ enum {
  * The address depends on part number of MAG3110.
  * For more information on SerialBus Address, refer Table 1 in Technical datasheet(MAG3110).
  */
-#ifndef MAG3110_I2C_ADDRESS
-#define MAG3110_I2C_ADDRESS             0x0E
+#ifndef CONFIG_MAG3110_I2C_ADDRESS
+#define CONFIG_MAG3110_I2C_ADDRESS             0x0E
 #endif
 /** @} */
 

--- a/drivers/mag3110/Kconfig
+++ b/drivers/mag3110/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_MAG3110
+    bool "Configure MAG3110 driver"
+    depends on MODULE_MAG3110
+    help
+        Configure the MAG3110 driver using Kconfig.
+
+if KCONFIG_MODULE_MAG3110
+
+config MAG3110_I2C_ADDRESS
+    hex "I2C default address"
+    range 0x0E 0x0F
+    default 0x0E
+    help
+        The address depends on part number of MAG3110.
+        For more information refer to the datasheet.
+
+endif # KCONFIG_MODULE_MAG3110

--- a/drivers/mag3110/include/mag3110_params.h
+++ b/drivers/mag3110/include/mag3110_params.h
@@ -36,7 +36,7 @@ extern "C" {
 #define MAG3110_PARAM_I2C       (I2C_DEV(0))
 #endif
 #ifndef MAG3110_PARAM_ADDR
-#define MAG3110_PARAM_ADDR      (MAG3110_I2C_ADDRESS)
+#define MAG3110_PARAM_ADDR      (CONFIG_MAG3110_I2C_ADDRESS)
 #endif
 #ifndef MAG3110_PARAM_OFFSET
 #define MAG3110_PARAM_OFFSET    { 0, 0, 0 }


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in MAG3110 Sensor Device driver to Kconfig.

### Testing procedure

The firmware was uploaded to FIT/IoT-LAB Test Bed and following results were obtained.

#### Default State:

##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-147-g8a1d9-Kconfig_mag3110)
CONFIG_MAG3110_I2C_ADDRESS=0x0E
MAG3110 magnetometer driver test application

Initializing MAG3110 magnetometer at I2C_0... mag3110_init: invalid WHO_AM_I value (0x20)!
[FAILED]

#### Usage with CFLAGS 

/tests/driver_mag3110/Makefile

> CFLAGS += -DCONFIG_MAG3110_I2C_ADDRESS=0x0F

##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-147-g8a1d9-Kconfig_mag3110)
CONFIG_MAG3110_I2C_ADDRESS=0x0F
MAG3110 magnetometer driver test application

Initializing MAG3110 magnetometer at I2C_0... mag3110_init: invalid WHO_AM_I value (0x20)!
[FAILED]

#### Usage with Kconfig

/tests/mag3110/

> make menuconfig

##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-147-g8a1d9-Kconfig_mag3110)
CONFIG_MAG3110_I2C_ADDRESS=0x0f
MAG3110 magnetometer driver test application

Initializing MAG3110 magnetometer at I2C_0... mag3110_init: invalid WHO_AM_I value (0x20)!
[FAILED]

Note : The network device is not available fro interfacing hence configurability of macros were only tested.

### Issues/PRs references

#12888
@leandrolanzieri 
