### PR TITLE
gnrc_netif: use gnrc_netif-submodules to pull in upper-layer struct members

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -352,6 +352,7 @@ ifneq (,$(filter gnrc_ipv6,$(USEMODULE)))
   USEMODULE += gnrc_ipv6_hdr
   USEMODULE += gnrc_ipv6_nib
   USEMODULE += gnrc_netif
+  USEMODULE += gnrc_netif_ipv6
   USEMODULE += gnrc_nettype_ipv6
 endif
 

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -274,6 +274,9 @@ ifneq (,$(filter gnrc_sixlowpan,$(USEMODULE)))
   DEFAULT_MODULE += auto_init_gnrc_sixlowpan
   USEMODULE += gnrc_nettype_sixlowpan
   USEMODULE += sixlowpan
+  ifneq (,$(filter gnrc_netif,$(USEMODULE)))
+    USEMODULE += gnrc_netif_6lo
+  endif
 endif
 
 ifneq (,$(filter gnrc_sixlowpan_ctx,$(USEMODULE)))

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -61,6 +61,9 @@ ifneq (,$(filter gnrc_mac,$(USEMODULE)))
   USEMODULE += gnrc_priority_pktqueue
   USEMODULE += csma_sender
   USEMODULE += evtimer
+  ifneq (,$(filter gnrc_netif,$(USEMODULE)))
+    USEMODULE += gnrc_netif_mac
+  endif
 endif
 
 ifneq (,$(filter gnrc_gomach,$(USEMODULE)))

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -33,6 +33,7 @@ PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox
 PSEUDOMODULES += gnrc_netif_events
 PSEUDOMODULES += gnrc_pktbuf_cmd
+PSEUDOMODULES += gnrc_netif_6lo
 PSEUDOMODULES += gnrc_netif_cmd_%
 PSEUDOMODULES += gnrc_netif_dedup
 PSEUDOMODULES += gnrc_nettype_%

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -35,6 +35,7 @@ PSEUDOMODULES += gnrc_netif_events
 PSEUDOMODULES += gnrc_pktbuf_cmd
 PSEUDOMODULES += gnrc_netif_6lo
 PSEUDOMODULES += gnrc_netif_ipv6
+PSEUDOMODULES += gnrc_netif_mac
 PSEUDOMODULES += gnrc_netif_cmd_%
 PSEUDOMODULES += gnrc_netif_dedup
 PSEUDOMODULES += gnrc_nettype_%

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -34,6 +34,7 @@ PSEUDOMODULES += gnrc_netapi_mbox
 PSEUDOMODULES += gnrc_netif_events
 PSEUDOMODULES += gnrc_pktbuf_cmd
 PSEUDOMODULES += gnrc_netif_6lo
+PSEUDOMODULES += gnrc_netif_ipv6
 PSEUDOMODULES += gnrc_netif_cmd_%
 PSEUDOMODULES += gnrc_netif_dedup
 PSEUDOMODULES += gnrc_nettype_%

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -94,11 +94,11 @@ static void _netif_init(gnrc_netif_t *netif)
     /* save the threads context pointer, so we can set its flags */
     _netif_thread = (thread_t *)thread_get(thread_getpid());
 
-#ifdef MODULE_GNRC_SIXLOWPAN
+#if IS_USED(MODULE_GNRC_NETIF_6LO)
     /* we disable fragmentation for this device, as the L2CAP layer takes care
      * of this */
     _nimble_netif->sixlo.max_frag_size = 0;
-#endif
+#endif  /* IS_USED(MODULE_GNRC_NETIF_6LO) */
 }
 
 static int _send_pkt(nimble_netif_conn_t *conn, gnrc_pktsnip_t *pkt)

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -48,7 +48,7 @@
 #if IS_USED(MODULE_GNRC_NETIF_IPV6)
 #include "net/gnrc/netif/ipv6.h"
 #endif
-#ifdef MODULE_GNRC_MAC
+#if IS_USED(MODULE_GNRC_NETIF_MAC)
 #include "net/gnrc/netif/mac.h"
 #endif
 #include "net/ndp.h"
