### PR TITLE
cpu/samd21: PWM don't hard-code number of channels to 3

### DIFF
--- a/boards/arduino-zero/include/periph_conf.h
+++ b/boards/arduino-zero/include/periph_conf.h
@@ -171,31 +171,36 @@ static const uart_conf_t uart_config[] = {
  */
 #define PWM_0_EN            1
 #define PWM_1_EN            1
-#define PWM_MAX_CHANNELS    2
-/* for compatibility with test application */
-#define PWM_0_CHANNELS      PWM_MAX_CHANNELS
-#define PWM_1_CHANNELS      PWM_MAX_CHANNELS
+
+#if PWM_0_EN
+/* PWM0 channels */
+static const pwm_conf_chan_t pwm_chan0_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PA, 8), GPIO_MUX_E,  0 },
+    { GPIO_PIN(PA, 9), GPIO_MUX_E,  1 },
+};
+#endif
+#if PWM_1_EN
+/* PWM1 channels */
+static const pwm_conf_chan_t pwm_chan1_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PA, 6), GPIO_MUX_E, 0 },
+    { GPIO_PIN(PA, 7), GPIO_MUX_E, 1 },
+};
+#endif
 
 /* PWM device configuration */
 static const pwm_conf_t pwm_config[] = {
 #if PWM_0_EN
-    {TCC0, {
-        /* GPIO pin, MUX value, TCC channel */
-        { GPIO_PIN(PA, 8), GPIO_MUX_E,  0 },
-        { GPIO_PIN(PA, 9), GPIO_MUX_E,  1 },
-    }},
+    {TCC0, pwm_chan0_config, ARRAY_SIZE(pwm_chan0_config)},
 #endif
 #if PWM_1_EN
-    {TCC1, {
-        /* GPIO pin, MUX value, TCC channel */
-        { GPIO_PIN(PA, 6), GPIO_MUX_E, 0 },
-        { GPIO_PIN(PA, 7), GPIO_MUX_E, 1 },
-    }},
+    {TCC1, pwm_chan1_config, ARRAY_SIZE(pwm_chan1_config)},
 #endif
 };
 
 /* number of devices that are actually defined */
-#define PWM_NUMOF           (2U)
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**

--- a/boards/common/arduino-mkr/include/periph_conf_common.h
+++ b/boards/common/arduino-mkr/include/periph_conf_common.h
@@ -128,18 +128,20 @@ static const tc32_conf_t timer_config[] = {
  * @{
  */
 #define PWM_0_EN            1
-#define PWM_MAX_CHANNELS    (2U)
-/* for compatibility with test application */
-#define PWM_0_CHANNELS      PWM_MAX_CHANNELS
+
+#if PWM_0_EN
+/* PWM0 channels */
+static const pwm_conf_chan_t pwm_chan0_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PA, 10), GPIO_MUX_F, 2 },    /* ~2 */
+    { GPIO_PIN(PA, 11), GPIO_MUX_F, 3 },    /* ~3 */
+};
+#endif
 
 /* PWM device configuration */
 static const pwm_conf_t pwm_config[] = {
 #if PWM_0_EN
-    {TCC0, {
-        /* GPIO pin, MUX value, TCC channel */
-        { GPIO_PIN(PA, 10), GPIO_MUX_F, 2 },    /* ~2 */
-        { GPIO_PIN(PA, 11), GPIO_MUX_F, 3 },    /* ~3 */
-    }}
+    {TCC0, pwm_chan0_config, ARRAY_SIZE(pwm_chan0_config)},
 #endif
 };
 

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -151,31 +151,34 @@ static const uart_conf_t uart_config[] = {
  */
 #define PWM_0_EN            1
 #define PWM_1_EN            1
-#define PWM_MAX_CHANNELS    2
-/* for compatibility with test application */
-#define PWM_0_CHANNELS      PWM_MAX_CHANNELS
-#define PWM_1_CHANNELS      PWM_MAX_CHANNELS
+
+#if PWM_0_EN
+/* PWM0 channels */
+static const pwm_conf_chan_t pwm_chan0_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PA, 7), GPIO_MUX_E, 1 }, /* ~9 */
+};
+#endif
+#if PWM_1_EN
+/* PWM1 channels */
+static const pwm_conf_chan_t pwm_chan1_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PA, 16), GPIO_MUX_E, 0 }, /* ~11 */
+};
+#endif
 
 /* PWM device configuration */
 static const pwm_conf_t pwm_config[] = {
 #if PWM_0_EN
-    {TCC0, {
-        /* GPIO pin, MUX value, TCC channel */
-        { GPIO_UNDEF, (gpio_mux_t)0,  0 },
-        { GPIO_PIN(PA, 7), GPIO_MUX_E, 1 }, /* ~9 */
-    }},
+    {TCC0, pwm_chan0_config, ARRAY_SIZE(pwm_chan0_config)},
 #endif
 #if PWM_1_EN
-    {TCC2, {
-        /* GPIO pin, MUX value, TCC channel */
-        { GPIO_PIN(PA, 16), GPIO_MUX_E, 0 }, /* ~11 */
-        { GPIO_UNDEF, (gpio_mux_t)0, 1 },
-    }},
+    {TCC2, pwm_chan1_config, ARRAY_SIZE(pwm_chan1_config)},
 #endif
 };
 
 /* number of devices that are actually defined */
