### PR TITLE
sys/ztimer/auto_init: fix rtt auto_init

### DIFF
--- a/sys/ztimer/auto_init.c
+++ b/sys/ztimer/auto_init.c
@@ -114,7 +114,7 @@ ztimer_clock_t *const ZTIMER_MSEC = &_ztimer_convert_frac_msec.super.super;
 #  define ZTIMER_MSEC_CONVERT_LOWER_FREQ    RTT_FREQUENCY
 #  define ZTIMER_MSEC_CONVERT_LOWER         (&_ztimer_periph_timer_rtt_msec)
 #    else
-ztimer_clock_t *const ZTIMER_MSEC = &_ztimer_periph_timer_rtt_msec.super;
+ztimer_clock_t *const ZTIMER_MSEC = &_ztimer_periph_timer_rtt_msec;
 #    endif
 #  elif MODULE_ZTIMER_USEC
 static ztimer_convert_frac_t _ztimer_convert_frac_msec;


### PR DESCRIPTION
### Contribution description

`ztimer_periph_rtt_t` has no `super` so when not converting it `ZTIMER_MSEC` is simply `&_ztimer_periph_timer_rtt_msec.`

### Testing procedure

```
CFLAGS=-DRTT_FREQUENCY=1000 BOARD=iotlab-m3 USEMODULE="ztimer_msec ztimer_periph_rtt" make -C tests/ztimer_msg/
make: Entering directory '/home/francisco/workspace/RIOT2/tests/ztimer_msg'
Building application "tests_ztimer_msg" for "iotlab-m3" with MCU "stm32f1".

"make" -C /home/francisco/workspace/RIOT2/boards/iotlab-m3
"make" -C /home/francisco/workspace/RIOT2/boards/common/iotlab
"make" -C /home/francisco/workspace/RIOT2/core
"make" -C /home/francisco/workspace/RIOT2/cpu/stm32f1
"make" -C /home/francisco/workspace/RIOT2/cpu/cortexm_common
"make" -C /home/francisco/workspace/RIOT2/cpu/cortexm_common/periph
"make" -C /home/francisco/workspace/RIOT2/cpu/stm32_common
"make" -C /home/francisco/workspace/RIOT2/cpu/stm32_common/periph
"make" -C /home/francisco/workspace/RIOT2/cpu/stm32f1/periph
"make" -C /home/francisco/workspace/RIOT2/drivers
"make" -C /home/francisco/workspace/RIOT2/drivers/periph_common
"make" -C /home/francisco/workspace/RIOT2/sys
"make" -C /home/francisco/workspace/RIOT2/sys/auto_init
"make" -C /home/francisco/workspace/RIOT2/sys/frac
"make" -C /home/francisco/workspace/RIOT2/sys/isrpipe
"make" -C /home/francisco/workspace/RIOT2/sys/newlib_syscalls_default
"make" -C /home/francisco/workspace/RIOT2/sys/pm_layered
"make" -C /home/francisco/workspace/RIOT2/sys/stdio_uart
"make" -C /home/francisco/workspace/RIOT2/sys/test_utils/interactive_sync
"make" -C /home/francisco/workspace/RIOT2/sys/tsrb
"make" -C /home/francisco/workspace/RIOT2/sys/ztimer
/home/francisco/workspace/RIOT2/sys/ztimer/auto_init.c:117:67: error: 'ztimer_periph_rtt_t {aka struct ztimer_clock}' has no member named 'super'
 ztimer_clock_t *const ZTIMER_MSEC = &_ztimer_periph_timer_rtt_msec.super;
                                                                   ^
/home/francisco/workspace/RIOT2/Makefile.base:108: recipe for target '/home/francisco/workspace/RIOT2/tests/ztimer_msg/bin/iotlab-m3/ztimer_core/auto_init.o' failed

```

