### PR TITLE
boards/stm32f4: Add DMA config for SPI

### DIFF
--- a/boards/msbiot/Makefile.features
+++ b/boards/msbiot/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32f415rg
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -28,6 +28,24 @@ extern "C" {
 #endif
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
+    { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
+};
+
+#define DMA_0_ISR           isr_dma2_stream3
+#define DMA_1_ISR           isr_dma2_stream2
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+
+#endif /* MODULE_PERIPH_DMA */
+/** @} */
+
+/**
  * @name    Timer configuration
  * @{
  */
@@ -165,17 +183,23 @@ static const uart_conf_t uart_config[] = {
  */
 static const spi_conf_t spi_config[] = {
     {
-        .dev      = SPI1,
-        .mosi_pin = GPIO_PIN(PORT_A, 7),
-        .miso_pin = GPIO_PIN(PORT_A, 6),
-        .sclk_pin = GPIO_PIN(PORT_A, 5),
-        .cs_pin   = GPIO_PIN(PORT_A, 4),
-        .mosi_af  = GPIO_AF5,
-        .miso_af  = GPIO_AF5,
-        .sclk_af  = GPIO_AF5,
-        .cs_af    = GPIO_AF5,
-        .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
+        .dev            = SPI1,
+        .mosi_pin       = GPIO_PIN(PORT_A, 7),
+        .miso_pin       = GPIO_PIN(PORT_A, 6),
+        .sclk_pin       = GPIO_PIN(PORT_A, 5),
+        .cs_pin         = GPIO_PIN(PORT_A, 4),
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB2ENR_SPI1EN,
+        .apbbus         = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 0,
+        .tx_dma_chan    = 3,
+        .rx_dma         = 1,
+        .rx_dma_chan    = 3,
+#endif
     }
 };
 

--- a/boards/nucleo-f401re/Makefile.features
+++ b/boards/nucleo-f401re/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32f401re
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f401re/include/periph_conf.h
+++ b/boards/nucleo-f401re/include/periph_conf.h
@@ -29,6 +29,32 @@ extern "C" {
 #endif
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
+    { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
+    { .stream = 4 },    /* DMA1 Stream 4 - SPI2_TX */
+    { .stream = 3 },    /* DMA1 Stream 3 - SPI2_RX */
+    { .stream = 5 },    /* DMA1 Stream 5 - SPI3_TX */
+    { .stream = 0 },    /* DMA1 Stream 0 - SPI3_RX */
+};
+
+#define DMA_0_ISR           isr_dma2_stream3
+#define DMA_1_ISR           isr_dma2_stream2
+#define DMA_2_ISR           isr_dma1_stream4
+#define DMA_3_ISR           isr_dma1_stream3
+#define DMA_4_ISR           isr_dma1_stream5
+#define DMA_5_ISR           isr_dma1_stream0
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+
+#endif /* MODULE_PERIPH_DMA */
+/** @} */
+
+/**
  * @name   UART configuration
  * @{
  */
@@ -163,43 +189,61 @@ static const uint8_t spi_divtable[2][5] = {
 
 static const spi_conf_t spi_config[] = {
     {
-        .dev      = SPI1,
-        .mosi_pin = GPIO_PIN(PORT_A, 7),
-        .miso_pin = GPIO_PIN(PORT_A, 6),
-        .sclk_pin = GPIO_PIN(PORT_A, 5),
-        .cs_pin   = GPIO_PIN(PORT_A, 4),
-        .mosi_af  = GPIO_AF5,
-        .miso_af  = GPIO_AF5,
-        .sclk_af  = GPIO_AF5,
-        .cs_af    = GPIO_AF5,
-        .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
+        .dev            = SPI1,
+        .mosi_pin       = GPIO_PIN(PORT_A, 7),
+        .miso_pin       = GPIO_PIN(PORT_A, 6),
+        .sclk_pin       = GPIO_PIN(PORT_A, 5),
+        .cs_pin         = GPIO_PIN(PORT_A, 4),
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB2ENR_SPI1EN,
+        .apbbus         = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 0,
+        .tx_dma_chan    = 3,
+        .rx_dma         = 1,
+        .rx_dma_chan    = 3,
+#endif
     },
     {
-        .dev      = SPI2,
-        .mosi_pin = GPIO_PIN(PORT_B, 15),
-        .miso_pin = GPIO_PIN(PORT_B, 14),
-        .sclk_pin = GPIO_PIN(PORT_B, 13),
-        .cs_pin   = GPIO_PIN(PORT_B, 12),
-        .mosi_af  = GPIO_AF5,
-        .miso_af  = GPIO_AF5,
-        .sclk_af  = GPIO_AF5,
-        .cs_af    = GPIO_AF5,
-        .rccmask  = RCC_APB1ENR_SPI2EN,
-        .apbbus   = APB1
+        .dev            = SPI2,
+        .mosi_pin       = GPIO_PIN(PORT_B, 15),
+        .miso_pin       = GPIO_PIN(PORT_B, 14),
+        .sclk_pin       = GPIO_PIN(PORT_B, 13),
+        .cs_pin         = GPIO_PIN(PORT_B, 12),
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB1ENR_SPI2EN,
+        .apbbus         = APB1,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 2,
+        .tx_dma_chan    = 0,
+        .rx_dma         = 3,
+        .rx_dma_chan    = 0,
+#endif
     },
     {
-        .dev      = SPI3,
-        .mosi_pin = GPIO_PIN(PORT_C, 12),
-        .miso_pin = GPIO_PIN(PORT_C, 11),
-        .sclk_pin = GPIO_PIN(PORT_C, 10),
-        .cs_pin   = GPIO_UNDEF,
-        .mosi_af  = GPIO_AF6,
-        .miso_af  = GPIO_AF6,
-        .sclk_af  = GPIO_AF6,
-        .cs_af    = GPIO_AF6,
-        .rccmask  = RCC_APB1ENR_SPI3EN,
-        .apbbus   = APB1
+        .dev            = SPI3,
+        .mosi_pin       = GPIO_PIN(PORT_C, 12),
+        .miso_pin       = GPIO_PIN(PORT_C, 11),
+        .sclk_pin       = GPIO_PIN(PORT_C, 10),
+        .cs_pin         = GPIO_UNDEF,
+        .mosi_af        = GPIO_AF6,
+        .miso_af        = GPIO_AF6,
+        .sclk_af        = GPIO_AF6,
+        .cs_af          = GPIO_AF6,
+        .rccmask        = RCC_APB1ENR_SPI3EN,
+        .apbbus         = APB1,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 4,
+        .tx_dma_chan    = 0,
+        .rx_dma         = 5,
+        .rx_dma_chan    = 0,
+#endif
     }
 };
 

--- a/boards/nucleo-f410rb/Makefile.features
+++ b/boards/nucleo-f410rb/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32f410rb
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-f410rb/include/periph_conf.h
+++ b/boards/nucleo-f410rb/include/periph_conf.h
@@ -29,6 +29,24 @@ extern "C" {
 #endif
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
+    { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
+};
+
+#define DMA_0_ISR           isr_dma2_stream3
+#define DMA_1_ISR           isr_dma2_stream2
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+
+#endif /* MODULE_PERIPH_DMA */
+/** @} */
+
+/**
  * @name   UART configuration
  * @{
  */
@@ -112,17 +130,23 @@ static const uint8_t spi_divtable[2][5] = {
 
 static const spi_conf_t spi_config[] = {
     {
-        .dev      = SPI1,
-        .mosi_pin = GPIO_PIN(PORT_A, 7),
-        .miso_pin = GPIO_PIN(PORT_A, 6),
-        .sclk_pin = GPIO_PIN(PORT_A, 5),
-        .cs_pin   = GPIO_PIN(PORT_A, 4),
-        .mosi_af  = GPIO_AF5,
-        .miso_af  = GPIO_AF5,
-        .sclk_af  = GPIO_AF5,
-        .cs_af    = GPIO_AF5,
-        .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
+        .dev            = SPI1,
+        .mosi_pin       = GPIO_PIN(PORT_A, 7),
+        .miso_pin       = GPIO_PIN(PORT_A, 6),
+        .sclk_pin       = GPIO_PIN(PORT_A, 5),
+        .cs_pin         = GPIO_PIN(PORT_A, 4),
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB2ENR_SPI1EN,
+        .apbbus         = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 0,
+        .tx_dma_chan    = 3,
+        .rx_dma         = 1,
+        .rx_dma_chan    = 3,
+#endif
     }
 };
 

--- a/boards/nucleo-f411re/Makefile.features
+++ b/boards/nucleo-f411re/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32f411re
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f411re/include/periph_conf.h
+++ b/boards/nucleo-f411re/include/periph_conf.h
@@ -29,6 +29,24 @@ extern "C" {
 #endif
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
+    { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
+};
+
+#define DMA_0_ISR           isr_dma2_stream3
+#define DMA_1_ISR           isr_dma2_stream2
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+
+#endif /* MODULE_PERIPH_DMA */
+/** @} */
+
+/**
  * @name    UART configuration
  * @{
  */
@@ -141,17 +159,23 @@ static const uint8_t spi_divtable[2][5] = {
 
 static const spi_conf_t spi_config[] = {
     {
-        .dev      = SPI1,
-        .mosi_pin = GPIO_PIN(PORT_A, 7),
-        .miso_pin = GPIO_PIN(PORT_A, 6),
-        .sclk_pin = GPIO_PIN(PORT_A, 5),
-        .cs_pin   = GPIO_PIN(PORT_A, 4),
-        .mosi_af  = GPIO_AF5,
-        .miso_af  = GPIO_AF5,
-        .sclk_af  = GPIO_AF5,
-        .cs_af    = GPIO_AF5,
-        .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
+        .dev            = SPI1,
+        .mosi_pin       = GPIO_PIN(PORT_A, 7),
+        .miso_pin       = GPIO_PIN(PORT_A, 6),
+        .sclk_pin       = GPIO_PIN(PORT_A, 5),
+        .cs_pin         = GPIO_PIN(PORT_A, 4),
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB2ENR_SPI1EN,
+        .apbbus         = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 0,
+        .tx_dma_chan    = 3,
+        .rx_dma         = 1,
+        .rx_dma_chan    = 3,
+#endif
     }
 };
 

--- a/boards/nucleo-f412zg/Makefile.features
+++ b/boards/nucleo-f412zg/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32f412zg
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f412zg/include/periph_conf.h
+++ b/boards/nucleo-f412zg/include/periph_conf.h
@@ -32,6 +32,24 @@ extern "C" {
 #endif
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
+    { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
+};
+
+#define DMA_0_ISR           isr_dma2_stream3
+#define DMA_1_ISR           isr_dma2_stream2
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+
+#endif /* MODULE_PERIPH_DMA */
+/** @} */
+
+/**
  * @name    UART configuration
  * @{
  */
@@ -143,17 +161,23 @@ static const uint8_t spi_divtable[2][5] = {
 
 static const spi_conf_t spi_config[] = {
     {
-        .dev      = SPI1,
-        .mosi_pin = GPIO_PIN(PORT_A, 7),
-        .miso_pin = GPIO_PIN(PORT_A, 6),
-        .sclk_pin = GPIO_PIN(PORT_A, 5),
-        .cs_pin   = GPIO_PIN(PORT_A, 4),
-        .mosi_af  = GPIO_AF5,
-        .miso_af  = GPIO_AF5,
-        .sclk_af  = GPIO_AF5,
-        .cs_af    = GPIO_AF5,
-        .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
+        .dev            = SPI1,
+        .mosi_pin       = GPIO_PIN(PORT_A, 7),
+        .miso_pin       = GPIO_PIN(PORT_A, 6),
+        .sclk_pin       = GPIO_PIN(PORT_A, 5),
+        .cs_pin         = GPIO_PIN(PORT_A, 4),
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB2ENR_SPI1EN,
+        .apbbus         = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 0,
+        .tx_dma_chan    = 3,
+        .rx_dma         = 1,
+        .rx_dma_chan    = 3,
+#endif
     }
 };
 

--- a/boards/nucleo-f413zh/Makefile.features
+++ b/boards/nucleo-f413zh/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32f413zh
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_can
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c

--- a/boards/nucleo-f413zh/include/periph_conf.h
+++ b/boards/nucleo-f413zh/include/periph_conf.h
@@ -38,18 +38,12 @@ extern "C" {
  */
 #ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
-    { .stream = 4  },
-    { .stream = 14 },
-    { .stream = 6  },
-    { .stream = 10 },
-    { .stream = 8  },
+    { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
+    { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
 };
 
-#define DMA_0_ISR  isr_dma1_stream4
-#define DMA_1_ISR  isr_dma2_stream6
-#define DMA_2_ISR  isr_dma1_stream6
-#define DMA_3_ISR  isr_dma2_stream2
-#define DMA_4_ISR  isr_dma2_stream0
+#define DMA_0_ISR           isr_dma2_stream3
+#define DMA_1_ISR           isr_dma2_stream2
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
 #endif
@@ -167,22 +161,22 @@ static const uint8_t spi_divtable[2][5] = {
 
 static const spi_conf_t spi_config[] = {
     {
-        .dev      = SPI1,
-        .mosi_pin = GPIO_PIN(PORT_A, 7),
-        .miso_pin = GPIO_PIN(PORT_A, 6),
-        .sclk_pin = GPIO_PIN(PORT_A, 5),
-        .cs_pin   = GPIO_PIN(PORT_A, 4),
-        .mosi_af  = GPIO_AF5,
-        .miso_af  = GPIO_AF5,
-        .sclk_af  = GPIO_AF5,
-        .cs_af    = GPIO_AF5,
-        .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2,
+        .dev            = SPI1,
+        .mosi_pin       = GPIO_PIN(PORT_A, 7),
+        .miso_pin       = GPIO_PIN(PORT_A, 6),
+        .sclk_pin       = GPIO_PIN(PORT_A, 5),
+        .cs_pin         = GPIO_PIN(PORT_A, 4),
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB2ENR_SPI1EN,
+        .apbbus         = APB2,
 #ifdef MODULE_PERIPH_DMA
-        .tx_dma   = 3,
-        .tx_dma_chan = 2,
-        .rx_dma   = 4,
-        .rx_dma_chan = 3,
+        .tx_dma         = 0,
+        .tx_dma_chan    = 3,
+        .rx_dma         = 1,
+        .rx_dma_chan    = 3,
 #endif
     }
 };

--- a/boards/nucleo-f429zi/Makefile.features
+++ b/boards/nucleo-f429zi/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32f429zi
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f429zi/include/periph_conf.h
+++ b/boards/nucleo-f429zi/include/periph_conf.h
@@ -31,6 +31,24 @@ extern "C" {
 #endif
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
+    { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
+};
+
+#define DMA_0_ISR           isr_dma2_stream3
+#define DMA_1_ISR           isr_dma2_stream2
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+
+#endif /* MODULE_PERIPH_DMA */
+/** @} */
+
+/**
  * @name    UART configuration
  * @{
  */
@@ -122,17 +140,23 @@ static const pwm_conf_t pwm_config[] = {
  */
 static const spi_conf_t spi_config[] = {
     {
-        .dev      = SPI1,
-        .mosi_pin = GPIO_PIN(PORT_A, 7),
-        .miso_pin = GPIO_PIN(PORT_A, 6),
-        .sclk_pin = GPIO_PIN(PORT_A, 5),
-        .cs_pin   = GPIO_UNDEF,
-        .mosi_af  = GPIO_AF5,
-        .miso_af  = GPIO_AF5,
-        .sclk_af  = GPIO_AF5,
-        .cs_af    = GPIO_AF5,
-        .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
+        .dev            = SPI1,
+        .mosi_pin       = GPIO_PIN(PORT_A, 7),
+        .miso_pin       = GPIO_PIN(PORT_A, 6),
+        .sclk_pin       = GPIO_PIN(PORT_A, 5),
+        .cs_pin         = GPIO_UNDEF,
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB2ENR_SPI1EN,
+        .apbbus         = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 0,
+        .tx_dma_chan    = 3,
+        .rx_dma         = 1,
+        .rx_dma_chan    = 3,
+#endif
     }
 };
 

--- a/boards/nucleo-f446re/Makefile.features
+++ b/boards/nucleo-f446re/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32f446re
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f446re/include/periph_conf.h
+++ b/boards/nucleo-f446re/include/periph_conf.h
@@ -30,6 +30,32 @@ extern "C" {
 #endif
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
+    { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
+    { .stream = 4 },    /* DMA1 Stream 4 - SPI2_TX */
+    { .stream = 3 },    /* DMA1 Stream 3 - SPI2_RX */
+    { .stream = 5 },    /* DMA1 Stream 5 - SPI3_TX */
+    { .stream = 0 },    /* DMA1 Stream 0 - SPI3_RX */
+};
+
+#define DMA_0_ISR           isr_dma2_stream3
+#define DMA_1_ISR           isr_dma2_stream2
+#define DMA_2_ISR           isr_dma1_stream4
+#define DMA_3_ISR           isr_dma1_stream3
+#define DMA_4_ISR           isr_dma1_stream5
+#define DMA_5_ISR           isr_dma1_stream0
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+
+#endif /* MODULE_PERIPH_DMA */
+/** @} */
+
+/**
  * @name   UART configuration
  * @{
  */
@@ -157,43 +183,61 @@ static const qdec_conf_t qdec_config[] = {
  */
 static const spi_conf_t spi_config[] = {
     {
-        .dev      = SPI1,
-        .mosi_pin = GPIO_PIN(PORT_A, 7),
-        .miso_pin = GPIO_PIN(PORT_A, 6),
-        .sclk_pin = GPIO_PIN(PORT_A, 5),
-        .cs_pin   = GPIO_PIN(PORT_A, 4),
-        .mosi_af  = GPIO_AF5,
-        .miso_af  = GPIO_AF5,
-        .sclk_af  = GPIO_AF5,
-        .cs_af    = GPIO_AF5,
-        .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
+        .dev            = SPI1,
+        .mosi_pin       = GPIO_PIN(PORT_A, 7),
+        .miso_pin       = GPIO_PIN(PORT_A, 6),
+        .sclk_pin       = GPIO_PIN(PORT_A, 5),
+        .cs_pin         = GPIO_PIN(PORT_A, 4),
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB2ENR_SPI1EN,
+        .apbbus         = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 0,
+        .tx_dma_chan    = 3,
+        .rx_dma         = 1,
+        .rx_dma_chan    = 3,
+#endif
     },
     {
-        .dev      = SPI2,
-        .mosi_pin = GPIO_PIN(PORT_B, 15),
-        .miso_pin = GPIO_PIN(PORT_B, 14),
-        .sclk_pin = GPIO_PIN(PORT_B, 13),
-        .cs_pin   = GPIO_PIN(PORT_B, 12),
-        .mosi_af  = GPIO_AF5,
-        .miso_af  = GPIO_AF5,
-        .sclk_af  = GPIO_AF5,
-        .cs_af    = GPIO_AF5,
-        .rccmask  = RCC_APB1ENR_SPI2EN,
-        .apbbus   = APB1
+        .dev            = SPI2,
+        .mosi_pin       = GPIO_PIN(PORT_B, 15),
+        .miso_pin       = GPIO_PIN(PORT_B, 14),
+        .sclk_pin       = GPIO_PIN(PORT_B, 13),
+        .cs_pin         = GPIO_PIN(PORT_B, 12),
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB1ENR_SPI2EN,
+        .apbbus         = APB1,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 2,
+        .tx_dma_chan    = 0,
+        .rx_dma         = 3,
+        .rx_dma_chan    = 0,
+#endif
     },
     {
-        .dev      = SPI3,
-        .mosi_pin = GPIO_PIN(PORT_C, 12),
-        .miso_pin = GPIO_PIN(PORT_C, 11),
-        .sclk_pin = GPIO_PIN(PORT_C, 10),
-        .cs_pin   = GPIO_UNDEF,
-        .mosi_af  = GPIO_AF6,
-        .miso_af  = GPIO_AF6,
-        .sclk_af  = GPIO_AF6,
-        .cs_af    = GPIO_AF6,
-        .rccmask  = RCC_APB1ENR_SPI3EN,
-        .apbbus   = APB1
+        .dev            = SPI3,
+        .mosi_pin       = GPIO_PIN(PORT_C, 12),
+        .miso_pin       = GPIO_PIN(PORT_C, 11),
+        .sclk_pin       = GPIO_PIN(PORT_C, 10),
+        .cs_pin         = GPIO_UNDEF,
+        .mosi_af        = GPIO_AF6,
+        .miso_af        = GPIO_AF6,
+        .sclk_af        = GPIO_AF6,
+        .cs_af          = GPIO_AF6,
+        .rccmask        = RCC_APB1ENR_SPI3EN,
+        .apbbus         = APB1,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 4,
+        .tx_dma_chan    = 0,
+        .rx_dma         = 5,
+        .rx_dma_chan    = 0,
+#endif
     }
 };
 

--- a/boards/nucleo-f446ze/Makefile.features
+++ b/boards/nucleo-f446ze/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32f4
 CPU_MODEL = stm32f446ze
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f446ze/include/periph_conf.h
+++ b/boards/nucleo-f446ze/include/periph_conf.h
@@ -31,6 +31,24 @@ extern "C" {
 #endif
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
+    { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
+};
+
+#define DMA_0_ISR           isr_dma2_stream3
+#define DMA_1_ISR           isr_dma2_stream2
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+
+#endif /* MODULE_PERIPH_DMA */
+/** @} */
+
+/**
  * @name    UART configuration
  * @{
  */
@@ -132,8 +150,14 @@ static const spi_conf_t spi_config[] = {
         .sclk_af  = GPIO_AF5,
         .cs_af    = GPIO_AF5,
         .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
-    }
+        .apbbus   = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 0,
+        .tx_dma_chan    = 3,
+        .rx_dma         = 1,
+        .rx_dma_chan    = 3,
+#endif
+    },
 };
 
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)

--- a/boards/pyboard/Makefile.features
+++ b/boards/pyboard/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32f4
 CPU_MODEL = stm32f405rg
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/pyboard/include/periph_conf.h
+++ b/boards/pyboard/include/periph_conf.h
@@ -60,6 +60,24 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
+    { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
+};
+
+#define DMA_0_ISR           isr_dma2_stream3
+#define DMA_1_ISR           isr_dma2_stream2
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+
+#endif /* MODULE_PERIPH_DMA */
+/** @} */
+
+/**
  * @name    Timer configuration
  * @{
  */
@@ -130,22 +148,22 @@ static const uint8_t spi_divtable[2][5] = {
 
 static const spi_conf_t spi_config[] = {
     {
-        .dev      = SPI1,
-        .mosi_pin = GPIO_PIN(PORT_A, 7),
-        .miso_pin = GPIO_PIN(PORT_A, 6),
-        .sclk_pin = GPIO_PIN(PORT_A, 5),
-        .cs_pin   = GPIO_UNDEF,
-        .mosi_af  = GPIO_AF5,
-        .miso_af  = GPIO_AF5,
-        .sclk_af  = GPIO_AF5,
-        .cs_af    = GPIO_AF5,
-        .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2,
+        .dev            = SPI1,
+        .mosi_pin       = GPIO_PIN(PORT_A, 7),
+        .miso_pin       = GPIO_PIN(PORT_A, 6),
+        .sclk_pin       = GPIO_PIN(PORT_A, 5),
+        .cs_pin         = GPIO_UNDEF,
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB2ENR_SPI1EN,
+        .apbbus         = APB2,
 #ifdef MODULE_PERIPH_DMA
-        .tx_dma   = 1,
-        .tx_dma_chan = 1,
-        .rx_dma   = 0,
-        .rx_dma_chan = 1,
+        .tx_dma         = 0,
+        .tx_dma_chan    = 3,
+        .rx_dma         = 1,
+        .rx_dma_chan    = 3,
 #endif
     }
 };

--- a/boards/stm32f429i-disc1/Makefile.features
+++ b/boards/stm32f429i-disc1/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32f4
 CPU_MODEL = stm32f429zi
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/stm32f429i-disc1/include/periph_conf.h
+++ b/boards/stm32f429i-disc1/include/periph_conf.h
@@ -30,6 +30,24 @@ extern "C" {
 #endif
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 14 },   /* DMA2 Stream 6 - SPI5_TX */
+    { .stream = 13 },   /* DMA2 Stream 5 - SPI5_RX */
+};
+
+#define DMA_0_ISR           isr_dma2_stream6
+#define DMA_1_ISR           isr_dma2_stream5
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+
+#endif /* MODULE_PERIPH_DMA */
+/** @} */
+
+/**
  * @name    UART configuration
  * @{
  */
@@ -64,17 +82,23 @@ static const uart_conf_t uart_config[] = {
  */
 static const spi_conf_t spi_config[] = {
     {
-        .dev      = SPI5,
-        .mosi_pin = GPIO_PIN(PORT_F, 9),
-        .miso_pin = GPIO_PIN(PORT_F, 8),
-        .sclk_pin = GPIO_PIN(PORT_F, 7),
-        .cs_pin   = GPIO_UNDEF,
-        .mosi_af  = GPIO_AF5,
-        .miso_af  = GPIO_AF5,
-        .sclk_af  = GPIO_AF5,
-        .cs_af    = GPIO_AF5,
-        .rccmask  = RCC_APB2ENR_SPI5EN,
-        .apbbus   = APB2
+        .dev            = SPI5,
+        .mosi_pin       = GPIO_PIN(PORT_F, 9),
+        .miso_pin       = GPIO_PIN(PORT_F, 8),
+        .sclk_pin       = GPIO_PIN(PORT_F, 7),
+        .cs_pin         = GPIO_UNDEF,
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB2ENR_SPI5EN,
+        .apbbus         = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 0,
+        .tx_dma_chan    = 7,
+        .rx_dma         = 1,
+        .rx_dma_chan    = 7,
+#endif
     }
 };
 

--- a/boards/stm32f4discovery/Makefile.features
+++ b/boards/stm32f4discovery/Makefile.features
@@ -4,6 +4,7 @@ CPU_MODEL = stm32f407vg
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -30,6 +30,28 @@ extern "C" {
 #endif
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
+    { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
+    { .stream = 4 },    /* DMA1 Stream 4 - SPI2_TX */
+    { .stream = 3 },    /* DMA1 Stream 3 - SPI2_RX */
+};
+
+#define DMA_0_ISR           isr_dma2_stream3
+#define DMA_1_ISR           isr_dma2_stream2
+#define DMA_2_ISR           isr_dma1_stream4
+#define DMA_3_ISR           isr_dma1_stream3
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+
+#endif /* MODULE_PERIPH_DMA */
+/** @} */
+
+/**
  * @name   Timer configuration
  * @{
  */
@@ -162,31 +184,43 @@ static const pwm_conf_t pwm_config[] = {
  */
 static const spi_conf_t spi_config[] = {
     {
-        .dev      = SPI1,
-        .mosi_pin = GPIO_PIN(PORT_A, 7),
-        .miso_pin = GPIO_PIN(PORT_A, 6),
-        .sclk_pin = GPIO_PIN(PORT_A, 5),
-        .cs_pin   = GPIO_PIN(PORT_A, 4),
-        .mosi_af  = GPIO_AF5,
-        .miso_af  = GPIO_AF5,
-        .sclk_af  = GPIO_AF5,
-        .cs_af    = GPIO_AF5,
-        .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
+        .dev            = SPI1,
+        .mosi_pin       = GPIO_PIN(PORT_A, 7),
+        .miso_pin       = GPIO_PIN(PORT_A, 6),
+        .sclk_pin       = GPIO_PIN(PORT_A, 5),
+        .cs_pin         = GPIO_PIN(PORT_A, 4),
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB2ENR_SPI1EN,
+        .apbbus         = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 0,
+        .tx_dma_chan    = 3,
+        .rx_dma         = 1,
+        .rx_dma_chan    = 3,
+#endif
     },
     {
-        .dev      = SPI2,
-        .mosi_pin = GPIO_PIN(PORT_B, 15),
-        .miso_pin = GPIO_PIN(PORT_B, 14),
-        .sclk_pin = GPIO_PIN(PORT_B, 13),
-        .cs_pin   = GPIO_PIN(PORT_B, 12),
-        .mosi_af  = GPIO_AF5,
-        .miso_af  = GPIO_AF5,
-        .sclk_af  = GPIO_AF5,
-        .cs_af    = GPIO_AF5,
-        .rccmask  = RCC_APB1ENR_SPI2EN,
-        .apbbus   = APB1
-    }
+        .dev            = SPI2,
+        .mosi_pin       = GPIO_PIN(PORT_B, 15),
+        .miso_pin       = GPIO_PIN(PORT_B, 14),
+        .sclk_pin       = GPIO_PIN(PORT_B, 13),
+        .cs_pin         = GPIO_PIN(PORT_B, 12),
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB1ENR_SPI2EN,
+        .apbbus         = APB1,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 2,
+        .tx_dma_chan    = 0,
+        .rx_dma         = 3,
+        .rx_dma_chan    = 0,
+#endif
+    },
 };
 
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)

--- a/boards/ublox-c030-u201/Makefile.features
+++ b/boards/ublox-c030-u201/Makefile.features
@@ -3,6 +3,7 @@ CPU_MODEL = stm32f437vg
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/ublox-c030-u201/include/periph_conf.h
+++ b/boards/ublox-c030-u201/include/periph_conf.h
@@ -58,6 +58,24 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 9 },   /* DMA2 Stream 1 - SPI4_TX */
+    { .stream = 8 },   /* DMA2 Stream 0 - SPI4_RX */
+};
+
+#define DMA_0_ISR           isr_dma2_stream1
+#define DMA_1_ISR           isr_dma2_stream0
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+
+#endif /* MODULE_PERIPH_DMA */
+/** @} */
+
+/**
  * @name    UART configuration
  * @{
  */
@@ -178,17 +196,23 @@ static const uint8_t spi_divtable[2][5] = {
 
 static const spi_conf_t spi_config[] = {
     {
-        .dev      = SPI4,
-        .mosi_pin = GPIO_PIN(PORT_E, 6),
-        .miso_pin = GPIO_PIN(PORT_E, 5),
-        .sclk_pin = GPIO_PIN(PORT_E, 2),
-        .cs_pin   = GPIO_PIN(PORT_E, 11),
-        .mosi_af  = GPIO_AF5,
-        .miso_af  = GPIO_AF5,
-        .sclk_af  = GPIO_AF5,
-        .cs_af    = GPIO_AF5,
-        .rccmask  = RCC_APB2ENR_SPI4EN,
-        .apbbus   = APB2
+        .dev            = SPI4,
+        .mosi_pin       = GPIO_PIN(PORT_E, 6),
+        .miso_pin       = GPIO_PIN(PORT_E, 5),
+        .sclk_pin       = GPIO_PIN(PORT_E, 2),
+        .cs_pin         = GPIO_PIN(PORT_E, 11),
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB2ENR_SPI4EN,
+        .apbbus         = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma         = 0,
+        .tx_dma_chan    = 4,
+        .rx_dma         = 1,
+        .rx_dma_chan    = 4,
+#endif
     },
 };
 


### PR DESCRIPTION
### Contribution description

This PR adds valid DMA configuration for the SPI peripherals of the boards containing an STM32F4 microcontroller. This adds the DMA as a provided feature for these boards and adds config to make it useable, but doesn't enable the DMA by default for SPI.

### Testing procedure

*with* `FEATURES_REQUIRED += periph_dma`, testing is to be done with `tests/periph_spi`. For a thorough test, check if the bytes send and received match what is expected. Otherwise simply triggering a bidirectional transaction should be sufficient, an incorrect DMA config will not set up the right interrupts and channels and will cause the SPI transfer to hang infinitely:

- [ ] msbiot
- [x] nucleo-f401re
- [ ] nucleo-f410rb
- [ ] nucleo-f411re
- [ ] nucleo-f412zg
- [ ] nucleo-f413zh
- [ ] nucleo-f429zi
- [x] nucleo-f446re
- [ ] nucleo-f446ze
- [ ] pyboard
- [x] stm32f429i-disc1
- [ ] stm32f4discovery
- [ ] ublox-c030-u201

Also please run the very short `tests/periph_dma` to verify that the UART shell doesn't break:

- [ ] msbiot
- [x] nucleo-f401re
- [ ] nucleo-f410rb
- [ ] nucleo-f411re
- [ ] nucleo-f412zg
- [ ] nucleo-f413zh
- [ ] nucleo-f429zi
- [x] nucleo-f446re
- [ ] nucleo-f446ze
- [ ] pyboard
- [x] stm32f429i-disc1
- [ ] stm32f4discovery
- [ ] ublox-c030-u201

### Issues/PRs references

Depends on #14090 to not break the shell (uart) completely when enabling DMA.