### PR TITLE
nanocoap: bugfix token overflow

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -162,6 +162,13 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    CoAP message format constants
+ * @{
+ */
+#define COAP_TOKEN_LENGTH_MAX    (8)
+/** @} */
+
+/**
  * @defgroup net_coap_conf    CoAP compile configurations
  * @ingroup  net_coap
  * @ingroup  config

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -81,6 +81,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     /* token value (tkl bytes) */
     if (coap_get_token_len(pkt)) {
         pkt->token = pkt_pos;
+        /* pkt_pos range is validated after options parsing loop below */
         pkt_pos += coap_get_token_len(pkt);
     }
     else {
@@ -92,7 +93,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     unsigned option_nr = 0;
 
     /* parse options */
-    while (pkt_pos != pkt_end) {
+    while (pkt_pos < pkt_end) {
         uint8_t *option_start = pkt_pos;
         uint8_t option_byte = *pkt_pos++;
         if (option_byte == 0xff) {
@@ -129,12 +130,12 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
             }
 
             pkt_pos += option_len;
-
-            if (pkt_pos > (buf + len)) {
-                DEBUG("nanocoap: bad pkt\n");
-                return -EBADMSG;
-            }
         }
+    }
+
+    if (pkt_pos > pkt_end) {
+        DEBUG("bad pkt len\n");
+        return -EBADMSG;
     }
 
     pkt->options_len = option_count;

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -79,13 +79,17 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     }
 
     /* token value (tkl bytes) */
-    if (coap_get_token_len(pkt)) {
+    if (coap_get_token_len(pkt) == 0) {
+        pkt->token = NULL;
+    }
+    else if (coap_get_token_len(pkt) <= COAP_TOKEN_LENGTH_MAX) {
         pkt->token = pkt_pos;
         /* pkt_pos range is validated after options parsing loop below */
         pkt_pos += coap_get_token_len(pkt);
     }
     else {
-        pkt->token = NULL;
+        DEBUG("nanocoap: token length invalid\n");
+        return -EBADMSG;
     }
 
     coap_optpos_t *optpos = pkt->options;
@@ -134,7 +138,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     }
 
     if (pkt_pos > pkt_end) {
-        DEBUG("bad pkt len\n");
+        DEBUG("nanocoap: bad packet length\n");
         return -EBADMSG;
     }
 


### PR DESCRIPTION
### Contribution description

Fix for nanocoap read ouf of the input buffer:
https://github.com/RIOT-OS/RIOT/issues/14074

Corrected the options parsing loop condition to prevent skip-over the buffer end condition.
Added a pointer boundary check after adding token length declared in the packet header, but before making any access to the memory pointed by the current pkt_pos pointer.

### Testing procedure

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/14074