### PR TITLE
sys/ztimer: expose ZTIMER_MSEC/USEC_BASE 

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -646,7 +646,7 @@ static inline int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t timeout);
 }
 #endif
 
-#endif /* MODULE_XTIMER_ON_ZTIMER */
+#endif /* MODULE_ZTIMER_XTIMER_COMPAT */
 
 /** @} */
 #endif /* XTIMER_H */

--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -513,6 +513,41 @@ extern ztimer_clock_t *const ZTIMER_USEC;
  */
 extern ztimer_clock_t *const ZTIMER_MSEC;
 
+/**
+ * @brief   Base ztimer for the microsecond clock (ZTIMER_USEC)
+ *
+ * This ztimer will reference the counter device object at the end of the
+ * chain of ztimer_clock_t for ZTIMER_USEC.
+ *
+ * If the base counter device object's frequency (CONFIG_ZTIMER_USEC_BASE_FREQ)
+ * is not 1MHz then ZTIMER_USEC will be converted on top of this one. Otherwise
+ * they will reference the same ztimer_clock.
+ *
+ * To avoid chained conversions its better to base new ztimer_clock on top of
+ * ZTIMER_USEC_BASE running at CONFIG_ZTIMER_USEC_BASE_FREQ.
+ *
+ */
+extern ztimer_clock_t *const ZTIMER_USEC_BASE;
+
+/**
+ * @brief   Base ztimer for the millisecond clock (ZTIMER_MSEC)
+ *
+ * This ztimer will reference the counter device object at the end of the
+ * chain of ztimer_clock_t for ZTIMER_MSEC.
+ *
+ * If ztimer_periph_rtt is not used then ZTIMER_MSEC_BASE will reference the
+ * same base as ZTIMER_USEC_BASE.
+ *
+ * If the base counter device object's frequency (CONFIG_ZTIMER_MSEC_BASE_FREQ)
+ * is not 1KHz then ZTIMER_MSEC will be converted on top of this one. Otherwise
+ * they will reference the same ztimer_clock.
+ *
+ * To avoid chained conversions its better to base new ztimer_clock on top of
+ * ZTIMER_MSEC_BASE running at CONFIG_ZTIMER_MSEC_BASE_FREQ.
+ *
+ */
+extern ztimer_clock_t *const ZTIMER_MSEC_BASE;
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sys/include/ztimer/config.h
+++ b/sys/include/ztimer/config.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     sys_ztimer
+ * @{
+ *
+ * @file
+ * @brief       ztimer default configuration
+ *
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#ifndef ZTIMER_CONFIG_H
+#define ZTIMER_CONFIG_H
+
+#include "board.h"
+#include "periph_conf.h"
+
+#include "ztimer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * @brief   Use periph_timer as the base timer for ZTIMER_USEC
+ */
+#define CONFIG_ZTIMER_USEC_TYPE_PERIPH_TIMER (1)
+
+/* for ZTIMER_USEC, use xtimer configuration if available and no ztimer
+ * specific configuration is set. */
+#if CONFIG_ZTIMER_USEC_TYPE_PERIPH_TIMER
+#  ifndef CONFIG_ZTIMER_USEC_DEV
+#    ifdef XTIMER_DEV
+#      define CONFIG_ZTIMER_USEC_DEV            XTIMER_DEV
+#    endif
+#  endif
+#  ifndef CONFIG_ZTIMER_USEC_BASE_FREQ
+#    ifdef XTIMER_HZ
+#      define CONFIG_ZTIMER_USEC_BASE_FREQ      XTIMER_HZ
+#    endif
+#  endif
+#  ifndef CONFIG_ZTIMER_USEC_WIDTH
+#    ifdef XTIMER_WIDTH
+#      define CONFIG_ZTIMER_USEC_WIDTH          XTIMER_WIDTH
+#    endif
+#  endif
+#endif
+
+/**
+ * @brief   Default timer device for ZTIMER_USEC
+ */
+#ifndef CONFIG_ZTIMER_USEC_DEV
+#define CONFIG_ZTIMER_USEC_DEV          (TIMER_DEV(0))
+#endif
+
+/**
+ * @brief   ZTIMER_USEC optimal minimum value for ztimer_set()
+ *
+ * When scheduling an ISR every timer will be set to:
+ * max(CONFIG_ZTIMER_USEC_MIN, value).
+ *
+ * This value only applies if the counter object used for ZTIMER_USEC is
+ * periph_timer. This is supposed to be defined per-device in e.g., board.h.
+ */
+#ifndef CONFIG_ZTIMER_USEC_MIN
+#define CONFIG_ZTIMER_USEC_MIN              (10)
+#endif
+
+/**
+   @brief   ZTIMER_USEC counter object width
+ */
+#ifndef CONFIG_ZTIMER_USEC_WIDTH
+#  if (TIMER_0_MAX_VALUE) == 0xffff
+#    define CONFIG_ZTIMER_USEC_WIDTH        (16)
+#  elif (TIMER_0_MAX_VALUE) == 0xffffffUL
+#    define CONFIG_ZTIMER_USEC_WIDTH        (24)
+#  else
+#    define CONFIG_ZTIMER_USEC_WIDTH        (32)
+#  endif
+#endif
+
+/**
+ * @brief   The frequency of ZTIMER_USEC_BASE (base ztimer for ZTIMER_USEC)
+ */
+#ifndef CONFIG_ZTIMER_USEC_BASE_FREQ
+#define CONFIG_ZTIMER_USEC_BASE_FREQ    (1000000LU)
+#endif
+
+/**
+ * @brief   The frequency of ZTIMER_MSEC_BASE (base ztimer for ZTIMER_MSEC)
+ */
+#ifdef MODULE_ZTIMER_PERIPH_RTT
+#  define CONFIG_ZTIMER_MSEC_BASE_FREQ   (RTT_FREQUENCY)
+# else
+#  define CONFIG_ZTIMER_MSEC_BASE_FREQ   (CONFIG_ZTIMER_USEC_BASE_FREQ)
+#endif  /* MODULE_ZTIMER_PERIPH_RTT */
+
+/**
+ * @brief   The minimum pm mode required for ZTIMER_USEC to run.
+ */
+#ifndef CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE
+#define CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE ZTIMER_CLOCK_NO_REQUIRED_PM_MODE
+#endif
+
+/**
+ * @brief   The minimum pm mode required for ZTIMER_MSEC to run
+ */
+#ifndef CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE
+#define CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE ZTIMER_CLOCK_NO_REQUIRED_PM_MODE
+#endif
+
+#endif /* ZTIMER_CONFIG_H */
+/** @} */

--- a/sys/ztimer/auto_init.c
+++ b/sys/ztimer/auto_init.c
@@ -43,64 +43,23 @@
 #include "ztimer/convert_muldiv64.h"
 #include "ztimer/periph_timer.h"
 #include "ztimer/periph_rtt.h"
+#include "ztimer/config.h"
 
 #include "log.h"
 
 #define WIDTH_TO_MAXVAL(width)  (UINT32_MAX >> (32 - width))
 
-#define CONFIG_ZTIMER_USEC_TYPE_PERIPH_TIMER (1)
-
 #define FREQ_1MHZ       1000000LU
 #define FREQ_250KHZ     250000LU
 #define FREQ_1KHZ       1000LU
-
-/* for ZTIMER_USEC, use xtimer configuration if available and no ztimer
- * specific configuration is set. */
-#if CONFIG_ZTIMER_USEC_TYPE_PERIPH_TIMER
-#  ifndef CONFIG_ZTIMER_USEC_DEV
-#    ifdef XTIMER_DEV
-#      define CONFIG_ZTIMER_USEC_DEV      XTIMER_DEV
-#    endif
-#    ifdef XTIMER_HZ
-#      define CONFIG_ZTIMER_USEC_FREQ     XTIMER_HZ
-#    endif
-#    ifdef XTIMER_WIDTH
-#      define CONFIG_ZTIMER_USEC_WIDTH    XTIMER_WIDTH
-#    endif
-#  endif
-#endif
-
-#ifndef CONFIG_ZTIMER_USEC_DEV
-#define CONFIG_ZTIMER_USEC_DEV (TIMER_DEV(0))
-#endif
-
-#ifndef CONFIG_ZTIMER_USEC_FREQ
-#define CONFIG_ZTIMER_USEC_FREQ (FREQ_1MHZ)
-#endif
-
-#ifndef CONFIG_ZTIMER_USEC_MIN
-#define CONFIG_ZTIMER_USEC_MIN (10)
-#endif
-
-#ifndef CONFIG_ZTIMER_USEC_WIDTH
-#define CONFIG_ZTIMER_USEC_WIDTH (32)
-#endif
-
-#ifndef CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE
-#define CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE ZTIMER_CLOCK_NO_REQUIRED_PM_MODE
-#endif
-
-#ifndef CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE
-#define CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE ZTIMER_CLOCK_NO_REQUIRED_PM_MODE
-#endif
 
 #if MODULE_ZTIMER_USEC
 #  if CONFIG_ZTIMER_USEC_TYPE_PERIPH_TIMER
 static ztimer_periph_timer_t _ztimer_periph_timer_usec = { .min = CONFIG_ZTIMER_USEC_MIN };
 ztimer_clock_t *const ZTIMER_USEC_BASE = &_ztimer_periph_timer_usec.super;
-#    if CONFIG_ZTIMER_USEC_FREQ == FREQ_1MHZ
+#    if CONFIG_ZTIMER_USEC_BASE_FREQ == FREQ_1MHZ
 ztimer_clock_t *const ZTIMER_USEC = &_ztimer_periph_timer_usec.super;
-#    elif CONFIG_ZTIMER_USEC_FREQ == 250000LU
+#    elif CONFIG_ZTIMER_USEC_BASE_FREQ == 250000LU
 static ztimer_convert_shift_t _ztimer_convert_shift_usec;
 ztimer_clock_t *const ZTIMER_USEC = &_ztimer_convert_shift_usec.super.super;
 #    else
@@ -130,9 +89,9 @@ ztimer_clock_t *const ZTIMER_MSEC = &_ztimer_periph_timer_rtt_msec;
 static ztimer_convert_frac_t _ztimer_convert_frac_msec;
 ztimer_clock_t *const ZTIMER_MSEC = &_ztimer_convert_frac_msec.super.super;
 ztimer_clock_t *const ZTIMER_MSEC_BASE = &_ztimer_periph_timer_usec.super;
-#    if CONFIG_ZTIMER_USEC_FREQ < FREQ_1MHZ
+#    if CONFIG_ZTIMER_USEC_BASE_FREQ < FREQ_1MHZ
 #      define ZTIMER_MSEC_CONVERT_LOWER         ZTIMER_USEC_CONVERT_LOWER
-#      define ZTIMER_MSEC_CONVERT_LOWER_FREQ    CONFIG_ZTIMER_USEC_FREQ
+#      define ZTIMER_MSEC_CONVERT_LOWER_FREQ    CONFIG_ZTIMER_USEC_BASE_FREQ
 #    else
 #      define ZTIMER_MSEC_CONVERT_LOWER (ZTIMER_USEC)
 #      define ZTIMER_MSEC_CONVERT_LOWER_FREQ    FREQ_1MHZ
@@ -148,22 +107,22 @@ void ztimer_init(void)
 #  if CONFIG_ZTIMER_USEC_TYPE_PERIPH_TIMER
     LOG_DEBUG(
         "ztimer_init(): ZTIMER_USEC using periph timer %u, freq %lu, width %u\n",
-        CONFIG_ZTIMER_USEC_DEV, CONFIG_ZTIMER_USEC_FREQ, CONFIG_ZTIMER_USEC_WIDTH);
+        CONFIG_ZTIMER_USEC_DEV, CONFIG_ZTIMER_USEC_BASE_FREQ, CONFIG_ZTIMER_USEC_WIDTH);
 
     ztimer_periph_timer_init(&_ztimer_periph_timer_usec, CONFIG_ZTIMER_USEC_DEV,
-                       CONFIG_ZTIMER_USEC_FREQ,
+                       CONFIG_ZTIMER_USEC_BASE_FREQ,
                        WIDTH_TO_MAXVAL(CONFIG_ZTIMER_USEC_WIDTH));
 #  endif