-#define PWM_NUMOF           (2U)
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -179,28 +179,37 @@ static const adc_conf_chan_t adc_channels[] = {
  */
 #define PWM_0_EN            1
 #define PWM_1_EN            1
-#define PWM_NUMOF           (PWM_0_EN + PWM_1_EN)
-#define PWM_MAX_CHANNELS    2
 
-/* PWM device configuration */
-#if PWM_NUMOF
-static const pwm_conf_t pwm_config[] = {
 #if PWM_0_EN
-    {TCC1, {
-        /* GPIO pin, MUX value, TCC channel */
-        {GPIO_PIN(PA, 6), GPIO_MUX_E, 0},
-        {GPIO_PIN(PA, 7), GPIO_MUX_E, 1}
-    }},
-#endif
-#if PWM_1_EN
-    {TCC0, {
-        /* GPIO pin, MUX value, TCC channel */
-        {GPIO_PIN(PA, 18), GPIO_MUX_F, 2},
-        {GPIO_PIN(PA, 19), GPIO_MUX_F, 3}
-    }},
-#endif
+/* PWM0 channels */
+static const pwm_conf_chan_t pwm_chan0_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    {GPIO_PIN(PA, 6), GPIO_MUX_E, 0},
+    {GPIO_PIN(PA, 7), GPIO_MUX_E, 1},
 };
 #endif
+#if PWM_1_EN
+/* PWM1 channels */
+static const pwm_conf_chan_t pwm_chan1_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    {GPIO_PIN(PA, 18), GPIO_MUX_F, 2},
+    {GPIO_PIN(PA, 19), GPIO_MUX_F, 3},
+};
+#endif
+
+
+/* PWM device configuration */
+static const pwm_conf_t pwm_config[] = {
+#if PWM_0_EN
+    {TCC1, pwm_chan0_config, ARRAY_SIZE(pwm_chan0_config)},
+#endif
+#if PWM_1_EN
+    {TCC0, pwm_chan1_config, ARRAY_SIZE(pwm_chan1_config)},
+#endif
+};
+
+/* number of devices that are actually defined */
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -201,39 +201,47 @@ static const uart_conf_t uart_config[] = {
 #define PWM_0_EN            1
 #define PWM_1_EN            0
 #define PWM_2_EN            0
-#define PWM_MAX_CHANNELS    2
-/* for compatibility with test application */
-#define PWM_0_CHANNELS      PWM_MAX_CHANNELS
-#define PWM_1_CHANNELS      PWM_MAX_CHANNELS
-#define PWM_2_CHANNELS      PWM_MAX_CHANNELS
+
+#if PWM_0_EN
+/* PWM0 channels */
+static const pwm_conf_chan_t pwm_chan0_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PA, 12), GPIO_MUX_E, 0 },
+    { GPIO_PIN(PA, 13), GPIO_MUX_E, 1 },
+};
+#endif
+#if PWM_1_EN
+/* PWM1 channels */
+static const pwm_conf_chan_t pwm_chan1_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PB, 12), GPIO_MUX_E, 0 },
+    { GPIO_PIN(PB, 13), GPIO_MUX_E, 1 },
+};
+#endif
+#if PWM_2_EN
+/* PWM2 channels */
+static const pwm_conf_chan_t pwm_chan2_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PB, 02), GPIO_MUX_E, 0 },
+    { GPIO_PIN(PB, 03), GPIO_MUX_E, 1 },
+};
+#endif
 
 /* PWM device configuration */
 static const pwm_conf_t pwm_config[] = {
 #if PWM_0_EN
-    {TCC2, {
-        /* GPIO pin, MUX value, TCC channel */
-        { GPIO_PIN(PA, 12), GPIO_MUX_E, 0 },
-        { GPIO_PIN(PA, 13), GPIO_MUX_E, 1 },
-    }},
+    {TCC2, pwm_chan0_config, ARRAY_SIZE(pwm_chan0_config)},
 #endif
 #if PWM_1_EN
-    {TC4, {
-        /* GPIO pin, MUX value, TCC channel */
-        { GPIO_PIN(PB, 12), GPIO_MUX_E, 0 },
-        { GPIO_PIN(PB, 13), GPIO_MUX_E, 1 },
-    }}
+    {TC4, pwm_chan1_config, ARRAY_SIZE(pwm_chan1_config)},
 #endif
 #if PWM_2_EN
-    {TC6, {
-        /* GPIO pin, MUX value, TCC channel */
-        { GPIO_PIN(PB, 02), GPIO_MUX_E, 0 },
-        { GPIO_PIN(PB, 03), GPIO_MUX_E, 1 },
-    }}
+    {TC6, pwm_chan2_config, ARRAY_SIZE(pwm_chan2_config)},
 #endif
 };
 
 /* number of devices that are actually defined */
