### PR TITLE
mtd_mapper: count offset in sectors

### DIFF
--- a/drivers/include/mtd_mapper.h
+++ b/drivers/include/mtd_mapper.h
@@ -41,7 +41,7 @@
  *         .page_size = PAGE_SIZE,
  *     },
  *     .parent = &parent,
- *     .offset = PAGE_PER_SECTOR * PAGE_SIZE * SECTOR_COUNT / 2
+ *     .sector = SECTOR_COUNT / 2
  * };
  *
  * mtd_dev_t *dev = &region.mtd;
@@ -96,7 +96,7 @@ typedef struct {
 typedef struct {
     mtd_dev_t mtd;                  /**< MTD context                         */
     mtd_mapper_parent_t *parent;    /**< MTD mapper parent device            */
-    uint32_t offset;                /**< Offset address to start this region */
+    uint32_t sector;                /**< first sector of the region */
 } mtd_mapper_region_t;
 
 /**

--- a/tests/mtd_mapper/main.c
+++ b/tests/mtd_mapper/main.c
@@ -131,7 +131,7 @@ static mtd_mapper_region_t _region_a = {
         .page_size = PAGE_SIZE,
     },
     .parent = &_parent,
-    .offset = 0,
+    .sector = 0,
 };
 
 static mtd_mapper_region_t _region_b = {
@@ -142,7 +142,7 @@ static mtd_mapper_region_t _region_b = {
         .page_size = PAGE_SIZE,
     },
     .parent = &_parent,
-    .offset = PAGE_PER_SECTOR * PAGE_SIZE * SECTOR_COUNT / 2,
+    .sector = SECTOR_COUNT / 2,
 };
 
 static mtd_dev_t *_dev_a = &_region_a.mtd;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The offset of MTD regions must be aligned with erase sectors.
So in order not to waste address space, avoid misconfiguration and eventually support storage media > 4 GiB, give the offset in sectors instead of bytes.


### Testing procedure

`tests/mtd_mapper` should still work


### Issues/PRs references

in preparation of #14038 which introduces `mtd_erase_sector()` & `mtd_write_page()`
