### PR TITLE
core/msg: add simple message bus

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1,5 +1,5 @@
 # exclude submodule sources from *.c wildcard source selection
-SRC := $(filter-out init.c mbox.c msg.c panic.c thread_flags.c,$(wildcard *.c))
+SRC := $(filter-out init.c mbox.c msg.c msg_bus.c panic.c thread_flags.c,$(wildcard *.c))
 
 # enable submodules
 SUBMODULES := 1

--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -363,6 +363,47 @@ int msg_reply_int(msg_t *m, msg_t *reply);
 int msg_avail(void);
 
 /**
+ * @brief Receive a message from the global message bus.
+ *
+ * This function blocks until an event of a matching type was posted on the bus.
+ *
+ * @param[out] m    Pointer to preallocated ``msg_t`` structure, must not be
+ *                  NULL.
+ * @param[in] array An array of event types types to listen to
+ * @param[in] len   Number of array elements
+ *
+ */
+void msg_bus_receive(msg_t *m, const uint16_t *array, uint8_t len);
+
+/**
+ * @brief Receive a message of ``type`` from the global message bus.
+ *
+ * This function blocks until an event of a matching type was posted on the bus.
+ *
+ * @param[out] m    Pointer to preallocated ``msg_t`` structure, must not be
+ *                  NULL.
+ * @param[in] type  The message type to listen to.
+ *
+ */
+static inline void msg_bus_receive_single(msg_t *m, uint16_t type) {
+    msg_bus_receive(m, &type, 1);
+}
+
+/**
+ * @brief Post an event of ``type`` to the global message bus.
+ *
+ * The function will wake up all threads waiting for a message of
+ * type @p type.
+ *
+ * @param[in] type  The message type to send.
+ * @param[in] arg   Optional message argument.
+ *
+ * @return          The number of threads that received the message.
+ *
+ */
+int msg_bus_post(uint16_t type, void *arg);
+
+/**
  * @brief Initialize the current thread's message queue.
  *
  * @pre @p num **MUST BE A POWER OF TWO!**

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -105,6 +105,7 @@ typedef enum {
     STATUS_SLEEPING,                /**< sleeping                                 */
     STATUS_MUTEX_BLOCKED,           /**< waiting for a locked mutex               */
     STATUS_RECEIVE_BLOCKED,         /**< waiting for a message                    */
+    STATUS_RECEIVE_BUS_BLOCKED,     /**< waiting for a broadcast message          */
     STATUS_SEND_BLOCKED,            /**< waiting for message to be delivered      */
     STATUS_REPLY_BLOCKED,           /**< waiting for a message response           */
     STATUS_FLAG_BLOCKED_ANY,        /**< waiting for any flag from flag_mask      */