-#define PWM_NUMOF           (3U)
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -185,33 +185,37 @@ static const uart_conf_t uart_config[] = {
  */
 #define PWM_0_EN            1
 #define PWM_1_EN            1
-#define PWM_MAX_CHANNELS    3
-/* for compatibility with test application */
-#define PWM_0_CHANNELS      PWM_MAX_CHANNELS
-#define PWM_1_CHANNELS      PWM_MAX_CHANNELS
+
+#if PWM_0_EN
+/* PWM0 channels */
+static const pwm_conf_chan_t pwm_chan0_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PA, 6), GPIO_MUX_E, 0 },
+    { GPIO_PIN(PA, 7), GPIO_MUX_E, 1 },
+};
+#endif
+#if PWM_1_EN
+/* PWM1 channels */
+static const pwm_conf_chan_t pwm_chan1_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PA, 16), GPIO_MUX_F, 0 },
+    { GPIO_PIN(PA, 18), GPIO_MUX_F, 2 },
+    { GPIO_PIN(PA, 19), GPIO_MUX_F, 3 },
+};
+#endif
 
 /* PWM device configuration */
 static const pwm_conf_t pwm_config[] = {
 #if PWM_0_EN
-    {TCC1, {
-        /* GPIO pin, MUX value, TCC channel */
-        { GPIO_PIN(PA, 6), GPIO_MUX_E, 0 },
-        { GPIO_PIN(PA, 7), GPIO_MUX_E, 1 },
-        { GPIO_UNDEF, (gpio_mux_t)0, 2 }
-    }},
+    {TCC1, pwm_chan0_config, ARRAY_SIZE(pwm_chan0_config)},
 #endif
 #if PWM_1_EN
-    {TCC0, {
-        /* GPIO pin, MUX value, TCC channel */
-        { GPIO_PIN(PA, 16), GPIO_MUX_F, 0 },
-        { GPIO_PIN(PA, 18), GPIO_MUX_F, 2 },
-        { GPIO_PIN(PA, 19), GPIO_MUX_F, 3 }
-    }}
+    {TCC0, pwm_chan1_config, ARRAY_SIZE(pwm_chan1_config)},
 #endif
 };
 
 /* number of devices that are actually defined */
