### PR TITLE
cpu/lm4f120: fix invalid doxygen group name

### DIFF
--- a/cpu/lm4f120/vectors.c
+++ b/cpu/lm4f120/vectors.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     cpu_stm32f4
+ * @ingroup     cpu_lm4f120
  * @{
  *
  * @file        vectors.c


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes an obvious (copy-paste) mistake in one of the Doxygen group name used for `lm4f120` cpu.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Read the documentation

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Raised by #14021 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
