### PR TITLE
gnrc_lorawan: refactor

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -89,7 +89,6 @@ ifneq (,$(filter gnrc_lorawan,$(USEMODULE)))
   USEMODULE += hashes
   USEMODULE += crypto_aes
   USEMODULE += netdev_layer
-  USEMODULE += gnrc_neterr
   USEMODULE += gnrc_nettype_lorawan
 endif
 

--- a/examples/gnrc_lorawan/Makefile
+++ b/examples/gnrc_lorawan/Makefile
@@ -7,6 +7,7 @@ USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_lorawan
 USEMODULE += gnrc_pktdump
+USEMODULE += gnrc_neterr
 
 BOARD ?= b-l072z-lrwan1
 RIOTBASE ?= ../../

--- a/examples/gnrc_lorawan/main.c
+++ b/examples/gnrc_lorawan/main.c
@@ -49,7 +49,7 @@ int tx_cmd(int argc, char **argv)
     uint8_t port = LORAWAN_PORT; /* Default: 2 */
     int interface;
 
-    if(argc < 3) {
+    if (argc < 3) {
         _usage();
         return 1;
     }
@@ -91,7 +91,7 @@ int tx_cmd(int argc, char **argv)
 }
 
 static const shell_command_t shell_commands[] = {
-    { "send",       "Send LoRaWAN data",     tx_cmd},
+    { "send",       "Send LoRaWAN data",     tx_cmd },
     { NULL, NULL, NULL }
 };
 
@@ -102,6 +102,7 @@ int main(void)
     puts("Initialization successful - starting the shell now");
     gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(LORAWAN_PORT,
                                                           gnrc_pktdump_pid);
+
     gnrc_netreg_register(GNRC_NETTYPE_LORAWAN, &dump);
     char line_buf[SHELL_DEFAULT_BUFSIZE];
 

--- a/examples/gnrc_lorawan/main.c
+++ b/examples/gnrc_lorawan/main.c
@@ -35,7 +35,8 @@
 #include "net/gnrc/pktdump.h"
 #include "net/gnrc/netreg.h"
 
