### PR TITLE
ztimer: pull in xtimer_on_ztimer only if ztimer_periph_timer is used

### DIFF
--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -23,11 +23,11 @@ ifneq (,$(filter ztimer,$(USEMODULE)))
   endif
 endif
 
-# unless ztimer_xtimer_compat is used, make xtimer use ztimer as backend.
-ifneq (,$(filter ztimer,$(USEMODULE)))
+# unless ztimer_xtimer_compat is used, make xtimer use ztimer_usec as backend.
+ifneq (,$(filter ztimer_periph_timer,$(USEMODULE)))
   ifneq  (,$(filter xtimer,$(USEMODULE)))
     ifeq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
-        USEMODULE += xtimer_on_ztimer
+      USEMODULE += xtimer_on_ztimer
     endif
   endif
 endif


### PR DESCRIPTION
### Contribution description

`xtimer_on_ztimer` is only required if `ztimer` backs any clock on `ztimer_periph_timer`. This PR changes the dependency resolution for ztimer accordingly.

### Testing procedure

Run any `tests/xtimer_*` with:

 * `USEMODULE="ztimer_msec"`
 * `USEMODULE="ztimer_usec"`

The latter should use `xtimer_on_ztimer`. The first one shouldn't touch `xtimer` at all.

### Issues/PRs references

