### PR TITLE
drivers/slipdev : Expose Configurations to Kconfig

### DIFF
--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -14,6 +14,7 @@ rsource "cc110x/Kconfig"
 rsource "dose/Kconfig"
 rsource "mrf24j40/Kconfig"
 rsource "pn532/Kconfig"
+rsource "slipdev/Kconfig"
 source "$(RIOTCPU)/nrf52/radio/nrf802154/Kconfig"
 endmenu # Network Device Drivers
 

--- a/drivers/include/slipdev.h
+++ b/drivers/include/slipdev.h
@@ -45,8 +45,8 @@ extern "C" {
  *
  * @pre Needs to be power of two and `<= INT_MAX`
  */
-#ifndef SLIPDEV_BUFSIZE
-#define SLIPDEV_BUFSIZE (2048U)
+#ifndef CONFIG_SLIPDEV_BUFSIZE
+#define CONFIG_SLIPDEV_BUFSIZE (2048U)
 #endif
 /** @} */
 
@@ -88,7 +88,7 @@ typedef struct {
     netdev_t netdev;                        /**< parent class */
     slipdev_params_t config;                /**< configuration parameters */
     tsrb_t inbuf;                           /**< RX buffer */
-    uint8_t rxmem[SLIPDEV_BUFSIZE];         /**< memory used by RX buffer */
+    uint8_t rxmem[CONFIG_SLIPDEV_BUFSIZE];  /**< memory used by RX buffer */
     /**
      * @brief   Device state
      * @see     [Device state definitions](@ref drivers_slipdev_states)

--- a/drivers/include/slipdev.h
+++ b/drivers/include/slipdev.h
@@ -45,6 +45,10 @@ extern "C" {
  *
  * @pre Needs to be power of two and `<= INT_MAX`
  */
+#ifdef CONFIG_SLIPDEV_BUFSIZE_EXP
+#define CONFIG_SLIPDEV_BUFSIZE (1<<CONFIG_SLIPDEV_BUFSIZE_EXP)
+#endif
+
 #ifndef CONFIG_SLIPDEV_BUFSIZE
 #define CONFIG_SLIPDEV_BUFSIZE (2048U)
 #endif

--- a/drivers/slipdev/Kconfig
+++ b/drivers/slipdev/Kconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_SLIPDEV
+    bool "Configure SLIPDEV driver"
+    depends on MODULE_SLIPDEV
+    help
+        Configure the SLIPDEV driver using Kconfig.
+
+if KCONFIG_MODULE_SLIPDEV
+
+config SLIPDEV_BUFSIZE_EXP
+    int "Buffer size (as exponent of 2^n)"
+    default 11
+    range 0 31
+    help
+        UART buffer size used for TX and RX buffers.
+        Reduce this value if your expected traffic does
+        not include full IPv6 MTU.
+        Value represents the exponent n of 2^n.
+
+endif # KCONFIG_MODULE_SLIPDEV


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in SLIPDEV Network  driver to Kconfig.

### Testing procedure

New folder (/tests/driver_slipdev) was added. New test file and Make file was introduced in tests/driver_slipdev/ for testing.

```
#define STR(x)   #x
#define SHOW_DEFINE(x) printf("%s=%s\n", #x, STR(x))
```
Firmware was tested on native.

#### Default State:

##### Firmware Output

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.07-devel-201-g2e015-Kconfig_slipdev_tests)
CONFIG_SLIPDEV_BUFSIZE=(2048U)

#### Usage with CFLAGS 

/tests/driver_slipdev/Makefile

> CFLAGS += -DCONFIG_SLIPDEV_BUFSIZE=128


##### Firmware Output

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.07-devel-201-g2e015-Kconfig_slipdev_tests)
CONFIG_SLIPDEV_BUFSIZE=128

#### Usage with Kconfig

/tests/driver_slipdev/

> make menuconfig

##### Firmware Output

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.07-devel-201-g2e015-Kconfig_slipdev_tests)
CONFIG_SLIPDEV_BUFSIZE=4096

### Issues/PRs references

#12888
@leandrolanzieri 
