### PR TITLE
sys/random/minstd: fix signedness

### DIFF
--- a/sys/random/minstd.c
+++ b/sys/random/minstd.c
@@ -16,11 +16,6 @@
  * @brief Simple Park & Miller "minimal standard" PRNG
  *
  * This file contains a simple Park-Miller pseudo random number generator.
- *
- * While not very random when considering crypto requirements, this is probably
- * random enough anywhere where pseudo-randomness is sufficient, e.g., when
- * provided with a sensible seed source, for MAC algorithms.
- *
  * The implementation is taken from the C FAQ, but modified to use magic number
  * division and adapted to RIOT's coding conventions..
  *

--- a/sys/random/minstd.c
+++ b/sys/random/minstd.c
@@ -39,13 +39,13 @@
 
 static uint32_t _seed = 1;
 
-int rand_minstd(void)
+int32_t rand_minstd(void)
 {
     uint32_t hi = div_u32_by_44488(_seed);
     uint32_t lo = div_u32_mod_44488(_seed);
-    uint32_t test = (a * lo) - (r * hi);
+    int32_t test = (a * lo) - (r * hi);
 
-    if(test > 0) {
+    if (test > 0) {
         _seed = test;
     }
     else {
@@ -61,7 +61,7 @@ uint32_t random_uint32(void)
      * so run it two times to get 32bits */
     uint16_t A = (rand_minstd() >> 15);
     uint16_t B = (rand_minstd() >> 15);
-    return  (((uint32_t)A) << 16) | B;
+    return (((uint32_t)A) << 16) | B;
 }
 
 void random_init(uint32_t val)


### PR DESCRIPTION
### Contribution description

The Park-Miller LCG has a period of 2<sup>31</sup>-1. In RIOT, we call the generator twice to get one 32bit integer, thus, at least half as many numbers should be generated before duplicates occur (2<sup>30</sup>-1). However, the signedness of [`test`](https://github.com/RIOT-OS/RIOT/blob/8136edca9572c6414450ed9e3fa1eff4c5919754/sys/random/minstd.c#L46) prevents negative values and as a consequence, the state [is never incremented](https://github.com/RIOT-OS/RIOT/blob/master/sys/random/minstd.c#L52) which leads to a heavily reduced period. This PR changes `test` to a signed variable to fix that.

See [wikipedia](https://en.wikipedia.org/wiki/Lehmer_random_number_generator) for reference.

### Testing procedure
- `USEMODULE=prng_minstd make -C tests/rng/ clean all term`
- `dump 500000` and pipe the output for later analysis.
**Currently**
- With `seed=0` (default), the sequence repeats with a period of 223717, after the first 102819 dumped integers.
**With this PR**
- Outputs should repeat only after 2<sup>30</sup>-1 requests.
