### PR TITLE
drivers/at86rf2xx: add support for high data rates

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -93,6 +93,7 @@ endif
 ifneq (,$(filter at86rf%, $(filter-out at86rf215%, $(USEMODULE))))
   USEMODULE += at86rf2xx
   DEFAULT_MODULE += auto_init_at86rf2xx
+  DEFAULT_MODULE += netdev_ieee802154_oqpsk
 
   USEMODULE += xtimer
   USEMODULE += luid

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -210,6 +210,48 @@ void at86rf2xx_set_page(at86rf2xx_t *dev, uint8_t page)
 #endif
 }
 
+uint8_t at86rf2xx_get_phy_mode(at86rf2xx_t *dev)
+{
+#ifdef MODULE_AT86RF212B
+    uint8_t ctrl2;
+    ctrl2 = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_2);
+    if (ctrl2 & AT86RF2XX_TRX_CTRL_2_MASK__BPSK_OQPSK) {
+        return IEEE802154_PHY_OQPSK;
+    } else {
+        return IEEE802154_PHY_BPSK;
+    }
+#else
+    (void) dev;
+    return IEEE802154_PHY_OQPSK;
+#endif
+}
+
+int at86rf2xx_set_rate(at86rf2xx_t *dev, uint8_t rate)
+{
+    uint8_t ctrl2;
+
+    if (rate > 3) {
+        return -ERANGE;
+    }
+
+    ctrl2 = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_2);
+    ctrl2 &= ~AT86RF2XX_TRX_CTRL_2_MASK__OQPSK_DATA_RATE;
+    ctrl2 |= rate;
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2, ctrl2);
+
+    return 0;
+}
+
+uint8_t at86rf2xx_get_rate(at86rf2xx_t *dev)
+{
+    uint8_t rate;
+
+    rate = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_2);
+    rate &= AT86RF2XX_TRX_CTRL_2_MASK__OQPSK_DATA_RATE;
+
+    return rate;
+}
+
 uint16_t at86rf2xx_get_pan(const at86rf2xx_t *dev)
 {
     return dev->netdev.pan;

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -451,6 +451,20 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             }
             break;
 
+#ifdef MODULE_NETDEV_IEEE802154_OQPSK
+
+        case NETOPT_IEEE802154_PHY:
+            assert(max_len >= sizeof(int8_t));
+            *(uint8_t *)val = at86rf2xx_get_phy_mode(dev);
+            return sizeof(uint8_t);
+
+        case NETOPT_OQPSK_RATE:
+            assert(max_len >= sizeof(int8_t));
+            *(uint8_t *)val = at86rf2xx_get_rate(dev);
+            return sizeof(uint8_t);
+
+#endif /* MODULE_NETDEV_IEEE802154_OQPSK */
+
         default:
             res = -ENOTSUP;
             break;
@@ -637,6 +651,19 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
             at86rf2xx_set_cca_threshold(dev, *((const int8_t *)val));
             res = sizeof(int8_t);
             break;
