### PR TITLE
examples/emcute: set GNRC_NETIF_SINGLE

### DIFF
--- a/examples/emcute_mqttsn/Makefile
+++ b/examples/emcute_mqttsn/Makefile
@@ -28,6 +28,9 @@ ifneq (,$(EMCUTE_ID))
   CFLAGS += -DEMCUTE_ID=\"$(EMCUTE_ID)\"
 endif
 
+# Optimize network stack to for use with a single network interface
+CFLAGS += -DGNRC_NETIF_SINGLE
+
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The shell command offers no capability to parse the outgoing network interface in the gateway host, so link-local addresses are not usable with this example without this patch.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile and run `examples/emcute_mqttsn` on `native` on `tap0`. In a second terminal sniff on `tap0` using `tshark`:

```sh
tshark -i tap0
```

In the RIOT application now type

```
con fe80::1
```

and hit enter. Nothing will happen, but in the sniffer you will see neighbor solicitations being sent, probing for `fe80::1`, signifying, that the packet is indeed trying to be sent.

```
[…]
    8 5.942474831 fe80::e0bc:7dff:fecb:f550 → ff02::1:ff00:1 ICMPv6 86 Neighbor Solicitation for fe80::1 from e2:bc:7d:cb:f5:50
    9 6.942905893 fe80::e0bc:7dff:fecb:f550 → ff02::1:ff00:1 ICMPv6 86 Neighbor Solicitation for fe80::1 from e2:bc:7d:cb:f5:50
   10 7.943482685 fe80::e0bc:7dff:fecb:f550 → ff02::1:ff00:1 ICMPv6 86 Neighbor Solicitation for fe80::1 from e2:bc:7d:cb:f5:50
```

Without this patch it won't work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See https://github.com/RIOT-OS/RIOT/issues/14035#issuecomment-627363581.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
