### PR TITLE
mtd: add page addressed operations to allow access > 4GiB on SD cards

### DIFF
--- a/drivers/at24cxxx/at24cxxx.c
+++ b/drivers/at24cxxx/at24cxxx.c
@@ -104,6 +104,42 @@ int _read(const at24cxxx_t *dev, uint32_t pos, void *data, size_t len)
 }
 
 static
+int _write_page(const at24cxxx_t *dev, uint32_t pos, const void *data, size_t len)
+{
+    int check;
+    uint8_t polls = DEV_MAX_POLLS;
+    uint8_t dev_addr;
+    uint16_t _pos;
+    uint8_t flags = 0;
+
+    if (DEV_EEPROM_SIZE > 2048) {
+        /* 2 bytes word address length if more than 11 bits are
+           used for addressing */
+        /* append page address bits to device address (if any) */
+        dev_addr  = (DEV_I2C_ADDR | ((pos & 0xFF0000) >> 16));
+        _pos = (pos & 0xFFFF);
+        flags = I2C_REG16;
+    }
+    else {
+        /* append page address bits to device address (if any) */
+        dev_addr = (DEV_I2C_ADDR | ((pos & 0xFF00) >> 8));
+        _pos = pos & 0xFF;
+    }
+
+    while (-ENXIO == (check = i2c_write_regs(DEV_I2C_BUS, dev_addr,
+                                             _pos, data, len, flags))) {
+        if (--polls == 0) {
+            break;
+        }
+        xtimer_usleep(AT24CXXX_POLL_DELAY_US);
+    }
+
+    DEBUG("[at24cxxx] i2c_write_regs(): %d; polls: %d\n", check, polls);
+
+    return check;
+}
+
+static
 int _write(const at24cxxx_t *dev, uint32_t pos, const void *data, size_t len)
 {
     int check = 0;
@@ -111,31 +147,9 @@ int _write(const at24cxxx_t *dev, uint32_t pos, const void *data, size_t len)
 
     while (len) {
         size_t clen = MIN(len, DEV_PAGE_SIZE - MOD_POW2(pos, DEV_PAGE_SIZE));
-        uint8_t polls = DEV_MAX_POLLS;
-        uint8_t dev_addr;
-        uint16_t _pos;
-        uint8_t flags = 0;
-        if (DEV_EEPROM_SIZE > 2048) {
-            /* 2 bytes word address length if more than 11 bits are
-               used for addressing */
-            /* append page address bits to device address (if any) */
-            dev_addr  = (DEV_I2C_ADDR | ((pos & 0xFF0000) >> 16));
-            _pos = (pos & 0xFFFF);
-            flags = I2C_REG16;
-        }
-        else {
-            /* append page address bits to device address (if any) */
-            dev_addr = (DEV_I2C_ADDR | ((pos & 0xFF00) >> 8));
-            _pos = pos & 0xFF;
-        }
-        while (-ENXIO == (check = i2c_write_regs(DEV_I2C_BUS, dev_addr,
-                                                 _pos, cdata, clen, flags))) {
-            if (--polls == 0) {
-                break;
-            }
-            xtimer_usleep(AT24CXXX_POLL_DELAY_US);
-        }
-        DEBUG("[at24cxxx] i2c_write_regs(): %d; polls: %d\n", check, polls);
+
+        check = _write_page(dev, pos, cdata, clen);
+
         if (!check) {
             len -= clen;
             pos += clen;
@@ -241,6 +255,24 @@ int at24cxxx_write(const at24cxxx_t *dev, uint32_t pos, const void *data,
         i2c_release(DEV_I2C_BUS);
     }
     return check;
+}
+
+int at24cxxx_write_page(const at24cxxx_t *dev, uint32_t page, uint32_t offset,
+                        const void *data, size_t len)
+{
+    int check;
+
+    assert(offset < DEV_PAGE_SIZE);
+
+    /* write no more than to the end of the current page to prevent wrap-around */
+    size_t remaining = DEV_PAGE_SIZE - offset;
+    len = MIN(len, remaining);
+
+    i2c_acquire(DEV_I2C_BUS);
+    check = _write_page(dev, page * DEV_PAGE_SIZE + offset, data, len);
+    i2c_release(DEV_I2C_BUS);
+
+    return check ? check : (int) len;
 }
 
 int at24cxxx_set(const at24cxxx_t *dev, uint32_t pos, uint8_t val,

--- a/drivers/at24cxxx/mtd/mtd.c
+++ b/drivers/at24cxxx/mtd/mtd.c
@@ -56,6 +56,12 @@ static int _mtd_at24cxxx_write(mtd_dev_t *mtd, const void *src, uint32_t addr,
     return at24cxxx_write(DEV(mtd), addr, src, size) == AT24CXXX_OK ? 0 : -EIO;
 }
 
+static int mtd_at24cxxx_write_page(mtd_dev_t *mtd, const void *src, uint32_t page,
+                                   uint32_t offset, uint32_t size)
+{
+    return at24cxxx_write_page(DEV(mtd), page, offset, src, size);
+}
+
 static int _mtd_at24cxxx_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size)
 {
     return at24cxxx_clear(DEV(mtd), addr, size) == AT24CXXX_OK ? 0 : -EIO;
@@ -72,6 +78,7 @@ const mtd_desc_t mtd_at24cxxx_driver = {
     .init = _mtd_at24cxxx_init,
     .read = _mtd_at24cxxx_read,
     .write = _mtd_at24cxxx_write,
+    .write_page = mtd_at24cxxx_write_page,
     .erase = _mtd_at24cxxx_erase,
     .power = _mtd_at24cxxx_power
 };

--- a/drivers/at25xxx/at25xxx.c
+++ b/drivers/at25xxx/at25xxx.c
@@ -26,6 +26,7 @@
 #include "at25xxx.h"
 #include "at25xxx_constants.h"
 #include "at25xxx_params.h"
+#include "bitarithm.h"
 #include "byteorder.h"
 
 #include "xtimer.h"
@@ -81,12 +82,14 @@ static inline int _wait_until_eeprom_ready(const at25xxx_t *dev)
     return tries == 0 ? -ETIMEDOUT : 0;
 }
 
-static ssize_t _write_page(const at25xxx_t *dev, uint32_t pos, const void *data, size_t len)
+static int _at25xxx_write_page(const at25xxx_t *dev, uint32_t page, uint32_t offset, const void *data, size_t len)
 {
+    assert(offset < PAGE_SIZE);
+
     /* write no more than to the end of the current page to prevent wrap-around */
-    size_t remaining = PAGE_SIZE - (pos & (PAGE_SIZE - 1));
+    size_t remaining = PAGE_SIZE - offset;
     len = min(len, remaining);
-    pos = _pos(CMD_WRITE, pos);
+    uint32_t pos = _pos(CMD_WRITE, page * PAGE_SIZE + offset);
 
     /* wait for previous write to finish - may take up to 5 ms */
     int res = _wait_until_eeprom_ready(dev);
@@ -111,6 +114,17 @@ static ssize_t _write_page(const at25xxx_t *dev, uint32_t pos, const void *data,
     return len;
 }
 
+int at25xxx_write_page(const at25xxx_t *dev, uint32_t page, uint32_t offset, const void *data, size_t len)
+{
+    int res;
+
+    getbus(dev);
+    res = _at25xxx_write_page(dev, page, offset, data, len);
+    spi_release(dev->params.spi);
+
+    return res;
+}
+
 int at25xxx_write(const at25xxx_t *dev, uint32_t pos, const void *data, size_t len)
 {
     int res = 0;
@@ -120,18 +134,32 @@ int at25xxx_write(const at25xxx_t *dev, uint32_t pos, const void *data, size_t l
         return -ERANGE;
     }
 
+    /* page size is always a power of two */
+    const uint32_t page_shift = bitarithm_msb(PAGE_SIZE);
+    const uint32_t page_mask = PAGE_SIZE - 1;
+
+    uint32_t page   = pos >> page_shift;
+    uint32_t offset = pos & page_mask;
+
     getbus(dev);
 
     while (len) {
-        ssize_t written = _write_page(dev, pos, d, len);
+        ssize_t written = _at25xxx_write_page(dev, page, offset, d, len);
+
         if (written < 0) {
             res = written;
             break;
         }
 
         len -= written;
-        pos += written;
-        d   += written;
+
+        if (len == 0) {
+            break;
+        }
+
+        d      += written;
+        page   += (offset + written) >> page_shift;
+        offset  = (offset + written) & page_mask;
     }
 
     spi_release(dev->params.spi);
@@ -177,7 +205,6 @@ uint8_t at25xxx_read_byte(const at25xxx_t *dev, uint32_t pos)
 int at25xxx_set(const at25xxx_t *dev, uint32_t pos, uint8_t val, size_t len)
 {
     uint8_t data[AT225XXXX_SET_BUF_SIZE];
-    size_t total = 0;
 
     if (pos + len > dev->params.size) {
         return -ERANGE;
@@ -185,13 +212,20 @@ int at25xxx_set(const at25xxx_t *dev, uint32_t pos, uint8_t val, size_t len)
 
     memset(data, val, sizeof(data));
 
+    /* page size is always a power of two */
+    const uint32_t page_shift = bitarithm_msb(PAGE_SIZE);
+    const uint32_t page_mask = PAGE_SIZE - 1;
+
+    uint32_t page   = pos >> page_shift;
+    uint32_t offset = pos & page_mask;
+
     getbus(dev);
 
     while (len) {
-        size_t written = _write_page(dev, pos, data, min(len, sizeof(data)));
-        len   -= written;
-        pos   += written;
-        total += written;
+        size_t written = _at25xxx_write_page(dev, page, offset, data, min(len, sizeof(data)));
+        len    -= written;
+        page   += (offset + written) >> page_shift;
+        offset  = (offset + written) & page_mask;
     }
 
     spi_release(dev->params.spi);

--- a/drivers/at25xxx/mtd/mtd.c
+++ b/drivers/at25xxx/mtd/mtd.c
@@ -57,6 +57,15 @@ static int mtd_at25xxx_write(mtd_dev_t *dev, const void *buff, uint32_t addr, ui
     return at25xxx_write(mtd_at25xxx_->at25xxx_eeprom, addr, buff, size);
 }
 
+static int mtd_at25xxx_write_page(mtd_dev_t *dev, const void *src, uint32_t page, uint32_t offset,
+                                  uint32_t size)
+{
+    DEBUG("[mtd_at25xxx] write_page: page:%" PRIu32 " offset:%" PRIu32 " size:%" PRIu32 "\n",
+          page, offset, size);
+    mtd_at25xxx_t *mtd_at25xxx_ = (mtd_at25xxx_t*)dev;
+    return at25xxx_write_page(mtd_at25xxx_->at25xxx_eeprom, page, offset, src, size);
+}
+
 static int mtd_at25xxx_erase(mtd_dev_t *dev, uint32_t addr, uint32_t size)
 {
     DEBUG("[mtd_at25xxx] mtd_at25xxx_erase: addr:%" PRIu32 " size:%" PRIu32 "\n", addr, size);
@@ -78,6 +87,7 @@ const mtd_desc_t mtd_at25xxx_driver = {
     .init = mtd_at25xxx_init,
     .read = mtd_at25xxx_read,
     .write = mtd_at25xxx_write,
+    .write_page = mtd_at25xxx_write_page,
     .erase = mtd_at25xxx_erase,
     .power = mtd_at25xxx_power,
 };

--- a/drivers/include/at24cxxx.h
+++ b/drivers/include/at24cxxx.h
@@ -130,6 +130,23 @@ int at24cxxx_write(const at24cxxx_t *dev, uint32_t pos, const void *data,
                    size_t len);
 
 /**
+ * @brief Sequentially write @p len bytes to a given @p page.
+ *        The function will write up to the page boundary and then return
+ *        the number of bytes written up to that.
+ *
+ * @param[in] dev       AT24CXXX device handle
+ * @param[in] page      page of EEPROM memory
+ * @param[in] offset    offset from the start of the page, must be < page size
+ * @param[in] data      write buffer
+ * @param[in] len       requested length to be written
+ *
+ * @return    number of bytes written on success
+ * @return    error on failure
+ */
+int at24cxxx_write_page(const at24cxxx_t *dev, uint32_t page, uint32_t offset,
+                        const void *data, size_t len);
+
+/**
  * @brief   Set @p len bytes from a given position @p pos to the
  * value @p val
  *

--- a/drivers/include/at25xxx.h
+++ b/drivers/include/at25xxx.h
@@ -110,6 +110,22 @@ void at25xxx_write_byte(const at25xxx_t *dev, uint32_t pos, uint8_t data);
 int at25xxx_write(const at25xxx_t *dev, uint32_t pos, const void *data, size_t len);
 
 /**
+ * @brief Sequentially write @p len bytes to a given @p page.
+ *        The function will write up to the page boundary and then return.
+ *
+ * @param[in] dev       AT25XXX device handle
+ * @param[in] page      page of EEPROM memory
+ * @param[in] offset    offset from the start of the page, must be < page size
+ * @param[in] data      write buffer
+ * @param[in] len       requested length to be written
+ *
+ * @return    number of bytes written on success
+ * @return    error on failure
+ */
+int at25xxx_write_page(const at25xxx_t *dev, uint32_t page, uint32_t offset,
+                       const void *data, size_t len);
+
+/**
  * @brief Set @p len bytes from a given position @p pos to the
  * value @p val
  *

--- a/drivers/include/mtd.h
+++ b/drivers/include/mtd.h
@@ -102,6 +102,27 @@ struct mtd_desc {
                 uint32_t size);
 
     /**
+     * @brief   Read from the Memory Technology Device (MTD) using
+     *          pagewise addressing.
+     *
+     * @p offset should not exceed the page size
+     *
+     * @param[in]  dev      Pointer to the selected driver
+     * @param[out] buff     Pointer to the data buffer to store read data
+     * @param[in]  page     Page number to start reading from
+     * @param[in]  offset   Byte offset from the start of the page
+     * @param[in]  size     Number of bytes
+     *
+     * @return number of bytes read on success
+     * @return < 0 value on error
+     */
+    int (*read_page)(mtd_dev_t *dev,
+                     void *buff,
+                     uint32_t page,
+                     uint32_t offset,
+                     uint32_t size);
+
+    /**
      * @brief   Write to the Memory Technology Device (MTD)
      *
      * @p addr + @p size must be inside a page boundary. @p addr can be anywhere
@@ -121,6 +142,27 @@ struct mtd_desc {
                  uint32_t size);
 
     /**
+     * @brief   Write to the Memory Technology Device (MTD) using
+     *          pagewise addressing.
+     *
+     * @p offset should not exceed the page size
+     *
+     * @param[in]  dev      Pointer to the selected driver
+     * @param[out] buff     Pointer to the data to be written
+     * @param[in]  page     Page number to start writing to
+     * @param[in]  offset   Byte offset from the start of the page
+     * @param[in]  size     Number of bytes
+     *
+     * @return bytes written on success
+     * @return < 0 value on error
+     */
+    int (*write_page)(mtd_dev_t *dev,
+                      const void *buff,
+                      uint32_t page,
+                      uint32_t offset,
+                      uint32_t size);
+
+    /**
      * @brief   Erase sector(s) over the Memory Technology Device (MTD)
      *
      * @p addr must be aligned on a sector boundary. @p size must be a multiple of a sector size.
@@ -135,6 +177,21 @@ struct mtd_desc {
     int (*erase)(mtd_dev_t *dev,
                  uint32_t addr,
                  uint32_t size);
+
+    /**
+     * @brief   Erase sector(s) of the Memory Technology Device (MTD)
+     *
+     * @param[in] dev       Pointer to the selected driver
+     * @param[in] sector    the first sector number to erase
+
+     * @param[in] count     Number of sectors to erase
+     *
+     * @return 0 on success
+     * @return < 0 value on error
+     */
+    int (*erase_sector)(mtd_dev_t *dev,
+                        uint32_t sector,
+                        uint32_t count);
 
     /**
      * @brief   Control power of Memory Technology Device (MTD)
@@ -177,6 +234,29 @@ int mtd_init(mtd_dev_t *mtd);
 int mtd_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t count);
 
 /**
+ * @brief   Read data from a MTD device with pagewise addressing
+ *
+ * The MTD layer will take care of splitting up the transaction into multiple
+ * reads if it is required by the underlying storage media.
+ *
+ * @p offset must be smaller than the page size
+ *
+ * @param      mtd      the device to read from
+ * @param[out] dest     the buffer to fill in
+ * @param[in]  page     Page number to start reading from
+ * @param[in]  offset   offset from the start of the page (in bytes)
+ * @param[in]  size     the number of bytes to read
+ *
+ * @return 0 on success
+ * @return < 0 if an error occurred
+ * @return -ENODEV if @p mtd is not a valid device
+ * @return -ENOTSUP if operation is not supported on @p mtd
+ * @return -EOVERFLOW if @p addr or @p count are not valid, i.e. outside memory
+ * @return -EIO if I/O error occurred
+ */
+int mtd_read_page(mtd_dev_t *mtd, void *dest, uint32_t page, uint32_t offset, uint32_t size);
+
+/**
  * @brief   Write data to a MTD device
  *
  * @p addr + @p count must be inside a page boundary. @p addr can be anywhere
@@ -200,6 +280,31 @@ int mtd_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t count);
 int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count);
 
 /**
+ * @brief   Write data to a MTD device with pagewise addressing
+ *
+ * The MTD layer will take care of splitting up the transaction into multiple
+ * writes if it is required by the underlying storage media.
+ *
+ * @p offset must be smaller than the page size
+ *
+ *
+ * @param      mtd      the device to write to
+ * @param[in]  src      the buffer to write
+ * @param[in]  page     Page number to start writing to
+ * @param[in]  offset   byte offset from the start of the page
+ * @param[in]  size     the number of bytes to write
+ *
+ * @return 0 on success
+ * @return < 0 if an error occurred
+ * @return -ENODEV if @p mtd is not a valid device
+ * @return -ENOTSUP if operation is not supported on @p mtd
+ * @return -EOVERFLOW if @p addr or @p count are not valid, i.e. outside memory,
+ * @return -EIO if I/O error occurred
+ * @return -EINVAL if parameters are invalid
+ */
+int mtd_write_page(mtd_dev_t *mtd, const void *src, uint32_t page, uint32_t offset, uint32_t size);
+
+/**
  * @brief   Erase sectors of a MTD device
  *
  * @p addr must be aligned on a sector boundary. @p count must be a multiple of a sector size.
@@ -216,6 +321,22 @@ int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count);
  * @return -EIO if I/O error occurred
  */
 int mtd_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t count);
+
+/**
+ * @brief   Erase sectors of a MTD device
+ *
+ * @param      mtd    the device to erase
+ * @param[in]  sector the first sector number to erase
+ * @param[in]  num    the number of sectors to erase
+ *
+ * @return 0 if erase successful
+ * @return < 0 if an error occurred
+ * @return -ENODEV if @p mtd is not a valid device
+ * @return -ENOTSUP if operation is not supported on @p mtd
+ * @return -EOVERFLOW if @p addr or @p sector are not valid, i.e. outside memory
+ * @return -EIO if I/O error occurred
+ */
+int mtd_erase_sector(mtd_dev_t *mtd, uint32_t sector, uint32_t num);
 
 /**
  * @brief   Set power mode on a MTD device

--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -18,8 +18,12 @@
  * @author      Vincent Dupont <vincent@otakeys.com>
  */
 
+#include <assert.h>
 #include <errno.h>
+#include <limits.h>
+#include <stddef.h>
 
+#include "bitarithm.h"
 #include "mtd.h"
 
 int mtd_init(mtd_dev_t *mtd)
@@ -42,12 +46,62 @@ int mtd_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t count)
         return -ENODEV;
     }
 
-    if (mtd->driver->read) {
-        return mtd->driver->read(mtd, dest, addr, count);
+    /* page size is always a power of two */
+    const uint32_t page_shift = bitarithm_msb(mtd->page_size);
+    const uint32_t page_mask = mtd->page_size - 1;
+
+    return mtd_read_page(mtd, dest, addr >> page_shift, addr & page_mask, count);
+}
+
+int mtd_read_page(mtd_dev_t *mtd, void *dest, uint32_t page, uint32_t offset,
+                  uint32_t count)
+{
+    if (!mtd || !mtd->driver) {
+        return -ENODEV;
     }
-    else {
-        return -ENOTSUP;
+
+    if (mtd->driver->read_page == NULL) {
+        /* TODO: remove when all backends implement read_page */
+        if (mtd->driver->read) {
+            return mtd->driver->read(mtd, dest, mtd->page_size * page + offset, count);
+        } else {
+            return -ENOTSUP;
+        }
     }
+
+    /* Implementation assumes page size is <= INT_MAX and a power of two. */
+    /* We didn't find hardware yet where this is not true.                */
+    assert(mtd->page_size <= INT_MAX);
+    assert(bitarithm_bits_set(mtd->page_size) == 1);
+
+    /* page size is always a power of two */
+    const uint32_t page_shift = bitarithm_msb(mtd->page_size);
+    const uint32_t page_mask = mtd->page_size - 1;
+
+    page  += offset >> page_shift;
+    offset = offset & page_mask;
+
+    char *_dst = dest;
+
+    while (count) {
+        int read_bytes = mtd->driver->read_page(mtd, _dst, page, offset, count);
+
+        if (read_bytes < 0) {
+            return read_bytes;
+        }
+
+        count -= read_bytes;
+
+        if (count == 0) {
+            break;
+        }
+
+        _dst   += read_bytes;
+        page   += (offset + read_bytes) >> page_shift;
+        offset  = (offset + read_bytes) & page_mask;
+    }
+
+    return 0;
 }
 
 int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count)
@@ -56,12 +110,62 @@ int mtd_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t count)
         return -ENODEV;
     }
 
-    if (mtd->driver->write) {
-        return mtd->driver->write(mtd, src, addr, count);
+    /* page size is always a power of two */
+    const uint32_t page_shift = bitarithm_msb(mtd->page_size);
+    const uint32_t page_mask = mtd->page_size - 1;
+
+    return mtd_write_page(mtd, src, addr >> page_shift, addr & page_mask, count);
+}
+
+int mtd_write_page(mtd_dev_t *mtd, const void *src, uint32_t page, uint32_t offset,
+                   uint32_t count)
+{
+    if (!mtd || !mtd->driver) {
+        return -ENODEV;
     }
-    else {
-        return -ENOTSUP;
+
+    if (mtd->driver->write_page == NULL) {
+        /* TODO: remove when all backends implement write_page */
+        if (mtd->driver->write) {
+            return mtd->driver->write(mtd, src, mtd->page_size * page + offset, count);
+        } else {
+            return -ENOTSUP;
+        }
     }
+
+    /* Implementation assumes page size is <= INT_MAX and a power of two. */
+    /* We didn't find hardware yet where this is not true.                */
+    assert(mtd->page_size <= INT_MAX);
+    assert(bitarithm_bits_set(mtd->page_size) == 1);
+
+    /* page size is always a power of two */
+    const uint32_t page_shift = bitarithm_msb(mtd->page_size);
+    const uint32_t page_mask = mtd->page_size - 1;
+
+    page  += offset >> page_shift;
+    offset = offset & page_mask;
+
+    const char *_src = src;
+
+    while (count) {
+        int written = mtd->driver->write_page(mtd, _src, page, offset, count);
+
+        if (written < 0) {
+            return written;
+        }
+
+        count -= written;
+
+        if (count == 0) {
+            break;
+        }
+
+        _src   += written;
+        page   += (offset + written) >> page_shift;
+        offset  = (offset + written) & page_mask;
+    }
+
+    return 0;
 }
 
 int mtd_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t count)
@@ -70,12 +174,42 @@ int mtd_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t count)
         return -ENODEV;
     }
 
