### PR TITLE
cpu/lpc2387: PM: enable SLEEP & POWERDOWN mode

### DIFF
--- a/cpu/lpc2387/clocks.c
+++ b/cpu/lpc2387/clocks.c
@@ -56,18 +56,18 @@ void cpu_init_pll(void)
     PLLCON &= ~0x0002;
     pllfeed();
 
-    while (PLLSTAT & BIT25);            /* wait until PLL is disconnected before
+    while (PLLSTAT & BIT25) {}          /* wait until PLL is disconnected before
                                          * disabling - deadlock otherwise */
     /* Disable PLL */
     PLLCON &= ~0x0001;
     pllfeed();
 
-    while (PLLSTAT & BIT24);            /* wait until PLL is disabled */
+    while (PLLSTAT & BIT24) {}          /* wait until PLL is disabled */
 
     SCS |= 0x10;                        /* main OSC between 15MHz and 24MHz (more stable in tests) */
     SCS |= 0x20;                        /* Enable main OSC */
 
-    while (!(SCS & 0x40));              /* Wait until main OSC is usable */
+    while (!(SCS & 0x40)) {}            /* Wait until main OSC is usable */
 
 #ifdef XTAL_HZ
     /* select main OSC (XTAL_HZ) as the PLL clock source */
@@ -90,14 +90,14 @@ void cpu_init_pll(void)
     CCLKCFG = CL_CPU_DIV - 1;           /* Fcpu = 72 MHz */
 
     /* Wait for the PLL to lock to set frequency */
-    while (!(PLLSTAT & BIT26));
+    while (!(PLLSTAT & BIT26)) {}
 
     /* Connect the PLL as the clock source */
     PLLCON = 0x0003;
     pllfeed();
 
     /* Check connect bit status */
-    while (!(PLLSTAT & BIT25));
+    while (!(PLLSTAT & BIT25)) {}
 }
 
 static void watchdog_init(void)

--- a/cpu/lpc2387/clocks.c
+++ b/cpu/lpc2387/clocks.c
@@ -43,14 +43,14 @@ static inline void pllfeed(void)
  * @brief   Enabling MAM and setting number of clocks used for Flash memory fetch
  * @internal
  */
-static inline void init_mam(void)
+void cpu_init_mam(void)
 {
     MAMCR  = 0x0000;
     MAMTIM = 0x0003;
     MAMCR  = 0x0002;
 }
 
-static void init_clks1(void)
+void cpu_init_pll(void)
 {
     /* Disconnect PLL */
     PLLCON &= ~0x0002;
@@ -88,10 +88,7 @@ static void init_clks1(void)
 
     /* Set clock divider to 4 (value+1) */
     CCLKCFG = CL_CPU_DIV - 1;           /* Fcpu = 72 MHz */
-}
 
-static void init_clks2(void)
-{
     /* Wait for the PLL to lock to set frequency */
     while (!(PLLSTAT & BIT26));
 
@@ -114,7 +111,6 @@ void cpu_init_clks(void)
 {
     watchdog_init();
     PCONP = PCRTC; /* switch off everything except RTC */
-    init_clks1();
-    init_clks2();
-    init_mam();
+    cpu_init_pll();
+    cpu_init_mam();
 }

--- a/cpu/lpc2387/include/cpu.h
+++ b/cpu/lpc2387/include/cpu.h
@@ -29,6 +29,16 @@ extern "C" {
 extern uintptr_t __stack_start;     /**< end of user stack memory space */
 
 /**
+ * @brief Initialize the phase lock loop oscillator
+ */
+void cpu_init_pll(void);
+
+/**
+ * @brief Initialize the Memory Acceleration Module
+ */
+void cpu_init_mam(void);
+
+/**
  * @brief Scale lpc2387 cpu speed
  */
 void lpc2387_pclk_scale(uint32_t source, uint32_t target, uint32_t *pclksel, uint32_t *prescale);

--- a/cpu/lpc2387/periph/pm.c
+++ b/cpu/lpc2387/periph/pm.c
@@ -22,6 +22,7 @@
  * @}
  */
 
+#include "cpu.h"
 #include "periph/pm.h"
 
 #define ENABLE_DEBUG (0)
@@ -34,18 +35,26 @@ void pm_set(unsigned mode)
             /* Everything except battery backup is powered down */
             DEBUG_PUTS("pm_set(): setting Deep Power Down mode.");
             PCON |= PM_DEEP_POWERDOWN;
+
+            /* CPU will reset on wake-up */
+
             break;
         case 1:
             /* PLL & Flash are powered down */
             DEBUG_PUTS("pm_set(): setting Power Down mode.");
-            /* PCON |= PM_POWERDOWN; */
-            PCON |= PM_IDLE; /* fixme */
+            PCON |= PM_POWERDOWN;
+
+            cpu_init_pll();
+            cpu_init_mam();
+
             break;
         case 2:
             /* PLL is powered down */
             DEBUG_PUTS("pm_set(): setting Sleep mode.");
-            /* PCON |= PM_SLEEP; */
-            PCON |= PM_IDLE; /* fixme */
+            PCON |= PM_SLEEP;
+
+            cpu_init_pll();
+
             break;
         default: /* Falls through */
         case 3:


### PR DESCRIPTION
### Contribution description

I'm not sure what it was that this wasn't working before, but when re-initializing PLL (& Flash) the sleep modes on this MCU work just fine.

### Testing procedure

Run `tests/periph_pm`.

 - `pm set 2`: wake up by button or RTC (`set_rtc 2`)
 - `pm set 1`: wake up by button or RTC (`set_rtc 1`)
 - `pm set 0`: will not wake by button, only RTC (`set_rtc 0`) - CPU will reset

### Issues/PRs references

Requires #13757 for `set_rtc`