### PR TITLE
Makefile.include: update the documentation of $(MAKEFILEDIR)

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -8,7 +8,13 @@ ifeq (,$(filter $(MATCH_MAKE_VERSION),$(MAKE_VERSION)))
       $(MATCH_MAKE_VERSION) or later.)
 endif
 
-# will evaluate to the absolute path of the Makefile it's evaluated in
+# Will evaluate to the absolute path of the Makefile it's evaluated in.¹
+#
+# This variable MUST be immediately evaluated (tmp_var := $(MAKEFILEDIR))
+# unless it is used directly.
+#
+# [1] Note that this will in fact return the path of the last Makefile that
+# was included, so it must be evaluated before any subsequent includes.
 MAKEFILEDIR = $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # 'Makefile.include' directory, must be evaluated before other 'include'

--- a/Makefile.include
+++ b/Makefile.include
@@ -10,15 +10,15 @@ endif
 
 # Will evaluate to the absolute path of the Makefile it's evaluated in.¹
 #
-# This variable MUST be immediately evaluated (tmp_var := $(MAKEFILEDIR))
+# This variable MUST be immediately evaluated (tmp_var := $(LAST_MAKEFILEDIR))
 # unless it is used directly.
 #
 # [1] Note that this will in fact return the path of the last Makefile that
 # was included, so it must be evaluated before any subsequent includes.
-MAKEFILEDIR = $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+LAST_MAKEFILEDIR = $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # 'Makefile.include' directory, must be evaluated before other 'include'
-_riotbase := $(MAKEFILEDIR)
+_riotbase := $(LAST_MAKEFILEDIR)
 
 # include RIOT_MAKEFILES_GLOBAL_PRE configuration files
 # allows setting user specific system wide configuration parsed before the body

--- a/cpu/kinetis/Makefile.include
+++ b/cpu/kinetis/Makefile.include
@@ -1,7 +1,7 @@
 ifeq (,$(KINETIS_SERIES))
   # Parse parameters from CPU_MODEL using the kinetis-info.mk script in the same
   # directory as this Makefile.
-  include $(MAKEFILEDIR)/kinetis-info.mk
+  include $(LAST_MAKEFILEDIR)/kinetis-info.mk
 endif
 
 # "The Vector table must be naturally aligned to a power of two whose alignment

--- a/tests/cpp_exclude/module_exclude/Makefile.include
+++ b/tests/cpp_exclude/module_exclude/Makefile.include
@@ -1,3 +1,3 @@
-# Use an immediate variable to evaluate `MAKEFILEDIR` now
-USEMODULE_INCLUDES_module_exclude := $(MAKEFILEDIR)
+# Use an immediate variable to evaluate `LAST_MAKEFILEDIR` now
+USEMODULE_INCLUDES_module_exclude := $(LAST_MAKEFILEDIR)
 USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_module_exclude)

--- a/tests/cpp_ext/module/Makefile.include
+++ b/tests/cpp_ext/module/Makefile.include
@@ -1,3 +1,3 @@
 # Use an immediate variable to evaluate `MAKEFILE_LIST` now
-USEMODULE_INCLUDES_module := $(MAKEFILEDIR)
+USEMODULE_INCLUDES_module := $(LAST_MAKEFILEDIR)
 USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_module)

--- a/tests/external_module_dirs/external_module/Makefile.include
+++ b/tests/external_module_dirs/external_module/Makefile.include
@@ -1,3 +1,3 @@
 # Use an immediate variable to evaluate `MAKEFILE_LIST` now
-USEMODULE_INCLUDES_external_module := $(MAKEFILEDIR)/include
+USEMODULE_INCLUDES_external_module := $(LAST_MAKEFILEDIR)/include
 USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_external_module)

--- a/tests/pkg_utensor/models/Makefile.include
+++ b/tests/pkg_utensor/models/Makefile.include
@@ -1,5 +1,5 @@
 # Use an immediate variable to evaluate `MAKEFILE_LIST` now
-USEMODULE_INCLUDES_models := $(MAKEFILEDIR)
+USEMODULE_INCLUDES_models := $(LAST_MAKEFILEDIR)
 USEMODULE_INCLUDES += $(USEMODULE_INCLUDES_models)
 
 CXXEXFLAGS += -Wno-unused-parameter


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

As @fjmolinas pointed out, there are some caveats with the `$(MAKEFILEDIR)` variable.
It will in fact return the path of the last Makefile included, so calling it after other Makefiles have been `include`d is an error.

Also point out that it must be evaluated immediately as it's value will of course change if it is evaluated recursively.

### Testing procedure

Read.


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/13846#issuecomment-619349193
