### PR TITLE
cpu/esp_common: revert the change in PR 14041

### DIFF
--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -109,8 +109,6 @@ PREFFLAGS += python3 $(RIOTTOOLS)/esptool/gen_esp32part.py
 PREFFLAGS += --verify $(BINDIR)/partitions.csv $(BINDIR)/partitions.bin
 FLASHDEPS += preflash
 
-BUILD_BEFORE_FLASH += $(FLASHFILE)
-
 # flasher configuration
 ifneq (,$(filter esp_qemu,$(USEMODULE)))
   FLASHER = dd


### PR DESCRIPTION
### Contribution description

This PR reverts commit d0cc9553945ac21df9963c0924608f2b169c44de to fix the problem with `flash-only` in CI for the moment.

### Testing procedure

Run tests should work again in CI.

### Issues/PRs references

Reopen #13492 