### PR TITLE
core/msg_bus: allow to differ between messages form bus and from thread

### DIFF
--- a/core/msg.c
+++ b/core/msg.c
@@ -241,7 +241,8 @@ int msg_send_bus(msg_t *m, msg_bus_t *bus)
     const uint32_t event_mask = (1UL << (m->type & 0x1F));
     int count = 0;
 
-    m->sender_pid = in_irq ? KERNEL_PID_ISR : thread_getpid();
+    m->sender_pid = (in_irq ? KERNEL_PID_ISR : thread_getpid())
+                  | MSB_BUS_PID_FLAG;
 
     unsigned state = irq_disable();
 

--- a/tests/thread_msg_bus/main.c
+++ b/tests/thread_msg_bus/main.c
@@ -46,6 +46,7 @@ void *thread1(void *arg)
 
     /* check if the message came from the right bus */
     assert(msg_is_from_bus(arg, &msg));
+    assert(msg_bus_get_sender_pid(&msg) == p_main);
 
     printf("T1 recv: %s (type=%d)\n",
           (char*) msg.content.ptr, msg_bus_get_type(&msg));
@@ -69,6 +70,7 @@ void *thread2(void *arg)
 
     /* check if the message came from the right bus */
     assert(msg_is_from_bus(arg, &msg));
+    assert(msg_bus_get_sender_pid(&msg) == p_main);
 
     printf("T2 recv: %s (type=%d)\n",
           (char*) msg.content.ptr, msg_bus_get_type(&msg));
@@ -92,6 +94,7 @@ void *thread3(void *arg)
 
     /* check if the message came from the right bus */
     assert(msg_is_from_bus(arg, &msg));
+    assert(msg_bus_get_sender_pid(&msg) == p_main);
 
     printf("T3 recv: %s (type=%d)\n",
           (char*) msg.content.ptr, msg_bus_get_type(&msg));


### PR DESCRIPTION
### Contribution description

Currently it is not possible to check if a message was sent over a bus or if it was send the usual way using `msg_send()`.

This adds a flag to the `sender_pid` if the message was sent over a bus.
`MAXTHREADS` is currently set to 32, so there is still plenty of room in the PID space. (since `kernel_pid_t` is `int16_t` and we are now using negative numbers for bus messages, there isn't even a reduction in PID space)

The message type for bus message type is already accessed through a getter function, so it's just consistent to do the same for `sender_pid`.

### Testing procedure

`tests/thread_msg_bus` includes a check for the new function.

### Issues/PRs references

#13947
