### PR TITLE
STM32_common/SPI: Reduce the overhead in the DMA hot path

### DIFF
--- a/cpu/stm32/periph/spi.c
+++ b/cpu/stm32/periph/spi.c
@@ -37,6 +37,16 @@
  */
 #define BR_SHIFT            (3U)
 
+#ifdef SPI_CR2_FRXTH
+/* configure SPI for 8-bit data width */
+#define SPI_CR2_SETTINGS    (SPI_CR2_FRXTH |\
+                             SPI_CR2_DS_0 |\
+                             SPI_CR2_DS_1 |\
+                             SPI_CR2_DS_2)
+#else
+#define SPI_CR2_SETTINGS    0
+#endif
+
 /**
  * @brief   Allocate one lock per SPI device
  */
@@ -62,12 +72,7 @@ void spi_init(spi_t bus)
 #ifdef SPI_I2SCFGR_I2SE
     dev(bus)->I2SCFGR = 0;
 #endif
-    /* configure SPI for 8-bit data width */
-#ifdef SPI_CR2_FRXTH
-    dev(bus)->CR2 = (SPI_CR2_FRXTH | SPI_CR2_DS_0 | SPI_CR2_DS_1 | SPI_CR2_DS_2);
-#else
-    dev(bus)->CR2 = 0;
-#endif
+    dev(bus)->CR2 = SPI_CR2_SETTINGS;
     periph_clk_dis(spi_config[bus].apbbus, spi_config[bus].rccmask);
 }
 
@@ -165,7 +170,7 @@ void spi_release(spi_t bus)
 {
     /* disable device and release lock */
     dev(bus)->CR1 = 0;
-    dev(bus)->CR2 &= ~(SPI_CR2_SSOE);
+    dev(bus)->CR2 = SPI_CR2_SETTINGS; /* Clear the DMA and SSOE flags */
     periph_clk_dis(spi_config[bus].apbbus, spi_config[bus].rccmask);
 #ifdef STM32_PM_STOP
     /* unblock STOP mode */

--- a/cpu/stm32/periph/spi.c
+++ b/cpu/stm32/periph/spi.c
@@ -152,6 +152,7 @@ int spi_init_with_gpio_mode(spi_t bus, spi_gpio_mode_t mode)
 
 int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
 {
+
     /* lock bus */
     mutex_lock(&locks[bus]);
 #ifdef STM32_PM_STOP
@@ -243,9 +244,8 @@ static void _transfer_dma(spi_t bus, const void *out, void *in, size_t len)
     dma_wait(spi_config[bus].rx_dma);
     dma_wait(spi_config[bus].tx_dma);
 
-
-    dma_stop(spi_config[bus].tx_dma);
-    dma_stop(spi_config[bus].rx_dma);
+    /* No need to stop the DMA here, it is automatically disabled when the
+     * transfer is finished */
 
     _wait_for_end(bus);
 }


### PR DESCRIPTION
### Contribution description

This PR reduces the number of instructions required for DMA-based SPI transfers and moves a number of setup calls from the spi_transfer_bytes to the acquire/release function. This reduces the overhead. 

1. Add a define for the always-on settings in the CR2 registers removing some of the volatile register read-modify-write sequences.
2. Use the define from the first commit to further reduce the number of read-modify-writes to the CR2 register.
3. Moves the DMA acquire inside the SPI acquire, it is overkill to acquire/release for every single SPI transfer.
4. Removes the DMA stop function call. The DMA stream is automatically stopped as soon as the transfer is finished and doesn't need to be manually stopped.
5. Refactor to use the new setup and prepare functions from #14096. A single setup is done during the SPI acquire. This reduces a few unnecessary register writes every transfer.

Together with #14096 this reduces the overhead with a single byte SPI transfer (not counting acquire/release overhead) using DMA from 17μs to 6.4μs, measured using the bench command in `tests/periph_spi`.

### Testing procedure

This probably needs testing with all affected stm32 devices.

`tests/periph_spi` can be used to verify the decrease in overhead on SPI DMA enabled boards. The test needs a `FEATURES_REQUIRED += periph_dma` in order to force DMA usage. 

### Issues/PRs references

Depends on #14096 