### PR TITLE
net/gnrc_netif_lorawan: fix unaligned copy

### DIFF
--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -69,14 +69,15 @@ void gnrc_lorawan_mlme_confirm(gnrc_lorawan_t *mac, mlme_confirm_t *confirm)
 
 static inline void _set_be_addr(gnrc_lorawan_t *mac, uint8_t *be_addr)
 {
-    uint32_t tmp = *((uint32_t*) be_addr);
-    tmp = byteorder_swapl(tmp);
+    uint32_t tmp = byteorder_bebuftohl(be_addr);
+    le_uint32_t dev_addr = byteorder_btoll(byteorder_htonl(tmp));
+
     mlme_request_t mlme_request;
     mlme_confirm_t mlme_confirm;
 
     mlme_request.type = MLME_SET;
     mlme_request.mib.type = MIB_DEV_ADDR;
-    mlme_request.mib.dev_addr = &tmp;
+    mlme_request.mib.dev_addr = &dev_addr;
 
     gnrc_lorawan_mlme_request(mac, &mlme_request, &mlme_confirm);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes an unaligned copy when setting the Device Address. The address array is not necessarily aligned because it's an `uint8_t` array, so parsing that to `uint32_t` might violate aligned memory access in Cortex M.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I got these weird hardfaults while refactoring `gnrc_lorawan`. I'm not sure if it's easy to reproduce the crash, but at least it should be enough to run `examples/gnrc_lorawan` and make sure it still joins, sends, etc.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
