### PR TITLE
drivers/tmp00x : Expose Configurations to Kconfig 

### DIFF
--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -27,6 +27,7 @@ rsource "mma8x5x/Kconfig"
 rsource "opt3001/Kconfig"
 rsource "sps30/Kconfig"
 rsource "tcs37727/Kconfig"
+rsource "tmp00x/Kconfig"
 endmenu # Sensor Device Drivers
 
 menu "Storage Device Drivers"

--- a/drivers/include/tmp00x.h
+++ b/drivers/include/tmp00x.h
@@ -103,15 +103,15 @@ extern "C"
  * I2C Address depends on the state of ADR0 and ADR1 Pins
  * For more information, please refer to section 7.3.6.2 of TMP007 datasheet (SBOS685B).
  */
-#ifndef TMP00X_I2C_ADDRESS
-#define TMP00X_I2C_ADDRESS         (0x40)
+#ifndef CONFIG_TMP00X_I2C_ADDRESS
+#define CONFIG_TMP00X_I2C_ADDRESS         (0x40)
 #endif
 
 /**
  * @brief   Default Conversion Time in us
  */
-#ifndef TMP00X_CONVERSION_TIME
-#define TMP00X_CONVERSION_TIME     (1E6)
+#ifndef CONFIG_TMP00X_CONVERSION_TIME
+#define CONFIG_TMP00X_CONVERSION_TIME     (1E6)
 #endif
 
 /**
@@ -119,11 +119,11 @@ extern "C"
  *
  * If set to 0, the device will be always-on
  * If set to 1, the device will be put in low power mode between measurements.
- * This adds a @c TMP00X_CONVERSION_TIME us delay to each measurement call
+ * This adds a @c CONFIG_TMP00X_CONVERSION_TIME us delay to each measurement call
  * for bringing the device out of standby.
  */
-#ifndef TMP00X_USE_LOW_POWER
-#define TMP00X_USE_LOW_POWER (0)
+#ifndef CONFIG_TMP00X_USE_LOW_POWER
+#define CONFIG_TMP00X_USE_LOW_POWER (0)
 #endif
 
 /**
@@ -132,8 +132,8 @@ extern "C"
  * If set to 0, measurements will be converted to Celsius.
  * If set to 1, raw adc readings will be returned.
  */
-#ifndef TMP00X_USE_RAW_VALUES
-#define TMP00X_USE_RAW_VALUES (0)
+#ifndef CONFIG_TMP00X_USE_RAW_VALUES
+#define CONFIG_TMP00X_USE_RAW_VALUES (0)
 #endif
 /** @} */
 

--- a/drivers/include/tmp00x.h
+++ b/drivers/include/tmp00x.h
@@ -83,6 +83,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "periph/i2c.h"
+#include "kernel_defines.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -111,29 +112,29 @@ extern "C"
  * @brief   Default Conversion Time in us
  */
 #ifndef CONFIG_TMP00X_CONVERSION_TIME
-#define CONFIG_TMP00X_CONVERSION_TIME     (1E6)
+#define CONFIG_TMP00X_CONVERSION_TIME                   (1E6)
 #endif
 
 /**
  * @brief   Default low power mode
  *
- * If set to 0, the device will be always-on
- * If set to 1, the device will be put in low power mode between measurements.
- * This adds a @c CONFIG_TMP00X_CONVERSION_TIME us delay to each measurement call
- * for bringing the device out of standby.
+ * Set this to 1 to put the device in low power mode between measurements
+ * otherwise the device will always be on.
+ * Enabling this adds a @c CONFIG_TMP00X_CONVERSION_TIME us delay to each
+ * measurement call for bringing the device out of standby.
  */
-#ifndef CONFIG_TMP00X_USE_LOW_POWER
-#define CONFIG_TMP00X_USE_LOW_POWER (0)
+#ifdef DOXYGEN
+#define CONFIG_TMP00X_USE_LOW_POWER
 #endif
 
 /**
  * @brief   Default raw value mode
  *
- * If set to 0, measurements will be converted to Celsius.
- * If set to 1, raw adc readings will be returned.
+ * Set this to 1 to return raw adc readings otherwise
+ * measurements will be converted to Celsius.
  */
