### PR TITLE
boards: purge gnrc_netdev_default from Makefile.dep

### DIFF
--- a/boards/avsextrem/Makefile.dep
+++ b/boards/avsextrem/Makefile.dep
@@ -1,3 +1,3 @@
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += cc1100
 endif

--- a/boards/cc2538dk/Makefile.dep
+++ b/boards/cc2538dk/Makefile.dep
@@ -1,3 +1,3 @@
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += cc2538_rf
 endif

--- a/boards/common/iotlab/Makefile.dep
+++ b/boards/common/iotlab/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += at86rf231
 endif
 

--- a/boards/common/kw41z/Makefile.dep
+++ b/boards/common/kw41z/Makefile.dep
@@ -3,6 +3,6 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += kw41zrf
 endif

--- a/boards/common/nrf51/Makefile.dep
+++ b/boards/common/nrf51/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += nrfmin
 endif
 

--- a/boards/common/nrf52/nrf52840/Makefile.dep
+++ b/boards/common/nrf52/nrf52840/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   ifeq (,$(filter nimble_% nrfmin,$(USEMODULE)))
     USEMODULE += nrf802154
   endif

--- a/boards/common/remote/Makefile.dep
+++ b/boards/common/remote/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += cc2538_rf
 endif
 

--- a/boards/fox/Makefile.dep
+++ b/boards/fox/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += at86rf231
 endif
 

--- a/boards/hamilton/Makefile.dep
+++ b/boards/hamilton/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += at86rf233
 endif
 

--- a/boards/msba2/Makefile.dep
+++ b/boards/msba2/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += cc1100
 endif
 

--- a/boards/msbiot/Makefile.dep
+++ b/boards/msbiot/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += cc1101
 endif
 

--- a/boards/mulle/Makefile.dep
+++ b/boards/mulle/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += at86rf212b
 endif
 

--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += netdev_tap
 endif
 

--- a/boards/nucleo-f207zg/Makefile.dep
+++ b/boards/nucleo-f207zg/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += stm32_eth
 endif
 

--- a/boards/nucleo-f767zi/Makefile.dep
+++ b/boards/nucleo-f767zi/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += stm32_eth
 endif
 

--- a/boards/openlabs-kw41z-mini/Makefile.dep
+++ b/boards/openlabs-kw41z-mini/Makefile.dep
@@ -3,6 +3,6 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += kw41zrf
 endif

--- a/boards/openmote-b/Makefile.dep
+++ b/boards/openmote-b/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   ifeq (,$(filter cc2538_rf,$(USEMODULE)))
     USEMODULE += at86rf215
   endif

--- a/boards/openmote-cc2538/Makefile.dep
+++ b/boards/openmote-cc2538/Makefile.dep
@@ -1,3 +1,3 @@
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += cc2538_rf
 endif

--- a/boards/pba-d-01-kw2x/Makefile.dep
+++ b/boards/pba-d-01-kw2x/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += kw2xrf
 endif
 

--- a/boards/samr21-xpro/Makefile.dep
+++ b/boards/samr21-xpro/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += at86rf233
 endif
 

--- a/boards/samr30-xpro/Makefile.dep
+++ b/boards/samr30-xpro/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += at86rf212b
 endif
 

--- a/boards/telosb/Makefile.dep
+++ b/boards/telosb/Makefile.dep
@@ -1,3 +1,3 @@
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += cc2420
 endif

--- a/boards/z1/Makefile.dep
+++ b/boards/z1/Makefile.dep
@@ -1,3 +1,3 @@
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += cc2420
 endif


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`gnrc_netdev_default` will pull in `netdev_default`, so no need to check for both in `Makefile.dep`


### Testing procedure

The default network interface should still be loaded.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
