### PR TITLE
sock_dtls: add timeout to sock_dtls_send and add sock_dtls_session_init

### DIFF
--- a/examples/dtls-sock/dtls-client.c
+++ b/examples/dtls-sock/dtls-client.c
@@ -74,7 +74,7 @@ static int client_send(char *addr_str, char *data, size_t datalen)
     sock_udp_t udp_sock;
     sock_dtls_t dtls_sock;
     sock_dtls_session_t session;
-    sock_udp_ep_t remote;
+    sock_udp_ep_t remote = SOCK_IPV6_EP_ANY;
     sock_udp_ep_t local = SOCK_IPV6_EP_ANY;
     local.port = 12345;
     remote.port = DTLS_DEFAULT_PORT;

--- a/examples/dtls-sock/dtls-client.c
+++ b/examples/dtls-sock/dtls-client.c
@@ -78,6 +78,7 @@ static int client_send(char *addr_str, char *data, size_t datalen)
     sock_udp_ep_t local = SOCK_IPV6_EP_ANY;
     local.port = 12345;
     remote.port = DTLS_DEFAULT_PORT;
+    uint8_t buf[DTLS_HANDSHAKE_BUFSIZE];
 
     /* get interface */
     char* iface = ipv6_addr_split_iface(addr_str);
@@ -122,26 +123,32 @@ static int client_send(char *addr_str, char *data, size_t datalen)
         return -1;
     }
 
-    res = sock_dtls_session_create(&dtls_sock, &remote, &session);
-    if (res < 0) {
+    res = sock_dtls_session_init(&dtls_sock, &remote, &session);
+    if (res <= 0) {
+        return res;
+    }
+
+    res = sock_dtls_recv(&dtls_sock, &session, buf, sizeof(buf),
+                         SOCK_NO_TIMEOUT);
+    if (res != -SOCK_DTLS_HANDSHAKE) {
         printf("Error creating session: %d\n", (int)res);
         sock_dtls_close(&dtls_sock);
         sock_udp_close(&udp_sock);
         return -1;
     }
+    printf("Connection to server successful\n");
 
-    if (sock_dtls_send(&dtls_sock, &session, data, datalen) < 0) {
+    if (sock_dtls_send(&dtls_sock, &session, data, datalen, 0) < 0) {
         puts("Error sending data");
     }
     else {
         printf("Sent DTLS message\n");
 
         uint8_t rcv[512];
-        if (sock_dtls_recv(&dtls_sock, &session, rcv, sizeof(rcv), SOCK_NO_TIMEOUT) < 0) {
-            printf("Error receiving DTLS message\n");
-        }
-        else {
-            printf("Received DTLS message\n");
+        if ((res = sock_dtls_recv(&dtls_sock, &session, rcv, sizeof(rcv),
+                                    SOCK_NO_TIMEOUT)) >= 0) {
+            printf("Received %d bytes: \"%.*s\"\n", (int)res, (int)res,
+                   (char *)rcv);
         }
     }
 

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -357,7 +357,8 @@ ssize_t sock_dtls_send(sock_dtls_t *sock, sock_dtls_session_t *remote,
         }
     }
 
-    return dtls_write(sock->dtls_ctx, &remote->dtls_session, (uint8_t *)data, len);
+    return dtls_write(sock->dtls_ctx, &remote->dtls_session,
+                      (uint8_t *)data, len);
 }
 
 static ssize_t _copy_buffer(sock_dtls_t *sock, void *data, size_t max_len)

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -29,7 +29,8 @@
  *   2. Add the credential using @ref credman_add()
  * - Server operation
  *   1. Create UDP sock @ref sock_udp_create()
- *   2. Create DTLS sock @ref sock_dtls_create() using role @ref SOCK_DTLS_SERVER
+ *   2. Create DTLS sock @ref sock_dtls_create() using role
+ *      @ref SOCK_DTLS_SERVER
  *   3. Start listening with @ref sock_dtls_recv()
  * - Client operation
  *   1. Create UDP sock @ref sock_udp_create()
@@ -111,7 +112,7 @@
  *                     .y = server_ecdsa_pub_key_y,
  *                 },
  *                 .client_keys = other_pubkeys,
- *                 .client_keys_size = sizeof(other_pubkeys) / sizeof(other_pubkeys[0]),
+ *                 .client_keys_size = ARRAY_SIZE(other_pubkeys),
  *             },
  *         },
  *     };
