### PR TITLE
tests/periph_pwm: limit OSC_STEPS to 256 so the test works on all platforms

### DIFF
--- a/tests/periph_pwm/main.c
+++ b/tests/periph_pwm/main.c
@@ -39,7 +39,7 @@
 #define OSC_STEP        (10)
 #define OSC_MODE        PWM_LEFT
 #define OSC_FREQU       (1000U)
-#define OSC_STEPS       (1000U)
+#define OSC_STEPS       (256U)
 #define PWR_SLEEP       (1U)
 
 static uint32_t initiated;


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The ATmega PWM implementation only supports a maximum resolution of 256.
Thus when running `osci` with `OSC_STEPS` = 1000 an assertion will fail and the test crashes, even though the PWM peripheral works perfectly fine.

Limit `OSC_STEPS` to 256 so it works on all platforms.
The LED flashing doesn't look any more coarse.


### Testing procedure

Flash `tests/periph_pwm` on any ATmega board that has the `periph_pwm` feature.
Run the `osci` command to oscillate on all PWM outputs.

On `master` this causes an [assertion](https://github.com/RIOT-OS/RIOT/blob/master/cpu/atmega_common/periph/pwm.c#L67) to trigger, crashing the test.

With this patch you should see the LED flashing (if a PWM output is configured to the on-board LED, which is usually the case)

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
