### PR TITLE
Add color depth types to disp_dev API

### DIFF
--- a/drivers/disp_dev/disp_dev.c
+++ b/drivers/disp_dev/disp_dev.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Inria
+ *               2020 Philipp-Alexander Blum <philipp-blum@jakiku.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief       Helper functions for generic API of display device
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Philipp-Alexander Blum <philipp-blum@jakiku.de>
  *
  * @}
  */
@@ -24,13 +26,12 @@
 
 #include "disp_dev.h"
 
-void disp_dev_map(const disp_dev_t *dev,
-                  uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2,
-                  const uint16_t *color)
+void disp_dev_map(disp_dev_t *dev, disp_dev_coordinates_t *coordinates,
+                 const uint16_t *color)
 {
     assert(dev);
 
-    dev->driver->map(dev, x1, x2, y1, y2, color);
+    dev->driver->map(dev, coordinates, color);
 }
 
 uint16_t disp_dev_height(const disp_dev_t *dev)

--- a/drivers/disp_dev/disp_dev.c
+++ b/drivers/disp_dev/disp_dev.c
@@ -27,11 +27,11 @@
 #include "disp_dev.h"
 
 void disp_dev_map(disp_dev_t *dev, disp_dev_coordinates_t *coordinates,
-                 const uint16_t *color)
+                  const void *color, disp_dev_color_depth_t color_depth)
 {
     assert(dev);
 
-    dev->driver->map(dev, coordinates, color);
+    dev->driver->map(dev, coordinates, color, color_depth);
 }
 
 uint16_t disp_dev_height(const disp_dev_t *dev)

--- a/drivers/ili9341/ili9341_disp_dev.c
+++ b/drivers/ili9341/ili9341_disp_dev.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Inria
+ *               2020 Philipp-Alexander Blum
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief       Driver adaption to disp_dev generic interface
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Philipp-Alexander Blum <philipp-blum@jakiku.de>
  * @}
  */
 
@@ -31,11 +33,11 @@
 #define ILI9341_DISP_COLOR_DEPTH    (16U)
 #endif
 
-static void _ili9341_map(const disp_dev_t *dev, uint16_t x1, uint16_t x2,
-                  uint16_t y1, uint16_t y2, const uint16_t *color)
+static void _ili9341_map(disp_dev_t *dev, disp_dev_coordinates_t *coordinates,
+                         const uint16_t *color)
 {
     ili9341_t *ili9341 = (ili9341_t *)dev;
-    ili9341_pixmap(ili9341, x1, x2, y1, y2, color);
+    ili9341_pixmap(ili9341, (ili9341_coordinates_t *)coordinates, color);
 }
 
 static uint16_t _ili9341_height(const disp_dev_t *disp_dev)

