### PR TITLE
mk/boards/stm32: add JLink support

### DIFF
--- a/makefiles/boards/stm32.inc.mk
+++ b/makefiles/boards/stm32.inc.mk
@@ -1,6 +1,6 @@
 PROGRAMMER ?= openocd
 
-PROGRAMMERS_SUPPORTED := bmp dfu-util openocd stm32flash
+PROGRAMMERS_SUPPORTED := bmp dfu-util openocd stm32flash jlink
 
 ifeq (,$(filter $(PROGRAMMER), $(PROGRAMMERS_SUPPORTED)))
   $(error Programmer $(PROGRAMMER) not supported)
@@ -35,6 +35,11 @@ endif
 
 ifeq (bmp,$(PROGRAMMER))
   include $(RIOTMAKE)/tools/bmp.inc.mk
+endif
+
+ifeq (jlink,$(PROGRAMMER))
+  JLINK_DEVICE ?= $(CPU_MODEL)
+  include $(RIOTMAKE)/tools/jlink.inc.mk
 endif
 
 ifeq (dfu-util,$(PROGRAMMER))


### PR DESCRIPTION
### Contribution description
The Jlink programmers are also capable of flashing STM32 targets via SWD - useful if you want to flash an stm32-based board and that is the only programmer available to you :-)

So this little PR adds support to use a Jlink for programming STM32 devices, simply cal `PROGRAMMER=jlink make flash`. I tested this with the `blxxpill`-boards, but it should work fine with every other stm32-based one. 

When having a look at the [list of supported stm32 devices](https://www.segger.com/downloads/supported-devices.php), the names that Segger uses for their targets are the same that RIOT boards define in their `CPU_MODEL` variable.

### Testing procedure
- take any stm32-based board (e.g. `bluepill`)
- connect programming pins to a Segger Jlink programmer (GND, SWDIO, SWCLK, VTref), see e.g. https://www.segger.com/products/debug-probes/j-link/technology/interface-description/
- flash any RIOT application to that board using the Jlink programmer by running `PROGRAMMER=jlink make flash`
- make sure your application is now running at your board

### Issues/PRs references
none