-#  if CONFIG_ZTIMER_USEC_FREQ != FREQ_1MHZ
-#    if CONFIG_ZTIMER_USEC_FREQ == FREQ_250KHZ
+#  if CONFIG_ZTIMER_USEC_BASE_FREQ != FREQ_1MHZ
+#    if CONFIG_ZTIMER_USEC_BASE_FREQ == FREQ_250KHZ
     LOG_DEBUG("ztimer_init(): ZTIMER_USEC convert_shift %lu to 1000000\n",
-            CONFIG_ZTIMER_USEC_FREQ);
+            CONFIG_ZTIMER_USEC_BASE_FREQ);
     ztimer_convert_shift_up_init(&_ztimer_convert_shift_usec, &_ztimer_periph_timer_usec.super, 2);
 #    else
     LOG_DEBUG("ztimer_init(): ZTIMER_USEC convert_frac %lu to 1000000\n",
-            CONFIG_ZTIMER_USEC_FREQ);
+            CONFIG_ZTIMER_USEC_BASE_FREQ);
     ztimer_convert_frac_init(&_ztimer_convert_frac_usec, &_ztimer_periph_timer_usec.super,
-            FREQ_1MHZ, CONFIG_ZTIMER_USEC_FREQ);
+            FREQ_1MHZ, CONFIG_ZTIMER_USEC_BASE_FREQ);
 #    endif
 #  endif
 #  ifdef CONFIG_ZTIMER_USEC_ADJUST

