### PR TITLE
boards/microduino-corerf: Fix duplicated includes

### DIFF
--- a/boards/microduino-corerf/Makefile.include
+++ b/boards/microduino-corerf/Makefile.include
@@ -2,7 +2,6 @@
 PORT_LINUX  ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 BAUD        ?= 115200
-include $(RIOTMAKE)/tools/serial.inc.mk
 
 # PROGRAMMER defaults to UM232H which is a FT232H breakout board
 # externally connected using wires
@@ -13,5 +12,4 @@ PROGRAMMER ?= $(PROGRAMMER_MICRODUINO_CORERF)
 BOOTLOADER_SIZE ?= 0
 ROM_RESERVED ?= $(BOOTLOADER_SIZE)
 
-include $(RIOTMAKE)/tools/avrdude.inc.mk
 include $(RIOTBOARD)/common/atmega/Makefile.include


### PR DESCRIPTION
### Contribution description

`avrdude.mk` and `serial.mk` was included twice. As a result of the former, `avrdude` wasted one flash cycle and some time by writing the same firmware twice.

This PR drops the duplicated include

### Testing procedure

```
make BOARD=microduino-corerf -C examples/default flash term
```

Should still work.

### Issues/PRs references

None