--- a/core/msg_bus.c
+++ b/core/msg_bus.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     core_msg
+ * @{
+ *
+ * @file
+ * @brief       Kernel messaging bus implementation
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include <stddef.h>
+#include <inttypes.h>
+#include <assert.h>
+#include "sched.h"
+#include "msg.h"
+#include "irq.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+struct msg_bus_consumer {
+    msg_t *m;
+    const uint16_t *type;
+    uint8_t max_idx;
+};
+
+int msg_bus_post(uint16_t type, void *arg)
+{
+    const bool in_irq = irq_is_in();
+    int threads_woken = 0;
+
+    msg_t m = {
+        .sender_pid = in_irq ? KERNEL_PID_ISR : sched_active_pid,
+        .type = type,
+        .content.ptr  = arg,
+    };
+
+    unsigned state = irq_disable();
+
+    for (kernel_pid_t i = KERNEL_PID_FIRST; i <= KERNEL_PID_LAST; i++) {
+        struct msg_bus_consumer *consumer;
+        thread_t *p = (thread_t *)sched_threads[i];
+
+        if (p == NULL) {
+            continue;
+        }
+
+        if (p->status != STATUS_RECEIVE_BUS_BLOCKED) {
+            continue;
+        }
+
+        assert(p->wait_data != NULL);
+
+        consumer = p->wait_data;
+        for (int j = consumer->max_idx; j >= 0; --j) {
+
+            if (consumer->type[j] != type) {
+                continue;
+            }
+
+            /* copy msg to target */
+            *consumer->m = m;
+            sched_set_status(p, STATUS_PENDING);
+            ++threads_woken;
+            break;
+        }
+    }
+
+    irq_restore(state);
+
+    /* no need to run scheduler if no threads waited for an event */
+    if (threads_woken == 0) {
+        return 0;
+    }
+
+    if (in_irq) {
+        sched_context_switch_request = 1;
+    } else {
+        thread_yield_higher();
+    }
+
+    return threads_woken;
+}
+
+void msg_bus_receive(msg_t *m, const uint16_t *events, uint8_t num_events)
+{
+    assert(m);
+    assert(events);
+    assert(num_events > 0);
+
+    unsigned state = irq_disable();
+
+    struct msg_bus_consumer consumer = {
+        .m = m,
+        .type = events,
+        .max_idx = num_events - 1,
+    };
+
+    thread_t *me = (thread_t *)sched_threads[sched_active_pid];
+    me->wait_data = &consumer;
+    sched_set_status(me, STATUS_RECEIVE_BUS_BLOCKED);
+
+    irq_restore(state);
+    thread_yield_higher();
+
+    /* sender copied message */
+    assert(sched_active_thread->status != STATUS_RECEIVE_BUS_BLOCKED);
+}

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -40,6 +40,7 @@ static const char *state_names[] = {
     [STATUS_ZOMBIE] = "zombie",
     [STATUS_MUTEX_BLOCKED] = "bl mutex",
     [STATUS_RECEIVE_BLOCKED] = "bl rx",
+    [STATUS_RECEIVE_BUS_BLOCKED] = "bl rx bus",
     [STATUS_SEND_BLOCKED] = "bl send",
     [STATUS_REPLY_BLOCKED] = "bl reply",
     [STATUS_FLAG_BLOCKED_ANY] = "bl anyfl",

--- a/tests/thread_msg_bus/Makefile
+++ b/tests/thread_msg_bus/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEMODULE += core_msg_bus
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/thread_msg_bus/Makefile.ci
+++ b/tests/thread_msg_bus/Makefile.ci
@@ -1,0 +1,10 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    nucleo-f031k6 \
+    nucleo-f042k6 \
+    stm32f030f4-demo \
+    #

--- a/tests/thread_msg_bus/main.c
+++ b/tests/thread_msg_bus/main.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Message bus test application
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "thread.h"
+#include "msg.h"
+
+char t1_stack[THREAD_STACKSIZE_MAIN];
+char t2_stack[THREAD_STACKSIZE_MAIN];
+char t3_stack[THREAD_STACKSIZE_MAIN];
+
+kernel_pid_t p_main, p1, p2, p3;
+
+void *thread1(void *arg)
+{
+    (void) arg;
+    puts("THREAD 1 start");
+
+    msg_t msg;
+    msg_bus_receive_single(&msg, 0x23);
+    printf("T1 recv: %s (type=%x)\n", (char*) msg.content.ptr, msg.type);
+
+    return NULL;
+}
+
+void *thread2(void *arg)
+{
+    (void) arg;
+    puts("THREAD 2 start");
+
+    msg_t msg;
+    msg_bus_receive_single(&msg, 0x24);
+    printf("T2 recv: %s (type=%x)\n", (char*) msg.content.ptr, msg.type);
+
+    return NULL;
+}
+
+void *thread3(void *arg)
+{
+    (void) arg;
+    puts("THREAD 3 start");
+
+    msg_t msg;
+    msg_bus_receive_single(&msg, 0x23);
+    printf("T3 recv: %s (type=%x)\n", (char*) msg.content.ptr, msg.type);
+
+    return NULL;
+}
+
+int main(void)
+{
+    p_main = sched_active_pid;
+    p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
+                       THREAD_CREATE_STACKTEST, thread1, NULL, "nr1");
+    p2 = thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN - 1,
+                       THREAD_CREATE_STACKTEST, thread2, NULL, "nr2");
+    p3 = thread_create(t3_stack, sizeof(t3_stack), THREAD_PRIORITY_MAIN - 1,
+                       THREAD_CREATE_STACKTEST, thread3, NULL, "nr3");
+    puts("THREADS CREATED");
+
+    const char hello[] = "Hello Threads!";
+
+    for (int id = 0x22; id < 0x25; ++id) {
+        int woken = msg_bus_post(id, (void*) hello);
+        printf("Posted event 0x%x to %d threads\n", id, woken);
+    }
+
+    puts("SUCCESS");
+
+    return 0;
+}

--- a/tests/thread_msg_bus/tests/01-run.py
+++ b/tests/thread_msg_bus/tests/01-run.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact('THREAD 1 start')
+    child.expect_exact('THREAD 2 start')
+    child.expect_exact('THREAD 3 start')
+    child.expect_exact('THREADS CREATED')
+
+    child.expect_exact('Posted event 0x22 to 0 threads')
+
+    child.expect_exact('T1 recv: Hello Threads! (type=23)')
+    child.expect_exact('T3 recv: Hello Threads! (type=23)')
+    child.expect_exact('Posted event 0x23 to 2 threads')
+
+    child.expect_exact('T2 recv: Hello Threads! (type=24)')
+    child.expect_exact('Posted event 0x24 to 1 threads')
+
+    child.expect_exact('SUCCESS')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This adds a simple message bus to RIOT.

A thread can wait for a list of events with `msg_bus_receive()`.
Any thread can post an event to the bus with `msg_bus_post()`. This will wake all threads waiting for the event.

Since [`msg_t`](https://riot-os.org/api/structmsg__t.html) is used, this allows for 65535 `type`s of events.

A use case for this is waiting for the network to be ready.
E.g. an application wants to send data to a host outside the WPAN as soon as the global prefix becomes valid.
It would be unwieldy for the application to hook into the network stack for a callback to this event, which might also be used by routing protocols.

The message bus solves this by informing all interested parties about such an event.

### Testing procedure

A simple test is provided in `tests/thread_msg_bus`.

### Issues/PRs references


