### PR TITLE
examples/gnrc_border_router: don't ignore ETHOS_BAUDRATE [backport 2020.04]

### DIFF
--- a/examples/gnrc_border_router/Makefile.ethos.conf
+++ b/examples/gnrc_border_router/Makefile.ethos.conf
@@ -9,4 +9,4 @@ endif
 # Configure terminal parameters
 TERMDEPS += host-tools
 TERMPROG ?= sudo sh $(RIOTTOOLS)/ethos/start_network.sh
-TERMFLAGS ?= $(FLAGS_EXTRAS) $(PORT) $(TAP) $(IPV6_PREFIX)
+TERMFLAGS ?= $(FLAGS_EXTRAS) $(PORT) $(TAP) $(IPV6_PREFIX) $(ETHOS_BAUDRATE)


### PR DESCRIPTION
# Backport of #13946



<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`ETHOS_BAUDRATE` must be a parameter to `start_network.sh`.
This must have been lost during refactoring.

### Testing procedure

Compile & run `examples/gnrc_border_router` with e.g.  `ETHOS_BAUDRATE=1000000`.

Without this patch, you will get no stdio output and ethos does not work.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
