### PR TITLE
cpu/sam0_common: implement periph/dac

### DIFF
--- a/boards/common/saml1x/Makefile.features
+++ b/boards/common/saml1x/Makefile.features
@@ -2,6 +2,7 @@ CPU = saml1x
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -165,6 +165,15 @@ static const adc_conf_chan_t adc_channels[] = {
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
 /** @} */
 
+/**
+ * @name DAC configuration
+ * @{
+ */
+#define DAC_CLOCK           SAM0_GCLK_32KHZ
+                            /* use Vcc as reference voltage */
+#define DAC_VREF            DAC_CTRLB_REFSEL_AVCC
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/samd21-xpro/Makefile.features
+++ b/boards/samd21-xpro/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = samd21j18a
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -347,6 +347,15 @@ static const adc_conf_chan_t adc_channels[] = {
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
 /** @} */
 
+/**
+ * @name DAC configuration
+ * @{
+ */
+#define DAC_CLOCK           SAM0_GCLK_1MHZ
+                            /* use Vcc as reference voltage */
+#define DAC_VREF            DAC_CTRLB_REFSEL_AVCC
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/same54-xpro/Makefile.features
+++ b/boards/same54-xpro/Makefile.features
@@ -2,6 +2,7 @@ CPU = samd5x
 CPU_MODEL = same54p20a
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -242,6 +242,19 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
         .gclk_src = SAM0_GCLK_48MHZ,
     }
 };
