### PR TITLE
shell/sc_gnrc_netif: workaround long printf with CDC ACM as stdio

### DIFF
--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -125,18 +125,17 @@ static int _netif_stats(netif_t *iface, unsigned module, bool reset)
         printf("Reset statistics for module %s!\n", _netstats_module_to_str(module));
     }
     else {
-        printf("          Statistics for %s\n"
-               "            RX packets %u  bytes %u\n"
-               "            TX packets %u (Multicast: %u)  bytes %u\n"
-               "            TX succeeded %u errors %u\n",
-               _netstats_module_to_str(module),
-               (unsigned) stats->rx_count,
-               (unsigned) stats->rx_bytes,
-               (unsigned) (stats->tx_unicast_count + stats->tx_mcast_count),
-               (unsigned) stats->tx_mcast_count,
-               (unsigned) stats->tx_bytes,
-               (unsigned) stats->tx_success,
-               (unsigned) stats->tx_failed);
+        printf("          Statistics for %s\n", _netstats_module_to_str(module));
+        printf("            RX packets %u  bytes %u\n",
+                            (unsigned) stats->rx_count,
+                            (unsigned) stats->rx_bytes);
+        printf("            TX packets %u (Multicast: %u)  bytes %u\n",
+                            (unsigned) (stats->tx_unicast_count + stats->tx_mcast_count),
+                            (unsigned) stats->tx_mcast_count,
+                            (unsigned) stats->tx_bytes);
+        printf("            TX succeeded %u errors %u\n",
+                            (unsigned) stats->tx_success,
+                            (unsigned) stats->tx_failed);
         res = 0;
     }
     return res;


### PR DESCRIPTION
### Contribution description

`stdio_cdc_acm` has trouble printing such a long line.

On master it is simply dropped:

```
2020-05-13 22:58:02,225 # Iface  8  HWaddr: 7C:26:67:15:37  Channel: 4
2020-05-13 22:58:02,226 #  TX-Power: 0dBm  State: TX  max. Retrans.: 5
2020-05-13 22:58:02,227 # AUTOACK  L2-PDU:26 MTU:1280  HL:64  RTR
2020-05-13 22:58:02,228 # RTR_ADV  6LO  IPHC
2020-05-13 22:58:02,229 # Source address length: 5
2020-05-13 22:58:02,229 # Link type: wireless
2020-05-13 22:58:02,231 # inet6 addr: fe80::a07c:26ff:fe67:1537  scope: link  VAL
2020-05-13 22:58:02,231 # inet6 group: ff02::2
2020-05-13 22:58:02,231 # inet6 group: ff02::1
2020-05-13 22:58:02,231 #
2020-05-13 22:58:02,232 #           Statistics for Layer 2
2020-05-13 22:58:02,232 #           Statistics for IPv6
2020-05-13 22:58:02,232 #
```

With this patch (splitting it into multiple `printf`s) it prints correctly

```
2020-05-13 23:04:01,371 # Iface  8  HWaddr: 7C:26:67:15:37  Channel: 4
2020-05-13 23:04:01,373 #  TX-Power: 0dBm  State: TX  max. Retrans.: 5
2020-05-13 23:04:01,374 # AUTOACK  L2-PDU:26 MTU:1280  HL:64  RTR
2020-05-13 23:04:01,374 # RTR_ADV  6LO  IPHC
2020-05-13 23:04:01,375 # Source address length: 5
2020-05-13 23:04:01,376 # Link type: wireless
2020-05-13 23:04:01,377 # inet6 addr: fe80::a07c:26ff:fe67:1537  scope: link  VAL
2020-05-13 23:04:01,378 # inet6 group: ff02::2
2020-05-13 23:04:01,378 # inet6 group: ff02::1
2020-05-13 23:04:01,378 #
2020-05-13 23:04:01,379 #           Statistics for Layer 2
2020-05-13 23:04:01,379 #             RX packets 0  bytes 0
2020-05-13 23:04:01,380 #             TX packets 3 (Multicast: 3)  bytes 78
2020-05-13 23:04:01,380 #             TX succeeded 0 errors 0
2020-05-13 23:04:01,381 #           Statistics for IPv6
2020-05-13 23:04:01,381 #             RX packets 0  bytes 0
2020-05-13 23:04:01,382 #             TX packets 3 (Multicast: 3)  bytes 168
2020-05-13 23:04:01,382 #             TX succeeded 3 errors 0
```
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->



<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

flash `examples/gnrc_networking` on a board that uses `stdio_cdc_acm`


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
