### PR TITLE
drivers/xbee: disable CTS/RTS pin unless periph_uart_hw_fc is used [backport 2020.04]

### DIFF
--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -599,6 +599,14 @@ int xbee_init(netdev_t *dev)
     _at_cmd(xbee, "ATMM2\r");
     /* put XBee module in "API mode without escaped characters" */
     _at_cmd(xbee, "ATAP1\r");
+    /* disable xbee CTS and RTS, unless hardware flow control is used */
+    if(!IS_USED(MODULE_PERIPH_UART_HW_FC)) {
+        DEBUG("[xbee] init: WARNING if using an arduino BOARD + arduino xbee " \
+            "shield with ICSP connector, hardware flow control can't be " \
+            "used since CTS pin is connected to ICSP RESET pin\n");
+        _at_cmd(xbee, "ATD6 0\r");
+        _at_cmd(xbee, "ATD7 0\r");
+    }
     /* apply AT commands */
     _at_cmd(xbee, "ATAC\r");
     /* exit command mode */


### PR DESCRIPTION
# Backport of #13224

### Contribution description

    If usinng an arduino xbee shield then CTS pin will be wired to the
    ICSP connector RESET pin.
    
    If also used on an arduino-% board then if xbee is busy sending or
    receiving data it will assert CTS and this will trigger a reset on
    the board.
    
    To avoid this disable CTS functionality on start up.

### Testing procedure

- On master if using `arduino-zero` + `xbee` the following should be enough to overload the `xbee` and
cause it to assert CTS: `ping6 -c 1000 -s 90 -i 100` and cause a reset.

```
2020-01-28 18:16:36,074 # main(): This is RIOT! (Version: 2020.04-devel-124-gd5a5b-HEAD)
2020-01-28 18:16:36,078 # RIOT network stack example application
2020-01-28 18:16:36,080 # All up, running the shell now
> 2020-01-28 18:16:40,543 #  gnrc_netif: netdev init failed: -5
```

Is debugging is enabled you can see it resets untill it fails to init the driver, which is another issue.

```
2020-01-27 10:17:54,488 # [xbee] AT_CMD: SL                                                                                                                                                                                                                               [81/1521]
2020-01-27 10:17:54,928 # [xbee] AT_CMD: CH                                                                                                                                                                                                                                        
2020-01-27 10:17:55,291 # [xbee] AT_CMD: ID                                                                                                                                                                                                                                        
2020-01-27 10:17:55,802 # [xbee] init: Initialization successful                                                                                                                                                                                                                   
2020-01-27 10:17:55,804 # [xbee] AT_CMD: MY���                                                                                                                                                                                                                                     
2020-01-27 10:17:56,239 # [xbee] isr: data available, waiting for read                                                                                                                                                                                                             
2020-01-27 10:17:56,243 # [xbee] recv: reading size without dropping: 106                                                                                                                                                                                                          
2020-01-27 10:17:56,247 # [xbee] recv: consuming packet: reading 106 byte                                                                                                                                                                                                          
2020-01-27 10:17:56,251 # [xbee] send: now sending out 36 byte                                                                                                                                                                                                                     
2020-01-27 10:17:56,293 # [xbee] send: now sending out 22 byte                                                                                                                                                                                                                     
2020-01-27 10:17:57,531 # [xbee] AT_CMD: +++                                                                                                                                                                                                                                       
2020-01-27 10:17:58,639 # [xbee] AT_CMD: ATMM2                                                                                                                                                                                                                                     
2020-01-27 10:17:58,647 # [xbee] AT_CMD: ATAP1                                                                                                                                                                                                                                     
2020-01-27 10:17:58,655 # [xbee] AT_CMD: ATAC                                                                                                                                                                                                                                      
2020-01-27 10:17:58,662 # [xbee] AT_CMD: ATCN                                                                                                                                                                                                                                      
2020-01-27 10:17:58,669 # [xbee] AT_CMD: SH                                                                                                                                                                                                                                        
2020-01-27 10:17:58,693 # [xbee] AT_CMD: SL                                                                                                                                                                                                                                        
2020-01-27 10:17:58,863 # [xbee] AT_CMD: CH                                                                                                                                                                                                                                        
2020-01-27 10:17:59,028 # [xbee] AT_CMD: ID                                                                                                                                                                                                                                        
2020-01-27 10:17:59,351 # [xbee] init: Initialization successful                                                                                                                                                                                                                   
2020-01-27 10:17:59,354 # [xbee] AT_CMD: MY���                                                                                                                                                                                                                                     
2020-01-27 10:17:59,788 # [xbee] isr: data available, waiting for read                                                                                                                                                                                                             
2020-01-27 10:17:59,793 # [xbee] recv: reading size without dropping: 106                                                                                                                                                                                                          
2020-01-27 10:17:59,797 # [xbee] recv: consuming packet: reading 106 byte
2020-01-27 10:17:59,801 # [xbee] send: now sending out 36 byte
2020-01-27 10:17:59,843 # [xbee] send: now sending out 22 byte
2020-01-27 10:17:59,873 # main(): This is RIOT! (Version: 2020.04-devel-16-g1d840-2020.01-branch)
```

- With this PR it doesn't and even if there is high packet loss the node will eventually answer to subsequent pings.

```
2020-01-28 18:09:42,563 #  ping6 -c 100 -s 91 -i 100 fe80::213:a200:40a1:642e
2020-01-28 18:09:43,118 # 99 bytes from fe80::213:a200:40a1:642e: icmp_seq=2 ttl=64 rssi=-31 dBm time=347.089 ms
2020-01-28 18:09:43,328 # 99 bytes from fe80::213:a200:40a1:642e: icmp_seq=3 ttl=64 rssi=-31 dBm time=456.454 ms
2020-01-28 18:09:53,470 # 
2020-01-28 18:09:53,474 # --- fe80::213:a200:40a1:642e PING statistics ---
2020-01-28 18:09:53,480 # 100 packets transmitted, 2 packets received, 98% packet loss
2020-01-28 18:09:53,485 # round-trip min/avg/max = 347.089/401.771/456.454 ms
> ping6 -c 1 -s 91 -i 100 fe80::213:a200:40a1:642e 
2020-01-28 18:09:59,483 #  ping6 -c 1 -s 91 -i 100 fe80::213:a200:40a1:642e
2020-01-28 18:10:00,484 # 
2020-01-28 18:10:00,488 # --- fe80::213:a200:40a1:642e PING statistics ---
2020-01-28 18:10:00,493 # 1 packets transmitted, 0 packets received, 100% packet loss
> ping6 -c 1 -s 91 -i 100 fe80::213:a200:40a1:642e 
2020-01-28 18:10:02,107 #  ping6 -c 1 -s 91 -i 100 fe80::213:a200:40a1:642e
2020-01-28 18:10:02,417 # 99 bytes from fe80::213:a200:40a1:642e: icmp_seq=0 ttl=64 rssi=-32 dBm time=302.050 ms
2020-01-28 18:10:02,417 # 
2020-01-28 18:10:02,421 # --- fe80::213:a200:40a1:642e PING statistics ---
2020-01-28 18:10:02,427 # 1 packets transmitted, 1 packets received, 0% packet loss
2020-01-28 18:10:02,431 # round-trip min/avg/max = 302.050/302.050/302.050 ms
```

### Related Issues

Tagging is a backport since without it task04.08 can't be run on iotlab for the release.