### PR TITLE
boards/common/msba2: Add MINITERMFLAGS to avoid reset [backport 2020.04]

### DIFF
--- a/boards/common/msba2/Makefile.include
+++ b/boards/common/msba2/Makefile.include
@@ -16,6 +16,9 @@ PORT_LINUX ?= /dev/ttyUSB0
 # This does not make a lot of sense, but it has the same value as the previous code
 PORT_DARWIN ?= /dev/tty.usbserial-ARM
 
+# when using miniterm set RTS and DTR lines to 0, otherwise the board is reset
+MINITERMFLAGS += --rts 0 --dtr 0
+
 PYTERMFLAGS += -tg
 include $(RIOTMAKE)/tools/serial.inc.mk
 

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -25,7 +25,7 @@ else ifeq ($(RIOT_TERMINAL),miniterm)
   TERMPROG  ?= miniterm.py
   # The RIOT shell will still transmit back a CRLF, but at least with --eol LF
   # we avoid sending two lines on every "enter".
-  TERMFLAGS ?= --eol LF "$(PORT)" "$(BAUD)"
+  TERMFLAGS ?= --eol LF "$(PORT)" "$(BAUD)" $(MINITERMFLAGS)
 else ifeq ($(RIOT_TERMINAL),jlink)
   TERMPROG = $(RIOTTOOLS)/jlink/jlink.sh
   TERMFLAGS = term-rtt


### PR DESCRIPTION
# Backport of #13917

### Contribution description
This adds the variable `MINITERMFLAGS` analog to `PYTERMFLAGS`, which allows adding extra flags to the terminal when using `miniterm.py`. This is needed in the case of the `msba2` which requires RTS and DTR lines to be 0.

### Testing procedure
Run some application on the `msba2`, that uses miniterm (e.g. `examples/micropython`) or specify `RIOT_TERMINAL = miniterm`. With this PR it should work.

### Issues/PRs references
Found while running tests for https://github.com/RIOT-OS/Release-Specs/issues/152