### PR TITLE
sys/luid: provide luid_get_lb(), fix documentation

### DIFF
--- a/sys/include/luid.h
+++ b/sys/include/luid.h
@@ -74,7 +74,7 @@ extern "C" {
  * @brief   Get a unique ID
  *
  * The resulting ID is built from the base ID generated with luid_base(), which
- * isXORed with an 8-bit incrementing counter value into the most significant
+ * isXORed with an 8-bit incrementing counter value into the first (lowest index)
  * byte.
  *
  * @note    The resulting LUID will repeat after 255 calls.
@@ -84,6 +84,21 @@ extern "C" {
  * @param[in]  len      length of the LUID in bytes
  */
 void luid_get(void *buf, size_t len);
+
+/**
+ * @brief   Get a unique ID with change in the last byte
+ *
+ * The resulting ID is built from the base ID generated with luid_base(), which
+ * isXORed with an 8-bit incrementing counter value into the last (highest index)
+ * byte.
+ *
+ * @note    The resulting LUID will repeat after 255 calls.
+ *
+ * @param[out] buf      memory location to copy the LUID into. MUST be able to
+ *                      hold at least @p len bytes
+ * @param[in]  len      length of the LUID in bytes
+ */
+void luid_get_lb(void *buf, size_t len);
 
 /**
  * @brief   Get a unique short unicast address

--- a/sys/luid/luid.c
+++ b/sys/luid/luid.c
@@ -54,6 +54,13 @@ void luid_get(void *buf, size_t len)
     ((uint8_t *)buf)[0] ^= lastused++;
 }
 
+void luid_get_lb(void *buf, size_t len)
+{
+    luid_base(buf, len);
+
+    ((uint8_t *)buf)[len - 1] ^= lastused++;
+}
+
 void luid_custom(void *buf, size_t len, int gen)
 {
     luid_base(buf, len);


### PR DESCRIPTION

### Contribution description

The documentation of `luid_get()` is wrong, or at least confusing.

It talks about

> an 8-bit incrementing counter value into the most significant byte

while the implementation does

```C
((uint8_t *)buf)[0] ^= lastused++;
```

Now it could be argued that the intention was that the ID is supposed to be used in Big Endian contexts and that was an omission, however to keep everyone's sanity, let's keep it simple and just state that this actually changes the LSB.

Also add a `luid_get_lb()` function that does the same, but modifies the ~~most significant~~ last byte - or the least significant one if interpreted as Big Endian.


### Testing procedure




### Issues/PRs references

This can be used directly by e.g. #13743
