### PR TITLE
pkg/softdevice: add deprecation warning

### DIFF
--- a/pkg/nordic_softdevice_ble/doc.txt
+++ b/pkg/nordic_softdevice_ble/doc.txt
@@ -1,8 +1,10 @@
 /**
- * @defgroup pkg_nordic-softdevice-ble   Nordic Softdevice BLE
- * @ingroup  pkg
- * @ingroup  net
- * @brief    Provides a RIOT adaption for Nordic Softdevice BLE library
+ * @defgroup    pkg_nordic-softdevice-ble   Nordic Softdevice BLE
+ * @ingroup     pkg
+ * @ingroup     net
+ * @brief       Provides a RIOT adaption for Nordic Softdevice BLE library
+ * @deprecated  Will be removed after the 2020.10 release. Use nimble for BLE
+ *              support instead.
 
 # Overview
 


### PR DESCRIPTION
### Contribution description

This PR adds a deprecation warning for the Nordic Softdevice BLE after the 2020.10 release.
Based on the approval of this PR I'd prepare removing the softdevice from riot master eventually.

### Testing procedure

Build the docs with `make doc` and make sure that `doc/doxygen/html/deprecated.html` looks fine.

### Issues/PRs references
See discussion in #13334 (also #6018 and #8357)
See abandoned update in #9473