### PR TITLE
sys/fmt: add fmt_hex_bytes size probing

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -160,6 +160,11 @@ size_t fmt_hex_bytes(uint8_t *out, const char *hex)
     }
 
     size_t final_len = len >> 1;
+
+    if (out == NULL) {
+        return final_len;
+    }
+
     for (size_t i = 0, j = 0; j < final_len; i += 2, j++) {
         out[j] = fmt_hex_byte(hex + i);
     }

--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -176,6 +176,9 @@ static void test_fmt_hex_bytes(void)
     TEST_ASSERT_EQUAL_INT(0, val);
     TEST_ASSERT_EQUAL_INT(0, bytes);
 
+    bytes = fmt_hex_bytes(NULL, "ABCDEF");
+    TEST_ASSERT_EQUAL_INT(3, bytes);
+
     char hex2[3] = "00";
     uint8_t val1[1] = { 0 };
     bytes = fmt_hex_bytes(val1, hex2);


### PR DESCRIPTION
### Contribution description

The `fmt.h` header file advertises `fmt_hex_bytes(NULL, "0123")` to be a valid input but it crashes the application because a NULL pointer gets dereferenced.

This PR implements the advertised feature.

### Testing procedure

I extended the unit test. Running the tests must work flawlessly.

`make -C tests/unittests tests-fmt test`

### Issues/PRs references

*none*