### PR TITLE
cpu/lpc2387: PM_NUM_MODES must only count non-idle modes

### DIFF
--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -36,7 +36,7 @@ extern "C" {
  * @name    Power mode configuration
  * @{
  */
-#define PM_NUM_MODES        (4)
+#define PM_NUM_MODES        (3)
 /** @} */
 
 /**


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

lpc23xx has 3 sleep modes and one idle mode.
`PM_NUM_MODES` must only count the idle modes.

In practise, this makes no difference since `mode 3` (IDLE) is the `default` case in `pm_set()` anyway.


### Testing procedure

No change in behavior / power consumption is expected, but now the define is consistent with the documentation.


### Issues/PRs references
split off #13475

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
