### PR TITLE
cpu/sam0_common: cpuid: save a few bytes

### DIFF
--- a/cpu/sam0_common/periph/cpuid.c
+++ b/cpu/sam0_common/periph/cpuid.c
@@ -21,7 +21,6 @@
  */
 
 #include <stdint.h>
-#include <string.h>
 
 #include "periph/cpuid.h"
 
@@ -39,6 +38,10 @@
 
 void cpuid_get(void *id)
 {
-    uint32_t addr[] = { WORD0, WORD1, WORD2, WORD3 };
-    memcpy(id, &addr[0], CPUID_LEN);
+    uint32_t *_id = id;
+
+    _id[0] = WORD0;
+    _id[1] = WORD1;
+    _id[2] = WORD2;
+    _id[3] = WORD3;
 }


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

No need to assemble a temp buffer and `memcpy` it, we can just directly write to the destination buffer.

Saves 12 bytes on `samr21-xpro` (and 16 bytes on the stack), CPU ID stays the same.


### Testing procedure

Run `tests/periph_cpuid`, verify that the output stays the same.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