-#define LORAWAN_PORT (2U)
+#define LORAWAN_PORT       (2U)
+#define LORAWAN_QUEUE_SIZE (4U)
 
 static void _usage(void)
 {
@@ -75,16 +76,17 @@ int tx_cmd(int argc, char **argv)
     gnrc_netapi_set(interface, NETOPT_LORAWAN_TX_PORT, 0, &port, sizeof(port));
     gnrc_netif_send(gnrc_netif_get_by_pid(interface), pkt);
 
-    msg_t msg;
     /* wait for packet status and check */
+    msg_t msg;
     msg_receive(&msg);
     if ((msg.type != GNRC_NETERR_MSG_TYPE) ||
         (msg.content.value != GNRC_NETERR_SUCCESS)) {
-        puts("Error sending packet (not joined?)");
+        printf("Error sending packet: (status: %d\n)", (int) msg.content.value);
     }
     else {
         puts("Successfully sent packet");
     }
+
     return 0;
 }
 

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -230,8 +230,9 @@ void gnrc_lorawan_mcps_request(gnrc_lorawan_t *mac, const mcps_request_t *mcps_r
  *        To be called on radio RX done event.
  *
  * @param[in] mac pointer to the MAC descriptor
+ * @param[in] pkt pointer to the packet
  */
-void gnrc_lorawan_radio_rx_done_cb(gnrc_lorawan_t *mac);
+void gnrc_lorawan_radio_rx_done_cb(gnrc_lorawan_t *mac, gnrc_pktsnip_t *pkt);
 
 /**
  * @brief MCPS indication callback

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -180,14 +180,14 @@ typedef struct {
  *
  * @param[in] mac pointer to the MAC descriptor
  */
-void gnrc_lorawan_event_timeout(gnrc_lorawan_t *mac);
+void gnrc_lorawan_radio_rx_timeout_cb(gnrc_lorawan_t *mac);
 
 /**
  * @brief Indicate the MAC layer when the transmission finished
  *
  * @param[in] mac pointer to the MAC descriptor
  */
-void gnrc_lorawan_event_tx_complete(gnrc_lorawan_t *mac);
+void gnrc_lorawan_radio_tx_done_cb(gnrc_lorawan_t *mac);
 
 /**
  * @brief Init GNRC LoRaWAN
@@ -231,7 +231,7 @@ void gnrc_lorawan_mcps_request(gnrc_lorawan_t *mac, const mcps_request_t *mcps_r
  *
  * @param[in] mac pointer to the MAC descriptor
  */
-void gnrc_lorawan_recv(gnrc_lorawan_t *mac);
+void gnrc_lorawan_radio_rx_done_cb(gnrc_lorawan_t *mac);
 
 /**
  * @brief MCPS indication callback

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -61,53 +61,53 @@ extern "C" {
  * @brief MCPS events
  */
 typedef enum {
-    MCPS_EVENT_RX,            /**< MCPS RX event */
-    MCPS_EVENT_NO_RX,         /**< MCPS no RX event */
+    MCPS_EVENT_RX,              /**< MCPS RX event */
+    MCPS_EVENT_NO_RX,           /**< MCPS no RX event */
 } mcps_event_t;
 
 /**
  * @brief LoRaWAN activation mechanism
  */
 typedef enum {
-    MLME_ACTIVATION_NONE,     /**< MAC layer is not activated */
-    MLME_ACTIVATION_ABP,      /**< MAC layer activated by ABP */
-    MLME_ACTIVATION_OTAA      /**< MAC layer activated by OTAA */
+    MLME_ACTIVATION_NONE,       /**< MAC layer is not activated */
+    MLME_ACTIVATION_ABP,        /**< MAC layer activated by ABP */
+    MLME_ACTIVATION_OTAA        /**< MAC layer activated by OTAA */
 } mlme_activation_t;
 
 /**
  * @brief MAC Information Base attributes
  */
 typedef enum {
-    MIB_ACTIVATION_METHOD,     /**< type is activation method */
-    MIB_DEV_ADDR,              /**< type is dev addr */
-    MIB_RX2_DR,                /**< type is rx2 DR */
+    MIB_ACTIVATION_METHOD,      /**< type is activation method */
+    MIB_DEV_ADDR,               /**< type is dev addr */
+    MIB_RX2_DR,                 /**< type is rx2 DR */
 } mlme_mib_type_t;
 
 /**
  * @brief MLME primitive types
  */
 typedef enum {
-    MLME_JOIN,                 /**< join a LoRaWAN network */
-    MLME_LINK_CHECK,           /**< perform a Link Check */
-    MLME_RESET,                /**< reset the MAC layer */
-    MLME_SET,                  /**< set the MIB */
-    MLME_GET,                  /**< get the MIB */
-    MLME_SCHEDULE_UPLINK       /**< schedule uplink indication */
+    MLME_JOIN,                  /**< join a LoRaWAN network */
+    MLME_LINK_CHECK,            /**< perform a Link Check */
+    MLME_RESET,                 /**< reset the MAC layer */
+    MLME_SET,                   /**< set the MIB */
+    MLME_GET,                   /**< get the MIB */
+    MLME_SCHEDULE_UPLINK        /**< schedule uplink indication */
 } mlme_type_t;
 
 /**
  * @brief MCPS primitive types
  */
 typedef enum {
-    MCPS_CONFIRMED,            /**< confirmed data */
-    MCPS_UNCONFIRMED           /**< unconfirmed data */
+    MCPS_CONFIRMED,             /**< confirmed data */
+    MCPS_UNCONFIRMED            /**< unconfirmed data */
 } mcps_type_t;
 
 /**
  * @brief MAC Information Base descriptor for MLME Request-Confirm
  */
 typedef struct {
-    mlme_mib_type_t type; /**< MIB attribute identifier */
+    mlme_mib_type_t type;               /**< MIB attribute identifier */
     union {
         mlme_activation_t activation;   /**< holds activation mechanism */
         void *dev_addr;                 /**< pointer to the dev_addr */
@@ -120,10 +120,10 @@ typedef struct {
  */
 typedef struct {
     union {
-        mlme_lorawan_join_t join; /**< Join Data holder */
-        mlme_mib_t mib;           /**< MIB holder */
+        mlme_lorawan_join_t join;   /**< Join Data holder */
+        mlme_mib_t mib;             /**< MIB holder */
     };
-    mlme_type_t type;   /**< type of the MLME request */
+    mlme_type_t type;               /**< type of the MLME request */
 } mlme_request_t;
 
 /**
@@ -131,20 +131,20 @@ typedef struct {
  */
 typedef struct {
     union {
-        mcps_data_t data;        /**< MCPS data holder */
+        mcps_data_t data;   /**< MCPS data holder */
     };
-    mcps_type_t type;    /**< type of the MCPS request */
+    mcps_type_t type;       /**< type of the MCPS request */
 } mcps_request_t;
 
 /**
  * @brief MAC (sub) Layer Management Entity (MLME) confirm representation
  */
 typedef struct {
-    int16_t status; /**< status of the MLME confirm */
-    mlme_type_t type;   /**< type of the MLME confirm */
+    int16_t status;                         /**< status of the MLME confirm */
+    mlme_type_t type;                       /**< type of the MLME confirm */
     union {
-        mlme_link_req_confirm_t link_req; /**< Link Check confirmation data */
-        mlme_mib_t mib;                   /**< MIB confirmation data */
+        mlme_link_req_confirm_t link_req;   /**< Link Check confirmation data */
+        mlme_mib_t mib;                     /**< MIB confirmation data */
     };
 } mlme_confirm_t;
 
@@ -152,7 +152,7 @@ typedef struct {
  * @brief Mac Common Part Sublayer (MCPS) confirm representation
  */
 typedef struct {
-    int16_t status; /**< status of the MCPS confirm */
+    int16_t status;     /**< status of the MCPS confirm */
     mcps_type_t type;   /**< type of the MCPS confirm */
     iolist_t *msdu;     /**< pointer to the msdu */
 } mcps_confirm_t;
@@ -161,9 +161,9 @@ typedef struct {
  * @brief Mac Common Part Sublayer (MCPS) indication representation
  */
 typedef struct {
-    mcps_type_t type; /**< type of the MCPS indication */
+    mcps_type_t type;       /**< type of the MCPS indication */
     union {
-        mcps_data_t data; /**< MCPS Data holder */
+        mcps_data_t data;   /**< MCPS Data holder */
     };
 } mcps_indication_t;
 
@@ -207,7 +207,8 @@ void gnrc_lorawan_init(gnrc_lorawan_t *mac, uint8_t *nwkskey, uint8_t *appskey);
  *             GNRC_LORAWAN_REQ_STATUS_DEFERRED if the confirmation is deferred
  *             or an standard error number
  */
-void gnrc_lorawan_mlme_request(gnrc_lorawan_t *mac, const mlme_request_t *mlme_request,
+void gnrc_lorawan_mlme_request(gnrc_lorawan_t *mac,
+                               const mlme_request_t *mlme_request,
                                mlme_confirm_t *mlme_confirm);
 
 /**
@@ -220,7 +221,8 @@ void gnrc_lorawan_mlme_request(gnrc_lorawan_t *mac, const mlme_request_t *mlme_r
  *             GNRC_LORAWAN_REQ_STATUS_DEFERRED if the confirmation is deferred
  *             or an standard error number
  */
-void gnrc_lorawan_mcps_request(gnrc_lorawan_t *mac, const mcps_request_t *mcps_request,
+void gnrc_lorawan_mcps_request(gnrc_lorawan_t *mac,
+                               const mcps_request_t *mcps_request,
                                mcps_confirm_t *mcps_confirm);
 
 /**
@@ -233,7 +235,8 @@ void gnrc_lorawan_mcps_request(gnrc_lorawan_t *mac, const mcps_request_t *mcps_r
  * allocation failed)
  * @param[in] size size of the PSDU
  */
-void gnrc_lorawan_radio_rx_done_cb(gnrc_lorawan_t *mac, uint8_t *data, size_t size);
+void gnrc_lorawan_radio_rx_done_cb(gnrc_lorawan_t *mac, uint8_t *data,
+                                   size_t size);
 
 /**
  * @brief MCPS indication callback

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -63,7 +63,6 @@ extern "C" {
 typedef enum {
     MCPS_EVENT_RX,            /**< MCPS RX event */
     MCPS_EVENT_NO_RX,         /**< MCPS no RX event */
-    MCPS_EVENT_ACK_TIMEOUT    /**< MCPS retrans event */
 } mcps_event_t;
 
 /**
@@ -153,9 +152,9 @@ typedef struct {
  * @brief Mac Common Part Sublayer (MCPS) confirm representation
  */
 typedef struct {
-    void *data;     /**< data of the MCPS confirm */
     int16_t status; /**< status of the MCPS confirm */
     mcps_type_t type;   /**< type of the MCPS confirm */
+    iolist_t *msdu;     /**< pointer to the msdu */
 } mcps_confirm_t;
 
 /**
@@ -230,9 +229,11 @@ void gnrc_lorawan_mcps_request(gnrc_lorawan_t *mac, const mcps_request_t *mcps_r
  *        To be called on radio RX done event.
  *
  * @param[in] mac pointer to the MAC descriptor
- * @param[in] pkt pointer to the packet
+ * @param[in] data pointer to the psdu. Pass NULL if the packet was wrong (or
+ * allocation failed)
+ * @param[in] size size of the PSDU
  */
-void gnrc_lorawan_radio_rx_done_cb(gnrc_lorawan_t *mac, gnrc_pktsnip_t *pkt);
+void gnrc_lorawan_radio_rx_done_cb(gnrc_lorawan_t *mac, uint8_t *data, size_t size);
 
 /**
  * @brief MCPS indication callback

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -147,7 +147,7 @@ void gnrc_lorawan_open_rx_window(gnrc_lorawan_t *mac)
     dev->driver->set(dev, NETOPT_STATE, &state, sizeof(state));
 }
 
-void gnrc_lorawan_event_tx_complete(gnrc_lorawan_t *mac)
+void gnrc_lorawan_radio_tx_done_cb(gnrc_lorawan_t *mac)
 {
     mac->msg.type = MSG_TYPE_TIMEOUT;
     mac->state = LORAWAN_STATE_RX_1;
@@ -166,7 +166,7 @@ void gnrc_lorawan_event_tx_complete(gnrc_lorawan_t *mac)
     _sleep_radio(mac);
 }
 
-void gnrc_lorawan_event_timeout(gnrc_lorawan_t *mac)
+void gnrc_lorawan_radio_rx_timeout_cb(gnrc_lorawan_t *mac)
 {
     (void) mac;
     switch (mac->state) {
@@ -273,7 +273,7 @@ void gnrc_lorawan_process_pkt(gnrc_lorawan_t *mac, gnrc_pktsnip_t *pkt)
     gnrc_lorawan_mac_release(mac);
 }
 
-void gnrc_lorawan_recv(gnrc_lorawan_t *mac)
+void gnrc_lorawan_radio_rx_done_cb(gnrc_lorawan_t *mac)
 {
     netdev_t *dev = gnrc_lorawan_get_netdev(mac);
     int bytes_expected = dev->driver->recv(dev, NULL, 0, 0);

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_crypto.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_crypto.c
@@ -45,20 +45,17 @@ typedef struct  __attribute__((packed)) {
     uint8_t len;
 } lorawan_block_t;
 
-void gnrc_lorawan_calculate_join_mic(const iolist_t *io, const uint8_t *key, le_uint32_t *out)
+void gnrc_lorawan_calculate_join_mic(const uint8_t *buf, size_t len, const uint8_t *key, le_uint32_t *out)
 {
     cmac_init(&CmacContext, key, LORAMAC_APPKEY_LEN);
-    while (io != NULL) {
-        cmac_update(&CmacContext, io->iol_base, io->iol_len);
-        io = io->iol_next;
-    }
+    cmac_update(&CmacContext, buf, len);
     cmac_final(&CmacContext, digest);
 
     memcpy(out, digest, sizeof(le_uint32_t));
 }
 
 void gnrc_lorawan_calculate_mic(const le_uint32_t *dev_addr, uint32_t fcnt,
-                                uint8_t dir, iolist_t *pkt, const uint8_t *nwkskey, le_uint32_t *out)
+                                uint8_t dir, iolist_t *frame, const uint8_t *nwkskey, le_uint32_t *out)
 {
     lorawan_block_t block;
 
@@ -72,11 +69,16 @@ void gnrc_lorawan_calculate_mic(const le_uint32_t *dev_addr, uint32_t fcnt,
 
     block.u32_pad = 0;
 
-    block.len = iolist_size(pkt);
+    block.len = iolist_size(frame);
 
-    iolist_t io = { .iol_base = &block, .iol_len = sizeof(block),
-                    .iol_next = pkt };
-    gnrc_lorawan_calculate_join_mic(&io, nwkskey, out);
+    cmac_init(&CmacContext, nwkskey, LORAMAC_APPKEY_LEN);
+    cmac_update(&CmacContext, &block, sizeof(block));
+    for (iolist_t *io = frame; io != NULL; io = io->iol_next) {
+        cmac_update(&CmacContext, io->iol_base, io->iol_len);
+    }
+    cmac_final(&CmacContext, digest);
+
+    memcpy(out, digest, sizeof(le_uint32_t));
 }
 
 void gnrc_lorawan_encrypt_payload(iolist_t *iolist, const le_uint32_t *dev_addr, uint32_t fcnt, uint8_t dir, const uint8_t *appskey)

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_crypto.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_crypto.c
@@ -45,7 +45,8 @@ typedef struct  __attribute__((packed)) {
     uint8_t len;
 } lorawan_block_t;
 
-void gnrc_lorawan_calculate_join_mic(const uint8_t *buf, size_t len, const uint8_t *key, le_uint32_t *out)
+void gnrc_lorawan_calculate_join_mic(const uint8_t *buf, size_t len,
+                                     const uint8_t *key, le_uint32_t *out)
 {
     cmac_init(&CmacContext, key, LORAMAC_APPKEY_LEN);
     cmac_update(&CmacContext, buf, len);
@@ -55,7 +56,8 @@ void gnrc_lorawan_calculate_join_mic(const uint8_t *buf, size_t len, const uint8
 }
 
 void gnrc_lorawan_calculate_mic(const le_uint32_t *dev_addr, uint32_t fcnt,
-                                uint8_t dir, iolist_t *frame, const uint8_t *nwkskey, le_uint32_t *out)
+                                uint8_t dir, iolist_t *frame,
+                                const uint8_t *nwkskey, le_uint32_t *out)
 {
     lorawan_block_t block;
 
@@ -81,7 +83,9 @@ void gnrc_lorawan_calculate_mic(const le_uint32_t *dev_addr, uint32_t fcnt,
     memcpy(out, digest, sizeof(le_uint32_t));
 }
 
-void gnrc_lorawan_encrypt_payload(iolist_t *iolist, const le_uint32_t *dev_addr, uint32_t fcnt, uint8_t dir, const uint8_t *appskey)
+void gnrc_lorawan_encrypt_payload(iolist_t *iolist, const le_uint32_t *dev_addr,
+                                  uint32_t fcnt, uint8_t dir,
+                                  const uint8_t *appskey)
 {
     uint8_t s_block[16];
     uint8_t a_block[16];
@@ -89,7 +93,7 @@ void gnrc_lorawan_encrypt_payload(iolist_t *iolist, const le_uint32_t *dev_addr,
     memset(s_block, 0, sizeof(s_block));
     memset(a_block, 0, sizeof(a_block));
 
-    lorawan_block_t *block = (lorawan_block_t *) a_block;
+    lorawan_block_t *block = (lorawan_block_t *)a_block;
 
     cipher_init(&AesContext, CIPHER_AES_128, appskey, LORAMAC_APPKEY_LEN);
 
@@ -104,6 +108,7 @@ void gnrc_lorawan_encrypt_payload(iolist_t *iolist, const le_uint32_t *dev_addr,
     block->u32_pad = 0;
 
     int c = 0;
+
     for (iolist_t *io = iolist; io != NULL; io = io->iol_next) {
         for (unsigned i = 0; i < io->iol_len; i++) {
             uint8_t *v = io->iol_base;
@@ -119,17 +124,22 @@ void gnrc_lorawan_encrypt_payload(iolist_t *iolist, const le_uint32_t *dev_addr,
     }
 }
 
-void gnrc_lorawan_decrypt_join_accept(const uint8_t *key, uint8_t *pkt, int has_clist, uint8_t *out)
+void gnrc_lorawan_decrypt_join_accept(const uint8_t *key, uint8_t *pkt,
+                                      int has_clist, uint8_t *out)
 {
     cipher_init(&AesContext, CIPHER_AES_128, key, LORAMAC_APPKEY_LEN);
     cipher_encrypt(&AesContext, pkt, out);
 
     if (has_clist) {
-        cipher_encrypt(&AesContext, pkt + LORAMAC_APPKEY_LEN, out + LORAMAC_APPKEY_LEN);
+        cipher_encrypt(&AesContext, pkt + LORAMAC_APPKEY_LEN,
+                       out + LORAMAC_APPKEY_LEN);
     }
 }
 
-void gnrc_lorawan_generate_session_keys(const uint8_t *app_nonce, const uint8_t *dev_nonce, const uint8_t *appkey, uint8_t *nwkskey, uint8_t *appskey)
+void gnrc_lorawan_generate_session_keys(const uint8_t *app_nonce,
+                                        const uint8_t *dev_nonce,
+                                        const uint8_t *appkey, uint8_t *nwkskey,
+                                        uint8_t *appskey)
 {
     uint8_t buf[LORAMAC_APPSKEY_LEN];
 
@@ -138,8 +148,10 @@ void gnrc_lorawan_generate_session_keys(const uint8_t *app_nonce, const uint8_t 
     cipher_init(&AesContext, CIPHER_AES_128, appkey, LORAMAC_APPSKEY_LEN);
 
     /* net_id comes right after app_nonce */
-    memcpy(buf + 1, app_nonce, GNRC_LORAWAN_APP_NONCE_SIZE + GNRC_LORAWAN_NET_ID_SIZE);
-    memcpy(buf + 1 + GNRC_LORAWAN_APP_NONCE_SIZE + GNRC_LORAWAN_NET_ID_SIZE, dev_nonce, GNRC_LORAWAN_DEV_NONCE_SIZE);
+    memcpy(buf + 1, app_nonce,
+           GNRC_LORAWAN_APP_NONCE_SIZE + GNRC_LORAWAN_NET_ID_SIZE);
+    memcpy(buf + 1 + GNRC_LORAWAN_APP_NONCE_SIZE + GNRC_LORAWAN_NET_ID_SIZE,
+           dev_nonce, GNRC_LORAWAN_DEV_NONCE_SIZE);
 
     /* Calculate Application Session Key */
     buf[0] = APP_SKEY_B0_START;

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
@@ -291,7 +291,7 @@ void gnrc_lorawan_mcps_request(gnrc_lorawan_t *mac, const mcps_request_t *mcps_r
 
     if (!gnrc_lorawan_mac_acquire(mac)) {
         mcps_confirm->status = -EBUSY;
-        goto out;
+        return;
     }
 
     if (mcps_request->data.port < LORAMAC_PORT_MIN ||

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
@@ -28,33 +28,39 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-static void _build_join_req_pkt(uint8_t *appeui, uint8_t *deveui, uint8_t *appkey, uint8_t *dev_nonce, uint8_t *psdu)
+static void _build_join_req_pkt(uint8_t *appeui, uint8_t *deveui,
+                                uint8_t *appkey, uint8_t *dev_nonce,
+                                uint8_t *psdu)
 {
-    lorawan_join_request_t *hdr = (lorawan_join_request_t *) psdu;
+    lorawan_join_request_t *hdr = (lorawan_join_request_t *)psdu;
 
     hdr->mt_maj = 0;
-    lorawan_hdr_set_mtype((lorawan_hdr_t *) hdr, MTYPE_JOIN_REQUEST);
-    lorawan_hdr_set_maj((lorawan_hdr_t *) hdr, MAJOR_LRWAN_R1);
+    lorawan_hdr_set_mtype((lorawan_hdr_t *)hdr, MTYPE_JOIN_REQUEST);
+    lorawan_hdr_set_maj((lorawan_hdr_t *)hdr, MAJOR_LRWAN_R1);
 
-    le_uint64_t l_appeui = *((le_uint64_t *) appeui);
-    le_uint64_t l_deveui = *((le_uint64_t *) deveui);
+    le_uint64_t l_appeui = *((le_uint64_t *)appeui);
+    le_uint64_t l_deveui = *((le_uint64_t *)deveui);
 
     hdr->app_eui = l_appeui;
     hdr->dev_eui = l_deveui;
 
-    le_uint16_t l_dev_nonce = *((le_uint16_t *) dev_nonce);
+    le_uint16_t l_dev_nonce = *((le_uint16_t *)dev_nonce);
+
     hdr->dev_nonce = l_dev_nonce;
 
-    gnrc_lorawan_calculate_join_mic(psdu, JOIN_REQUEST_SIZE - MIC_SIZE, appkey, &hdr->mic);
+    gnrc_lorawan_calculate_join_mic(psdu, JOIN_REQUEST_SIZE - MIC_SIZE, appkey,
+                                    &hdr->mic);
 }
 
 static int gnrc_lorawan_send_join_request(gnrc_lorawan_t *mac, uint8_t *deveui,
-                                          uint8_t *appeui, uint8_t *appkey, uint8_t dr)
+                                          uint8_t *appeui, uint8_t *appkey,
+                                          uint8_t dr)
 {
     netdev_t *dev = gnrc_lorawan_get_netdev(mac);
 
     /* Dev Nonce */
     uint32_t random_number;
+
     dev->driver->get(dev, NETOPT_RANDOM, &random_number, sizeof(random_number));
 
     mac->mlme.dev_nonce[0] = random_number & 0xFF;
@@ -63,7 +69,9 @@ static int gnrc_lorawan_send_join_request(gnrc_lorawan_t *mac, uint8_t *deveui,
     /* build join request */
     uint8_t psdu[sizeof(lorawan_join_request_t)];
 
-    iolist_t pkt = {.iol_base = &psdu, .iol_len = sizeof(psdu), .iol_next = NULL};
+    iolist_t pkt =
+    { .iol_base = &psdu, .iol_len = sizeof(psdu), .iol_next = NULL };
+
     _build_join_req_pkt(appeui, deveui, appkey, mac->mlme.dev_nonce, psdu);
 
     /* We need a random delay for join request. Otherwise there might be
@@ -76,7 +84,8 @@ static int gnrc_lorawan_send_join_request(gnrc_lorawan_t *mac, uint8_t *deveui,
     return GNRC_LORAWAN_REQ_STATUS_DEFERRED;
 }
 
-void gnrc_lorawan_mlme_process_join(gnrc_lorawan_t *mac, uint8_t *data, size_t size)
+void gnrc_lorawan_mlme_process_join(gnrc_lorawan_t *mac, uint8_t *data,
+                                    size_t size)
 {
     int status;
     mlme_confirm_t mlme_confirm;
@@ -95,12 +104,14 @@ void gnrc_lorawan_mlme_process_join(gnrc_lorawan_t *mac, uint8_t *data, size_t s
     /* Subtract 1 from join accept max size, since the MHDR was already read */
     uint8_t out[GNRC_LORAWAN_JOIN_ACCEPT_MAX_SIZE - 1];
     uint8_t has_cflist = (size - 1) >= CFLIST_SIZE;
+
     gnrc_lorawan_decrypt_join_accept(mac->appskey, data + 1,
                                      has_cflist, out);
     memcpy(data + 1, out, size - 1);
 
     le_uint32_t mic;
-    le_uint32_t *expected_mic = (le_uint32_t *) (data + size - MIC_SIZE);
+    le_uint32_t *expected_mic = (le_uint32_t *)(data + size - MIC_SIZE);
+
     gnrc_lorawan_calculate_join_mic(data, size - MIC_SIZE, mac->appskey, &mic);
     if (mic.u32 != expected_mic->u32) {
         DEBUG("gnrc_lorawan_mlme: wrong MIC.\n");
@@ -108,10 +119,14 @@ void gnrc_lorawan_mlme_process_join(gnrc_lorawan_t *mac, uint8_t *data, size_t s
         goto out;
     }
 
-    lorawan_join_accept_t *ja_hdr = (lorawan_join_accept_t *) data;
-    gnrc_lorawan_generate_session_keys(ja_hdr->app_nonce, mac->mlme.dev_nonce, mac->appskey, mac->nwkskey, mac->appskey);
+    lorawan_join_accept_t *ja_hdr = (lorawan_join_accept_t *)data;
+
+    gnrc_lorawan_generate_session_keys(ja_hdr->app_nonce, mac->mlme.dev_nonce,
+                                       mac->appskey, mac->nwkskey,
+                                       mac->appskey);
 
     le_uint32_t le_nid;
+
     le_nid.u32 = 0;
     memcpy(&le_nid, ja_hdr->net_id, 3);
     mac->mlme.nid = byteorder_ntohl(byteorder_ltobl(le_nid));
@@ -168,19 +183,20 @@ void gnrc_lorawan_mlme_backoff_expire(gnrc_lorawan_t *mac)
 }
 
 static void _mlme_set(gnrc_lorawan_t *mac, const mlme_request_t *mlme_request,
-                               mlme_confirm_t *mlme_confirm)
+                      mlme_confirm_t *mlme_confirm)
 {
     mlme_confirm->status = -EINVAL;
-    switch(mlme_request->mib.type) {
+    switch (mlme_request->mib.type) {
         case MIB_ACTIVATION_METHOD:
-            if(mlme_request->mib.activation != MLME_ACTIVATION_OTAA) {
+            if (mlme_request->mib.activation != MLME_ACTIVATION_OTAA) {
                 mlme_confirm->status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
                 mac->mlme.activation = mlme_request->mib.activation;
             }
             break;
         case MIB_DEV_ADDR:
             mlme_confirm->status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
-            memcpy(&mac->dev_addr, mlme_request->mib.dev_addr, sizeof(uint32_t));
+            memcpy(&mac->dev_addr, mlme_request->mib.dev_addr,
+                   sizeof(uint32_t));
             break;
         case MIB_RX2_DR:
             mlme_confirm->status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
@@ -192,9 +208,9 @@ static void _mlme_set(gnrc_lorawan_t *mac, const mlme_request_t *mlme_request,
 }
 
 static void _mlme_get(gnrc_lorawan_t *mac, const mlme_request_t *mlme_request,
-                               mlme_confirm_t *mlme_confirm)
+                      mlme_confirm_t *mlme_confirm)
 {
-    switch(mlme_request->mib.type) {
+    switch (mlme_request->mib.type) {
         case MIB_ACTIVATION_METHOD:
             mlme_confirm->status = GNRC_LORAWAN_REQ_STATUS_SUCCESS;
             mlme_confirm->mib.activation = mac->mlme.activation;
@@ -209,12 +225,13 @@ static void _mlme_get(gnrc_lorawan_t *mac, const mlme_request_t *mlme_request,
     }
 }
 
-void gnrc_lorawan_mlme_request(gnrc_lorawan_t *mac, const mlme_request_t *mlme_request,
+void gnrc_lorawan_mlme_request(gnrc_lorawan_t *mac,
+                               const mlme_request_t *mlme_request,
                                mlme_confirm_t *mlme_confirm)
 {
     switch (mlme_request->type) {
         case MLME_JOIN:
-            if(mac->mlme.activation != MLME_ACTIVATION_NONE) {
+            if (mac->mlme.activation != MLME_ACTIVATION_NONE) {
                 mlme_confirm->status = -EINVAL;
                 break;
             }
@@ -228,11 +245,14 @@ void gnrc_lorawan_mlme_request(gnrc_lorawan_t *mac, const mlme_request_t *mlme_r
                 break;
             }
             memcpy(mac->appskey, mlme_request->join.appkey, LORAMAC_APPKEY_LEN);
-            mlme_confirm->status = gnrc_lorawan_send_join_request(mac, mlme_request->join.deveui,
-                                                                  mlme_request->join.appeui, mlme_request->join.appkey, mlme_request->join.dr);
+            mlme_confirm->status = gnrc_lorawan_send_join_request(mac,
+                                                                  mlme_request->join.deveui,
+                                                                  mlme_request->join.appeui, mlme_request->join.appkey,
+                                                                  mlme_request->join.dr);
             break;
         case MLME_LINK_CHECK:
-            mac->mlme.pending_mlme_opts |= GNRC_LORAWAN_MLME_OPTS_LINK_CHECK_REQ;
+            mac->mlme.pending_mlme_opts |=
+                GNRC_LORAWAN_MLME_OPTS_LINK_CHECK_REQ;
             mlme_confirm->status = GNRC_LORAWAN_REQ_STATUS_DEFERRED;
             break;
         case MLME_SET:
@@ -263,6 +283,7 @@ int _fopts_mlme_link_check_req(lorawan_buffer_t *buf)
 static void _mlme_link_check_ans(gnrc_lorawan_t *mac, uint8_t *p)
 {
     mlme_confirm_t mlme_confirm;
+
     mlme_confirm.link_req.margin = p[1];
     mlme_confirm.link_req.num_gateways = p[2];
 
@@ -273,16 +294,18 @@ static void _mlme_link_check_ans(gnrc_lorawan_t *mac, uint8_t *p)
     mac->mlme.pending_mlme_opts &= ~GNRC_LORAWAN_MLME_OPTS_LINK_CHECK_REQ;
 }
 
-void gnrc_lorawan_process_fopts(gnrc_lorawan_t *mac, uint8_t *fopts, size_t size)
+void gnrc_lorawan_process_fopts(gnrc_lorawan_t *mac, uint8_t *fopts,
+                                size_t size)
 {
     if (!fopts || !size) {
         return;
     }
 
     uint8_t ret = 0;
-    void (*cb)(gnrc_lorawan_t*, uint8_t *p) = NULL;
 
-    for(uint8_t pos = 0; pos < size; pos += ret) {
+    void (*cb)(gnrc_lorawan_t *, uint8_t *p) = NULL;
+
+    for (uint8_t pos = 0; pos < size; pos += ret) {
         switch (fopts[pos]) {
             case GNRC_LORAWAN_CID_LINK_CHECK_ANS:
                 ret += GNRC_LORAWAN_FOPT_LINK_CHECK_ANS_SIZE;
@@ -292,7 +315,7 @@ void gnrc_lorawan_process_fopts(gnrc_lorawan_t *mac, uint8_t *fopts, size_t size
                 return;
         }
 
-        if(pos + ret > size) {
+        if (pos + ret > size) {
             return;
         }
 
@@ -304,7 +327,7 @@ uint8_t gnrc_lorawan_build_options(gnrc_lorawan_t *mac, lorawan_buffer_t *buf)
 {
     size_t size = 0;
 
-    if(mac->mlme.pending_mlme_opts & GNRC_LORAWAN_MLME_OPTS_LINK_CHECK_REQ) {
+    if (mac->mlme.pending_mlme_opts & GNRC_LORAWAN_MLME_OPTS_LINK_CHECK_REQ) {
         size += _fopts_mlme_link_check_req(buf);
     }
 

--- a/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
+++ b/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
@@ -150,27 +150,27 @@ typedef struct {
  * @brief MCPS service access point descriptor
  */
 typedef struct {
-    uint32_t fcnt;                  /**< uplink framecounter */
-    uint32_t fcnt_down;             /**< downlink frame counter */
-    iolist_t *msdu;             /**< current MSDU */
-    int nb_trials;              /**< holds the remaining number of retransmissions */
-    int ack_requested;          /**< whether the network server requested an ACK */
-    int waiting_for_ack;        /**< true if the MAC layer is waiting for an ACK */
-    char mhdr_mic[MHDR_MIC_BUF_SIZE]; /**< internal retransmissions buffer */
+    uint32_t fcnt;                      /**< uplink framecounter */
+    uint32_t fcnt_down;                 /**< downlink frame counter */
+    iolist_t *msdu;                     /**< current MSDU */
+    int nb_trials;                      /**< holds the remaining number of retransmissions */
+    int ack_requested;                  /**< whether the network server requested an ACK */
+    int waiting_for_ack;                /**< true if the MAC layer is waiting for an ACK */
+    char mhdr_mic[MHDR_MIC_BUF_SIZE];   /**< internal retransmissions buffer */
 } gnrc_lorawan_mcps_t;
 
 /**
  * @brief MLME service access point descriptor
  */
 typedef struct {
-    xtimer_t backoff_timer;     /**< timer used for backoff expiration */
-    msg_t backoff_msg;          /**< msg for backoff expiration */
-    uint8_t activation;         /**< Activation mechanism of the MAC layer */
+    xtimer_t backoff_timer; /**< timer used for backoff expiration */
+    msg_t backoff_msg;      /**< msg for backoff expiration */
+    uint8_t activation;     /**< Activation mechanism of the MAC layer */
     int pending_mlme_opts;  /**< holds pending mlme opts */
-    uint32_t nid;               /**< current Network ID */
-    int32_t backoff_budget;     /**< remaining Time On Air budget */
-    uint8_t dev_nonce[2];       /**< Device Nonce */
-    uint8_t backoff_state;      /**< state in the backoff state machine */
+    uint32_t nid;           /**< current Network ID */
+    int32_t backoff_budget; /**< remaining Time On Air budget */
+    uint8_t dev_nonce[2];   /**< Device Nonce */
+    uint8_t backoff_state;  /**< state in the backoff state machine */
 } gnrc_lorawan_mlme_t;
 
 /**
@@ -207,7 +207,9 @@ typedef struct {
  * @param[in] dir direction of the packet (0 if uplink, 1 if downlink)
  * @param[in] appskey pointer to the Application Session Key
  */
-void gnrc_lorawan_encrypt_payload(iolist_t *iolist, const le_uint32_t *dev_addr, uint32_t fcnt, uint8_t dir, const uint8_t *appskey);
+void gnrc_lorawan_encrypt_payload(iolist_t *iolist, const le_uint32_t *dev_addr,
+                                  uint32_t fcnt, uint8_t dir,
+                                  const uint8_t *appskey);
 
 /**
  * @brief Decrypts join accept message
@@ -217,7 +219,8 @@ void gnrc_lorawan_encrypt_payload(iolist_t *iolist, const le_uint32_t *dev_addr,
  * @param[in] has_clist true if the Join Accept frame has CFList
  * @param[out] out buffer where the decryption is stored
  */
-void gnrc_lorawan_decrypt_join_accept(const uint8_t *key, uint8_t *pkt, int has_clist, uint8_t *out);
+void gnrc_lorawan_decrypt_join_accept(const uint8_t *key, uint8_t *pkt,
+                                      int has_clist, uint8_t *out);
 
 /**
  * @brief Generate LoRaWAN session keys
@@ -231,7 +234,10 @@ void gnrc_lorawan_decrypt_join_accept(const uint8_t *key, uint8_t *pkt, int has_
  * @param[out] nwkskey pointer to the NwkSKey
  * @param[out] appskey pointer to the AppSKey
  */
-void gnrc_lorawan_generate_session_keys(const uint8_t *app_nonce, const uint8_t *dev_nonce, const uint8_t *appkey, uint8_t *nwkskey, uint8_t *appskey);
+void gnrc_lorawan_generate_session_keys(const uint8_t *app_nonce,
+                                        const uint8_t *dev_nonce,
+                                        const uint8_t *appkey, uint8_t *nwkskey,
+                                        uint8_t *appskey);
 
 /**
  * @brief Set datarate for the next transmission
@@ -255,7 +261,8 @@ int gnrc_lorawan_set_dr(gnrc_lorawan_t *mac, uint8_t datarate);
  * @return full LoRaWAN frame including payload
  * @return NULL if packet buffer is full. `payload` is released
  */
-size_t gnrc_lorawan_build_uplink(gnrc_lorawan_t *mac, iolist_t *payload, int confirmed_data, uint8_t port);
+size_t gnrc_lorawan_build_uplink(gnrc_lorawan_t *mac, iolist_t *payload,
+                                 int confirmed_data, uint8_t port);
 
 /**
  * @brief pick a random available LoRaWAN channel
@@ -284,7 +291,8 @@ uint8_t gnrc_lorawan_build_options(gnrc_lorawan_t *mac, lorawan_buffer_t *buf);
  * @param[in] fopts pointer to fopts frame
  * @param[in] size size of fopts frame
  */
-void gnrc_lorawan_process_fopts(gnrc_lorawan_t *mac, uint8_t *fopts, size_t size);
+void gnrc_lorawan_process_fopts(gnrc_lorawan_t *mac, uint8_t *fopts,
+                                size_t size);
 
 /**
  * @brief calculate join Message Integrity Code
@@ -294,7 +302,8 @@ void gnrc_lorawan_process_fopts(gnrc_lorawan_t *mac, uint8_t *fopts, size_t size
  * @param[in] key key used to calculate the MIC
  * @param[out] out calculated MIC
  */
-void gnrc_lorawan_calculate_join_mic(const uint8_t *buf, size_t len, const uint8_t *key, le_uint32_t *out);
+void gnrc_lorawan_calculate_join_mic(const uint8_t *buf, size_t len,
+                                     const uint8_t *key, le_uint32_t *out);
 
 /**
  * @brief Calculate Message Integrity Code for a MCPS message
@@ -307,7 +316,8 @@ void gnrc_lorawan_calculate_join_mic(const uint8_t *buf, size_t len, const uint8
  * @param[out] out calculated MIC
  */
 void gnrc_lorawan_calculate_mic(const le_uint32_t *dev_addr, uint32_t fcnt,
-                                uint8_t dir, iolist_t *frame, const uint8_t *nwkskey, le_uint32_t *out);
+                                uint8_t dir, iolist_t *frame,
+                                const uint8_t *nwkskey, le_uint32_t *out);
 /**
  * @brief Build a MCPS LoRaWAN header
  *
@@ -320,7 +330,9 @@ void gnrc_lorawan_calculate_mic(const le_uint32_t *dev_addr, uint32_t fcnt,
  *
  * @return the size of the header
  */
-size_t gnrc_lorawan_build_hdr(uint8_t mtype, le_uint32_t *dev_addr, uint32_t fcnt, uint8_t ack, uint8_t fopts_length, lorawan_buffer_t *buf);
+size_t gnrc_lorawan_build_hdr(uint8_t mtype, le_uint32_t *dev_addr,
+                              uint32_t fcnt, uint8_t ack, uint8_t fopts_length,
+                              lorawan_buffer_t *buf);
 
 /**
  * @brief Process an MCPS downlink message (confirmable or non comfirmable)
@@ -329,7 +341,8 @@ size_t gnrc_lorawan_build_hdr(uint8_t mtype, le_uint32_t *dev_addr, uint32_t fcn
  * @param[in] psdu pointer to the downlink PSDU
  * @param[in] size size of the PSDU
  */
-void  gnrc_lorawan_mcps_process_downlink(gnrc_lorawan_t *mac, uint8_t *psdu, size_t size);
+void  gnrc_lorawan_mcps_process_downlink(gnrc_lorawan_t *mac, uint8_t *psdu,
+                                         size_t size);
 
 /**
  * @brief Init regional channel settings.
@@ -365,7 +378,8 @@ void gnrc_lorawan_send_pkt(gnrc_lorawan_t *mac, iolist_t *psdu, uint8_t dr);
  * @param[in] data the Join Accept packet
  * @param[in] size size of the Join Accept packet
  */
-void gnrc_lorawan_mlme_process_join(gnrc_lorawan_t *mac, uint8_t *data, size_t size);
+void gnrc_lorawan_mlme_process_join(gnrc_lorawan_t *mac, uint8_t *data,
+                                    size_t size);
 
 /**
  * @brief Inform the MAC layer that no packet was received during reception.

--- a/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
+++ b/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
@@ -99,6 +99,17 @@ extern "C" {
 #define GNRC_LORAWAN_NET_ID_SIZE (3U)                   /**< Net ID size */
 #define GNRC_LORAWAN_DEV_NONCE_SIZE (2U)                /**< Dev Nonce size */
 
+#define GNRC_LORAWAN_FOPTS_MAX_SIZE (15U)               /**< Maximum size of Fopts field */
+#define GNRC_LORAWAN_FPORT_SIZE (1U)                    /**< Size of the Fport field */
+
+/**
+ * @brief Size of the internal MHDR-MIC buffer
+ */
+#define MHDR_MIC_BUF_SIZE (sizeof(lorawan_hdr_t) + \
+                           GNRC_LORAWAN_FOPTS_MAX_SIZE + \
+                           GNRC_LORAWAN_FPORT_SIZE + \
+                           MIC_SIZE)
+
 /**
  * @brief buffer helper for parsing and constructing LoRaWAN packets.
  */
@@ -130,7 +141,7 @@ typedef struct {
  * @brief MCPS data
  */
 typedef struct {
-    gnrc_pktsnip_t *pkt;    /**< packet of the request */
+    iolist_t *pkt;          /**< packet of the request */
     uint8_t port;           /**< port of the request */
     uint8_t dr;             /**< datarate of the request */
 } mcps_data_t;
@@ -141,10 +152,11 @@ typedef struct {
 typedef struct {
     uint32_t fcnt;                  /**< uplink framecounter */
     uint32_t fcnt_down;             /**< downlink frame counter */
-    gnrc_pktsnip_t *outgoing_pkt;   /**< holds the outgoing packet in case of retransmissions */
+    iolist_t *msdu;             /**< current MSDU */
     int nb_trials;              /**< holds the remaining number of retransmissions */
     int ack_requested;          /**< whether the network server requested an ACK */
     int waiting_for_ack;        /**< true if the MAC layer is waiting for an ACK */
+    char mhdr_mic[MHDR_MIC_BUF_SIZE]; /**< internal retransmissions buffer */
 } gnrc_lorawan_mcps_t;
 
 /**
@@ -189,7 +201,7 @@ typedef struct {
  *
  * @note This function is also used for decrypting a LoRaWAN packet. The LoRaWAN server encrypts the packet using decryption, so the end device only needs to implement encryption
  *
- * @param[in] iolist packet iolist representation
+ * @param[in] iolist pointer to the MSDU frame
  * @param[in] dev_addr device address
  * @param[in] fcnt frame counter
  * @param[in] dir direction of the packet (0 if uplink, 1 if downlink)
@@ -243,7 +255,7 @@ int gnrc_lorawan_set_dr(gnrc_lorawan_t *mac, uint8_t datarate);
  * @return full LoRaWAN frame including payload
  * @return NULL if packet buffer is full. `payload` is released
  */
-gnrc_pktsnip_t *gnrc_lorawan_build_uplink(gnrc_lorawan_t *mac, gnrc_pktsnip_t *payload, int confirmed_data, uint8_t port);
+size_t gnrc_lorawan_build_uplink(gnrc_lorawan_t *mac, iolist_t *payload, int confirmed_data, uint8_t port);
 
 /**
  * @brief pick a random available LoRaWAN channel
@@ -277,11 +289,12 @@ void gnrc_lorawan_process_fopts(gnrc_lorawan_t *mac, uint8_t *fopts, size_t size
 /**
  * @brief calculate join Message Integrity Code
  *
- * @param[in] io iolist representation of the packet
+ * @param[in] buf pointer to the frame
+ * @param[in] len length of the frame
  * @param[in] key key used to calculate the MIC
  * @param[out] out calculated MIC
  */
-void  gnrc_lorawan_calculate_join_mic(const iolist_t *io, const uint8_t *key, le_uint32_t *out);
+void gnrc_lorawan_calculate_join_mic(const uint8_t *buf, size_t len, const uint8_t *key, le_uint32_t *out);
 
 /**
  * @brief Calculate Message Integrity Code for a MCPS message
@@ -289,13 +302,12 @@ void  gnrc_lorawan_calculate_join_mic(const iolist_t *io, const uint8_t *key, le
  * @param[in] dev_addr the Device Address
  * @param[in] fcnt frame counter
  * @param[in] dir direction of the packet (0 is uplink, 1 is downlink)
- * @param[in] pkt the pkt
+ * @param[in] frame pointer to the PSDU frame (witout MIC)
  * @param[in] nwkskey pointer to the Network Session Key
  * @param[out] out calculated MIC
  */
 void gnrc_lorawan_calculate_mic(const le_uint32_t *dev_addr, uint32_t fcnt,
-                                uint8_t dir, iolist_t *pkt, const uint8_t *nwkskey, le_uint32_t *out);
-
+                                uint8_t dir, iolist_t *frame, const uint8_t *nwkskey, le_uint32_t *out);
 /**
  * @brief Build a MCPS LoRaWAN header
  *
@@ -314,9 +326,10 @@ size_t gnrc_lorawan_build_hdr(uint8_t mtype, le_uint32_t *dev_addr, uint32_t fcn
  * @brief Process an MCPS downlink message (confirmable or non comfirmable)
  *
  * @param[in] mac pointer to the MAC descriptor
- * @param[in] pkt pointer to the downlink message
+ * @param[in] psdu pointer to the downlink PSDU
+ * @param[in] size size of the PSDU
  */
-void  gnrc_lorawan_mcps_process_downlink(gnrc_lorawan_t *mac, gnrc_pktsnip_t *pkt);
+void  gnrc_lorawan_mcps_process_downlink(gnrc_lorawan_t *mac, uint8_t *psdu, size_t size);
 
 /**
  * @brief Init regional channel settings.
@@ -340,18 +353,19 @@ void gnrc_lorawan_reset(gnrc_lorawan_t *mac);
  * @brief Send a LoRaWAN packet
  *
  * @param[in] mac pointer to the MAC descriptor
- * @param[in] pkt the packet to be sent
+ * @param[in] psdu the psdu frame to be sent
  * @param[in] dr the datarate used for the transmission
  */
-void gnrc_lorawan_send_pkt(gnrc_lorawan_t *mac, gnrc_pktsnip_t *pkt, uint8_t dr);
+void gnrc_lorawan_send_pkt(gnrc_lorawan_t *mac, iolist_t *psdu, uint8_t dr);
 
 /**
  * @brief Process join accept message
  *
  * @param[in] mac pointer to the MAC descriptor
- * @param[in] pkt the Join Accept packet
+ * @param[in] data the Join Accept packet
+ * @param[in] size size of the Join Accept packet
  */
-void gnrc_lorawan_mlme_process_join(gnrc_lorawan_t *mac, gnrc_pktsnip_t *pkt);
+void gnrc_lorawan_mlme_process_join(gnrc_lorawan_t *mac, uint8_t *data, size_t size);
 
 /**
  * @brief Inform the MAC layer that no packet was received during reception.
@@ -364,13 +378,18 @@ void gnrc_lorawan_mlme_process_join(gnrc_lorawan_t *mac, gnrc_pktsnip_t *pkt);
 void gnrc_lorawan_mlme_no_rx(gnrc_lorawan_t *mac);
 
 /**
- * @brief Trigger a MCPS event
+ * @brief Mac callback for no RX
  *
  * @param[in] mac pointer to the MAC descriptor
- * @param[in] event the event to be processed.
- * @param[in] data set to true if the packet contains payload
  */
-void gnrc_lorawan_mcps_event(gnrc_lorawan_t *mac, int event, int data);
+void gnrc_lorawan_event_no_rx(gnrc_lorawan_t *mac);
+
+/**
+ * @brief Mac callback for ACK timeout event
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ */
+void gnrc_lorawan_event_ack_timeout(gnrc_lorawan_t *mac);
 
 /**
  * @brief Get the maximum MAC payload (M value) for a given datarate.
@@ -400,7 +419,7 @@ void gnrc_lorawan_mlme_backoff_expire(gnrc_lorawan_t *mac);
  * @param[in] mac pointer to the MAC descriptor
  * @param[in] pkt the received packet
  */
-void gnrc_lorawan_process_pkt(gnrc_lorawan_t *mac, gnrc_pktsnip_t *pkt);
+void gnrc_lorawan_process_pkt(gnrc_lorawan_t *mac, iolist_t *pkt);
 
 /**
  * @brief Open a reception window

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -125,13 +125,13 @@ static void _driver_cb(netdev_t *dev, netdev_event_t event)
         DEBUG("gnrc_netif: event triggered -> %i\n", event);
         switch (event) {
             case NETDEV_EVENT_RX_COMPLETE:
-                gnrc_lorawan_recv(mac);
+                gnrc_lorawan_radio_rx_done_cb(mac);
                 break;
             case NETDEV_EVENT_TX_COMPLETE:
-                gnrc_lorawan_event_tx_complete(mac);
+                gnrc_lorawan_radio_tx_done_cb(mac);
                 break;
             case NETDEV_EVENT_RX_TIMEOUT:
-                gnrc_lorawan_event_timeout(mac);
+                gnrc_lorawan_radio_rx_timeout_cb(mac);
                 break;
             default:
                 DEBUG("gnrc_netif: warning: unhandled event %u.\n", event);

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -51,7 +51,9 @@ static const gnrc_netif_ops_t lorawan_ops = {
 
 void gnrc_lorawan_mlme_confirm(gnrc_lorawan_t *mac, mlme_confirm_t *confirm)
 {
-    gnrc_netif_lorawan_t *lw_netif = container_of(mac, gnrc_netif_lorawan_t, mac);
+    gnrc_netif_lorawan_t *lw_netif =
+        container_of(mac, gnrc_netif_lorawan_t, mac);
+
     if (confirm->type == MLME_JOIN) {
         if (confirm->status == 0) {
             DEBUG("gnrc_lorawan: join succeeded\n");
@@ -84,18 +86,21 @@ static inline void _set_be_addr(gnrc_lorawan_t *mac, uint8_t *be_addr)
 
 void gnrc_lorawan_mcps_indication(gnrc_lorawan_t *mac, mcps_indication_t *ind)
 {
-    (void) mac;
-    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, ind->data.pkt->iol_base, ind->data.pkt->iol_len, GNRC_NETTYPE_LORAWAN);
+    (void)mac;
+    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, ind->data.pkt->iol_base,
+                                          ind->data.pkt->iol_len,
+                                          GNRC_NETTYPE_LORAWAN);
+
     if (!gnrc_netapi_dispatch_receive(GNRC_NETTYPE_LORAWAN, ind->data.port,
-                pkt)) {
+                                      pkt)) {
         gnrc_pktbuf_release(pkt);
     }
 }
 
 void gnrc_lorawan_mlme_indication(gnrc_lorawan_t *mac, mlme_indication_t *ind)
 {
-    (void) mac;
-    (void) ind;
+    (void)mac;
+    (void)ind;
 }
 
 void gnrc_lorawan_mcps_confirm(gnrc_lorawan_t *mac, mcps_confirm_t *confirm)
@@ -114,7 +119,9 @@ static void _rx_done(gnrc_lorawan_t *mac)
     int bytes_expected = dev->driver->recv(dev, NULL, 0, 0);
     int nread;
     struct netdev_radio_rx_info rx_info;
-    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL, bytes_expected, GNRC_NETTYPE_UNDEF);
+    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL, bytes_expected,
+                                          GNRC_NETTYPE_UNDEF);
+
     if (pkt == NULL) {
         DEBUG("_recv_lorawan: cannot allocate pktsnip.\n");
         /* Discard packet on netdev device */
@@ -167,7 +174,8 @@ static void _driver_cb(netdev_t *dev, netdev_event_t event)
 
 static void _reset(gnrc_netif_t *netif)
 {
-    netif->lorawan.otaa = LORAMAC_DEFAULT_JOIN_PROCEDURE == LORAMAC_JOIN_OTAA ? NETOPT_ENABLE : NETOPT_DISABLE;
+    netif->lorawan.otaa = LORAMAC_DEFAULT_JOIN_PROCEDURE ==
+                          LORAMAC_JOIN_OTAA ? NETOPT_ENABLE : NETOPT_DISABLE;
     netif->lorawan.datarate = LORAMAC_DEFAULT_DR;
     netif->lorawan.demod_margin = 0;
     netif->lorawan.num_gateways = 0;
@@ -178,14 +186,15 @@ static void _reset(gnrc_netif_t *netif)
 
 static void _memcpy_reversed(uint8_t *dst, uint8_t *src, size_t size)
 {
-    for(size_t i=0;i<size;i++) {
-        dst[size-i-1] = src[i];
+    for (size_t i = 0; i < size; i++) {
+        dst[size - i - 1] = src[i];
     }
 }
 
 netdev_t *gnrc_lorawan_get_netdev(gnrc_lorawan_t *mac)
 {
     gnrc_netif_t *netif = container_of(mac, gnrc_netif_t, lorawan.mac);
+
     return netif->dev;
 }
 
@@ -203,7 +212,8 @@ static void _init(gnrc_netif_t *netif)
     _memcpy_reversed(netif->lorawan.appeui, _appeui, sizeof(_appeui));
 
     _set_be_addr(&netif->lorawan.mac, _devaddr);
-    gnrc_lorawan_init(&netif->lorawan.mac, netif->lorawan.nwkskey, netif->lorawan.appskey);
+    gnrc_lorawan_init(&netif->lorawan.mac, netif->lorawan.nwkskey,
+                      netif->lorawan.appskey);
 }
 
 int gnrc_netif_lorawan_create(gnrc_netif_t *netif, char *stack, int stacksize,
@@ -215,7 +225,7 @@ int gnrc_netif_lorawan_create(gnrc_netif_t *netif, char *stack, int stacksize,
 
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
-    (void) netif;
+    (void)netif;
     /* Unused */
     return 0;
 }
@@ -227,12 +237,16 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *payload)
 
     if (netif->lorawan.flags & GNRC_NETIF_LORAWAN_FLAGS_LINK_CHECK) {
         mlme_request.type = MLME_LINK_CHECK;
-        gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request, &mlme_confirm);
+        gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request,
+                                  &mlme_confirm);
     }
-    mcps_request_t req = { .type = netif->lorawan.ack_req ? MCPS_CONFIRMED : MCPS_UNCONFIRMED,
-                           .data = { .pkt = (iolist_t*) payload, .port = netif->lorawan.port,
-                           .dr = netif->lorawan.datarate } };
+    mcps_request_t req =
+    { .type = netif->lorawan.ack_req ? MCPS_CONFIRMED : MCPS_UNCONFIRMED,
+      .data =
+      { .pkt = (iolist_t *)payload, .port = netif->lorawan.port,
+          .dr = netif->lorawan.datarate } };
     mcps_confirm_t conf;
+
     gnrc_lorawan_mcps_request(&netif->lorawan.mac, &req, &conf);
     if (conf.status < 0) {
         gnrc_pktbuf_release_error(payload, conf.status);
@@ -242,8 +256,8 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *payload)
 
 static void _msg_handler(gnrc_netif_t *netif, msg_t *msg)
 {
-    (void) netif;
-    (void) msg;
+    (void)netif;
+    (void)msg;
     switch (msg->type) {
         case MSG_TYPE_TIMEOUT:
             gnrc_lorawan_open_rx_window(&netif->lorawan.mac);
@@ -265,42 +279,48 @@ static int _get(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
 
     mlme_confirm_t mlme_confirm;
     mlme_request_t mlme_request;
+
     switch (opt->opt) {
         case NETOPT_OTAA:
             assert(opt->data_len >= sizeof(netopt_enable_t));
-            *((netopt_enable_t *) opt->data) = netif->lorawan.otaa;
+            *((netopt_enable_t *)opt->data) = netif->lorawan.otaa;
             break;
         case NETOPT_LINK:
             mlme_request.type = MLME_GET;
             mlme_request.mib.type = MIB_ACTIVATION_METHOD;
-            gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request, &mlme_confirm);
-            *((netopt_enable_t *) opt->data) = mlme_confirm.mib.activation != MLME_ACTIVATION_NONE;
+            gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request,
+                                      &mlme_confirm);
+            *((netopt_enable_t *)opt->data) = mlme_confirm.mib.activation !=
+                                              MLME_ACTIVATION_NONE;
             break;
         case NETOPT_LINK_CHECK:
             assert(opt->data_len == sizeof(netopt_enable_t));
-            *((netopt_enable_t *) opt->data) = (netif->lorawan.flags & GNRC_NETIF_LORAWAN_FLAGS_LINK_CHECK) ?
-                                               NETOPT_ENABLE : NETOPT_DISABLE;
+            *((netopt_enable_t *)opt->data) =
+                (netif->lorawan.flags & GNRC_NETIF_LORAWAN_FLAGS_LINK_CHECK) ?
+                NETOPT_ENABLE : NETOPT_DISABLE;
             break;
         case NETOPT_NUM_GATEWAYS:
             assert(opt->data_len == sizeof(uint8_t));
-            *((uint8_t *) opt->data) = netif->lorawan.num_gateways;
+            *((uint8_t *)opt->data) = netif->lorawan.num_gateways;
             break;
         case NETOPT_DEMOD_MARGIN:
             assert(opt->data_len == sizeof(uint8_t));
-            *((uint8_t *) opt->data) = netif->lorawan.demod_margin;
+            *((uint8_t *)opt->data) = netif->lorawan.demod_margin;
             break;
         case NETOPT_ADDRESS:
             mlme_request.type = MLME_GET;
             mlme_request.mib.type = MIB_DEV_ADDR;
 
-            gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request, &mlme_confirm);
-            tmp = *((uint32_t*) mlme_confirm.mib.dev_addr);
+            gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request,
+                                      &mlme_confirm);
+            tmp = *((uint32_t *)mlme_confirm.mib.dev_addr);
             tmp = byteorder_swapl(tmp);
             memcpy(opt->data, &tmp, sizeof(uint32_t));
             res = sizeof(uint32_t);
             break;
         default:
-            res = netif->dev->driver->get(netif->dev, opt->opt, opt->data, opt->data_len);
+            res = netif->dev->driver->get(netif->dev, opt->opt, opt->data,
+                                          opt->data_len);
             break;
     }
     return res;
@@ -316,15 +336,15 @@ static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt)
     switch (opt->opt) {
         case NETOPT_LORAWAN_DR:
             assert(opt->data_len == sizeof(uint8_t));
-            netif->lorawan.datarate = *((uint8_t *) opt->data);
+            netif->lorawan.datarate = *((uint8_t *)opt->data);
             break;
         case NETOPT_LORAWAN_TX_PORT:
             assert(opt->data_len == sizeof(uint8_t));
-            netif->lorawan.port = *((uint8_t *) opt->data);
+            netif->lorawan.port = *((uint8_t *)opt->data);
             break;
         case NETOPT_ACK_REQ:
             assert(opt->data_len == sizeof(netopt_enable_t));
-            netif->lorawan.ack_req = *((netopt_enable_t *) opt->data);
+            netif->lorawan.ack_req = *((netopt_enable_t *)opt->data);
             break;
         case NETOPT_LORAWAN_APPKEY:
             assert(opt->data_len == LORAMAC_APPKEY_LEN);
@@ -332,15 +352,17 @@ static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt)
             break;
         case NETOPT_ADDRESS_LONG:
             assert(opt->data_len == LORAMAC_DEVEUI_LEN);
-            _memcpy_reversed(netif->lorawan.deveui, opt->data, LORAMAC_DEVEUI_LEN);
+            _memcpy_reversed(netif->lorawan.deveui, opt->data,
+                             LORAMAC_DEVEUI_LEN);
             break;
         case NETOPT_LORAWAN_APPEUI:
             assert(opt->data_len == LORAMAC_APPEUI_LEN);
-            _memcpy_reversed(netif->lorawan.appeui, opt->data, LORAMAC_APPEUI_LEN);
+            _memcpy_reversed(netif->lorawan.appeui, opt->data,
+                             LORAMAC_APPEUI_LEN);
             break;
         case NETOPT_OTAA:
             assert(opt->data_len == sizeof(netopt_enable_t));
-            netif->lorawan.otaa = *((netopt_enable_t *) opt->data);
+            netif->lorawan.otaa = *((netopt_enable_t *)opt->data);
             break;
         case NETOPT_LORAWAN_APPSKEY:
             assert(opt->data_len >= LORAMAC_APPSKEY_LEN);
@@ -352,26 +374,29 @@ static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt)
             break;
         case NETOPT_LINK:
         {
-            netopt_enable_t en = *((netopt_enable_t *) opt->data);
+            netopt_enable_t en = *((netopt_enable_t *)opt->data);
             if (en) {
-                if(netif->lorawan.otaa) {
+                if (netif->lorawan.otaa) {
                     mlme_request.type = MLME_JOIN;
                     mlme_request.join.deveui = netif->lorawan.deveui;
                     mlme_request.join.appeui = netif->lorawan.appeui;
                     mlme_request.join.appkey = netif->lorawan.appkey;
                     mlme_request.join.dr = netif->lorawan.datarate;
-                    gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request, &mlme_confirm);
+                    gnrc_lorawan_mlme_request(&netif->lorawan.mac,
+                                              &mlme_request, &mlme_confirm);
                 }
                 else {
                     mlme_request.type = MLME_SET;
                     mlme_request.mib.type = MIB_ACTIVATION_METHOD;
                     mlme_request.mib.activation = MLME_ACTIVATION_ABP;
-                    gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request, &mlme_confirm);
+                    gnrc_lorawan_mlme_request(&netif->lorawan.mac,
+                                              &mlme_request, &mlme_confirm);
                 }
             }
             else {
                 mlme_request.type = MLME_RESET;
-                gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request, &mlme_confirm);
+                gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request,
+                                          &mlme_confirm);
                 res = mlme_confirm.status;
                 if (mlme_confirm.status == 0) {
                     /* reset netif as well */
@@ -391,11 +416,13 @@ static int _set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt)
             assert(opt->data_len == sizeof(uint8_t));
             mlme_request.type = MLME_SET;
             mlme_request.mib.type = MIB_RX2_DR;
-            mlme_request.mib.rx2_dr = *((uint8_t*) opt->data);
-            gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request, &mlme_confirm);
+            mlme_request.mib.rx2_dr = *((uint8_t *)opt->data);
+            gnrc_lorawan_mlme_request(&netif->lorawan.mac, &mlme_request,
+                                      &mlme_confirm);
             break;
         default:
-            res = netif->dev->driver->set(netif->dev, opt->opt, opt->data, opt->data_len);
+            res = netif->dev->driver->set(netif->dev, opt->opt, opt->data,
+                                          opt->data_len);
             break;
     }
     gnrc_netif_release(netif);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR:

- Removes the dependency to `gnrc_pktbuf` in GNRC LoRaWAN. Besides reducing the ROM usage a lot, this allows the usage of GNRC LoRaWAN without depending on GNRC specific stuff
- Rename radio events functions to ease maintaining
- Some minor fixes wit "BUSY" logic
- Remove dependency to `gnrc_neterr` (now `gnrc_lorawan` is fully asynchronous)
- Uncrustifies GNRC LoRaWAN files

This step is required in order to add missing class B and class C support.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
This should be tested with care.
I suggest trying the following:
- Join a LoRaWAN network using ABP and OTAA
- Send some uplinks and downlinks (to port 2). Check that data is received in both directions and that there aren't leaks in the pktbuf (use `gnrc_pktbuf_cmd`module).
- Try sending several packets in a row. It shouldn't crash and the MAC layer should just drop a packet if the MAC is busy.


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
~~Depends on #14058~~
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
