### PR TITLE
sam0_common: clarify memcpy in cpuid_get

### DIFF
--- a/cpu/sam0_common/periph/cpuid.c
+++ b/cpu/sam0_common/periph/cpuid.c
@@ -39,6 +39,8 @@
 
 void cpuid_get(void *id)
 {
+    /* Use memcpy to prevent unaligned access, which is not supported on
+     * cortex-m0+, to id */
     uint32_t addr[] = { WORD0, WORD1, WORD2, WORD3 };
     memcpy(id, &addr[0], CPUID_LEN);
 }


### PR DESCRIPTION
### Contribution description

Adds a small comment to `sam0_common/periph/cpuid.c` explaining the reason for the memcpy.

### Testing procedure

Verify that this indeed clarifies why a memcpy is used and not a direct copy of the 4 words to the `id` argument.

### Issues/PRs references

To prevent duplicates of #13970 