### PR TITLE
boards/atmegaxxxp: Bugfixes

### DIFF
--- a/boards/atmega1284p/Makefile.include
+++ b/boards/atmega1284p/Makefile.include
@@ -5,7 +5,7 @@ BAUD                ?= 9600
 ATMEGA1284P_CLOCK   ?=
 
 # Allow overwriting programmer via env variables without affecting other boards
-PROGRAMMER_BOARD_ATMEGA1284P ?= dragon_isp
+PROGRAMMER_BOARD_ATMEGA1284P ?= atmelice
 # ICSP programmer to use for avrdude
 PROGRAMMER ?= $(PROGRAMMER_BOARD_ATMEGA1284P)
 

--- a/boards/atmega1284p/Makefile.include
+++ b/boards/atmega1284p/Makefile.include
@@ -2,8 +2,7 @@
 PORT_LINUX          ?= /dev/ttyUSB0
 PORT_DARWIN         ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD                ?= 9600
-ATMEGA328P_CLOCK    ?=
-include $(RIOTMAKE)/tools/serial.inc.mk
+ATMEGA1284P_CLOCK   ?=
 
 # Allow overwriting programmer via env variables without affecting other boards
 PROGRAMMER_BOARD_ATMEGA1284P ?= dragon_isp
@@ -14,5 +13,4 @@ ifneq (,$(ATMEGA1284P_CLOCK))
   CFLAGS += -DCLOCK_CORECLOCK=$(ATMEGA1284P_CLOCK)
 endif
 
-include $(RIOTMAKE)/tools/avrdude.inc.mk
 include $(RIOTBOARD)/common/atmega/Makefile.include

--- a/boards/atmega1284p/doc.txt
+++ b/boards/atmega1284p/doc.txt
@@ -11,7 +11,7 @@ it. (An ISP programmer will be needed to program it; or to program a bootloader
 to subsequently allow programming via UART.)
 
 ### MCU
-| MCU           | ATmega328p                             |
+| MCU           | ATmega1284p                            |
 |:------------- |:-------------------------------------- |
 | Family        | AVR/ATmega                             |
 | Vendor        | Microchip (previously Atmel)           |

--- a/boards/atmega1284p/doc.txt
+++ b/boards/atmega1284p/doc.txt
@@ -46,10 +46,10 @@ fuse is set, so that the clock is divided down to 1MHz. By disabling the
 can be done with:
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-avrdude -c dragon_isp -p m1284p -B 32 -U lfuse:w:0xc2:m
+avrdude -c atmelice -p m1284p -B 32 -U lfuse:w:0xc2:m
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-(Replace `dragon_isp` with the programmer you are using. The -B 32 might be
+(Replace `atmelice` with the programmer you are using. The -B 32 might be
 needed for some programmers to successfully communicate with ATmegas clocked at
 less than 2MHz. It will no longer be needed after disabling `CKDIV8`.)
 
@@ -80,8 +80,8 @@ needed. Connect the programmer as follows:
 | RESET    | 9/RESET        |
 | Ground   | 11/GND         |
 
-The tool `avrdude` needs to be installed. When using the AVR Dragon for
-programming, running
+The tool `avrdude` needs to be installed. When using the Atmel ICE for
+connected via JTAG for programming, running
 
     make BOARD=atmega1284p flash
 
@@ -100,21 +100,20 @@ the TTL adapter. Usually everything between 3.3 V and 5 V should work.
 
 ## On-Chip Debugging
 
-In order to debug the ATmega1284P, an compatible debugger is needed. The AVR
-Dragon is the ~~cheapest~~ least expensive option currently available. (But at
-least it can program and debug pretty much all AVRs and can even be used to
-de-brick ATmega MCUs using high voltage programming.)
+In order to debug the ATmega1284P, an compatible debugger is needed. The Atmel
+ICE is the ~~cheapest~~ least expensive option currently available. (But at
+least it can program and debug pretty much all Atmel AVR and ARM chips.)
 
-Once the AVR Dragon is correctly connected, the ATmega1284P has the JTAG
+Once the Atmel ICE is correctly connected, the ATmega1284P has the JTAG
 interface enabled, and the required software is installed, debugging can be
 started using
 
     make debug
 
-@note       If you are using a different debugger than the AVR Dragon, you have
+@note       If you are using a different debugger than the Atmel ICE, you have
             to export the `AVR_DEBUGDEVICE` environment variable to the required
-            flag to pass to AVaRICE, e.g. when using the Atmel-ICE you have to
-            export `AVR_DEBUGDEVICE=--edbg`. If the debug device is not
+            flag to pass to AVaRICE, e.g. when using the AVR Dragon you have to
+            export `AVR_DEBUGDEVICE=--dragon`. If the debug device is not
             connected via USB, you also need to export `AVR_DEBUGINTERFACE` to
             the correct value.
 
@@ -128,7 +127,7 @@ version of AVaRICE, you'll have to build the tool from source.
 
 ### JTAG Pin Mapping
 
-| Pin Name  | Pin   | Signal    | AVR Dragon Pin    |
+| Pin Name  | Pin   | Signal    | Atmel ICE Pin     |
 |:----------|:------|:----------|:------------------|
 | PC5       | 27    | TDI       | JTAG-9            |
 | PC4       | 26    | TDO       | JTAG-3            |

--- a/boards/atmega328p/Makefile.include
+++ b/boards/atmega328p/Makefile.include
@@ -3,7 +3,6 @@ PORT_LINUX          ?= /dev/ttyUSB0
 PORT_DARWIN         ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD                ?= 9600
 ATMEGA328P_CLOCK    ?=
-include $(RIOTMAKE)/tools/serial.inc.mk
 
 # Allow overwriting programmer via env variables without affecting other boards
 PROGRAMMER_BOARD_ATMEGA328P ?= usbtiny
@@ -14,5 +13,4 @@ ifneq (,$(ATMEGA328P_CLOCK))
   CFLAGS += -DCLOCK_CORECLOCK=$(ATMEGA328P_CLOCK)
 endif
 
-include $(RIOTMAKE)/tools/avrdude.inc.mk
 include $(RIOTBOARD)/common/atmega/Makefile.include


### PR DESCRIPTION
### Contribution description

- Both the atmega328p and the atmega1284p board still had the include of `avrdude.mk` and `serial.mk` in their `Makefile.include`, even though the corresponding include has been added to `boards/common/atmega`.
    - Including the files twice resulted in duplicated flasher flags to `avrdude`, which in turn wrote the firmware twice
- The atmega1284p documentation contained outdated information and typos, that were fixed
- The default programmer of the `atmega1284p` has been changed to the Atmel ICE, as the AVR Dragon is out of production an can no longer be obtained

### Testing procedure

- `make -C examples/hello-world flash BOARD=atmega328p` should now call avrdude with `-U flash:w:<PATH_TO_FIRMWARE>.hex` only once as argument
    - No board needed; only checking that avrdude is called correctly is sufficient
- `make -C examples/hello-world term BOARD=atmega328p` should still open a terminal
    - Again, only verifying that pyterm is opened with 9600 baud is enough
- Same tests for atmega1284p
    - Additionally, search for `-c atmelice` as argument to `avrdude` to verify new flasher is selected

### Issues/PRs references

None