@@ -300,7 +301,7 @@
  * #define SOCK_DTLS_CLIENT_TAG (20)
  *
  * #ifndef SERVER_ADDR
- * #define SERVER_ADDR "fe80::aa:bb:cc:dd" // replace this with the server address
+ * #define SERVER_ADDR "fe80::aa:bb:cc:dd" // replace with the server address
  * #endif
  *
  * int main(void)
@@ -339,7 +340,8 @@
  *         return -1;
  *     }
  *
- *     if (sock_dtls_session_create(&dtls_sock, &remote, &session, SOCK_NO_TIMEOUT) < 0) {
+ *     if (sock_dtls_session_create(&dtls_sock, &remote, &session,
+ *                                  SOCK_NO_TIMEOUT) < 0) {
  *         puts("Error creating session");
  *         sock_dtls_close(&dtls_sock);
  *         sock_udp_close(&udp_sock);
@@ -350,7 +352,8 @@
  *     int res = sock_dtls_send(&dtls_sock, &session, data, sizeof(data), 0);
  *     if (res >= 0) {
  *         printf("Sent %d bytes\n", res);
- *         res = sock_dtls_recv(&dtls_sock, &session, rcv, sizeof(rcv), SOCK_NO_TIMEOUT);
+ *         res = sock_dtls_recv(&dtls_sock, &session, rcv, sizeof(rcv),
+ *                              SOCK_NO_TIMEOUT);
  *         if (res > 0) {
  *             printf("Received %d bytes\n", res);
  *         }
@@ -425,7 +428,8 @@
  *     return -1;
  * }
  *
- * if (sock_dtls_session_create(&dtls_sock, &remote, &session, SOCK_NO_TIMEOUT) < 0) {
+ * if (sock_dtls_session_create(&dtls_sock, &remote, &session,
+ *                              SOCK_NO_TIMEOUT) < 0) {
  *     puts("Error creating session");
  *     sock_dtls_close(&dtls_sock);
  *     sock_udp_close(&udp_sock);
@@ -436,7 +440,8 @@
  * int res = sock_dtls_send(&dtls_sock, &session, data, sizeof(data), 0);
  * if (res >= 0) {
  *     printf("Sent %d bytes: %*.s\n", res, res, data);
- *     res = sock_dtls_recv(&dtls_sock, &session, rcv, sizeof(rcv), SOCK_NO_TIMEOUT);
+ *     res = sock_dtls_recv(&dtls_sock, &session, rcv, sizeof(rcv),
+ *                          SOCK_NO_TIMEOUT);
  *     if (res > 0) {
  *         printf("Received %d bytes: %*.s\n", res, res, rcv);
  *     }
@@ -563,7 +568,6 @@ void sock_dtls_init(void);
  */
 int sock_dtls_create(sock_dtls_t *sock, sock_udp_t *udp_sock,
                      credman_tag_t tag, unsigned version, unsigned role);
-
 
 /**
  * @brief Initialize session handshake.
@@ -741,8 +745,10 @@ void sock_dtls_close(sock_dtls_t *sock);
  * @return  -EINVAL, if @p remote is invalid or @p sock is not properly
  *          initialized (or closed while sock_udp_recv() blocks).
  */
-static inline int sock_dtls_session_create(sock_dtls_t *sock, const sock_udp_ep_t *ep,
-                                    sock_dtls_session_t *remote, unsigned timeout)
+static inline int sock_dtls_session_create(sock_dtls_t *sock,
+                                           const sock_udp_ep_t *ep,
+                                           sock_dtls_session_t *remote,
+                                           unsigned timeout)
 {
     int res;
     uint8_t buf[DTLS_HANDSHAKE_BUFSIZE];


### PR DESCRIPTION
### Contribution description

This PR adds the `timeout` parameter to `sock_dtls_send()`, enabling user to set their own timeout to use. It also deprecates `sock_dtls_session_create()` and introduces the new `sock_dtls_session_init()`. This is part of the work to add async support as described by https://github.com/RIOT-OS/RIOT/pull/12907#issuecomment-625289418.

### Testing procedure

Make sure the documentation makes sense and understandable.

With each one node as client and server, change the timeout value of `sock_dtls_send()` in client/server of `examples/dtls-sock`:

- These values should have no problem:
    - default values working
    - `sock_dtls_send` in client to 0
    - `sock_dtls_send` in server to 0

### Issues/PRs references

#12907 
