### PR TITLE
cpu/stm32_common: fix issue while clearing EXTI->PR reg

### DIFF
--- a/cpu/stm32_common/periph/rtc.c
+++ b/cpu/stm32_common/periph/rtc.c
@@ -237,7 +237,7 @@ void rtc_init(void)
     EXTI->FTSR &= ~(EXTI_FTSR_BIT);
     EXTI->RTSR |= EXTI_RTSR_BIT;
     EXTI->IMR  |= EXTI_IMR_BIT;
-    EXTI->PR   |= EXTI_PR_BIT;
+    EXTI->PR   = EXTI_PR_BIT;
     /* enable global RTC interrupt */
     NVIC_EnableIRQ(IRQN);
 }
@@ -351,7 +351,7 @@ void ISR_NAME(void)
         }
         RTC->ISR &= ~RTC_ISR_ALRAF;
     }
-    EXTI->PR |= EXTI_PR_BIT;
+    EXTI->PR = EXTI_PR_BIT; /* only clear the associated bit */
     cortexm_isr_end();
 }
 

--- a/cpu/stm32_common/periph/rtt.c
+++ b/cpu/stm32_common/periph/rtt.c
@@ -115,7 +115,7 @@ void rtt_init(void)
     !defined(CPU_FAM_STM32WB)
     EXTI->FTSR_REG &= ~(EXTI_FTSR_BIT);
     EXTI->RTSR_REG |= EXTI_RTSR_BIT;
-    EXTI->PR_REG |= EXTI_PR_BIT;
+    EXTI->PR_REG = EXTI_PR_BIT;
 #endif
     NVIC_EnableIRQ(LPTIM1_IRQn);
     /* enable timer */
@@ -206,7 +206,7 @@ void isr_lptim1(void)
     LPTIM1->ICR = (LPTIM_ICR_ARRMCF | LPTIM_ICR_CMPMCF);
 #if !defined(CPU_FAM_STM32L4) && !defined(CPU_FAM_STM32L0) && \
     !defined(CPU_FAM_STM32WB)
-    EXTI->PR_REG |= EXTI_PR_BIT;
+    EXTI->PR_REG = EXTI_PR_BIT; /* only clear the associated bit */
 #endif
 
     cortexm_isr_end();


### PR DESCRIPTION
Since the **EXTI->PR** is an **rc_w1** type register, we need to be careful when clearing our interrupt flag in the register. When there are multiple interrupt flags set in the register, the `|=` operation will mistakenly clear all pending interrupts instead of just ours.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
- The ISRs in **rtc.c** and **rtt.c** drivers are involved.
- If there are multiple bits set in the Pending Register in **EXTI**, clearing the bit by
`EXTI->PR |= EXTI_PR_BIT;` operation will mistakenly delete the other flags as well due to the fact that `EXTI->PR` is an `rc_w1` type register.
- Instead of this, we just need to do `EXTI->PR = EXTI_PR_BIT` in order to clear our flag and preserve the other possible flags like it is done so in `isr_exti` in **gpio.c**.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
- We observed a strange issue in our FW where, _sometimes_, the `isr_exti` ISR is executed with `EXTI->PR = 0x0` which should ideally not happen. After some investigation, we detected this bug.
- It's really hard to describe a test procedure for this issue, since it completely depends on interrupt timings and ISR execution order.
- The expected behavior is that all ISRs only clear their corresponding interrupt flag.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
No known references.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
