### PR TITLE
gnrc_netif: doxygen does not process IS_ACTIVE()

### DIFF
--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -95,7 +95,7 @@ typedef struct {
      * @see net_gnrc_netif_flags
      */
     uint32_t flags;
-#if IS_USED(MODULE_GNRC_NETIF_EVENTS) || IS_ACTIVE(DOXYGEN)
+#if IS_USED(MODULE_GNRC_NETIF_EVENTS) || defined(DOXYGEN)
     /**
      * @brief   Event queue for asynchronous events
      */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The `IS_ACTIVE()` macro is not resolved by doxygen, so anything within a `IS_ACTIVE(DOXYGEN)` does not show up in the documentation. This changes the currently only occurrence of `IS_ACTIVE(DOXYGEN)` to `defined(DOXYGEN)`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile the documentation with

```
make doc
```

without this change, `gnrc_netif_t::evq` and `gnrc_netif_t::event_isr` do not show up in the documentation, as can be seen in the current doc build on [doc.riot-os.org](https://doc.riot-os.org/structgnrc__netif__t.html). With the change, it should show up.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but found when testing the doc for #13994.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
