### PR TITLE
dist/tools/uncrustify: temporarily disable error on check failure

### DIFF
--- a/dist/tools/uncrustify/uncrustify.sh
+++ b/dist/tools/uncrustify/uncrustify.sh
@@ -19,7 +19,10 @@ check () {
             --check > /dev/null 2>&1 || {
             echo "file $F needs to be uncrustified."
             echo "Please run 'dist/tools/uncrustify/uncrustify.sh'"
-            exit 1
+
+            # Disable error until versioning issue is sorted out.
+            #exit 1
+            exit 0
         }
     done
     echo "All files are uncrustified!"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Unfortunately it seems different uncrustify versions produce different output. This makes it difficult to enforce uncrustifying.

I hope this is just the CI's version being quite outdated, hoping an [update](https://github.com/RIOT-OS/riotdocker/pull/104) might fix it.

Anyhow, this PR disables the error exit for now.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/13999

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
