### PR TITLE
gnrc: Use exponent to configure message queue sizes

### DIFF
--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -49,6 +49,11 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup   net_gnrc_gomach_conf     GNRC GoMacH compile configuration
+ * @ingroup    net_gnrc_conf
+ * @{
+ */
+/**
  * @brief The default duration of GoMacH's wake-up period (WP).
  *
  * GoMacH adopts the duty-cycle scheme that, by default, a node only wakes up
@@ -342,13 +347,25 @@ extern "C" {
 #endif
 
 /**
- * @brief Default message queue size to use for the GoMacH thread.
+ * @brief Default message queue size to use for the GoMacH thread (as exponent
+ *        of 2^n).
+ *
+ * As the queue size ALWAYS needs to be power of two, this option represents the
+ * exponent of 2^n, which will be used as the size of the queue.
  *
  * The value of this macro should be enough for supporting the manipulation of
  * GoMacH.
  */
+#ifndef CONFIG_GNRC_GOMACH_IPC_MSG_QUEUE_SIZE_EXP
+#define CONFIG_GNRC_GOMACH_IPC_MSG_QUEUE_SIZE_EXP        (3U)
+#endif
+/** @} */
+
+/**
+ * @brief Message queue size to use for the GoMacH thread.
+ */
 #ifndef GNRC_GOMACH_IPC_MSG_QUEUE_SIZE
-#define GNRC_GOMACH_IPC_MSG_QUEUE_SIZE        (8U)
+#define GNRC_GOMACH_IPC_MSG_QUEUE_SIZE  (1 << CONFIG_GNRC_GOMACH_IPC_MSG_QUEUE_SIZE_EXP)
 #endif
 
 /**

--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -138,10 +138,15 @@ extern "C" {
 #endif
 
 /**
- * @brief   Default message queue size to use for the IPv6 thread.
+ * @brief   Default message queue size to use for the IPv6 thread (as exponent
+ *          of 2^n).
+ *
+ *          As the queue size ALWAYS needs to be power of two, this option
+ *          represents the exponent of 2^n, which will be used as the size of
+ *          the queue.
  */
-#ifndef CONFIG_GNRC_IPV6_MSG_QUEUE_SIZE
-#define CONFIG_GNRC_IPV6_MSG_QUEUE_SIZE    (8U)
+#ifndef CONFIG_GNRC_IPV6_MSG_QUEUE_SIZE_EXP
+#define CONFIG_GNRC_IPV6_MSG_QUEUE_SIZE_EXP    (3U)
 #endif
 
 #ifdef DOXYGEN
@@ -163,6 +168,13 @@ extern "C" {
 #define GNRC_IPV6_STATIC_LLADDR
 #endif /* DOXYGEN */
 /** @} */
+
+/**
+ * @brief Message queue size to use for the IPv6 thread.
+ */
+#ifndef GNRC_IPV6_MSG_QUEUE_SIZE
+#define GNRC_IPV6_MSG_QUEUE_SIZE    (1 << CONFIG_GNRC_IPV6_MSG_QUEUE_SIZE_EXP)
+#endif
 
 /**
  * @brief   The PID to the IPv6 thread.

--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -81,6 +81,11 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup net_gnrc_lwmac_conf    GNRC LWMAC compile configurations
+ * @ingroup  net_gnrc_conf
+ * @{
+ */
+/**
  * @brief Time between consecutive wake-ups.
  *
  * This macro governs power consumption, latency and throughput!
@@ -287,14 +292,26 @@ extern "C" {
 #endif
 
 /**
- * @brief Default message queue size to use for the LWMAC thread.
+ * @brief Default message queue size to use for the LWMAC thread (as exponent of
+ *        2^n).
+ *
+ * As the queue size ALWAYS needs to be power of two, this option represents the
+ * exponent of 2^n, which will be used as the size of the queue.
  *
  * The value of this macro should be enough for supporting the manipulation of
  * LWMAC.
  *
  */
+#ifndef CONFIG_GNRC_LWMAC_IPC_MSG_QUEUE_SIZE_EXP
+#define CONFIG_GNRC_LWMAC_IPC_MSG_QUEUE_SIZE_EXP        (3U)
+#endif
+/** @} */
+
+/**
+ * @brief Message queue size to use for the LWMAC thread.
+ */
 #ifndef GNRC_LWMAC_IPC_MSG_QUEUE_SIZE
-#define GNRC_LWMAC_IPC_MSG_QUEUE_SIZE        (8U)
+#define GNRC_LWMAC_IPC_MSG_QUEUE_SIZE       (1 << CONFIG_GNRC_LWMAC_IPC_MSG_QUEUE_SIZE_EXP)
 #endif
 
 /**

--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -51,14 +51,19 @@ extern "C" {
 #endif
 
 /**
- * @brief       Message queue size for network interface threads
+ * @brief       Default message queue size for network interface threads (as
+ *              exponent of 2^n).
+ *
+ *              As the queue size ALWAYS needs to be power of two, this option
+ *              represents the exponent of 2^n, which will be used as the size
+ *              of the queue.
  *
  * @attention   This has influence on the used stack memory of the thread, so
  *              the thread's stack size might need to be adapted if this is
  *              changed.
  */
-#ifndef CONFIG_GNRC_NETIF_MSG_QUEUE_SIZE
-#define CONFIG_GNRC_NETIF_MSG_QUEUE_SIZE  (16U)
+#ifndef CONFIG_GNRC_NETIF_MSG_QUEUE_SIZE_EXP
+#define CONFIG_GNRC_NETIF_MSG_QUEUE_SIZE_EXP  (4U)
 #endif
 
 /**
@@ -151,10 +156,17 @@ extern "C" {
 #ifndef CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US
 #define CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US   (0U)
 #endif
+/** @} */
+
+/**
+ * @brief   Message queue size for network interface threads
+ */
+#ifndef GNRC_NETIF_MSG_QUEUE_SIZE
+#define GNRC_NETIF_MSG_QUEUE_SIZE   (1 << CONFIG_GNRC_NETIF_MSG_QUEUE_SIZE_EXP)
+#endif
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* NET_GNRC_NETIF_CONF_H */
-/** @} */

--- a/sys/include/net/gnrc/nettest.h
+++ b/sys/include/net/gnrc/nettest.h
@@ -40,6 +40,11 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup    net_gnrc_nettest_conf   GNRC NETAPI test compile configurations
+ * @ingroup     net_gnrc_conf
+ * @{
+ */
+/**
  * @brief   Timeout for tests in microseconds
  */
 #ifndef GNRC_NETTEST_TIMEOUT
@@ -61,12 +66,24 @@ extern "C" {
 #endif
 
 /**
- * @brief   Default message queue size to use for the nettest thread.
+ * @brief   Default message queue size to use for the nettest thread (as
+ *          exponent of 2^n).
+ *
+ *          As the queue size ALWAYS needs to be power of two, this option
+ *          represents the exponent of 2^n, which will be used as the size of
+ *          the queue.
+ */
+#ifndef CONFIG_GNRC_NETTEST_MSG_QUEUE_SIZE_EXP
+#define CONFIG_GNRC_NETTEST_MSG_QUEUE_SIZE_EXP    (3U)
+#endif
+/** @} */
+
+/**
+ * @brief   Message queue size to use for the nettest thread.
  */
 #ifndef GNRC_NETTEST_MSG_QUEUE_SIZE
-#define GNRC_NETTEST_MSG_QUEUE_SIZE (8U)
+#define GNRC_NETTEST_MSG_QUEUE_SIZE (1 << CONFIG_GNRC_NETTEST_MSG_QUEUE_SIZE_EXP)
 #endif
-
 
 /**
  * @brief   Type for get/set callbacks.

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -136,10 +136,22 @@ extern "C" {
 #endif
 
 /**
- * @brief   Default message queue size to use for the RPL thread.
+ * @brief   Default message queue size to use for the RPL thread (as exponent of
+ *          2^n).
+ *
+ *          As the queue size ALWAYS needs to be power of two, this option
+ *          represents the exponent of 2^n, which will be used as the size of
+ *          the queue.
  */
-#ifndef CONFIG_GNRC_RPL_MSG_QUEUE_SIZE
-#define CONFIG_GNRC_RPL_MSG_QUEUE_SIZE (8U)
+#ifndef CONFIG_GNRC_RPL_MSG_QUEUE_SIZE_EXP
+#define CONFIG_GNRC_RPL_MSG_QUEUE_SIZE_EXP   (3U)
+#endif
+
+/**
+ * @brief   Message queue size to use for the RPL thread.
+ */
+#ifndef GNRC_RPL_MSG_QUEUE_SIZE
+#define GNRC_RPL_MSG_QUEUE_SIZE     (1 << CONFIG_GNRC_RPL_MSG_QUEUE_SIZE_EXP)
 #endif
 
 /**

--- a/sys/include/net/gnrc/sixlowpan/config.h
+++ b/sys/include/net/gnrc/sixlowpan/config.h
@@ -43,10 +43,14 @@ extern "C" {
 #endif
 
 /**
- * @brief   Default message queue size to use for the 6LoWPAN thread.
+ * @brief   Default message queue size to use for the 6LoWPAN thread (as
+ *          exponent of 2^n).
+ *
+ * As the queue size ALWAYS needs to be power of two, this option represents the
+ * exponent of 2^n, which will be used as the size of the queue.
  */
-#ifndef CONFIG_GNRC_SIXLOWPAN_MSG_QUEUE_SIZE
-#define CONFIG_GNRC_SIXLOWPAN_MSG_QUEUE_SIZE       (8U)
+#ifndef CONFIG_GNRC_SIXLOWPAN_MSG_QUEUE_SIZE_EXP
+#define CONFIG_GNRC_SIXLOWPAN_MSG_QUEUE_SIZE_EXP   (3U)
 #endif
 
 /**
@@ -306,6 +310,13 @@ extern "C" {
 #define GNRC_SIXLOWPAN_SFR_DG_RETRIES       (0U)
 #endif
 /** @} */
+
+/**
+ * @brief   Message queue size to use for the 6LoWPAN thread.
+ */
+#ifndef GNRC_SIXLOWPAN_MSG_QUEUE_SIZE
+#define GNRC_SIXLOWPAN_MSG_QUEUE_SIZE    (1 << CONFIG_GNRC_SIXLOWPAN_MSG_QUEUE_SIZE_EXP)
+#endif
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -29,6 +29,7 @@ extern "C" {
 /**
  * @defgroup net_gnrc_tcp_conf GNRC TCP compile configurations
  * @ingroup net_gnrc_conf
+ * @ingroup net_gnrc_tcp
  *
  * ## Calculating RTO
  * To calculate retransmission timeout (RTO), Round Trip Time (RTT) needs to be

--- a/sys/include/net/gnrc/tcp/tcb.h
+++ b/sys/include/net/gnrc/tcp/tcb.h
@@ -39,9 +39,25 @@ extern "C" {
 #endif
 
 /**
+ * @{
+ * @ingroup net_gnrc_tcp_conf
+ * @brief Size of the TCB mbox (as exponent of 2^n).
+ *
+ *        As the mbox buffer size ALWAYS needs to be power of two, this option
+ *        represents the exponent of 2^n, which will be used as the size of the
+ *        mbox.
+ */
+#ifndef CONFIG_GNRC_TCP_TCB_MBOX_SIZE_EXP
+#define CONFIG_GNRC_TCP_TCB_MBOX_SIZE_EXP (3U)
+#endif
+/** @} */
+
+/**
  * @brief Size of the TCB mbox
  */
-#define GNRC_TCP_TCB_MBOX_SIZE (8U)
+#ifndef GNRC_TCP_TCB_MBOX_SIZE
+#define GNRC_TCP_TCB_MBOX_SIZE (1 << CONFIG_GNRC_TCP_TCB_MBOX_SIZE_EXP)
+#endif
 
 /**
  * @brief Transmission control block of GNRC TCP.

--- a/sys/include/net/gnrc/udp.h
+++ b/sys/include/net/gnrc/udp.h
@@ -33,10 +33,19 @@ extern "C" {
 #endif
 
 /**
- * @brief   Default message queue size for the UDP thread
+ * @defgroup net_gnrc_udp_conf  GNRC UDP compile configurations
+ * @ingroup  net_gnrc_conf
+ * @{
  */
-#ifndef GNRC_UDP_MSG_QUEUE_SIZE
-#define GNRC_UDP_MSG_QUEUE_SIZE (8U)
+/**
+ * @brief   Default message queue size for the UDP thread (as exponent of 2^n).
+ *
+ *          As the queue size ALWAYS needs to be power of two, this option
+ *          represents the exponent of 2^n, which will be used as the size of
+ *          the queue.
+ */
+#ifndef CONFIG_GNRC_UDP_MSG_QUEUE_SIZE_EXP
+#define CONFIG_GNRC_UDP_MSG_QUEUE_SIZE_EXP (3U)
 #endif
 
 /**
@@ -51,6 +60,14 @@ extern "C" {
  */
 #ifndef GNRC_UDP_STACK_SIZE
 #define GNRC_UDP_STACK_SIZE     (THREAD_STACKSIZE_DEFAULT)
+#endif
+/** @} */
+
+/**
+ * @brief   Message queue size to use for the UDP thread.
+ */
+#ifndef GNRC_UDP_MSG_QUEUE_SIZE
+#define GNRC_UDP_MSG_QUEUE_SIZE    (1 << CONFIG_GNRC_UDP_MSG_QUEUE_SIZE_EXP)
 #endif
 
 /**

--- a/sys/net/gnrc/netif/Kconfig
+++ b/sys/net/gnrc/netif/Kconfig
@@ -12,9 +12,13 @@ menuconfig KCONFIG_MODULE_GNRC_NETIF
 
 if KCONFIG_MODULE_GNRC_NETIF
 
-config GNRC_NETIF_MSG_QUEUE_SIZE
-    int "Message queue size for network interface threads"
-    default 16
+config GNRC_NETIF_MSG_QUEUE_SIZE_EXP
+    int "Exponent for the message queue size for network interface threads (as 2^n)"
+    default 4
+    help
+        As the queue size ALWAYS needs to be power of two, this option
+        represents the exponent of 2^n, which will be used as the size of
+        the queue.
 
 config GNRC_NETIF_IPV6_ADDRS_NUMOF
     int "Maximum number of unicast and anycast addresses per interface"

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1463,7 +1463,7 @@ static void *_gnrc_netif_thread(void *args)
     netdev_t *dev;
     int res;
     msg_t reply = { .type = GNRC_NETAPI_MSG_TYPE_ACK };
-    msg_t msg_queue[CONFIG_GNRC_NETIF_MSG_QUEUE_SIZE];
+    msg_t msg_queue[GNRC_NETIF_MSG_QUEUE_SIZE];
 
     DEBUG("gnrc_netif: starting thread %i\n", sched_active_pid);
     netif = args;
@@ -1478,7 +1478,7 @@ static void *_gnrc_netif_thread(void *args)
 #endif /* MODULE_GNRC_NETIF_EVENTS */
 
     /* setup the link-layer's message queue */
-    msg_init_queue(msg_queue, CONFIG_GNRC_NETIF_MSG_QUEUE_SIZE);
+    msg_init_queue(msg_queue, GNRC_NETIF_MSG_QUEUE_SIZE);
     /* register the event callback with the device driver */
     dev->event_callback = _event_cb;
     dev->context = netif;

--- a/sys/net/gnrc/netif/init_devs/auto_init_cc110x.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_cc110x.c
@@ -24,7 +24,7 @@
 #include "cc110x_params.h"
 #include "log.h"
 #include "msg.h"
-#include "net/gnrc/netif/conf.h"    /* <- CONFIG_GNRC_NETIF_MSG_QUEUE_SIZE */
+#include "net/gnrc/netif/conf.h"    /* <- GNRC_NETIF_MSG_QUEUE_SIZE */
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
@@ -32,11 +32,11 @@
 /**
  * @brief   Additional stack size required by the driver
  *
- * With increasing of CONFIG_GNRC_NETIF_MSG_QUEUE_SIZE the required stack size
+ * With increasing of GNRC_NETIF_MSG_QUEUE_SIZE the required stack size
  * increases as well. A queue size of 8 messages works with default stack size,
  * so we increase the stack by `sizeof(msg_t)` for each additional element
  */
-#define CC110X_EXTRA_STACKSIZE          ((CONFIG_GNRC_NETIF_MSG_QUEUE_SIZE - 8) * sizeof(msg_t))
+#define CC110X_EXTRA_STACKSIZE          ((GNRC_NETIF_MSG_QUEUE_SIZE - 8) * sizeof(msg_t))
 #endif
 
 /**

--- a/sys/net/gnrc/network_layer/ipv6/Kconfig
+++ b/sys/net/gnrc/network_layer/ipv6/Kconfig
@@ -14,9 +14,13 @@ menuconfig KCONFIG_MODULE_GNRC_IPV6
 
 if KCONFIG_MODULE_GNRC_IPV6
 
-config GNRC_IPV6_MSG_QUEUE_SIZE
-    int "Default message queue size to use for the IPv6 thread"
-    default 8
+config GNRC_IPV6_MSG_QUEUE_SIZE_EXP
+    int "Exponent for the message queue size used for the IPv6 thread (as 2^n)"
+    default 3
+    help
+        As the queue size ALWAYS needs to be power of two, this option
+        represents the exponent of 2^n, which will be used as the size of
+        the queue.
 
 endif # KCONFIG_MODULE_GNRC_IPV6
 

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -173,12 +173,12 @@ static void _dispatch_next_header(gnrc_pktsnip_t *pkt, unsigned nh,
 
 static void *_event_loop(void *args)
 {
-    msg_t msg, reply, msg_q[CONFIG_GNRC_IPV6_MSG_QUEUE_SIZE];
+    msg_t msg, reply, msg_q[GNRC_IPV6_MSG_QUEUE_SIZE];
     gnrc_netreg_entry_t me_reg = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
                                                             sched_active_pid);
 
     (void)args;
-    msg_init_queue(msg_q, CONFIG_GNRC_IPV6_MSG_QUEUE_SIZE);
+    msg_init_queue(msg_q, GNRC_IPV6_MSG_QUEUE_SIZE);
 
     /* initialize fragmentation data-structures */
 #ifdef MODULE_GNRC_IPV6_EXT_FRAG

--- a/sys/net/gnrc/network_layer/sixlowpan/Kconfig
+++ b/sys/net/gnrc/network_layer/sixlowpan/Kconfig
@@ -16,8 +16,12 @@ if KCONFIG_MODULE_GNRC_SIXLOWPAN
 rsource "frag/Kconfig"
 rsource "nd/Kconfig"
 
-config GNRC_SIXLOWPAN_MSG_QUEUE_SIZE
-    int "Message queue size for the 6LoWPAN thread"
-    default 8
+config GNRC_SIXLOWPAN_MSG_QUEUE_SIZE_EXP
+    int "Exponent for the message queue size for the 6LoWPAN thread (as 2^n)"
+    default 3
+    help
+        As the queue size ALWAYS needs to be power of two, this option
+        represents the exponent of 2^n, which will be used as the size of
+        the queue.
 
 endif # KCONFIG_MODULE_GNRC_SIXLOWPAN

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -308,12 +308,12 @@ static void _send(gnrc_pktsnip_t *pkt)
 
 static void *_event_loop(void *args)
 {
-    msg_t msg, reply, msg_q[CONFIG_GNRC_SIXLOWPAN_MSG_QUEUE_SIZE];
+    msg_t msg, reply, msg_q[GNRC_SIXLOWPAN_MSG_QUEUE_SIZE];
     gnrc_netreg_entry_t me_reg = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
                                                             sched_active_pid);
 
     (void)args;
-    msg_init_queue(msg_q, CONFIG_GNRC_SIXLOWPAN_MSG_QUEUE_SIZE);
+    msg_init_queue(msg_q, GNRC_SIXLOWPAN_MSG_QUEUE_SIZE);
 
     /* register interest in all 6LoWPAN packets */
     gnrc_netreg_register(GNRC_NETTYPE_SIXLOWPAN, &me_reg);

--- a/sys/net/gnrc/routing/rpl/Kconfig
+++ b/sys/net/gnrc/routing/rpl/Kconfig
@@ -143,8 +143,12 @@ config GNRC_RPL_DEFAULT_NETIF
     default 0
     depends on MODULE_AUTO_INIT_GNRC_RPL
 
-config GNRC_RPL_MSG_QUEUE_SIZE
-    int "Thread's message queue size"
-    default 8
+config GNRC_RPL_MSG_QUEUE_SIZE_EXP
+    int "Exponent for the thread's message queue size (as 2^n)"
+    default 3
+    help
+        As the queue size ALWAYS needs to be power of two, this option
+        represents the exponent of 2^n, which will be used as the size of
+        the queue.
 
 endif # KCONFIG_MODULE_GNRC_RPL

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -44,7 +44,7 @@ static uint32_t _lt_time = GNRC_RPL_LIFETIME_UPDATE_STEP * US_PER_SEC;
 static xtimer_t _lt_timer;
 static msg_t _lt_msg = { .type = GNRC_RPL_MSG_TYPE_LIFETIME_UPDATE };
 #endif
-static msg_t _msg_q[CONFIG_GNRC_RPL_MSG_QUEUE_SIZE];
+static msg_t _msg_q[GNRC_RPL_MSG_QUEUE_SIZE];
 static gnrc_netreg_entry_t _me_reg;
 static mutex_t _inst_id_mutex = MUTEX_INIT;
 static uint8_t _instance_id;
@@ -247,7 +247,7 @@ static void *_event_loop(void *args)
     msg_t msg, reply;
 
     (void)args;
-    msg_init_queue(_msg_q, CONFIG_GNRC_RPL_MSG_QUEUE_SIZE);
+    msg_init_queue(_msg_q, GNRC_RPL_MSG_QUEUE_SIZE);
 
     /* preinitialize ACK */
     reply.type = GNRC_NETAPI_MSG_TYPE_ACK;

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -75,7 +75,7 @@ static void _netapi_cb(uint16_t cmd, gnrc_pktsnip_t *pkt, void *ctx)
 
 void gnrc_sock_create(gnrc_sock_reg_t *reg, gnrc_nettype_t type, uint32_t demux_ctx)
 {
-    mbox_init(&reg->mbox, reg->mbox_queue, SOCK_MBOX_SIZE);
+    mbox_init(&reg->mbox, reg->mbox_queue, GNRC_SOCK_MBOX_SIZE);
 #ifdef SOCK_HAS_ASYNC
     reg->async_cb.generic = NULL;
     reg->netreg_cb.cb = _netapi_cb;
@@ -106,7 +106,7 @@ ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
     }
 #endif
 
-    if (reg->mbox.cib.mask != (SOCK_MBOX_SIZE - 1)) {
+    if (reg->mbox.cib.mask != (GNRC_SOCK_MBOX_SIZE - 1)) {
         return -EINVAL;
     }
 #ifdef MODULE_XTIMER

--- a/sys/net/gnrc/sock/include/sock_types.h
+++ b/sys/net/gnrc/sock/include/sock_types.h
@@ -39,8 +39,28 @@
 extern "C" {
 #endif
 
-#ifndef SOCK_MBOX_SIZE
-#define SOCK_MBOX_SIZE      (8)         /**< Size for gnrc_sock_reg_t::mbox_queue */
+/**
+ * @defgroup net_gnrc_sock_conf  GNRC sock implementation compile configurations
+ * @ingroup  net_gnrc_conf
+ * @{
+ */
+/**
+ * @brief   Default size for gnrc_sock_reg_t::mbox_queue (as exponent of 2^n).
+ *
+ *          As the queue size ALWAYS needs to be power of two, this option
+ *          represents the exponent of 2^n, which will be used as the size of
+ *          the queue.
+ */
+#ifndef CONFIG_GNRC_SOCK_MBOX_SIZE_EXP
+#define CONFIG_GNRC_SOCK_MBOX_SIZE_EXP      (3)
+#endif
+/** @} */
+
+/**
+ * @brief Size for gnrc_sock_reg_t::mbox_queue
+ */
+#ifndef GNRC_SOCK_MBOX_SIZE
+#define GNRC_SOCK_MBOX_SIZE  (1 << CONFIG_GNRC_SOCK_MBOX_SIZE_EXP)
 #endif
 
 /**
@@ -65,13 +85,13 @@ typedef void (*gnrc_sock_reg_cb_t)(gnrc_sock_reg_t *sock,
  */
 struct gnrc_sock_reg {
 #ifdef MODULE_GNRC_SOCK_CHECK_REUSE
-    struct gnrc_sock_reg *next;         /**< list-like for internal storage */
+    struct gnrc_sock_reg *next;            /**< list-like for internal storage */
 #endif
-    gnrc_netreg_entry_t entry;          /**< @ref net_gnrc_netreg entry for mbox */
-    mbox_t mbox;                        /**< @ref core_mbox target for the sock */
-    msg_t mbox_queue[SOCK_MBOX_SIZE];   /**< queue for gnrc_sock_reg_t::mbox */
+    gnrc_netreg_entry_t entry;             /**< @ref net_gnrc_netreg entry for mbox */
+    mbox_t mbox;                           /**< @ref core_mbox target for the sock */
+    msg_t mbox_queue[GNRC_SOCK_MBOX_SIZE]; /**< queue for gnrc_sock_reg_t::mbox */
 #ifdef SOCK_HAS_ASYNC
-    gnrc_netreg_entry_cbd_t netreg_cb;  /**< netreg callback */
+    gnrc_netreg_entry_cbd_t netreg_cb;     /**< netreg callback */
     /**
      * @brief   asynchronous upper layer callback
      *
@@ -79,17 +99,17 @@ struct gnrc_sock_reg {
      *          pair, so casting between these function pointers is okay.
      */
     union {
-        gnrc_sock_reg_cb_t generic;     /**< generic version */
+        gnrc_sock_reg_cb_t generic;        /**< generic version */
 #ifdef MODULE_SOCK_IP
-        sock_ip_cb_t ip;                /**< IP version */
+        sock_ip_cb_t ip;                   /**< IP version */
 #endif
 #ifdef MODULE_SOCK_UDP
-        sock_udp_cb_t udp;              /**< UDP version */
+        sock_udp_cb_t udp;                 /**< UDP version */
 #endif
     } async_cb;
-    void *async_cb_arg;                 /**< asynchronous callback argument */
+    void *async_cb_arg;                    /**< asynchronous callback argument */
 #ifdef SOCK_HAS_ASYNC_CTX
-    sock_async_ctx_t async_ctx;         /**< asynchronous event context */
+    sock_async_ctx_t async_ctx;            /**< asynchronous event context */
 #endif
 #endif  /* SOCK_HAS_ASYNC */
 };
@@ -99,10 +119,10 @@ struct gnrc_sock_reg {
  * @internal
  */
 struct sock_ip {
-    gnrc_sock_reg_t reg;                /**< netreg info */
-    sock_ip_ep_t local;                 /**< local end-point */
-    sock_ip_ep_t remote;                /**< remote end-point */
-    uint16_t flags;                     /**< option flags */
+    gnrc_sock_reg_t reg;                   /**< netreg info */
+    sock_ip_ep_t local;                    /**< local end-point */
+    sock_ip_ep_t remote;                   /**< remote end-point */
+    uint16_t flags;                        /**< option flags */
 };
 
 /**
@@ -110,10 +130,10 @@ struct sock_ip {
  * @internal
  */
 struct sock_udp {
-    gnrc_sock_reg_t reg;                /**< netreg info */
-    sock_udp_ep_t local;                /**< local end-point */
-    sock_udp_ep_t remote;               /**< remote end-point */
-    uint16_t flags;                     /**< option flags */
+    gnrc_sock_reg_t reg;                   /**< netreg info */
+    sock_udp_ep_t local;                   /**< local end-point */
+    sock_udp_ep_t remote;                  /**< remote end-point */
+    uint16_t flags;                        /**< option flags */
 };
 
 #ifdef __cplusplus

--- a/sys/net/gnrc/transport_layer/tcp/Kconfig
+++ b/sys/net/gnrc/transport_layer/tcp/Kconfig
@@ -112,4 +112,12 @@ config GNRC_TCP_PROBE_UPPER_BOUND
     int "Lower bound for the duration between probes in microseconds"
     default 60000000
 
+config GNRC_TCP_TCB_MBOX_SIZE_EXP
+    int "Size of the TCB mbox (as exponent of 2^n)"
+    default 3
+    help
+        As the mbox buffer size ALWAYS needs to be power of two, this option
+        represents the exponent of 2^n, which will be used as the size of the
+        mbox.
+
 endif # KCONFIG_MODULE_GNRC_TCP


### PR DESCRIPTION
### Contribution description
This changes the definition of the macros that set the sizes of the message queues for the following GNRC modules:
- ipv6
- nettest
- rpl
- udp
- gomach
- lwmac
- netif
- sixlowpan
- tcp

Using the exponent to define the queue size helps to enforce the condition that it should be power of two. The correspondent Kconfig files were updated as well.

Also, I added Doxygen config groups for some of the modules which did not have it.

### Testing procedure
Applications using these modules should still be compiling and working.

### Issues/PRs references
Change proposed by @miri64 [here](https://github.com/RIOT-OS/RIOT/pull/13941#discussion_r425182351).
