### PR TITLE
gnrc/pktdump : Expose Configurations to Kconfig

### DIFF
--- a/sys/include/net/gnrc/pktdump.h
+++ b/sys/include/net/gnrc/pktdump.h
@@ -29,11 +29,17 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup net_gnrc_pktdump_conf GNRC PKTDUMP compile configurations
+ * @ingroup net_gnrc_conf
+ * @{
+ */
+/**
  * @brief   Message queue size for the pktdump thread
  */
 #ifndef GNRC_PKTDUMP_MSG_QUEUE_SIZE
 #define GNRC_PKTDUMP_MSG_QUEUE_SIZE     (8U)
 #endif
+/** @} */
 
 /**
  * @brief   Priority of the pktdump thread

--- a/sys/include/net/gnrc/pktdump.h
+++ b/sys/include/net/gnrc/pktdump.h
@@ -34,12 +34,24 @@ extern "C" {
  * @{
  */
 /**
+ * @brief   Default message queue size for the PKTDUMP thread (as exponent of
+ *          2^n).
+ *
+ *          As the queue size ALWAYS needs to be power of two, this option
+ *          represents the exponent of 2^n, which will be used as the size of
+ *          the queue.
+ */
+#ifndef CONFIG_GNRC_PKTDUMP_MSG_QUEUE_SIZE_EXP
+#define CONFIG_GNRC_PKTDUMP_MSG_QUEUE_SIZE_EXP  3
+#endif
+/** @} */
+
+/**
  * @brief   Message queue size for the pktdump thread
  */
 #ifndef GNRC_PKTDUMP_MSG_QUEUE_SIZE
-#define GNRC_PKTDUMP_MSG_QUEUE_SIZE     (8U)
+#define GNRC_PKTDUMP_MSG_QUEUE_SIZE  (1 << CONFIG_GNRC_PKTDUMP_MSG_QUEUE_SIZE_EXP)
 #endif
-/** @} */
 
 /**
  * @brief   Priority of the pktdump thread

--- a/sys/net/gnrc/Kconfig
+++ b/sys/net/gnrc/Kconfig
@@ -12,6 +12,7 @@ rsource "link_layer/lorawan/Kconfig"
 rsource "netif/Kconfig"
 rsource "network_layer/ipv6/Kconfig"
 rsource "network_layer/sixlowpan/Kconfig"
+rsource "pktdump/Kconfig"
 rsource "routing/rpl/Kconfig"
 rsource "transport_layer/tcp/Kconfig"
 

--- a/sys/net/gnrc/pktdump/Kconfig
+++ b/sys/net/gnrc/pktdump/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_GNRC_PKTDUMP
+    bool "Configure GNRC Packet Dump"
+    depends on MODULE_GNRC_PKTDUMP
+    help
+        Configure the GNRC_PKTDUMP using Kconfig.
+
+if KCONFIG_MODULE_GNRC_PKTDUMP
+
+config GNRC_PKTDUMP_MSG_QUEUE_SIZE_EXP
+    int "Exponent for the queue size (resulting in the queue size 2^n)"
+    default 3
+    help
+        As the queue size ALWAYS needs to be power of two, this option
+        represents the exponent of 2^n, which will be used as the size of
+        the queue.
+
+endif # KCONFIG_MODULE_GNRC_PKTDUMP


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in PKTDUMP GNRC to Kconfig.

### Testing procedure

1. New documentation was built using doxygen 

The build works fine.

2. Test folder and files were introduced to show the macro on Native environment.

[Test Files](https://github.com/akshaim/RIOT/commit/e1e224a59e5dcd6b329cf10161ff9e191d273680) - **Updated**


#### Default State:

##### Firmware Output

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.07-devel-608-g1171d8-Kconfig_pktdump_tests)
CONFIG_GNRC_PKTDUMP_MSG_QUEUE_SIZE_EXP=3
GNRC_PKTDUMP_MSG_QUEUE_SIZE=(1<<3)

#### Usage with CFLAGS 

[/tests/gnrc_pkdump/Makefile](https://github.com/akshaim/RIOT/commit/e1e224a59e5dcd6b329cf10161ff9e191d273680)

> CFLAGS += -DCONFIG_GNRC_PKTDUMP_MSG_QUEUE_SIZE_EXP=4

##### Firmware Output

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.07-devel-608-g1171d8-Kconfig_pktdump_tests)
CONFIG_GNRC_PKTDUMP_MSG_QUEUE_SIZE_EXP=4
GNRC_PKTDUMP_MSG_QUEUE_SIZE=(1<<4)

#### Usage with Kconfig

[/tests/gnrc_pktdump](https://github.com/akshaim/RIOT/commit/e1e224a59e5dcd6b329cf10161ff9e191d273680)

> make menuconfig

##### Firmware Output

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.07-devel-608-g1171d8-Kconfig_pktdump_tests)
CONFIG_GNRC_PKTDUMP_MSG_QUEUE_SIZE_EXP=7
GNRC_PKTDUMP_MSG_QUEUE_SIZE=(1<<7)

### Issues/PRs references

#12888