### PR TITLE
cpu/sam0_common: GPIO: use tamper detection to wake from Deep Sleep

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -1069,6 +1069,32 @@ void dma_wait(dma_t dma);
 void dma_cancel(dma_t dma);
 /** @} */
 
+/**
+ * @name sam0 RTC Tamper Detection
+ * @{
+ */
+
+/**
+ * @brief   Power on the RTC (if the RTC/RTT is not otherwise used)
+ */
+void rtc_tamper_init(void);
+
+/**
+ * @brief   Enable Tamper Detection IRQs
+ *
+ * @param   pin     The GPIO pin to be used for tamper detection
+ * @param   flank   The Flank to trigger the even
+ *
+ * @return  0 on success, -1 if pin is not RTC pin
+ */
+int rtc_tamper_register(gpio_t pin, gpio_flank_t flank);
+
+/**
+ * @brief   Enable Tamper Detection IRQs
+ */
+void rtc_tamper_enable(void);
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/samd5x/Kconfig
+++ b/cpu/samd5x/Kconfig
@@ -12,6 +12,7 @@ config CPU_COMMON_SAMD5X
     select HAS_BACKUP_RAM
     select HAS_CORTEXM_MPU
     select HAS_CPU_SAMD5X
+    select HAS_PERIPH_GPIO_TAMPER_WAKE
     select HAS_PERIPH_HWRNG
 
 config CPU_FAM_SAMD51

--- a/cpu/samd5x/Makefile.dep
+++ b/cpu/samd5x/Makefile.dep
@@ -1,1 +1,5 @@
+ifneq (,$(filter periph_gpio_tamper_wake,$(USEMODULE)))
+  USEMODULE += periph_rtc_rtt
+endif
+
 include $(RIOTCPU)/sam0_common/Makefile.dep

--- a/cpu/samd5x/Makefile.features
+++ b/cpu/samd5x/Makefile.features
@@ -3,5 +3,6 @@ CPU_CORE = cortex-m4f
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += backup_ram
 FEATURES_PROVIDED += cortexm_mpu
+FEATURES_PROVIDED += periph_gpio_tamper_wake
 
 include $(RIOTCPU)/sam0_common/Makefile.features

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -116,6 +116,15 @@ typedef enum {
 #define RTT_MAX_FREQUENCY   (RTT_CLOCK_FREQUENCY)         /* in Hz */
 /** @} */
 
+/**
+ * @brief   RTC input pins that can be used for tamper detection and
+ *          wake from Deep Sleep
+ */
+static const gpio_t rtc_tamper_pins[RTC_NUM_OF_TAMPERS] = {
+    GPIO_PIN(PB, 0), GPIO_PIN(PB, 2), GPIO_PIN(PA, 2),
+    GPIO_PIN(PC, 0), GPIO_PIN(PC, 1)
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/saml1x/include/periph_cpu.h
+++ b/cpu/saml1x/include/periph_cpu.h
@@ -82,6 +82,15 @@ typedef enum {
 #define RTT_MAX_FREQUENCY   (RTT_CLOCK_FREQUENCY)         /* in Hz */
 /** @} */
 
+/**
+ * @brief   RTC input pins that can be used for tamper detection and
+ *          wake from Deep Sleep
+ */
+static const gpio_t rtc_tamper_pins[RTC_NUM_OF_TAMPERS] = {
+    GPIO_PIN(PA, 8), GPIO_PIN(PA, 9), GPIO_PIN(PA, 16),
+    GPIO_PIN(PA, 17)
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -22,6 +22,8 @@
 
 #define USB_H_USER_IS_RIOT_INTERNAL
 
+#include "periph_cpu.h"
+
 #ifdef MODULE_PERIPH_INIT
 #ifdef MODULE_PERIPH_INIT_I2C
 #include "periph/i2c.h"
@@ -71,6 +73,11 @@ void periph_init(void)
     /* Initialize RTC */
 #ifdef MODULE_PERIPH_INIT_RTC
     rtc_init();
+#endif
+
+    /* Initialize Tamper Detection */
+#ifdef MODULE_PERIPH_INIT_GPIO_TAMPER_WAKE
+    rtc_tamper_init();
 #endif
 
 #ifdef MODULE_PERIPH_INIT_HWRNG

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -150,6 +150,12 @@ config HAS_PERIPH_GPIO_FAST_READ
 	operations are faster, usually with a tradeoff against a different
 	property.
 
+config HAS_PERIPH_GPIO_TAMPER_WAKE
+    bool
+    help
+        Indicates that Tamper Detection can be used to wake the CPU from
+        Deep Sleep.
+
 config HAS_PERIPH_HWRNG
     bool
     help

--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -1,8 +1,9 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_gpio
-FEATURES_OPTIONAL = periph_gpio_irq
+FEATURES_REQUIRED += periph_gpio
+FEATURES_OPTIONAL += periph_gpio_irq
 FEATURES_OPTIONAL += periph_gpio_fast_read
+FEATURES_OPTIONAL += periph_gpio_tamper_wake
 
 USEMODULE += shell
 USEMODULE += shell_commands


### PR DESCRIPTION
### Contribution description

On `samd5x` only the RTC can wake the CPU from Deep Sleep (`pm` modes 0 & 1).
The external interrupt controller is disabled, but we can use the tamper detection of the RTC.

If an gpio interrupt is configured on one of the five tamper detect pins, those can be used to wake the CPU from Deep Sleep / Hibernate.


### Testing procedure

Run `tests/periph_pm`. You will have to set `BTN0_PIN` to one of the RTC pins and connect a wire that you can pull high or low.
You should see the `BTN0 pressed.` message when an interrupt is triggered.

Now enter Deep Sleep with `pm set 0`.

The CPU should now reset when an event on the RTC GPIO happens.

**edit** as `pm` functionality has now been integrated into the `tests/periph_pm` test, you can also use that to test the functionality of this PR.
A RTC/Tamper pin configured as interrupt should be able to wake up the CPU from the deepest sleep state.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
