### PR TITLE
nrf52840dk: Add MTD configuration

### DIFF
--- a/boards/nrf52840dk/Makefile.dep
+++ b/boards/nrf52840dk/Makefile.dep
@@ -1,3 +1,7 @@
 USEMODULE += boards_common_nrf52xxdk
 
+ifneq (,$(filter mtd,$(USEMODULE)))
+  USEMODULE += mtd_spi_nor
+endif
+
 include $(RIOTBOARD)/common/nrf52xxxdk/Makefile.dep

--- a/boards/nrf52840dk/include/board.h
+++ b/boards/nrf52840dk/include/board.h
@@ -21,6 +21,7 @@
 #define BOARD_H
 
 #include "board_common.h"
+#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,6 +59,28 @@ extern "C" {
 #define LED3_OFF            (LED_PORT->OUTSET = LED3_MASK)
 #define LED3_TOGGLE         (LED_PORT->OUT   ^= LED3_MASK)
 /** @} */
+
+/**
+ * @name SPI NOR flash hardware configuration
+ *
+ * A Macronix MX25R6435F is present on the board
+ * @{
+ */
+#define NRF52840DK_NOR_PAGE_SIZE          (256)
+#define NRF52840DK_NOR_PAGES_PER_SECTOR   (16)
+#define NRF52840DK_NOR_SECTOR_COUNT       (2048)
+#define NRF52840DK_NOR_FLAGS              (SPI_NOR_F_SECT_4K | SPI_NOR_F_SECT_32K)
+#define NRF52840DK_NOR_SPI_DEV            SPI_DEV(1)
+#define NRF52840DK_NOR_SPI_CLK            SPI_CLK_10MHZ
+#define NRF52840DK_NOR_SPI_CS             GPIO_PIN(0, 17)
+#define NRF52840DK_NOR_SPI_MODE           SPI_MODE_0
+/** @} */
+
+/** Default MTD device */
+#define MTD_0 mtd0
+
+/** mtd flash emulation device */
+extern mtd_dev_t *mtd0;
 
 /**
  * @name    Button pin configuration

--- a/boards/nrf52840dk/include/periph_conf.h
+++ b/boards/nrf52840dk/include/periph_conf.h
@@ -36,6 +36,12 @@ static const spi_conf_t spi_config[] = {
         .sclk = GPIO_PIN(1, 15),
         .mosi = GPIO_PIN(1, 13),
         .miso = GPIO_PIN(1, 14),
+    },
+    {
+        .dev  = NRF_SPI1,
+        .sclk = GPIO_PIN(0, 19),
+        .mosi = GPIO_PIN(0, 20),
+        .miso = GPIO_PIN(0, 21),
     }
 };
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)

--- a/boards/nrf52840dk/mtd.c
+++ b/boards/nrf52840dk/mtd.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840dk
+ * @{
+ *
+ * @file
+ * @brief       MTD configuration for the nRF52840 DK
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#ifdef MODULE_MTD
+
+#include "board.h"
+#include "mtd.h"
+#include "mtd_spi_nor.h"
+#include "periph_conf.h"
+#include "timex.h"
+
+static const mtd_spi_nor_params_t _nrf52840dk_nor_params = {
+    .opcode = &mtd_spi_nor_opcode_default,
+    .wait_chip_erase = 50LU * US_PER_SEC,
+    .wait_32k_erase = 240LU *US_PER_MS,
+    .wait_sector_erase = 40LU * US_PER_MS,
+    .wait_4k_erase = 40LU * US_PER_MS,
+    .wait_chip_wake_up = 35LU * US_PER_MS,
+    .clk = NRF52840DK_NOR_SPI_CLK,
+    .flag = NRF52840DK_NOR_FLAGS,
+    .spi = NRF52840DK_NOR_SPI_DEV,
+    .mode = NRF52840DK_NOR_SPI_MODE,
+    .cs = NRF52840DK_NOR_SPI_CS,
+    .addr_width = 3,
+};
+
+static mtd_spi_nor_t nrf52840dk_nor_dev = {
+    .base = {
+        .driver = &mtd_spi_nor_driver,
+        .page_size = NRF52840DK_NOR_PAGE_SIZE,
+        .pages_per_sector = NRF52840DK_NOR_PAGES_PER_SECTOR,
+        .sector_count = NRF52840DK_NOR_SECTOR_COUNT,
+    },
+    .params = &_nrf52840dk_nor_params,
+};
+
+mtd_dev_t *mtd0 = (mtd_dev_t *)&nrf52840dk_nor_dev;
+
+#endif


### PR DESCRIPTION
### Contribution description

This PR adds configuration to the nRF52840 DK board for the MTD present on the board.

### Testing procedure

Use a filesystem related test to verify the functionality. For example `tests/pkg_littlefs2`. Note that the both the SPI driver and the MTD are rather slow, the littlefs2 test takes around 2.5 mins.

### Issues/PRs references

None