### PR TITLE
sys/net/gnrc/sock: release pktsnip when message queue is full

### DIFF
--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -61,6 +61,9 @@ static void _netapi_cb(uint16_t cmd, gnrc_pktsnip_t *pkt, void *ctx)
         if (mbox_try_put(&reg->mbox, &msg) < 1) {
             LOG_WARNING("gnrc_sock: dropped message to %p (was full)\n",
                         (void *)&reg->mbox);
+            /* packet could not be delivered so it should be dropped */
+            gnrc_pktbuf_release(pkt);
+            return;
         }
         if (reg->async_cb.generic) {
             reg->async_cb.generic(reg, SOCK_ASYNC_MSG_RECV, reg->async_cb_arg);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Testing fixes for #14034 showed that pktsnips are not properly released with sock async when the message queue is full. This lead to packets becoming stuck in the packet buffer and eventually the node didn't respond because no packets could be allocated.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

add the following to `examples/gcoap/Makefile`:
```
USEMODULE += gnrc_pktbuf_cmd
```

Then run:
```
sudo dist/tools/tapsetup/tapsetup -c 1
BOARD=native make -C examples/gcoap clean all term
```

In another terminal run this or some equivalent:
```
for i in {1..100}; \
do \
coap-client -m put coap://[riotlladdr%tapbr0]/cli/stats -e 123 &; \
done
```

Wait a bit till the (expected) overload settles and then type pktbuf in the RIOT shell.
In master you will see packets stuck in the pktbuf that will never be cleared.
With this PR that should be fixed.

On native I had some trouble reproducing the issue (too good good performance maybe?), on ESP32 I could reproduce very reliable with the above steps.
On the on ESP you might want to add this to `examples/gcoap/Makefile`:

```
CFLAGS += -DESP_WIFI_SSID=\"yourWiFiName\"
CFLAGS += -DESP_WIFI_PASS=\"supernicepassword\"
USEMODULE += esp_wifi
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes #14034 also on real hardware.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
