### PR TITLE
STM32_common/dma: Optimize the latency in the hot path

### DIFF
--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -405,17 +405,17 @@ typedef unsigned dma_t;
  * @brief   DMA modes
  */
 typedef enum {
-    DMA_PERIPH_TO_MEM,     /**< Peripheral to memory */
-    DMA_MEM_TO_PERIPH,     /**< Memory to peripheral */
-    DMA_MEM_TO_MEM,        /**< Memory to memory */
+    DMA_PERIPH_TO_MEM = 0,     /**< Peripheral to memory */
+    DMA_MEM_TO_PERIPH = 1,     /**< Memory to peripheral */
+    DMA_MEM_TO_MEM = 2,        /**< Memory to memory */
 } dma_mode_t;
 
 /**
  * @name    DMA Increment modes
  * @{
  */
-#define DMA_INC_SRC_ADDR  (0x01)
-#define DMA_INC_DST_ADDR  (0x02)
+#define DMA_INC_SRC_ADDR  (0x04)
+#define DMA_INC_DST_ADDR  (0x08)
 #define DMA_INC_BOTH_ADDR (DMA_INC_SRC_ADDR | DMA_INC_DST_ADDR)
 /** @} */
 
@@ -424,10 +424,10 @@ typedef enum {
  * @{
  */
 #define DMA_DATA_WIDTH_BYTE      (0x00)
-#define DMA_DATA_WIDTH_HALF_WORD (0x04)
-#define DMA_DATA_WIDTH_WORD      (0x08)
-#define DMA_DATA_WIDTH_MASK      (0x0C)
-#define DMA_DATA_WIDTH_SHIFT     (2)
+#define DMA_DATA_WIDTH_HALF_WORD (0x01)
+#define DMA_DATA_WIDTH_WORD      (0x02)
+#define DMA_DATA_WIDTH_MASK      (0x03)
+#define DMA_DATA_WIDTH_SHIFT     (0)
 /** @} */
 #endif /* MODULE_PERIPH_DMA */
 
@@ -913,6 +913,33 @@ void dma_wait(dma_t dma);
  */
 int dma_configure(dma_t dma, int chan, const volatile void *src, volatile void *dst, size_t len,
                   dma_mode_t mode, uint8_t flags);
+
+/**
+ * @brief   Low level initial DMA stream configuration
+ *
+ * This function is supposed to be used together with @ref dma_prepare. This
+ * function sets up the one-time configuration of a stream and @ref dma_prepare
+ * configures the per-transfer registers.
+ *
+ * @param[in]   dma         Logical DMA stream
+ * @param[in]   chan        DMA channel (on stm32f2/4/7, CxS or unused on others)
+ * @param[in]   periph_addr Peripheral register address
+ * @param[in]   mode        DMA direction mode
+ * @param[in]   width       DMA transfer width
+ * @param[in]   inc_periph  Increment peripheral address after read/write
+ */
+void dma_setup(dma_t dma, int chan, void *periph_addr, dma_mode_t mode,
+               uint8_t width, bool inc_periph);
+
+/**
+ * @brief   Low level DMA transfer configuration
+ *
+ * @param[in]   dma         Logical DMA stream
+ * @param[in]   mem         Memory address
+ * @param[in]   len         Transfer length
+ * @param[in]   inc_mem     Increment the memory address after read/write
+ */
+void dma_prepare(dma_t dma, void *mem, size_t len, bool incr_mem);
 
 #endif /* MODULE_PERIPH_DMA */
 

--- a/cpu/stm32/periph/dma.c
+++ b/cpu/stm32/periph/dma.c
@@ -331,6 +331,8 @@ void dma_acquire(dma_t dma)
 
     mutex_lock(&dma_ctx[dma].conf_lock);
 
+    dma_clear_all_flags(dma);
+
 #if CPU_FAM_STM32F2 || CPU_FAM_STM32F4 || CPU_FAM_STM32F7
     stream->FCR = 0;
 #endif
@@ -363,8 +365,6 @@ int dma_configure(dma_t dma, int chan, const volatile void *src, volatile void *
     uint32_t inc_periph;
     uint32_t inc_mem;
     STM32_DMA_Stream_Type *stream = dma_stream(stream_n);
-
-    dma_clear_all_flags(dma);
 
     switch (mode) {
         case DMA_MEM_TO_MEM:

--- a/cpu/stm32/periph/dma.c
+++ b/cpu/stm32/periph/dma.c
@@ -327,8 +327,14 @@ int dma_transfer(dma_t dma, int chan, const volatile void *src, volatile void *d
 void dma_acquire(dma_t dma)
 {
     assert(dma < DMA_NUMOF);
+    int stream_n = dma_config[dma].stream;
 
     mutex_lock(&dma_ctx[dma].conf_lock);
+
+#if CPU_FAM_STM32F2 || CPU_FAM_STM32F4 || CPU_FAM_STM32F7
+    stream->FCR = 0;
+#endif
+
 #ifdef STM32_PM_STOP
     /* block STOP mode */
     pm_block(STM32_PM_STOP);
@@ -388,7 +394,6 @@ int dma_configure(dma_t dma, int chan, const volatile void *src, volatile void *
     /* Enable interrupts */
     stream->CR |= DMA_SxCR_TCIE | DMA_SxCR_TEIE;
     /* Configure FIFO */
-    stream->FCR = 0;
 #else
 #if defined(DMA_CSELR_C1S) || defined(DMA1_CSELR_DEFAULT)
     dma_req(stream_n)->CSELR &= ~((0xF) << ((stream_n & 0x7) << 2));

--- a/cpu/stm32/periph/dma.c
+++ b/cpu/stm32/periph/dma.c
@@ -248,8 +248,6 @@ static inline void dma_isr_enable(int stream)
 
 static inline uint32_t dma_all_flags(dma_t dma)
 {
-    assert(dma < DMA_NUMOF);
-
 #if CPU_FAM_STM32F2 || CPU_FAM_STM32F4 || CPU_FAM_STM32F7
     switch (dma_config[dma].stream & 0x3) {
         case 0: /* 0 and 4 */
@@ -270,8 +268,6 @@ static inline uint32_t dma_all_flags(dma_t dma)
 
 static void dma_clear_all_flags(dma_t dma)
 {
-    assert(dma < DMA_NUMOF);
-
     DMA_TypeDef *dma_dev = dma_base(dma_config[dma].stream);
 
 #if CPU_FAM_STM32F2 || CPU_FAM_STM32F4 || CPU_FAM_STM32F7
@@ -359,7 +355,6 @@ int dma_configure(dma_t dma, int chan, const volatile void *src, volatile void *
 {
     assert(src != NULL);
     assert(dst != NULL);
-    assert(dma < DMA_NUMOF);
 
     int stream_n = dma_config[dma].stream;
     uint32_t inc_periph;
@@ -415,8 +410,6 @@ int dma_configure(dma_t dma, int chan, const volatile void *src, volatile void *
 
 void dma_start(dma_t dma)
 {
-    assert(dma < DMA_NUMOF);
-
     STM32_DMA_Stream_Type *stream = dma_stream(dma_config[dma].stream);
 
     stream->CONTROL_REG |= DMA_EN;
@@ -460,8 +453,6 @@ void dma_resume(dma_t dma, uint16_t remaining)
 
 void dma_stop(dma_t dma)
 {
-    assert(dma < DMA_NUMOF);
-
     STM32_DMA_Stream_Type *stream = dma_stream(dma_config[dma].stream);
 
     stream->CONTROL_REG &= ~(uint32_t)DMA_EN;
@@ -469,8 +460,6 @@ void dma_stop(dma_t dma)
 
 void dma_wait(dma_t dma)
 {
-    assert(dma < DMA_NUMOF);
-
     mutex_lock(&dma_ctx[dma].sync_lock);
 }
 


### PR DESCRIPTION
### Contribution description

This PR optimizes the stm32 DMA controller to reduce the number of operations in the hot path of a DMA stream configuration.

1. Move power-on and enable function to the DMA init. The DMA is never powered off, so the most this will do is prematurely enable the DMA before it is strictly required.
2. FCR configuration changes only during memory-to-memory transfers. clearing the DMDIS flag during the acquire should be sufficient for now
3. Same as above, clearing the flags during the acquire and not every transfer is sufficient as these are also cleared in the ISR.
4. This removes a number of asserts that should have been triggered during proper functional call usage anyway. This is why the dma asserts remain in the acquire function. No need to assert this again during the transfer, start and wait call.
5. This commit splits the `dma_configure` into a setup function, called once in a series of DMA transfers, and a prepare, called every DMA transfer. The setup configures the stream channel, direction, the peripheral address and transfer width. This is usually only required once in a set of transfers (for example a spi_transfer_regs, which consists of a transfer for the device register and a transfer for the data.). The `dma_prepare` is called before every transfer to change the memory address and the length of the transfer.
6. Cache the DMA stream register base address in RAM. Calculating the register base address during init and not every call reduced the overhead from a single transfer from 7.4μs to 6.4μs. This comes at the cost of 4 bytes per logical DMA stream configured.

Let me know if it is preferred to split this commit in multiple PRs

### Testing procedure

This should be tested on the different stm32 (f0, f1, f2, f4, l4 and f7) classes to ensure that I didn't accidentally broke the DMA peripheral.

Testing is probably easiest with SPI, using #14087 and #14093.

Boards that have DMA configured (and thus might break) are:

- b-l072z-lrwan1 (SPI and UART)
- b-l475e-iot01a (SPI and UART)
- iotlab-(a8-)m3 (UART)
- nucleo-f207zg (SPI, UART and ethernet)
- nucleo-f767zi (SPI, UART and ethernet)
- nucleo-l152re (SPI and UART)
- nucleo-l476rg (SPI and UART)

### Issues/PRs references

Depends on #14087 for some measurements on this.
