### PR TITLE
sys/ztimer: fix extern "C" guard

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -549,7 +549,7 @@ extern ztimer_clock_t *const ZTIMER_USEC_BASE;
 extern ztimer_clock_t *const ZTIMER_MSEC_BASE;
 
 #ifdef __cplusplus
-extern "C" {
+}
 #endif
 
 #endif /* ZTIMER_H */

--- a/sys/include/ztimer/config.h
+++ b/sys/include/ztimer/config.h
@@ -117,5 +117,9 @@ extern "C" {
 #define CONFIG_ZTIMER_MSEC_REQUIRED_PM_MODE ZTIMER_CLOCK_NO_REQUIRED_PM_MODE
 #endif
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* ZTIMER_CONFIG_H */
 /** @} */


### PR DESCRIPTION
### Contribution description

The closing curly braces for the extern "C" are missing in two files, this PR allows to use ztimer from C++.


### Testing procedure

No change in the compiled binaries.


### Issues/PRs references

None
