### PR TITLE
drivers/ethos: use luid_get_eui48()

### DIFF
--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -22,11 +22,11 @@
 #include <errno.h>
 #include <string.h>
 
-#include "random.h"
 #include "ethos.h"
 #include "periph/uart.h"
 #include "tsrb.h"
 #include "irq.h"
+#include "luid.h"
 
 #include "net/netdev.h"
 #include "net/netdev/eth.h"
@@ -67,13 +67,7 @@ void ethos_setup(ethos_t *dev, const ethos_params_t *params)
     tsrb_init(&dev->inbuf, params->buf, params->bufsize);
     mutex_init(&dev->out_mutex);
 
-    uint32_t a = random_uint32();
-    memcpy(dev->mac_addr, (char*)&a, 4);
-    a = random_uint32();
-    memcpy(dev->mac_addr+4, (char*)&a, 2);
-
-    dev->mac_addr[0] &= (0x2);      /* unset globally unique bit */
-    dev->mac_addr[0] &= ~(0x1);     /* set unicast bit*/
+    luid_get_eui48((eui48_t *) &dev->mac_addr);
 
     uart_init(params->uart, params->baudrate, ethos_isr, (void*)dev);
 


### PR DESCRIPTION



### Contribution description

Previously the MAC address of the border router was entirely random.
That meant that as a DHCPv6 client it would get a new prefix with every reboot.

Due to #12210 the nodes will never use the new address.

Fix this by using `luid_get_eui48()` which will always return the same address across reboots.

It also makes the code simpler.


### Testing procedure

- Flash `examples/gnrc_border_router` with the default options (`UPLINK=ethos`).
- Run `ifconfig` to view the address of the upstream interface.
- `reboot` the border router
- Inspect the address of the upstream interface again with `ifconfig`.

On `master`, the upstream interface will have a different address with each reboot.
This fixes that.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
