### PR TITLE
makefiles/info.inc.mk: fix supported boards output

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -99,8 +99,11 @@ endif
 ifneq (,$(BOARDSDIR))
   # Only warn users, not the CI.
   ifneq ($(RIOT_CI_BUILD),1)
-    $(warning Using BOARDSDIR is deprecated use EXTERNAL_BOARD_DIRS instead)
-    $(info EXTERNAL_BOARD_DIRS can contain multiple folders separated by space)
+    # Do not warn when set from sub-make
+    ifeq ($(MAKELEVEL),0)
+      $(warning Using BOARDSDIR is deprecated use EXTERNAL_BOARD_DIRS instead)
+      $(info EXTERNAL_BOARD_DIRS can contain multiple folders separated by space)
+    endif
   endif
   EXTERNAL_BOARD_DIRS += $(BOARDSDIR)
 endif

--- a/Makefile.include
+++ b/Makefile.include
@@ -186,10 +186,6 @@ GLOBAL_GOALS += buildtest \
                 #
 
 ifneq (, $(filter $(GLOBAL_GOALS), $(MAKECMDGOALS)))
-  BOARD=none
-endif
-
-ifeq (none,$(BOARD))
   include $(RIOTMAKE)/info-global.inc.mk
   include $(RIOTMAKE)/buildtests.inc.mk
 else
@@ -950,7 +946,7 @@ ifneq ($(_BASELIBS_VALUE_BEFORE_USAGE),$(BASELIBS))
   $(error BASELIBS value changed)
 endif
 
-endif # BOARD=none
+endif
 
 # include RIOT_MAKEFILES_GLOBAL_POST configuration files
 # allows setting user specific system wide configuration parsed after the body


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes 2 issues I got with the `info-build` target:
- the list of supported boards for a given application was empty
- a warning about BOARDSDIR being used was displayed on stderr.

Hopefully both issues come from the same problem: the BOARD variable was still set in the environment of the `make info-board-supported` command which is run under `make info-build`.

Clearing the env of the subcommand fixes the issue, so that's what this PR is doing.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try the following commands:
```
make BOARD=nucleo-f103rb -C examples/hello-world --no-print-directory info-build
make BOARD=nucleo-f103rb -C examples/hello-world --no-print-directory info-build > /dev/null
```

<details><summary>this PR</summary>

