### PR TITLE
boards/samr30-xpro: add ztimer configuration

### DIFF
--- a/boards/samr30-xpro/include/board.h
+++ b/boards/samr30-xpro/include/board.h
@@ -93,6 +93,15 @@ enum {
 /** @} */
 
 /**
+ * @name    ztimer configuration
+ * @{
+ */
+#define CONFIG_ZTIMER_USEC_ADJUST_SET       (19)
+#define CONFIG_ZTIMER_USEC_ADJUST_SLEEP     (23)
+#define CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE (1)
+/** @} */
+
+/**
  * @brief   Set antenna switch
  */
 void board_antenna_config(uint8_t antenna);

--- a/tests/ztimer_pm_layered/Makefile
+++ b/tests/ztimer_pm_layered/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += pm_layered
+USEMODULE += ztimer ztimer_msec ztimer_usec
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/ztimer_pm_layered/README.md
+++ b/tests/ztimer_pm_layered/README.md
@@ -1,0 +1,8 @@
+# Introduction
+
+This test application runs an endless loop of ztimer_sleep() based on the clocks
+ZTIMER_USEC and ZTIMER_MSEC alternating.
+
+If the board running this application has configured
+CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE, it should consume less power when sleeping
+on the ZTIMER_MSEC clock.

--- a/tests/ztimer_pm_layered/main.c
+++ b/tests/ztimer_pm_layered/main.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2020 Juergen Fitschen <me@jue.yt>
+ *               2020 SSV Software Systems GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     test
+ * @{
+ *
+ * @file
+ * @brief       ztimer test application for interacting with pm_layered
+ *
+ * @author      2020 SSV Software Systems GmbH
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#include "board.h"
+#include "ztimer.h"
+#include "timex.h"
+#include "pm_layered.h"
+
+#define SLEEP_SEC  (5LU)
+#define SLEEP_MSEC (SLEEP_SEC * MS_PER_SEC)
+#define SLEEP_USEC (SLEEP_SEC * MS_PER_SEC * MS_PER_SEC)
+
+static void dump_time(void)
+{
+    static uint32_t past_msec = 0;
+    static uint32_t past_usec = 0;
+
+    uint32_t now_msec = ztimer_now(ZTIMER_MSEC);
+    uint32_t now_usec = ztimer_now(ZTIMER_USEC);
+
+    printf("Elapsed time - ZTIMER_MSEC: %4" PRIu32 "ms, ZTIMER_USEC: %4" PRIu32 "ms\n",
+            (now_msec - past_msec), (now_usec - past_usec) / US_PER_MS);
+
+    past_msec = now_msec;
+    past_usec = now_usec;
+}
+
+int main(void)
+{
+    printf("This test application lets the CPU sleep for %" PRIu32 " seconds using the clocks \n"
+           "ZTIMER_MSEC and ZTIMER_USEC alternating.\n", SLEEP_SEC);
+
+#if (!defined(CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE) || \
+    CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE == ZTIMER_CLOCK_NO_REQUIRED_PM_MODE) && \
+    (!defined(CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE) || \
+    CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE == ZTIMER_CLOCK_NO_REQUIRED_PM_MODE)
+    printf("WARNING: Neither ZTIMER_MSEC nor ZTIMER_USEC is interacting with pm_layered!\n"
+           "Don't expect any power saving.\n");
+#else
+    printf("\nUnblocking all pm modes related to ztimer clocks ...\n");
+#endif
+
+#if defined(CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE) && \
+    CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE != ZTIMER_CLOCK_NO_REQUIRED_PM_MODE
+    while (pm_get_blocker().val_u8[CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE]) {
+        printf("pm_unblock(CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE)\n");
+        pm_unblock(CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE);
+    }
+#endif
+
+#if defined(CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE) && \
+    CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE != ZTIMER_CLOCK_NO_REQUIRED_PM_MODE
+    /* If ztimer_msec is based on ztimer_usec, it already blocked
+     * CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE once during auto_init.
+     * Don't remove that ... */
+    uint8_t usec_pm_mode = (ZTIMER_MSEC_BASE == ZTIMER_USEC_BASE) ? 1 : 0;
+    while (pm_get_blocker().val_u8[CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE] > usec_pm_mode) {
+        printf("pm_unblock(CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE)\n");
+        pm_unblock(CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE);
+    }
+#endif
+
+    printf("\nEntering the sleepy loop ...\n");
+
+    while (1) {
+        dump_time();
+        printf("ztimer_sleep(ZTIMER_MSEC, %" PRIu32 ")\n", SLEEP_MSEC);
+        ztimer_sleep(ZTIMER_MSEC, SLEEP_MSEC);
+        dump_time();
+        printf("ztimer_sleep(ZTIMER_USEC, %" PRIu32 ")\n", SLEEP_USEC);
+        ztimer_sleep(ZTIMER_USEC, SLEEP_USEC);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

This PR adds ztimer configuration for the `samr30-xpro` board. This should reduce its power consumption when no timer is running on the `ZTIMER_USEC` clock.

### Testing procedure

`make -C tests/ztimer_pm_layered BOARD=samr30-xpro flash term`

Expected output:

```
2020-05-06 13:42:13,558 # main(): This is RIOT! (Version: 2020.07-devel-446-g8ffd34)
2020-05-06 13:42:13,565 # This test application lets the CPU sleep for 5 seconds using the clocks 
2020-05-06 13:42:13,568 # ZTIMER_MSEC and ZTIMER_USEC alternating.
2020-05-06 13:42:13,569 # 
2020-05-06 13:42:13,573 # Unblocking all pm modes related to ztimer clocks ...
2020-05-06 13:42:13,577 # pm_unblock(CONFIG_ZTIMER_USEC_REQUIRED_PM_MODE)
2020-05-06 13:42:13,578 # 
2020-05-06 13:42:13,580 # Entering the sleepy loop ...
2020-05-06 13:42:13,585 # Elapsed time - ZTIMER_MSEC:   27ms, ZTIMER_USEC:   27ms
2020-05-06 13:42:13,588 # ztimer_sleep(ZTIMER_MSEC, 5000)
2020-05-06 13:42:18,593 # Elapsed time - ZTIMER_MSEC: 5008ms, ZTIMER_USEC:    8ms
2020-05-06 13:42:18,597 # ztimer_sleep(ZTIMER_USEC, 5000000)
2020-05-06 13:42:23,607 # Elapsed time - ZTIMER_MSEC: 5014ms, ZTIMER_USEC: 5008ms
2020-05-06 13:42:23,610 # ztimer_sleep(ZTIMER_MSEC, 5000)
2020-05-06 13:42:28,616 # Elapsed time - ZTIMER_MSEC: 5008ms, ZTIMER_USEC:    8ms
2020-05-06 13:42:28,619 # ztimer_sleep(ZTIMER_USEC, 5000000)
```

`make -C tests/ztimer_overhead BOARD=samr30-xpro flash term`

Expected output:

```
2020-05-06 14:07:25,183 # main(): This is RIOT! (Version: 2020.07-devel-448-ga4511b-feature/board_samr30-xpro_ztimer)
2020-05-06 14:07:25,185 # ZTIMER_USEC->adjust = 16
2020-05-06 14:07:26,232 # min=0 max=0 avg_diff=0
```

### Issues/PRs references

#13722 
