### PR TITLE
nanocoap: add coap_get_proxy_uri()

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -615,6 +615,22 @@ ssize_t coap_opt_get_next(const coap_pkt_t *pkt, coap_optpos_t *opt,
 ssize_t coap_opt_get_opaque(const coap_pkt_t *pkt, unsigned opt_num, uint8_t **value);
 /**@}*/
 
+/**
+ * @brief   Convenience function for getting the packet's Proxy-Uri option
+ *
+ * @param[in]   pkt     pkt to work on
+ * @param[out]  target  pointer to the PROXY_URI in @p pkt
+ *
+ * @pre     ((pkt != NULL) && (target != NULL))
+ *
+ * @return      length of the Proxy-Uri option
+ * @return      -ENOENT if Proxy-Uri option not found
+ * @return      -EINVAL if Proxy-Uri option cannot be parsed
+ */
+static inline ssize_t coap_get_proxy_uri(const coap_pkt_t *pkt, char **target)
+{
+    return coap_opt_get_opaque(pkt, COAP_OPT_PROXY_URI, (uint8_t **)target);
+}
 
 /**
  * @name    Functions -- Options for Block

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -774,6 +774,34 @@ static void test_nanocoap__add_path_unterminated_string(void)
     TEST_ASSERT_EQUAL_INT(0, strncmp(path, uri, path_len));
 }
 
+/*
+ * Test adding and retrieving the Proxy-URI option to and from a request.
+ */
+static void test_nanocoap__add_get_proxy_uri(void)
+{
+    uint8_t buf[_BUF_SIZE];
+    coap_pkt_t pkt;
+    uint16_t msgid = 0xABCD;
+    uint8_t token[2] = {0xDA, 0xEC};
+    char proxy_uri[60] = "coap://[2001:db8::1]:5683/.well-known/core";
+
+    size_t len = coap_build_hdr((coap_hdr_t *)&buf[0], COAP_TYPE_NON,
+                                &token[0], 2, COAP_METHOD_GET, msgid);
+
+    coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+
+    len = coap_opt_add_proxy_uri(&pkt, proxy_uri);
+
+    /* strlen + 1 byte option number + 2 bytes length */
+    TEST_ASSERT_EQUAL_INT(strlen(proxy_uri) + 3, len);
+
+    char *uri;
+    len = coap_get_proxy_uri(&pkt, (char **) &uri);
+
+    TEST_ASSERT_EQUAL_INT(strlen(proxy_uri), len);
+    TEST_ASSERT_EQUAL_INT(0, strncmp((char *) proxy_uri, (char *) uri, len));
+}
+
 Test *tests_nanocoap_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -799,6 +827,7 @@ Test *tests_nanocoap_tests(void)
         new_TestFixture(test_nanocoap__server_option_count_overflow),
         new_TestFixture(test_nanocoap__empty),
         new_TestFixture(test_nanocoap__add_path_unterminated_string),
+        new_TestFixture(test_nanocoap__add_get_proxy_uri),
     };
 
     EMB_UNIT_TESTCALLER(nanocoap_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -746,7 +746,7 @@ static void test_nanocoap__empty(void)
 }
 
 /*
- * Test adding a path from an unterminated string
+ * Test adding a path from an unterminated string.
  */
 static void test_nanocoap__add_path_unterminated_string(void)
 {


### PR DESCRIPTION
### Contribution description
This PR is a cut-out of #13790 in order to reduce the reviewing overhead of that PR. The change is quite small and self-contained. It adds a helper function `coap_get_proxy_uri()` to retrieve the proxy-uri option and extends the unittests.

### Testing procedure
The unittests for nanocoap should run properly.

### Issues/PRs references
--