### PR TITLE
boards/common/nrf52: Allow external boards

### DIFF
--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -21,7 +21,7 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # This HACK can be removed either when Makefile.include is included after
 # Makefile.features (see #9913) or if 'nordic_softdevice_ble' is deprecated.
 -include $(APPDIR)/Makefile.board.dep
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+include $(BOARDDIR)/Makefile.dep
 
 PROGRAMMER ?= jlink
 ifeq (jlink,$(PROGRAMMER))


### PR DESCRIPTION
### Contribution description

This PR replaces `$(RIOTBOARD)/$(BOARD)` with `$(BOARDDIR)` in `$(RIOTBOARD)/common/nrf52/Makefile.include`. `$(BOARDDIR)` also works for external boards. This allows external boards to build on top of
`$(RIOTBOARD)/common/nrf52`.

### Testing procedure

1. Officially supported nRF52 boards should still compile (Murdock has your back)
2. External nRF52 based boards should also compile even when they build upon `$(RIOTBOARD)/common/nrf52/`

### Issues/PRs references

Noticed during https://github.com/RIOT-OS/RIOT/pull/14077