### PR TITLE
gnrc_nettype: indirect NETTYPE definition via pseudo-modules

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -65,6 +65,7 @@ endif
 
 ifneq (,$(filter gnrc_gomach,$(USEMODULE)))
   USEMODULE += gnrc_netif
+  USEMODULE += gnrc_nettype_gomach
   USEMODULE += random
   USEMODULE += xtimer
   USEMODULE += gnrc_mac
@@ -78,6 +79,7 @@ ifneq (,$(filter gnrc_lorawan,$(USEMODULE)))
   USEMODULE += crypto_aes
   USEMODULE += netdev_layer
   USEMODULE += gnrc_neterr
+  USEMODULE += gnrc_nettype_lorawan
 endif
 
 ifneq (,$(filter sntp,$(USEMODULE)))
@@ -270,6 +272,7 @@ endif
 
 ifneq (,$(filter gnrc_sixlowpan,$(USEMODULE)))
   DEFAULT_MODULE += auto_init_gnrc_sixlowpan
+  USEMODULE += gnrc_nettype_sixlowpan
   USEMODULE += sixlowpan
 endif
 
@@ -304,6 +307,7 @@ endif
 ifneq (,$(filter gnrc_icmpv6,$(USEMODULE)))
   USEMODULE += inet_csum
   USEMODULE += gnrc_ipv6
+  USEMODULE += gnrc_nettype_icmpv6
   USEMODULE += icmpv6
 endif
 
@@ -322,6 +326,7 @@ endif
 
 ifneq (,$(filter gnrc_ipv6_ext,$(USEMODULE)))
   USEMODULE += gnrc_ipv6
+  USEMODULE += gnrc_nettype_ipv6_ext
 endif
 
 ifneq (,$(filter gnrc_ipv6_whitelist,$(USEMODULE)))
@@ -344,6 +349,7 @@ ifneq (,$(filter gnrc_ipv6,$(USEMODULE)))
   USEMODULE += gnrc_ipv6_hdr
   USEMODULE += gnrc_ipv6_nib
   USEMODULE += gnrc_netif
+  USEMODULE += gnrc_nettype_ipv6
 endif
 
 ifneq (,$(filter gnrc_ipv6_hdr,$(USEMODULE)))
@@ -396,12 +402,14 @@ endif
 
 ifneq (,$(filter gnrc_udp,$(USEMODULE)))
   DEFAULT_MODULE += auto_init_gnrc_udp
+  USEMODULE += gnrc_nettype_udp
   USEMODULE += inet_csum
   USEMODULE += udp
 endif
 
 ifneq (,$(filter gnrc_tcp,$(USEMODULE)))
   DEFAULT_MODULE += auto_init_gnrc_tcp
+  USEMODULE += gnrc_nettype_tcp
   USEMODULE += inet_csum
   USEMODULE += random
   USEMODULE += tcp
@@ -631,6 +639,7 @@ endif
 
 ifneq (,$(filter gnrc_lwmac,$(USEMODULE)))
   USEMODULE += gnrc_netif
+  USEMODULE += gnrc_nettype_lwmac
   USEMODULE += gnrc_mac
   FEATURES_REQUIRED += periph_rtt
 endif

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -35,6 +35,7 @@ PSEUDOMODULES += gnrc_netif_events
 PSEUDOMODULES += gnrc_pktbuf_cmd
 PSEUDOMODULES += gnrc_netif_cmd_%
 PSEUDOMODULES += gnrc_netif_dedup
+PSEUDOMODULES += gnrc_nettype_%
 PSEUDOMODULES += gnrc_sixloenc
 PSEUDOMODULES += gnrc_sixlowpan_border_router_default
 PSEUDOMODULES += gnrc_sixlowpan_default

--- a/pkg/ccn-lite/Makefile.dep
+++ b/pkg/ccn-lite/Makefile.dep
@@ -1,4 +1,5 @@
 USEMODULE += ccn-lite-utils
+USEMODULE += gnrc_nettype_ccn
 USEMODULE += evtimer
 USEMODULE += random
 USEMODULE += timex