-#define PWM_NUMOF           (2U)
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -149,33 +149,37 @@ static const adc_conf_chan_t adc_channels[] = {
  */
 #define PWM_0_EN            1
 #define PWM_1_EN            1
-#define PWM_MAX_CHANNELS    3
-/* for compatibility with test application */
-#define PWM_0_CHANNELS      PWM_MAX_CHANNELS
-#define PWM_1_CHANNELS      PWM_MAX_CHANNELS
+
+#if PWM_0_EN
+/* PWM0 channels */
+static const pwm_conf_chan_t pwm_chan0_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PA, 6), GPIO_MUX_E, 0 },
+    { GPIO_PIN(PA, 7), GPIO_MUX_E, 1 },
+};
+#endif
+#if PWM_1_EN
+/* PWM1 channels */
+static const pwm_conf_chan_t pwm_chan1_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PA, 16), GPIO_MUX_F, 0 },
+    { GPIO_PIN(PA, 18), GPIO_MUX_F, 2 },
+    { GPIO_PIN(PA, 19), GPIO_MUX_F, 3 }
+};
+#endif
 
 /* PWM device configuration */
 static const pwm_conf_t pwm_config[] = {
 #if PWM_0_EN
-    {TCC1, {
-        /* GPIO pin, MUX value, TCC channel */
-        { GPIO_PIN(PA, 6), GPIO_MUX_E, 0 },
-        { GPIO_PIN(PA, 7), GPIO_MUX_E, 1 },
-        { GPIO_UNDEF, (gpio_mux_t)0, 2 }
-    }},
+    {TCC1, pwm_chan0_config, ARRAY_SIZE(pwm_chan0_config)},
 #endif
 #if PWM_1_EN
-    {TCC0, {
-        /* GPIO pin, MUX value, TCC channel */
-        { GPIO_PIN(PA, 16), GPIO_MUX_F, 0 },
-        { GPIO_PIN(PA, 18), GPIO_MUX_F, 2 },
-        { GPIO_PIN(PA, 19), GPIO_MUX_F, 3 }
-    }}
+    {TCC0, pwm_chan1_config, ARRAY_SIZE(pwm_chan1_config)},
 #endif
 };
 
 /* number of devices that are actually defined */
-#define PWM_NUMOF           (2U)
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */
 
 /**

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -84,7 +84,8 @@ typedef struct {
  */
 typedef struct {
     Tcc *dev;                   /**< TCC device to use */
-    pwm_conf_chan_t chan[3];    /**< channel configuration */
+    const pwm_conf_chan_t *chan;/**< channel configuration */
+    const uint8_t chan_numof;   /**< number of channels */
 } pwm_conf_t;
 
 /**

--- a/cpu/samd21/periph/pwm.c
+++ b/cpu/samd21/periph/pwm.c
@@ -151,7 +151,7 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
     f_real = (CLOCK_CORECLOCK / (scale * res));
 
     /* configure the used pins */
-    for (unsigned i = 0; i < PWM_MAX_CHANNELS; i++) {
+    for (unsigned i = 0; i < pwm_config[dev].chan_numof; i++) {
         if (pwm_config[dev].chan[i].pin != GPIO_UNDEF) {
             gpio_init(pwm_config[dev].chan[i].pin, GPIO_OUT);
             gpio_init_mux(pwm_config[dev].chan[i].pin, pwm_config[dev].chan[i].mux);
@@ -195,12 +195,12 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
 
 uint8_t pwm_channels(pwm_t dev)
 {
-    return ARRAY_SIZE(pwm_config[dev].chan);
+    return pwm_config[dev].chan_numof;
 }
 
 void pwm_set(pwm_t dev, uint8_t channel, uint16_t value)
 {
-    if ((channel >= PWM_MAX_CHANNELS) ||
+    if ((channel >= pwm_config[dev].chan_numof) ||
         (pwm_config[dev].chan[channel].pin == GPIO_UNDEF)) {
         return;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Each TCC can have 8 PWM channels, so don't hard-code 3 channels/TCC.
This allows for a more flexible PWM configuration and allows to use more than 3 PWM channels per timer device.


### Testing procedure

`tests/periph_pwm` should still work.
The `oscillate` command will oscillate all channels, often an LED is connected that then will flash.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
