### PR TITLE
sys/shell: commands: Check argc in _pm_handler

### DIFF
--- a/sys/shell/commands/sc_pm.c
+++ b/sys/shell/commands/sc_pm.c
@@ -149,6 +149,11 @@ static int cmd_off(char *arg)
 
 int _pm_handler(int argc, char **argv)
 {
+    if (argc < 2) {
+        _print_usage();
+        return 1;
+    }
+
 #ifdef MODULE_PM_LAYERED
     if (!strcmp(argv[1], "show")) {
         if (argc != 2) {
@@ -182,8 +187,6 @@ int _pm_handler(int argc, char **argv)
 
         return cmd_set(argv[2]);
     }
-#else
-    (void)argc;
 #endif /* MODULE_PM_LAYERED */
 
     if (!strcmp(argv[1], "off")) {


### PR DESCRIPTION
### Contribution description

I noticed that the command `pm` is now available in the shell when a board is flashed with `examples/default`. However, when I only entered `pm` and not `pm off`, I got a data bus error on a 6lowpan-clicker. On a pic32-wifire, the board reboots.

This is due to accessing args out-of-bound in function `_pm_handler` at line 153 and line 189. 

### Testing procedure

Flash `examples/default` on a board. If you only type `pm`, the board should not crash/reboot. It should simply print how to use this command.

### Issues/PRs references

None. Found while working on #13820 .