### PR TITLE
drivers/sps30 : Expose Configurations to Kconfig

### DIFF
--- a/drivers/Kconfig.net
+++ b/drivers/Kconfig.net
@@ -23,4 +23,5 @@ rsource "hdc1000/Kconfig"
 rsource "mag3110/Kconfig"
 rsource "mma8x5x/Kconfig"
 rsource "opt3001/Kconfig"
+rsource "sps30/Kconfig"
 endmenu # Sensor Device Drivers

--- a/drivers/include/sps30.h
+++ b/drivers/include/sps30.h
@@ -144,8 +144,8 @@ typedef enum {
  *            suboptimal wiring.
  *
  */
-#ifndef SPS30_ERROR_RETRY
-#define SPS30_ERROR_RETRY    (500U)
+#ifndef CONFIG_SPS30_ERROR_RETRY
+#define CONFIG_SPS30_ERROR_RETRY    (500U)
 #endif
 /** @} */
 

--- a/drivers/sps30/Kconfig
+++ b/drivers/sps30/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_SPS30
+    bool "Configure SPS30 driver"
+    depends on MODULE_SPS30
+    help
+        Configure the SPS30 driver using Kconfig.
+
+if KCONFIG_MODULE_SPS30
+
+config SPS30_ERROR_RETRY
+    int "Maximum number of error retries"
+    default 500
+    help
+        Maximum number of automatic retries on communication errors.
+        Change this to 0 if more fine-grained feedback is required.
+        The value may be increased if the device is connected over
+        suboptimal wiring.
+
+endif # KCONFIG_MODULE_SPS30

--- a/drivers/sps30/sps30.c
+++ b/drivers/sps30/sps30.c
@@ -142,7 +142,7 @@ static int _rx_tx_data(const sps30_t *dev, uint16_t ptr_addr,
                        uint8_t *data, size_t len, bool read)
 {
     int res = 0;
-    unsigned retr = SPS30_ERROR_RETRY;
+    unsigned retr = CONFIG_SPS30_ERROR_RETRY;
 
     if (i2c_acquire(dev->p.i2c_dev) != 0) {
         LOG_ERROR("could not acquire I2C bus %d\n", dev->p.i2c_dev);


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in SPS30 Sensor Device driver to Kconfig.

### Testing procedure

New macro was introduced in tests/driver_sps30/main.c for testing.

```
#define STR(x)   #x
#define SHOW_DEFINE(x) printf("%s=%s\n", #x, STR(x))
```
Firmware was uploaded to FIT IoT Lab test bed.

#### Default State:

##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-200-gea488-Kconfig_sps30_tests)
CONFIG_SPS30_ERROR_RETRY=(500U)
SPS30 test application

sps30_init: [I2C_ERROR]
sps30_read_article_code: [I2C_ERROR]
sps30_read_serial_number: [I2C_ERROR]
sps30_start_fan_clean: [I2C_ERROR]

#### Usage with CFLAGS 

/tests/driver_sps30/Makefile

> CFLAGS += -DCONFIG_SPS30_ERROR_RETRY=10


##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-200-gea488-Kconfig_sps30_tests)
CONFIG_SPS30_ERROR_RETRY=10
SPS30 test application

sps30_init: [I2C_ERROR]
sps30_read_article_code: [I2C_ERROR]
sps30_read_serial_number: [I2C_ERROR]
sps30_start_fan_clean: [I2C_ERROR]

#### Usage with Kconfig

/tests/driver_sps30/

> make menuconfig

##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-200-gea488-Kconfig_sps30_tests)
CONFIG_SPS30_ERROR_RETRY=0
SPS30 test application

sps30_init: [I2C_ERROR]
sps30_read_article_code: [I2C_ERROR]
sps30_read_serial_number: [I2C_ERROR]
sps30_start_fan_clean: [I2C_ERROR]

Note : The sensor is not available for interfacing hence configurability of macros were only tested.

### Issues/PRs references

#12888
@leandrolanzieri 
