### PR TITLE
boards/common/blxxxpill: provide periph_rtt

### DIFF
--- a/boards/common/blxxxpill/Makefile.features
+++ b/boards/common/blxxxpill/Makefile.features
@@ -4,6 +4,7 @@ CPU = stm32f1
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/common/blxxxpill/include/periph_conf.h
+++ b/boards/common/blxxxpill/include/periph_conf.h
@@ -60,6 +60,15 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    Real time counter configuration
+ * @{
+ */
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (16384)      /* in Hz */
+#endif
+/** @} */
+
+/**
  * @name    ADC configuration
  * @{
  */


### PR DESCRIPTION
### Contribution description

`blxxpill` share the same `periph_conf` and they all have `CLOCK_LSE`, `periph_rtt` should work on them.

### Testing procedure

I don't have a `blxxxpill` but verify:

`BOARD=<blxxxpill> make -C tests/peripsh_rtt flash test`

### Issues/PRs references

Based on https://github.com/RIOT-OS/RIOT/pull/13907