### PR TITLE
cpu/esp*: Allow compilation with external boards

### DIFF
--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/port/Makefile
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/port/Makefile
@@ -11,7 +11,7 @@ CFLAGS += -D__ets__
 
 include $(RIOTCPU)/$(CPU)/Makefile.include
 
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include
+INCLUDES += -I$(BOARDDIR)/include
 INCLUDES += -I$(RIOTBASE)/core/include
 INCLUDES += -I$(RIOTBASE)/drivers/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/Makefile
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/Makefile
@@ -16,4 +16,4 @@ include $(RIOTCPU)/$(CPU)/Makefile.include
 INCLUDES += -I$(RIOTBASE)/core/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/log
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include
+INCLUDES += -I$(BOARDDIR)/include

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/wpa2/eap_peer/Makefile
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/wpa2/eap_peer/Makefile
@@ -17,4 +17,4 @@ include $(RIOTCPU)/$(CPU)/Makefile.include
 INCLUDES += -I$(RIOTBASE)/core/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/log
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include
+INCLUDES += -I$(BOARDDIR)/include

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/wpa2/tls/Makefile
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/wpa2/tls/Makefile
@@ -16,4 +16,4 @@ include $(RIOTCPU)/$(CPU)/Makefile.include
 INCLUDES += -I$(RIOTBASE)/core/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/log
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include
+INCLUDES += -I$(BOARDDIR)/include

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/wpa2/utils/Makefile
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/wpa2/utils/Makefile
@@ -16,4 +16,4 @@ include $(RIOTCPU)/$(CPU)/Makefile.include
 INCLUDES += -I$(RIOTBASE)/core/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/log
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include
+INCLUDES += -I$(BOARDDIR)/include

--- a/cpu/esp8266/vendor/esp-idf/wpa_supplicant/port/Makefile
+++ b/cpu/esp8266/vendor/esp-idf/wpa_supplicant/port/Makefile
@@ -16,4 +16,4 @@ INCLUDES += -I$(RIOTBASE)/core/include
 INCLUDES += -I$(RIOTBASE)/sys/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/log/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include
+INCLUDES += -I$(BOARDDIR)/include

--- a/cpu/esp8266/vendor/esp-idf/wpa_supplicant/src/crypto/Makefile
+++ b/cpu/esp8266/vendor/esp-idf/wpa_supplicant/src/crypto/Makefile
@@ -17,5 +17,5 @@ INCLUDES += -I$(RIOTBASE)/core/include
 INCLUDES += -I$(RIOTBASE)/sys/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/log/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include
+INCLUDES += -I$(BOARDDIR)/include
 


### PR DESCRIPTION
### Contribution description

This PR replaces `$(RIOTBOARD)/$(BOARD)` with `$(BOARDDIR)`, which also works for external boards.

### Testing procedure

Compilation should still work. (Murdock should test this.)

### Issues/PRs references

Reported offline by @jmgraeffe