### PR TITLE
cpu/atmega_common: Update to inlineable IRQ API

### DIFF
--- a/cpu/atmega_common/include/cpu_conf.h
+++ b/cpu/atmega_common/include/cpu_conf.h
@@ -63,6 +63,11 @@ extern "C" {
  */
 #define HAVE_HEAP_STATS
 
+/**
+ * @brief   This arch uses the inlined IRQ API.
+ */
+#define IRQ_API_INLINED     (1)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/atmega_common/include/irq_arch.h
+++ b/cpu/atmega_common/include/irq_arch.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
  *               2018 RWTH Aachen, Josua Arndt <jarndt@ias.rwth-aachen.de>
+ *               2020 Otto-von-Guericke-Universität Magdeburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -17,6 +18,7 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
  * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  *
  */
 
@@ -34,40 +36,19 @@ extern "C" {
 #endif
 
 /**
- * @brief Macro returns state of the global interrupt register
- */
-static uint8_t atmega_get_interrupt_state(void);
-static void atmega_set_interrupt_state(uint8_t state);
-
-__attribute__((always_inline)) static inline uint8_t atmega_get_interrupt_state(void)
-{
-    uint8_t sreg;
-    __asm__ volatile( "in __tmp_reg__, __SREG__ \n\t"
-                      "mov %0, __tmp_reg__      \n\t"
-                      : "=g"(sreg) );
-    return sreg & (1 << 7);
-}
-
-__attribute__((always_inline)) static inline void atmega_set_interrupt_state(uint8_t state)
-{
-    __asm__ volatile( "mov r15,%0        \n\t"
-                      "in r16, __SREG__  \n\t"
-                      "cbr r16,7         \n\t"
-                      "or r15,r16        \n\t"
-                      "out __SREG__, r15 \n\t"
-                      :
-                      : "g"(state)
-                      : "r15", "r16", "memory");
-}
-
-/**
  * @brief Disable all maskable interrupts
  */
 __attribute__((always_inline)) static inline unsigned int irq_disable(void)
 {
-    uint8_t mask = atmega_get_interrupt_state();
-    cli(); /* <-- acts as memory barrier, see doc of avr-libc */
-    return (unsigned int) mask;
+    uint8_t mask;
+    __asm__ volatile(
+        "in %[dest], __SREG__"      "\n\t"
+        "cli"                       "\n\t"
+        : [dest]    "=r"(mask)
+        : /* no inputs */
+        : "memory"
+    );
+    return mask;
 }
 
 /**
@@ -75,17 +56,41 @@ __attribute__((always_inline)) static inline unsigned int irq_disable(void)
  */
 __attribute__((always_inline)) static inline unsigned int irq_enable(void)
 {
-    uint8_t mask = atmega_get_interrupt_state();
-    sei(); /* <-- acts as memory barrier, see doc of avr-libc */
+    uint8_t mask;
+    __asm__ volatile(
+        "in %[dest], __SREG__"      "\n\t"
+        "sei"                       "\n\t"
+        : [dest]    "=r"(mask)
+        : /* no inputs */
+        : "memory"
+    );
     return mask;
 }
 
 /**
  * @brief Restore the state of the IRQ flags
  */
-__attribute__((always_inline)) static inline void irq_restore(unsigned int state)
+__attribute__((always_inline)) static inline void irq_restore(unsigned int _state)
 {
-    atmega_set_interrupt_state(state);
+    uint8_t state = (uint8_t)_state;
+    /*
+     * Implementation in pseudo-code:
+     *
+     * disable_irqs();
+     * if (state & BIT7) {
+     *    enable_irqs();
+     * }
+     *
+     * This takes 3 CPU Cycles if BIT7 is set (IRQs are enabled), otherwise 2.
+     */
+    __asm__ volatile(
+        "cli"                       "\n\t"
+        "sbrc %[state], 7"          "\n\t"
+        "sei"                       "\n\t"
+        : /* no outputs */
+        : [state]           "r"(state)
+        : "memory"
+    );
 }
 
 /**

--- a/cpu/atmega_common/include/irq_arch.h
+++ b/cpu/atmega_common/include/irq_arch.h
@@ -18,14 +18,20 @@
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
  * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  *
- * @}
  */
+
+#ifndef IRQ_ARCH_H
+#define IRQ_ARCH_H
 
 #include <stdint.h>
 #include <stdio.h>
 #include <stdint.h>
 #include "irq.h"
 #include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief Macro returns state of the global interrupt register
@@ -42,7 +48,7 @@ __attribute__((always_inline)) static inline uint8_t atmega_get_interrupt_state(
     return sreg & (1 << 7);
 }
 
-__attribute__((always_inline)) inline void atmega_set_interrupt_state(uint8_t state)
+__attribute__((always_inline)) static inline void atmega_set_interrupt_state(uint8_t state)
 {
     __asm__ volatile( "mov r15,%0        \n\t"
                       "in r16, __SREG__  \n\t"
@@ -57,7 +63,7 @@ __attribute__((always_inline)) inline void atmega_set_interrupt_state(uint8_t st
 /**
  * @brief Disable all maskable interrupts
  */
-unsigned int irq_disable(void)
+__attribute__((always_inline)) static inline unsigned int irq_disable(void)
 {
     uint8_t mask = atmega_get_interrupt_state();
     cli(); /* <-- acts as memory barrier, see doc of avr-libc */
@@ -67,7 +73,7 @@ unsigned int irq_disable(void)
 /**
  * @brief Enable all maskable interrupts
  */
-unsigned int irq_enable(void)
+__attribute__((always_inline)) static inline unsigned int irq_enable(void)
 {
     uint8_t mask = atmega_get_interrupt_state();
     sei(); /* <-- acts as memory barrier, see doc of avr-libc */
@@ -77,7 +83,7 @@ unsigned int irq_enable(void)
 /**
  * @brief Restore the state of the IRQ flags
  */
-void irq_restore(unsigned int state)
+__attribute__((always_inline)) static inline void irq_restore(unsigned int state)
 {
     atmega_set_interrupt_state(state);
 }
@@ -85,8 +91,15 @@ void irq_restore(unsigned int state)
 /**
  * @brief See if the current context is inside an ISR
  */
-int irq_is_in(void)
+__attribute__((always_inline)) static inline int irq_is_in(void)
 {
     uint8_t state = atmega_get_state();
     return (state & ATMEGA_STATE_FLAG_ISR);
 }
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* IRQ_ARCH_H */


### PR DESCRIPTION
### Contribution description

- Update IRQ API to the inline-able version
- Cleaned up the implementation
    - irq_disable() now is 2 CPU cycles instead of 4 CPU cycles
    - irq_restore() now is 3 CPU cycles (or 2 in the best case), instead of 5

### Testing procedure

1. Let Murdock check if everything still compiles
2. `make BOARD=arduino-mega2560 -C tests/irq_disable_restore flash test` (or any other ATmega based board)

### Issues/PRs references

Follow up of https://github.com/RIOT-OS/RIOT/pull/13999