### PR TITLE
pkg/fs: initialize MTD device before accessing it's properties

### DIFF
--- a/pkg/littlefs/fs/littlefs_fs.c
+++ b/pkg/littlefs/fs/littlefs_fs.c
@@ -132,6 +132,12 @@ static int prepare(littlefs_desc_t *fs)
     mutex_init(&fs->lock);
     mutex_lock(&fs->lock);
 
+    int ret = mtd_init(fs->dev);
+
+    if (ret) {
+        return ret;
+    }
+
     memset(&fs->fs, 0, sizeof(fs->fs));
 
     if (!fs->config.block_count) {
@@ -163,7 +169,7 @@ static int prepare(littlefs_desc_t *fs)
     fs->config.prog_buffer = fs->prog_buf;
 #endif
 
-    return mtd_init(fs->dev);
+    return 0;
 }
 
 static int _format(vfs_mount_t *mountp)

--- a/pkg/littlefs2/fs/littlefs2_fs.c
+++ b/pkg/littlefs2/fs/littlefs2_fs.c
@@ -132,6 +132,12 @@ static int prepare(littlefs_desc_t *fs)
     mutex_init(&fs->lock);
     mutex_lock(&fs->lock);
 
+    int ret = mtd_init(fs->dev);
+
+    if (ret) {
+        return ret;
+    }
+
     memset(&fs->fs, 0, sizeof(fs->fs));
 
     if (!fs->config.block_count) {
@@ -169,7 +175,7 @@ static int prepare(littlefs_desc_t *fs)
     fs->config.prog_buffer = fs->prog_buf;
 #endif
 
-    return mtd_init(fs->dev);
+    return 0;
 }
 
 static int _format(vfs_mount_t *mountp)

--- a/pkg/spiffs/fs/spiffs_fs.c
+++ b/pkg/spiffs/fs/spiffs_fs.c
@@ -129,6 +129,12 @@ static int prepare(spiffs_desc_t *fs_desc)
     mtd_dev_t *dev = SPIFFS_MTD_DEV;
 #endif
 
+    int res = mtd_init(dev);
+
+    if (res) {
+        return res;
+    }
+
     fs_desc->config.hal_read_f = _dev_read;
     fs_desc->config.hal_write_f = _dev_write;
     fs_desc->config.hal_erase_f = _dev_erase;
@@ -149,7 +155,7 @@ static int prepare(spiffs_desc_t *fs_desc)
     fs_desc->config.phys_erase_block = dev->page_size * dev->pages_per_sector;
 #endif
 
-    return mtd_init(dev);
+    return 0;
 }
 
 static int _format(vfs_mount_t *mountp)


### PR DESCRIPTION
### Contribution description

This includes a bunch of small misc fixes around SD card use.

 - ~~`sdcard_spi` relies on `auto_init_storage`. This was previously pulled in by FatFS. But it makes much more sense for the SD card driver to pull that in as it's the only module that uses `auto_init_storage`.~~
 - Some file systems would read physical properties from `fs->dev` *before* initializing `fs->dev`. If those parameters are determined at run-time (SD card, but this can also be done for SPI flash) they would read 0 here.

### Testing procedure

Together with #13993 you should now be able to use all file systems on SD card.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
