### PR TITLE
pkg/semtech-loramac: fix rx thread documentation

### DIFF
--- a/pkg/semtech-loramac/doc.txt
+++ b/pkg/semtech-loramac/doc.txt
@@ -126,8 +126,6 @@
  *         loramac.rx_data.payload[loramac.rx_data.payload_len] = 0;
  *         printf("Data received: %s, port: %d\n",
  *                (char *)loramac.rx_data.payload, loramac.rx_data.port);
- *         }
- *
  *     }
  *     return NULL;
  * }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes an issue with the semtech-loramac doxygen documentation. The fix is quite obvious (there's an extra `}`) but it makes the rx thread example wrong when one follows the documentation.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Just read
- follow the doc in order to write a sample application and verify that the build is fixed with this PR but broken with the doc in master

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
