### PR TITLE
periph/gpio: add gpio_update_int() class of functions

### DIFF
--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -358,6 +358,28 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+void gpio_update_cb(gpio_t pin, gpio_cb_t cb)
+{
+    int8_t int_num = _int_num(pin);
+    config[int_num].cb = cb;
+}
+
+void gpio_update_arg(gpio_t pin, void *arg)
+{
+    int8_t int_num = _int_num(pin);
+    config[int_num].arg = arg;
+}
+
+void gpio_update_int(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    int8_t int_num = _int_num(pin);
+
+    EIMSK &= ~(1 << int_num);
+    config[int_num].cb = cb;
+    config[int_num].arg = arg;
+    EIMSK |= (1 << int_num);
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     EIFR |= (1 << _int_num(pin));

--- a/cpu/lpc2387/periph/gpio.c
+++ b/cpu/lpc2387/periph/gpio.c
@@ -248,6 +248,28 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
+void gpio_update_int(gpio_t pin, gpio_cb_t cb, void *arg)
+{
+    int _state_index = _gpio_isr_map[_isr_map_entry(pin)];
+
+    unsigned state = irq_disable();
+    _gpio_states[_state_index].cb = cb;
+    _gpio_states[_state_index].arg = arg;
+    irq_restore(state);
+}
+
+void gpio_update_cb(gpio_t pin, gpio_cb_t cb)
+{
+    int _state_index = _gpio_isr_map[_isr_map_entry(pin)];
+    _gpio_states[_state_index].cb = cb;
+}
+
+void gpio_update_arg(gpio_t pin, void *arg)
+{
+    int _state_index = _gpio_isr_map[_isr_map_entry(pin)];
+    _gpio_states[_state_index].arg = arg;
+}
+
 void gpio_irq_enable(gpio_t pin)
 {
     int isr_map_entry =_isr_map_entry(pin);

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -209,6 +209,39 @@ void gpio_irq_enable(gpio_t pin);
  */
 void gpio_irq_disable(gpio_t pin);
 
+/**
+ * @brief   Update the interrupt callback function & argument for a pin
+ *
+ * @pre     @ref gpio_init_int has been called on @p pin
+ *
+ * @param[in] pin       pin to initialize
+ * @param[in] cb        callback that is called from interrupt context
+ *                      must not be NULL
+ * @param[in] arg       optional argument passed to the callback
+ */
+void gpio_update_int(gpio_t pin, gpio_cb_t cb, void *arg);
+
+/**
+ * @brief   Update the interrupt callback function for a pin
+ *
+ * @pre     @ref gpio_init_int has been called on @p pin
+ *
+ * @param[in] pin       pin to initialize
+ * @param[in] cb        callback that is called from interrupt context
+ *                      must not be NULL
+ */
+void gpio_update_cb(gpio_t pin, gpio_cb_t cb);
+
+/**
+ * @brief   Update the interrupt callback argument for a pin
+ *
+ * @pre     @ref gpio_init_int has been called on @p pin
+ *
+ * @param[in] pin       pin to initialize
+ * @param[in] arg       optional argument passed to the callback
+ */
+void gpio_update_arg(gpio_t pin, void *arg);
+
 #endif /* defined(MODULE_PERIPH_GPIO_IRQ) || defined(DOXYGEN) */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

It can be desirable to change the function or behavior associated with a GPIO interrupt.
Currently this can only be achieved by calling `gpio_init_int()` again, which not only does lots of unnecessary and possibly time-consuming work, but also forces to expose the GPIO configuration to callers that only want to change the callback argument.

As proposed in https://github.com/RIOT-OS/RIOT/pull/12082#issuecomment-539402827 this introduces three new functions:

```C
void gpio_update_int(gpio_t pin, gpio_cb_t cb, void *arg);
void gpio_update_cb(gpio_t pin, gpio_cb_t cb);
void gpio_update_arg(gpio_t pin, void *arg);
```

`gpio_init_int()` must have been called successfully before on `pin`, so no error checking is needed which greatly simplifies the implementation.

If the API is acceptable, I will update the remaining GPIO drivers.

- [ ] `stm32f1/periph/gpio.c`
- [ ] `mips_pic32_common/periph/gpio.c`
- [ ] `lpc1768/periph/gpio.c`
- [ ] `stm32_common/periph/gpio.c`
- [ ] `efm32/periph/gpio.c`
- [ ] `native/periph/gpio.c`
- [ ] `lm4f120/periph/gpio.c`
- [ ] `fe310/periph/gpio.c`
- [ ] `esp8266/periph/gpio.c`
- [ ] `msp430fxyz/periph/gpio.c`
- [ ] `cc26xx_cc13xx/periph/gpio.c`
- [ ] `cc2538/periph/gpio.c`
- [ ] `esp32/periph/gpio.c`
- [x] `lpc2387/periph/gpio.c`
- [ ] `kinetis/periph/gpio.c`
- [x] `atmega_common/periph/gpio.c`
- [x] `sam0_common/periph/gpio.c`
- [ ] `nrf5x_common/periph/gpio.c`
- [ ] `sam3/periph/gpio.c`
- [ ] `ezr32wg/periph/gpio.c`

### Testing procedure

The following program should alternate between the two messages with each press of a button.

```C
#include <stdio.h>
#include "periph/gpio.h"
#include "board.h"

static char* messages[] = {
    "Hello IRQ!",
    "Goodby IRQ!"
};

static void _irq_handler(void *arg)
{
    puts(arg);
    gpio_update_cb(BTN0_PIN, arg == messages[0] ? messages[1] : messages[0]);
}

int main(void)
{
    gpio_init_int(BTN0_PIN, GPIO_IN, GPIO_RISING, _irq_handler, messages[0]);
    return 0;
}
```


### Issues/PRs references

alternative to #12082
