### PR TITLE
sys/ztimer/Makefilde.dep: periph_rtt as FEATURES_OPTIONAL

### DIFF
--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -74,4 +74,8 @@ endif
 
 ifneq (,$(filter ztimer_msec,$(USEMODULE)))
   USEMODULE += ztimer
+  FEATURES_OPTIONAL += periph_rtt
+  ifneq (,$(filter periph_rtt,$(FEATURES_USED)))
+    USEMODULE += ztimer_periph_rtt
+  endif
 endif


### PR DESCRIPTION

### Contribution description

If `ztimer_msec` is used include `periph_rtt` as an optional features,
and if used include `ztimer_periph_rtt`.

This is based on the expectation that you want `ZTIMER_MSEC` to run in sleep mode.

### Testing procedure

- boards not providing rtt don't include `ztimer_periph_rtt`

```
BOARD=nucleo-l152re USEMODULE=ztimer_msec make -C examples/hello-world/ --no-print-directory info-modules | grep rtt
```

- boards providing it do

```
BOARD=nucleo-l073rz USEMODULE=ztimer_msec make -C examples/hello-world/ --no-print-directory info-modules | grep rtt
periph_init_rtt
periph_rtt
ztimer_periph_rtt
```
