### PR TITLE
cpu/lpc2387: fix RTC leap year calculation [backport 2020.04]

### DIFF
--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -233,6 +233,16 @@ typedef struct {
 #define PERIPH_I2C_NEED_WRITE_REG
 /** @} */
 
+/**
+ * Enable yday and wday calculation in rtc_normalize().
+ * Those fields are used by the RTC.
+ * @{
+ */
+#if defined(MODULE_PERIPH_RTC) && !defined(RTC_NORMALIZE_COMPAT)
+#define RTC_NORMALIZE_COMPAT    (1)
+#endif
+/* @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
# Backport of #13919

### Contribution description

The conversion to `rtc_normalize()` introduced a bug insofar that the calculation of day of week / day of year are disabled by default since they are not needed by most RTCs.
The lpc2387 RTC however uses those values, so writing `0` here will lead to wrong results.

The lpc2387 RTC year register also has a range of 0…4095, so it expects whole years.
`struct tm` however only contains the years since 1900.
This may throw off the leap year calculation - `tests/periph_rtc` was recently changed to test for this 'edge case'.

### Testing procedure

`tests/periph_rtc` should work again.

### Issues/PRs references

found in https://github.com/RIOT-OS/Release-Specs/issues/152