### PR TITLE
Initial nrf52811 support

### DIFF
--- a/cpu/nrf52/Makefile.include
+++ b/cpu/nrf52/Makefile.include
@@ -10,6 +10,10 @@ export MCUBOOT_SLOT1_SIZE = 0x3C000
 export MCUBOOT_SLOT2_SIZE = 0x3C000
 
 # Set ROM and RAM lengths according to CPU model
+ifneq (,$(filter nrf52811xxaa,$(CPU_MODEL)))
+  ROM_LEN ?= 0x30000
+  RAM_LEN ?= 0x6000
+endif
 ifneq (,$(filter nrf52832xxaa,$(CPU_MODEL)))
   ROM_LEN ?= 0x80000
   RAM_LEN ?= 0x10000

--- a/cpu/nrf52/include/cpu_conf.h
+++ b/cpu/nrf52/include/cpu_conf.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Freie Universität Berlin
+ *               2020 Philipp-Alexander Blum <philipp-blum@jakiku.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -16,6 +17,7 @@
  * @brief       nRF52 specific CPU configuration
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Philipp-Alexander Blum <philipp-blum@jakiku.de>
  *
  */
 
@@ -27,7 +29,7 @@
 #ifdef CPU_MODEL_NRF52832XXAA
 #include "vendor/nrf52.h"
 #include "vendor/nrf52_bitfields.h"
-#elif defined(CPU_MODEL_NRF52840XXAA)
+#elif defined(CPU_MODEL_NRF52811XXAA) || defined(CPU_MODEL_NRF52840XXAA)
 #include "vendor/nrf52840.h"
 #include "vendor/nrf52840_bitfields.h"
 #else
