### PR TITLE
tools/kconfiglib: Add riot_kconfig to override default behaviours

### DIFF
--- a/dist/tools/kconfiglib/riot_kconfig.py
+++ b/dist/tools/kconfiglib/riot_kconfig.py
@@ -1,0 +1,53 @@
+""" RIOT customization of Kconfig """
+import argparse
+import sys
+
+from kconfiglib import Kconfig, KconfigError
+
+
+class RiotKconfig(Kconfig):
+    """ RIOT adaption of Kconfig class """
+    def _parse_help(self, node):
+        """ Parses the help section of a node, removing Doxygen markers """
+        doxygen_markers = ["@ref ", "@see "]
+
+        # call default parsing
+        super(RiotKconfig, self)._parse_help(node)
+
+        # remove Doxygen markers
+        for marker in doxygen_markers:
+            node.help = node.help.replace(marker, "")
+
+
+def standard_riot_kconfig(description=None):
+    """
+    Argument parsing helper for tools that take a single optional Kconfig file
+    argument (default: Kconfig). Returns the RiotKconfig instance for the parsed
+    configuration. Uses argparse internally.
+
+    Exits with sys.exit() (which raises SystemExit) on errors.
+
+    description (default: None):
+      The 'description' passed to argparse.ArgumentParser().
+      argparse.RawDescriptionHelpFormatter is used, so formatting is preserved.
+    """
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=description)
+
+    parser.add_argument(
+        "kconfig",
+        metavar="KCONFIG",
+        default="Kconfig",
+        nargs="?",
+        help="Kconfig file (default: Kconfig)")
+
+    args = parser.parse_args()
+
+    # Suppress backtraces for expected exceptions
+    try:
+        return RiotKconfig(args.kconfig)
+    except (EnvironmentError, KconfigError) as e:
+        # Some long exception messages have extra newlines for better
+        # formatting when reported as an unhandled exception. Strip them here.
+        sys.exit(str(e).strip())

--- a/dist/tools/kconfiglib/riot_menuconfig.py
+++ b/dist/tools/kconfiglib/riot_menuconfig.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+""" Menuconfig variant which uses RiotKconfig as base class """
+import menuconfig
+from riot_kconfig import standard_riot_kconfig
+
+# keep documentation from the original tool
+__doc__ = menuconfig.__doc__
+
+if __name__ == "__main__":
+    menuconfig.menuconfig(standard_riot_kconfig(__doc__))

--- a/makefiles/tools/kconfiglib.inc.mk
+++ b/makefiles/tools/kconfiglib.inc.mk
@@ -1,13 +1,14 @@
 # Define tools to use
-MENUCONFIG ?= $(RIOTTOOLS)/kconfiglib/menuconfig.py
+MENUCONFIG ?= $(RIOTTOOLS)/kconfiglib/riot_menuconfig.py
+BASE_MENUCONFIG ?= $(RIOTTOOLS)/kconfiglib/menuconfig.py
 GENCONFIG ?= $(RIOTTOOLS)/kconfiglib/genconfig.py
 MERGECONFIG ?= $(RIOTTOOLS)/kconfiglib/merge_config.py
 
-$(MENUCONFIG):
+$(BASE_MENUCONFIG):
 	@echo "[INFO] Kconfiglib not found - getting it"
 	@make -C $(RIOTTOOLS)/kconfiglib
 	@echo "[INFO] Kconfiglib downloaded"
 
-$(GENCONFIG): $(MENUCONFIG)
+$(GENCONFIG): $(BASE_MENUCONFIG)
 
-$(MERGECONFIG): $(MENUCONFIG)
+$(MERGECONFIG): $(BASE_MENUCONFIG)


### PR DESCRIPTION
### Contribution description
This PR adds a `RiotKconfig` class which can be used to override behaviours from the base `Kconfig`. It also patches menuconfig.py to use the new class. For now it implements a version of `_parse_help` which removes Doxygen markers.

`standard_riot_kconfig` is taken from the original `standard_kconfig`.

### Testing procedure
- Check that `make menuconfig` still works as usual
- Check that the help string of a symbol with Doxygen markers (e.g. `GNRC_NETIF_IPV6_ADDRS_NUMOF`) does not show them.


### Issues/PRs references
Solves issue presented here https://github.com/RIOT-OS/RIOT/pull/13227#discussion_r412118812