### PR TITLE
boards/common/nrf5x: add configurable RTT_FREQUENCY

### DIFF
--- a/boards/common/nrf51/include/cfg_rtt_default.h
+++ b/boards/common/nrf51/include/cfg_rtt_default.h
@@ -29,10 +29,20 @@ extern "C" {
  * @name    Real time counter configuration
  * @{
  */
-#define RTT_DEV             (1)             /* NRF_RTC1 */
-#define RTT_MAX_VALUE       (0x00ffffff)
-#define RTT_FREQUENCY       (1024)
+#ifndef RTT_DEV
+#define RTT_DEV             (1)                 /* NRF_RTC1 */
+#endif
+
+#define RTT_MAX_VALUE       (0x00ffffff)         /* 24bit */
+#define RTT_MAX_FREQUENCY   (32768U)             /* in Hz */
+#define RTT_MIN_FREQUENCY   (8U)                 /* in Hz */
+#define RTT_CLOCK_FREQUENCY (32768U)             /* in Hz, LFCLK*/
+
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (1024U)              /* in Hz */
+#endif
 /** @} */
+
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/boards/common/nrf52/include/cfg_rtt_default.h
+++ b/boards/common/nrf52/include/cfg_rtt_default.h
@@ -28,9 +28,18 @@ extern "C" {
  * @name    Real time counter configuration
  * @{
  */
-#define RTT_DEV             (1)             /* NRF_RTC1 */
-#define RTT_MAX_VALUE       (0x00ffffff)
-#define RTT_FREQUENCY       (1024)
+#ifndef RTT_DEV
+#define RTT_DEV             (1)                 /* NRF_RTC1 */
+#endif
+
+#define RTT_MAX_VALUE       (0x00ffffff)         /* 24bit */
+#define RTT_MAX_FREQUENCY   (32768U)             /* in Hz */
+#define RTT_MIN_FREQUENCY   (8U)                 /* in Hz */
+#define RTT_CLOCK_FREQUENCY (32768U)             /* in Hz, LFCLK*/
+
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (1024U)              /* in Hz */
+#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/nrf5x_common/periph/rtt.c
+++ b/cpu/nrf5x_common/periph/rtt.c
@@ -38,8 +38,6 @@
 #error "RTT configuration: invalid or no RTC device specified (RTT_DEV)"
 #endif
 
-#define LFCLK_FREQ      (32768U)
-
 /* allocate memory for callbacks and their args */
 static rtt_cb_t alarm_cb;
 static void *alarm_arg;
@@ -59,7 +57,7 @@ void rtt_init(void)
     /* configure interrupt */
     NVIC_EnableIRQ(IRQn);
     /* set prescaler */
-    DEV->PRESCALER = (LFCLK_FREQ / RTT_FREQUENCY) - 1;
+    DEV->PRESCALER = (RTT_CLOCK_FREQUENCY / RTT_FREQUENCY) - 1;
     /* start the actual RTT thing */
     DEV->TASKS_START = 1;
 }


### PR DESCRIPTION
### Contribution description

This PR make `RTT_FREQUENCY` configurable for these platforms as well as defining there max an min values.

I didn't move this to `periph_cpu` because they could use an external oscilotr for the RTT which would make it a `BOARD` configuration.

Same default have been kept.

### Testing procedure

- base test works `BOARD=nrf52dk make -C tests/periph_rtt flash test -j3`

```
main(): This is RIOT! (Version: 2020.07-devel-412-g409185-pr_nrf5x_rtt_conf)

RIOT RTT low-level driver test
This test will display 'Hello' every 5 seconds

Initializing the RTT driver
RTT now: 0
Setting initial alarm to now + 5 s (5120)
Done setting up the RTT, wait for many Hellos
Hello
Hello
Hello
Hello
Hello
```

- can change frequency `CFLAGS=-DRTT_FREQUENCY=32768 BOARD=nrf52dk make -C tests/periph_rtt flash test -j3`

```
main(): This is RIOT! (Version: 2020.07-devel-412-g409185-pr_nrf5x_rtt_conf)

RIOT RTT low-level driver test
This test will display 'Hello' every 5 seconds

Initializing the RTT driver
RTT now: 0
Setting initial alarm to now + 5 s (163840)
Done setting up the RTT, wait for many Hellos
Hello
Hello
Hello
Hello

```

### Issues/PRs references

Split from # #13874