### PR TITLE
lwip_sock: re-issue receive events if there are still received messages after `*_recv()` or `*_accept()` was called.

### DIFF
--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -549,6 +549,13 @@ int lwip_sock_recv(struct netconn *conn, uint32_t timeout, struct netbuf **buf)
 #if LWIP_SO_RCVTIMEO
     netconn_set_recvtimeout(conn, 0);
 #endif
+#if IS_ACTIVE(SOCK_HAS_ASYNC)
+    lwip_sock_base_t *sock = netconn_get_callback_arg(conn);
+
+    if (sock && sock->async_cb.gen && cib_avail(&conn->recvmbox.mbox.cib)) {
+        sock->async_cb.gen(sock, SOCK_ASYNC_MSG_RECV, sock->async_cb_arg);
+    }
+#endif
     return res;
 }
 #endif /* defined(MODULE_LWIP_SOCK_UDP) || defined(MODULE_LWIP_SOCK_IP) */

--- a/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
+++ b/pkg/lwip/contrib/sock/tcp/lwip_sock_tcp.c
@@ -255,6 +255,13 @@ int sock_tcp_accept(sock_tcp_queue_t *queue, sock_tcp_t **sock,
 #if LWIP_SO_RCVTIMEO
     netconn_set_recvtimeout(queue->base.conn, 0);
 #endif
+#if IS_ACTIVE(SOCK_HAS_ASYNC)
+    if (queue->base.async_cb.gen &&
+        cib_avail(&queue->base.conn->acceptmbox.mbox.cib)) {
+        queue->base.async_cb.gen(&queue->base, SOCK_ASYNC_CONN_RECV,
+                                 queue->base.async_cb_arg);
+    }
+#endif
     mutex_unlock(&queue->mutex);
     return res;
 }


### PR DESCRIPTION
### Contribution description
This prevents a client from needing to call `*_recv()` or `*_accept()` in a loop.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
See #14034, but with `USEPKG = lwip` instead of using GNRC.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #14034 when used with lwIP.
See also #14059 for the GNRC variant of this fix.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
