### PR TITLE
cpu/stm32f1: dont provide periph_rtc at cpu level

### DIFF
--- a/boards/common/blxxxpill/Makefile.features
+++ b/boards/common/blxxxpill/Makefile.features
@@ -4,6 +4,7 @@ CPU = stm32f1
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/common/iotlab/Makefile.features
+++ b/boards/common/iotlab/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32f103re
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/fox/Makefile.features
+++ b/boards/fox/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32f103re
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/nucleo-f103rb/Makefile.features
+++ b/boards/nucleo-f103rb/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32f103rb
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/cpu/stm32f1/Makefile.features
+++ b/cpu/stm32f1/Makefile.features
@@ -3,7 +3,6 @@ CPU_FAM  = stm32f1
 
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw
-FEATURES_PROVIDED += periph_rtc
 
 FEATURES_CONFLICT += periph_rtc:periph_rtt
 FEATURES_CONFLICT_MSG += "On the STM32F1, the RTC and RTT map to the same hardware peripheral."


### PR DESCRIPTION
### Contribution description

The `stm32f1` `periph_rtc` implementation gets a 1s resolution by dividing the clock by `32768`. This only make sense if `CLOCK_LSE` is set, otherwise `CLOCK_LSI ~40000`, which will lead to an imprecise `rtc`.

This PR therefore removes `periph_rtc` as a `cpu` feature and provides it only in `stm32f1` `BOARD`a with a `CLOCK_LSE`.

### Testing procedure

Testing that `tests/periph_rtt` still works shouldn't be necessary IMO only reviewing that those `BOARD`s provide a `CLOCK_LSE` in the config.
 
- stm32f1 boards that where left out because of no `CLOCK_LSE`: `maple-mini`, `spark-core`, `opencm904`.

- stm32f1 boards already providing `periph_rtc`: `olimexinostm32`