```
make BOARD=nucleo-f103rb -C examples/hello-world --no-print-directory info-build
APPLICATION: hello-world
APPDIR:      /work/riot/RIOT/examples/hello-world

supported boards:
6lowpan-clicker acd52832 airfy-beacon arduino-due arduino-duemilanove arduino-leonardo arduino-mega2560 arduino-nano arduino-uno arduino-zero atmega1284p atmega256rfr2-xpro atmega328p avr-rss2 avsextrem b-l072z-lrwan1 b-l475e-iot01a blackpill blackpill-128kib bluepill bluepill-128kib calliope-mini cc1312-launchpad cc1352-launchpad cc1352p-launchpad cc2538dk cc2650-launchpad cc2650stk chronos derfmega128 derfmega256 ek-lm4f120xl esp32-heltec-lora32-v2 esp32-mh-et-live-minikit esp32-olimex-evb esp32-ttgo-t-beam esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing f4vi1 feather-nrf52840 firefly fox frdm-k22f frdm-k64f frdm-kw41z hamilton hifive1 hifive1b i-nucleo-lrwan1 ikea-tradfri im880b iotlab-a8-m3 iotlab-m3 limifrog-v1 lobaro-lorabox lsn50 maple-mini mbed_lpc1768 mcb2388 mega-xplained microbit microduino-corerf msb-430 msb-430h msba2 msbiot mulle native nrf51dk nrf51dongle nrf52832-mdk nrf52840-mdk nrf52840dk nrf52dk nrf6310 nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 nucleo-f070rb nucleo-f072rb nucleo-f091rc nucleo-f103rb nucleo-f207zg nucleo-f302r8 nucleo-f303k8 nucleo-f303re nucleo-f303ze nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f446re nucleo-f446ze nucleo-f722ze nucleo-f746zg nucleo-f767zi nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l412kb nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg nucleo-l4r5zi nz32-sc151 olimexino-stm32 opencm904 openlabs-kw41z-mini openlabs-kw41z-mini-256kib openmote-b openmote-cc2538 p-l496g-cell02 p-nucleo-wb55 particle-argon particle-boron particle-xenon pba-d-01-kw2x phynode-kw41z pic32-wifire pinetime pyboard reel remote-pa remote-reva remote-revb ruuvitag samd21-xpro same54-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro samr34-xpro seeeduino_arch-pro sensebox_samd21 slstk3401a slstk3402a sltb001a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a slwstk6220a spark-core stk3600 stk3700 stm32f030f4-demo stm32f0discovery stm32f3discovery stm32f429i-disc1 stm32f4discovery stm32f723e-disco stm32f769i-disco stm32l0538-disco stm32l476g-disco teensy31 telosb thingy52 ublox-c030-u201 udoo usb-kw41z waspmote-pro wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1

BOARD:   nucleo-f103rb
CPU:     stm32f1
MCU:     stm32f1

RIOTBASE:    /work/riot/RIOT
BOARDDIR:    /work/riot/RIOT/boards/nucleo-f103rb
EXTERNAL_BOARD_DIRS:
RIOTCPU:     /work/riot/RIOT/cpu
RIOTPKG:     /work/riot/RIOT/pkg

DEFAULT_MODULE: auto_init board core core_init core_msg core_panic cpu periph_init periph_init_gpio periph_init_pm periph_init_uart sys
DISABLE_MODULE: 
USEMODULE:      boards_common_nucleo cortexm_common cortexm_common_periph newlib newlib_nano newlib_syscalls_default periph periph_common periph_gpio periph_pm periph_uart pm_layered stdio_uart stm32_common stm32_common_periph

ELFFILE: /work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/hello-world.elf
HEXFILE: /work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/hello-world.hex
BINFILE: /work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/hello-world.bin
FLASHFILE: /work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/hello-world.elf

FEATURES_USED:
         arch_32bit arch_arm arch_cortexm periph_gpio periph_pm periph_uart
FEATURES_REQUIRED:
         arch_32bit arch_arm arch_cortexm periph_uart
FEATURES_REQUIRED_ANY:
         -none-
FEATURES_OPTIONAL_ONLY (optional that are not required, strictly "nice to have"):
         cortexm_fpu periph_gpio periph_pm
FEATURES_OPTIONAL_MISSING (missing optional features):
         cortexm_fpu
FEATURES_PROVIDED (by the board or USEMODULE'd drivers):
         arch_32bit arch_arm arch_cortexm arduino cpp cpu_check_address cpu_stm32f1 periph_cpuid periph_flashpage periph_flashpage_raw periph_gpio periph_gpio_irq periph_i2c periph_pm periph_rtc periph_rtt periph_spi periph_timer periph_uart periph_uart_modecfg periph_wdt puf_sram ssp
FEATURES_MISSING (only non optional features):
         -none-
FEATURES_BLACKLIST (blacklisted features):
         bootloader_arduino bootloader_nrfutil
FEATURES_USED_BLACKLISTED (used but blacklisted features):
         -none-

FEATURES_CONFLICT:     periph_rtc:periph_rtt
FEATURES_CONFLICT_MSG: "On the STM32F1, the RTC and RTT map to the same hardware peripheral."
FEATURES_CONFLICTING:
         -none-

INCLUDES: 
	-isystem  
	/work/tools/gcc-arm-none-eabi-9-2019-q4-major/arm-none-eabi/include/newlib-nano  
	-I/work/riot/RIOT/core/include  
	-I/work/riot/RIOT/drivers/include  
	-I/work/riot/RIOT/sys/include  
	-I/work/riot/RIOT/boards/nucleo-f103rb/include  
	-I/work/riot/RIOT/boards/common/nucleo/include  
	-I/work/riot/RIOT/boards/common/stm32/include  
	-I/work/riot/RIOT/boards/common/nucleo64/include  
	-I/work/riot/RIOT/cpu/stm32f1/include  
	-I/work/riot/RIOT/cpu/stm32_common/include  
	-I/work/riot/RIOT/cpu/cortexm_common/include  
	-I/work/riot/RIOT/cpu/cortexm_common/include/vendor  
	-I/work/riot/RIOT/sys/libc/include

CC:      arm-none-eabi-gcc
CFLAGS: 
	-DDEVELHELP  
	-Werror  
	-DSTM32F1_DISABLE_JTAG  
	-DCPU_FAM_STM32F1  
	-DSTM32F103xB  
	-DCPU_LINE_STM32F103xB  
	-DSTM32_FLASHSIZE=131072U  
	-mno-thumb-interwork  
	-mcpu=cortex-m3  
	-mlittle-endian  
	-mthumb  
	-mfloat-abi=soft  
	-ffunction-sections  
	-fdata-sections  
	-fno-builtin  
	-fshort-enums  
	-ggdb  
	-g3  
	-Os  
	-DCPU_MODEL_STM32F103RB  
	-DCPU_ARCH_CORTEX_M3  
	-DRIOT_APPLICATION=\"hello-world\"  
	-DBOARD_NUCLEO_F103RB=\"nucleo-f103rb\"  
	-DRIOT_BOARD=BOARD_NUCLEO_F103RB  
	-DCPU_STM32F1=\"stm32f1\"  
	-DRIOT_CPU=CPU_STM32F1  
	-DMCU_STM32F1=\"stm32f1\"  
	-DRIOT_MCU=MCU_STM32F1  
	-std=c99  
	-fno-common  
	-Wall  
	-Wextra  
	-Wmissing-include-dirs  
	-fno-delete-null-pointer-checks  
	-fdiagnostics-color  
	-Wstrict-prototypes  
	-Wold-style-definition  
	-gz  
	-Wformat=2  
	-Wformat-overflow  
	-Wformat-truncation  
	-include  
	/work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/riotbuild/riotbuild.h

CXX:     arm-none-eabi-g++
CXXUWFLAGS: 
	-std=%  
	-Wstrict-prototypes  
	-Wold-style-definition
CXXEXFLAGS:

LINK:    arm-none-eabi-gcc
LINKFLAGS: 
	-L/work/riot/RIOT/cpu/stm32_common/ldscripts  
	-L/work/riot/RIOT/cpu/stm32f1/ldscripts  
	-L/work/riot/RIOT/cpu/cortexm_common/ldscripts  
	-Tstm32_common.ld  
	-Wl,--fatal-warnings  
	-mcpu=cortex-m3  
	-mlittle-endian  
	-mthumb  
	-mfloat-abi=soft  
	-ggdb  
	-g3  
	-Os  
	-static  
	-lgcc  
	-nostartfiles  
	-Wl,--gc-sections  
	-Wl,--defsym=_rom_start_addr=0x08000000  
	-Wl,--defsym=_ram_start_addr=0x20000000  
	-Wl,--defsym=_rom_length=128K  
	-Wl,--defsym=_ram_length=20K  
	-specs=nano.specs  
	-lc

OBJCOPY: /work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin//arm-none-eabi-objcopy
OFLAGS:  

FLASHER: /work/riot/RIOT/dist/tools/openocd/openocd.sh
FFLAGS:  flash /work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/hello-world.elf

TERMPROG:  /work/riot/RIOT/dist/tools/pyterm/pyterm
TERMFLAGS: -p "/dev/ttyACM0" -b "115200" 
PORT:      /dev/ttyACM0
PROG_DEV:  /dev/ttyACM0

DEBUGGER:       /work/riot/RIOT/dist/tools/openocd/openocd.sh
DEBUGGER_FLAGS: debug /work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/hello-world.elf

DOWNLOAD_TO_FILE:   /usr/bin/wget -nv -c -O
DOWNLOAD_TO_STDOUT: /usr/bin/curl -s
UNZIP_HERE:         /usr/bin/unzip -q

DEBUGSERVER:       /work/riot/RIOT/dist/tools/openocd/openocd.sh
DEBUGSERVER_FLAGS: debug-server

RESET:       /work/riot/RIOT/dist/tools/openocd/openocd.sh
RESET_FLAGS: reset

MAKEFILE_LIST: 
	/work/riot/RIOT/examples/hello-world/Makefile  
	/work/riot/RIOT/Makefile.include  
	/work/riot/RIOT/makefiles/utils/variables.mk  
	/work/riot/RIOT/makefiles/utils/strings.mk  
	/work/riot/RIOT/makefiles/utils/checks.mk  
	/work/riot/RIOT/makefiles/docker.inc.mk  
	/work/riot/RIOT/makefiles/color.inc.mk  
	/work/riot/RIOT/makefiles/info-nproc.inc.mk  
	/work/riot/RIOT/makefiles/boards.inc.mk  
	/work/riot/RIOT/makefiles/dependencies_debug.inc.mk  
	/work/riot/RIOT/makefiles/info.inc.mk  
	/work/riot/RIOT/makefiles/scan-build.inc.mk  
	/work/riot/RIOT/makefiles/kconfig.mk  
	/work/riot/RIOT/makefiles/tools/kconfiglib.inc.mk  
	/work/riot/RIOT/Makefile.features  
	/work/riot/RIOT/boards/nucleo-f103rb/Makefile.features  
	/work/riot/RIOT/boards/common/nucleo64/Makefile.features  
	/work/riot/RIOT/cpu/stm32f1/Makefile.features  
	/work/riot/RIOT/cpu/stm32_common/Makefile.features  
	/work/riot/RIOT/cpu/cortexm_common/Makefile.features  
	/work/riot/RIOT/makefiles/pseudomodules.inc.mk  
	/work/riot/RIOT/makefiles/defaultmodules.inc.mk  
	/work/riot/RIOT/boards/nucleo-f103rb/Makefile.include  
	/work/riot/RIOT/boards/common/nucleo64/Makefile.include  
	/work/riot/RIOT/boards/common/nucleo/Makefile.include  
	/work/riot/RIOT/makefiles/boards/stm32.inc.mk  
	/work/riot/RIOT/makefiles/tools/serial.inc.mk  
	/work/riot/RIOT/makefiles/tools/openocd.inc.mk  
	/work/riot/RIOT/makefiles/tools/openocd-adapters/stlink.inc.mk  
	/work/riot/RIOT/cpu/stm32f1/Makefile.include  
	/work/riot/RIOT/cpu/stm32_common/Makefile.include  
	/work/riot/RIOT/cpu/stm32_common/stm32_mem_lengths.mk  
	/work/riot/RIOT/cpu/stm32f1/stm32_line.mk  
	/work/riot/RIOT/makefiles/arch/cortexm.inc.mk  
	/work/riot/RIOT/cpu/cortexm_common/Makefile.include  
	/work/riot/RIOT/makefiles/toolchain/gnu.inc.mk  
	/work/riot/RIOT/makefiles/tools/gdb.inc.mk  
	/work/riot/RIOT/makefiles/dependency_resolution.inc.mk  
	/work/riot/RIOT/Makefile.dep  
	/work/riot/RIOT/boards/nucleo-f103rb/Makefile.dep  
	/work/riot/RIOT/boards/common/nucleo/Makefile.dep  
	/work/riot/RIOT/cpu/stm32f1/Makefile.dep  
	/work/riot/RIOT/cpu/stm32_common/Makefile.dep  
	/work/riot/RIOT/cpu/cortexm_common/Makefile.dep  
	/work/riot/RIOT/sys/Makefile.dep  
	/work/riot/RIOT/sys/test_utils/Makefile.dep  
	/work/riot/RIOT/drivers/Makefile.dep  
	/work/riot/RIOT/makefiles/stdio.inc.mk  
	/work/riot/RIOT/makefiles/features_check.inc.mk  
	/work/riot/RIOT/makefiles/features_modules.inc.mk  
	/work/riot/RIOT/makefiles/dependency_resolution.inc.mk  
	/work/riot/RIOT/Makefile.dep  
	/work/riot/RIOT/boards/nucleo-f103rb/Makefile.dep  
	/work/riot/RIOT/boards/common/nucleo/Makefile.dep  
	/work/riot/RIOT/cpu/stm32f1/Makefile.dep  
	/work/riot/RIOT/cpu/stm32_common/Makefile.dep  
	/work/riot/RIOT/cpu/cortexm_common/Makefile.dep  
	/work/riot/RIOT/sys/Makefile.dep  
	/work/riot/RIOT/sys/test_utils/Makefile.dep  
	/work/riot/RIOT/drivers/Makefile.dep  
	/work/riot/RIOT/makefiles/stdio.inc.mk  
	/work/riot/RIOT/makefiles/features_check.inc.mk  
	/work/riot/RIOT/makefiles/features_modules.inc.mk  
	/work/riot/RIOT/makefiles/cflags.inc.mk  
	/work/riot/RIOT/makefiles/git_version.inc.mk  
	/work/riot/RIOT/sys/Makefile.include  
	/work/riot/RIOT/makefiles/libc/newlib.mk  
	/work/riot/RIOT/sys/newlib_syscalls_default/Makefile.include  
	/work/riot/RIOT/drivers/Makefile.include  
	/work/riot/RIOT/makefiles/bindist.inc.mk  
	/work/riot/RIOT/makefiles/modules.inc.mk  
	/work/riot/RIOT/makefiles/boot/riotboot.mk  
	/work/riot/RIOT/makefiles/eclipse.inc.mk  
	/work/riot/RIOT/makefiles/vars.inc.mk  
	/work/riot/RIOT/makefiles/tools/targets.inc.mk  
	/work/riot/RIOT/dist/tools/desvirt/Makefile.desvirt  
	/work/riot/RIOT/makefiles/mcuboot.mk  
	/work/riot/RIOT/makefiles/murdock.inc.mk
```

