### PR TITLE
doc/build-system-basics: fix typo

### DIFF
--- a/doc/doxygen/src/build-system-basics.md
+++ b/doc/doxygen/src/build-system-basics.md
@@ -61,11 +61,11 @@ For a `FEATURE` to be provided by a `board` it must meet 2 criteria, and for
   `FEATURES_REQUIRED_ANY += arch_avr8|arch_native` if both are provide then
   `arch_avr8` will be used.
 
-- `FEATURES_BLACKLIST` are `FEATURES` that can't be used by a `MODULE` or `APPLCIATION`.
+- `FEATURES_BLACKLIST` are `FEATURES` that can't be used by a `MODULE` or `APPLICATION`.
   They are usually used for _hw_ characteristics like `arch_` to easily resolve
   unsupported configurations for a group.
 
-- `FEATURES_USED` are the final list of `FEATURES` that will be used by an `APPLCIATION`
+- `FEATURES_USED` are the final list of `FEATURES` that will be used by an `APPLICATION`
 
 ### Where to define FEATURES_%
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes an obvious typo on the `APPLICATION` variable in the build system basics documentation page.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Read the docs

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while commenting about build system basics in #13146 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
