### PR TITLE
drivers/at : Expose Configurations to Kconfig 

### DIFF
--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -10,8 +10,11 @@ menu "Actuator Device Drivers"
 rsource "motor_driver/Kconfig"
 endmenu # Actuator Device Drivers
 
-rsource "Kconfig.net"
+menu "Miscellaneous Device Drivers"
+rsource "at/Kconfig"
+endmenu # Miscellaneous Device Drivers
 
+rsource "Kconfig.net"
 rsource "periph_common/Kconfig"
 
 menu "Sensor Device Drivers"

--- a/drivers/at/Kconfig
+++ b/drivers/at/Kconfig
@@ -1,0 +1,63 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_AT
+    bool "Configure AT driver"
+    depends on MODULE_AT
+    help
+        Configure the AT driver using Kconfig.
+
+if KCONFIG_MODULE_AT
+
+choice
+    bool "End of line character"
+    default AT_SEND_EOL_MAC
+    help
+        Select the EOL character to send after the AT command.
+        The character sequence depends on target device.
+        By default "\r", aka carriage return, is used.
+
+config AT_SEND_EOL_WINDOWS
+    bool "\\r\\n"
+
+config AT_SEND_EOL_UNIX
+    bool "\\n"
+
+config AT_SEND_EOL_MAC
+    bool "\\r"
+
+endchoice
+
+config AT_SEND_SKIP_ECHO
+    bool "Disable check for echo"
+    help
+        Enable this to disable check for echo after an AT
+        command is sent.
+
+config AT_RECV_OK
+    string "OK reply string"
+    default "OK"
+    help
+        Change okay response of the AT device.
+
+config AT_RECV_ERROR
+    string "Error reply string"
+    default "ERROR"
+    help
+        Change error response of the AT device.
+
+config AT_BUF_SIZE_EXP
+    int "Exponent for the buffer size (resulting in the queue size 2^n)"
+    range 0 31
+    default 7
+    depends on MODULE_AT_URC
+    help
+        Size of buffer used to process unsolicited result code data. (as
+        exponent of 2^n). As the buffer size ALWAYS needs to be power of two,
+        this option represents the exponent of 2^n, which will be used as the
+        size of the buffer.
+
+endif # KCONFIG_MODULE_AT

--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -114,14 +114,14 @@ int at_send_cmd(at_dev_t *dev, const char *command, uint32_t timeout)
     size_t cmdlen = strlen(command);
 
     uart_write(dev->uart, (const uint8_t *)command, cmdlen);