--- a/sys/ztimer/auto_init.c
+++ b/sys/ztimer/auto_init.c
@@ -97,6 +97,7 @@
 #if MODULE_ZTIMER_USEC
 #  if CONFIG_ZTIMER_USEC_TYPE_PERIPH_TIMER
 static ztimer_periph_timer_t _ztimer_periph_timer_usec = { .min = CONFIG_ZTIMER_USEC_MIN };
+ztimer_clock_t *const ZTIMER_USEC_BASE = &_ztimer_periph_timer_usec.super;
 #    if CONFIG_ZTIMER_USEC_FREQ == FREQ_1MHZ
 ztimer_clock_t *const ZTIMER_USEC = &_ztimer_periph_timer_usec.super;
 #    elif CONFIG_ZTIMER_USEC_FREQ == 250000LU
@@ -113,20 +114,22 @@ ztimer_clock_t *const ZTIMER_USEC = &_ztimer_convert_frac_usec.super.super;
 #endif
 
 #if MODULE_ZTIMER_MSEC
-#  if MODULE_PERIPH_RTT
+#  if MODULE_ZTIMER_PERIPH_RTT
 static ztimer_periph_rtt_t _ztimer_periph_timer_rtt_msec;
-#  define ZTIMER_RTT_INIT (&_ztimer_periph_timer_rtt_msec)
+ztimer_clock_t *const ZTIMER_MSEC_BASE = &_ztimer_periph_timer_rtt_msec;
+#  define ZTIMER_RTT_INIT (ZTIMER_MSEC_BASE)
 #    if RTT_FREQUENCY!=FREQ_1KHZ
 static ztimer_convert_frac_t _ztimer_convert_frac_msec;
 ztimer_clock_t *const ZTIMER_MSEC = &_ztimer_convert_frac_msec.super.super;
 #  define ZTIMER_MSEC_CONVERT_LOWER_FREQ    RTT_FREQUENCY
 #  define ZTIMER_MSEC_CONVERT_LOWER         (&_ztimer_periph_timer_rtt_msec)
 #    else
