### PR TITLE
drivers/mrf24j40: add Turbo Mode

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -486,6 +486,7 @@ endif
 
 ifneq (,$(filter mrf24j40m%,$(USEMODULE)))
   USEMODULE += mrf24j40
+  DEFAULT_MODULE += netdev_ieee802154_oqpsk
 
   ifndef CONFIG_KCONFIG_MODULE_MRF24J40
     # all modules but mrf24j40ma have an external PA

--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -361,6 +361,27 @@ void mrf24j40_set_option(mrf24j40_t *dev, uint16_t option, bool state);
 void mrf24j40_set_state(mrf24j40_t *dev, uint8_t state);
 
 /**
+ * @brief   Enable or disable proprietary Turbo Mode.
+ *
+ * Turbo mode is only compatible with other mrf24j40 chips.
+ *
+ * turbo off:   250 kbit/s (IEEE mode)
+ * turbo  on:   625 kbit/s
+ *
+ * @param[in] dev           device to change state of
+ * @param[in] enable        turbo mode control
+ */
+void mrf24j40_set_turbo(mrf24j40_t *dev, bool enable);
+
+/**
+ * @brief   Query the state of the turbo mode
+ *
+ * @param[in] dev           device to query
+ * @return                  true if Turbo Mode is enabled
+ */
+bool mrf24j40_get_turbo(mrf24j40_t *dev);
+
+/**
  * @brief   Put in sleep mode
  *
  * @param[in] dev       device to put to sleep

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -330,6 +330,20 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             }
             break;
 
+#ifdef MODULE_NETDEV_IEEE802154_OQPSK
+
+        case NETOPT_IEEE802154_PHY:
+            assert(max_len >= sizeof(int8_t));
+            *(uint8_t *)val = IEEE802154_PHY_OQPSK;
+            return sizeof(uint8_t);
+
+        case NETOPT_OQPSK_RATE:
+            assert(max_len >= sizeof(int8_t));
+            *(uint8_t *)val = mrf24j40_get_turbo(dev);
+            return sizeof(uint8_t);
+
+#endif /* MODULE_NETDEV_IEEE802154_OQPSK */
+
         default:
             /* try netdev settings */
             res = netdev_ieee802154_get((netdev_ieee802154_t *)netdev, opt,
@@ -523,6 +537,16 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
                 res = sizeof(int8_t);
             }
             break;
+
+#ifdef MODULE_NETDEV_IEEE802154_OQPSK
+
+        case NETOPT_OQPSK_RATE:
+            res = !!*(uint8_t *)val;
+            mrf24j40_set_turbo(dev, res);
+            res = sizeof(uint8_t);
+            break;
+
+#endif /* MODULE_NETDEV_IEEE802154_OQPSK */
 
         default:
             break;


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

MRF24J40 supports a proprietary turbo mode with a data rate of 625 kbit/s instead of the standard 250 kbit/s.

It can be enabled through

    ifconfig 7 set high_rate 1


### Testing procedure

Enable High Data rate on a pair of nodes with a mrf24j40 transceiver

```
2020-05-09 16:16:29,865 #  ifconfig 7 set high_rate 1
2020-05-09 16:16:29,869 # success: set high rate on interface 7 to 1
2020-05-09 16:16:32,943 #  ifconfig
2020-05-09 16:16:32,950 # Iface  7  HWaddr: 3B:66  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2020-05-09 16:16:32,952 #            high data rate: 1 
2020-05-09 16:16:32,956 #           Long HWaddr: 8F:1B:32:02:AE:20:BB:66 
2020-05-09 16:16:32,963 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-05-09 16:16:32,968 #           ACK_REQ  CSMA  L2-PDU:102 MTU:1280  HL:64  RTR  
2020-05-09 16:16:32,970 #           6LO  IPHC  
2020-05-09 16:16:32,974 #           Source address length: 8
2020-05-09 16:16:32,976 #           Link type: wireless
2020-05-09 16:16:32,982 #           inet6 addr: fe80::8d1b:3202:ae20:bb66  scope: link  VAL
2020-05-09 16:16:32,985 #           inet6 group: ff02::2
2020-05-09 16:16:32,987 #           inet6 group: ff02::1
2020-05-09 16:16:32,991 #           inet6 group: ff02::1:ff20:bb66
2020-05-09 16:16:32,992 #           
2020-05-09 16:16:32,995 #           Statistics for Layer 2
2020-05-09 16:16:32,998 #             RX packets 4  bytes 172
2020-05-09 16:16:33,002 #             TX packets 3 (Multicast: 3)  bytes 129
2020-05-09 16:16:33,006 #             TX succeeded 3 errors 0
2020-05-09 16:16:33,008 #           Statistics for IPv6
2020-05-09 16:16:33,011 #             RX packets 4  bytes 256
2020-05-09 16:16:33,016 #             TX packets 3 (Multicast: 3)  bytes 192
2020-05-09 16:16:33,019 #             TX succeeded 3 errors 0
```

The two nodes can now ping each other, slightly faster than before:

```
2020-05-09 16:18:22,016 #  ping6 fe80::2123:2323:2323:2322 -s 64
2020-05-09 16:18:22,039 # 72 bytes from fe80::2123:2323:2323:2322%7: icmp_seq=0 ttl=64 rssi=-35 dBm time=15.217 ms
2020-05-09 16:18:23,038 # 72 bytes from fe80::2123:2323:2323:2322%7: icmp_seq=1 ttl=64 rssi=-35 dBm time=14.255 ms
2020-05-09 16:18:24,039 # 72 bytes from fe80::2123:2323:2323:2322%7: icmp_seq=2 ttl=64 rssi=-35 dBm time=14.889 ms
2020-05-09 16:18:24,039 # 
2020-05-09 16:18:24,043 # --- fe80::2123:2323:2323:2322 PING statistics ---
2020-05-09 16:18:24,048 # 3 packets transmitted, 3 packets received, 0% packet loss
2020-05-09 16:18:24,052 # round-trip min/avg/max = 14.255/14.787/15.217 ms

2020-05-09 16:18:26,567 #  ifconfig 7 set high_rate 1
2020-05-09 16:18:26,571 # success: set high rate on interface 7 to 1

2020-05-09 16:18:31,008 #  ping6 fe80::2123:2323:2323:2322 -s 64
2020-05-09 16:18:31,024 # 72 bytes from fe80::2123:2323:2323:2322%7: icmp_seq=0 ttl=64 rssi=-36 dBm time=8.313 ms
2020-05-09 16:18:32,026 # 72 bytes from fe80::2123:2323:2323:2322%7: icmp_seq=1 ttl=64 rssi=-36 dBm time=9.913 ms
2020-05-09 16:18:33,027 # 72 bytes from fe80::2123:2323:2323:2322%7: icmp_seq=2 ttl=64 rssi=-35 dBm time=10.873 ms
2020-05-09 16:18:33,027 # 
2020-05-09 16:18:33,031 # --- fe80::2123:2323:2323:2322 PING statistics ---
2020-05-09 16:18:33,036 # 3 packets transmitted, 3 packets received, 0% packet loss
2020-05-09 16:18:33,040 # round-trip min/avg/max = 8.313/9.699/10.873 ms
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
