### PR TITLE
sys/pm: Fix behavior of fallback pm_off() implementation

### DIFF
--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -82,8 +82,9 @@ void pm_unblock(unsigned mode)
 #ifndef PROVIDES_PM_LAYERED_OFF
 void pm_off(void)
 {
-    pm_blocker.val_u32 = 0;
-    pm_set_lowest();
-    while(1) {}
+    irq_disable();
+    while(1) {
+        pm_set(0);
+    }
 }
 #endif


### PR DESCRIPTION
### Contribution description

- pm_off() should prevent other threads from getting executed after it is called, as it should turn off the MCU completely according to its doc
    - Previously, the fallback implementation would still allow other threads to continue working
    - Simply disabling IRQs and never enabling them again should make sure the MCU behaves like it would be completely off
- pm_off() should reduce the power consumption as much as possible
    - Previously, when IRQs came after the call to pm_set_lowest() in the fallback implementation of pm_off(), `while(1) {}` got executed at full power consumption
    - Just calling `pm_set(0);` in a loop while make sure that lowest power mode is restored if the MCU wakes up again.
    - The check if the lowest power mode is available is skipped, as no code gets executed afterwards anyway

### Testing procedure

The fallback implementation of `pm_off()` should now prevent any code from being executed after it is called.

~~I'll add a test application to this PR later on.~~ Update: `tests/periph_pm` is fully sufficient for testing this.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/13973 (but improved afterwards)