### PR TITLE
sys/include/xtimer.h: include board.h with ztimer

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -42,8 +42,8 @@
 #include "ztimer/xtimer_compat.h"
 #else
 
-#ifndef MODULE_XTIMER_ON_ZTIMER
 #include "board.h"
+#ifndef MODULE_XTIMER_ON_ZTIMER
 #include "periph_conf.h"
 #endif
 


### PR DESCRIPTION
### Contribution description

When using `xtimer_on_ztimer` `board.h` should still be included or it can lead to some macros redefinition.

### Testing procedure

Without this PR:

```
USEMODULE=ztimer_usec make -C tests/driver_at86rf2xx/ --no-print-directory
```

```
Building application "tests_driver_at86rf2xx" for "samr21-xpro" with MCU "samd21".

In file included from /home/francisco/workspace/RIOT2/drivers/include/at86rf2xx.h:35:0,
                 from /home/francisco/workspace/RIOT2/tests/driver_at86rf2xx/common.h:23,
                 from /home/francisco/workspace/RIOT2/tests/driver_at86rf2xx/main.c:29:
/home/francisco/workspace/RIOT2/boards/samr21-xpro/include/board.h:36:0: error: "XTIMER_DEV" redefined [-Werror]
 #define XTIMER_DEV          TIMER_DEV(1)
 
In file included from /home/francisco/workspace/RIOT2/tests/driver_at86rf2xx/main.c:27:0:
/home/francisco/workspace/RIOT2/sys/include/xtimer.h:536:0: note: this is the location of the previous definition
 #define XTIMER_DEV TIMER_DEV(0)
 
cc1: all warnings being treated as errors
/home/francisco/workspace/RIOT2/Makefile.base:108: recipe for target '/home/francisco/workspace/RIOT2/tests/driver_at86rf2xx/bin/samr21-xpro/application_tests_driver_at86rf2xx/main.o' failed
make[1]: *** [/home/francisco/workspace/RIOT2/tests/driver_at86rf2xx/bin/samr21-xpro/application_tests_driver_at86rf2xx/main.o] Error 1
/home/francisco/workspace/RIOT2/tests/driver_at86rf2xx/../../Makefile.include:541: recipe for target '/home/francisco/workspace/RIOT2/tests/driver_at86rf2xx/bin/samr21-xpro/application_tests_driver_at86rf2xx.a' failed
make: *** [/home/francisco/workspace/RIOT2/tests/driver_at86rf2xx/bin/samr21-xpro/application_tests_driver_at86rf2xx.a] Error 2
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
