### PR TITLE
nimble/netif: fix deadlock when sending multicast under load

### DIFF
--- a/pkg/nimble/netif/include/nimble_netif_conn.h
+++ b/pkg/nimble/netif/include/nimble_netif_conn.h
@@ -127,6 +127,20 @@ void nimble_netif_conn_foreach(uint16_t filter,
                                nimble_netif_conn_iter_t cb, void *arg);
 
 /**
+ * @brief   Find the next context that matches the filter condition
+ *
+ * This function allows for iterating connection contexts in a non-blocking way.
+ *
+ * @param[in] handle        last used handle, set to NIMBLE_NETIF_CONN_INVALID
+                            to get the first matching entry
+ * @param[in] filter        filter mask
+ *
+ * @return  handle of the next matching connection context
+ * @return  NIMBLE_NETIF_CONN_INVALID if no matching context was found
+ */
+int nimble_netif_conn_get_next(int handle, uint16_t filter);
+
+/**
  * @brief   Count the number of connections contexts for which the given filter
  *          applies
  *

--- a/pkg/nimble/netif/nimble_netif_conn.c
+++ b/pkg/nimble/netif/nimble_netif_conn.c
@@ -188,6 +188,21 @@ void nimble_netif_conn_foreach(uint16_t filter,
     mutex_unlock(&_lock);
 }
 
+int nimble_netif_conn_get_next(int handle, uint16_t filter)
+{
+    /* if handle is undefined, start from the beginning */
+    if (handle < 0) {
+        handle = -1;
+    }
+    for (int i = (handle + 1); i < (int)CONN_CNT; i++) {
+        if (_conn[i].state & filter) {
+            return i;
+        }
+    }
+
+    return NIMBLE_NETIF_CONN_INVALID;
+}
+
 unsigned nimble_netif_conn_count(uint16_t filter)
 {
     unsigned cnt = 0;


### PR DESCRIPTION
### Contribution description
The current `nimble_netif` implementation may end up in a deadlock when sending multicast packets while receiving incoming BLE traffic at the same time. 

When sending multicast packets over BLE, `nimble_netif` duplicates that packet and sends it one instance to each connected peer via the designated L2CAP channel. For this `nimble_netif` needs to get a mapping of BLE link layer addresses (as used by GNRC) and a corresponding pointer to the open L2CAP channel (used by NimBLE). All access to this mapping table is encapsulated in the `nimble_netif_conn` submodule, which is made thread safe by using an internal mutex for synchronizing all access. 

`nimble_netif` is using the `nimble_netif_conn_foreach` iterator function for doing the aforementioned multicast packet duplication. This function blocks the mapping table until finished, effecting it to be blocked until all instances for a multicast packets are handed over to NimBLE. Under load it is however possible, that this sending process is stalled and waits until signalled by the NimBLE thread (via `thread_flag`), causing the `nimble_netif_conn` table to be blocked for any amount of time.

Now to the deadlock: when the above described situation happens AND a node receives incoming packets at exactly that time AND the node is a GAP slave (-> L2CAP server) the receive function does also do a lookup into the `nimble_netif_conn` table. This makes the NimBLE host thread wait for the `nimble_netif_conn` mutex to be freed while the `nimble_netif` thread waits for a flag to be set by the NimBLE thread before it releases that Mutex... 

The fix is quite simple: with this PR the iteration of the `nimble_netif_conn` table when sending multicast does not lock the `nimble_netif_conn` table anymore. This is save, as the actual `_send_pkt()` function does a validity check on the given `conn` pointer, as well as NimBLE does a validity check on the given l2cap channel pointer.

### Testing procedure
- take any 2 NimBLE capable boards (e.g. `nrf52dk`), also available in the iotlab testbed
- flash the `gnrc_networking` example
- open a BLE connection:
  - node A: `ble adv foo`
  - node B: `ble connect foo`
- run a ping using the all nodes multicast address (ff02::1) in both directions
  - node A and node B: `ping6 ff02::1 -c 100 -i 50 -s 250`

-> if stressed enough, at least one of the two nodes will run into the described deadlock situation using the current master. When calling `ifconfig` after the ping command has finished, the shell will also hang, as ifconfig does a `msg_send_receive` to the `nimble_netif` thread, which is in turn blocked...

Applying the fix in this PR should resolve this issue, now both nodes should run through their ping just fine...

Side note: when stressing the links too much, one may see massive lags and packet loss due to overflowing buffers etc. But this should not cause any of the nodes to get stuck!

### Issues/PRs references
None