--- a/pkg/ndn-riot/Makefile.dep
+++ b/pkg/ndn-riot/Makefile.dep
@@ -1,5 +1,6 @@
 USEMODULE += ndn-encoding
 USEMODULE += gnrc
+USEMODULE += gnrc_nettype_ndn
 USEMODULE += xtimer
 USEMODULE += random
 USEMODULE += hashes

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -151,9 +151,8 @@ typedef enum {
 
 /**
  * @brief   Translates an Ether Type number to @ref net_gnrc_nettype
- * @see     <a href="http://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml#ieee-802-numbers-1">
- *              IANA, ETHER TYPES
- *          </a>
+ * @see     [IANA, ETHER TYPES]
+ *          (http://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml)
  *
  * @param[in] type  An Ether Type number
  *
@@ -186,9 +185,8 @@ static inline gnrc_nettype_t gnrc_nettype_from_ethertype(uint16_t type)
 
 /**
  * @brief   Translates @ref net_gnrc_nettype to an Ether Type number
- * @see     <a href="http://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml#ieee-802-numbers-1">
- *              IANA, ETHER TYPES
- *          </a>
+ * @see     [IANA, ETHER TYPES]
+ *          (http://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml)
  *
  * @param[in] type  A protocol type
  *

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -15,6 +15,13 @@
  * the @ref net_gnrc_netreg, and the @ref net_gnrc_pkt to identify network protocols
  * throughout the network stack.
  *
+ * To include a nettype into your build, use the corresponding pseudo-module
+ * e.g. to use `GNRC_NETTYPE_IPV6` in your code, use
+ *
+ * ```
+ * USEMODULE += gnrc_nettype_ipv6
+ * ```
+ *
  * @{
  *
  * @file
@@ -27,6 +34,7 @@
 
 #include <inttypes.h>
 
+#include "kernel_defines.h"
 #include "net/ethertype.h"
 #include "net/protnum.h"
 
@@ -56,7 +64,7 @@ typedef enum {
     GNRC_NETTYPE_NETIF = -1,
     GNRC_NETTYPE_UNDEF = 0,     /**< Protocol is undefined */
 
-#ifdef MODULE_GNRC_SIXLOWPAN
+#if IS_USED(MODULE_GNRC_NETTYPE_SIXLOWPAN) || defined(DOXYGEN)
     GNRC_NETTYPE_SIXLOWPAN,     /**< Protocol is 6LoWPAN */
 #endif
 
@@ -64,7 +72,7 @@ typedef enum {
      * @{
      * @name Link layer
      */
-#ifdef MODULE_GNRC_GOMACH
+#if IS_USED(MODULE_GNRC_NETTYPE_GOMACH) || defined(DOXYGEN)
     GNRC_NETTYPE_GOMACH,         /**< Protocol is GoMacH */
 #endif
     /**
@@ -75,7 +83,7 @@ typedef enum {
      * @{
      * @name Link layer
      */
-#ifdef MODULE_GNRC_LWMAC
+#if IS_USED(MODULE_GNRC_NETTYPE_LWMAC) || defined(DOXYGEN)
     GNRC_NETTYPE_LWMAC,          /**< Protocol is lwMAC */
 #endif
     /**
@@ -86,13 +94,13 @@ typedef enum {
      * @{
      * @name Network layer
      */
-#ifdef MODULE_GNRC_IPV6
+#if IS_USED(MODULE_GNRC_NETTYPE_IPV6) || defined(DOXYGEN)
     GNRC_NETTYPE_IPV6,          /**< Protocol is IPv6 */
 #endif
-#ifdef MODULE_GNRC_IPV6_EXT
+#if IS_USED(MODULE_GNRC_NETTYPE_IPV6_EXT) || defined(DOXYGEN)
     GNRC_NETTYPE_IPV6_EXT,      /**< Protocol is IPv6 extension header */
 #endif
-#ifdef MODULE_GNRC_ICMPV6
+#if IS_USED(MODULE_GNRC_NETTYPE_ICMPV6) || defined(DOXYGEN)
     GNRC_NETTYPE_ICMPV6,        /**< Protocol is ICMPv6 */
 #endif
     /**
@@ -103,27 +111,27 @@ typedef enum {
      * @{
      * @name Transport layer
      */
-#ifdef MODULE_GNRC_TCP
+#if IS_USED(MODULE_GNRC_NETTYPE_TCP) || defined(DOXYGEN)
     GNRC_NETTYPE_TCP,           /**< Protocol is TCP */
 #endif
-#ifdef MODULE_GNRC_UDP
+#if IS_USED(MODULE_GNRC_NETTYPE_UDP) || defined(DOXYGEN)
     GNRC_NETTYPE_UDP,           /**< Protocol is UDP */
 #endif
     /**
      * @}
      */
 
-#ifdef MODULE_CCN_LITE
+#if IS_USED(MODULE_GNRC_NETTYPE_CCN) || defined(DOXYGEN)
     GNRC_NETTYPE_CCN,           /**< Protocol is CCN */
     GNRC_NETTYPE_CCN_CHUNK,     /**< Protocol is CCN, packet contains a content
                                      chunk */
 #endif
 
-#ifdef MODULE_NDN_RIOT
+#if IS_USED(MODULE_GNRC_NETTYPE_NDN) || defined(DOXYGEN)
     GNRC_NETTYPE_NDN,           /**< Protocol is NDN */
 #endif
 
-#ifdef MODULE_GNRC_LORAWAN
+#if IS_USED(MODULE_GNRC_NETTYPE_LORAWAN) || defined(DOXYGEN)
     GNRC_NETTYPE_LORAWAN,       /**< Protocol is LoRaWAN */
 #endif
 
@@ -155,19 +163,19 @@ typedef enum {
 static inline gnrc_nettype_t gnrc_nettype_from_ethertype(uint16_t type)
 {
     switch (type) {
-#ifdef MODULE_GNRC_IPV6
+#if IS_USED(MODULE_GNRC_NETTYPE_IPV6)
         case ETHERTYPE_IPV6:
             return GNRC_NETTYPE_IPV6;
 #endif
-#if defined(MODULE_CCN_LITE) || defined(MODULE_NDN_RIOT)
+#if IS_USED(MODULE_GNRC_NETTYPE_CCN) || IS_USED(MODULE_GNRC_NETTYPE_NDN)
         case ETHERTYPE_NDN:
-#if defined(MODULE_CCN_LITE)
+#if IS_USED(MODULE_GNRC_NETTYPE_CCN)
             return GNRC_NETTYPE_CCN;
-#elif defined(MODULE_NDN_RIOT)
+#elif IS_USED(MODULE_GNRC_NETTYPE_NDN)
             return GNRC_NETTYPE_NDN;
 #endif
 #endif
-#ifdef MODULE_GNRC_SIXLOENC
+#if IS_USED(MODULE_GNRC_SIXLOENC) && IS_USED(MODULE_GNRC_NETTYPE_SIXLOWPAN)
         case ETHERTYPE_6LOENC:
             return GNRC_NETTYPE_SIXLOWPAN;
 #endif
@@ -190,19 +198,19 @@ static inline gnrc_nettype_t gnrc_nettype_from_ethertype(uint16_t type)
 static inline uint16_t gnrc_nettype_to_ethertype(gnrc_nettype_t type)
 {
     switch (type) {
-#ifdef MODULE_GNRC_SIXLOENC
+#if IS_USED(MODULE_GNRC_SIXLOENC) && IS_USED(MODULE_GNRC_NETTYPE_SIXLOWPAN)
         case GNRC_NETTYPE_SIXLOWPAN:
             return ETHERTYPE_6LOENC;
 #endif
-#ifdef MODULE_GNRC_IPV6
+#if IS_USED(MODULE_GNRC_NETTYPE_IPV6)
         case GNRC_NETTYPE_IPV6:
             return ETHERTYPE_IPV6;
 #endif
-#ifdef MODULE_CCN_LITE
+#if IS_USED(MODULE_GNRC_NETTYPE_CCN)
         case GNRC_NETTYPE_CCN:
             return ETHERTYPE_NDN;
 #endif
-#ifdef MODULE_NDN_RIOT
+#if IS_USED(MODULE_GNRC_NETTYPE_NDN)
         case GNRC_NETTYPE_NDN:
             return ETHERTYPE_NDN;
 #endif
@@ -225,23 +233,23 @@ static inline uint16_t gnrc_nettype_to_ethertype(gnrc_nettype_t type)
 static inline gnrc_nettype_t gnrc_nettype_from_protnum(uint8_t num)
 {
     switch (num) {
-#ifdef MODULE_GNRC_ICMPV6
+#if IS_USED(MODULE_GNRC_NETTYPE_ICMPV6)
         case PROTNUM_ICMPV6:
             return GNRC_NETTYPE_ICMPV6;
 #endif
-#ifdef MODULE_GNRC_IPV6
+#if IS_USED(MODULE_GNRC_NETTYPE_IPV6)
         case PROTNUM_IPV6:
             return GNRC_NETTYPE_IPV6;
 #endif
-#ifdef MODULE_GNRC_TCP
+#if IS_USED(MODULE_GNRC_NETTYPE_TCP)
         case PROTNUM_TCP:
             return GNRC_NETTYPE_TCP;
 #endif
-#ifdef MODULE_GNRC_UDP
+#if IS_USED(MODULE_GNRC_NETTYPE_UDP)
         case PROTNUM_UDP:
             return GNRC_NETTYPE_UDP;
 #endif
-#ifdef MODULE_GNRC_IPV6_EXT
+#if IS_USED(MODULE_GNRC_NETTYPE_IPV6_EXT)
         case PROTNUM_IPV6_EXT_HOPOPT:
         case PROTNUM_IPV6_EXT_DST:
         case PROTNUM_IPV6_EXT_RH:
@@ -270,19 +278,19 @@ static inline gnrc_nettype_t gnrc_nettype_from_protnum(uint8_t num)
 static inline uint8_t gnrc_nettype_to_protnum(gnrc_nettype_t type)
 {
     switch (type) {
-#ifdef MODULE_GNRC_ICMPV6
+#if IS_USED(MODULE_GNRC_NETTYPE_ICMPV6)
         case GNRC_NETTYPE_ICMPV6:
             return PROTNUM_ICMPV6;
 #endif
-#ifdef MODULE_GNRC_IPV6
+#if IS_USED(MODULE_GNRC_NETTYPE_IPV6)
         case GNRC_NETTYPE_IPV6:
             return PROTNUM_IPV6;
 #endif
-#ifdef MODULE_GNRC_TCP
+#if IS_USED(MODULE_GNRC_NETTYPE_TCP)
         case GNRC_NETTYPE_TCP:
             return PROTNUM_TCP;
 #endif
-#ifdef MODULE_GNRC_UDP
+#if IS_USED(MODULE_GNRC_NETTYPE_UDP)
         case GNRC_NETTYPE_UDP:
             return PROTNUM_UDP;
 #endif


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Instead of making a NETTYPE definition dependent on an implementation module, this change makes it dependent on a pseudo-module for each specific NETTYPE and makes the respective implementation modules dependent on it.
    
This has two advantages:
- one does not need include the whole implementation module to subscribe to a NETTYPE for testing or to provide an alternative implementation
- A lot of circular dependencies related to GNRC could be untangled. E.g. the only reason `gnrc_icmpv6` needs the `gnrc_ipv6` is because it uses `GNRC_NETTYPE_IPV6` to search for the IPv6 header in an ICMPv6 when demultiplexing an ICMPv6 header.
    
This change does not resolve these dependencies or include usages where needed. The only dependency change is the addition of the pseudo-modules to the implementation modules.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Everything should still compile and the binaries stay the same.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but among the things mentioned above it helps with phase II of the Kconfig migration.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
