### PR TITLE
tests/periph_spi: Expose default SPI CS pins

### DIFF
--- a/tests/periph_spi/README.md
+++ b/tests/periph_spi/README.md
@@ -6,3 +6,9 @@ as master or slave, and to send and receive data via SPI.
 Background
 ==========
 Test for the low-level SPI driver.
+
+## Default SPI CS pin
+
+To overwrite the optional default cs pin CFLAGS can be used:
+
+`CFLAGS="-DDEFAULT_SPI_CS_PORT=<my_port_int> -DDEFAULT_SPI_CS_PIN=<my_pin_int>" BOARD=<my_board> make flash term`

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -29,6 +29,20 @@
 #include "periph/spi.h"
 
 /**
+ * @brief   Default port number used for the CS pin if unassigned
+ */
+#ifndef DEFAULT_SPI_CS_PORT
+#define DEFAULT_SPI_CS_PORT 0
+#endif
+
+/**
+ * @brief   Default port number used for the CS pin if unassigned
+ */
+#ifndef DEFAULT_SPI_CS_PIN
+#define DEFAULT_SPI_CS_PIN 0
+#endif
+
+/**
  * @brief   Some parameters used for benchmarking
  */
 #define BENCH_REDOS             (1000)
@@ -83,8 +97,8 @@ int cmd_init(int argc, char **argv)
 {
     int dev, mode, clk, port, pin, tmp;
 
-    if (argc < 5) {
-        printf("usage: %s <dev> <mode> <clk> <cs port> <cs pin>\n", argv[0]);
+    if (argc < 4) {
+        printf("usage: %s <dev> <mode> <clk> [cs port] [cs pin]\n", argv[0]);
         puts("\tdev:");
         for (int i = 0; i < (int)SPI_NUMOF; i++) {
             printf("\t\t%i: SPI_DEV(%i)\n", i, i);
@@ -142,8 +156,20 @@ int cmd_init(int argc, char **argv)
     }
 
     /* parse chip select port and pin */
-    port = atoi(argv[4]);
-    pin = atoi(argv[5]);
+    if (argc > 5) {
+        pin = atoi(argv[5]);
+    }
+    else {
+        pin = DEFAULT_SPI_CS_PIN;
+    }
+
+    if (argc > 4) {
+        port = atoi(argv[4]);
+    }
+    else {
+        port = DEFAULT_SPI_CS_PORT;
+    }
+
     if (pin < 0 || port < -1) {
         puts("error: invalid CS port/pin combination specified");
     }


### PR DESCRIPTION
### Contribution description

Expose the option to use default cs pins defined as `DEFAULT_SPI_CS_PORT` and `DEFAULT_SPI_CS_PIN`.
This is used if a wiring environment is already defined.
CFLAGS can be used to define the CS pin from the environment provided allowing easier automation of tests.


### Testing procedure

TLDR; Test all cs options and build with different defaults `tests/periph_spi`

Build without any CFLAGS:
`BOARD=<my_board> make flash term -C tests/periph_spi`

Test the arg parsing of `init`:
<details>

```
> init 0 0
2020-05-19 17:19:44,473 #  init 0 0
2020-05-19 17:19:44,477 # usage: init <dev> <mode> <clk> [cs port] [cs pin]
2020-05-19 17:19:44,478 # 	dev:
2020-05-19 17:19:44,479 # 		0: SPI_DEV(0)
2020-05-19 17:19:44,480 # 		1: SPI_DEV(1)
2020-05-19 17:19:44,481 # 	mode:
2020-05-19 17:19:44,485 # 		0: POL:0, PHASE:0 - on first rising edge
2020-05-19 17:19:44,489 # 		1: POL:0, PHASE:1 - on second rising edge
2020-05-19 17:19:44,493 # 		2: POL:1, PHASE:0 - on first falling edge
2020-05-19 17:19:44,497 # 		3: POL:1, PHASE:1 - on second falling edge
2020-05-19 17:19:44,497 # 	clk:
2020-05-19 17:19:44,499 # 		0: 100 KHz
2020-05-19 17:19:44,500 # 		1: 400 KHz
2020-05-19 17:19:44,501 # 		2: 1 MHz
2020-05-19 17:19:44,502 # 		3: 5 MHz
2020-05-19 17:19:44,503 # 		4: 10 MHz
2020-05-19 17:19:44,505 # 	cs port:
2020-05-19 17:19:44,509 # 		Port of the CS pin, set to -1 for hardware chip select
2020-05-19 17:19:44,509 # 	cs pin:
2020-05-19 17:19:44,514 # 		Pin used for chip select. If hardware chip select is enabled,
2020-05-19 17:19:44,519 # 		this value specifies the internal HWCS line

> init 0 0 0
2020-05-19 17:20:04,792 #  init 0 0 0
2020-05-19 17:20:04,798 # SPI_DEV(0) initialized: mode: 0, clk: 0, cs_port: 0, cs_pin: 0

> init 0 0 0 1
2020-05-19 17:20:16,586 #  init 0 0 0 1
2020-05-19 17:20:16,592 # SPI_DEV(0) initialized: mode: 0, clk: 0, cs_port: 1, cs_pin: 0

> init 0 0 0 1 2
2020-05-19 17:20:27,106 #  init 0 0 0 1 2
2020-05-19 17:20:27,111 # SPI_DEV(0) initialized: mode: 0, clk: 0, cs_port: 1, cs_pin: 2
```
</details>

Build with one CFLAGS:
`CFLAGS="-DDEFAULT_SPI_CS_PORT=3"  BOARD=<my_board> make flash term -C tests/periph_spi`

Verify value is correct in `init`:
```
> init 0 0 0
2020-05-19 17:22:27,267 # init 0 0 0
2020-05-19 17:22:27,272 # SPI_DEV(0) initialized: mode: 0, clk: 0, cs_port: 3, cs_pin: 0
```

Build with all CFLAGS:
`CFLAGS="-DDEFAULT_SPI_CS_PORT=3 -DDEFAULT_SPI_CS_PIN=4" BOARD=nucleo-f103rb make flash term -C tests/periph_spi/`

Verify value is correct in `init`:
```
> init 0 0 0
2020-05-19 17:24:01,403 # init 0 0 0
2020-05-19 17:24:01,409 # SPI_DEV(0) initialized: mode: 0, clk: 0, cs_port: 3, cs_pin: 4
```

Verify override is works in `init`:
```
> init 0 0 0 1 2
2020-05-19 17:25:08,924 #  init 0 0 0 1 2
2020-05-19 17:25:08,929 # SPI_DEV(0) initialized: mode: 0, clk: 0, cs_port: 1, cs_pin: 2
```
### Issues/PRs references