@@ -86,9 +86,9 @@ typedef struct {
 #if IS_USED(MODULE_GNRC_NETIF_IPV6) || defined(DOXYGEN)
     gnrc_netif_ipv6_t ipv6;                 /**< IPv6 component */
 #endif
-#if defined(MODULE_GNRC_MAC) || DOXYGEN
+#if IS_USED(MODULE_GNRC_NETIF_MAC) || defined(DOXYGEN)
     gnrc_netif_mac_t mac;                  /**< @ref net_gnrc_mac component */
-#endif  /* MODULE_GNRC_MAC */
+#endif  /* IS_USED(MODULE_GNRC_NETIF_MAC) || defined(DOXYGEN) */
     /**
      * @brief   Flags for the interface
      *

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -35,7 +35,7 @@
 #include "net/gnrc/netapi.h"
 #include "net/gnrc/pkt.h"
 #include "net/gnrc/netif/conf.h"
-#ifdef MODULE_GNRC_LORAWAN
+#if IS_USED(MODULE_GNRC_NETIF_LORAWAN)
 #include "net/gnrc/netif/lorawan.h"
 #endif
 #ifdef MODULE_GNRC_SIXLOWPAN
@@ -80,7 +80,7 @@ typedef struct {
 #ifdef MODULE_NETSTATS_L2
     netstats_t stats;                       /**< transceiver's statistics */
 #endif
-#if defined(MODULE_GNRC_LORAWAN) || DOXYGEN
+#if IS_USED(MODULE_GNRC_NETIF_LORAWAN) || defined(DOXYGEN)
     gnrc_netif_lorawan_t lorawan;           /**< LoRaWAN component */
 #endif
 #if defined(MODULE_GNRC_IPV6) || DOXYGEN

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -38,7 +38,7 @@
 #if IS_USED(MODULE_GNRC_NETIF_LORAWAN)
 #include "net/gnrc/netif/lorawan.h"
 #endif
-#ifdef MODULE_GNRC_SIXLOWPAN
+#if IS_USED(MODULE_GNRC_NETIF_6LO)
 #include "net/gnrc/netif/6lo.h"
 #endif
 #if defined(MODULE_GNRC_NETIF_DEDUP) && (GNRC_NETIF_L2ADDR_MAXLEN > 0)
@@ -129,7 +129,7 @@ typedef struct {
     gnrc_netif_dedup_t last_pkt;
 #endif
 #endif
-#if defined(MODULE_GNRC_SIXLOWPAN) || DOXYGEN
+#if IS_USED(MODULE_GNRC_NETIF_6LO) || defined(DOXYGEN)
     gnrc_netif_6lo_t sixlo;                 /**< 6Lo component */
 #endif
     uint8_t cur_hl;                         /**< Current hop-limit for out-going packets */

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -45,7 +45,7 @@
 #include "net/gnrc/netif/dedup.h"
 #endif
 #include "net/gnrc/netif/flags.h"
-#ifdef MODULE_GNRC_IPV6
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
 #include "net/gnrc/netif/ipv6.h"
 #endif
 #ifdef MODULE_GNRC_MAC
@@ -83,7 +83,7 @@ typedef struct {
 #if IS_USED(MODULE_GNRC_NETIF_LORAWAN) || defined(DOXYGEN)
     gnrc_netif_lorawan_t lorawan;           /**< LoRaWAN component */
 #endif
-#if defined(MODULE_GNRC_IPV6) || DOXYGEN
+#if IS_USED(MODULE_GNRC_NETIF_IPV6) || defined(DOXYGEN)
     gnrc_netif_ipv6_t ipv6;                 /**< IPv6 component */
 #endif
 #if defined(MODULE_GNRC_MAC) || DOXYGEN

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -58,7 +58,7 @@ void gnrc_netif_acquire(gnrc_netif_t *netif);
  */
 void gnrc_netif_release(gnrc_netif_t *netif);
 
-#if defined(MODULE_GNRC_IPV6) || DOXYGEN
+#if IS_USED(MODULE_GNRC_NETIF_IPV6) || DOXYGEN
 /**
  * @brief   Adds an IPv6 address to the interface
  *
@@ -284,7 +284,7 @@ void gnrc_netif_ipv6_group_leave_internal(gnrc_netif_t *netif,
  */
 int gnrc_netif_ipv6_group_idx(gnrc_netif_t *netif,
                               const ipv6_addr_t *addr);
-#endif  /* MODULE_GNRC_IPV6 */
+#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) || defined(DOXYGEN) */
 
 /**
  * @brief   Checks if the interface represents a router according to RFC 4861
@@ -536,7 +536,7 @@ static inline int gnrc_netif_get_eui64(gnrc_netif_t *netif, eui64_t *eui64)
  */
 void gnrc_netif_init_6ln(gnrc_netif_t *netif);
 
-#if defined(MODULE_GNRC_IPV6) || defined(DOXYGEN)
+#if IS_USED(MODULE_GNRC_NETIF_IPV6) || defined(DOXYGEN)
 /**
  * @brief   Initialize IPv6 MTU and other packet length related members of
  *          @ref gnrc_netif_t based on gnrc_netif_t::device_type
@@ -669,13 +669,13 @@ static inline int gnrc_netif_ndp_addr_len_from_l2ao(gnrc_netif_t *netif,
     assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
     return l2util_ndp_addr_len_from_l2ao(netif->device_type, opt);
 }
-#else   /* defined(MODULE_GNRC_IPV6) || defined(DOXYGEN) */
+#else   /* IS_USED(MODULE_GNRC_NETIF_IPV6) || defined(DOXYGEN) */
 #define gnrc_netif_ipv6_init_mtu(netif)                             (void)netif
 #define gnrc_netif_ipv6_iid_from_addr(netif, addr, addr_len, iid)   (-ENOTSUP)
 #define gnrc_netif_ipv6_iid_to_addr(netif, iid, addr)               (-ENOTSUP)
 #define gnrc_netif_ndp_addr_len_from_l2ao(netif, opt)               (-ENOTSUP)
 #define gnrc_netif_ipv6_get_iid(netif, iid)                         (-ENOTSUP)
-#endif  /* defined(MODULE_GNRC_IPV6) || defined(DOXYGEN) */
+#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) || defined(DOXYGEN) */
 /** @} */
 
 #ifdef __cplusplus

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1296,14 +1296,14 @@ static void _test_options(gnrc_netif_t *netif)
             assert((IEEE802154_SHORT_ADDRESS_LEN == netif->l2addr_len) ||
                    (IEEE802154_LONG_ADDRESS_LEN == netif->l2addr_len));
 #ifdef MODULE_GNRC_IPV6
-#ifdef MODULE_GNRC_SIXLOWPAN
+#if IS_USED(MODULE_GNRC_NETIF_6LO)
             assert(netif->ipv6.mtu == IPV6_MIN_MTU);
             assert(netif->sixlo.max_frag_size > 0);
             assert(-ENOTSUP != netif->dev->driver->get(netif->dev, NETOPT_PROTO,
                                                        &tmp, sizeof(tmp)));
-#else   /* MODULE_GNRC_SIXLOWPAN */
+#else   /* IS_USED(MODULE_GNRC_NETIF_6LO) */
             assert(netif->ipv6.mtu < UINT16_MAX);
-#endif  /* MODULE_GNRC_SIXLOWPAN */
+#endif  /* IS_USED(MODULE_GNRC_NETIF_6LO) */
 #endif  /* MODULE_GNRC_IPV6 */
 #ifdef MODULE_GNRC_SIXLOWPAN_ND
             assert((netif->device_type != NETDEV_TYPE_IEEE802154) ||

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -135,7 +135,7 @@ int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
         case NETOPT_STATS:
             /* XXX discussed this with Oleg, it's supposed to be a pointer */
             switch ((int16_t)opt->context) {
-#if defined(MODULE_NETSTATS_IPV6) && defined(MODULE_GNRC_IPV6)
+#if IS_USED(MODULE_NETSTATS_IPV6) && IS_USED(MODULE_GNRC_NETIF_IPV6)
                 case NETSTATS_IPV6:
                     assert(opt->data_len == sizeof(netstats_t *));
                     *((netstats_t **)opt->data) = &netif->ipv6.stats;
@@ -154,7 +154,7 @@ int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
                     break;
             }
             break;
-#ifdef MODULE_GNRC_IPV6
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
         case NETOPT_IPV6_ADDR: {
                 assert(opt->data_len >= sizeof(ipv6_addr_t));
                 ipv6_addr_t *tgt = opt->data;
@@ -233,7 +233,7 @@ int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
             res = sizeof(netopt_enable_t);
             break;
 #endif  /* CONFIG_GNRC_IPV6_NIB_ROUTER */
-#endif  /* MODULE_GNRC_IPV6 */
+#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC
         case NETOPT_6LO_IPHC:
             assert(opt->data_len == sizeof(netopt_enable_t));
@@ -266,7 +266,7 @@ int gnrc_netif_set_from_netdev(gnrc_netif_t *netif,
             netif->cur_hl = *((uint8_t *)opt->data);
             res = sizeof(uint8_t);
             break;
-#ifdef MODULE_GNRC_IPV6
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
         case NETOPT_IPV6_ADDR: {
                 assert(opt->data_len == sizeof(ipv6_addr_t));
                 /* always assume manually added */
@@ -335,7 +335,7 @@ int gnrc_netif_set_from_netdev(gnrc_netif_t *netif,
             res = sizeof(netopt_enable_t);
             break;
 #endif  /* CONFIG_GNRC_IPV6_NIB_ROUTER */
-#endif  /* MODULE_GNRC_IPV6 */
+#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC
         case NETOPT_6LO_IPHC:
             assert(opt->data_len == sizeof(netopt_enable_t));
@@ -497,7 +497,7 @@ void gnrc_netif_release(gnrc_netif_t *netif)
     }
 }
 
-#ifdef MODULE_GNRC_IPV6
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
 static int _addr_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr);
 static int _group_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr);
 
@@ -1189,7 +1189,7 @@ static ipv6_addr_t *_src_addr_selection(gnrc_netif_t *netif,
         return &netif->ipv6.addrs[idx];
     }
 }
-#endif  /* MODULE_GNRC_IPV6 */
+#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
 
 static void _update_l2addr_from_dev(gnrc_netif_t *netif)
 {
@@ -1273,7 +1273,7 @@ static void _test_options(gnrc_netif_t *netif)
         case NETDEV_TYPE_ESP_NOW:
             assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
             assert(ETHERNET_ADDR_LEN == netif->l2addr_len);
-#ifdef MODULE_GNRC_IPV6
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
             switch (netif->device_type) {
                 case NETDEV_TYPE_BLE:
                     assert(netif->ipv6.mtu == IPV6_MIN_MTU);
@@ -1284,7 +1284,7 @@ static void _test_options(gnrc_netif_t *netif)
                 case NETDEV_TYPE_ESP_NOW:
                     assert(netif->ipv6.mtu <= ETHERNET_DATA_LEN);
             }
-#endif  /* MODULE GNRC_IPV6 */
+#endif  /* IS_USED(MODULE GNRC_NETIF_IPV6) */
             break;
         case NETDEV_TYPE_IEEE802154:
         case NETDEV_TYPE_NRFMIN: {
@@ -1295,7 +1295,7 @@ static void _test_options(gnrc_netif_t *netif)
             assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
             assert((IEEE802154_SHORT_ADDRESS_LEN == netif->l2addr_len) ||
                    (IEEE802154_LONG_ADDRESS_LEN == netif->l2addr_len));
-#ifdef MODULE_GNRC_IPV6
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
 #if IS_USED(MODULE_GNRC_NETIF_6LO)
             assert(netif->ipv6.mtu == IPV6_MIN_MTU);
             assert(netif->sixlo.max_frag_size > 0);
@@ -1304,7 +1304,7 @@ static void _test_options(gnrc_netif_t *netif)
 #else   /* IS_USED(MODULE_GNRC_NETIF_6LO) */
             assert(netif->ipv6.mtu < UINT16_MAX);
 #endif  /* IS_USED(MODULE_GNRC_NETIF_6LO) */
-#endif  /* MODULE_GNRC_IPV6 */
+#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
 #ifdef MODULE_GNRC_SIXLOWPAN_ND
             assert((netif->device_type != NETDEV_TYPE_IEEE802154) ||
                    (-ENOTSUP != netif->dev->driver->get(netif->dev,
@@ -1317,9 +1317,9 @@ static void _test_options(gnrc_netif_t *netif)
         case NETDEV_TYPE_CC110X:
             assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
             assert(1U == netif->l2addr_len);
-#ifdef MODULE_GNRC_IPV6
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
             assert(netif->ipv6.mtu < UINT16_MAX);
-#endif  /* MODULE_GNRC_IPV6 */
+#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
             break;
         case NETDEV_TYPE_LORA: /* LoRa doesn't provide L2 ADDR */
         case NETDEV_TYPE_SLIP:
@@ -1335,11 +1335,11 @@ static void _test_options(gnrc_netif_t *netif)
     }
     /* These functions only apply to network devices having link-layers */
     if (netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR) {
-#ifdef MODULE_GNRC_IPV6
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
         assert(-ENOTSUP != gnrc_netif_ipv6_get_iid(netif, (eui64_t *)&tmp64));
         assert(-ENOTSUP != gnrc_netif_ndp_addr_len_from_l2ao(netif,
                                                              &dummy_opt));
-#endif  /* MODULE_GNRC_IPV6 */
+#endif  /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
         assert(-ENOTSUP != gnrc_netif_ipv6_iid_to_addr(netif, (eui64_t *)&tmp64,
                                                        dummy_addr));

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -144,12 +144,12 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
             res = dev->driver->get(dev, NETOPT_MAX_PDU_SIZE,
                                    &tmp, sizeof(tmp));
             assert(res == sizeof(tmp));
-#ifdef MODULE_GNRC_SIXLOWPAN
+#if IS_USED(MODULE_GNRC_NETIF_6LO)
             netif->ipv6.mtu = MAX(IPV6_MIN_MTU, tmp);
             netif->sixlo.max_frag_size = tmp;
-#else
+#else   /* IS_USED(MODULE_GNRC_NETIF_6LO) */
             netif->ipv6.mtu = tmp;
-#endif
+#endif  /* IS_USED(MODULE_GNRC_NETIF_6LO) */
             break;
 #endif  /* defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_NRFMIN) || \
          * defined(MODULE_XBEE) || defined(MODULE_ESP_NOW) */

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -18,7 +18,7 @@
 #include <kernel_defines.h>
 
 #include "log.h"
-#ifdef MODULE_GNRC_IPV6
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
 #include "net/ipv6.h"
 #endif
 #include "net/gnrc/netif.h"
@@ -121,10 +121,9 @@ void gnrc_netif_init_6ln(gnrc_netif_t *netif)
     }
 }
 
-#ifdef MODULE_GNRC_IPV6
+#if IS_USED(MODULE_GNRC_NETIF_IPV6)
 void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
 {
-#ifdef MODULE_GNRC_IPV6
     netdev_t *dev = netif->dev;
     int res;
     uint16_t tmp;
@@ -155,9 +154,7 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
          * defined(MODULE_XBEE) || defined(MODULE_ESP_NOW) */
 #ifdef MODULE_NETDEV_ETH
         case NETDEV_TYPE_ETHERNET:
-#ifdef MODULE_GNRC_IPV6
             netif->ipv6.mtu = ETHERNET_DATA_LEN;
-#endif
 #ifdef MODULE_GNRC_SIXLOENC
             netif->flags |= GNRC_NETIF_FLAGS_6LO;
 #ifdef MODULE_GNRC_SIXLOWPAN_IPHC
@@ -190,7 +187,6 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
             }
             break;
     }
-#endif
 }
 
 int gnrc_netif_ipv6_iid_from_addr(const gnrc_netif_t *netif,
@@ -206,6 +202,6 @@ int gnrc_netif_ipv6_iid_from_addr(const gnrc_netif_t *netif,
     return -ENOTSUP;
 }
 
-#endif /* MODULE_GNRC_IPV6 */
+#endif /* IS_USED(MODULE_GNRC_NETIF_IPV6) */
 
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_sx127x.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_sx127x.c
@@ -21,11 +21,8 @@
 
 #include "log.h"
 #include "board.h"
-#ifdef MODULE_GNRC_LORAWAN
 #include "net/gnrc/netif/lorawan_base.h"
-#else
 #include "net/gnrc/netif/raw.h"
-#endif
 #include "net/gnrc.h"
 
 #include "sx127x.h"
@@ -61,16 +58,19 @@ void auto_init_sx127x(void)
 #endif
 
         sx127x_setup(&sx127x_devs[i], &sx127x_params[i]);
-#ifdef MODULE_GNRC_LORAWAN
-        /* Currently only one lora device is supported */
-        assert(SX127X_NUMOF == 1);
+        if (IS_USED(MODULE_GNRC_NETIF_LORAWAN)) {
+            /* Currently only one lora device is supported */
+            assert(SX127X_NUMOF == 1);
 
-        gnrc_netif_lorawan_create(&_netif[i], sx127x_stacks[i], SX127X_STACKSIZE, SX127X_PRIO,
+            gnrc_netif_lorawan_create(&_netif[i], sx127x_stacks[i],
+                                      SX127X_STACKSIZE, SX127X_PRIO,
+                                      "sx127x", (netdev_t *)&sx127x_devs[i]);
+        }
+        else {
+            gnrc_netif_raw_create(&_netif[i], sx127x_stacks[i],
+                                  SX127X_STACKSIZE, SX127X_PRIO,
                                   "sx127x", (netdev_t *)&sx127x_devs[i]);
-#else
-        gnrc_netif_raw_create(&_netif[i], sx127x_stacks[i], SX127X_STACKSIZE, SX127X_PRIO,
-                              "sx127x", (netdev_t *)&sx127x_devs[i]);
-#endif
+        }
     }
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Instead of using the upper-layer modules directly to pull in upper-layer specific struct members, this changes `gnrc_netif` to use (in some cases newly introduced pseudo-)submodules to pull them in. This is aiming to reduce circular dependencies within GNRC in a follow-up PR.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Everything should still compile and build sizes should stay the same.

In particular I compile-tested

- `examples/gnrc_loramac`
- `examples/gnrc_networking_mac`

and ran the tests on `native` for

- `tests/gnrc_netif`
- `tests/gnrc_ipv6_nib`
- `tests/gnrc_ipv6_nib_6ln`
- the `tests-gnrc_mac_internal` suite for `tests/unittests`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but among the things mentioned above it helps with phase II of the Kconfig migration.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
