### PR TITLE
cpu/esp_common: fix the dependency of the flash image on the ELF file

### DIFF
--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -109,6 +109,8 @@ PREFFLAGS += python3 $(RIOTTOOLS)/esptool/gen_esp32part.py
 PREFFLAGS += --verify $(BINDIR)/partitions.csv $(BINDIR)/partitions.bin
 FLASHDEPS += preflash
 
+BUILD_BEFORE_FLASH += $(FLASHFILE)
+
 # flasher configuration
 ifneq (,$(filter esp_qemu,$(USEMODULE)))
   FLASHER = dd


### PR DESCRIPTION
### Contribution description

This PR fixes the dependency of the flash image on the ELF file for the ESP* make system.

Flashing an ESP board first requires the creation of a flash image from the ELF file.  This is realized in the `preflash` target. However, the `preflash` target only depends on the variable `BUILD_BEFORE_FLASH` but on the ELF file. Therefore, the variable `BUILD_BEFORE_FLASH` must be set to the ELF file to ensure that when using multiple make processes, the compilation of the ELF file is completed before the flash image is created.

### Testing procedure

- In `examples/hello-world` run `make BOARD=esp32-wroom-32 -j flash term`.
- Change the text in `main.c`, better yet print it in a` while(1)` loop.
- Run `make BOARD=esp32-wroom-32 -j flash term` again

### Issues/PRs references

Fixes #13492 