### PR TITLE
cpu/cortexm_common: add inlined header only def for irq_%

### DIFF
--- a/core/include/irq.h
+++ b/core/include/irq.h
@@ -22,10 +22,17 @@
 #define IRQ_H
 
 #include <stdbool.h>
+#include "cpu_conf.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifdef IRQ_API_INLINED
+#define MAYBE_INLINE static inline __attribute__((always_inline))
+#else
+#define MAYBE_INLINE
+#endif /* IRQ_API_INLINED */
 
 /**
  * @brief   This function sets the IRQ disable bit in the status register
@@ -36,7 +43,7 @@ extern "C" {
  *
  * @see     irq_restore
  */
-unsigned irq_disable(void);
+MAYBE_INLINE unsigned irq_disable(void);
 
 /**
  * @brief   This function clears the IRQ disable bit in the status register
@@ -47,7 +54,7 @@ unsigned irq_disable(void);
  *
  * @see     irq_restore
  */
-unsigned irq_enable(void);
+MAYBE_INLINE unsigned irq_enable(void);
 
 /**
  * @brief   This function restores the IRQ disable bit in the status register
@@ -58,13 +65,17 @@ unsigned irq_enable(void);
  * @see     irq_enable
  * @see     irq_disable
  */
-void irq_restore(unsigned state);
+MAYBE_INLINE void irq_restore(unsigned state);
 
 /**
  * @brief   Check whether called from interrupt service routine
  * @return  true, if in interrupt service routine, false if not
  */
-int irq_is_in(void);
+MAYBE_INLINE int irq_is_in(void);
+
+#ifdef IRQ_API_INLINED
+#include "irq_arch.h"
+#endif /* IRQ_API_INLINED */
 
 #ifdef __cplusplus
 }

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -170,12 +170,7 @@ static inline void cortexm_sleep(int deep)
     unsigned state = irq_disable();
     __DSB();
     __WFI();
-#if defined(CPU_MODEL_STM32L152RE)
-    /* STM32L152RE crashes if branching to irq_restore(state). See #11830. */
-    __set_PRIMASK(state);
-#else
     irq_restore(state);
-#endif
 }
 
 /**

--- a/cpu/cortexm_common/include/cpu_conf_common.h
+++ b/cpu/cortexm_common/include/cpu_conf_common.h
@@ -164,6 +164,12 @@ extern "C" {
 #define BACKUP_RAM_DATA __attribute__((section(".backup.data")))
 #endif /* CPU_HAS_BACKUP_RAM */
 
+
+/**
+ * @brief   This arch uses the inlined irq API.
+ */
+#define IRQ_API_INLINED     (1)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/cortexm_common/include/irq_arch.h
+++ b/cpu/cortexm_common/include/irq_arch.h
@@ -19,8 +19,8 @@
  */
 
 
-#ifndef _IRQ_ARCH_H
-#define _IRQ_ARCH_H
+#ifndef IRQ_ARCH_H
+#define IRQ_ARCH_H
 
 #include <stdint.h>
 #include "cpu_conf.h"
@@ -35,6 +35,7 @@ extern "C" {
 static inline __attribute__((always_inline)) unsigned int irq_disable(void)
 {
     uint32_t mask = __get_PRIMASK();
+
     __disable_irq();
     return mask;
 }
@@ -45,8 +46,10 @@ static inline __attribute__((always_inline)) unsigned int irq_disable(void)
 static inline __attribute__((always_inline)) __attribute__((used)) unsigned int
 irq_enable(void)
 {
+    unsigned result = __get_PRIMASK();
+
     __enable_irq();
-    return __get_PRIMASK();
+    return result;
 }
 
 /**
@@ -70,5 +73,5 @@ static inline __attribute__((always_inline)) int irq_is_in(void)
 }
 #endif
 
-#endif /* _IRQ_ARCH_H */
+#endif /* IRQ_ARCH_H */
 /** @} */

--- a/cpu/cortexm_common/include/irq_arch.h
+++ b/cpu/cortexm_common/include/irq_arch.h
@@ -18,14 +18,21 @@
  * @}
  */
 
+
+#ifndef _IRQ_ARCH_H
+#define _IRQ_ARCH_H
+
 #include <stdint.h>
-#include "irq.h"
-#include "cpu.h"
+#include "cpu_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Disable all maskable interrupts
  */
-unsigned int irq_disable(void)
+static inline __attribute__((always_inline)) unsigned int irq_disable(void)
 {
     uint32_t mask = __get_PRIMASK();
     __disable_irq();
@@ -35,7 +42,8 @@ unsigned int irq_disable(void)
 /**
  * @brief Enable all maskable interrupts
  */
-__attribute__((used)) unsigned int irq_enable(void)
+static inline __attribute__((always_inline)) __attribute__((used)) unsigned int
+irq_enable(void)
 {
     __enable_irq();
     return __get_PRIMASK();
@@ -44,7 +52,8 @@ __attribute__((used)) unsigned int irq_enable(void)
 /**
  * @brief Restore the state of the IRQ flags
  */
-void irq_restore(unsigned int state)
+static inline __attribute__((always_inline)) void irq_restore(
+    unsigned int state)
 {
     __set_PRIMASK(state);
 }
@@ -52,7 +61,14 @@ void irq_restore(unsigned int state)
 /**
  * @brief See if the current context is inside an ISR
  */
-int irq_is_in(void)
+static inline __attribute__((always_inline)) int irq_is_in(void)
 {
     return (__get_IPSR() & 0xFF);
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _IRQ_ARCH_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

irq_% are not inlined by the compiler which leads to it branching
to a function that actually implement a single machine instruction.

Inlining these functions makes the call more efficient as well as
saving some bytes in ROM.

This could probably be done for more arch, but I wanted to first do
it for a single arch first.

### Testing procedure

- All applications should still work

- check footprint difference, `BUILD_IN_DOCKER=1 BOARD=<board>make -C examples/gnrc_networking`

**iotlab-m3 cortexm3:**

- PR

```
  text    data     bss     dec     hex filename
  87536     184   19240  106960   1a1d0 /data/riotbuild/riotbase/examples/gnrc_networking/bin/iotlab-m3/gnrc_networking.elf
```

- master

```
  text    data     bss     dec     hex filename
  87740     184   19240  107164   1a29c /data/riotbuild/riotbase/examples/gnrc_networking/bin/iotlab-m3/gnrc_networking.elf
```

**samr21-xpro cortexm0:**

- PR

```
  text    data     bss     dec     hex filename
  91488     184   19240  110912   1b140 /data/riotbuild/riotbase/examples/gnrc_networking/bin/samr21-xpro/gnrc_networking.elf
```

- master

```
  text    data     bss     dec     hex filename
  91588     184   19240  111012   1b1a4 /data/riotbuild/riotbase/examples/gnrc_networking/bin/samr21-xpro/gnrc_networking.elf
```

**nrf52dk cortexm4:**

- PR

```
  text    data     bss     dec     hex filename
  162048     284   47616  209948   3341c /data/riotbuild/riotbase/examples/gnrc_networking/bin/nrf52dk/gnrc_networking.elf
```

- master

```
  text    data     bss     dec     hex filename
  162248     284   47616  210148   334e4 /data/riotbuild/riotbase/examples/gnrc_networking/bin/nrf52dk/gnrc_networking.elf
```

### Issues/PRs references

Came up a while ago in #11919