-    if (mtd->driver->erase) {
-        return mtd->driver->erase(mtd, addr, count);
+    uint32_t sector_size = mtd->pages_per_sector * mtd->page_size;
+
+    if (count % sector_size) {
+        return -EOVERFLOW;
     }
-    else {
-        return -ENOTSUP;
+
+    if (addr % sector_size) {
+        return -EOVERFLOW;
     }
+
+    return mtd_erase_sector(mtd, addr / sector_size, count / sector_size);
+}
+
+int mtd_erase_sector(mtd_dev_t *mtd, uint32_t sector, uint32_t count)
+{
+    if (!mtd || !mtd->driver) {
+        return -ENODEV;
+    }
+
+    if (sector >= mtd->sector_count) {
+        return -EOVERFLOW;
+    }
+
+    if (mtd->driver->erase_sector == NULL) {
+        /* TODO: remove when all backends implement erase_sector */
+        if (mtd->driver->erase) {
+            uint32_t sector_size = mtd->pages_per_sector * mtd->page_size;
+            return mtd->driver->erase(mtd,
+                                      sector * sector_size,
+                                      count * sector_size);
+        } else {
+            return -ENOTSUP;
+        }
+    }
+
+    return mtd->driver->erase_sector(mtd, sector, count);
 }
 
 int mtd_power(mtd_dev_t *mtd, enum mtd_power_state power)

--- a/pkg/fatfs/fatfs_diskio/mtd/mtd_diskio.c
+++ b/pkg/fatfs/fatfs_diskio/mtd/mtd_diskio.c
@@ -95,15 +95,15 @@ DRESULT disk_read(BYTE pdrv, BYTE *buff, DWORD sector, UINT count)
         return RES_PARERR;
     }
 