--- a/drivers/include/disp_dev.h
+++ b/drivers/include/disp_dev.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020 Inria
+ *               2020 Philipp-Alexander Blum
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,6 +16,7 @@
  * @{
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Philipp-Alexander Blum <philipp-blum@jakiku.de>
  */
 
 #ifndef DISP_DEV_H
@@ -43,21 +45,27 @@ extern "C" {
 typedef struct disp_dev disp_dev_t;
 
 /**
+ * @brief Type to store the update coordinates in
+ */
+typedef struct {
+    uint16_t x1; /**< Left coordinate */
+    uint16_t x2; /**< Right coordinate */
+    uint16_t y1; /**< Top coordinate */
+    uint16_t y2; /**< Bottom coordinate */
+} disp_dev_coordinates_t;
+
+/**
  * @brief   Generic type for a display driver
  */
 typedef struct {
     /**
      * @brief   Map an area to display on the device
      *
-     * @param[in] dev   Pointer to the display device
-     * @param[in] x1    Left coordinate
-     * @param[in] x2    Right coordinate
-     * @param[in] y1    Top coordinate
-     * @param[in] y2    Bottom coordinate
-     * @param[in] color Array of color to map to the display
+     * @param[in] dev           Pointer to the display device
+     * @param[in] coordinates   Coordinate
+     * @param[in] color         Array of color to map to the display
      */
-    void (*map)(const disp_dev_t *dev,
-                uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2,
+    void (*map)(disp_dev_t *dev, disp_dev_coordinates_t *coordinates,
                 const uint16_t *color);
 
     /**
@@ -104,15 +112,11 @@ struct disp_dev {
 /**
  * @brief   Map an area to display on the device
  *
- * @param[in] dev   Pointer to the display device
- * @param[in] x1    Left coordinate
- * @param[in] x2    Right coordinate
- * @param[in] y1    Top coordinate
- * @param[in] y2    Bottom coordinate
- * @param[in] color Array of color to map to the display
+ * @param[in] dev            Pointer to the display device
+ * @param[in] coordinates    Coordinate
+ * @param[in] color          Array of color to map to the display
  */
-void disp_dev_map(const disp_dev_t *dev,
-                  uint16_t x1, uint16_t x2, uint16_t y1, uint16_t y2,
+void disp_dev_map(disp_dev_t *dev, disp_dev_coordinates_t *coordinates,
                   const uint16_t *color);
 
 /**

--- a/drivers/include/disp_dev.h
+++ b/drivers/include/disp_dev.h
@@ -55,6 +55,63 @@ typedef struct {
 } disp_dev_coordinates_t;
 
 /**
+ * @brief Type for color depth.
+ */
+typedef enum {
+    MONOCHROME = 0,
+    2_BIT_COLOR,
+    GRAYSCALE,
+    8_BIT_COLOR,
+    16_BIT_HIGH_COLOR,
+    24_BIT_TRUE_COLOR
+} disp_dev_color_depth_t;
+
+/**
+ * @brief Type to hold a pixel for monochrome data
+ */
+typedef struct {
+    bool color;
+} disp_dev_pix_mono_t;
+
+/**
+ * @brief Type to hold a pixel for 2bit color data
+ */
+typedef struct {
+    bool black;
+    bool color;
+} disp_dev_pix_2bit_color_t;
+
+/**
+ * @brief Type to hold a pixel for greyscale data
+ */
+typedef struct {
+    uint8_t contrast;
+} disp_dev_pix_greyscale_t;
+
+/**
+ * @brief Type to hold a pixel for 8bit color data
+ */
+typedef struct {
+    uint8_t rgb;
+} disp_dev_pix_8bit_color_t;
+
+/**
+ * @brief Type to hold a pixel for 16bit high color data
+ */
+typedef struct {
+    uint16_t rgb;
+} disp_dev_pix_16bit_hc_t;
+
+/**
+ * @brief Type to hold a pixel for monochrome color data
+ */
+typedef struct {
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+} disp_dev_pix_24bit_tc_t;
+
+/**
  * @brief   Generic type for a display driver
  */
 typedef struct {
@@ -64,9 +121,10 @@ typedef struct {
      * @param[in] dev           Pointer to the display device
      * @param[in] coordinates   Coordinate
      * @param[in] color         Array of color to map to the display
+     * @param[in] color_depth   Color depth of color
      */
     void (*map)(disp_dev_t *dev, disp_dev_coordinates_t *coordinates,
-                const uint16_t *color);
+                const void *color, disp_dev_color_depth_t color_depth);
 
     /**
      * @brief   Get the height of the display device
@@ -91,7 +149,7 @@ typedef struct {
      *
      * @return              The color depth
      */
-    uint8_t (*color_depth)(const disp_dev_t *dev);
+    disp_dev_color_depth_t (*color_depth)(const disp_dev_t *dev);
 
     /**
      * @brief   Invert the display device colors
@@ -115,9 +173,10 @@ struct disp_dev {
  * @param[in] dev            Pointer to the display device
  * @param[in] coordinates    Coordinate
  * @param[in] color          Array of color to map to the display
+ * @param[in] color_depth    Color depth of color
  */
 void disp_dev_map(disp_dev_t *dev, disp_dev_coordinates_t *coordinates,
-                  const uint16_t *color);
+                  const void *color, disp_dev_color_depth_t color_depth);
 
 /**
  * @brief   Get the height of the display device
@@ -142,7 +201,7 @@ uint16_t disp_dev_width(const disp_dev_t *dev);
  *
  * @return              The color depth
  */
-uint8_t disp_dev_color_depth(const disp_dev_t *dev);
+disp_dev_color_depth_t disp_dev_color_depth(const disp_dev_t *dev);
 
 /**
  * @brief   Invert the display device colors

--- a/drivers/include/ili9341.h
+++ b/drivers/include/ili9341.h
@@ -104,6 +104,16 @@ typedef struct {
 } ili9341_params_t;
 
 /**
+ * @brief Type to store the update coordinates in
+ */
+typedef struct {
+    uint16_t x1;        /**< Left coordinate */
+    uint16_t x2;        /**< Right coordinate */
+    uint16_t y1;        /**< Top coordinate */
+    uint16_t y2;        /**< Bottom coordinate */
+} ili9341_coordinates_t;
+
+/**
  * @brief   Device descriptor for a ili9341
  */
 typedef struct {
@@ -129,15 +139,12 @@ int ili9341_init(ili9341_t *dev, const ili9341_params_t *params);
  * x2 being the last column of pixels to fill. similar to that, y1 is the first
  * row to fill and y2 is the last row to fill.
  *
- * @param[in]   dev     device descriptor
- * @param[in]   x1      x coordinate of the first corner
- * @param[in]   x2      x coordinate of the opposite corner
- * @param[in]   y1      y coordinate of the first corner
- * @param[in]   y2      y coordinate of the opposite corner
- * @param[in]   color   single color to fill the area with
+ * @param[in]   dev              device descriptor
+ * @param[in]   coordinates      coordinates to fill with data
+ * @param[in]   color            single color to fill the area with
  */
-void ili9341_fill(const ili9341_t *dev, uint16_t x1, uint16_t x2,
-                  uint16_t y1, uint16_t y2, uint16_t color);
+void ili9341_fill(const ili9341_t *dev, ili9341_coordinates_t *coordinates,
+                  uint16_t color);
 
 /**
  * @brief   Fill a rectangular area with an array of pixels
@@ -148,15 +155,12 @@ void ili9341_fill(const ili9341_t *dev, uint16_t x1, uint16_t x2,
  *
  * @note @p color must have a length equal to `(x2 - x1 + 1) * (y2 - y1 + 1)`
  *
- * @param[in]   dev     device descriptor
- * @param[in]   x1      x coordinate of the first corner
- * @param[in]   x2      x coordinate of the opposite corner
- * @param[in]   y1      y coordinate of the first corner
- * @param[in]   y2      y coordinate of the opposite corner
- * @param[in]   color   array of colors to fill the area with
+ * @param[in]   dev              device descriptor
+ * @param[in]   coordinates      coordinates to fill with data
+ * @param[in]   color            array of colors to fill the area with
  */
-void ili9341_pixmap(const ili9341_t *dev, uint16_t x1, uint16_t x2, uint16_t y1,
-                 uint16_t y2, const uint16_t *color);
+void ili9341_pixmap(const ili9341_t *dev, ili9341_coordinates_t *coordinates,
+                    const uint16_t *color);
 
 /**
  * @brief   Raw write command

--- a/pkg/lvgl/contrib/lvgl.c
+++ b/pkg/lvgl/contrib/lvgl.c
@@ -84,8 +84,9 @@ static void _disp_map(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *col
         return;
     }
 
-    disp_dev_map(_dev, area->x1, area->x2, area->y1, area->y2,
-                 (const uint16_t *)color_p);
+    disp_dev_coordinates_t coordinates =
+            { .x1 = area->x1, .x2 = area->x2, .y1 = area->y1, .y2 = area->y1 };
+    disp_dev_map(_dev, &coordinates, (const uint16_t *)color_p);
 
     LOG_DEBUG("[lvgl] flush display\n");
 

--- a/tests/disp_dev/main.c
+++ b/tests/disp_dev/main.c
@@ -50,13 +50,22 @@ int main(void)
     expect(max_height == 240);
 
     uint16_t color = 0;
+    disp_dev_coordinates_t coordinates;
     for (uint16_t y = 0; y < max_height; ++y) {
+        coordinates.y1 = y;
+        coordinates.y2 = y;
         for (uint16_t x = 0; x < max_width; ++x) {
-            disp_dev_map(dev, x, x, y, y, &color);
+            coordinates.x1 = x;
+            coordinates.x2 = x;
+            disp_dev_map(dev, &coordinates, &color);
         }
     }
 
-    disp_dev_map(dev, 95, 222, 85, 153, (const uint16_t *)picture);
+    coordinates.x1 = 95;
+    coordinates.x2 = 222;
+    coordinates.y1 = 85;
+    coordinates.y2 = 153;
+    disp_dev_map(dev, &coordinates, (const uint16_t *)picture);
 
     puts("SUCCESS");
 

--- a/tests/driver_ili9341/main.c
+++ b/tests/driver_ili9341/main.c
@@ -47,22 +47,31 @@ int main(void)
         puts("[Failed]");
         return 1;
     }
+    ili9341_coordinates_t coordinates;
 
     puts("ili9341 TFT display filling map");
-    ili9341_fill(&dev, 0, 319, 0, 239, 0x0000);
+    coordinates.x1 = 0;
+    coordinates.x2 = 319;
+    coordinates.y1 = 0;
+    coordinates.y2 = 239;
+    ili9341_fill(&dev, &coordinates, 0x0000);
     puts("ili9341 TFT display map filled");
 
     /* Fill square with blue */
     puts("Drawing blue rectangle");
-    ili9341_fill(&dev, 10, 59, 10, 109, 0x001F);
+    coordinates.x1 = 10;
+    coordinates.x2 = 59;
+    coordinates.y1 = 10;
+    coordinates.y2 = 109;
+    ili9341_fill(&dev, &coordinates, 0x001F);
     xtimer_sleep(1);
 
     puts("Drawing green rectangle");
-    ili9341_fill(&dev, 10, 59, 10, 109, 0x07E0);
+    ili9341_fill(&dev, &coordinates, 0x07E0);
     xtimer_sleep(1);
 
     puts("Drawing red rectangle");
-    ili9341_fill(&dev, 10, 59, 10, 109, 0xf800);
+    ili9341_fill(&dev, &coordinates, 0xf800);
     xtimer_sleep(1);
 
     ili9341_invert_on(&dev);
@@ -72,11 +81,15 @@ int main(void)
     puts("ili9341 TFT display normal");
 
     /* Make the same square black again */
-    ili9341_fill(&dev, 10, 59, 10, 109, 0x0000);
+    ili9341_fill(&dev, &coordinates, 0x0000);
 
 #ifndef NO_RIOT_IMAGE
     /* Approximate middle of the display */
-    ili9341_pixmap(&dev, 95, 222, 85, 153, (const uint16_t *)picture);
+    coordinates.x1 = 95;
+    coordinates.x2 = 222;
+    coordinates.y1 = 85;
+    coordinates.y2 = 153;
+    ili9341_pixmap(&dev, &coordinates, (const uint16_t *)picture);
 #endif
     while (1) {
     }


### PR DESCRIPTION
### Contribution description

This PR addresses the issue with colors in the disp_dev API. Mentioned briefly in #13787 
It's a proposal how to address it. 
The idea behind this is simple: The user application shouldn't care too much about the underlying color depth of a display. 
It should provide the color data in the correct format. The driver should do the rest. This also makes it possible to switch displays with different color depths without changing the color data itself. Also the application code should be the same. The user only has to change the makefile.
For example: 
- User applications uses 24bit color data and a 24bit color display. The driver itself doesn't need to change the data that much, since it can display it directly. 
- For another version of the hardware, the user changes the display to a 16bit display. The driver abstracts this, accepts the 24bit color data and transforms it to the needed 16bit color.
This is an down scaling example. The same can be done for up scaling as well. 
The biggest benefit is backwards compatibility. The user can simply maintain backwards compatibility, without caring too much about the old hardware.

### Testing procedure
The tests are not changed yet.


### Issues/PRs references
Addresses #13787 . Should be merged after #14051 .
