### PR TITLE
Add bmp config for nrf52

### DIFF
--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -1,9 +1,18 @@
 # include this module into the build
 INCLUDES += -I$(RIOTBOARD)/common/nrf52/include
 
-# set default port depending on operating system
-PORT_LINUX ?= /dev/ttyACM0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+ifeq (bmp,$(PROGRAMMER))
+  # On Blackmagic Probe, the first ACM is used to connect to the gdb server,
+  # the second is the BMP's UART interface
+  PORT_LINUX ?= /dev/ttyACM1
+  PORT_DARWIN ?= $(wordlist 2, 2, $(sort $(wildcard /dev/tty.usbmodem*)))
+else
+  # configure the serial terminal
+  PORT_LINUX ?= /dev/ttyACM0
+  PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+endif
+
+# setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # The following configuration are dependencies specific, specifically they need
@@ -63,4 +72,6 @@ else ifeq (openocd,$(PROGRAMMER))
   DEBUG_ADAPTER ?= jlink
   OPENOCD_CONFIG = $(RIOTBOARD)/common/nrf52/dist/openocd.cfg
   include $(RIOTMAKE)/tools/openocd.inc.mk
+else ifeq (bmp,$(PROGRAMMER))
+  include $(RIOTMAKE)/tools/bmp.inc.mk
 endif


### PR DESCRIPTION
### Contribution description

Using `PROGRAMMER=bmp` for nrf52 boards failed. This should do the job.

### Testing procedure
Tested it with nrf52dk.
1. [Flash a black magic probe on a bluepill](https://buger.dread.cz/black-magic-probe-bmp-on-bluepill-stm32f103c8-minimum-system-development-board.html) or use the official bmp.
2. Connect the blackmagicprobe accordingly. 
3. Use `PROGRAMMER=bmp` to flash your application. `make term` also works.
