### PR TITLE
Kconfig: Allow using external boards

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -10,7 +10,7 @@ mainmenu "RIOT Configuration"
 osource "$(KCONFIG_GENERATED_DEPENDENCIES)"
 
 # Load first board configurations, which might override CPU's
-orsource "$(RIOTBOARD)/$(BOARD)/Kconfig"
+orsource "$(BOARDDIR)/Kconfig"
 orsource "$(RIOTCPU)/$(CPU)/Kconfig"
 
 rsource "$(RIOTBOARD)/Kconfig"


### PR DESCRIPTION
### Contribution description

This PR replaces `$(RIOTBOARD)/$(BOARD)` by `$(BOARDDIR)` to allow using external boards.

### Testing procedure

The boards `Kconfig` file should still be included correctly for official boards and now should be included correctly for external boards.

### Issues/PRs references

Noticed during https://github.com/RIOT-OS/RIOT/pull/14077