-    uint32_t nread = count * fatfs_mtd_devs[pdrv]->page_size;
-    int res = mtd_read(fatfs_mtd_devs[pdrv], buff,
-                       sector * fatfs_mtd_devs[pdrv]->page_size,
-                       nread);
+    uint32_t sector_size = fatfs_mtd_devs[pdrv]->page_size
+                         * fatfs_mtd_devs[pdrv]->pages_per_sector;
+
+    int res = mtd_read_page(fatfs_mtd_devs[pdrv], buff,
+                            sector, 0, count * sector_size);
 
     if (res != 0) {
         return RES_ERROR;
     }
-    assert((nread / fatfs_mtd_devs[pdrv]->page_size) == count);
     return RES_OK;
 }
 
@@ -127,23 +127,21 @@ DRESULT disk_write(BYTE pdrv, const BYTE *buff, DWORD sector, UINT count)
     }
 
     /* erase memory before writing to it */
-    int res = mtd_erase(fatfs_mtd_devs[pdrv],
-                        sector * fatfs_mtd_devs[pdrv]->page_size,
-                        count * fatfs_mtd_devs[pdrv]->page_size);
+    int res = mtd_erase_sector(fatfs_mtd_devs[pdrv], sector, count);
 
     if (res != 0) {
         return RES_ERROR; /* erase failed! */
     }
 