-    uart_write(dev->uart, (const uint8_t *)AT_SEND_EOL, AT_SEND_EOL_LEN);
+    uart_write(dev->uart, (const uint8_t *)CONFIG_AT_SEND_EOL, AT_SEND_EOL_LEN);
 
     if (AT_SEND_ECHO) {
         if (at_expect_bytes(dev, command, timeout)) {
             return -1;
         }
 
-        if (at_expect_bytes(dev, AT_SEND_EOL AT_RECV_EOL_1 AT_RECV_EOL_2, timeout)) {
+        if (at_expect_bytes(dev, CONFIG_AT_SEND_EOL AT_RECV_EOL_1 AT_RECV_EOL_2, timeout)) {
             return -2;
         }
     }
@@ -194,17 +194,17 @@ ssize_t at_send_cmd_get_lines(at_dev_t *dev, const char *command,
         }
         else if (res > 0) {
             bytes_left -= res;
-            size_t len_ok = sizeof(AT_RECV_OK) - 1;
-            size_t len_error = sizeof(AT_RECV_ERROR) - 1;
+            size_t len_ok = sizeof(CONFIG_AT_RECV_OK) - 1;
+            size_t len_error = sizeof(CONFIG_AT_RECV_ERROR) - 1;
             if (((size_t )res == (len_ok + keep_eol)) &&
                 (len_ok != 0) &&
-                (strncmp(pos, AT_RECV_OK, len_ok) == 0)) {
+                (strncmp(pos, CONFIG_AT_RECV_OK, len_ok) == 0)) {
                 res = len - bytes_left;
                 break;
             }
             else if (((size_t )res == (len_error + keep_eol)) &&
                      (len_error != 0) &&
-                     (strncmp(pos, AT_RECV_ERROR, len_error) == 0)) {
+                     (strncmp(pos, CONFIG_AT_RECV_ERROR, len_error) == 0)) {
                 return -1;
             }
             else if (strncmp(pos, "+CME ERROR:", 11) == 0) {
@@ -240,13 +240,13 @@ int at_send_cmd_wait_prompt(at_dev_t *dev, const char *command, uint32_t timeout
     at_drain(dev);
 
     uart_write(dev->uart, (const uint8_t *)command, cmdlen);
-    uart_write(dev->uart, (const uint8_t *)AT_SEND_EOL, AT_SEND_EOL_LEN);
+    uart_write(dev->uart, (const uint8_t *)CONFIG_AT_SEND_EOL, AT_SEND_EOL_LEN);
 
     if (at_expect_bytes(dev, command, timeout)) {
         return -1;
     }
 
-    if (at_expect_bytes(dev, AT_SEND_EOL AT_RECV_EOL_2, timeout)) {
+    if (at_expect_bytes(dev, CONFIG_AT_SEND_EOL AT_RECV_EOL_2, timeout)) {
         return -2;
     }
 
@@ -265,8 +265,8 @@ int at_send_cmd_wait_ok(at_dev_t *dev, const char *command, uint32_t timeout)
     res = at_send_cmd_get_resp(dev, command, resp_buf, sizeof(resp_buf), timeout);
 
     if (res > 0) {
-        ssize_t len_ok = sizeof(AT_RECV_OK) - 1;
-        if ((len_ok != 0) && (strcmp(resp_buf, AT_RECV_OK) == 0)) {
+        ssize_t len_ok = sizeof(CONFIG_AT_RECV_OK) - 1;
+        if ((len_ok != 0) && (strcmp(resp_buf, CONFIG_AT_RECV_OK) == 0)) {
             res = 0;
         }
         else {

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -40,6 +40,7 @@
 #include "isrpipe.h"
 #include "periph/uart.h"
 #include "clist.h"
+#include "kernel_defines.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,10 +59,24 @@ extern "C" {
 #endif
 
 /**
+ * @brief Disable echo after an AT command is sent.
+ */
+#ifdef DOXYGEN
+#define AT_SEND_SKIP_ECHO
+#endif
+
+/**
  * @brief Enable/disable the expected echo after an AT command is sent.
+ * 
+ * @deprecated Use inverse @ref AT_SEND_SKIP_ECHO instead.
+ * Will be removed after 2021.01 release.
  */
 #ifndef AT_SEND_ECHO
+#if IS_ACTIVE(AT_SEND_SKIP_ECHO)
+#define AT_SEND_ECHO 0
+#else
 #define AT_SEND_ECHO 1
+#endif
 #endif
 
 /**

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -54,25 +54,25 @@ extern "C" {
 /**
  * @brief End of line character to send after the AT command.
  */
-#ifndef AT_SEND_EOL
-#define AT_SEND_EOL "\r"
+#ifndef CONFIG_AT_SEND_EOL
+#define CONFIG_AT_SEND_EOL "\r"
 #endif
 
 /**
  * @brief Disable echo after an AT command is sent.
  */
 #ifdef DOXYGEN
-#define AT_SEND_SKIP_ECHO
+#define CONFIG_AT_SEND_SKIP_ECHO
 #endif
 
 /**
  * @brief Enable/disable the expected echo after an AT command is sent.
- * 
- * @deprecated Use inverse @ref AT_SEND_SKIP_ECHO instead.
+ *
+ * @deprecated Use inverse @ref CONFIG_AT_SEND_SKIP_ECHO instead.
  * Will be removed after 2021.01 release.
  */
 #ifndef AT_SEND_ECHO
-#if IS_ACTIVE(AT_SEND_SKIP_ECHO)
+#if IS_ACTIVE(CONFIG_AT_SEND_SKIP_ECHO)
 #define AT_SEND_ECHO 0
 #else
 #define AT_SEND_ECHO 1
@@ -96,26 +96,25 @@ extern "C" {
 /**
  * @brief default OK reply of an AT device.
  */
-#ifndef AT_RECV_OK
-#define AT_RECV_OK "OK"
+#ifndef CONFIG_AT_RECV_OK
+#define CONFIG_AT_RECV_OK "OK"
 #endif
 
 /**
  * @brief default ERROR reply of an AT device.
  */
-#ifndef AT_RECV_ERROR
-#define AT_RECV_ERROR "ERROR"
+#ifndef CONFIG_AT_RECV_ERROR
+#define CONFIG_AT_RECV_ERROR "ERROR"
 #endif
-/** @} */
 
-/** Shortcut for getting send end of line length */
-#define AT_SEND_EOL_LEN  (sizeof(AT_SEND_EOL) - 1)
-
+/**
+ * @brief Internal buffer size used to process unsolicited result code data.
+ */
 #if defined(MODULE_AT_URC) || DOXYGEN
 #ifndef AT_BUF_SIZE
-/** Internal buffer size used to process unsolicited result code data */
 #define AT_BUF_SIZE (128)
 #endif
+/** @} */
 
 /**
  * @brief   Unsolicited result code callback
@@ -136,6 +135,9 @@ typedef struct {
 } at_urc_t;
 
 #endif /* MODULE_AT_URC */
+
+/** Shortcut for getting send end of line length */
+#define AT_SEND_EOL_LEN  (sizeof(CONFIG_AT_SEND_EOL) - 1)
 
 /**
  * @brief AT device structure

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -54,12 +54,21 @@ extern "C" {
 /**
  * @brief End of line character to send after the AT command.
  */
+#if IS_ACTIVE(CONFIG_AT_SEND_EOL_WINDOWS)
+#define CONFIG_AT_SEND_EOL   "\r\n"
+#elif IS_ACTIVE(CONFIG_AT_SEND_EOL_UNIX)
+#define CONFIG_AT_SEND_EOL   "\n"
+#elif IS_ACTIVE(CONFIG_AT_SEND_EOL_MAC)
+#define CONFIG_AT_SEND_EOL   "\r"
+#endif
+
 #ifndef CONFIG_AT_SEND_EOL
 #define CONFIG_AT_SEND_EOL "\r"
 #endif
 
 /**
- * @brief Disable echo after an AT command is sent.
+ * @brief Enable this to disable check for echo after an AT
+ * command is sent.
  */
 #ifdef DOXYGEN
 #define CONFIG_AT_SEND_SKIP_ECHO
@@ -107,14 +116,27 @@ extern "C" {
 #define CONFIG_AT_RECV_ERROR "ERROR"
 #endif
 
-/**
- * @brief Internal buffer size used to process unsolicited result code data.
- */
 #if defined(MODULE_AT_URC) || DOXYGEN
-#ifndef AT_BUF_SIZE
-#define AT_BUF_SIZE (128)
+
+/**
+ * @brief   Default buffer size used to process unsolicited result code data.
+ *          (as exponent of 2^n).
+ *
+ *          As the buffer size ALWAYS needs to be power of two, this option
+ *          represents the exponent of 2^n, which will be used as the size of
+ *          the buffer.
+ */
+#ifndef CONFIG_AT_BUF_SIZE_EXP
+#define CONFIG_AT_BUF_SIZE_EXP (7U)
 #endif
 /** @} */
+
+/**
+ * @brief   Size of buffer used to process unsolicited result code data.
+ */
+#ifndef AT_BUF_SIZE
+#define AT_BUF_SIZE   (1 << CONFIG_AT_BUF_SIZE_EXP)
+#endif
 
 /**
  * @brief   Unsolicited result code callback

--- a/tests/driver_at/main.c
+++ b/tests/driver_at/main.c
@@ -124,7 +124,7 @@ static int send_recv_bytes(int argc, char **argv)
         return 1;
     }
 
-    sprintf(buffer, "%s%s", argv[1], AT_SEND_EOL);
+    sprintf(buffer, "%s%s", argv[1], CONFIG_AT_SEND_EOL);
     at_send_bytes(&at_dev, buffer, strlen(buffer));
 
     ssize_t len = at_recv_bytes(&at_dev, buffer, atoi(argv[2]), 10 * US_PER_SEC);
@@ -146,7 +146,7 @@ static int send_recv_bytes_until_string(int argc, char **argv)
         return 1;
     }
 
-    sprintf(buffer, "%s%s", argv[1], AT_SEND_EOL);
+    sprintf(buffer, "%s%s", argv[1], CONFIG_AT_SEND_EOL);
     at_send_bytes(&at_dev, buffer, strlen(buffer));
     memset(buffer, 0, sizeof(buffer));
 


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in AT  Device driver to Kconfig.

Attention : AT_SEND_ECHO is expected to be deprecated and CONFIG_AT_SEND_SKIP_ECHO 
introduced. Macro to be removed after 2021.01 release.

### Testing procedure
1. New documentation was built using doxygen 

The build worked fine.

2. New macro was introduced in tests/driver_at/main.c for testing.

```
#define STR(x)   #x
#define SHOW_DEFINE(x) printf("%s=%s\n", #x, STR(x))
```
Firmware was uploaded to FIT IoT Lab test bed.

#### Default State:

##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-386-ge9126a-Kconfig_at_tests)
CONFIG_AT_SEND_EOL="\r"
CONFIG_AT_SEND_SKIP_ECHO=
AT_SEND_ECHO=1
CONFIG_AT_RECV_OK="OK"
CONFIG_AT_RECV_ERROR="ERROR"
AT_BUF_SIZE=(1<<(7))
AT command test app


#### Usage with CFLAGS 

/tests/driver_at/Makefile

> CFLAGS += -DCONFIG_AT_SEND_EOL_UNIX
> CFLAGS += -DCONFIG_AT_SEND_SKIP_ECHO
> CFLAGS += -DCONFIG_AT_RECV_OK="\"DONE\""
> CFLAGS += -DCONFIG_AT_RECV_ERROR="\"EXIT\""

##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-386-ge9126a-Kconfig_at_tests)
CONFIG_AT_SEND_EOL="\r"
CONFIG_AT_SEND_SKIP_ECHO=
AT_SEND_ECHO=1
CONFIG_AT_RECV_OK="OK"
CONFIG_AT_RECV_ERROR="ERROR"
AT command test app


#### Usage with Kconfig

/tests/driver_at/

> make menuconfig

##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-557-g871cb-Kconfig_at_tests)
CONFIG_AT_SEND_EOL="\r"
CONFIG_AT_SEND_SKIP_ECHO=
AT_SEND_ECHO=1
CONFIG_AT_RECV_OK="OK"
CONFIG_AT_RECV_ERROR="ERROR"
AT_BUF_SIZE=(1<<5)
AT command test app

### Issues/PRs references

#12888
@leandrolanzieri 