+
+#ifdef MODULE_NETDEV_IEEE802154_OQPSK
+
+        case NETOPT_OQPSK_RATE:
+            assert(len <= sizeof(int8_t));
+            if (at86rf2xx_set_rate(dev, *((const uint8_t *)val)) < 0) {
+                res = -EINVAL;
+            } else {
+                res = sizeof(uint8_t);
+            }
+            break;
+
+#endif /* MODULE_NETDEV_IEEE802154_OQPSK */
 
         default:
             break;

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -375,6 +375,39 @@ uint8_t at86rf2xx_get_page(const at86rf2xx_t *dev);
 void at86rf2xx_set_page(at86rf2xx_t *dev, uint8_t page);
 
 /**
+ * @brief   Get the PHY mode of the given device
+ *
+ * @param[in,out] dev       device to read from
+ * @return                  the currently set phy mode
+ */
+uint8_t at86rf2xx_get_phy_mode(at86rf2xx_t *dev);
+
+/**
+ * @brief   Get the current O-QPSK rate mode of the PHY
+ *
+ * @param[in] dev           device to read from
+ *
+ * @return                  the currenty set rate mode
+ */
+uint8_t at86rf2xx_get_rate(at86rf2xx_t *dev);
+
+/**
+ * @brief   Set the current O-QPSK rate mode of the PHY
+ *          rate modes > 0 are proprietary.
+ *
+ *          rate 0:   250 kbit/s (IEEE mode)
+ *          rate 1:   500 kbit/s
+ *          rate 2:  1000 kbit/s (compatible with AT86RF215)
+ *          rate 3:  2000 kbit/s
+ *
+ * @param[in] dev           device to write to
+ * @param[in] rate          the selected data rate mode (0-3)
+ *
+ * @return                  0 on success, otherwise error value
+ */
+int at86rf2xx_set_rate(at86rf2xx_t *dev, uint8_t rate);
+
+/**
  * @brief   Get the configured PAN ID of the given device
  *
  * @param[in] dev           device to read from


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

AT86RF2xx supports high data rates in O-QPSK mode.
This is a proprietary feature, so data rates > 0 are only supported by other AT86RF2xx devices.

 - high_rate 0:   250 kbit/s (IEEE mode)
 - high_rate 1:   500 kbit/s
 - high_rate 2:  1000 kbit/s (compatible with at86rf215)
 - high_rate 3:  2000 kbit/s

### Testing procedure

You can configure the high date rates with `ifconfig`:

```
> ifconfig 7 set high_rate 2
2020-05-09 01:26:00,636 # Iface  7  HWaddr: 71:A1  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2020-05-09 01:26:00,639 #            high data rate: 2 
2020-05-09 01:26:00,643 #           Long HWaddr: 5A:06:59:C9:2C:36:7D:78 
2020-05-09 01:26:00,650 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-05-09 01:26:00,657 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102 MTU:1280  HL:64  RTR  
2020-05-09 01:26:00,659 #           6LO  IPHC  
2020-05-09 01:26:00,662 #           Source address length: 8
2020-05-09 01:26:00,665 #           Link type: wireless
2020-05-09 01:26:00,671 #           inet6 addr: fe80::5806:59c9:2c36:7d78  scope: link  VAL
2020-05-09 01:26:00,674 #           inet6 group: ff02::2
2020-05-09 01:26:00,676 #           inet6 group: ff02::1
2020-05-09 01:26:00,681 #           inet6 group: ff02::1:ff36:7d78
2020-05-09 01:26:00,682 #           
2020-05-09 01:26:00,684 #           Statistics for Layer 2
2020-05-09 01:26:00,687 #             RX packets 11  bytes 473
2020-05-09 01:26:00,693 #             TX packets 16 (Multicast: 16)  bytes 688
2020-05-09 01:26:00,695 #             TX succeeded 16 errors 0
2020-05-09 01:26:00,698 #           Statistics for IPv6
2020-05-09 01:26:00,701 #             RX packets 11  bytes 704
2020-05-09 01:26:00,706 #             TX packets 16 (Multicast: 16)  bytes 1024
2020-05-09 01:26:00,710 #             TX succeeded 16 errors 0
```

You can do the same on a device with the `at86rf215` driver. There this feature is also implemented, but the chip only supports one high data rate mode - any value other than 0 will enable it, so you can also do

```
> ifconfig 8 set high_rate 2
2020-05-09 01:28:20,449 # Iface  8  HWaddr: 01:55  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2020-05-09 01:28:20,452 #            high data rate: 1 
2020-05-09 01:28:20,456 #           Long HWaddr: 1A:F9:8F:5F:30:5D:05:8C 
2020-05-09 01:28:20,463 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-05-09 01:28:20,469 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102 MTU:1280  HL:64  RTR  
2020-05-09 01:28:20,471 #           6LO  IPHC  
2020-05-09 01:28:20,474 #           Source address length: 8
2020-05-09 01:28:20,477 #           Link type: wireless
2020-05-09 01:28:20,482 #           inet6 addr: fe80::18f9:8f5f:305d:58c  scope: link  VAL
2020-05-09 01:28:20,485 #           inet6 group: ff02::2
2020-05-09 01:28:20,488 #           inet6 group: ff02::1
2020-05-09 01:28:20,491 #           inet6 group: ff02::1:ff5d:58c
2020-05-09 01:28:20,492 #           
2020-05-09 01:28:20,495 #           Statistics for Layer 2
2020-05-09 01:28:20,498 #             RX packets 29  bytes 1184
2020-05-09 01:28:20,503 #             TX packets 34 (Multicast: 25)  bytes 1399
2020-05-09 01:28:20,507 #             TX succeeded 34 errors 0
2020-05-09 01:28:20,509 #           Statistics for IPv6
2020-05-09 01:28:20,515 #             RX packets 29  bytes 1748
2020-05-09 01:28:20,517 #             TX packets 34 (Multicast: 25)  bytes 2068
2020-05-09 01:28:20,520 #             TX succeeded 34 errors 0
```

The two nodes can now ping each other, slightly faster than before:

```
2020-05-09 01:29:54,228 #  ping6 fe80::18f9:8f5f:305d:58c -s 64
2020-05-09 01:29:54,249 # 72 bytes from fe80::18f9:8f5f:305d:58c%7: icmp_seq=0 ttl=64 rssi=-49 dBm time=12.264 ms
2020-05-09 01:29:55,250 # 72 bytes from fe80::18f9:8f5f:305d:58c%7: icmp_seq=1 ttl=64 rssi=-49 dBm time=10.998 ms
2020-05-09 01:29:56,252 # 72 bytes from fe80::18f9:8f5f:305d:58c%7: icmp_seq=2 ttl=64 rssi=-50 dBm time=10.979 ms
2020-05-09 01:29:56,253 # 
2020-05-09 01:29:56,257 # --- fe80::18f9:8f5f:305d:58c PING statistics ---
2020-05-09 01:29:56,262 # 3 packets transmitted, 3 packets received, 0% packet loss
2020-05-09 01:29:56,269 # round-trip min/avg/max = 10.979/11.413/12.264 ms
2020-05-09 01:30:00,723 #  ifconfig 7 set high_rate 2
2020-05-09 01:30:00,727 # success: set high rate on interface 7 to 2
2020-05-09 01:30:07,668 #  ping6 fe80::18f9:8f5f:305d:58c -s 64
2020-05-09 01:30:07,683 # 72 bytes from fe80::18f9:8f5f:305d:58c%7: icmp_seq=0 ttl=64 rssi=-53 dBm time=5.580 ms
2020-05-09 01:30:08,685 # 72 bytes from fe80::18f9:8f5f:305d:58c%7: icmp_seq=1 ttl=64 rssi=-45 dBm time=6.207 ms
2020-05-09 01:30:09,687 # 72 bytes from fe80::18f9:8f5f:305d:58c%7: icmp_seq=2 ttl=64 rssi=-43 dBm time=6.515 ms
2020-05-09 01:30:09,688 # 
2020-05-09 01:30:09,692 # --- fe80::18f9:8f5f:305d:58c PING statistics ---
2020-05-09 01:30:09,697 # 3 packets transmitted, 3 packets received, 0% packet loss
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
