### PR TITLE
ztimer: periph_rtt: ensure RTT_MAX_VALUE is honored [backport 2020.04]

### DIFF
--- a/sys/ztimer/periph_rtt.c
+++ b/sys/ztimer/periph_rtt.c
@@ -19,6 +19,7 @@
  *
  * @}
  */
+#include "assert.h"
 #include "periph/rtt.h"
 #include "ztimer/periph_rtt.h"
 
@@ -50,7 +51,16 @@ static void _ztimer_periph_rtt_set(ztimer_clock_t *clock, uint32_t val)
     }
 
     unsigned state = irq_disable();
-    rtt_set_alarm(rtt_get_counter() + val, _ztimer_periph_rtt_callback, clock);
+
+    /* ensure RTT_MAX_VALUE is (2^n - 1) */
+    static_assert((RTT_MAX_VALUE == UINT32_MAX) ||
+                  !((RTT_MAX_VALUE + 1) & (RTT_MAX_VALUE)),
+                  "RTT_MAX_VALUE needs to be (2^n) - 1");
+
+    rtt_set_alarm(
+        (rtt_get_counter() + val) & RTT_MAX_VALUE, _ztimer_periph_rtt_callback,
+        clock);
+
     irq_restore(state);
 }
 


### PR DESCRIPTION
# Backport of #13922



<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Previously, ztimer would happily set an absolute RTT alarm value that exceeds
RTT's maximum value (though not a longer interval), as the `val` was
simply added to `rtt_get_counter()`.
This commit ensures that the target value wraps around RTT_MAX_VALUE.

Fixes #13920.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

See #13920.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Reported wonderfully in #13920.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
