### PR TITLE
drivers/mtd_sdcard : Expose Configurations to Kconfig 

### DIFF
--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -12,6 +12,8 @@ endmenu # Actuator Device Drivers
 
 rsource "Kconfig.net"
 
+rsource "periph_common/Kconfig"
+
 menu "Sensor Device Drivers"
 rsource "ads101x/Kconfig"
 rsource "fxos8700/Kconfig"
@@ -22,6 +24,8 @@ rsource "opt3001/Kconfig"
 rsource "sps30/Kconfig"
 endmenu # Sensor Device Drivers
 
-rsource "periph_common/Kconfig"
+menu "Storage Device Drivers"
+rsource "mtd_sdcard/Kconfig"
+endmenu # Storage Device Drivers
 
 endmenu # Drivers

--- a/drivers/include/mtd_sdcard.h
+++ b/drivers/include/mtd_sdcard.h
@@ -49,15 +49,16 @@ typedef struct {
  * @{
  */
 /**
- * @brief   Enable Skip SDCard Erase
+ * @brief   Enable SDCard Erase
  * @note    SDCards handle sector erase internally so it's
- * possible to directly write to the card without erasing
- * the sector first.
- * Attention: an erase call will therefore NOT touch the content,
- * so disable this feature to ensure overriding the data.
+ *          possible to directly write to the card without erasing
+ *          the sector first.
+ *          Attention: an erase call will therefore NOT touch the content,
+ *          so enable this feature to ensure overriding the data.
+ *          This feature is currently not supported.
  */
-#ifndef MTD_SDCARD_SKIP_ERASE
-#define MTD_SDCARD_SKIP_ERASE (1)
+#ifdef DOXYGEN
+#define CONFIG_MTD_SDCARD_ERASE
 #endif
 /** @} */
 

--- a/drivers/mtd_sdcard/Kconfig
+++ b/drivers/mtd_sdcard/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_MTD_SDCARD
+    bool "Configure MTD_SDCARD driver"
+    depends on MODULE_MTD_SDCARD
+    help
+        Configure the MTD_SDCARD driver using Kconfig.
+
+if KCONFIG_MODULE_MTD_SDCARD
+
+config MTD_SDCARD_ERASE
+    bool "Enable SD card erase"
+    help
+        Enable this to erase sector before a data write operation.
+        SDCards handle sector erase internally so it's
+        possible to directly write to the card without erasing
+        the sector first hence this feature is disabled by default.
+
+endif # KCONFIG_MODULE_MTD_SDCARD

--- a/drivers/mtd_sdcard/mtd_sdcard.c
+++ b/drivers/mtd_sdcard/mtd_sdcard.c
@@ -24,6 +24,7 @@
 #include "mtd_sdcard.h"
 #include "sdcard_spi.h"
 #include "sdcard_spi_internal.h"
+#include "kernel_defines.h"
 
 #include <inttypes.h>
 #include <errno.h>
@@ -103,11 +104,12 @@ static int mtd_sdcard_erase(mtd_dev_t *dev,
     (void)addr;
     (void)size;
 
-#if MTD_SDCARD_SKIP_ERASE == 1
-    return 0;
-#else
-    return -ENOTSUP; /* explicit erase currently not supported */
-#endif
+    if (!IS_ACTIVE(CONFIG_MTD_SDCARD_ERASE)) {
+        return 0;
+    }
+    else {
+        return -ENOTSUP; /* explicit erase currently not supported */
+    }
 }
 
 static int mtd_sdcard_power(mtd_dev_t *dev, enum mtd_power_state power)


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in MTD SD Card Storage driver to Kconfig. 

#### Important 

 ~~MTD_SDCARD_SKIP_ERASE to be deprecated and CONFIG_MTD_SDCARD_ERASE introduced.~~

MTD_SDCARD_SKIP_ERASE removed and CONFIG_MTD_SDCARD_ERASE introduced, since the feature is not implemented yet.

### Testing procedure

Doxygen build works fine.

Following Macro was introduced in main.c for testing.
```
#define STR(x)   #x
#define SHOW_DEFINE(x) printf("%s=%s\n", #x, STR(x))
```
USEMODULE += mtd_sdcard introduced in make file.

#### Default State:

##### Firmware Output

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.07-devel-174-g79e16-Kconfig_mtd_sdcard_tests)
CONFIG_MTD_SDCARD_ERASE=CONFIG_MTD_SDCARD_ERASE
MTD_SDCARD_SKIP_ERASE=(1)

#### Usage with CFLAGS 

New File -> /tests/driver_mtd_sdcard/Makefile

> CFLAGS += -DCONFIG_MTD_SDCARD_ERASE=1

##### Firmware Output

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.07-devel-174-g79e16-Kconfig_mtd_sdcard_tests)
CONFIG_MTD_SDCARD_ERASE=1
MTD_SDCARD_SKIP_ERASE=(0)

#### Usage with Kconfig

New Folder  -> /tests/driver_mtd_sdcard

> make menuconfig

##### Firmware Output

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.07-devel-174-g79e16-Kconfig_mtd_sdcard_tests)
CONFIG_MTD_SDCARD_ERASE=1
MTD_SDCARD_SKIP_ERASE=(0)

Note : Hardware is not available fro interfacing hence configurability of macros were only tested.

### Issues/PRs references

#12888
@leandrolanzieri 