+/** @} */
+
+/**
+ * @name DAC configuration
+ * @{
+ */
+                            /* Must not exceed 12 MHz */
+#define DAC_CLOCK           SAM0_GCLK_8MHZ
+                            /* Use external reference voltage on PA03 */
+                            /* (You have to manually connect PA03 with Vcc) */
+                            /* Internal reference only gives 1V */
+#define DAC_VREF            DAC_CTRLB_REFSEL_VREFPU
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/boards/saml21-xpro/Makefile.features
+++ b/boards/saml21-xpro/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = saml21j18a
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -184,6 +184,16 @@ static const adc_conf_chan_t adc_channels[] = {
 #define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
 /** @} */
 
+/**
+ * @name DAC configuration
+ * @{
+ */
+                            /* Must not exceed 12 MHz */
+#define DAC_CLOCK           SAM0_GCLK_8MHZ
+                            /* use Vcc as reference voltage */
+#define DAC_VREF            DAC_CTRLB_REFSEL_VDDANA
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/sam0_common/periph/dac.c
+++ b/cpu/sam0_common/periph/dac.c
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2020 Beuth Hochschule für Technik Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_sam0_common
+ * @{
+ *
+ * @file
+ * @brief       Low-level DAC driver implementation
+ *
+ * @author      Benjamin Valentin <benpicco@beuth-hochschule.de>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "periph/dac.h"
+#include "periph/gpio.h"
+
+#define DAC_VAL(in) (in >> (16 - DAC_RES_BITS))
+
+static void _dac_init_clock(dac_t line)
+{
+    sam0_gclk_enable(DAC_CLOCK);
+
+    /* GCLK Setup */
+#ifdef GCLK_PCHCTRL_CHEN
+    GCLK->PCHCTRL[DAC_GCLK_ID].reg = GCLK_PCHCTRL_CHEN
+                                   | GCLK_PCHCTRL_GEN(DAC_CLOCK);
+#else
+    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN
+                      | GCLK_CLKCTRL_GEN(DAC_CLOCK)
+                      | GCLK_CLKCTRL_ID(DAC_GCLK_ID);
+#endif
+
+    dac_poweron(line);
+}
+
+static inline bool _ext_vref(void)
+{
+#ifdef DAC_CTRLB_REFSEL_VREFP
+    return DAC_VREF == DAC_CTRLB_REFSEL_VREFP;
+#endif
+#ifdef DAC_CTRLB_REFSEL_VREFPU
+    return (DAC_VREF == DAC_CTRLB_REFSEL_VREFPU) ||
+           (DAC_VREF == DAC_CTRLB_REFSEL_VREFPB);
+#endif
+}
+
+static inline void _sync(void)
+{
+#ifdef DAC_SYNCBUSY_MASK
+    while (DAC->SYNCBUSY.reg) {}
+#else
+    while (DAC->STATUS.bit.SYNCBUSY) {}
+#endif
+}
+
+#ifdef DAC_DACCTRL_CCTRL_Msk
+static uint32_t _get_CCTRL(uint32_t freq)
+{
+    if (freq < 1200000) {
+        return DAC_DACCTRL_CCTRL_CC100K;
+    }
+
+    if (freq < 6000000) {
+        return DAC_DACCTRL_CCTRL_CC1M;
+    }
+
+    if (freq < 12000000) {
+        return DAC_DACCTRL_CCTRL_CC12M;
+    }
+
+    assert(0);
+    return 0;
+}
+#endif
+
+int8_t dac_init(dac_t line)
+{
+    switch (line) {
+    case 0:
+        /* DAC0 is always connected to PA2 */
+        gpio_init(GPIO_PIN(PA, 2), GPIO_OUT);
+        gpio_init_mux(GPIO_PIN(PA, 2), GPIO_MUX_B);
+        break;
+#ifdef PIN_PA05B_DAC_VOUT1
+    case 1:
+        /* DAC1 is always connected to PA5 */
+        gpio_init(GPIO_PIN(PA, 5), GPIO_OUT);
+        gpio_init_mux(GPIO_PIN(PA, 5), GPIO_MUX_B);
+        break;
+#endif
+    default:
+        return DAC_NOLINE;
+    }
+
+    if (_ext_vref()) {
+        /* PA3 is external reference voltage */
+        gpio_init_mux(GPIO_PIN(PA, 3), GPIO_MUX_B);
+    }
+
+    _dac_init_clock(line);
+
+    /* Settings can only be changed when DAC is disabled */
+    DAC->CTRLA.bit.ENABLE = 0;
+    _sync();
+
+#ifdef DAC_DACCTRL_ENABLE
+    DAC->DACCTRL[line].reg = DAC_DACCTRL_ENABLE
+                           | _get_CCTRL(sam0_gclk_freq(DAC_CLOCK));
+#endif
+
+    /* Set Reference Voltage & enable Output if needed */
+    DAC->CTRLB.reg = DAC_VREF
+#ifdef DAC_CTRLB_EOEN
+                   | DAC_CTRLB_EOEN
+#endif
+                   ;
+
+    DAC->CTRLA.bit.ENABLE = 1;
+    _sync();
+
+    return DAC_OK;
+}
+
+void dac_set(dac_t line, uint16_t value)
+{
+#ifdef DAC_SYNCBUSY_DATA1
+    /* DAC has multiple outputs */
+    const uint32_t mask = (1 << (DAC_SYNCBUSY_DATA_Pos + line));
+    while (DAC->SYNCBUSY.reg & mask) {}
+
+    DAC->DATA[line].reg = DAC_VAL(value);
+#else
+    /* DAC has only one output */
+    (void) line;
+
+    _sync();
+    DAC->DATA.reg = DAC_VAL(value);
+#endif
+}
+
+void dac_poweron(dac_t line)
+{
+    (void) line;
+
+#ifdef PM_APBCMASK_DAC
+     PM->APBCMASK.reg |= PM_APBCMASK_DAC;
+#endif
+#ifdef MCLK_APBCMASK_DAC
+     MCLK->APBCMASK.reg |= MCLK_APBCMASK_DAC;
+#endif
+#ifdef MCLK_APBDMASK_DAC
+     MCLK->APBDMASK.reg |= MCLK_APBDMASK_DAC;
+#endif
+}
+
+void dac_poweroff(dac_t line)
+{
+    (void) line;
+
+#ifdef PM_APBCMASK_DAC
+     PM->APBCMASK.reg &= ~PM_APBCMASK_DAC;
+#endif
+#ifdef MCLK_APBCMASK_DAC
+     MCLK->APBCMASK.reg &= ~MCLK_APBCMASK_DAC;
+#endif
+#ifdef MCLK_APBDMASK_DAC
+     MCLK->APBDMASK.reg &= ~MCLK_APBDMASK_DAC;
+#endif
+}

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -115,6 +115,17 @@ typedef enum {
 } adc_res_t;
 /** @} */
 #endif /* ndef DOXYGEN */
+
+/**
+ * @brief   The MCU has a 10 bit DAC
+ */
+#define DAC_RES_BITS        (10)
+
+/**
+ * @brief   The MCU has one DAC Output.
+ */
+#define DAC_NUMOF           (1)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -69,6 +69,16 @@ enum {
  */
 #define SPI_HWCS(x)     (UINT_MAX - 1)
 
+/**
+ * @brief   The MCU has a 12 bit DAC
+ */
+#define DAC_RES_BITS        (12)
+
+/**
+ * @brief   The MCU has two DAC outputs.
+ */
+#define DAC_NUMOF           (2)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/saml1x/include/periph_cpu.h
+++ b/cpu/saml1x/include/periph_cpu.h
@@ -62,6 +62,16 @@ typedef enum {
 #endif /* ndef DOXYGEN */
 /** @} */
 
+/**
+ * @brief   The MCU has a 10 bit DAC
+ */
+#define DAC_RES_BITS        (10)
+
+/**
+ * @brief   The MCU has one DAC Output.
+ */
+#define DAC_NUMOF           (1)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -62,6 +62,16 @@ typedef enum {
 /** @} */
 #endif /* ndef DOXYGEN */
 
+/**
+ * @brief   The MCU has a 12 bit DAC
+ */
+#define DAC_RES_BITS        (12)
+
+/**
+ * @brief   The MCU has two DAC outputs.
+ */
+#define DAC_NUMOF           (2)
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The sam0 MCUs all have a DAC peripheral.
The DAC has a resulution of 10 or 12 bits and can have one or two output channels.

The output pins are always hard-wired to PA2 for DAC0 and PA5 for DAC1 if it exists.

On the `same54-xpro` I would only get a max value of ~1V when using the internal reference, so I configured it to use an external voltage reference.

The external reference pin is hard-wired to PA3, so there you'll have to connect that to 3.3V to get results.


### Testing procedure

Run `tests/periph_dac` and connect a multimeter to PA02. (and PA05 if supported)
I had to increase `DELAY` to 10000 (10ms / step) for my meter to keep up.
If you have an oscilloscope you should see a square wave directly.

Only tested on `same54-xpro` and `saml10-xpro`.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
