### PR TITLE
sys/ztimer: properly initialize intermediate extension callback

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -485,6 +485,23 @@ void ztimer_update_head_offset(ztimer_clock_t *clock);
  */
 void ztimer_init(void);
 
+/**
+ * @brief   Initialize possible ztimer extension intermediate timer
+ *
+ * This will basically just set a timer to (clock->max_value >> 1), *if*
+ * max_value is not UINT32_MAX.
+ *
+ * This is called automatically by all ztimer backends and extension modules.
+ *
+ * @internal
+ */
+static inline void ztimer_init_extend(ztimer_clock_t *clock)
+{
+    if (clock->max_value < UINT32_MAX) {
+        clock->ops->set(clock, clock->max_value >> 1);
+    }
+}
+
 /* default ztimer virtual devices */
 /**
  * @brief   Default ztimer microsecond clock

--- a/sys/ztimer/convert_frac.c
+++ b/sys/ztimer/convert_frac.c
@@ -91,6 +91,7 @@ void ztimer_convert_frac_init(ztimer_convert_frac_t *self, ztimer_clock_t *lower
     ztimer_convert_frac_compute_scale(self, freq_self, freq_lower);
     if (freq_self < freq_lower) {
         self->super.super.max_value = frac_scale(&self->scale_set, UINT32_MAX);
+        ztimer_init_extend(&self->super.super);
     }
     else {
         DEBUG("ztimer_convert_frac_init: rounding up val:%" PRIu32"\n",

--- a/sys/ztimer/convert_muldiv64.c
+++ b/sys/ztimer/convert_muldiv64.c
@@ -120,4 +120,5 @@ void ztimer_convert_muldiv64_init(
     ztimer_convert_muldiv64->super.super.ops = &_ztimer_convert_muldiv64_ops;
     ztimer_convert_muldiv64->div = div;
     ztimer_convert_muldiv64->mul = mul;
+    ztimer_init_extend(&ztimer_convert_muldiv64->super.super);
 }

--- a/sys/ztimer/periph_rtt.c
+++ b/sys/ztimer/periph_rtt.c
@@ -88,4 +88,5 @@ void ztimer_periph_rtt_init(ztimer_periph_rtt_t *clock)
     clock->max_value = RTT_MAX_VALUE;
     rtt_init();
     rtt_poweron();
+    ztimer_init_extend(clock);
 }

--- a/sys/ztimer/periph_timer.c
+++ b/sys/ztimer/periph_timer.c
@@ -79,4 +79,5 @@ void ztimer_periph_timer_init(ztimer_periph_timer_t *clock, tim_t dev, unsigned 
     clock->super.ops = &_ztimer_periph_timer_ops;
     clock->super.max_value = max_val;
     timer_init(dev, freq, _ztimer_periph_timer_callback, clock);
+    ztimer_init_extend(&clock->super);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

ztimer's extension mechanismn relies on an intermediate timer that triggers at around clock->max_value/2, otherwise it doesn't realize an underflow in the underlying timer.
But this timer was never explicitly initialized, unless any other timer got set.

This PR adds a helper function and calls it where needed.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

One way is to print the current time of ZTIMER_MSEC and ZTIMER_USEC, without setting a timer on ZTIMER_USEC, e.g. using this application: https://gist.github.com/518a012a91fd07ddd5034f2cc92abca1

I tested this on iotlab on an iotlab-m3 node.
Output on master (please excuse the missing space before "usec"):

```
main(): This is RIOT! (Version: 2020.07-devel-380-gd0388)
msec: 1usec: 1516
msec: 1002usec: 19021
msec: 2002usec: 36605
msec: 3003usec: 54188
msec: 4004usec: 71772
msec: 5004usec: 89355
msec: 6005usec: 106939
msec: 7006usec: 124584
msec: 8006usec: 142228
msec: 9007usec: 159873
msec: 10008usec: 177518
```

Output with this PR:

```
main(): This is RIOT! (Version: 2020.07-devel-381-g36db3-ztimer_init_extend)                                                       
msec: 1usec: 1957        
msec: 1002usec: 1002550  
msec: 2003usec: 2003234  
msec: 3003usec: 3003919  
msec: 4004usec: 4004604  
msec: 5005usec: 5005288  
msec: 6006usec: 6005973  
msec: 7006usec: 7006658  
msec: 8007usec: 8007342  
msec: 9008usec: 9008027  
msec: 10009usec: 10008712
```

Note that with the PR, the usec value is roughly the msec value * 1000, but on master, usec seems to run slower.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Thanks @fjmolinas for pointing me to this!
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
