### PR TITLE
boards: add for cc1352p-launchpad board

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,6 +31,7 @@
 /boards/sodaq-sara-aff/                     @leandrolanzieri
 /boards/stk3*00/                            @basilfx
 /boards/openmote*/                          @MrKevinWeiss
+/boards/cc1352p-launchpad                   @luisan00
 
 /core/                                      @kaspar030
 

--- a/boards/cc1352p-launchpad/Makefile
+++ b/boards/cc1352p-launchpad/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/cc1352p-launchpad/Makefile.features
+++ b/boards/cc1352p-launchpad/Makefile.features
@@ -1,0 +1,8 @@
+CPU = cc26x2_cc13x2
+CPU_MODEL = cc1352p1
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_gpio_irq
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart

--- a/boards/cc1352p-launchpad/Makefile.include
+++ b/boards/cc1352p-launchpad/Makefile.include
@@ -1,0 +1,11 @@
+XDEBUGGER = XDS110
+
+# set default port depending on operating system
+PORT_LINUX  ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# configure the flash tool
+include $(RIOTBOARD)/common/cc26x2_cc13x2/Makefile.include

--- a/boards/cc1352p-launchpad/board.c
+++ b/boards/cc1352p-launchpad/board.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C)    2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup         boards_cc1352p_launchpad
+ * @{
+ *
+ * @file
+ * @brief           Board specific implementations for TI CC1352P LaunchPad
+ *
+ * @author          Luis A. Ruiz <luisan00@hotmail.com>
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+/**
+ * @brief           Initialise the board.
+ */
+
+void board_init(void)
+{
+    cpu_init();
+
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+}

--- a/boards/cc1352p-launchpad/dist/cc1352p1_XDS110.ccxml
+++ b/boards/cc1352p-launchpad/dist/cc1352p1_XDS110.ccxml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<configurations XML_version="1.2" id="configurations_0">
+    <configuration XML_version="1.2" id="Texas Instruments XDS110 USB Debug Probe_0">
+        <instance XML_version="1.2" desc="Texas Instruments XDS110 USB Debug Probe_0" href="connections/TIXDS110_Connection.xml" id="Texas Instruments XDS110 USB Debug Probe_0" xml="TIXDS110_Connection.xml" xmlpath="connections"/>
+        <connection XML_version="1.2" id="Texas Instruments XDS110 USB Debug Probe_0">
+            <instance XML_version="1.2" href="drivers/tixds510icepick_c.xml" id="drivers" xml="tixds510icepick_c.xml" xmlpath="drivers"/>
+            <instance XML_version="1.2" href="drivers/tixds510cs_dap.xml" id="drivers" xml="tixds510cs_dap.xml" xmlpath="drivers"/>
+            <instance XML_version="1.2" href="drivers/tixds510cortexM.xml" id="drivers" xml="tixds510cortexM.xml" xmlpath="drivers"/>
+            <property Type="choicelist" Value="1" id="Power Selection">
+                <choice Name="Probe supplied power" value="1">
+                    <property Type="stringfield" Value="3.3" id="Voltage Level"/>
+                </choice>
+            </property>
+            <property Type="choicelist" Value="0" id="JTAG Signal Isolation"/>
+            <property Type="choicelist" Value="4" id="SWD Mode Settings">
+                <choice Name="cJTAG (1149.7) 2-pin advanced modes" value="enable">
+                    <property Type="choicelist" Value="1" id="XDS110 Aux Port"/>
+                </choice>
+            </property>
+            <platform XML_version="1.2" id="platform_0">
+                <instance XML_version="1.2" desc="CC1352P1F3_0" href="devices/cc1352p1f3.xml" id="CC1352P1F3_0" xml="cc1352p1f3.xml" xmlpath="devices"/>
+            </platform>
+        </connection>
+    </configuration>
+</configurations>

--- a/boards/cc1352p-launchpad/dist/cc1352p1_XDS110.dat
+++ b/boards/cc1352p-launchpad/dist/cc1352p1_XDS110.dat
@@ -1,0 +1,42 @@
+# config version=3.5
+$ sepk
+  pod_drvr=libjioxds110.so
+  pod_port=0
+  pod_supply=1
+  pod_voltage_selection=1
+  pod_voltage=3.3
+  pod_power_isolate=0
+$ /
+$ product
+  title="Texas Instruments XDS110 USB"
+  alias=TI_XDS110_USB
+  name=XDS110
+$ /
+$ uscif
+  tdoedge=FALL
+  tclk_program=DEFAULT
+  tclk_frequency=5.5MHz
+  jtag_isolate=disable
+$ /
+$ dot7
+  dts_usage=enable
+  dts_type=xds110
+  dts_program=emulator
+  dts_frequency=1.0MHz
+  ts_format=oscan2
+  ts_pin_width=only_two
+$ /
+$ swd
+  swd_debug=disabled
+  swo_data=tdo_pin
+$ /
+@ icepick_c family=icepick_c irbits=6 drbits=1 subpaths=2 systemresetsupported=1
+  & subpath_2 address=0 default=no custom=yes force=yes pseudo=no cancelreset=0x1
+    @ bypass_0 family=bypass irbits=4 drbits=1
+  & subpath_0 address=16 default=no custom=yes force=yes pseudo=no cancelreset=0x1
+    @ cs_dap_0 family=cs_dap irbits=4 drbits=1 subpaths=1 identify=0x4BA00477 revision=Legacy systemresetwhileconnected=1
+      & subpath_1 type=debug address=0 default=no custom=yes force=yes pseudo=no
+        @ cortex_m4_0 family=cortex_mxx irbits=0 drbits=0 identify=0x02000000 traceid=0x0
+      & /
+  & /
+# /

--- a/boards/cc1352p-launchpad/dist/cc1352p1_gdb.conf
+++ b/boards/cc1352p-launchpad/dist/cc1352p1_gdb.conf
@@ -1,0 +1,1 @@
+target extended-remote :3333

--- a/boards/cc1352p-launchpad/doc.txt
+++ b/boards/cc1352p-launchpad/doc.txt
@@ -1,0 +1,95 @@
+/**
+@defgroup        boards_cc1352p_launchpad TI CC1352P LaunchPad
+@ingroup         boards
+@brief           Texas Instruments SimpleLink(TM) CC1352P Wireless MCU LaunchPad(TM) Kit
+*/
+
+## Overview
+
+The [LAUNCHXL-CC1352P](http://www.ti.com/tool/LAUNCHXL-CC1352P) is a Texas
+Instrument's development kit for the CC1352P SoC which combines dual-band wireless MCU
+with integrated power amplifier.
+
+## Hardware
+
+![LAUNCHPAD-CC1352P](http://www.ti.com/diagrams/launchxl-cc1352p_launchxl-cc1352p_mcu041a_cc1352p1.jpg)
+
+The board comes in two variants with different RF matching network on the 20 dBm PA output port:
+
+- LAUNCHXL-CC1352P1: 868/915 MHz up to 20 dBm, 2.4 GHz up to 5 dBm
+- LAUNCHXL-CC1352P-2: 868/915 MHz up to 14 dBm, 2.4 GHz up to 20 dBm.
+
+For a more detailed information, please check out the [CC1352P datasheet](http://www.ti.com/lit/ds/swrs192c/swrs192c.pdf) or the [quick start guide](http://www.ti.com/lit/ug/swau108a/swau108a.pdf)
+
+## Flashing and Debugging
+
+The LAUNCHXL-CC1352P comes with an XDS110 on-board debug probe that provides
+programming, flashing and debugging capabilities.
+
+### TI Code Composer Studio _CCS_
+
+The TI's [Code Composer Studio _CCS_](http://www.ti.com/tool/CCSTUDIO) is an Integrated Development Environment which provides the necessary tools to use the debug features of the XDS110.
+
+### Uniflash
+
+[Uniflash](http://www.ti.com/tool/UNIFLASH) is a standalone flash tool for TI MCUs, Sitara Processors & SimpleLink devices.
+
+#### Setting up the environment
+
+In order to make use of the programming and debugging capabilities of the XDS110 some environment variable needs to be set:
+
+```
+export CCS_PATH=<path to ti install folder>/ti/ccs930
+export UNIFLASH_PATH<path to ti install folder>/ti/uniflash_5.2.0
+```
+
+That assumes you have CCS 9.3.0 (for the path name) and Uniflash 5.2.0, adjust
+accordingly.
+
+After that you can flash using the RIOT `make flash` command on your application
+or to debug you first start the debug server:
+
+```
+make debug-server
+```
+
+And then on another terminal you can run:
+
+```
+make debug
+```
+
+It will open GDB and connect to the debug server automatically.
+
+### Using OpenOCD
+
+To use OpenOCD with the XDS110 you need to use the an special version of
+OpenOCD made by TI (upstream version is not _yet_ compatible). You can
+clone and compile it from source:
+
+```
+# Clone into the openocd-ti folder
+git clone https://git.ti.com/cgit/sdo-emu/openocd openocd-ti
+
+# Change directory to the openocd source code
+cd openocd-ti/openocd
+
+# Configure, build, install
+./configure
+make
+sudo make install
+```
+
+#### Setting up the environment
+
+Now that we have the TI version of OpenOCD we need to export the `PROGRAMMER`
+environment variable, this is to enable OpenOCD instead of Uniflash.
+
+```
+export PROGRAMMER=openocd
+```
+
+Now we can just do `make debug-server` and then `make debug`, this all using
+OpenOCD.
+
+*/

--- a/boards/cc1352p-launchpad/include/board.h
+++ b/boards/cc1352p-launchpad/include/board.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C)    2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup         boards_cc1352p_launchpad
+ * @{
+ *
+ * @file
+ * @brief           Board specific definitions for TI CC1352P LaunchPad
+ *
+ * @author          Luis A. Ruiz <luisan00@hotmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH        (16)
+#define XTIMER_BACKOFF      (25)
+#define XTIMER_ISR_BACKOFF  (20)
+/** @} */
+
+/**
+ * @name    On-board button configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(0, 13)
+#define BTN0_MODE           GPIO_IN_PU
+
+#define BTN1_PIN            GPIO_PIN(0, 14)
+#define BTN1_MODE           GPIO_IN_PU
+/** @} */
+
+/**
+ * @brief   On-board LED configuration and controlling
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 6)          /**< red   */
+#define LED1_PIN            GPIO_PIN(0, 7)          /**< green */
+
+#define LED0_ON             gpio_set(LED0_PIN)
+#define LED0_OFF            gpio_clear(LED0_PIN)
+#define LED0_TOGGLE         gpio_toggle(LED0_PIN)
+
+#define LED1_ON             gpio_set(LED1_PIN)
+#define LED1_OFF            gpio_clear(LED1_PIN)
+#define LED1_TOGGLE         gpio_toggle(LED1_PIN)
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/cc1352p-launchpad/include/periph_conf.h
+++ b/boards/cc1352p-launchpad/include/periph_conf.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C)    2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         boards_cc1352p_launchpad
+ * @{
+ *
+ * @file
+ * @brief           Peripheral MCU configuration for TI CC1312 LaunchPad
+ *
+ * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
+ * @author          Luis A. Ruiz <luisan00@hotmail.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* @name    Clock configuration
+* @{
+*/
+/* the main clock is fixed to 48MHZ */
+#define CLOCK_CORECLOCK     (48000000U)
+/** @} */
+
+/**
+* @name    Timer configuration
+*
+* General purpose timers (GPT[0-3]) are configured consecutively and in order
+* (without gaps) starting from GPT0, i.e. if multiple timers are enabled.
+*
+* @{
+*/
+static const timer_conf_t timer_config[] = {
+ {
+     .cfg = GPT_CFG_16T,
+     .chn = 2,
+ },
+ {
+     .cfg = GPT_CFG_32T,
+     .chn = 1,
+ },
+ {
+     .cfg = GPT_CFG_16T,
+     .chn = 2,
+ },
+ {
+     .cfg = GPT_CFG_32T,
+     .chn = 1,
+ }
+};
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name    UART configuration
+ *
+ * The used LAUNCHXL-CC1352P1 board has available a single UART device through
+ * the debugger, so all we need to configure are the RX and TX pins.
+ *
+ * Optionally we can enable hardware flow control, by setting UART_HW_FLOW_CTRL
+ * to 1 and defining pins for cts_pin and rts_pin.
+ *
+ * @{
+ */
+
+static const uart_conf_t uart_config[] = {
+ {
+     .regs = UART0,
+     .tx_pin = 13,
+     .rx_pin = 12,
+#ifdef MODULE_PERIPH_UART_HW_FC
+     .rts_pin = GPIO_UNDEF,
+     .cts_pin = GPIO_UNDEF,
+#endif
+     .intn = UART0_IRQN
+ },
+ {
+     .regs = UART1,
+     .tx_pin = 26,
+     .rx_pin = 25,
+#ifdef MODULE_PERIPH_UART_HW_FC
+     .rts_pin = GPIO_UNDEF,
+     .cts_pin = GPIO_UNDEF,
+#endif
+     .intn = UART1_IRQN
+  }
+};
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The board is  similar to other 13x2 launchpads, same buttons and LEDs, what changes is the SoC which integrates a PA up to +20dBm output power. Few files was changed, _.CCXML_, _.dat_, and a minor fix  in periph_conf

### Testing procedure

Go to any example and execute `make flash BOARD=cc1352p-launchpad`,  should build and flash on the connected board.

### Issues/PRs references
- Require: https://github.com/RIOT-OS/RIOT/pull/13295 for the netdev driver.
- See also:  https://github.com/RIOT-OS/RIOT/pull/13134

Any suggestion is welcome