### PR TITLE
dist/tools/uncrustify/uncrustify.sh: fix uncrustify check logic

### DIFF
--- a/dist/tools/uncrustify/uncrustify.sh
+++ b/dist/tools/uncrustify/uncrustify.sh
@@ -15,11 +15,12 @@ FILES=$(changed_files | grep -xf "$WHITELIST" | grep -xvf "$BLACKLIST")
 check () {
     for F in $FILES
     do
-        OUT="$(uncrustify -c "$UNCRUSTIFY_CFG" -f "$RIOTBASE/$F" --check 2> /dev/null)"
-        if [ "$OUT" ] ; then
+        uncrustify -c "$UNCRUSTIFY_CFG" -f "$RIOTBASE/$F" \
+            --check > /dev/null 2>&1 || {
+            echo "file $F needs to be uncrustified."
             echo "Please run 'dist/tools/uncrustify/uncrustify.sh'"
             exit 1
-        fi
+        }
     done
     echo "All files are uncrustified!"
 }


### PR DESCRIPTION
### Contribution description

Previously, uncrustify.sh would fail (report uncrustifying necessary) if
there was any output of uncrustify. Turns out uncrustify sometimes
outputs something.

This commit changes the logic to use uncrustify's output value as
indicator, not the presence of any output.

Also, adds printing which file causes the check to fail.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->



<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

For example, I'm using "Uncrustify_d-0.70.1_f", which outputs something even if a file passed:

 ```$ uncrustify -c uncrustify-riot.cfg --check -f core/include/thread.h 2> /dev/null
Parsing: core/include/thread.h as language C-Header
parse_cleanup(444): pc->orig_line is 545, orig_col is 1, text() is '}', type is BRACE_CLOSE
parse_cleanup(446): (frm.top().type + 1) is UNKNOWN
PASS: core/include/thread.h (17382 bytes)
[kaspar@ng riot.tmp (fix_uncrustify_logic)]$
```

### Testing procedure

Uncrustify a file, commit it, add it to `dist/tools/uncrustify/whitelist.txt`, run ```dist/tools/uncrustify/uncrustify.sh --check`. On master, this fails with my uncrustify version.


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
