### PR TITLE
cpu/sam0_common: RTC cleanup

### DIFF
--- a/cpu/sam0_common/periph/rtc.c
+++ b/cpu/sam0_common/periph/rtc.c
@@ -66,7 +66,9 @@ static inline void _rtc_set_enabled(bool on)
 static void _rtc_clock_setup(void)
 {
     /* Use 1024 Hz GCLK3 */
-    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN(SAM0_GCLK_1KHZ) | GCLK_CLKCTRL_ID_RTC;
+    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN
+                      | GCLK_CLKCTRL_GEN(SAM0_GCLK_1KHZ)
+                      | GCLK_CLKCTRL_ID_RTC;
     while (GCLK->STATUS.bit.SYNCBUSY) {}
 }
 #else
@@ -121,7 +123,8 @@ int rtc_set_time(struct tm *time)
     /* normalize input */
     rtc_tm_normalize(time);
 
-    if ((time->tm_year < reference_year) || (time->tm_year > reference_year + 63)) {
+    if ((time->tm_year < reference_year) ||
+        (time->tm_year > reference_year + 63)) {
         return -1;
     }
     else {
@@ -139,15 +142,18 @@ int rtc_set_time(struct tm *time)
 
 int rtc_get_time(struct tm *time)
 {
- RTC_MODE2_CLOCK_Type clock;
+    RTC_MODE2_CLOCK_Type clock;
 
     /* Read register in one time */
     clock.reg = RTC->MODE2.CLOCK.reg;
 
     time->tm_year = clock.bit.YEAR + reference_year;
-    if ((time->tm_year < reference_year) || (time->tm_year > (reference_year + 63))) {
+
+    if ((time->tm_year < reference_year) ||
+        (time->tm_year > (reference_year + 63))) {
         return -1;
     }
+
     time->tm_mon = clock.bit.MONTH - 1;
     time->tm_mday = clock.bit.DAY;
     time->tm_hour = clock.bit.HOUR;
@@ -158,11 +164,14 @@ int rtc_get_time(struct tm *time)
 
 int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
 {
+    /* prevent old alarm from ringing */
+    rtc_clear_alarm();
+
     /* normalize input */
     rtc_tm_normalize(time);
 
-    rtc_clear_alarm();
-    if ((time->tm_year < reference_year) || (time->tm_year > (reference_year + 63))) {
+    if ((time->tm_year < reference_year) ||
+        (time->tm_year > (reference_year + 63))) {
         return -2;
     }
     else {
@@ -197,9 +206,11 @@ int rtc_get_alarm(struct tm *time)
     alarm.reg = RTC->MODE2.Mode2Alarm[0].ALARM.reg;
 
     time->tm_year = alarm.bit.YEAR + reference_year;
-    if ((time->tm_year < reference_year) || (time->tm_year > (reference_year + 63))) {
+    if ((time->tm_year < reference_year) ||
+        (time->tm_year > (reference_year + 63))) {
         return -1;
     }
+
     time->tm_mon = alarm.bit.MONTH - 1;
     time->tm_mday = alarm.bit.DAY;
     time->tm_hour = alarm.bit.HOUR;

--- a/cpu/sam0_common/periph/rtc.c
+++ b/cpu/sam0_common/periph/rtc.c
@@ -110,8 +110,8 @@ void rtc_init(void)
     RTC->MODE2.INTENSET.reg = RTC_MODE2_INTENSET_OVF;
 
     /* Clear interrupt flags */
-    RTC->MODE2.INTFLAG.reg |= RTC_MODE2_INTFLAG_OVF;
-    RTC->MODE2.INTFLAG.reg |= RTC_MODE2_INTFLAG_ALARM0;
+    RTC->MODE2.INTFLAG.reg = RTC_MODE2_INTFLAG_OVF
+                           | RTC_MODE2_INTFLAG_ALARM0;
 
     _rtc_set_enabled(1);
 }
@@ -183,7 +183,7 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
     /* Enable IRQ */
     rtc_callback.cb = cb;
     rtc_callback.arg = arg;
-    RTC->MODE2.INTFLAG.reg |= RTC_MODE2_INTFLAG_ALARM0;
+    RTC->MODE2.INTFLAG.reg = RTC_MODE2_INTFLAG_ALARM0;
     RTC->MODE2.INTENSET.bit.ALARM0 = 1;
 
     return 0;
@@ -240,11 +240,11 @@ void isr_rtc(void)
     if (RTC->MODE2.INTFLAG.bit.ALARM0) {
         rtc_callback.cb(rtc_callback.arg);
         /* clear flag */
-        RTC->MODE2.INTFLAG.reg |= RTC_MODE2_INTFLAG_ALARM0;
+        RTC->MODE2.INTFLAG.reg = RTC_MODE2_INTFLAG_ALARM0;
     }
     if (RTC->MODE2.INTFLAG.bit.OVF) {
         /* clear flag */
-        RTC->MODE2.INTFLAG.reg |= RTC_MODE2_INTFLAG_OVF;
+        RTC->MODE2.INTFLAG.reg = RTC_MODE2_INTFLAG_OVF;
         /* At 1Hz, RTC goes till 63 years (2^5, see 17.8.22 in datasheet)
         * Start RTC again with reference_year 64 years more (Be careful with alarm set) */
         reference_year += 64;


### PR DESCRIPTION

### Contribution description

RTC `INTFLAG` is clear on write - writing a 1 bit clears the interrupt flag, writing with `|=` is thus
unnecessary (and actually an error as this would clear *all* flags).

This cleanup was already done for `rtt.c`, but `rtc.c` missed out.

Also fix formatting issues to make the code easier to read.

### Testing procedure

`tests/periph_rtc` still works.

```
2020-05-06 14:12:22,292 # This test will display 'Alarm!' every 2 seconds for 4 times
2020-05-06 14:12:22,296 #   Setting clock to   2020-02-28 23:59:57
2020-05-06 14:12:22,302 # Clock value is now   2020-02-28 23:59:57
2020-05-06 14:12:22,306 #   Setting alarm to   2020-02-28 23:59:59
2020-05-06 14:12:22,312 #    Alarm is set to   2020-02-28 23:59:59
2020-05-06 14:12:22,312 # 
2020-05-06 14:12:24,554 # Alarm!
2020-05-06 14:12:26,554 # Alarm!
2020-05-06 14:12:28,554 # Alarm!
2020-05-06 14:12:30,554 # Alarm!
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
