### PR TITLE
examples/filesystem: add support for fatfs on SD card

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -628,6 +628,7 @@ endif
 ifneq (,$(filter sdcard_spi,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_spi
+  DEFAULT_MODULE += auto_init_storage
   USEMODULE += checksum
   USEMODULE += xtimer
 endif

--- a/examples/filesystem/Makefile
+++ b/examples/filesystem/Makefile
@@ -34,7 +34,7 @@ USEMODULE += vfs
 # Use a file system
 USEMODULE += littlefs
 # USEMODULE += spiffs
-# USEMODULE += fatfs
+# USEMODULE += fatfs_vfs
 USEMODULE += constfs
 # USEMODULE += devfs
 
@@ -44,6 +44,8 @@ ifneq (,$(filter littlefs, $(USEMODULE)))
 else ifneq (,$(filter spiffs, $(USEMODULE)))
     SPIFFS_NB_FD ?= 8
     CFLAGS += '-DSPIFFS_FS_FD_SPACE_SIZE=(32 * $(SPIFFS_NB_FD))'
+else ifneq (,$(filter fatfs_vfs, $(USEMODULE)))
+    CFLAGS += -DVFS_FILE_BUFFER_SIZE=72 -DVFS_DIR_BUFFER_SIZE=44
 endif
 
 include $(RIOTBASE)/Makefile.include

--- a/examples/filesystem/Makefile
+++ b/examples/filesystem/Makefile
@@ -26,6 +26,7 @@ USEMODULE += ps
 
 # Use MTD (flash layer)
 USEMODULE += mtd
+# USEMODULE += mtd_sdcard
 
 # Use VFS
 USEMODULE += vfs

--- a/examples/filesystem/main.c
+++ b/examples/filesystem/main.c
@@ -26,18 +26,26 @@
 #include "shell.h"
 #include "board.h" /* MTD_0 is defined in board.h */
 
+/* Configure MTD device for SD card if none is provided */
 #if !defined(MTD_0) && MODULE_MTD_SDCARD
 #include "mtd_sdcard.h"
 #include "sdcard_spi.h"
 #include "sdcard_spi_params.h"
 
 #define SDCARD_SPI_NUM ARRAY_SIZE(sdcard_spi_params)
+
+/* SD card devices are provided by auto_init_sdcard_spi */
 extern sdcard_spi_t sdcard_spi_devs[SDCARD_SPI_NUM];
-mtd_sdcard_t mtd_sdcard_devs[SDCARD_SPI_NUM];
 
-/* always default to first sdcard*/
-static mtd_dev_t *mtd0 = (mtd_dev_t*)&mtd_sdcard_devs[0];
-
+/* Configure MTD device for the first SD card */
+static mtd_sdcard_t mtd_sdcard_dev = {
+    .base = {
+        .driver = &mtd_sdcard_driver
+    },
+    .sd_card = &sdcard_spi_devs[0],
+    .params = &sdcard_spi_params[0],
+};
+static mtd_dev_t *mtd0 = (mtd_dev_t*)&mtd_sdcard_dev;
 #define MTD_0 mtd0
 #endif
 
@@ -77,6 +85,21 @@ static spiffs_desc_t fs_desc = {
 
 /* spiffs driver will be used */
 #define FS_DRIVER spiffs_file_system
+
+#elif defined(MODULE_FATFS_VFS)
+/* include file system header */
+#include "fs/fatfs.h"
+
+/* file system specific descriptor
+ * as for littlefs, some fields can be changed if needed,
+ * this example focus on basic usage, i.e. entire memory used */
+static fatfs_desc_t fs_desc;
+
+/* provide mtd devices for use within diskio layer of fatfs */
+mtd_dev_t *fatfs_mtd_devs[FF_VOLUMES];
+
+/* fatfs driver will be used */
+#define FS_DRIVER fatfs_file_system
 #endif
 
 /* this structure defines the vfs mount point:
@@ -130,7 +153,7 @@ static int _mount(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS))
+#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS) || defined(MODULE_FATFS_VFS))
     int res = vfs_mount(&flash_mount);
     if (res < 0) {
         printf("Error while mounting %s...try format\n", FLASH_MOUNT_POINT);
@@ -149,7 +172,7 @@ static int _format(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS))
+#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS) || defined(MODULE_FATFS_VFS))
     int res = vfs_format(&flash_mount);
     if (res < 0) {
         printf("Error while formatting %s\n", FLASH_MOUNT_POINT);
@@ -168,7 +191,7 @@ static int _umount(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS))
+#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS) || defined(MODULE_FATFS_VFS))
     int res = vfs_umount(&flash_mount);
     if (res < 0) {
         printf("Error while unmounting %s\n", FLASH_MOUNT_POINT);
@@ -259,18 +282,12 @@ static const shell_command_t shell_commands[] = {
 
 int main(void)
 {
-#if MODULE_MTD_SDCARD
-    for (unsigned int i = 0; i < SDCARD_SPI_NUM; i++){
-        mtd_sdcard_devs[i].base.driver = &mtd_sdcard_driver;
-        mtd_sdcard_devs[i].sd_card = &sdcard_spi_devs[i];
-        mtd_sdcard_devs[i].params = &sdcard_spi_params[i];
-    }
-#endif
-
 #if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS))
     /* spiffs and littlefs need a mtd pointer
      * by default the whole memory is used */
     fs_desc.dev = MTD_0;
+#elif defined(MTD_0) && defined(MODULE_FATFS_VFS)
+    fatfs_mtd_devs[fs_desc.vol_idx] = MTD_0;
 #endif
     int res = vfs_mount(&const_mount);
     if (res < 0) {

--- a/pkg/fatfs/Makefile.dep
+++ b/pkg/fatfs/Makefile.dep
@@ -1,5 +1,4 @@
 USEMODULE += fatfs_diskio_mtd
-DEFAULT_MODULE += auto_init_storage
 USEMODULE += mtd
 
 # Use RTC for timestamps if available


### PR DESCRIPTION
### Contribution description

This adds support for fatfs to `examples/filesystem`.

This whole vfs/filesystem thing is in dire need of a cleanup.
But add this first to have a test-case that actually works for most supported file systems.


### Testing procedure

Attach an SD card using SPI. The easiest way is to solder jumper wires to one of those ubiquitous microSD -> SD Adapters. You will also have to provide a `sdcard_spi_params.h` for your board - just fill in the SPI pins.

![Vss = GND](http://elm-chan.org/docs/mmc/i/sdmm_contact.jpeg)

Now enable `mtd_sdcard` and `fatfs_vfs` - you should be able to `mount` and view the files on the SD card.

Note: VFS uses 32bit for size, so accessing areas beyond 4 GiB is probably broken.

### Issues/PRs references

The example still defaults to littlefs, so 21f8adb0b48bded1a71f63f5738e3b9d8a1deb41 from #14006 is needed to prevent a build failure on boards that have an SD card pre-configured.