### PR TITLE
tests/gnrc_dhcpv6_client: Fix term and increase timeout [backport 2020.04]

### DIFF
--- a/tests/gnrc_dhcpv6_client/Makefile
+++ b/tests/gnrc_dhcpv6_client/Makefile
@@ -20,7 +20,7 @@ else
   IFACE ?= tap0
   ETHOS_BAUDRATE ?= 115200
   CFLAGS += -DETHOS_BAUDRATE=$(ETHOS_BAUDRATE)
-  TERMPROG ?= sudo sh $(RIOTBASE)/dist/tools/ethos/ethos
+  TERMPROG ?= sudo $(RIOTBASE)/dist/tools/ethos/ethos
   TERMFLAGS ?= $(IFACE) $(PORT) $(ETHOS_BAUDRATE)
   TERMDEPS += ethos
 endif

--- a/tests/gnrc_dhcpv6_client/tests/01-run.py
+++ b/tests/gnrc_dhcpv6_client/tests/01-run.py
@@ -29,4 +29,4 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc, timeout=5))
+    sys.exit(run(testfunc, timeout=6))


### PR DESCRIPTION
# Backport of #13961

### Contribution description
This PR changes the way `ethos` is called in the `gnrc_dhcpv6_client` test (removes `sh`) and increases the timeout a bit. The test application is supposed to print the interface information after 5 seconds, but sometimes the test script timeouts before the application can print it.

### Testing procedure
- Run `test/gnrc_dhcpv6_client` application test.


### Issues/PRs references
None