### PR TITLE
 cpu/nrf5x_common: enable bias correction in hwrng

### DIFF
--- a/cpu/nrf5x_common/periph/hwrng.c
+++ b/cpu/nrf5x_common/periph/hwrng.c
@@ -30,7 +30,8 @@
 
 void hwrng_init(void)
 {
-    /* nothing to do here */
+    /* enable bias correction */
+    NRF_RNG->CONFIG = 1;
 }
 
 /*


### PR DESCRIPTION
### Contribution description

The nRF5x MCUs embed a bias correction mechanism for the hardware random number generator ("digital error correction" on nRF51) to ensure a statistically uniform distribution of the random values. This post processing increases generation time (factor of more than 2), but statistically it is absolutely worth it. Since we typically use the HWRNG only once for PRNG seeding, its numbers should be high quality whereas performance is secondary.

This PR enables bias correction for all nRF5x platforms. I've checked the manuals for nRF51, nRF52832, nRF5840 and they all support it.


### Testing procedure

- "Play" with *tests/rng* (change random source to HWRNG by `source 2`).
- "Play" with *tests/periph_hwrng*.
- Check reference manuals.
- Optionally, pipe data to a statistical analysis tool and see that random properties are notably improved with bias correction.
