### PR TITLE
drivers/motor_driver : Expose Configurations to Kconfig

### DIFF
--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -4,6 +4,10 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
+menu "Actuator Device Drivers"
+rsource "motor_driver/Kconfig"
+endmenu # Actuator Device Drivers
+
 menu "Network Device Drivers"
 rsource "at86rf215/Kconfig"
 rsource "cc110x/Kconfig"

--- a/drivers/include/motor_driver.h
+++ b/drivers/include/motor_driver.h
@@ -17,9 +17,9 @@
  * Mainly designed for H-bridge, it could also drive some brushless drivers.
  *
  * Some H-bridge driver circuits handle several motors.
- * Maximum motor number by H-bridge is set to 2 with MOTOR_DRIVER_MAX macro.
+ * Maximum motor number by H-bridge is set to 2 with CONFIG_MOTOR_DRIVER_MAX macro.
  * This macro can be overridden to support H-bridge drivers with more outputs.
- * However, MOTOR_DRIVER_MAX should not exceed PWM channels number.
+ * However, CONFIG_MOTOR_DRIVER_MAX should not exceed PWM channels number.
  *
  * motor_driver_t structure represents an H-bridge.
  * As several H-bridge can share a same PWM device, motor_driver_t can
@@ -99,8 +99,8 @@ extern "C" {
 /**
  * @brief Maximum number of motors by motor driver
  */
-#ifndef MOTOR_DRIVER_MAX
-#define MOTOR_DRIVER_MAX    (2)
+#ifndef CONFIG_MOTOR_DRIVER_MAX
+#define CONFIG_MOTOR_DRIVER_MAX    (2)
 #endif
 /** @} */
 
@@ -173,7 +173,7 @@ typedef struct {
     uint32_t pwm_frequency;                 /**< PWM device frequency */
     uint32_t pwm_resolution;                /**< PWM device resolution */
     uint8_t nb_motors;                      /**< number of moros */
-    motor_t motors[MOTOR_DRIVER_MAX];       /**< motors array */
+    motor_t motors[CONFIG_MOTOR_DRIVER_MAX];       /**< motors array */
     motor_driver_cb_t cb;                   /**< callback on motor_set */
 } motor_driver_config_t;
 

--- a/drivers/motor_driver/Kconfig
+++ b/drivers/motor_driver/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_MOTOR_DRIVER
+    bool "Configure the DC Motor driver"
+    depends on MODULE_MOTOR_DRIVER
+    help
+        Configure the DC Motor driver using Kconfig.
+
+if KCONFIG_MODULE_MOTOR_DRIVER
+
+config MOTOR_DRIVER_MAX
+    int "Maximum number of motors"
+    default 2
+    help
+        Maximum number of motors depends on the H-bridge.
+        The value should not exceed the number of PWM channels
+        Default value is set to 2.
+
+endif # KCONFIG_MODULE_MOTOR_DRIVER


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in Motor Driver Actuator Device driver to Kconfig.

### Testing procedure

New macro was introduced in main.c for testing.

```
#define STR(x)   #x
#define SHOW_DEFINE(x) printf("%s=%s\n", #x, STR(x))
```

#### Default State:

##### Firmware Output

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Auto init xtimer.
main(): This is RIOT! (Version: 2020.07-devel-166-g1774d-Kconfig_motor_driver)
CONFIG_MOTOR_DRIVER_MAX=(2)
Brake motors !!!

#### Usage with CFLAGS 

/tests/driver_mma8x5x/Makefile

> CFLAGS += -DCONFIG_MOTOR_DRIVER_MAX=4

##### Firmware Output

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Auto init xtimer.
main(): This is RIOT! (Version: 2020.07-devel-166-g1774d-Kconfig_motor_driver)
CONFIG_MOTOR_DRIVER_MAX=4
Brake motors !!!

#### Usage with Kconfig

/tests/driver_motor_driver/

> make menuconfig

##### Firmware Output

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Auto init xtimer.
main(): This is RIOT! (Version: 2020.07-devel-166-g1774d-Kconfig_motor_driver)
CONFIG_MOTOR_DRIVER_MAX=6
Brake motors !!!

Note : The network device is not available fro interfacing hence configurability of macros were only tested.

### Issues/PRs references

#12888
@leandrolanzieri 
