### PR TITLE
sys/pm: Bugfixes and improvements

### DIFF
--- a/sys/include/pm_layered.h
+++ b/sys/include/pm_layered.h
@@ -83,6 +83,15 @@ void pm_unblock(unsigned mode);
  */
 void pm_set(unsigned mode);
 
+/**
+ * @brief   Get currently blocked PM modes
+ *
+ * @return  The current blocker state
+ *
+ * This function atomically retrieves the currently blocked PM modes.
+ */
+pm_blocker_t pm_get_blocker(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/shell/commands/sc_pm.c
+++ b/sys/shell/commands/sc_pm.c
@@ -28,7 +28,6 @@
 #ifdef MODULE_PM_LAYERED
 #include "pm_layered.h"
 
-extern volatile pm_blocker_t pm_blocker; /* sys/pm_layered/pm.c */
 #endif /* MODULE_PM_LAYERED */
 
 static void _print_usage(void) {
@@ -107,6 +106,7 @@ static int cmd_unblock(char *arg)
         return 1;
     }
 
+    pm_blocker_t pm_blocker = pm_get_blocker();
     if (pm_blocker.val_u8[mode] == 0) {
         printf("Mode %d is already unblocked.\n", mode);
         return 1;
@@ -125,6 +125,7 @@ static int cmd_show(char *arg)
     (void)arg;
     uint8_t lowest_allowed_mode = 0;
 
+    pm_blocker_t pm_blocker = pm_get_blocker();
     for (unsigned i = 0; i < PM_NUM_MODES; i++) {
         printf("mode %u blockers: %u \n", i, pm_blocker.val_u8[i]);
         if (pm_blocker.val_u8[i]) {

--- a/tests/periph_pm/main.c
+++ b/tests/periph_pm/main.c
@@ -44,8 +44,6 @@ extern int _pm_handler(int argc, char **argv);
 
 #ifdef MODULE_PM_LAYERED
 
-extern volatile pm_blocker_t pm_blocker; /* sys/pm_layered/pm.c */
-
 #ifdef MODULE_PERIPH_RTC
 static int check_mode_duration(int argc, char **argv)
 {
@@ -100,6 +98,8 @@ static int cmd_unblock_rtc(int argc, char **argv)
     if (mode < 0 || duration < 0) {
         return 1;
     }
+
+    pm_blocker_t pm_blocker = pm_get_blocker();
 
     if (pm_blocker.val_u8[mode] == 0) {
         printf("Mode %d is already unblocked.\n", mode);


### PR DESCRIPTION
### Contribution description

- Don't use `volatile` for pm_blocker
    - This does not provide atomic access (e.g. on devices with a memory bus of less than 32 bit)
- Add `pm_blocker_t pm_get_blocker()`
    - This functions allows atomic access to the current state of `pm_blocker`
    - The variable pm_blocker is made static to prevent non-atomic access by applications
- `pm_set_lowest()`: Simplify logic by disabling IRQs before searching the lowest allowed mode
    - Comparing up to four bytes is so fast, so no need to do this without IRQs disabled
- `pm_block()` and `pm_unblock()`: Move the `assert()` into the critical core to
    - Otherwise we have TOC/TOU issues
- Fix race condition `pm_off()` fallback implementation
    - The list of blockers was previously cleared with IRQs still enabled
  ==> It could occur that after clearing it and before pm_set_lowest() disables IRQs another thread blocks PM modes again. As a result, the pm_off() would have consumed more power than needed
    - Simply disabling IRQs makes sure that no additional power is consumed. In addition, this will prevent any thread to run after pm_off() is called, as IRQs will no longer wake up the device

### Testing procedure

- `tests/periph_pm` should still wore as expected
- The recently added `pm` shell command should still work as expected

### Issues/PRs references

None