### PR TITLE
cpu/atmega_common: Fix periph_timer

### DIFF
--- a/cpu/atmega_common/include/periph_cpu_common.h
+++ b/cpu/atmega_common/include/periph_cpu_common.h
@@ -158,6 +158,11 @@ typedef struct {
 /** @} */
 
 /**
+ * @brief   A low-level timer_set() implementation is provided
+ */
+#define PERIPH_TIMER_PROVIDES_SET
+
+/**
  * @brief   EEPROM clear byte
  */
 #define EEPROM_CLEAR_BYTE              (0xff)

--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -24,6 +24,7 @@
 
 #include "board.h"
 #include "cpu.h"
+#include "irq.h"
 #include "thread.h"
 
 #include "periph/timer.h"
@@ -136,9 +137,11 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
         return -1;
     }
 
+    unsigned state = irq_disable();
     ctx[tim].dev->OCR[channel] = (uint16_t)value;
     *ctx[tim].flag &= ~(1 << (channel + OCF1A));
     *ctx[tim].mask |= (1 << (channel + OCIE1A));
+    irq_restore(state);
 
     return 0;
 }
@@ -156,7 +159,17 @@ int timer_clear(tim_t tim, int channel)
 
 unsigned int timer_read(tim_t tim)
 {
-    return (unsigned int)ctx[tim].dev->CNT;
+    /* CNT is a 16 bit register, but atomic access is implemented by hardware:
+     * A read from the low byte causes the value in the high byte being stored
+     * in parallel into a temporary register. The read of the high byte will
+     * instead access the temporary register. However, the AVR only has one
+     * temporary register that is used to implement atomic access to all 16 bit
+     * registers. Thus, access has to be guarded by disabling IRQs.
+     */
+    unsigned state = irq_disable();
+    unsigned result = ctx[tim].dev->CNT;
+    irq_restore(state);
+    return result;
 }
 
 void timer_stop(tim_t tim)


### PR DESCRIPTION
### Contribution description

- Fixed a potential data race in `periph_timer` when accessing 16 bit registers atomically
    - AVR assists atomic access to 16 bit registers with a single 8 bit temporary registers: Reads to the low byte of a 16 bit registers causes the high byte simultaneously being read into the temporary register. A subsequent read of the high byte will access the temporary register instead.
    - But as there is only a single temporary register shared by all 16 bit register, ISRs executing between the read of the low and the high register might invalidate the date in the temporary register
    - --> Atomic accesses need to be wrapped into `irq_disable()` ... `irq_restore()
- Added low level implementation of `timer_set()` that works for low relative timeouts (as low as 0)
    - `tests/periph_timer_short_relative_set` now passes

### Testing procedure

Confirm that `tests/periph_timer_short_relative_set` now passes.

### Issues/PRs references

None