@@ -44,9 +46,12 @@ extern "C" {
  */
 #define CPU_DEFAULT_IRQ_PRIO            (2U)
 #define CPU_FLASH_BASE                  (0x00000000)
-#ifdef CPU_MODEL_NRF52832XXAA
+
+#if defined(CPU_MODEL_NRF52811XXAA)
+#define CPU_IRQ_NUMOF                   (29U)
+#elif defined(CPU_MODEL_NRF52832XXAA)
 #define CPU_IRQ_NUMOF                   (38U)
-#elif CPU_MODEL_NRF52840XXAA
+#elif defined(CPU_MODEL_NRF52840XXAA)
 #define CPU_IRQ_NUMOF                   (46U)
 #endif
 /** @} */
@@ -57,7 +62,9 @@ extern "C" {
  */
 #define FLASHPAGE_SIZE                  (4096U)
 
-#if defined(CPU_MODEL_NRF52832XXAA)
+#if defined(CPU_MODEL_NRF52811XXAA)
+#define FLASHPAGE_NUMOF                 (48U)
+#elif defined(CPU_MODEL_NRF52832XXAA)
 #define FLASHPAGE_NUMOF                 (128U)
 #elif defined(CPU_MODEL_NRF52840XXAA)
 #define FLASHPAGE_NUMOF                 (256U)

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015-2018 Freie Universität Berlin
+ *               2020 Philipp-Alexander Blum <philipp-blum@jakiku.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief           nRF52 specific definitions for handling peripherals
  *
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author          Philipp-Alexander Blum <philipp-blum@jakiku.de>
  */
 
 #ifndef PERIPH_CPU_H
@@ -42,7 +44,7 @@ extern "C" {
 #define SPI_SCKSEL          (dev(bus)->PSEL.SCK)
 #define SPI_MOSISEL         (dev(bus)->PSEL.MOSI)
 #define SPI_MISOSEL         (dev(bus)->PSEL.MISO)
-#ifndef CPU_MODEL_NRF52840XXAA
+#ifdef CPU_MODEL_NRF52832XXAA
 #define UART_IRQN           (UARTE0_UART0_IRQn)
 #endif
 /** @} */
@@ -161,12 +163,13 @@ typedef struct {
     gpio_t pin[PWM_CHANNELS];           /**< PWM out pins */
 } pwm_conf_t;
 
-#ifdef CPU_MODEL_NRF52840XXAA
+#if defined(CPU_MODEL_NRF52811XXAA) || defined(CPU_MODEL_NRF52840XXAA)
 /**
  * @brief   Structure for UART configuration data
  */
 typedef struct {
-    NRF_UARTE_Type *dev;    /**< UART with EasyDMA device base register address */
+    NRF_UARTE_Type *dev;    /**< UART with EasyDMA device base
+                             * register address */
     gpio_t rx_pin;          /**< RX pin */
     gpio_t tx_pin;          /**< TX pin */
 #ifdef MODULE_PERIPH_UART_HW_FC

--- a/cpu/nrf52/vectors.c
+++ b/cpu/nrf52/vectors.c
@@ -1,11 +1,11 @@
 /*
  * Copyright (C) 2016 Freie Universität Berlin
+ *               2020 Philipp-Alexander Blum <philipp-blum@jakiku.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
-
 
 /**
  * @ingroup     cpu_nrf52
@@ -15,6 +15,7 @@
  * @brief       nRF52 interrupt vector definitions
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Philipp-Alexander Blum <philipp-blum@jakiku.de>
  *
  * @}
  */
@@ -34,6 +35,7 @@ void dummy_handler(void) {
 WEAK_DEFAULT void isr_power_clock(void);
 WEAK_DEFAULT void isr_radio(void);
 WEAK_DEFAULT void isr_uart0(void);
+WEAK_DEFAULT void isr_spi0(void);
 WEAK_DEFAULT void isr_spi0_twi0(void);
 WEAK_DEFAULT void isr_spi1_twi1(void);
 WEAK_DEFAULT void isr_nfct(void);
@@ -96,8 +98,43 @@ WEAK_DEFAULT void isr_pwm3(void);
 extern void SWI2_EGU2_IRQHandler(void);
 #endif
 
+#if defined(CPU_MODEL_NRF52811XXAA)
 /* CPU specific interrupt vector table */
 ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
+    isr_power_clock,       /* power_clock */
+    isr_radio,             /* radio */
+    isr_uart0,             /* uart0 */
+    isr_spi1_twi1,         /* spi1_twi1 */
+    isr_spi0,              /* spi 0 */
+    (0UL),                 /* reserved */
+    isr_gpiote,            /* gpiote */
+    isr_saadc,             /* adc */
+    isr_timer0,            /* timer0 */
+    isr_timer1,            /* timer1 */
+    isr_timer2,            /* timer2 */
+    isr_rtc0,              /* rtc0 */
+    isr_temp,              /* temp */
+    isr_rng,               /* rng */
+    isr_ecb,               /* ecb */
+    isr_ccm_aar,           /* ccm_aar */
+    isr_wdt,               /* wdt */
+    isr_rtc1,              /* rtc1 */
+    isr_qdec,              /* qdec */
+    isr_lpcomp,            /* lpcomp */
+    isr_swi0,              /* swi0 */
+    isr_swi1,              /* swi1 */
+    isr_swi3,              /* swi3 */
+    isr_swi4,              /* swi4 */
+    isr_swi5,              /* swi5 */
+    (0UL),                 /* reserved */
+    (0UL),                 /* reserved */
+    isr_pwm0,              /* pwm 0 */
+    isr_pdm,               /* pdm */
+};
+#else
+/* CPU specific interrupt vector table */
+ISR_VECTOR(1)
+const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_power_clock,       /* power_clock */
     isr_radio,             /* radio */
     isr_uart0,             /* uart0 */
@@ -132,8 +169,8 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_timer4,            /* timer 4 */
     isr_pwm0,              /* pwm 0 */
     isr_pdm,               /* pdm */
-    (0UL),                  /* reserved */
-    (0UL),                  /* reserved */
+    (0UL),                 /* reserved */
+    (0UL),                 /* reserved */
     isr_mwu,               /* mwu */
     isr_pwm1,              /* pwm 1 */
     isr_pwm2,              /* pwm 2 */
@@ -151,3 +188,4 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_pwm3,              /* pwm3 */
 #endif
 };
+#endif


### PR DESCRIPTION
### Contribution description
Initial support for the nrf52811 MCU. Will, at some point, add the board configuration for the [nrf52811 mdk](https://www.aliexpress.com/item/4000120757699.html?spm=a2g0s.9042311.0.0.27424c4dCWvTWJ) as well.
Restructuring files etc. makes probably sense at this point.


### Testing procedure
Only tested hello world on the [nrf52811mdk](https://www.aliexpress.com/item/4000120757699.html?spm=a2g0s.9042311.0.0.27424c4dCWvTWJ).


### Issues/PRs references
Intitial support the nrf52811 as mentioned in #13054.
