### PR TITLE
 sock_util: add interface descriptor parsing to str2ep 

### DIFF
--- a/sys/net/sock/sock_util.c
+++ b/sys/net/sock/sock_util.c
@@ -33,6 +33,9 @@
 #include "fmt.h"
 #endif
 
+#define PORT_STR_LEN    (5)
+#define NETIF_STR_LEN   (5)
+
 int sock_udp_ep_fmt(const sock_udp_ep_t *endpoint, char *addr_str, uint16_t *port)
 {
     void *addr_ptr;
@@ -147,6 +150,45 @@ int sock_urlsplit(const char *url, char *hostport, char *urlpath)
     return 0;
 }
 
+int _parse_port(sock_udp_ep_t *ep_out, const char *portstart)
+{
+    int port_len = strlen(portstart);
+
+    /* Checks here verify that the supplied port number is up to 5 (random)
+     * chars in size and result is smaller or equal to UINT16_MAX. */
+    if (port_len > PORT_STR_LEN) {
+        return -EINVAL;
+    }
+    uint32_t port = atol(portstart);
+    if (port > UINT16_MAX) {
+        return -EINVAL;
+    }
+    ep_out->port = (uint16_t)port;
+    return port_len;
+}
+
+int _parse_netif(sock_udp_ep_t *ep_out, char *netifstart)
+{
+    char *netifend;
+    size_t netiflen;
+    char netifbuf[NETIF_STR_LEN + 1];
+
+    for (netifend = netifstart; *netifend && *netifend != ']';
+         netifend++);
+    netiflen = netifend - netifstart;
+    if (!*netifend || (netiflen >= NETIF_STR_LEN) || (netiflen == 0)) {
+        /* no netif found, bail out */
+        return -EINVAL;
+    }
+    strncpy(netifbuf, netifstart, netiflen);
+    int netif = strtol(netifbuf, NULL, 10);
+    if ((netif < 0) || (((unsigned)netif) > UINT16_MAX)) {
+        return -EINVAL;
+    }
+    ep_out->netif = (uint16_t)netif;
+    return (netifend - netifstart);
+}
+
 int sock_udp_str2ep(sock_udp_ep_t *ep_out, const char *str)
 {
     unsigned brackets_flag;
@@ -159,8 +201,9 @@ int sock_udp_str2ep(sock_udp_ep_t *ep_out, const char *str)
 
     if (*hoststart == '[') {
         brackets_flag = 1;
-        for (hostend = ++hoststart; *hostend && *hostend != ']';
-                hostend++);
+        for (hostend = ++hoststart;
+             *hostend && *hostend != ']' && *hostend != '%';
+             hostend++);
         if (! *hostend || ((size_t)(hostend - hoststart) >= sizeof(hostbuf))) {
             /* none found, bail out */
             return -EINVAL;
@@ -171,26 +214,28 @@ int sock_udp_str2ep(sock_udp_ep_t *ep_out, const char *str)
         for (hostend = hoststart; *hostend && (*hostend != ':') && \
                 ((size_t)(hostend - hoststart) < sizeof(hostbuf)); hostend++) {}
     }
-
     size_t hostlen = hostend - hoststart;
     if (*(hostend + brackets_flag) == ':') {
-        char *portstart = hostend + brackets_flag + 1;
-        /* Checks here verify that the supplied port number is up to 5 (random)
-         * chars in size and result is smaller or equal to UINT16_MAX. */
-        if (strlen(portstart) > 5) {
-            return -EINVAL;
+        int res = _parse_port(ep_out, hostend + brackets_flag + 1);
+        if (res < 0) {
+            return res;
         }
-        uint32_t port = atol(portstart);
-        if (port > UINT16_MAX) {
-            return -EINVAL;
+    }
+    else if (brackets_flag && (*hostend == '%')) {
+        int res = _parse_netif(ep_out, hostend + 1);
+        if (res < 0) {
+            return res;
         }
-        ep_out->port = (uint16_t)port;
+        char *colon_ptr = hostend + res + brackets_flag + 1;
+        if ((*colon_ptr == ':') &&
+            ((res = _parse_port(ep_out, colon_ptr + 1)) < 0)) {
+            return res;
+        }
     }
 
     if (hostlen >= sizeof(hostbuf)) {
         return -EINVAL;
     }
-
     memcpy(hostbuf, hoststart, hostlen);
 
     hostbuf[hostlen] = '\0';


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When using `sock_udp_str2ep()` there was previously no way to parse the network interface when provided in the string, e.g. `[fe80::1%3]:5241`. This adds this feature.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I provided unittests for the new cases so just run
```sh
make -C tests/unittests/ tests-sock_util flash-only test
```
on a board of your liking.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See https://github.com/RIOT-OS/RIOT/issues/14035#issuecomment-627359833
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