-    uint32_t nwrite = count * fatfs_mtd_devs[pdrv]->page_size;
-    res = mtd_write(fatfs_mtd_devs[pdrv], buff,
-                    sector * fatfs_mtd_devs[pdrv]->page_size,
-                    nwrite);
+    uint32_t sector_size = fatfs_mtd_devs[pdrv]->page_size
+                         * fatfs_mtd_devs[pdrv]->pages_per_sector;
+
+    res = mtd_write_page(fatfs_mtd_devs[pdrv], buff,
+                         sector, 0, count * sector_size);
 
     if (res != 0) {
         return RES_ERROR;
     }
-    assert((nwrite / fatfs_mtd_devs[pdrv]->page_size) == count);
     return RES_OK;
 }
 

--- a/tests/pkg_fatfs_vfs/Makefile.ci
+++ b/tests/pkg_fatfs_vfs/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     msb-430 \
     msb-430h \
     nucleo-f031k6 \
+    nucleo-l031k6 \
     nucleo-f042k6 \
     stm32f030f4-demo \
     telosb \


### PR DESCRIPTION
### Contribution description

Currently `read()`, `write()` and `erase()` all use 32 bit addressing.
This is a problem when writing to media > 4 GiB, e.g. SD cards.

The current implementation would wrap around after 4 GiB and corrupt data.