-ztimer_clock_t *const ZTIMER_MSEC = &_ztimer_periph_timer_rtt_msec.super;
+ztimer_clock_t *const ZTIMER_MSEC = &_ztimer_periph_timer_rtt_msec;
 #    endif
 #  elif MODULE_ZTIMER_USEC
 static ztimer_convert_frac_t _ztimer_convert_frac_msec;
 ztimer_clock_t *const ZTIMER_MSEC = &_ztimer_convert_frac_msec.super.super;
+ztimer_clock_t *const ZTIMER_MSEC_BASE = &_ztimer_periph_timer_usec.super;
 #    if CONFIG_ZTIMER_USEC_FREQ < FREQ_1MHZ
 #      define ZTIMER_MSEC_CONVERT_LOWER         ZTIMER_USEC_CONVERT_LOWER
 #      define ZTIMER_MSEC_CONVERT_LOWER_FREQ    CONFIG_ZTIMER_USEC_FREQ


### PR DESCRIPTION
### Contribution description

`ztimer` comes with a lot of flexibility, specially with the option to chain `ztimer_clock_t`. If I would want I can configure timers with different resolutions.

But since `ZTIMER_MSEC` or `ZTIMER_USEC` can themselves have been already shifted/frac/divided to get the desired frequency it makes sense to branch new timers from the base timer instead of chaining them, that way conversions are not as well chained.

To allow that this PR exposes the `BASE` timer as well as its frequency. The base frequency assumes that the timer is running at `1Mhz` or at `XTIMER_HZ` and that `RTT` is used when possible for `ZTIMER_MSEC`.

I wanted to expose the base for `ZTIMER_MSEC` or `ZTIMER_USEC` since the api expects these to be available.

It might make sense instead of exposing a `ZTIMER_BASE_LPM` (low power mode capabilities) and `ZTIMER_BASE`, since if there is no timer that can sleep, the base for `ZTIMER_MSEC` is likely to be the same than for `ZTIMER_USEC`.

### Testing procedure

- `tests/ztimer_%`still pass

