### PR TITLE
tests: dns: use correct macro names

### DIFF
--- a/tests/gnrc_ipv6_nib_dns/Makefile
+++ b/tests/gnrc_ipv6_nib_dns/Makefile
@@ -29,8 +29,8 @@ LOW_MEMORY_BOARDS := nucleo-f334r8 msb-430 msb-430h
 
 ifeq ($(BOARD),$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
     CFLAGS += -DGNRC_PKTBUF_SIZE=512 -DCONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF=2 \
-              -DGNRC_NETIF_IPV6_GROUPS_NUMOF=2 -DGNRC_IPV6_NIB_NUMOF=1 \
-              -DNRC_IPV6_NIB_OFFL_NUMOF=1
+              -DGNRC_NETIF_IPV6_GROUPS_NUMOF=2 -DCONFIG_GNRC_IPV6_NIB_NUMOF=1 \
+              -DCONFIG_GNRC_IPV6_NIB_OFFL_NUMOF=1
 endif
 
 # The test requires some setup and to be run as root

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -33,7 +33,7 @@ LOW_MEMORY_BOARDS := nucleo-f334r8 msb-430 msb-430h
 ifeq ($(BOARD),$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
     CFLAGS += -DGNRC_PKTBUF_SIZE=512 -DCONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF=2 \
               -DGNRC_NETIF_IPV6_GROUPS_NUMOF=2 -DCONFIG_GNRC_IPV6_NIB_NUMOF=1 \
-              -DNRC_IPV6_NIB_OFFL_NUMOF=1
+              -DCONFIG_GNRC_IPV6_NIB_OFFL_NUMOF=1
 endif
 
 # The test requires some setup and to be run as root


### PR DESCRIPTION
### Contribution description
The dns test application uses non-existing macro names in the `Makefile`.

### Testing procedure
Compile the test application with different values for the fixed macro names in the `Makefile`.

### Issues/PRs references
none