### PR TITLE
drivers/disp_dev: use const qualifier

### DIFF
--- a/drivers/disp_dev/disp_dev.c
+++ b/drivers/disp_dev/disp_dev.c
@@ -19,41 +19,42 @@
  */
 
 #include <assert.h>
+#include <stdbool.h>
 #include <inttypes.h>
 
 #include "disp_dev.h"
 
-void disp_dev_map(disp_dev_t *dev,
-                 uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2,
-                 const uint16_t *color)
+void disp_dev_map(const disp_dev_t *dev,
+                  uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2,
+                  const uint16_t *color)
 {
     assert(dev);
 
     dev->driver->map(dev, x1, x2, y1, y2, color);
 }
 
-uint16_t disp_dev_height(disp_dev_t *dev)
+uint16_t disp_dev_height(const disp_dev_t *dev)
 {
     assert(dev);
 
     return dev->driver->height(dev);
 }
 
-uint16_t disp_dev_width(disp_dev_t *dev)
+uint16_t disp_dev_width(const disp_dev_t *dev)
 {
     assert(dev);
 
     return dev->driver->width(dev);
 }
 
-uint8_t disp_dev_color_depth(disp_dev_t *dev)
+uint8_t disp_dev_color_depth(const disp_dev_t *dev)
 {
     assert(dev);
 
     return dev->driver->color_depth(dev);
 }
 
-void disp_dev_set_invert(disp_dev_t *dev, bool invert)
+void disp_dev_set_invert(const disp_dev_t *dev, bool invert)
 {
     assert(dev);
 

--- a/drivers/ili9341/ili9341_disp_dev.c
+++ b/drivers/ili9341/ili9341_disp_dev.c
@@ -31,20 +31,20 @@
 #define ILI9341_DISP_COLOR_DEPTH    (16U)
 #endif
 
-static void _ili9341_map(disp_dev_t *dev, uint16_t x1, uint16_t x2,
+static void _ili9341_map(const disp_dev_t *dev, uint16_t x1, uint16_t x2,
                   uint16_t y1, uint16_t y2, const uint16_t *color)
 {
     ili9341_t *ili9341 = (ili9341_t *)dev;
     ili9341_pixmap(ili9341, x1, x2, y1, y2, color);
 }
 
-static uint16_t _ili9341_height(disp_dev_t *disp_dev)
+static uint16_t _ili9341_height(const disp_dev_t *disp_dev)
 {
     (void)disp_dev;
     return ILI9341_DISP_DEV_HEIGHT;
 }
 
-static uint16_t _ili9341_width(disp_dev_t *disp_dev)
+static uint16_t _ili9341_width(const disp_dev_t *disp_dev)
 {
     const ili9341_t *dev = (ili9341_t *)disp_dev;
     assert(dev);
@@ -52,13 +52,13 @@ static uint16_t _ili9341_width(disp_dev_t *disp_dev)
     return dev->params->lines;
 }
 
-static uint8_t _ili9341_color_depth(disp_dev_t *disp_dev)
+static uint8_t _ili9341_color_depth(const disp_dev_t *disp_dev)
 {
     (void)disp_dev;
     return ILI9341_DISP_COLOR_DEPTH;
 }
 
-static void _ili9341_set_invert(disp_dev_t *disp_dev, bool invert)
+static void _ili9341_set_invert(const disp_dev_t *disp_dev, bool invert)
 {
     const ili9341_t *dev = (ili9341_t *)disp_dev;
 

--- a/drivers/include/disp_dev.h
+++ b/drivers/include/disp_dev.h
@@ -56,7 +56,7 @@ typedef struct {
      * @param[in] y2    Bottom coordinate
      * @param[in] color Array of color to map to the display
      */
-    void (*map)(disp_dev_t *dev,
+    void (*map)(const disp_dev_t *dev,
                 uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2,
                 const uint16_t *color);
 
@@ -67,7 +67,7 @@ typedef struct {
      *
      * @return              Height in pixels
      */
-    uint16_t (*height)(disp_dev_t *dev);
+    uint16_t (*height)(const disp_dev_t *dev);
 
     /**
      * @brief   Get the width of the display device
@@ -76,14 +76,14 @@ typedef struct {
      *
      * @return              Width in pixels
      */
-    uint16_t (*width)(disp_dev_t *dev);
+    uint16_t (*width)(const disp_dev_t *dev);
 
     /**
      * @brief   Get the color depth of the display device
      *
      * @return              The color depth
      */
-    uint8_t (*color_depth)(disp_dev_t *dev);
+    uint8_t (*color_depth)(const disp_dev_t *dev);
 
     /**
      * @brief   Invert the display device colors
@@ -91,7 +91,7 @@ typedef struct {
      * @param[in] dev       Network device descriptor
      * @param[in] invert    Invert mode (true if invert, false otherwise)
      */
-    void (*set_invert)(disp_dev_t *dev, bool invert);
+    void (*set_invert)(const disp_dev_t *dev, bool invert);
 } disp_dev_driver_t;
 
 /**
@@ -111,9 +111,9 @@ struct disp_dev {
  * @param[in] y2    Bottom coordinate
  * @param[in] color Array of color to map to the display
  */
-void disp_dev_map(disp_dev_t *dev,
-                 uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2,
-                 const uint16_t *color);
+void disp_dev_map(const disp_dev_t *dev,
+                  uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2,
+                  const uint16_t *color);
 
 /**
  * @brief   Get the height of the display device
@@ -122,7 +122,7 @@ void disp_dev_map(disp_dev_t *dev,
  *
  * @return              Height in pixels
  */
-uint16_t disp_dev_height(disp_dev_t *dev);
+uint16_t disp_dev_height(const disp_dev_t *dev);
 
 /**
  * @brief   Get the width of the display device
@@ -131,14 +131,14 @@ uint16_t disp_dev_height(disp_dev_t *dev);
  *
  * @return              Width in pixels
  */
-uint16_t disp_dev_width(disp_dev_t *dev);
+uint16_t disp_dev_width(const disp_dev_t *dev);
 
 /**
  * @brief   Get the color depth of the display device
  *
  * @return              The color depth
  */
-uint8_t disp_dev_color_depth(disp_dev_t *dev);
+uint8_t disp_dev_color_depth(const disp_dev_t *dev);
 
 /**
  * @brief   Invert the display device colors
@@ -146,7 +146,7 @@ uint8_t disp_dev_color_depth(disp_dev_t *dev);
  * @param[in] dev       Pointer to the display device
  * @param[in] invert    Invert mode (true if invert, false otherwise)
  */
-void disp_dev_set_invert(disp_dev_t *dev, bool invert);
+void disp_dev_set_invert(const disp_dev_t *dev, bool invert);
 
 /**
  * @brief   Enable the backlight pin


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds the `const` qualifier to `disp_dev_t` pointer params in the disp_dev api.

I realized the API was not using it after this https://github.com/RIOT-OS/RIOT/pull/13879#discussion_r416385959.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Verify `tests/disp_dev` and `tests/pkg_lvgl` are still working (already tested with success on adafruit-clue)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