-#ifndef CONFIG_TMP00X_USE_RAW_VALUES
-#define CONFIG_TMP00X_USE_RAW_VALUES (0)
+#ifdef DOXYGEN
+#define CONFIG_TMP00X_USE_RAW_VALUES
 #endif
 /** @} */
 

--- a/drivers/include/tmp00x.h
+++ b/drivers/include/tmp00x.h
@@ -101,8 +101,10 @@ extern "C"
 /**
  * @brief   Default Address
  *
- * I2C Address depends on the state of ADR0 and ADR1 Pins
- * For more information, please refer to section 7.3.6.2 of TMP007 datasheet (SBOS685B).
+ * TMP006/TMP007 allows for up to 8 devices on a single bus. The address value
+ * depends on the state of ADR0 and ADR1 pins. Default value (0x40) corresponds
+ * to ADR0 and ADR1 pins tied to GND. For more information refer to the 'Serial
+ * Bus Address' section in the datasheet.
  */
 #ifndef CONFIG_TMP00X_I2C_ADDRESS
 #define CONFIG_TMP00X_I2C_ADDRESS         (0x40)
@@ -110,7 +112,23 @@ extern "C"
 
 /**
  * @brief   Default Conversion Time in us
+ *
+ * The duration of the analog-to-digital(A/D) conversion is determined by the
+ * conversion rate bits CR0, CR1 and CR2. For more information refer to the
+ * datasheet.
  */
+#if IS_ACTIVE(CONFIG_TMP00X_CONVERSION_TIME_0_25S)
+#define CONFIG_TMP00X_CONVERSION_TIME                   (25E4)
+#elif IS_ACTIVE(CONFIG_TMP00X_CONVERSION_TIME_0_5S)
+#define CONFIG_TMP00X_CONVERSION_TIME                   (5E5)
+#elif IS_ACTIVE(CONFIG_TMP00X_CONVERSION_TIME_1S)
+#define CONFIG_TMP00X_CONVERSION_TIME                   (1E6)
+#elif IS_ACTIVE(CONFIG_TMP00X_CONVERSION_TIME_2S)
+#define CONFIG_TMP00X_CONVERSION_TIME                   (2E6)
+#elif IS_ACTIVE(CONFIG_TMP00X_CONVERSION_TIME_4S)
+#define CONFIG_TMP00X_CONVERSION_TIME                   (4E6)
+#endif
+
 #ifndef CONFIG_TMP00X_CONVERSION_TIME
 #define CONFIG_TMP00X_CONVERSION_TIME                   (1E6)
 #endif
@@ -130,8 +148,8 @@ extern "C"
 /**
  * @brief   Default raw value mode
  *
- * Set this to 1 to return raw adc readings otherwise
- * measurements will be converted to Celsius.
+ * Set this to 1 to return raw adc readings otherwise measurements will be
+ * converted to Celsius.
  */
 #ifdef DOXYGEN
 #define CONFIG_TMP00X_USE_RAW_VALUES

--- a/drivers/saul/init_devs/auto_init_tmp00x.c
+++ b/drivers/saul/init_devs/auto_init_tmp00x.c
@@ -70,12 +70,12 @@ void auto_init_tmp00x(void)
             LOG_ERROR("[auto_init_saul] error set active tmp00x #%u\n", i);
             continue;
         }
-    if (IS_ACTIVE(CONFIG_TMP00X_USE_LOW_POWER)) {
+        if (IS_ACTIVE(CONFIG_TMP00X_USE_LOW_POWER)) {
             if (tmp00x_set_standby(&tmp00x_devs[i]) != TMP00X_OK) {
                 LOG_ERROR("[auto_init_saul] error set standby tmp00x #%u\n", i);
                 continue;
             }
-    }
+        }
         saul_entries[i].dev = &(tmp00x_devs[i]);
         saul_entries[i].name = tmp00x_saul_info[i].name;
         saul_entries[i].driver = &tmp00x_saul_driver;