=> boards supported are correctly listed

```
make BOARD=nucleo-f103rb -C examples/hello-world --no-print-directory info-build > /dev/null
```

=> output on stdout is empty

</details>

<details><summary>master</summary>

```
make BOARD=nucleo-f103rb -C examples/hello-world --no-print-directory info-build
APPLICATION: hello-world
APPDIR:      /work/riot/RIOT/examples/hello-world

supported boards:
/work/riot/RIOT/Makefile.include:102: Using BOARDSDIR is deprecated use EXTERNAL_BOARD_DIRS instead
EXTERNAL_BOARD_DIRS can contain multiple folders separated by space make[1]: Nothing to be done for 'info-boards-supported'.

BOARD:   nucleo-f103rb
CPU:     stm32f1
MCU:     stm32f1

RIOTBASE:    /work/riot/RIOT
BOARDDIR:    /work/riot/RIOT/boards/nucleo-f103rb
EXTERNAL_BOARD_DIRS:
RIOTCPU:     /work/riot/RIOT/cpu
RIOTPKG:     /work/riot/RIOT/pkg

DEFAULT_MODULE: auto_init board core core_init core_msg core_panic cpu periph_init periph_init_gpio periph_init_pm periph_init_uart sys
DISABLE_MODULE: 
USEMODULE:      boards_common_nucleo cortexm_common cortexm_common_periph newlib newlib_nano newlib_syscalls_default periph periph_common periph_gpio periph_pm periph_uart pm_layered stdio_uart stm32_common stm32_common_periph

ELFFILE: /work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/hello-world.elf
HEXFILE: /work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/hello-world.hex
BINFILE: /work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/hello-world.bin
FLASHFILE: /work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/hello-world.elf

FEATURES_USED:
         arch_32bit arch_arm arch_cortexm periph_gpio periph_pm periph_uart
FEATURES_REQUIRED:
         arch_32bit arch_arm arch_cortexm periph_uart
FEATURES_REQUIRED_ANY:
         -none-
FEATURES_OPTIONAL_ONLY (optional that are not required, strictly "nice to have"):
         cortexm_fpu periph_gpio periph_pm
FEATURES_OPTIONAL_MISSING (missing optional features):
         cortexm_fpu
FEATURES_PROVIDED (by the board or USEMODULE'd drivers):
         arch_32bit arch_arm arch_cortexm arduino cpp cpu_check_address cpu_stm32f1 periph_cpuid periph_flashpage periph_flashpage_raw periph_gpio periph_gpio_irq periph_i2c periph_pm periph_rtc periph_rtt periph_spi periph_timer periph_uart periph_uart_modecfg periph_wdt puf_sram ssp
FEATURES_MISSING (only non optional features):
         -none-
FEATURES_BLACKLIST (blacklisted features):
         bootloader_arduino bootloader_nrfutil
FEATURES_USED_BLACKLISTED (used but blacklisted features):
         -none-

FEATURES_CONFLICT:     periph_rtc:periph_rtt
FEATURES_CONFLICT_MSG: "On the STM32F1, the RTC and RTT map to the same hardware peripheral."
FEATURES_CONFLICTING:
         -none-

INCLUDES: 
	-isystem  
	/work/tools/gcc-arm-none-eabi-9-2019-q4-major/arm-none-eabi/include/newlib-nano  
	-I/work/riot/RIOT/core/include  
	-I/work/riot/RIOT/drivers/include  
	-I/work/riot/RIOT/sys/include  
	-I/work/riot/RIOT/boards/nucleo-f103rb/include  
	-I/work/riot/RIOT/boards/common/nucleo/include  
	-I/work/riot/RIOT/boards/common/stm32/include  
	-I/work/riot/RIOT/boards/common/nucleo64/include  
	-I/work/riot/RIOT/cpu/stm32f1/include  
	-I/work/riot/RIOT/cpu/stm32_common/include  
	-I/work/riot/RIOT/cpu/cortexm_common/include  
	-I/work/riot/RIOT/cpu/cortexm_common/include/vendor  
	-I/work/riot/RIOT/sys/libc/include

CC:      arm-none-eabi-gcc
CFLAGS: 
	-DDEVELHELP  
	-Werror  
	-DSTM32F1_DISABLE_JTAG  
	-DCPU_FAM_STM32F1  
	-DSTM32F103xB  
	-DCPU_LINE_STM32F103xB  
	-DSTM32_FLASHSIZE=131072U  
	-mno-thumb-interwork  
	-mcpu=cortex-m3  
	-mlittle-endian  
	-mthumb  
	-mfloat-abi=soft  
	-ffunction-sections  
	-fdata-sections  
	-fno-builtin  
	-fshort-enums  
	-ggdb  
	-g3  
	-Os  
	-DCPU_MODEL_STM32F103RB  
	-DCPU_ARCH_CORTEX_M3  
	-DRIOT_APPLICATION=\"hello-world\"  
	-DBOARD_NUCLEO_F103RB=\"nucleo-f103rb\"  
	-DRIOT_BOARD=BOARD_NUCLEO_F103RB  
	-DCPU_STM32F1=\"stm32f1\"  
	-DRIOT_CPU=CPU_STM32F1  
	-DMCU_STM32F1=\"stm32f1\"  
	-DRIOT_MCU=MCU_STM32F1  
	-std=c99  
	-fno-common  
	-Wall  
	-Wextra  
	-Wmissing-include-dirs  
	-fno-delete-null-pointer-checks  
	-fdiagnostics-color  
	-Wstrict-prototypes  
	-Wold-style-definition  
	-gz  
	-Wformat=2  
	-Wformat-overflow  
	-Wformat-truncation  
	-include  
	/work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/riotbuild/riotbuild.h

CXX:     arm-none-eabi-g++
CXXUWFLAGS: 
	-std=%  
	-Wstrict-prototypes  
	-Wold-style-definition
CXXEXFLAGS:

LINK:    arm-none-eabi-gcc
LINKFLAGS: 
	-L/work/riot/RIOT/cpu/stm32_common/ldscripts  
	-L/work/riot/RIOT/cpu/stm32f1/ldscripts  
	-L/work/riot/RIOT/cpu/cortexm_common/ldscripts  
	-Tstm32_common.ld  
	-Wl,--fatal-warnings  
	-mcpu=cortex-m3  
	-mlittle-endian  
	-mthumb  
	-mfloat-abi=soft  
	-ggdb  
	-g3  
	-Os  
	-static  
	-lgcc  
	-nostartfiles  
	-Wl,--gc-sections  
	-Wl,--defsym=_rom_start_addr=0x08000000  
	-Wl,--defsym=_ram_start_addr=0x20000000  
	-Wl,--defsym=_rom_length=128K  
	-Wl,--defsym=_ram_length=20K  
	-specs=nano.specs  
	-lc

OBJCOPY: /work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin//arm-none-eabi-objcopy
OFLAGS:  

FLASHER: /work/riot/RIOT/dist/tools/openocd/openocd.sh
FFLAGS:  flash /work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/hello-world.elf

TERMPROG:  /work/riot/RIOT/dist/tools/pyterm/pyterm
TERMFLAGS: -p "/dev/ttyACM0" -b "115200" 
PORT:      /dev/ttyACM0
PROG_DEV:  /dev/ttyACM0

DEBUGGER:       /work/riot/RIOT/dist/tools/openocd/openocd.sh
DEBUGGER_FLAGS: debug /work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/hello-world.elf

DOWNLOAD_TO_FILE:   /usr/bin/wget -nv -c -O
DOWNLOAD_TO_STDOUT: /usr/bin/curl -s
UNZIP_HERE:         /usr/bin/unzip -q

DEBUGSERVER:       /work/riot/RIOT/dist/tools/openocd/openocd.sh
DEBUGSERVER_FLAGS: debug-server

RESET:       /work/riot/RIOT/dist/tools/openocd/openocd.sh
RESET_FLAGS: reset

MAKEFILE_LIST: 
	/work/riot/RIOT/examples/hello-world/Makefile  
	/work/riot/RIOT/Makefile.include  
	/work/riot/RIOT/makefiles/utils/variables.mk  
	/work/riot/RIOT/makefiles/utils/strings.mk  
	/work/riot/RIOT/makefiles/utils/checks.mk  
	/work/riot/RIOT/makefiles/docker.inc.mk  
	/work/riot/RIOT/makefiles/color.inc.mk  
	/work/riot/RIOT/makefiles/info-nproc.inc.mk  
	/work/riot/RIOT/makefiles/boards.inc.mk  
	/work/riot/RIOT/makefiles/dependencies_debug.inc.mk  
	/work/riot/RIOT/makefiles/info.inc.mk  
	/work/riot/RIOT/makefiles/scan-build.inc.mk  
	/work/riot/RIOT/makefiles/kconfig.mk  
	/work/riot/RIOT/makefiles/tools/kconfiglib.inc.mk  
	/work/riot/RIOT/Makefile.features  
	/work/riot/RIOT/boards/nucleo-f103rb/Makefile.features  
	/work/riot/RIOT/boards/common/nucleo64/Makefile.features  
	/work/riot/RIOT/cpu/stm32f1/Makefile.features  
	/work/riot/RIOT/cpu/stm32_common/Makefile.features  
	/work/riot/RIOT/cpu/cortexm_common/Makefile.features  
	/work/riot/RIOT/makefiles/pseudomodules.inc.mk  
	/work/riot/RIOT/makefiles/defaultmodules.inc.mk  
	/work/riot/RIOT/boards/nucleo-f103rb/Makefile.include  
	/work/riot/RIOT/boards/common/nucleo64/Makefile.include  
	/work/riot/RIOT/boards/common/nucleo/Makefile.include  
	/work/riot/RIOT/makefiles/boards/stm32.inc.mk  
	/work/riot/RIOT/makefiles/tools/serial.inc.mk  
	/work/riot/RIOT/makefiles/tools/openocd.inc.mk  
	/work/riot/RIOT/makefiles/tools/openocd-adapters/stlink.inc.mk  
	/work/riot/RIOT/cpu/stm32f1/Makefile.include  
	/work/riot/RIOT/cpu/stm32_common/Makefile.include  
	/work/riot/RIOT/cpu/stm32_common/stm32_mem_lengths.mk  
	/work/riot/RIOT/cpu/stm32f1/stm32_line.mk  
	/work/riot/RIOT/makefiles/arch/cortexm.inc.mk  
	/work/riot/RIOT/cpu/cortexm_common/Makefile.include  
	/work/riot/RIOT/makefiles/toolchain/gnu.inc.mk  
	/work/riot/RIOT/makefiles/tools/gdb.inc.mk  
	/work/riot/RIOT/makefiles/dependency_resolution.inc.mk  
	/work/riot/RIOT/Makefile.dep  
	/work/riot/RIOT/boards/nucleo-f103rb/Makefile.dep  
	/work/riot/RIOT/boards/common/nucleo/Makefile.dep  
	/work/riot/RIOT/cpu/stm32f1/Makefile.dep  
	/work/riot/RIOT/cpu/stm32_common/Makefile.dep  
	/work/riot/RIOT/cpu/cortexm_common/Makefile.dep  
	/work/riot/RIOT/sys/Makefile.dep  
	/work/riot/RIOT/sys/test_utils/Makefile.dep  
	/work/riot/RIOT/drivers/Makefile.dep  
	/work/riot/RIOT/makefiles/stdio.inc.mk  
	/work/riot/RIOT/makefiles/features_check.inc.mk  
	/work/riot/RIOT/makefiles/features_modules.inc.mk  
	/work/riot/RIOT/makefiles/dependency_resolution.inc.mk  
	/work/riot/RIOT/Makefile.dep  
	/work/riot/RIOT/boards/nucleo-f103rb/Makefile.dep  
	/work/riot/RIOT/boards/common/nucleo/Makefile.dep  
	/work/riot/RIOT/cpu/stm32f1/Makefile.dep  
	/work/riot/RIOT/cpu/stm32_common/Makefile.dep  
	/work/riot/RIOT/cpu/cortexm_common/Makefile.dep  
	/work/riot/RIOT/sys/Makefile.dep  
	/work/riot/RIOT/sys/test_utils/Makefile.dep  
	/work/riot/RIOT/drivers/Makefile.dep  
	/work/riot/RIOT/makefiles/stdio.inc.mk  
	/work/riot/RIOT/makefiles/features_check.inc.mk  
	/work/riot/RIOT/makefiles/features_modules.inc.mk  
	/work/riot/RIOT/makefiles/cflags.inc.mk  
	/work/riot/RIOT/makefiles/git_version.inc.mk  
	/work/riot/RIOT/sys/Makefile.include  
	/work/riot/RIOT/makefiles/libc/newlib.mk  
	/work/riot/RIOT/sys/newlib_syscalls_default/Makefile.include  
	/work/riot/RIOT/drivers/Makefile.include  
	/work/riot/RIOT/makefiles/bindist.inc.mk  
	/work/riot/RIOT/makefiles/modules.inc.mk  
	/work/riot/RIOT/makefiles/boot/riotboot.mk  
	/work/riot/RIOT/makefiles/eclipse.inc.mk  
	/work/riot/RIOT/makefiles/vars.inc.mk  
	/work/riot/RIOT/makefiles/tools/targets.inc.mk  
	/work/riot/RIOT/dist/tools/desvirt/Makefile.desvirt  
	/work/riot/RIOT/makefiles/mcuboot.mk  
	/work/riot/RIOT/makefiles/murdock.inc.mk
```

=> the list of boards supported is **empty**

```
make BOARD=nucleo-f103rb -C examples/hello-world --no-print-directory info-build > /dev/null
/work/riot/RIOT/Makefile.include:102: Using BOARDSDIR is deprecated use EXTERNAL_BOARD_DIRS instead
```

=> a warning is displayed on stderr

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
