### PR TITLE
tests/periph_uart: fix for !stdio_uart

### DIFF
--- a/tests/periph_uart/main.c
+++ b/tests/periph_uart/main.c
@@ -28,8 +28,11 @@
 #include "msg.h"
 #include "ringbuffer.h"
 #include "periph/uart.h"
-#include "stdio_uart.h"
 #include "xtimer.h"
+
+#ifdef MODULE_STDIO_UART
+#include "stdio_uart.h"
+#endif
 
 #ifndef SHELL_BUFSIZE
 #define SHELL_BUFSIZE       (128U)
@@ -283,11 +286,15 @@ int main(void)
      * value given in STDIO_UART_DEV is not a numeral (depends on the CPU
      * implementation), so we rather break the output by printing a
      * non-numerical value instead of breaking the UART device descriptor */
-    sleep_test(STDIO_UART_DEV, STDIO_UART_DEV);
+    if (STDIO_UART_DEV != UART_UNDEF) {
+        sleep_test(STDIO_UART_DEV, STDIO_UART_DEV);
+    }
 
     puts("\nUART INFO:");
     printf("Available devices:               %i\n", UART_NUMOF);
-    printf("UART used for STDIO (the shell): UART_DEV(%i)\n\n", STDIO_UART_DEV);
+    if (STDIO_UART_DEV != UART_UNDEF) {
+        printf("UART used for STDIO (the shell): UART_DEV(%i)\n\n", STDIO_UART_DEV);
+    }
 
     /* initialize ringbuffers */
     for (unsigned i = 0; i < UART_NUMOF; i++) {


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Only include `stdio_uart.h` if stdio over UART is used.
This makes it possible to use the default stdio UART0 for the test.

This is needed if e.g. the default stdio of a board is USB CDC ACM.


### Testing procedure

Run `tests/periph_uart` on a board that has stdio over USB.

Before this patch you would not be able to initialize UART0 for the test.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
