### PR TITLE
gnrc/netif: 6lo: use 16 bit for max_frag_size

### DIFF
--- a/sys/include/net/gnrc/netif/6lo.h
+++ b/sys/include/net/gnrc/netif/6lo.h
@@ -34,7 +34,7 @@ typedef struct {
      * @note    Only available with module
      *          @ref net_gnrc_sixlowpan_frag "gnrc_sixlowpan_frag".
      */
-    uint8_t max_frag_size;
+    uint16_t max_frag_size;
 } gnrc_netif_6lo_t;
 
 #ifdef __cplusplus

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -27,6 +27,8 @@
 #include "net/ieee802154.h"
 #include "net/l2util.h"
 
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+
 netopt_t gnrc_netif_get_l2addr_opt(const gnrc_netif_t *netif)
 {
     netopt_t res = NETOPT_ADDRESS;
@@ -143,7 +145,7 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
                                    &tmp, sizeof(tmp));
             assert(res == sizeof(tmp));
 #ifdef MODULE_GNRC_SIXLOWPAN
-            netif->ipv6.mtu = IPV6_MIN_MTU;
+            netif->ipv6.mtu = MAX(IPV6_MIN_MTU, tmp);
             netif->sixlo.max_frag_size = tmp;
 #else
             netif->ipv6.mtu = tmp;


### PR DESCRIPTION
### Contribution description

Using 8 bit for `max_frag_size` limits that value to 255.
802.15.4g (`at86rf215`, `cc26x2_cc13x2_rf`) specifies a PDU of 2047 bytes which exceeds that limit.

Using a 16 bit value here allows to use the full L2 PDU.

Before:

    12:02:16,300 # ping6 fe80::2068:3123:59f5:d238%8 -s 400
    12:02:16,302 # sending 244 bytes
    12:02:16,387 # sending 218 bytes
    12:02:16,624 # 408 bytes from fe80::2068:3123:59f5:d238%8: icmp_seq=0 ttl=64 rssi=-49 dBm time=316.307 ms
    12:02:17,302 # sending 244 bytes
    12:02:17,387 # sending 218 bytes
    12:02:17,624 # 408 bytes from fe80::2068:3123:59f5:d238%8: icmp_seq=1 ttl=64 rssi=-49 dBm time=316.307 ms
    12:02:18,302 # sending 244 bytes
    12:02:18,387 # sending 218 bytes
    12:02:18,624 # 408 bytes from fe80::2068:3123:59f5:d238%8: icmp_seq=2 ttl=64 rssi=-50 dBm time=316.306 ms
    12:02:18,625 #
    12:02:18,629 # --- fe80::2068:3123:59f5:d238 PING statistics ---

With this patch:

    12:09:44,276 #  ping6 fe80::2068:3123:59f5:d238%8 -s 400
    12:09:44,278 # sending 432 bytes
    12:09:44,574 # 408 bytes from fe80::2068:3123:59f5:d238%8: icmp_seq=0 ttl=64 rssi=-52 dBm time=289.888 ms
    12:09:45,279 # sending 432 bytes
    12:09:45,574 # 408 bytes from fe80::2068:3123:59f5:d238%8: icmp_seq=1 ttl=64 rssi=-52 dBm time=289.885 ms
    12:09:46,069 # sending 43 bytes
    12:09:46,279 # sending 432 bytes
    12:09:46,499 # sending 43 bytes
    12:09:46,574 # 408 bytes from fe80::2068:3123:59f5:d238%8: icmp_seq=2 ttl=64 rssi=-47 dBm time=289.886 ms
    12:09:46,574 #
    12:09:46,578 # --- fe80::2068:3123:59f5:d238 PING statistics ---


### Testing procedure

Apply this patch to print the size of the TX frames:

```patch
--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -146,6 +146,8 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
         }
     }
 
+    printf("sending %d bytes\n", len);
+
     /* send data out directly if pre-loading id disabled */
     if (!(dev->flags & AT86RF215_OPT_PRELOADING)) {
         at86rf215_tx_exec(dev);
```

Enable a 802.15.4g PHY mode

    ifconfig 8 set phy mr-o-qpsk

    12:10:47,350 # Iface  8  HWaddr: 01:55  Channel: 26  NID: 0x23  PHY: MR-O-QPSK 
    12:10:47,354 #            chip rate: 2000  rate mode: 0 
    12:10:47,358 #           Long HWaddr: 1A:F9:8F:5F:30:5D:05:8C 
    12:10:47,364 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
    12:10:47,371 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:2022 MTU:1280  HL:64  RTR  
    12:10:47,373 #           6LO  IPHC  
    12:10:47,376 #           Source address length: 8
    12:10:47,378 #           Link type: wireless
    12:10:47,384 #           inet6 addr: fe80::18f9:8f5f:305d:58c  scope: link  VAL
    12:10:47,387 #           inet6 group: ff02::2
    12:10:47,389 #           inet6 group: ff02::1
    12:10:47,393 #           inet6 group: ff02::1:ff5d:58c
    12:10:47,394 #           
    12:10:47,397 #           Statistics for Layer 2
    12:10:47,400 #             RX packets 7  bytes 1429
    12:10:47,405 #             TX packets 9 (Multicast: 6)  bytes 1554
    12:10:47,408 #             TX succeeded 9 errors 0
    12:10:47,413 #           Statistics for IPv6
    12:10:47,413 #             RX packets 4  bytes 1408
    12:10:47,418 #             TX packets 9 (Multicast: 6)  bytes 1728
    12:10:47,421 #             TX succeeded 9 errors 0

Unfortunately the MTU is still smaller than the L2-PDU so packets are still limited to 1280 bytes.

### Issues/PRs references

 #13912
