### PR TITLE
cpu/msp430_common: Fix missing include

### DIFF
--- a/cpu/msp430_common/include/stdatomic.h
+++ b/cpu/msp430_common/include/stdatomic.h
@@ -34,6 +34,7 @@
 
 #include <sys/cdefs.h>
 #include <sys/_types.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
### Contribution description

Add `#include <stdint.h>` to `stdatomic.h`.

### Testing procedure

https://github.com/RIOT-OS/RIOT/pull/14011 should now compile

### Issues/PRs references

Found by @fjmolinas in https://github.com/RIOT-OS/RIOT/pull/14011