### PR TITLE
nanocoap/kconfig: Explicitly define type of MODULE_NANOCOAP

### DIFF
--- a/sys/net/application_layer/nanocoap/Kconfig
+++ b/sys/net/application_layer/nanocoap/Kconfig
@@ -7,6 +7,7 @@
 
 # Nanocoap provides CoAP functionalities
 config MODULE_NANOCOAP
+    bool
     select HAS_PROTOCOL_COAP
 
 menuconfig KCONFIG_MODULE_NANOCOAP


### PR DESCRIPTION
### Contribution description
This explicitly defines the type for `MODULE_NANOCOAP` symbol. When nanocoap is used that symbol is defined in `Kconfig.dep`, but when it's not a warning is raised. As modules are always defined as `bool` it's safe to define it here as such.

### Testing procedure
On an application which does not use nanocoap module, run `make menuconfig` and exit:
   - Without this PR you should see some warnings printed
```
warning: MODULE_NANOCOAP (defined at /<your_path>/RIOT/sys/net/application_layer/nanocoap/Kconfig:9) defined without a type
```
   - With this PR the warning should not appear.

### Issues/PRs references
Introduced here #13243 
