### PR TITLE
drivers/mtd_sdcard : Expose Configurations to Kconfig 

### DIFF
--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -16,3 +16,7 @@ menu "Sensor Device Drivers"
 rsource "ads101x/Kconfig"
 rsource "hdc1000/Kconfig"
 endmenu # Sensor Device Drivers
+
+menu "Storage Device Drivers"
+rsource "mtd_sdcard/Kconfig"
+endmenu # Storage Device Drivers

--- a/drivers/include/mtd_sdcard.h
+++ b/drivers/include/mtd_sdcard.h
@@ -58,23 +58,23 @@ typedef struct {
  *          so enable this feature to ensure overriding the data.
  */
 #ifdef DOXYGEN
-#define MTD_SDCARD_ERASE
+#define CONFIG_MTD_SDCARD_ERASE
 #endif
 /** @} */
 
 /**
  * @brief   Enable Skip SDCard Erase
  * @note    SDCards handle sector erase internally so it's
- * possible to directly write to the card without erasing
- * the sector first.
- * Attention: an erase call will therefore NOT touch the content,
- * so disable this feature to ensure overriding the data.
- * 
- *  * @deprecated Use inverse @ref GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE instead.
- *             Will be removed after 2020.10 release.
+ *          possible to directly write to the card without erasing
+ *          the sector first.
+ *          Attention: an erase call will therefore NOT touch the content,
+ *          so disable this feature to ensure overriding the data.
+ *
+ *          @deprecated Use inverse @ref CONFIG_MTD_SDCARD_ERASE instead.
+ *          Will be removed after 2021.01 release.
  */
 #ifndef MTD_SDCARD_SKIP_ERASE
-#if IS_ACTIVE(MTD_SDCARD_ERASE)
+#if IS_ACTIVE(CONFIG_MTD_SDCARD_ERASE)
 #define MTD_SDCARD_SKIP_ERASE (0)
 #else
 #define MTD_SDCARD_SKIP_ERASE (1)

--- a/drivers/include/mtd_sdcard.h
+++ b/drivers/include/mtd_sdcard.h
@@ -26,6 +26,7 @@
 
 #include "sdcard_spi.h"
 #include "mtd.h"
+#include "kernel_defines.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -49,17 +50,36 @@ typedef struct {
  * @{
  */
 /**
+ * @brief   Enable SDCard Erase
+ * @note    SDCards handle sector erase internally so it's
+ *          possible to directly write to the card without erasing
+ *          the sector first.
+ *          Attention: an erase call will therefore NOT touch the content,
+ *          so enable this feature to ensure overriding the data.
+ */
+#ifdef DOXYGEN
+#define MTD_SDCARD_ERASE
+#endif
+/** @} */
+
+/**
  * @brief   Enable Skip SDCard Erase
  * @note    SDCards handle sector erase internally so it's
  * possible to directly write to the card without erasing
  * the sector first.
  * Attention: an erase call will therefore NOT touch the content,
  * so disable this feature to ensure overriding the data.
+ * 
+ *  * @deprecated Use inverse @ref GNRC_SIXLOWPAN_FRAG_RBUF_DO_NOT_OVERRIDE instead.
+ *             Will be removed after 2020.10 release.
  */
 #ifndef MTD_SDCARD_SKIP_ERASE
+#if IS_ACTIVE(MTD_SDCARD_ERASE)
+#define MTD_SDCARD_SKIP_ERASE (0)
+#else
 #define MTD_SDCARD_SKIP_ERASE (1)
 #endif
-/** @} */
+#endif
 
 /**
  * @brief   sdcard device operations table for mtd

--- a/drivers/mtd_sdcard/Kconfig
+++ b/drivers/mtd_sdcard/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_MTD_SDCARD
+    bool "Configure MTD_SDCARD driver"
+    depends on MODULE_MTD_SDCARD
+    help
+        Configure the MTD_SDCARD driver using Kconfig.
+
+if KCONFIG_MODULE_MTD_SDCARD
+
+config MTD_SDCARD_ERASE
+    bool "Enable SD card erase"
+    help
+        Enable this to erase sector before a data write operation.
+        SDCards handle sector erase internally so it's
+        possible to directly write to the card without erasing
+        the sector first hence this feature is disabled by default.
+
+endif # KCONFIG_MODULE_MTD_SDCARD


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in MTD SD Card Storage driver to Kconfig. 

#### Important 

 MTD_SDCARD_SKIP_ERASE to be deprecated and CONFIG_MTD_SDCARD_ERASE introduced.

### Testing procedure

Doxygen build works fine.

Following Macro was introduced in main.c for testing.
```
#define STR(x)   #x
#define SHOW_DEFINE(x) printf("%s=%s\n", #x, STR(x))
```
USEMODULE += mtd_sdcard introduced in make file.

#### Default State:

##### Firmware Output

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.07-devel-174-g79e16-Kconfig_mtd_sdcard_tests)
CONFIG_MTD_SDCARD_ERASE=CONFIG_MTD_SDCARD_ERASE
MTD_SDCARD_SKIP_ERASE=(1)

#### Usage with CFLAGS 

New File -> /tests/driver_mtd_sdcard/Makefile

> CFLAGS += -DCONFIG_MTD_SDCARD_ERASE=1

##### Firmware Output

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.07-devel-174-g79e16-Kconfig_mtd_sdcard_tests)
CONFIG_MTD_SDCARD_ERASE=1
MTD_SDCARD_SKIP_ERASE=(0)

#### Usage with Kconfig

New Folder  -> /tests/driver_mtd_sdcard

> make menuconfig

##### Firmware Output

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.07-devel-174-g79e16-Kconfig_mtd_sdcard_tests)
CONFIG_MTD_SDCARD_ERASE=1
MTD_SDCARD_SKIP_ERASE=(0)

Note : Hardware is not available fro interfacing hence configurability of macros were only tested.

### Issues/PRs references

#12888
@leandrolanzieri 