--- a/drivers/saul/init_devs/auto_init_tmp00x.c
+++ b/drivers/saul/init_devs/auto_init_tmp00x.c
@@ -28,6 +28,7 @@
 
 #include "tmp00x.h"
 #include "tmp00x_params.h"
+#include "kernel_defines.h"
 
 /**
  * @brief   Define the number of configured sensors
@@ -69,12 +70,12 @@ void auto_init_tmp00x(void)
             LOG_ERROR("[auto_init_saul] error set active tmp00x #%u\n", i);
             continue;
         }
-#if TMP00X_USE_LOW_POWER
-        if (tmp00x_set_standby(&tmp00x_devs[i]) != TMP00X_OK) {
-            LOG_ERROR("[auto_init_saul] error set standby tmp00x #%u\n", i);
-            continue;
-        }
-#endif
+    if (IS_ACTIVE(CONFIG_TMP00X_USE_LOW_POWER)) {
+            if (tmp00x_set_standby(&tmp00x_devs[i]) != TMP00X_OK) {
+                LOG_ERROR("[auto_init_saul] error set standby tmp00x #%u\n", i);
+                continue;
+            }
+    }
         saul_entries[i].dev = &(tmp00x_devs[i]);
         saul_entries[i].name = tmp00x_saul_info[i].name;
         saul_entries[i].driver = &tmp00x_saul_driver;

--- a/drivers/tmp00x/Kconfig
+++ b/drivers/tmp00x/Kconfig
@@ -1,0 +1,64 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_TMP00X
+    bool "Configure TMP00X driver"
+    depends on MODULE_TMP00X
+    help
+        Configure the TMP00X driver using Kconfig.
+
+if KCONFIG_MODULE_TMP00X
+
+config TMP00X_I2C_ADDRESS
+    hex "Default I2C Address"
+    range 0x40 0x47
+    default 0x40
+    help
+        TMP006/TMP007 allows for up to 8 devices on a single bus. The address
+        value depends on the state of ADR0 and ADR1 pins. Default value (0x40)
+        corresponds to ADR0 and ADR1 pins tied to GND. For more information
+        refer to the 'Serial Bus Address' section in the datasheet.
+
+choice
+    bool "Conversion time"
+    default TMP00X_CONVERSION_TIME_1S
+    help
+        The duration of the analog-to-digital(A/D) conversion is determined by
+        the conversion rate bits CR0, CR1 and CR2. For more information refer
+        datasheet.
+
+config TMP00X_CONVERSION_TIME_0_25S
+    bool "0.25 s"
+
+config TMP00X_CONVERSION_TIME_0_5S
+    bool "0.5 s"
+
+config TMP00X_CONVERSION_TIME_1S
+    bool "1 s"
+
+config TMP00X_CONVERSION_TIME_2S
+    bool "2 s"
+
+config TMP00X_CONVERSION_TIME_4S
+    bool "4 s"
+
+endchoice
+
+config TMP00X_USE_LOW_POWER
+    bool "Enable low power mode"
+    help
+        Enable this to put the device in low power mode between measurements.
+        By default the device will always be on. Enabling this also adds a delay
+        based on "Conversion time" to each measurement call for bringing the
+        device out of standby.
+
+config TMP00X_USE_RAW_VALUES
+    bool "Enable raw ADC readings"
+    help
+        Enable this to return raw ADC readings. By default measurements are
+        converted to Celsius.
+
+endif # KCONFIG_MODULE_TMP00X

--- a/drivers/tmp00x/include/tmp00x_params.h
+++ b/drivers/tmp00x/include/tmp00x_params.h
@@ -36,7 +36,7 @@ extern "C" {
 #define TMP00X_PARAM_I2C           I2C_DEV(0)
 #endif
 #ifndef TMP00X_PARAM_ADDR
-#define TMP00X_PARAM_ADDR          (TMP00X_I2C_ADDRESS)
+#define TMP00X_PARAM_ADDR          (CONFIG_TMP00X_I2C_ADDRESS)
 #endif
 #ifndef TMP00X_PARAM_RATE
 #define TMP00X_PARAM_RATE           TMP00X_CONFIG_CR_DEF

--- a/drivers/tmp00x/tmp00x.c
+++ b/drivers/tmp00x/tmp00x.c
@@ -211,7 +211,7 @@ int tmp00x_read_temperature(const tmp00x_t *dev, int16_t *ta, int16_t *to)
     if (tmp00x_set_active(dev)) {
         return TMP00X_ERROR;
     }
-    xtimer_usleep(TMP00X_CONVERSION_TIME);
+    xtimer_usleep(CONFIG_TMP00X_CONVERSION_TIME);
 #endif
 
 int ret;

--- a/drivers/tmp00x/tmp00x.c
+++ b/drivers/tmp00x/tmp00x.c
@@ -32,10 +32,12 @@
 #include "periph/i2c.h"
 #include "tmp00x.h"
 #include "tmp00x_regs.h"
-#if TMP00X_USE_LOW_POWER
+#include "byteorder.h"
+#include "kernel_defines.h"
+
+#if IS_ACTIVE(CONFIG_TMP00X_USE_LOW_POWER)
 #include "xtimer.h"
 #endif
-#include "byteorder.h"
 
 #define ENABLE_DEBUG                (0)
 #include "debug.h"
@@ -202,12 +204,12 @@ int tmp00x_read_temperature(const tmp00x_t *dev, int16_t *ta, int16_t *to)
 {
 
     uint16_t drdy;
-#if (!TMP00X_USE_RAW_VALUES)
+#if (!IS_ACTIVE(CONFIG_TMP00X_USE_RAW_VALUES))
     int16_t rawtemp, rawvolt;
     float tamb, tobj;
 #endif
 
-#if TMP00X_USE_LOW_POWER
+#if IS_ACTIVE(CONFIG_TMP00X_USE_LOW_POWER)
     if (tmp00x_set_active(dev)) {
         return TMP00X_ERROR;
     }
@@ -215,13 +217,13 @@ int tmp00x_read_temperature(const tmp00x_t *dev, int16_t *ta, int16_t *to)
 #endif
 
 int ret;
-#if TMP00X_USE_RAW_VALUES
+#if IS_ACTIVE(CONFIG_TMP00X_USE_RAW_VALUES)
     if ((ret = tmp00x_read(dev, to, ta, &drdy)) < 0) {
         return ret;
     }
 
     if (!drdy) {
-#if TMP00X_USE_LOW_POWER
+#if IS_ACTIVE(CONFIG_TMP00X_USE_LOW_POWER)
         tmp00x_set_standby(dev);
 #endif
         return -TMP00X_ERROR;
@@ -232,7 +234,7 @@ int ret;
     }
 
     if (!drdy) {
-#if TMP00X_USE_LOW_POWER
+#if IS_ACTIVE(CONFIG_TMP00X_USE_LOW_POWER)
         tmp00x_set_standby(dev);
 #endif
         return -TMP00X_ERROR;
@@ -243,11 +245,11 @@ int ret;
     *to = (int16_t)(tobj*100);
 #endif
 
-#if TMP00X_USE_LOW_POWER
-    if (tmp00x_set_standby(dev)) {
-        return -TMP00X_ERROR;
+    if (IS_ACTIVE(CONFIG_TMP00X_USE_LOW_POWER)) {
+        if (tmp00x_set_standby(dev)) {
+            return -TMP00X_ERROR;
+        }
     }
-#endif
 
     return TMP00X_OK;
 }

--- a/drivers/tmp00x/tmp00x_saul.c
+++ b/drivers/tmp00x/tmp00x_saul.c
@@ -22,6 +22,7 @@
 
 #include "saul.h"
 #include "tmp00x.h"
+#include "kernel_defines.h"
 
 static int read_temp(const void *dev, phydat_t *res)
 {
@@ -30,13 +31,14 @@ static int read_temp(const void *dev, phydat_t *res)
         return -ECANCELED;
     }
     res->val[2] = 0;
-#if TMP00X_USE_RAW_VALUES
-    res->unit = UNIT_NONE;
-    res->scale = 0;
-#else
-    res->unit = UNIT_TEMP_C;
-    res->scale = -2;
-#endif
+    if (IS_ACTIVE(CONFIG_TMP00X_USE_RAW_VALUES)) {
+        res->unit = UNIT_NONE;
+        res->scale = 0;
+    }
+    else {
+        res->unit = UNIT_TEMP_C;
+        res->scale = -2;
+    }
     return 2;
 }
 

--- a/tests/driver_tmp00x/main.c
+++ b/tests/driver_tmp00x/main.c
@@ -46,7 +46,7 @@ int main(void)
         puts("start measurement [ERROR]");
         return -1;
     }
-    xtimer_usleep(TMP00X_CONVERSION_TIME);
+    xtimer_usleep(CONFIG_TMP00X_CONVERSION_TIME);
     puts("[SUCCESS]\n");
 
     while (1) {
@@ -60,7 +60,7 @@ int main(void)
         else {
             puts("conversion in progress ... ");
         }
-        xtimer_usleep(TMP00X_CONVERSION_TIME);
+        xtimer_usleep(CONFIG_TMP00X_CONVERSION_TIME);
     }
 
     return 0;


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in TMP006/TMP007 Sensor Device driver to Kconfig.

### Testing procedure
1. New documentation was built using doxygen 

The build worked fine.

2. New macro was introduced in tests/driver_tmp00x/main.c for testing.

```
#define STR(x)   #x
#define SHOW_DEFINE(x) printf("%s=%s\n", #x, STR(x))
```
Firmware was uploaded to FIT IoT Lab test bed.

#### Default State:

##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-309-g0af78-Kconfig_tmp00x_1_tests)
CONFIG_TMP00X_I2C_ADDRESS=(0x40)
CONFIG_TMP00X_CONVERSION_TIME=(1E6)
CONFIG_TMP00X_USE_LOW_POWER=CONFIG_TMP00X_USE_LOW_POWER
CONFIG_TMP00X_USE_RAW_VALUES=CONFIG_TMP00X_USE_RAW_VALUES
TMP00X infrared thermopile sensor driver test application

Initializing TMP00X sensor at I2C_0 ... tmp00x_init: error reading device ID!
init device [ERROR]

#### Usage with CFLAGS 

/tests/driver_tmp00x/Makefile

> CFLAGS += -DCONFIG_TMP00X_I2C_ADDRESS=0x41
> CFLAGS += -DCONFIG_TMP00X_CONVERSION_TIME=2E6
> CFLAGS += -DCONFIG_TMP00X_USE_LOW_POWER=1
> CFLAGS += -DCONFIG_TMP00X_USE_RAW_VALUES=1


##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-310-gba881-Kconfig_tmp00x_1_tests)
CONFIG_TMP00X_I2C_ADDRESS=0x41
CONFIG_TMP00X_CONVERSION_TIME=2E6
CONFIG_TMP00X_USE_LOW_POWER=1
CONFIG_TMP00X_USE_RAW_VALUES=1
TMP00X infrared thermopile sensor driver test application

Initializing TMP00X sensor at I2C_0 ... tmp00x_init: error reading device ID!
init device [ERROR]

#### Usage with Kconfig

/tests/driver_tmp00x/

> make menuconfig

##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-310-ga6e69-Kconfig_tmp00x_1_tests)
CONFIG_TMP00X_I2C_ADDRESS=0x45
CONFIG_TMP00X_CONVERSION_TIME=(25E4)
CONFIG_TMP00X_USE_LOW_POWER=1
CONFIG_TMP00X_USE_RAW_VALUES=1
TMP00X infrared thermopile sensor driver test application

Initializing TMP00X sensor at I2C_0 ... tmp00x_init: error reading device ID!
init device [ERROR]

Note : The sensor is not available for interfacing hence configurability of macros were only tested.

### Issues/PRs references

#12888
@leandrolanzieri  Please merge this only after  #13981
