### PR TITLE
drivers/periph/cpuid: Fix typo in doc

### DIFF
--- a/drivers/include/periph/cpuid.h
+++ b/drivers/include/periph/cpuid.h
@@ -48,7 +48,7 @@ extern "C" {
 /**
  * @brief   Gets the serial number of the CPU.
  *
- * @param[out] id   The serial number of the CPU of length CPU_ID_LEN (must be
+ * @param[out] id   The serial number of the CPU of length CPUID_LEN (must be
  *                  defined in the CPU's cpu_conf.h)
  */
 void cpuid_get(void *id);


### PR DESCRIPTION
### Contribution description

Just as the title says.

### Testing procedure

Read the docu and confirm that it should indeed be named `CPUID_LEN` rather than `CPU_ID_LEN`.

### Issues/PRs references

None