### PR TITLE
net/gnrc/netif/lorawan: fix ABP device activation

### DIFF
--- a/examples/gnrc_lorawan/README.md
+++ b/examples/gnrc_lorawan/README.md
@@ -121,14 +121,14 @@ E.g send confirmable messages:
 
 ```
 ifconfig 3 ack_req
-send "My confirmable message"
+send 3 "My confirmable message"
 ```
 
 And unconfirmable messages:
 
 ```
 ifconfig 3 -ack_req
-send "My unconfirmable message"
+send 3 "My unconfirmable message"
 ```
 
 Current state and future plans

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -241,7 +241,7 @@ static int _get(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
             assert(opt->data_len >= sizeof(netopt_enable_t));
             *((netopt_enable_t *) opt->data) = netif->lorawan.otaa;
             break;
-        case NETOPT_LINK_CONNECTED:
+        case NETOPT_LINK:
             mlme_request.type = MLME_GET;
             mlme_request.mib.type = MIB_ACTIVATION_METHOD;
             gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request, &mlme_confirm);
@@ -321,7 +321,7 @@ static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt)
             assert(opt->data_len >= LORAMAC_NWKSKEY_LEN);
             memcpy(netif->lorawan.nwkskey, opt->data, LORAMAC_NWKSKEY_LEN);
             break;
-        case NETOPT_LINK_CONNECTED:
+        case NETOPT_LINK:
         {
             netopt_enable_t en = *((netopt_enable_t *) opt->data);
             if (en) {

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -335,6 +335,7 @@ static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt)
                 }
                 else {
                     mlme_request.type = MLME_SET;
+                    mlme_request.mib.type = MIB_ACTIVATION_METHOD;
                     mlme_request.mib.activation = MLME_ACTIVATION_ABP;
                     gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request, &mlme_confirm);
                 }


### PR DESCRIPTION
### Contribution description

`mlme_request.mib.type` must be `MIB_ACTIVATION_METHOD` to set the LoRaWAN netif's activation method.

### Testing procedure

```
make -C examples/gnrc_lorawan flash term
> ifconfig
2020-05-09 20:24:15,083 # ifconfig
2020-05-09 20:24:15,092 # Iface  4  HWaddr: 00:00:00:00  Frequency: 868299987Hz  BW: 125kHz  SF: 12  CR: 4/5  Link: down 
2020-05-09 20:24:15,094 #            TX-Power: 14dBm  State: SLEEP  Demod margin.: 0  Num gateways.: 0 
2020-05-09 20:24:15,095 #           OTAA 
2020-05-09 20:24:15,097 #           L2-PDU:8447 
2020-05-09 20:24:15,098 #           
> ifconfig 4 -otaa
2020-05-09 20:24:29,943 #  ifconfig 4 -otaa
2020-05-09 20:24:29,944 # success: unset option
> ifconfig 4 up
2020-05-09 20:24:37,029 #  ifconfig 4 up
2020-05-09 20:24:37,030 # ABP start
> ifconfig
2020-05-09 20:24:39,118 #  ifconfig
2020-05-09 20:24:39,126 # Iface  4  HWaddr: 00:00:00:00  Frequency: 868299987Hz  BW: 125kHz  SF: 12  CR: 4/5  Link: up 
2020-05-09 20:24:39,131 #            TX-Power: 14dBm  State: SLEEP  Demod margin.: 0  Num gateways.: 0 
2020-05-09 20:24:39,134 #           L2-PDU:8447 
2020-05-09 20:24:39,136 #           
```

Without this patch, the device stays `down`.
