### PR TITLE
drivers/rn2xx3 : Expose Configurations to Kconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -6,6 +6,9 @@
 #
 mainmenu "RIOT Configuration"
 
+# Load macro definitions
+rsource "kconfig/Kconfig.consts"
+
 # For now, get used modules as macros from this file (see kconfig.mk)
 osource "$(KCONFIG_GENERATED_DEPENDENCIES)"
 

--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -10,6 +10,7 @@ rsource "cc110x/Kconfig"
 rsource "dose/Kconfig"
 rsource "mrf24j40/Kconfig"
 rsource "pn532/Kconfig"
+rsource "rn2xx3/Kconfig"
 rsource "slipdev/Kconfig"
 source "$(RIOTCPU)/nrf52/radio/nrf802154/Kconfig"
 endmenu # Network Device Drivers

--- a/drivers/include/rn2xx3.h
+++ b/drivers/include/rn2xx3.h
@@ -64,8 +64,8 @@ extern "C" {
 /**
  * @brief   Default sleep duration (in ms)
  */
-#ifndef RN2XX3_DEFAULT_SLEEP
-#define RN2XX3_DEFAULT_SLEEP            (5000U)
+#ifndef CONFIG_RN2XX3_DEFAULT_SLEEP
+#define CONFIG_RN2XX3_DEFAULT_SLEEP            (5000U)
 #endif
 /** @} */
 

--- a/drivers/rn2xx3/Kconfig
+++ b/drivers/rn2xx3/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_RN2XX3
+    bool "Configure RN2XX3 driver"
+    depends on MODULE_RN2XX3
+    help
+        Configure the RN2XX3 driver using Kconfig.
+
+if KCONFIG_MODULE_RN2XX3
+
+config RN2XX3_DEFAULT_SLEEP
+    int "Sleep duration in milliseconds [ms]"
+    range 100 $(UINT32_MAX)
+    default 5000
+    help
+        Set the sleep duration (in ms).
+        The value should be greater than RN2XX3_SLEEP_MIN (100 ms)
+
+endif # KCONFIG_MODULE_RN2XX3

--- a/drivers/rn2xx3/rn2xx3.c
+++ b/drivers/rn2xx3/rn2xx3.c
@@ -171,7 +171,7 @@ int rn2xx3_init(rn2xx3_t *dev)
     dev->sleep_timer.callback = _sleep_timer_cb;
     dev->sleep_timer.arg = dev;
 
-    rn2xx3_sys_set_sleep_duration(dev, RN2XX3_DEFAULT_SLEEP);
+    rn2xx3_sys_set_sleep_duration(dev, CONFIG_RN2XX3_DEFAULT_SLEEP);
 
     /* sending empty command to clear uart buffer */
     if (rn2xx3_write_cmd(dev) == RN2XX3_TIMEOUT) {

--- a/kconfig/Kconfig.consts
+++ b/kconfig/Kconfig.consts
@@ -1,0 +1,7 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+UINT32_MAX:=4294967295


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in RN2XX3 Network Device driver to Kconfig.

### Testing procedure

New macro was introduced in tests/driver_rn2xx3/main.c for testing.

```
#define STR(x)   #x
#define SHOW_DEFINE(x) printf("%s=%s\n", #x, STR(x))
```
Firmware was uploaded to FIT IoT Lab test bed.

#### Default State:

##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-199-gd936bb-Kconfig_rn2xx3)
CONFIG_RN2XX3_DEFAULT_SLEEP=(5000U)
RN2XX3 device driver test
RN2XX3 initialization failed

#### Usage with CFLAGS 

/tests/driver_rn2xx3/Makefile

> CFLAGS += -DCONFIG_RN2XX3_DEFAULT_SLEEP=7000


##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-199-gd936bb-Kconfig_rn2xx3)
CONFIG_RN2XX3_DEFAULT_SLEEP=7000
RN2XX3 device driver test
RN2XX3 initialization failed

#### Usage with Kconfig

/tests/driver_rn2xx3/

> make menuconfig

##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-199-gd936bb-Kconfig_rn2xx3)
CONFIG_RN2XX3_DEFAULT_SLEEP=10000
RN2XX3 device driver test
RN2XX3 initialization failed
Note : The sensor is not available for interfacing hence configurability of macros were only tested.

### Issues/PRs references

#12888
@leandrolanzieri 