To avoid this, add functions to the MTD subsystem that allow for page-wise addressing.
This is how most of the underling storage drivers and the file-systems above work anyway.

In the future we should then deprecate the 32-bit functions if all drivers are converted.

### Testing procedure

~~So far only the SD card and FAT drivers have been converted~~ - `tests/pkg_fatfs_vfs` should still work. But it should now also work if you previously filled up the SD card > 4 GiB

SD card filled with 4 files ~1 GiB each, `examples/filesystem`:

#### master

```
>  mount
2020-06-25 00:39:50,589 # /sda successfully mounted
> ls /sda
2020-06-25 00:40:03,007 #  ls /sda
2020-06-25 00:40:03,010 # vfs_readdir error: -EIO
```

#### this PR

```
>  mount
2020-06-25 00:46:14,191 # /sda successfully mounted
> ls /sda
2020-06-25 00:46:16,773 # TEST.TXT
2020-06-25 00:46:16,773 # LINED.C
2020-06-25 00:46:16,774 # HELLO.TXT
2020-06-25 00:46:16,775 # SYSTEM~1
2020-06-25 00:46:16,778 # WESTWO~1.MKV
2020-06-25 00:46:16,779 # WESTWO~2.MKV
2020-06-25 00:46:16,780 # WESTWO~3.MKV
2020-06-25 00:46:16,783 # WESTWO~4.MKV
2020-06-25 00:46:16,783 # WUT.TXT
2020-06-25 00:46:16,785 # total 9 files
> cat /sda/wut.txt
2020-06-25 00:46:20,925 # I never saw a purple cow.
2020-06-25 00:46:20,927 # I never hope to see one.
2020-06-25 00:46:20,929 # But I can tell you anyhow
2020-06-25 00:46:20,932 # I'd rather see than be one.
```

### Issues/PRs references

fixes #14773
