### PR TITLE
sys/pm: Add pm_get_blocker()

### DIFF
--- a/sys/include/pm_layered.h
+++ b/sys/include/pm_layered.h
@@ -83,6 +83,15 @@ void pm_unblock(unsigned mode);
  */
 void pm_set(unsigned mode);
 
+/**
+ * @brief   Get currently blocked PM modes
+ *
+ * @return  The current blocker state
+ *
+ * This function atomically retrieves the currently blocked PM modes.
+ */
+pm_blocker_t pm_get_blocker(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -36,7 +36,7 @@
 /**
  * @brief Global variable for keeping track of blocked modes
  */
-volatile pm_blocker_t pm_blocker = { .val_u32 = PM_BLOCKER_INITIAL };
+static volatile pm_blocker_t pm_blocker = { .val_u32 = PM_BLOCKER_INITIAL };
 
 void pm_set_lowest(void)
 {
@@ -77,6 +77,11 @@ void pm_unblock(unsigned mode)
     unsigned state = irq_disable();
     pm_blocker.val_u8[mode]--;
     irq_restore(state);
+}
+
+pm_blocker_t pm_get_blocker(void)
+{
+    return pm_blocker;
 }
 
 #ifndef PROVIDES_PM_LAYERED_OFF

--- a/sys/shell/commands/sc_pm.c
+++ b/sys/shell/commands/sc_pm.c
@@ -28,7 +28,6 @@
 #ifdef MODULE_PM_LAYERED
 #include "pm_layered.h"
 
-extern volatile pm_blocker_t pm_blocker; /* sys/pm_layered/pm.c */
 #endif /* MODULE_PM_LAYERED */
 
 static void _print_usage(void) {
@@ -107,6 +106,7 @@ static int cmd_unblock(char *arg)
         return 1;
     }
 
+    pm_blocker_t pm_blocker = pm_get_blocker();
     if (pm_blocker.val_u8[mode] == 0) {
         printf("Mode %d is already unblocked.\n", mode);
         return 1;
@@ -125,6 +125,7 @@ static int cmd_show(char *arg)
     (void)arg;
     uint8_t lowest_allowed_mode = 0;
 
+    pm_blocker_t pm_blocker = pm_get_blocker();
     for (unsigned i = 0; i < PM_NUM_MODES; i++) {
         printf("mode %u blockers: %u \n", i, pm_blocker.val_u8[i]);
         if (pm_blocker.val_u8[i]) {

--- a/tests/periph_pm/main.c
+++ b/tests/periph_pm/main.c
@@ -44,8 +44,6 @@ extern int _pm_handler(int argc, char **argv);
 
 #ifdef MODULE_PM_LAYERED
 
-extern volatile pm_blocker_t pm_blocker; /* sys/pm_layered/pm.c */
-
 #ifdef MODULE_PERIPH_RTC
 static int check_mode_duration(int argc, char **argv)
 {
@@ -101,6 +99,7 @@ static int cmd_unblock_rtc(int argc, char **argv)
         return 1;
     }
 
+    pm_blocker_t pm_blocker = pm_get_blocker();
     if (pm_blocker.val_u8[mode] == 0) {
         printf("Mode %d is already unblocked.\n", mode);
         return 1;


### PR DESCRIPTION
### Contribution description

Provide access to pm_blocker via a well-defined API rather than hacks.

### Testing procedure

`tests/periph_pm` and the shell command `pm` should still work.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/13973