### PR TITLE
sys/ztimer: uncrustify

### DIFF
--- a/dist/tools/uncrustify/whitelist.txt
+++ b/dist/tools/uncrustify/whitelist.txt
@@ -1,2 +1,5 @@
 core/.*\.c
 core/include/.*\.h
+sys/ztimer/.*\.c
+sys/ztimer.h
+sys/include/ztimer/.*\.h

--- a/sys/include/ztimer/convert_frac.h
+++ b/sys/include/ztimer/convert_frac.h
@@ -70,7 +70,8 @@ typedef struct {
  * @param[in]   freq_self   desired frequency of this clock
  * @param[in]   freq_lower  frequency of the underlying clock
  */
-void ztimer_convert_frac_init(ztimer_convert_frac_t *self, ztimer_clock_t *lower,
+void ztimer_convert_frac_init(ztimer_convert_frac_t *self,
+                              ztimer_clock_t *lower,
                               uint32_t freq_self, uint32_t freq_lower);
 
 /**

--- a/sys/ztimer/auto_init.c
+++ b/sys/ztimer/auto_init.c
@@ -55,7 +55,10 @@
 
 #if MODULE_ZTIMER_USEC
 #  if CONFIG_ZTIMER_USEC_TYPE_PERIPH_TIMER
-static ztimer_periph_timer_t _ztimer_periph_timer_usec = { .min = CONFIG_ZTIMER_USEC_MIN };
+static ztimer_periph_timer_t _ztimer_periph_timer_usec = {
+    .min = CONFIG_ZTIMER_USEC_MIN
+};
+
 ztimer_clock_t *const ZTIMER_USEC_BASE = &_ztimer_periph_timer_usec.super;
 #    if CONFIG_ZTIMER_USEC_BASE_FREQ == FREQ_1MHZ
 ztimer_clock_t *const ZTIMER_USEC = &_ztimer_periph_timer_usec.super;
@@ -77,7 +80,7 @@ ztimer_clock_t *const ZTIMER_USEC = &_ztimer_convert_frac_usec.super.super;
 static ztimer_periph_rtt_t _ztimer_periph_timer_rtt_msec;
 ztimer_clock_t *const ZTIMER_MSEC_BASE = &_ztimer_periph_timer_rtt_msec;
 #  define ZTIMER_RTT_INIT (ZTIMER_MSEC_BASE)
-#    if RTT_FREQUENCY!=FREQ_1KHZ
+#    if RTT_FREQUENCY != FREQ_1KHZ
 static ztimer_convert_frac_t _ztimer_convert_frac_msec;
 ztimer_clock_t *const ZTIMER_MSEC = &_ztimer_convert_frac_msec.super.super;
 #  define ZTIMER_MSEC_CONVERT_LOWER_FREQ    RTT_FREQUENCY
@@ -107,32 +110,35 @@ void ztimer_init(void)
 #  if CONFIG_ZTIMER_USEC_TYPE_PERIPH_TIMER
     LOG_DEBUG(
         "ztimer_init(): ZTIMER_USEC using periph timer %u, freq %lu, width %u\n",
-        CONFIG_ZTIMER_USEC_DEV, CONFIG_ZTIMER_USEC_BASE_FREQ, CONFIG_ZTIMER_USEC_WIDTH);
+        CONFIG_ZTIMER_USEC_DEV, CONFIG_ZTIMER_USEC_BASE_FREQ,
+        CONFIG_ZTIMER_USEC_WIDTH);
 
     ztimer_periph_timer_init(&_ztimer_periph_timer_usec, CONFIG_ZTIMER_USEC_DEV,
-                       CONFIG_ZTIMER_USEC_BASE_FREQ,
-                       WIDTH_TO_MAXVAL(CONFIG_ZTIMER_USEC_WIDTH));
+                             CONFIG_ZTIMER_USEC_BASE_FREQ,
+                             WIDTH_TO_MAXVAL(CONFIG_ZTIMER_USEC_WIDTH));
 #  endif
 #  if CONFIG_ZTIMER_USEC_BASE_FREQ != FREQ_1MHZ
 #    if CONFIG_ZTIMER_USEC_BASE_FREQ == FREQ_250KHZ
     LOG_DEBUG("ztimer_init(): ZTIMER_USEC convert_shift %lu to 1000000\n",
-            CONFIG_ZTIMER_USEC_BASE_FREQ);
-    ztimer_convert_shift_up_init(&_ztimer_convert_shift_usec, &_ztimer_periph_timer_usec.super, 2);
+              CONFIG_ZTIMER_USEC_BASE_FREQ);
+    ztimer_convert_shift_up_init(&_ztimer_convert_shift_usec,
+                                 &_ztimer_periph_timer_usec.super, 2);
 #    else
     LOG_DEBUG("ztimer_init(): ZTIMER_USEC convert_frac %lu to 1000000\n",
-            CONFIG_ZTIMER_USEC_BASE_FREQ);
-    ztimer_convert_frac_init(&_ztimer_convert_frac_usec, &_ztimer_periph_timer_usec.super,
-            FREQ_1MHZ, CONFIG_ZTIMER_USEC_BASE_FREQ);
+              CONFIG_ZTIMER_USEC_BASE_FREQ);
+    ztimer_convert_frac_init(&_ztimer_convert_frac_usec,
+                             &_ztimer_periph_timer_usec.super,
+                             FREQ_1MHZ, CONFIG_ZTIMER_USEC_BASE_FREQ);
 #    endif
 #  endif
 #  ifdef CONFIG_ZTIMER_USEC_ADJUST
     LOG_DEBUG("ztimer_init(): ZTIMER_USEC setting adjust value to %i\n",
-            CONFIG_ZTIMER_USEC_ADJUST);
+              CONFIG_ZTIMER_USEC_ADJUST);
     ZTIMER_USEC->adjust = CONFIG_ZTIMER_USEC_ADJUST;
 #  endif
 #  ifdef MODULE_PM_LAYERED
     LOG_DEBUG("ztimer_init(): ZTIMER_USEC setting required_pm_mode to %i\n",
-            CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE);
+              CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE);
     ZTIMER_USEC->required_pm_mode = CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE;
 #  endif
 #endif
@@ -145,19 +151,19 @@ void ztimer_init(void)
 #if MODULE_ZTIMER_MSEC
 #  if ZTIMER_MSEC_CONVERT_LOWER_FREQ
     LOG_DEBUG("ztimer_init(): ZTIMER_MSEC convert_frac from %lu to 1000\n",
-            (long unsigned) ZTIMER_MSEC_CONVERT_LOWER_FREQ);
+              (long unsigned)ZTIMER_MSEC_CONVERT_LOWER_FREQ);
     ztimer_convert_frac_init(&_ztimer_convert_frac_msec,
                              ZTIMER_MSEC_CONVERT_LOWER,
                              FREQ_1KHZ, ZTIMER_MSEC_CONVERT_LOWER_FREQ);
 #  endif
 #  ifdef CONFIG_ZTIMER_MSEC_ADJUST
     LOG_DEBUG("ztimer_init(): ZTIMER_MSEC setting adjust value to %i\n",
-            CONFIG_ZTIMER_MSEC_ADJUST);
+              CONFIG_ZTIMER_MSEC_ADJUST);
     ZTIMER_MSEC->adjust = CONFIG_ZTIMER_MSEC_ADJUST;
 #  endif
 #  ifdef MODULE_PM_LAYERED
     LOG_DEBUG("ztimer_init(): ZTIMER_MSEC setting required_pm_mode to %i\n",
-            CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE);
+              CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE);
     ZTIMER_MSEC->required_pm_mode = CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE;
 #  endif
 #endif

--- a/sys/ztimer/convert.c
+++ b/sys/ztimer/convert.c
@@ -34,7 +34,8 @@ void ztimer_convert_cancel(ztimer_clock_t *clock)
     ztimer_remove(ztimer_convert->lower, &ztimer_convert->lower_entry);
 }
 
-void ztimer_convert_init(ztimer_convert_t *ztimer_convert, ztimer_clock_t *lower,
+void ztimer_convert_init(ztimer_convert_t *ztimer_convert,
+                         ztimer_clock_t *lower,
                          uint32_t max_value)
 {
     ztimer_convert_t tmp = {

--- a/sys/ztimer/convert_frac.c
+++ b/sys/ztimer/convert_frac.c
@@ -40,13 +40,16 @@
  * @param[in]   freq_self   desired frequency of this clock
  * @param[in]   freq_lower  frequency of the underlying clock
  */
-static void ztimer_convert_frac_compute_scale(ztimer_convert_frac_t *self, uint32_t freq_self, uint32_t freq_lower);
+static void ztimer_convert_frac_compute_scale(ztimer_convert_frac_t *self,
+                                              uint32_t freq_self,
+                                              uint32_t freq_lower);
 
 static void ztimer_convert_frac_op_set(ztimer_clock_t *z, uint32_t val)
 {
     ztimer_convert_frac_t *self = (ztimer_convert_frac_t *)z;
     uint32_t target_lower = frac_scale(&self->scale_set, val + self->round);
-    DEBUG("ztimer_convert_frac_op_set(%"PRIu32")=%"PRIu32"\n", val,
+
+    DEBUG("ztimer_convert_frac_op_set(%" PRIu32 ")=%" PRIu32 "\n", val,
           target_lower);
     ztimer_set(self->super.lower, &self->super.lower_entry, target_lower);
 }
@@ -55,21 +58,25 @@ static uint32_t ztimer_convert_frac_op_now(ztimer_clock_t *z)
 {
     ztimer_convert_frac_t *self = (ztimer_convert_frac_t *)z;
     uint32_t lower_now = ztimer_now(self->super.lower);
+
     if (lower_now == 0) {
         return 0;
     }
     uint32_t scaled = frac_scale(&self->scale_now, lower_now);
-    DEBUG("ztimer_convert_frac_op_now() %"PRIu32"->%"PRIu32"\n", lower_now, scaled);
+    DEBUG("ztimer_convert_frac_op_now() %" PRIu32 "->%" PRIu32 "\n", lower_now,
+          scaled);
     return scaled;
 }
 
 static const ztimer_ops_t ztimer_convert_frac_ops = {
-    .set    = ztimer_convert_frac_op_set,
-    .now    = ztimer_convert_frac_op_now,
+    .set = ztimer_convert_frac_op_set,
+    .now = ztimer_convert_frac_op_now,
     .cancel = ztimer_convert_cancel,
 };
 
-static void ztimer_convert_frac_compute_scale(ztimer_convert_frac_t *self, uint32_t freq_self, uint32_t freq_lower)
+static void ztimer_convert_frac_compute_scale(ztimer_convert_frac_t *self,
+                                              uint32_t freq_self,
+                                              uint32_t freq_lower)
 {
     assert(freq_self);
     assert(freq_lower);
@@ -77,15 +84,18 @@ static void ztimer_convert_frac_compute_scale(ztimer_convert_frac_t *self, uint3
     frac_init(&self->scale_set, freq_lower, freq_self);
 }
 
-void ztimer_convert_frac_init(ztimer_convert_frac_t *self, ztimer_clock_t *lower, uint32_t freq_self, uint32_t freq_lower)
+void ztimer_convert_frac_init(ztimer_convert_frac_t *self,
+                              ztimer_clock_t *lower, uint32_t freq_self,
+                              uint32_t freq_lower)
 {
     DEBUG("ztimer_convert_frac_init: %p->%p fs=%" PRIu32 " fl=%" PRIu32 "\n",
-        (void *)self, (void *)lower, freq_self, freq_lower);
+          (void *)self, (void *)lower, freq_self, freq_lower);
 
     *self = (ztimer_convert_frac_t) {
         .super.super = { .ops = &ztimer_convert_frac_ops, },
         .super.lower = lower,
-        .super.lower_entry = { .callback = (void (*)(void *))ztimer_handler, .arg = &self->super, },
+        .super.lower_entry =
+        { .callback = (void (*)(void *))ztimer_handler, .arg = &self->super, },
     };
 
     ztimer_convert_frac_compute_scale(self, freq_self, freq_lower);
@@ -94,8 +104,8 @@ void ztimer_convert_frac_init(ztimer_convert_frac_t *self, ztimer_clock_t *lower
         ztimer_init_extend(&self->super.super);
     }
     else {
-        DEBUG("ztimer_convert_frac_init: rounding up val:%" PRIu32"\n",
-                (uint32_t)(freq_self / freq_lower));
+        DEBUG("ztimer_convert_frac_init: rounding up val:%" PRIu32 "\n",
+              (uint32_t)(freq_self / freq_lower));
         self->round = freq_self / freq_lower;
         self->super.super.max_value = UINT32_MAX;
     }

--- a/sys/ztimer/convert_muldiv64.c
+++ b/sys/ztimer/convert_muldiv64.c
@@ -90,7 +90,8 @@ static uint32_t _ztimer_convert_muldiv64_now(ztimer_clock_t *ztimer)
         (ztimer_convert_muldiv64_t *)ztimer;
 
     return _convert_muldiv64_now(ztimer_convert_muldiv64,
-                                 ztimer_now(ztimer_convert_muldiv64->super.lower));
+                                 ztimer_now(
+                                     ztimer_convert_muldiv64->super.lower));
 }
 
 static const ztimer_ops_t _ztimer_convert_muldiv64_ops = {

--- a/sys/ztimer/core.c
+++ b/sys/ztimer/core.c
@@ -41,7 +41,8 @@ static void _ztimer_update(ztimer_clock_t *clock);
 static void _ztimer_print(const ztimer_clock_t *clock);
 
 #ifdef MODULE_ZTIMER_EXTEND
-static inline uint32_t _min_u32(uint32_t a, uint32_t b) {
+static inline uint32_t _min_u32(uint32_t a, uint32_t b)
+{
     return a < b ? a : b;
 }
 #endif
@@ -50,7 +51,8 @@ static unsigned _is_set(const ztimer_clock_t *clock, const ztimer_t *t)
 {
     if (!clock->list.next) {
         return 0;
-    } else {
+    }
+    else {
         return (t->base.next || &t->base == clock->last);
     }
 }
@@ -71,8 +73,8 @@ void ztimer_remove(ztimer_clock_t *clock, ztimer_t *timer)
 
 void ztimer_set(ztimer_clock_t *clock, ztimer_t *timer, uint32_t val)
 {
-    DEBUG("ztimer_set(): %p: set %p at %"PRIu32" offset %"PRIu32"\n",
-            (void *)clock, (void *)timer, clock->ops->now(clock), val);
+    DEBUG("ztimer_set(): %p: set %p at %" PRIu32 " offset %" PRIu32 "\n",
+          (void *)clock, (void *)timer, clock->ops->now(clock), val);
 
     unsigned state = irq_disable();
 
@@ -84,7 +86,8 @@ void ztimer_set(ztimer_clock_t *clock, ztimer_t *timer, uint32_t val)
     /* optionally subtract a configurable adjustment value */
     if (val > clock->adjust) {
         val -= clock->adjust;
-    } else {
+    }
+    else {
         val = 0;
     }
 
@@ -95,7 +98,7 @@ void ztimer_set(ztimer_clock_t *clock, ztimer_t *timer, uint32_t val)
         if (clock->max_value < UINT32_MAX) {
             val = _min_u32(val, clock->max_value >> 1);
         }
-        DEBUG("ztimer_set(): %p setting %"PRIu32"\n", (void *)clock, val);
+        DEBUG("ztimer_set(): %p setting %" PRIu32 "\n", (void *)clock, val);
 #endif
         clock->ops->set(clock, val);
     }
@@ -111,7 +114,8 @@ static void _add_entry_to_list(ztimer_clock_t *clock, ztimer_base_t *entry)
 
 #ifdef MODULE_PM_LAYERED
     /* First timer on the clock's linked list */
-    if (list->next == NULL && clock->required_pm_mode != ZTIMER_CLOCK_NO_REQUIRED_PM_MODE) {
+    if (list->next == NULL &&
+        clock->required_pm_mode != ZTIMER_CLOCK_NO_REQUIRED_PM_MODE) {
         pm_block(clock->required_pm_mode);
     }
 #endif
@@ -136,7 +140,8 @@ static void _add_entry_to_list(ztimer_clock_t *clock, ztimer_base_t *entry)
         clock->last = entry;
     }
     list->next = entry;
-    DEBUG("_add_entry_to_list() %p offset %"PRIu32"\n", (void *)entry, entry->offset);
+    DEBUG("_add_entry_to_list() %p offset %" PRIu32 "\n", (void *)entry,
+          entry->offset);
 
 }
 
@@ -145,7 +150,7 @@ static uint32_t _add_modulo(uint32_t a, uint32_t b, uint32_t mod)
     if (a < b) {
         a += mod + 1;
     }
-    return a-b;
+    return a - b;
 }
 
 #ifdef MODULE_ZTIMER_EXTEND
@@ -154,12 +159,14 @@ ztimer_now_t _ztimer_now_extend(ztimer_clock_t *clock)
     assert(clock->max_value);
     unsigned state = irq_disable();
     uint32_t lower_now = clock->ops->now(clock);
-    DEBUG("ztimer_now() checkpoint=%"PRIu32" lower_last=%"PRIu32" lower_now=%"PRIu32" diff=%"PRIu32"\n",
-            (uint32_t)clock->checkpoint, clock->lower_last, lower_now,
-            _add_modulo(lower_now, clock->lower_last, clock->max_value));
-    clock->checkpoint += _add_modulo(lower_now, clock->lower_last, clock->max_value);
+    DEBUG(
+        "ztimer_now() checkpoint=%" PRIu32 " lower_last=%" PRIu32 " lower_now=%" PRIu32 " diff=%" PRIu32 "\n",
+        (uint32_t)clock->checkpoint, clock->lower_last, lower_now,
+        _add_modulo(lower_now, clock->lower_last, clock->max_value));
+    clock->checkpoint += _add_modulo(lower_now, clock->lower_last,
+                                     clock->max_value);
     clock->lower_last = lower_now;
-    DEBUG("ztimer_now() returning %"PRIu32"\n", (uint32_t)clock->checkpoint);
+    DEBUG("ztimer_now() returning %" PRIu32 "\n", (uint32_t)clock->checkpoint);
     ztimer_now_t now = clock->checkpoint;
     irq_restore(state);
     return now;
@@ -173,7 +180,9 @@ void ztimer_update_head_offset(ztimer_clock_t *clock)
     uint32_t diff = now - old_base;
 
     ztimer_base_t *entry = clock->list.next;
-    DEBUG("clock %p: ztimer_update_head_offset(): diff=%" PRIu32 " old head %p\n",
+
+    DEBUG(
+        "clock %p: ztimer_update_head_offset(): diff=%" PRIu32 " old head %p\n",
         (void *)clock, diff, (void *)entry);
     if (entry) {
         do {
@@ -192,7 +201,8 @@ void ztimer_update_head_offset(ztimer_clock_t *clock)
                 }
             }
         } while (diff && entry);
-        DEBUG("ztimer %p: ztimer_update_head_offset(): now=%" PRIu32 " new head %p",
+        DEBUG(
+            "ztimer %p: ztimer_update_head_offset(): now=%" PRIu32 " new head %p",
             (void *)clock, now, (void *)entry);
         if (entry) {
             DEBUG(" offset %" PRIu32 "\n", entry->offset);
@@ -236,7 +246,8 @@ static void _del_entry_from_list(ztimer_clock_t *clock, ztimer_base_t *entry)
 
 #ifdef MODULE_PM_LAYERED
     /* The last timer just got removed from the clock's linked list */
-    if (clock->list.next == NULL && clock->required_pm_mode != ZTIMER_CLOCK_NO_REQUIRED_PM_MODE) {
+    if (clock->list.next == NULL &&
+        clock->required_pm_mode != ZTIMER_CLOCK_NO_REQUIRED_PM_MODE) {
         pm_unblock(clock->required_pm_mode);
     }
 #endif
@@ -257,7 +268,7 @@ static ztimer_t *_now_next(ztimer_clock_t *clock)
             }
 #endif
         }
-        return (ztimer_t*)entry;
+        return (ztimer_t *)entry;
     }
     else {
         return NULL;
@@ -269,7 +280,9 @@ static void _ztimer_update(ztimer_clock_t *clock)
 #ifdef MODULE_ZTIMER_EXTEND
     if (clock->max_value < UINT32_MAX) {
         if (clock->list.next) {
-            clock->ops->set(clock, _min_u32(clock->list.next->offset, clock->max_value >> 1));
+            clock->ops->set(clock,
+                            _min_u32(clock->list.next->offset,
+                                     clock->max_value >> 1));
         }
         else {
             clock->ops->set(clock, clock->max_value >> 1);
@@ -290,7 +303,8 @@ static void _ztimer_update(ztimer_clock_t *clock)
 
 void ztimer_handler(ztimer_clock_t *clock)
 {
-    DEBUG("ztimer_handler(): %p now=%"PRIu32"\n", (void *)clock, clock->ops->now(clock));
+    DEBUG("ztimer_handler(): %p now=%" PRIu32 "\n", (void *)clock, clock->ops->now(
+              clock));
     if (ENABLE_DEBUG) {
         _ztimer_print(clock);
     }
@@ -304,12 +318,14 @@ void ztimer_handler(ztimer_clock_t *clock)
             uint32_t target = clock->list.offset + clock->list.next->offset;
             int32_t diff = (int32_t)(target - now);
             if (diff > 0) {
-                DEBUG("ztimer_handler(): %p postponing by %"PRIi32"\n", (void *)clock, diff);
+                DEBUG("ztimer_handler(): %p postponing by %" PRIi32 "\n",
+                      (void *)clock, diff);
                 clock->ops->set(clock, _min_u32(diff, clock->max_value >> 1));
                 return;
             }
             else {
-                DEBUG("ztimer_handler(): %p diff=%"PRIi32"\n", (void *)clock, diff);
+                DEBUG("ztimer_handler(): %p diff=%" PRIi32 "\n", (void *)clock,
+                      diff);
             }
         }
         else {
@@ -328,8 +344,8 @@ void ztimer_handler(ztimer_clock_t *clock)
 
     ztimer_t *entry = _now_next(clock);
     while (entry) {
-        DEBUG("ztimer_handler(): trigger %p->%p at %"PRIu32"\n",
-                (void *)entry, (void *)entry->base.next, clock->ops->now(clock));
+        DEBUG("ztimer_handler(): trigger %p->%p at %" PRIu32 "\n",
+              (void *)entry, (void *)entry->base.next, clock->ops->now(clock));
         entry->callback(entry->arg);
         entry = _now_next(clock);
         if (!entry) {
@@ -355,9 +371,12 @@ static void _ztimer_print(const ztimer_clock_t *clock)
 {
     const ztimer_base_t *entry = &clock->list;
     uint32_t last_offset = 0;
+
     do {
-        printf("0x%08x:%" PRIu32 "(%" PRIu32 ")%s", (unsigned)entry, entry->offset, entry->offset +
-                last_offset, entry->next ? "->" : (entry==clock->last ? "" : "!"));
+        printf("0x%08x:%" PRIu32 "(%" PRIu32 ")%s", (unsigned)entry,
+               entry->offset, entry->offset +
+               last_offset,
+               entry->next ? "->" : (entry == clock->last ? "" : "!"));
         last_offset += entry->offset;
 
     } while ((entry = entry->next));

--- a/sys/ztimer/mock.c
+++ b/sys/ztimer/mock.c
@@ -32,11 +32,14 @@
 
 void ztimer_mock_advance(ztimer_mock_t *self, uint32_t val)
 {
-    DEBUG("zmock_advance: start now=0x%08" PRIx32 " + 0x%08" PRIx32 ", target=0x%08" PRIx32 " (%u)\n",
+    DEBUG(
+        "zmock_advance: start now=0x%08" PRIx32 " + 0x%08" PRIx32 ", target=0x%08" PRIx32 " (%u)\n",
         self->now, val, self->target, self->armed);
     while (val) {
-        uint32_t step = self->armed ? (self->target < val ? self->target : val) : val;
-        DEBUG("zmock_advance: step now=0x%08" PRIx32 " + 0x%08" PRIx32 ", target=0x%08" PRIx32 " (%u)\n",
+        uint32_t step =
+            self->armed ? (self->target < val ? self->target : val) : val;
+        DEBUG(
+            "zmock_advance: step now=0x%08" PRIx32 " + 0x%08" PRIx32 ", target=0x%08" PRIx32 " (%u)\n",
             self->now, step, self->target, self->armed);
 
         self->now = (self->now + step) & self->mask;
@@ -52,7 +55,8 @@ void ztimer_mock_advance(ztimer_mock_t *self, uint32_t val)
         }
         val -= step;
     }
-    DEBUG("zmock_advance: done now=0x%08" PRIx32 " + 0x%08" PRIx32 ", target=0x%08" PRIx32 " (%u)\n",
+    DEBUG(
+        "zmock_advance: done now=0x%08" PRIx32 " + 0x%08" PRIx32 ", target=0x%08" PRIx32 " (%u)\n",
         self->now, val, self->target, self->armed);
 }
 
@@ -60,14 +64,14 @@ void ztimer_mock_jump(ztimer_mock_t *self, uint32_t target)
 {
     self->now = target & self->mask;
     DEBUG("zmock_jump: now=0x%08" PRIx32 ", target=0x%08" PRIx32 " (%u)\n",
-        self->now, self->target, self->armed);
+          self->now, self->target, self->armed);
     /* Do not touch target */
 }
 
 void ztimer_mock_fire(ztimer_mock_t *self)
 {
     DEBUG("zmock_fire: now=0x%08" PRIx32 ", target=0x%08" PRIx32 " (%u)\n",
-        self->now, self->target, self->armed);
+          self->now, self->target, self->armed);
     self->target = 0;
     self->armed = 0;
     /* Execute ztimer core interrupt handler */
@@ -78,46 +82,54 @@ void ztimer_mock_fire(ztimer_mock_t *self)
 
 static void ztimer_mock_op_set(ztimer_clock_t *clock, uint32_t val)
 {
-    ztimer_mock_t *self = (ztimer_mock_t*)clock;
+    ztimer_mock_t *self = (ztimer_mock_t *)clock;
+
     ++self->calls.set;
     self->target = val & self->mask;
     self->armed = 1;
-    DEBUG("zmock_set:    %3u now=0x%08" PRIx32 ", target=0x%08" PRIx32 " (%u)\n",
+    DEBUG(
+        "zmock_set:    %3u now=0x%08" PRIx32 ", target=0x%08" PRIx32 " (%u)\n",
         self->calls.set, self->now, self->target, self->armed);
 }
 
 static uint32_t ztimer_mock_op_now(ztimer_clock_t *clock)
 {
-    ztimer_mock_t *self = (ztimer_mock_t*)clock;
+    ztimer_mock_t *self = (ztimer_mock_t *)clock;
+
     ++self->calls.now;
-    DEBUG("zmock_now:    %3u now=0x%08" PRIx32 ", target=0x%08" PRIx32 " (%u)\n",
+    DEBUG(
+        "zmock_now:    %3u now=0x%08" PRIx32 ", target=0x%08" PRIx32 " (%u)\n",
         self->calls.now, self->now, self->target, self->armed);
     return self->now;
 }
 
 static void ztimer_mock_op_cancel(ztimer_clock_t *clock)
 {
-    ztimer_mock_t *self = (ztimer_mock_t*)clock;
+    ztimer_mock_t *self = (ztimer_mock_t *)clock;
+
     ++self->calls.cancel;
-    DEBUG("zmock_cancel: %3u now=0x%08" PRIx32 ", target=0x%08" PRIx32 " (%u)\n",
+    DEBUG(
+        "zmock_cancel: %3u now=0x%08" PRIx32 ", target=0x%08" PRIx32 " (%u)\n",
         self->calls.cancel, self->now, self->target, self->armed);
     self->armed = 0;
 }
 
 static const ztimer_ops_t ztimer_mock_ops = {
-    .set    = ztimer_mock_op_set,
-    .now    = ztimer_mock_op_now,
+    .set = ztimer_mock_op_set,
+    .now = ztimer_mock_op_now,
     .cancel = ztimer_mock_op_cancel,
 };
 
 void ztimer_mock_init(ztimer_mock_t *self, unsigned width)
 {
     uint32_t max_value = (~((uint32_t)0ul)) >> (32 - width);
+
     *self = (ztimer_mock_t){
         .mask = max_value,
         .super = { .ops = &ztimer_mock_ops, .max_value = max_value },
     };
-    DEBUG("zmock_init: %p width=%u mask=0x%08" PRIx32 "\n", (void *)self, width, self->mask);
+    DEBUG("zmock_init: %p width=%u mask=0x%08" PRIx32 "\n", (void *)self, width,
+          self->mask);
     if (max_value < UINT32_MAX) {
         self->super.ops->set(&self->super, self->super.max_value >> 1);
     }

--- a/sys/ztimer/periph_timer.c
+++ b/sys/ztimer/periph_timer.c
@@ -72,8 +72,9 @@ static const ztimer_ops_t _ztimer_periph_timer_ops = {
     .cancel = _ztimer_periph_timer_cancel,
 };
 
-void ztimer_periph_timer_init(ztimer_periph_timer_t *clock, tim_t dev, unsigned long freq,
-                        uint32_t max_val)
+void ztimer_periph_timer_init(ztimer_periph_timer_t *clock, tim_t dev,
+                              unsigned long freq,
+                              uint32_t max_val)
 {
     clock->dev = dev;
     clock->super.ops = &_ztimer_periph_timer_ops;

--- a/sys/ztimer/util.c
+++ b/sys/ztimer/util.c
@@ -34,9 +34,10 @@ typedef struct {
     int timeout;
 } mutex_thread_t;
 
-static void _callback_unlock_mutex(void* arg)
+static void _callback_unlock_mutex(void *arg)
 {
-    mutex_t *mutex = (mutex_t *) arg;
+    mutex_t *mutex = (mutex_t *)arg;
+
     mutex_unlock(mutex);
 }
 
@@ -47,19 +48,21 @@ void ztimer_sleep(ztimer_clock_t *clock, uint32_t duration)
 
     ztimer_t timer = {
         .callback = _callback_unlock_mutex,
-        .arg = (void*) &mutex,
+        .arg = (void *)&mutex,
     };
 
     ztimer_set(clock, &timer, duration);
     mutex_lock(&mutex);
 }
 
-void ztimer_periodic_wakeup(ztimer_clock_t *clock, ztimer_now_t *last_wakeup, uint32_t period)
+void ztimer_periodic_wakeup(ztimer_clock_t *clock, ztimer_now_t *last_wakeup,
+                            uint32_t period)
 {
     unsigned state = irq_disable();
     ztimer_now_t now = ztimer_now(clock);
     ztimer_now_t target = *last_wakeup + period;
     ztimer_now_t offset = target - now;
+
     irq_restore(state);
 
     if (offset <= period) {
@@ -72,35 +75,39 @@ void ztimer_periodic_wakeup(ztimer_clock_t *clock, ztimer_now_t *last_wakeup, ui
 }
 
 #ifdef MODULE_CORE_MSG
-static void _callback_msg(void* arg)
+static void _callback_msg(void *arg)
 {
-    msg_t *msg = (msg_t*)arg;
+    msg_t *msg = (msg_t *)arg;
+
     msg_send_int(msg, msg->sender_pid);
 }
 
-static inline void _setup_msg(ztimer_t *timer, msg_t *msg, kernel_pid_t target_pid)
+static inline void _setup_msg(ztimer_t *timer, msg_t *msg,
+                              kernel_pid_t target_pid)
 {
     timer->callback = _callback_msg;
-    timer->arg = (void*) msg;
+    timer->arg = (void *)msg;
 
     /* use sender_pid field to get target_pid into callback function */
     msg->sender_pid = target_pid;
 }
 
-void ztimer_set_msg(ztimer_clock_t *clock, ztimer_t *timer, uint32_t offset, msg_t *msg, kernel_pid_t target_pid)
+void ztimer_set_msg(ztimer_clock_t *clock, ztimer_t *timer, uint32_t offset,
+                    msg_t *msg, kernel_pid_t target_pid)
 {
     _setup_msg(timer, msg, target_pid);
     ztimer_set(clock, timer, offset);
 }
 
-int ztimer_msg_receive_timeout(ztimer_clock_t *clock, msg_t *msg, uint32_t timeout)
+int ztimer_msg_receive_timeout(ztimer_clock_t *clock, msg_t *msg,
+                               uint32_t timeout)
 {
     if (msg_try_receive(msg) == 1) {
         return 1;
     }
 
     ztimer_t t;
-    msg_t m = { .type=MSG_ZTIMER, .content.ptr=&m };
+    msg_t m = { .type = MSG_ZTIMER, .content.ptr = &m };
 
     ztimer_set_msg(clock, &t, timeout, &m, sched_active_pid);
 
@@ -118,12 +125,13 @@ int ztimer_msg_receive_timeout(ztimer_clock_t *clock, msg_t *msg, uint32_t timeo
 #endif /* MODULE_CORE_MSG */
 
 #ifdef MODULE_CORE_THREAD_FLAGS
-static void _set_timeout_flag_callback(void* arg)
+static void _set_timeout_flag_callback(void *arg)
 {
     thread_flags_set(arg, THREAD_FLAG_TIMEOUT);
 }
 
-void ztimer_set_timeout_flag(ztimer_clock_t *clock, ztimer_t *t, uint32_t timeout)
+void ztimer_set_timeout_flag(ztimer_clock_t *clock, ztimer_t *t,
+                             uint32_t timeout)
 {
     t->callback = _set_timeout_flag_callback;
     t->arg = (thread_t *)sched_active_thread;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR uncrustifies ztimer. Also, adds the ztimer files to force uncrustify in the future.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

~~This fails the uncrustify check locally because of #13974.~~ #13974 is merged.


### Testing procedure

Honestly, I didn't look at the actual output. That's the point. As ztimer maintainer, I'd like to avoid any formatting discussions or time spent on them in the future.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
