### PR TITLE
gnrc_ipv6_nib: fix NS sending for multiple upstream interfaces

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -174,7 +174,7 @@ static inline bool _is_valid(const gnrc_netif_t *netif, int idx)
 void _handle_rereg_address(const ipv6_addr_t *addr)
 {
     gnrc_netif_t *netif = gnrc_netif_get_by_ipv6_addr(addr);
-    _nib_dr_entry_t *router = _nib_drl_get_dr();
+    _nib_dr_entry_t *router = _nib_drl_get(NULL, netif->pid);
     const bool router_reachable = (router != NULL) &&
                                   _is_reachable(router->next_hop);
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -37,9 +37,9 @@ void _snd_ns(const ipv6_addr_t *tgt, gnrc_netif_t *netif,
     gnrc_pktsnip_t *ext_opt = NULL;
 
 #ifdef MODULE_GNRC_SIXLOWPAN_ND
-    _nib_dr_entry_t *dr = _nib_drl_get_dr();
-
     assert(netif != NULL);
+    _nib_dr_entry_t *dr = _nib_drl_get(NULL, netif->pid);
+
     /* add ARO based on interface */
     if ((src != NULL) && gnrc_netif_is_6ln(netif) &&
         (_nib_onl_get_if(dr->next_hop) == (unsigned)netif->pid) &&

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -403,13 +403,15 @@ _nib_dr_entry_t *_nib_drl_iter(const _nib_dr_entry_t *last)
 
 _nib_dr_entry_t *_nib_drl_get(const ipv6_addr_t *router_addr, unsigned iface)
 {
+    assert((router_addr != NULL) || (iface != 0));
     for (unsigned i = 0; i < CONFIG_GNRC_IPV6_NIB_DEFAULT_ROUTER_NUMOF; i++) {
         _nib_dr_entry_t *def_router = &_def_routers[i];
         _nib_onl_entry_t *node = def_router->next_hop;
 
         if ((node != NULL) &&
-            (_nib_onl_get_if(node) == iface) &&
-            (ipv6_addr_equal(router_addr, &node->ipv6))) {
+            ((iface == 0) || (_nib_onl_get_if(node) == iface)) &&
+            ((router_addr == NULL) ||
+             ipv6_addr_equal(router_addr, &node->ipv6))) {
             /* It is linked to the default router list so it *should* be set */
             assert(node->mode & _DRL);
             return def_router;

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -465,11 +465,12 @@ _nib_dr_entry_t *_nib_drl_iter(const _nib_dr_entry_t *last);
 /**
  * @brief   Gets a default router by IPv6 address and interface
  *
- * @pre     `(router_addr != NULL)`
+ * @pre     `(router_addr != NULL) || (iface != 0)`
  *
- * @param[in] router_addr   The address of a default router. Must not be NULL.
+ * @param[in] router_addr   The address of a default router. May be NULL for
+ *                          any address, but then @p iface must not be NULL.
  * @param[in] iface         The interface to the node. May be 0 for any
- *                          interface.
+ *                          interface, but then @p router_addr must not be NULL.
  *
  * @return  The NIB entry for node with @p router_addr and @p iface onsuccess.
  * @return  NULL, if there is no such entry.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This fixes https://github.com/RIOT-OS/RIOT/issues/13838. The issue was caused by two things

1. a configuration issue (NIB and DHCPv6 client need to be configured for the 2 interface operation provided by the `at86rf215`,
2. the default router to send the neighbor solicitation for address registration to was _always_ the default route (aka the prime default router). This, as we want to register with the router the Router Advertisement came over. This is because the router advertisement contains the prefix information the address is based on we want to register.

This PR fixes second point. The first point needs to be dealt with via a documentation update.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run a `gnrc_border_router` and a `gnrc_networking` example using `USE_DHCPV6=1` and the following `CFLAGS`:
```sh
export CFLAGS = ${CFLAGS} -DDHCPV6_CLIENT_PFX_LEASE_MAX=2 \
        -DCONFIG_GNRC_IPV6_NIB_DEFAULT_ROUTER_NUMOF=2 \
        -DCONFIG_GNRC_IPV6_NIB_ABR_NUMOF=2
```

Without this PR the behavior described in https://github.com/RIOT-OS/RIOT/issues/13838, with it it should not be reproducable again (unless more nodes interfering, but this comes from issue 1).

The following tests should still pass:

- `tests/unittests`
- `tests/gnrc_ipv6_nib`
- `tests/gnrc_ipv6_nib_6ln`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes https://github.com/RIOT-OS/RIOT/issues/13838
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
