### PR TITLE
gnrc/gomach : Expose configurations to Kconfig

### DIFF
--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -275,11 +275,11 @@ extern "C" {
  *
  * In GoMacH, the WP period of a receiver will be extended upon each successful
  * packet reception (except receiving broadcast or preamble packet) to receive
- * more potentialincoming packets. This macro defines the maximum WP period
+ * more potential incoming packets. This macro defines the maximum WP period
  * extension number allowed in GoMacH.
  */
-#ifndef GNRC_GOMACH_CP_EXTEND_THRESHOLD
-#define GNRC_GOMACH_CP_EXTEND_THRESHOLD      (5U)
+#ifndef CONFIG_GNRC_GOMACH_CP_EXTEND_THRESHOLD
+#define CONFIG_GNRC_GOMACH_CP_EXTEND_THRESHOLD      (5U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -183,8 +183,8 @@ extern "C" {
  * hardware abnormal event. Upon this timeout expiration, GoMach will
  * accordingly take actions to maintain its state-machine.
  */
-#ifndef GNRC_GOMACH_NO_TX_ISR_US
-#define GNRC_GOMACH_NO_TX_ISR_US          (50U * US_PER_MS)
+#ifndef CONFIG_GNRC_GOMACH_NO_TX_ISR_US
+#define CONFIG_GNRC_GOMACH_NO_TX_ISR_US          (50U * US_PER_MS)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -82,25 +82,25 @@ extern "C" {
  * listening. In GoMacH, by default, we regard the wake-up period (WP) as the
  * beginning of a cycle.
  *
- * @note GoMacH's superframe duration @ref GNRC_GOMACH_SUPERFRAME_DURATION_US
- * should not be shorter than 10 times of
- * @ref CONFIG_GNRC_GOMACH_CP_DURATION_US and not shorter than the RTT tickle
- * interval.
+ * @note GoMacH's superframe duration
+ * @ref CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US should not be shorter than 10
+ * times of @ref CONFIG_GNRC_GOMACH_CP_DURATION_US and not shorter than the RTT
+ * tickle interval.
  */
-#ifndef GNRC_GOMACH_SUPERFRAME_DURATION_US
-#define GNRC_GOMACH_SUPERFRAME_DURATION_US        (300LU * US_PER_MS)
+#ifndef CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US
+#define CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US        (300LU * US_PER_MS)
 #endif
 
 #ifndef RTT_FREQUENCY
 #error "RTT_FREQUENCY undefined."
 #else
-#if ((GNRC_GOMACH_SUPERFRAME_DURATION_US < ((1000LU *US_PER_MS) / RTT_FREQUENCY)) || \
-     (GNRC_GOMACH_SUPERFRAME_DURATION_US < (10 * CONFIG_GNRC_GOMACH_CP_DURATION_US)))
-#undef GNRC_GOMACH_SUPERFRAME_DURATION_US
+#if ((CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US < ((1000LU *US_PER_MS) / RTT_FREQUENCY)) || \
+     (CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US < (10 * CONFIG_GNRC_GOMACH_CP_DURATION_US)))
+#undef CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US
 #if (((1000LU *US_PER_MS) / RTT_FREQUENCY) > (10 * CONFIG_GNRC_GOMACH_CP_DURATION_US))
-#define GNRC_GOMACH_SUPERFRAME_DURATION_US        ((1000LU * US_PER_MS) / RTT_FREQUENCY)
+#define CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US   ((1000LU * US_PER_MS) / RTT_FREQUENCY)
 #else
-#define GNRC_GOMACH_SUPERFRAME_DURATION_US        (10 * CONFIG_GNRC_GOMACH_CP_DURATION_US)
+#define CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US   (10 * CONFIG_GNRC_GOMACH_CP_DURATION_US)
 #endif
 #endif
 #endif
@@ -218,9 +218,9 @@ extern "C" {
  *
  * In GoMacH, when sending a broadcast packet, the sender broadcasts the same
  * packet frame on its two public channels simultaneously, with a total duration
- * of @ref GNRC_GOMACH_SUPERFRAME_DURATION_US to guarantee that all neighbors
- * will get a copy. This macro defines the time interval between sending two
- * consecutive broadcast copies.
+ * of @ref CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US to guarantee that all
+ * neighbors will get a copy. This macro defines the time interval between
+ * ending two consecutive broadcast copies.
  */
 #ifndef GNRC_GOMACH_BCAST_INTERVAL_US
 #define GNRC_GOMACH_BCAST_INTERVAL_US        (1U * US_PER_MS)
@@ -235,10 +235,11 @@ extern "C" {
  * in a critical case that one public channel is jammed, the sender repeatedly
  * broadcasts a stream of preamble packets with the broadcast duration
  * (preamble duration) slightly longer than twice of
- * @ref GNRC_GOMACH_SUPERFRAME_DURATION_US.
+ * @ref CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US.
  */
 #ifndef GNRC_GOMACH_PREAMBLE_DURATION_US
-#define GNRC_GOMACH_PREAMBLE_DURATION_US        (21LU * GNRC_GOMACH_SUPERFRAME_DURATION_US / 10)
+#define GNRC_GOMACH_PREAMBLE_DURATION_US \
+     (21LU * CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US / 10)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -247,12 +247,12 @@ extern "C" {
  *
  * GoMacH adopts dynamic slots allocation scheme to allocate transmission slots
  * to senders that have pending packets. Each slot is for one data packet with
- * ACK transmission. @ref GNRC_GOMACH_VTDMA_SLOT_SIZE_US is right sufficient
- * for the transmission of the longest packet in IEEE 802.15.4 with ACK. Should
- * not be changed.
+ * ACK transmission. @ref CONFIG_GNRC_GOMACH_VTDMA_SLOT_SIZE_US is right
+ * sufficient for the transmission of the longest packet in IEEE 802.15.4 with
+ * ACK. Should not be changed.
  */
-#ifndef GNRC_GOMACH_VTDMA_SLOT_SIZE_US
-#define GNRC_GOMACH_VTDMA_SLOT_SIZE_US        (5U * US_PER_MS)
+#ifndef CONFIG_GNRC_GOMACH_VTDMA_SLOT_SIZE_US
+#define CONFIG_GNRC_GOMACH_VTDMA_SLOT_SIZE_US        (5U * US_PER_MS)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -57,11 +57,11 @@ extern "C" {
  * @brief The default duration of GoMacH's wake-up period (WP).
  *
  * GoMacH adopts the duty-cycle scheme that, by default, a node only wakes up
- * for a short period of @ref CONFIG_GNRC_GOMACH_CP_DURATION_US in each cycle. In the
- * rest of the cycle (except vTDMA), the node turns off the radio  to conserve
- * power. @ref CONFIG_GNRC_GOMACH_CP_DURATION_US should be at least longer than
- * @ref GNRC_GOMACH_MAX_PREAM_INTERVAL_US, thus to guarantee that the receiver
- * will not miss the preamble packet.
+ * for a short period of @ref CONFIG_GNRC_GOMACH_CP_DURATION_US in each cycle.
+ * In the rest of the cycle (except vTDMA), the node turns off the radio  to
+ * conserve power. @ref CONFIG_GNRC_GOMACH_CP_DURATION_US should be at least
+ * longer than @ref CONFIG_GNRC_GOMACH_MAX_PREAM_INTERVAL_US, thus to guarantee
+ * that the receiver will not miss the preamble packet.
  */
 #ifndef CONFIG_GNRC_GOMACH_CP_DURATION_US
 #define CONFIG_GNRC_GOMACH_CP_DURATION_US        (10U * US_PER_MS)
@@ -194,8 +194,8 @@ extern "C" {
  * wake-up phase (WP), if the receiver's WP is unknown. This macro defines the
  * maximum time interval between twoconsecutive preamble packets.
  */
-#ifndef GNRC_GOMACH_MAX_PREAM_INTERVAL_US
-#define GNRC_GOMACH_MAX_PREAM_INTERVAL_US        (6U * US_PER_MS)
+#ifndef CONFIG_GNRC_GOMACH_MAX_PREAM_INTERVAL_US
+#define CONFIG_GNRC_GOMACH_MAX_PREAM_INTERVAL_US        (6U * US_PER_MS)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -316,12 +316,12 @@ extern "C" {
  * procedure to transmit packet to the phase-known device. However, due to
  * factors like timer driftor busy-channel, a transmission attempt may fail
  * in t2k. If the t2k failure count has reached this
- * @ref GNRC_GOMACH_REPHASELOCK_THRESHOLD, the sender regards phase-locked
- * failed due to timer drift. In this case, it will adopt t2u
+ * @ref CONFIG_GNRC_GOMACH_REPHASELOCK_THRESHOLD, the sender regards
+ * phase-locked failed due to timer drift. In this case, it will adopt t2u
  * (transmit-to-unknown) procedure to get re-phase-locked with the receiver.
  */
-#ifndef GNRC_GOMACH_REPHASELOCK_THRESHOLD
-#define GNRC_GOMACH_REPHASELOCK_THRESHOLD      (4U)
+#ifndef CONFIG_GNRC_GOMACH_REPHASELOCK_THRESHOLD
+#define CONFIG_GNRC_GOMACH_REPHASELOCK_THRESHOLD      (4U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -159,8 +159,8 @@ extern "C" {
  * finds its wake-up phase too closed to its receiver's, it will randomly
  * select a new phase for itself.
  */
-#ifndef GNRC_GOMACH_CP_MIN_GAP_US
-#define GNRC_GOMACH_CP_MIN_GAP_US        (25U * US_PER_MS)
+#ifndef CONFIG_GNRC_GOMACH_CP_MIN_GAP_US
+#define CONFIG_GNRC_GOMACH_CP_MIN_GAP_US        (25U * US_PER_MS)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -261,13 +261,13 @@ extern "C" {
  *
  * Senders in GoMacH adopt CSMA scheme to send data packets in the WP period of
  * the receiver. In case of having medium-busy feedback in WP and the TX failure
- * count (due to busy) is below @ref GNRC_GOMACH_TX_BUSY_THRESHOLD, the sender
- * continue to send the packet with CSMAin the receiver's WP, with the
- * consideration that there may be multi-senderssimultaneously competing in WP
+ * count (due to busy) is below @ref CONFIG_GNRC_GOMACH_TX_BUSY_THRESHOLD, the
+ * sender continue to send the packet with CSMAin the receiver's WP, with the
+ * consideration that there may be multi-senders simultaneously competing in WP
  * and the WP will be continuously extended (thus the packet can be received).
  */
-#ifndef GNRC_GOMACH_TX_BUSY_THRESHOLD
-#define GNRC_GOMACH_TX_BUSY_THRESHOLD      (5U)
+#ifndef CONFIG_GNRC_GOMACH_TX_BUSY_THRESHOLD
+#define CONFIG_GNRC_GOMACH_TX_BUSY_THRESHOLD      (5U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -222,8 +222,8 @@ extern "C" {
  * neighbors will get a copy. This macro defines the time interval between
  * ending two consecutive broadcast copies.
  */
-#ifndef GNRC_GOMACH_BCAST_INTERVAL_US
-#define GNRC_GOMACH_BCAST_INTERVAL_US        (1U * US_PER_MS)
+#ifndef CONFIG_GNRC_GOMACH_BCAST_INTERVAL_US
+#define CONFIG_GNRC_GOMACH_BCAST_INTERVAL_US        (1U * US_PER_MS)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -342,12 +342,12 @@ extern "C" {
  * After a long period of run time, a radio may be in wrong condition which
  * needs to be re-calibrated. This is indicated by having a series of
  * continuous t2u failures (no preambleACK) in GoMacH. In case we have
- * @ref GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD number of t2u failures, then
+ * @ref CONFIG_GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD number of t2u failures, then
  * we re-initiate the radio, trying to re-calibrate the radio for bringing it
  * back to normal condition.
  */
-#ifndef GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD
-#define GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD          (10U)
+#ifndef CONFIG_GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD
+#define CONFIG_GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD          (10U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -57,14 +57,14 @@ extern "C" {
  * @brief The default duration of GoMacH's wake-up period (WP).
  *
  * GoMacH adopts the duty-cycle scheme that, by default, a node only wakes up
- * for a short period of @ref GNRC_GOMACH_CP_DURATION_US in each cycle. In the
+ * for a short period of @ref CONFIG_GNRC_GOMACH_CP_DURATION_US in each cycle. In the
  * rest of the cycle (except vTDMA), the node turns off the radio  to conserve
- * power. @ref GNRC_GOMACH_CP_DURATION_US should be at least longer than
+ * power. @ref CONFIG_GNRC_GOMACH_CP_DURATION_US should be at least longer than
  * @ref GNRC_GOMACH_MAX_PREAM_INTERVAL_US, thus to guarantee that the receiver
  * will not miss the preamble packet.
  */
-#ifndef GNRC_GOMACH_CP_DURATION_US
-#define GNRC_GOMACH_CP_DURATION_US        (10U * US_PER_MS)
+#ifndef CONFIG_GNRC_GOMACH_CP_DURATION_US
+#define CONFIG_GNRC_GOMACH_CP_DURATION_US        (10U * US_PER_MS)
 #endif
 
 /**
@@ -83,8 +83,9 @@ extern "C" {
  * beginning of a cycle.
  *
  * @note GoMacH's superframe duration @ref GNRC_GOMACH_SUPERFRAME_DURATION_US
- * should not be shorter than 10 times of @ref GNRC_GOMACH_CP_DURATION_US and
- * not shorter than the RTT tickle interval.
+ * should not be shorter than 10 times of
+ * @ref CONFIG_GNRC_GOMACH_CP_DURATION_US and not shorter than the RTT tickle
+ * interval.
  */
 #ifndef GNRC_GOMACH_SUPERFRAME_DURATION_US
 #define GNRC_GOMACH_SUPERFRAME_DURATION_US        (300LU * US_PER_MS)
@@ -94,12 +95,12 @@ extern "C" {
 #error "RTT_FREQUENCY undefined."
 #else
 #if ((GNRC_GOMACH_SUPERFRAME_DURATION_US < ((1000LU *US_PER_MS) / RTT_FREQUENCY)) || \
-     (GNRC_GOMACH_SUPERFRAME_DURATION_US < (10 *GNRC_GOMACH_CP_DURATION_US)))
+     (GNRC_GOMACH_SUPERFRAME_DURATION_US < (10 * CONFIG_GNRC_GOMACH_CP_DURATION_US)))
 #undef GNRC_GOMACH_SUPERFRAME_DURATION_US
-#if (((1000LU *US_PER_MS) / RTT_FREQUENCY) > (10 * GNRC_GOMACH_CP_DURATION_US))
+#if (((1000LU *US_PER_MS) / RTT_FREQUENCY) > (10 * CONFIG_GNRC_GOMACH_CP_DURATION_US))
 #define GNRC_GOMACH_SUPERFRAME_DURATION_US        ((1000LU * US_PER_MS) / RTT_FREQUENCY)
 #else
-#define GNRC_GOMACH_SUPERFRAME_DURATION_US        (10 * GNRC_GOMACH_CP_DURATION_US)
+#define GNRC_GOMACH_SUPERFRAME_DURATION_US        (10 * CONFIG_GNRC_GOMACH_CP_DURATION_US)
 #endif
 #endif
 #endif
@@ -109,9 +110,10 @@ extern "C" {
  *        wake-up period (WP).
  *
  * Currently, GoMacH's WP is actually composed of
- * @ref GNRC_GOMACH_CP_DURATION_US and (+) @ref GNRC_GOMACH_CP_RANDOM_END_US.
- * We currently introduced this random period to avoid beacon collision among
- * neighbor nodes. This macro may be removed in the future.
+ * @ref CONFIG_GNRC_GOMACH_CP_DURATION_US and (+)
+ * @ref GNRC_GOMACH_CP_RANDOM_END_US. We currently introduced this random
+ * period to avoid beacon collision amongneighbor nodes. This macro may be
+ * removed in the future.
  */
 #ifndef GNRC_GOMACH_CP_RANDOM_END_US
 #define GNRC_GOMACH_CP_RANDOM_END_US        (1U * US_PER_MS)
@@ -129,7 +131,7 @@ extern "C" {
  * reaches this @ref GNRC_GOMACH_CP_DURATION_MAX_US duration.
  */
 #ifndef GNRC_GOMACH_CP_DURATION_MAX_US
-#define GNRC_GOMACH_CP_DURATION_MAX_US        (5LU * GNRC_GOMACH_CP_DURATION_US)
+#define GNRC_GOMACH_CP_DURATION_MAX_US (5LU * CONFIG_GNRC_GOMACH_CP_DURATION_US)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -300,13 +300,13 @@ extern "C" {
  *
  * Exclude the static GoMacH MAC header payload in the beacon, which is 20
  * bytes, we have 107 bytes left for constructing the sender-ID list and the
- * related slots-numberlist. A combined slots allocation information pair
+ * related slots-number list. A combined slots allocation information pair
  * (sender ID with its corresponded allocate slots number) will cost 9 (8+1)
  * bytes, thus we can hold a maximum of 11 i.e., ((127 - 20) / 9), sender IDs
  * in the beacon.
  */
-#ifndef GNRC_GOMACH_MAX_ALLOC_SENDER_NUM
-#define GNRC_GOMACH_MAX_ALLOC_SENDER_NUM          (11U)
+#ifndef CONFIG_GNRC_GOMACH_MAX_ALLOC_SENDER_NUM
+#define CONFIG_GNRC_GOMACH_MAX_ALLOC_SENDER_NUM          (11U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -70,21 +70,21 @@ extern "C" {
 /**
  * @brief GoMacH's superframe duration, i.e., time between two consecutive wake-ups.
  *
- * This macro governs power consumption and GoMacH's reactiveness to traffic loads.
- * In GoMacH, nodes adopt duty-cycle scheme to conserve power. That is,
- * time is divided into repeated cycles (superframes), and in each
- * cycle, a node only wakes up for a short period of time for receiving potential
+ * This macro governs power consumption and GoMacH's reactiveness to traffic
+ * loads. In GoMacH, nodes adopt duty-cycle scheme to conserve power. That is,
+ * time is divided into repeated cycles (superframes), and in each cycle, a
+ * node only wakes up for a short period of time for receiving potential
  * incoming packets for itself. This macro defines the wake-up interval, or,
  * in other words, defines the cycle duration used in GoMacH. If the wake-up
- *  interval is short, nodes will wake up more frequently, which leads to quicker
- * reactiveness of the MAC protocol for handling packet reception and transmission,
- * but also results in higher power consumption due to more idle listening.
- * In GoMacH, by default, we regard the wake-up period (WP) as the beginning of
- * a cycle.
+ * interval is short, nodes will wake up more frequently, which leads to quicker
+ * reactiveness of the MAC protocol for handling packet reception and
+ * transmission, but also results in higher power consumption due to more idle
+ * listening. In GoMacH, by default, we regard the wake-up period (WP) as the
+ * beginning of a cycle.
  *
- * Note that, GoMacH's superframe duration @ref GNRC_GOMACH_SUPERFRAME_DURATION_US
- * should not be shorter than 10 times of @ref GNRC_GOMACH_CP_DURATION_US and not
- * shorter than the RTT tickle interval.
+ * @note GoMacH's superframe duration @ref GNRC_GOMACH_SUPERFRAME_DURATION_US
+ * should not be shorter than 10 times of @ref GNRC_GOMACH_CP_DURATION_US and
+ * not shorter than the RTT tickle interval.
  */
 #ifndef GNRC_GOMACH_SUPERFRAME_DURATION_US
 #define GNRC_GOMACH_SUPERFRAME_DURATION_US        (300LU * US_PER_MS)
@@ -108,10 +108,10 @@ extern "C" {
  * @brief The maximum duration of the random period at the end of GoMacH's
  *        wake-up period (WP).
  *
- * Currently, GoMacH's WP is actually composed of @ref GNRC_GOMACH_CP_DURATION_US
- * and (+) @ref GNRC_GOMACH_CP_RANDOM_END_US. We currently introduced this random
- * period to avoid beacon collision among neighbor nodes. This macro may be removed
- * in the future.
+ * Currently, GoMacH's WP is actually composed of
+ * @ref GNRC_GOMACH_CP_DURATION_US and (+) @ref GNRC_GOMACH_CP_RANDOM_END_US.
+ * We currently introduced this random period to avoid beacon collision among
+ * neighbor nodes. This macro may be removed in the future.
  */
 #ifndef GNRC_GOMACH_CP_RANDOM_END_US
 #define GNRC_GOMACH_CP_RANDOM_END_US        (1U * US_PER_MS)
@@ -123,10 +123,10 @@ extern "C" {
  * @ref GNRC_GOMACH_CP_DURATION_MAX_US defines the allowed maximum duration
  * of GoMacH's WP period. A node will quit WP once it reaches this maximum
  * duration.
- * Note that, in GoMacH's WP, after each normal packet reception (except
- * broadcast packet), a receiver will automatically extends the WP period
- * (reset WP timeout), to receiver more potential incoming packets, before
- * WP reaches this @ref GNRC_GOMACH_CP_DURATION_MAX_US duration.
+ * @note In GoMacH's WP, after each normal packet reception (except broadcast
+ * packet), a receiver will automatically extends the WP period (reset WP
+ * timeout), to receiver more potential incoming packets, before WP
+ * reaches this @ref GNRC_GOMACH_CP_DURATION_MAX_US duration.
  */
 #ifndef GNRC_GOMACH_CP_DURATION_MAX_US
 #define GNRC_GOMACH_CP_DURATION_MAX_US        (5LU * GNRC_GOMACH_CP_DURATION_US)
@@ -135,9 +135,9 @@ extern "C" {
 /**
  * @brief The maximum time for waiting the receiver's beacon in GoMacH.
  *
- * After transmissions in the WP, if the sender still has pending packets
- * for the receiver, it will wait for the receiver's incoming beacon that
- * allocates dynamic transmission slots to it. @ref GNRC_GOMACH_WAIT_BEACON_TIME_US
+ * After transmissions in the WP, if the sender still has pending packets for
+ * the receiver, it will wait for the receiver's incoming beacon that allocates
+ * dynamic transmission slots to it. @ref GNRC_GOMACH_WAIT_BEACON_TIME_US
  * defines the maximum waiting time for the beacon. Once the beacon-waiting
  * timeout expires, the sender will quit the vTMDA (slotted transmission)
  * procedure, and restarts transmissions (started with normal CSMA attempts
@@ -151,8 +151,8 @@ extern "C" {
 /**
  * @brief The minimum gap between neighbor nodes' wake-up phases in GoMacH.
  *
- * To reduce beacon collisions and transmission collisions, GoMacH intends
- * to avoid neighbor nodes' phases being too close to each other. This macro
+ * To reduce beacon collisions and transmission collisions, GoMacH intends to
+ * avoid neighbor nodes' phases being too close to each other. This macro
  * defines the minimum gap between two nodes's wake-up phases. If the sender
  * finds its wake-up phase too closed to its receiver's, it will randomly
  * select a new phase for itself.
@@ -176,10 +176,10 @@ extern "C" {
 /**
  * @brief Timeout duration for confirming TX-No-ISR event in GoMacH.
  *
- * This macro is used to confirm/catch a case that a transmission doesn't have its
- * @ref NETDEV_EVENT_TX_COMPLETE interrupt event, which is considered as a hardware
- * abnormal event. Upon this timeout expiration, GoMach will accordingly take
- *  actions to maintain its state-machine.
+ * This macro is used to confirm/catch a case that a transmission doesn't have
+ * its @ref NETDEV_EVENT_TX_COMPLETE interrupt event, which is considered as a
+ * hardware abnormal event. Upon this timeout expiration, GoMach will
+ * accordingly take actions to maintain its state-machine.
  */
 #ifndef GNRC_GOMACH_NO_TX_ISR_US
 #define GNRC_GOMACH_NO_TX_ISR_US          (50U * US_PER_MS)
@@ -188,9 +188,9 @@ extern "C" {
 /**
  * @brief Maximum time interval between two consecutive preamble packets in GoMacH.
  *
- * In GoMacH, a sender first uses preamble stream to track the receiver's wake-up
- * phase (WP), if the receiver's WP is unknown. This macro defines the maximum
- * time interval between twoconsecutive preamble packets.
+ * In GoMacH, a sender first uses preamble stream to track the receiver's
+ * wake-up phase (WP), if the receiver's WP is unknown. This macro defines the
+ * maximum time interval between twoconsecutive preamble packets.
  */
 #ifndef GNRC_GOMACH_MAX_PREAM_INTERVAL_US
 #define GNRC_GOMACH_MAX_PREAM_INTERVAL_US        (6U * US_PER_MS)
@@ -232,8 +232,8 @@ extern "C" {
  * To ensure that the receiver will catch at least one preamble packet
  * in a critical case that one public channel is jammed, the sender repeatedly
  * broadcasts a stream of preamble packets with the broadcast duration
- * (preamble duration) slightly longer than twice
- * of @ref GNRC_GOMACH_SUPERFRAME_DURATION_US.
+ * (preamble duration) slightly longer than twice of
+ * @ref GNRC_GOMACH_SUPERFRAME_DURATION_US.
  */
 #ifndef GNRC_GOMACH_PREAMBLE_DURATION_US
 #define GNRC_GOMACH_PREAMBLE_DURATION_US        (21LU * GNRC_GOMACH_SUPERFRAME_DURATION_US / 10)
@@ -242,9 +242,9 @@ extern "C" {
 /**
  * @brief The transmission slot size in GoMacH.
  *
- * GoMacH adopts dynamic slots allocation scheme to allocate transmission
- * slots to senders that have pending packets. Each slot is for one data packet
- * with ACK transmission. @ref GNRC_GOMACH_VTDMA_SLOT_SIZE_US is right sufficient
+ * GoMacH adopts dynamic slots allocation scheme to allocate transmission slots
+ * to senders that have pending packets. Each slot is for one data packet with
+ * ACK transmission. @ref GNRC_GOMACH_VTDMA_SLOT_SIZE_US is right sufficient
  * for the transmission of the longest packet in IEEE 802.15.4 with ACK. Should
  * not be changed.
  */
@@ -259,9 +259,9 @@ extern "C" {
  * Senders in GoMacH adopt CSMA scheme to send data packets in the WP period of
  * the receiver. In case of having medium-busy feedback in WP and the TX failure
  * count (due to busy) is below @ref GNRC_GOMACH_TX_BUSY_THRESHOLD, the sender
- * continue to send the packet with CSMAin the receiver's WP, with the consideration
- * that there may be multi-senderssimultaneously competing in WP and the WP will
- * be continuously extended (thus the packet can be received).
+ * continue to send the packet with CSMAin the receiver's WP, with the
+ * consideration that there may be multi-senderssimultaneously competing in WP
+ * and the WP will be continuously extended (thus the packet can be received).
  */
 #ifndef GNRC_GOMACH_TX_BUSY_THRESHOLD
 #define GNRC_GOMACH_TX_BUSY_THRESHOLD      (5U)
@@ -295,11 +295,12 @@ extern "C" {
 /**
  * @brief Maximum number of senders allowed to be allocated slots in one cycle.
  *
- * Exclude the static GoMacH MAC header payload in the beacon, which is 20 bytes,
- * we have 107 bytes left for constructing the sender-ID list and the related slots-number
- * list. A combined slots allocation information pair (sender ID with its corresponded
- * allocate slots number) will cost 9 (8+1) bytes, thus we can hold a maximum of 11
- * i.e., ((127 - 20) / 9), sender IDs in the beacon.
+ * Exclude the static GoMacH MAC header payload in the beacon, which is 20
+ * bytes, we have 107 bytes left for constructing the sender-ID list and the
+ * related slots-numberlist. A combined slots allocation information pair
+ * (sender ID with its corresponded allocate slots number) will cost 9 (8+1)
+ * bytes, thus we can hold a maximum of 11 i.e., ((127 - 20) / 9), sender IDs
+ * in the beacon.
  */
 #ifndef GNRC_GOMACH_MAX_ALLOC_SENDER_NUM
 #define GNRC_GOMACH_MAX_ALLOC_SENDER_NUM          (11U)
@@ -312,9 +313,9 @@ extern "C" {
  * procedure to transmit packet to the phase-known device. However, due to
  * factors like timer driftor busy-channel, a transmission attempt may fail
  * in t2k. If the t2k failure count has reached this
- * @ref GNRC_GOMACH_REPHASELOCK_THRESHOLD, the sender regards phase-locked failed
- * due to timer drift. In this case, it will adopt t2u (transmit-to-unknown)
- *  procedure to get re-phase-locked with the receiver.
+ * @ref GNRC_GOMACH_REPHASELOCK_THRESHOLD, the sender regards phase-locked
+ * failed due to timer drift. In this case, it will adopt t2u
+ * (transmit-to-unknown) procedure to get re-phase-locked with the receiver.
  */
 #ifndef GNRC_GOMACH_REPHASELOCK_THRESHOLD
 #define GNRC_GOMACH_REPHASELOCK_THRESHOLD      (4U)
@@ -323,10 +324,10 @@ extern "C" {
 /**
  * @brief Maximum t2u attempts before dropping data packet in GoMacH.
  *
- * In case the receiver's phase is unknown to the sender, the sender adopts
- * the t2u (transmit-to-unknown) procedure to get phase-locked with the
- * receiver. This macrodefines the maximum t2u attempts before dropping the
- * data packet in GoMacH.
+ * In case the receiver's phase is unknown to the sender, the sender adopts the
+ * t2u (transmit-to-unknown) procedure to get phase-locked with the receiver.
+ * This macro defines the maximum t2u attempts before dropping the data packet
+ * in GoMacH.
  */
 #ifndef GNRC_GOMACH_T2U_RETYR_THRESHOLD
 #define GNRC_GOMACH_T2U_RETYR_THRESHOLD      (2U)
@@ -337,9 +338,9 @@ extern "C" {
  *
  * After a long period of run time, a radio may be in wrong condition which
  * needs to be re-calibrated. This is indicated by having a series of
- * continuous t2u failures (no preambleACK) in GoMacH. In cast we have
- * @ref GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD number of t2u failures, then we
- * re-initiate the radio, trying to re-calibrate the radio for bringing it
+ * continuous t2u failures (no preambleACK) in GoMacH. In case we have
+ * @ref GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD number of t2u failures, then
+ * we re-initiate the radio, trying to re-calibrate the radio for bringing it
  * back to normal condition.
  */
 #ifndef GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD
@@ -367,6 +368,8 @@ extern "C" {
 #ifndef GNRC_GOMACH_IPC_MSG_QUEUE_SIZE
 #define GNRC_GOMACH_IPC_MSG_QUEUE_SIZE  (1 << CONFIG_GNRC_GOMACH_IPC_MSG_QUEUE_SIZE_EXP)
 #endif
+/** @} */
+
 
 /**
  * @brief   Creates an IEEE 802.15.4 GoMacH network interface

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -168,11 +168,11 @@ extern "C" {
  *
  * Sometimes in GoMacH, if a node finds RX ongoing when it is just about to
  * enter the next MAC state, it will set up a timeout for waiting this packet
- * reception complete with a timeout of this @ref GNRC_GOMACH_WAIT_RX_END_US
- * duration.
+ * reception complete with a timeout of this
+ * @ref CONFIG_GNRC_GOMACH_WAIT_RX_END_US duration.
  */
-#ifndef GNRC_GOMACH_WAIT_RX_END_US
-#define GNRC_GOMACH_WAIT_RX_END_US        (6U * US_PER_MS)
+#ifndef CONFIG_GNRC_GOMACH_WAIT_RX_END_US
+#define CONFIG_GNRC_GOMACH_WAIT_RX_END_US        (6U * US_PER_MS)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -111,12 +111,12 @@ extern "C" {
  *
  * Currently, GoMacH's WP is actually composed of
  * @ref CONFIG_GNRC_GOMACH_CP_DURATION_US and (+)
- * @ref GNRC_GOMACH_CP_RANDOM_END_US. We currently introduced this random
- * period to avoid beacon collision amongneighbor nodes. This macro may be
+ * @ref CONFIG_GNRC_GOMACH_CP_RANDOM_END_US. We currently introduced this random
+ * period to avoid beacon collision among neighbor nodes. This macro may be
  * removed in the future.
  */
-#ifndef GNRC_GOMACH_CP_RANDOM_END_US
-#define GNRC_GOMACH_CP_RANDOM_END_US        (1U * US_PER_MS)
+#ifndef CONFIG_GNRC_GOMACH_CP_RANDOM_END_US
+#define CONFIG_GNRC_GOMACH_CP_RANDOM_END_US        (1U * US_PER_MS)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -291,8 +291,8 @@ extern "C" {
  * check-duplicate-packet data unit's life time in cycle count. Once expired,
  * the related data unit will be reset. This macro maybe removed in the future.
  */
-#ifndef GNRC_GOMACH_RX_DUPCHK_UNIT_LIFE
-#define GNRC_GOMACH_RX_DUPCHK_UNIT_LIFE            (30U)
+#ifndef CONFIG_GNRC_GOMACH_RX_DUPCHK_UNIT_LIFE
+#define CONFIG_GNRC_GOMACH_RX_DUPCHK_UNIT_LIFE            (30U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -332,8 +332,8 @@ extern "C" {
  * This macro defines the maximum t2u attempts before dropping the data packet
  * in GoMacH.
  */
-#ifndef GNRC_GOMACH_T2U_RETYR_THRESHOLD
-#define GNRC_GOMACH_T2U_RETYR_THRESHOLD      (2U)
+#ifndef CONFIG_GNRC_GOMACH_T2U_RETYR_THRESHOLD
+#define CONFIG_GNRC_GOMACH_T2U_RETYR_THRESHOLD      (2U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -202,15 +202,15 @@ extern "C" {
  * @brief Time interval between two consecutive preamble packets in GoMacH.
  *
  * In GoMacH, after a preamble is sent, the sender sets a timeout with
- * @ref GNRC_GOMACH_PREAMBLE_INTERVAL_US duration for waiting to send the next
- * preamble. Notably, this macro is with a very small value. In GoMacH, for
- * receiving the preamble-ACK packet, the sender doesn't wait for the whole
- * reception of the preamble-ACK. Instead, it only waits for the
+ * @ref CONFIG_GNRC_GOMACH_PREAMBLE_INTERVAL_US duration for waiting to send
+ * the next preamble. Notably, this macro is with a very small value. In
+ * GoMacH, for receiving the preamble-ACK packet, the sender doesn't wait for
+ * the whole reception of the preamble-ACK. Instead, it only waits for the
  * @ref NETDEV_EVENT_RX_STARTED event which leads to shorter time interval
  * between two consecutive preamble transmissions.
  */
-#ifndef GNRC_GOMACH_PREAMBLE_INTERVAL_US
-#define GNRC_GOMACH_PREAMBLE_INTERVAL_US        (2U * US_PER_MS)
+#ifndef CONFIG_GNRC_GOMACH_PREAMBLE_INTERVAL_US
+#define CONFIG_GNRC_GOMACH_PREAMBLE_INTERVAL_US        (2U * US_PER_MS)
 #endif
 
 /**

--- a/sys/net/gnrc/Kconfig
+++ b/sys/net/gnrc/Kconfig
@@ -8,6 +8,7 @@ menu "GNRC Network stack"
     depends on MODULE_GNRC
 
 rsource "application_layer/dhcpv6/Kconfig"
+rsource "link_layer/gomach/Kconfig"
 rsource "link_layer/lorawan/Kconfig"
 rsource "link_layer/mac/Kconfig"
 rsource "netif/Kconfig"

--- a/sys/net/gnrc/link_layer/gomach/Kconfig
+++ b/sys/net/gnrc/link_layer/gomach/Kconfig
@@ -1,0 +1,227 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_GNRC_GOMACH
+    bool "Configure GNRC GOMACH"
+    depends on MODULE_GNRC_GOMACH
+    help
+        Configure the GNRC GOMACH using Kconfig.
+
+if KCONFIG_MODULE_GNRC_GOMACH
+
+config GNRC_GOMACH_CP_DURATION_US
+    int "Wake-up period (WP) duration in microseconds"
+    default 10000
+    help
+        Configure 'CONFIG_GNRC_GOMACH_CP_DURATION_US'. GoMacH adopts the
+        duty-cycle scheme that, by default, a node only wakes up for a short
+        period of 'CONFIG_GNRC_GOMACH_CP_DURATION_US' in each cycle. In the
+        rest of the cycle (except vTDMA), the node turns off the radio  to
+        conserve power. 'CONFIG_GNRC_GOMACH_CP_DURATION_US' should be at least
+        longer than 'CONFIG_GNRC_GOMACH_MAX_PREAM_INTERVAL_US', thus to
+        guarantee that the receiver will not miss the preamble packet.
+
+config GNRC_GOMACH_SUPERFRAME_DURATION_US
+    int "Duration of superframe in microseconds"
+    default 300000
+    help
+        Configure 'CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US' ,superframe
+        duration, i.e , time between two consecutive wake-ups.
+        The configurations should not be shorter than 10 times of
+        'CONFIG_GNRC_GOMACH_CP_DURATION_US' and not shorter than the RTT tickle
+        interval.This configuration governs power consumption and GoMacH's
+        reactiveness to traffic loads.In GoMacH, nodes adopt duty-cycle scheme
+        to conserve power. That is, time is divided into repeated cycles
+        (superframes), and in each cycle, a node only wakes up for a short
+        period of time for receiving potential incoming packets for itself.
+        This configuration defines the wake-up interval, or, in other words,
+        defines the cycle duration used in GoMacH. For more information refer
+        file 'gomach.h' in sys/include/net/gnrc.
+
+config GNRC_GOMACH_CP_RANDOM_END_US
+    int "Duration of random period at the end of WP in microseconds"
+    default 1000
+    help
+        Configure 'CONFIG_GNRC_GOMACH_CP_RANDOM_END_US', the maximum duration
+        of the random period at the end of GoMacH's wake-up period (WP).
+        Currently, GoMacH's WP is composed of
+        'CONFIG_GNRC_GOMACH_CP_DURATION_US' and (+)
+        'CONFIG_GNRC_GOMACH_CP_RANDOM_END_US'. This random was introduced
+        to avoid beacon collision among neighbor nodes. This configuration may
+        be removed in the future.
+
+config GNRC_GOMACH_CP_MIN_GAP_US
+    int "Time interval between neighbor nodes' Wake-up phases in microseconds"
+    default 25000
+    help
+        Configure 'CONFIG_GNRC_GOMACH_CP_MIN_GAP_US', the minimum gap between
+        neighbor nodes' wake-up phases in GoMacH.To reduce beacon collisions
+        and transmission collisions, GoMacH intends to avoid neighbor nodes'
+        phases  being too close to each other. This configuration defines the
+        minimum gap between two nodes's wake-up phases. If the sender finds its
+        wake-up phase too closed to its receiver's, it will randomly select a
+        new phase for itself.
+
+config GNRC_GOMACH_WAIT_RX_END_US
+    int "Timeout for 'NETDEV_EVENT_RX_COMPLETE' in GoMacH in microseconds"
+    default 6000
+    help
+        Configure 'CONFIG_GNRC_GOMACH_WAIT_RX_END_US', the timeout duration for
+        waiting 'NETDEV_EVENT_RX_COMPLETE' event in GoMacH. Sometimes in
+        GoMacH, if a node finds RX ongoing when it is just about to enter the
+        next MAC state, it will set up a timeout for waiting this packet
+        reception complete with a timeout of this
+        'CONFIG_GNRC_GOMACH_WAIT_RX_END_US' duration.
+
+config GNRC_GOMACH_NO_TX_ISR_US
+    int "Timeout duration for confirming TX-No-ISR event in microseconds"
+    default 50000
+    help
+        Configure 'CONFIG_GNRC_GOMACH_NO_TX_ISR_US',the timeout duration for
+        confirming TX-No-ISR event in GoMacH. This configuration is used to
+        confirm/catch a case that a transmission doesn't have its
+        'NETDEV_EVENT_TX_COMPLETE' interrupt event, which is considered as a
+        hardware abnormal event. Upon this timeout expiration, GoMach will
+        accordingly take actions to maintain its state-machine.
+
+config GNRC_GOMACH_MAX_PREAM_INTERVAL_US
+    int "Maximum time interval between two preamble packets in microseconds"
+    default 6000
+    help
+        Configure 'CONFIG_GNRC_GOMACH_MAX_PREAM_INTERVAL_US',the maximum time
+        interval between two consecutive preamble packets in GoMacH. In GoMacH,
+        a sender first uses preamble stream to track the receiver's wake-up
+        phase (WP), if the receiver's WP is unknown. This configuration defines
+        the maximum time interval between twoconsecutive preamble packets.
+
+config GNRC_GOMACH_PREAMBLE_INTERVAL_US
+    int "Time interval between two preamble packets in microseconds"
+    default 2000
+    help
+        Configure 'CONFIG_GNRC_GOMACH_PREAMBLE_INTERVAL_US', the time interval
+        between two consecutive preamble packets in GoMacH. In GoMacH, after a
+        preamble is sent, the sender sets a timeout with
+        'CONFIG_GNRC_GOMACH_PREAMBLE_INTERVAL_US' duration for waiting to send
+        the next preamble. Notably, this configuration is with a very small
+        value. In GoMacH, for receiving the preamble-ACK packet, the sender
+        doesn't wait for the whole reception of the preamble-ACK. Instead, it
+        only waits for the 'NETDEV_EVENT_RX_STARTED' event which leads to
+        shorter time interval between two consecutive preamble transmissions.
+
+config GNRC_GOMACH_BCAST_INTERVAL_US
+    int "Time interval between two broadcast packets in microseconds"
+    default 1000
+    help
+        Configure 'CONFIG_GNRC_GOMACH_BCAST_INTERVAL_US', the time interval
+        between two consecutive broadcast packets in GoMacH. In GoMacH, when
+        sending a broadcast packet, the sender broadcasts the same packet frame
+        on its two public channels simultaneously, with a total duration of
+        'CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US' to guarantee that all
+        neighbors will get a copy. This configuration defines the time interval
+        between ending two consecutive broadcast copies.
+
+config GNRC_GOMACH_VTDMA_SLOT_SIZE_US
+    int "Transmission slot size in microseconds **Should not be changed**"
+    default 5000
+    help
+        Configure 'CONFIG_GNRC_GOMACH_VTDMA_SLOT_SIZE_US', the transmission slot
+        size in GoMacH. GoMacH adopts dynamic slots allocation scheme to
+        allocate transmission slots to senders that have pending packets. Each
+        slot is for one data packet with ACK transmission.
+        'CONFIG_GNRC_GOMACH_VTDMA_SLOT_SIZE_US' is right sufficient for the
+        transmission of the longest packet in IEEE 802.15.4 with ACK. Should
+        not be changed.
+
+config GNRC_GOMACH_TX_BUSY_THRESHOLD
+    int "Maximum number of CSMA TX attempts under busy-indication in the WP"
+    default 5
+    help
+        Configure 'CONFIG_GNRC_GOMACH_TX_BUSY_THRESHOLD', maximum number of
+        CSMA TX attempts under busy-indication in the WP period of the receiver.
+        Senders in GoMacH adopt CSMA scheme to send data packets in the WP
+        period of the receiver. In case of having medium-busy feedback in WP
+        and the TX failure count (due to busy) is below
+        'CONFIG_GNRC_GOMACH_TX_BUSY_THRESHOLD', the sender continue to send the
+        packet with CSMAin the receiver's WP, with the consideration that there
+        may be multi-senders simultaneously competing in WP and the WP will be
+        continuously extended (thus the packet can be received).
+
+config GNRC_GOMACH_CP_EXTEND_THRESHOLD
+    int "Maximum WP period extension number"
+    default 5
+    help
+        Configure 'CONFIG_GNRC_GOMACH_CP_EXTEND_THRESHOLD', maximum WP period
+        extension number in GoMacH. The WP period of a receiver will be
+        extended upon each successful packet reception (except receiving
+        broadcast or preamble packet) to receive more potential incoming
+        packets.
+
+config GNRC_GOMACH_RX_DUPCHK_UNIT_LIFE
+    int "Life time of check-duplicate-packet in cycle count"
+    default 30
+    help
+        Configure 'CONFIG_GNRC_GOMACH_RX_DUPCHK_UNIT_LIFE', GoMacH's
+        check-duplicate-packet unit life time in cycle count. In GoMacH, to
+        avoid receiving duplicate-packet, we currently introduce a data type of
+        'gnrc_gomach_dupchk_unit_t' to record the recent senders' information
+        (especially MAC TX sequence). This configuration defines the
+        check-duplicate-packet data unit's life time in cycle count. Once
+        expired, the related data unit will be reset. This configuration maybe
+        removed in the future.
+
+config GNRC_GOMACH_MAX_ALLOC_SENDER_NUM
+    int "Maximum number of senders allowed to be allocated slots in one cycle"
+    default 11
+    help
+        Configure 'CONFIG_GNRC_GOMACH_MAX_ALLOC_SENDER_NUM', maximum number of
+        senders allowed to be allocated slots in one cycle. Exclude the static
+        GoMacH MAC header payload in the beacon, which is 20 bytes, we have 107
+        bytes left for constructing the sender-ID list and the related
+        slots-number list. A combined slots allocation information pair (sender
+        ID with its corresponded allocate slots number) will cost 9 (8+1)
+        bytes, thus we can hold a maximum of 11 i.e., ((127 - 20) / 9), sender
+        IDs in the beacon.
+
+config GNRC_GOMACH_REPHASELOCK_THRESHOLD
+    int "Maximum number of t2k attempts before t2u"
+    default 4
+    help
+        Configure 'CONFIG_GNRC_GOMACH_REPHASELOCK_THRESHOLD', maximum t2k
+        attempts before going to t2u in GoMacH.After phase-locked with the
+        receiver, a sender runs a t2k (transmit-to-known) procedure to transmit
+        packet to the phase-known device. However, due to factors like timer
+        driftor busy-channel, a transmission attempt may fail in t2k. If the
+        t2k failure count has reached this
+        'CONFIG_GNRC_GOMACH_REPHASELOCK_THRESHOLD', the sender regards
+        phase-locked failed due to timer drift. In this case, it will adopt t2u
+        (transmit-to-unknown) procedure to get re-phase-locked with the
+        receiver.
+
+config GNRC_GOMACH_T2U_RETYR_THRESHOLD
+    int "Maximum number of t2u attempts before dropping data packet"
+    default 2
+    help
+        Configure 'CONFIG_GNRC_GOMACH_T2U_RETYR_THRESHOLD', maximum number of
+        t2u attempts before dropping data packet in GoMacH. In case the
+        receiver's phase is unknown to the sender, the sender adopts the t2u
+        (transmit-to-unknown) procedure to get phase-locked with the receiver.
+        This configuration defines the maximum t2u attempts before dropping the
+        data packet in GoMacH.
+
+config GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD
+    int "Maximum t2u attempts before re-initiating radio"
+    default 10
+    help
+        Configure 'CONFIG_GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD', maximum number
+        of t2u attempts before re-initiaing radio in GoMacH. After a long
+        period of run time, a radio may be in wrong condition which needs to be
+        re-calibrated. This is indicated by having a series of continuous t2u
+        failures (no preambleACK) in GoMacH. In case we have
+        'CONFIG_GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD' number of t2u failures,
+        then we re-initiate the radio, trying to re-calibrate the radio for
+        bringing it back to normal condition.
+
+endif # KCONFIG_MODULE_GNRC_GOMACH

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -1211,7 +1211,7 @@ static void gomach_t2u_wait_preamble_ack(gnrc_netif_t *netif)
         netif->mac.tx.t2u_retry_counter++;
 
         /* If we reach the maximum t2u retry limit, release the data packet. */
-        if (netif->mac.tx.t2u_retry_counter >= GNRC_GOMACH_T2U_RETYR_THRESHOLD) {
+        if (netif->mac.tx.t2u_retry_counter >= CONFIG_GNRC_GOMACH_T2U_RETYR_THRESHOLD) {
             LOG_DEBUG("[GOMACH] t2u failed: no preamble-ACK.\n");
             netif->mac.tx.t2u_retry_counter = 0;
             netif->mac.tx.t2u_state = GNRC_GOMACH_T2U_END;
@@ -1309,7 +1309,7 @@ static void _t2u_data_tx_fail(gnrc_netif_t *netif)
 {
     netif->mac.tx.t2u_retry_counter++;
     /* If we meet t2u retry limit, release the packet. */
-    if (netif->mac.tx.t2u_retry_counter >= GNRC_GOMACH_T2U_RETYR_THRESHOLD) {
+    if (netif->mac.tx.t2u_retry_counter >= CONFIG_GNRC_GOMACH_T2U_RETYR_THRESHOLD) {
         LOG_DEBUG("[GOMACH] t2u send data failed on channel %d,"
                   " drop packet.\n", netif->mac.tx.current_neighbor->pub_chanseq);
         gnrc_pktbuf_release(netif->mac.tx.packet);

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -193,7 +193,7 @@ static void _gomach_rtt_handler(uint32_t event, gnrc_netif_t *netif)
 
             /* Set next cycle's starting time. */
             uint32_t alarm = netif->mac.prot.gomach.last_wakeup +
-                             RTT_US_TO_TICKS(GNRC_GOMACH_SUPERFRAME_DURATION_US);
+                             RTT_US_TO_TICKS(CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US);
             rtt_set_alarm(alarm, _gomach_rtt_cb, NULL);
 
             /* Update neighbors' public channel phases. */
@@ -241,7 +241,7 @@ static void gomach_bcast_init(gnrc_netif_t *netif)
     }
 
     gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_BCAST_FINISH,
-                            GNRC_GOMACH_SUPERFRAME_DURATION_US);
+                            CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US);
 
     gnrc_priority_pktqueue_flush(&netif->mac.rx.queue);
     netif->mac.tx.bcast_state = GNRC_GOMACH_BCAST_SEND;
@@ -402,7 +402,7 @@ static void gomach_init_prepare(gnrc_netif_t *netif)
     rtt_clear_alarm();
 
     /* Random delay for avoiding the same wake-up phase among devices. */
-    uint32_t random_backoff = random_uint32_range(0, GNRC_GOMACH_SUPERFRAME_DURATION_US);
+    uint32_t random_backoff = random_uint32_range(0, CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US);
     xtimer_usleep(random_backoff);
 
     gnrc_gomach_set_quit_cycle(netif, false);
@@ -463,7 +463,7 @@ static void gomach_t2k_init(gnrc_netif_t *netif)
                                    gnrc_gomach_phase_now(netif);
 
     if (wait_phase_duration < 0) {
-        wait_phase_duration += GNRC_GOMACH_SUPERFRAME_DURATION_US;
+        wait_phase_duration += CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US;
     }
 
     /* Upon several times of t2k failure, we now doubt that the phase-lock may fail due to drift.
@@ -473,7 +473,8 @@ static void gomach_t2k_init(gnrc_netif_t *netif)
      * of the recorded one */
     if (netif->mac.tx.no_ack_counter == (GNRC_GOMACH_REPHASELOCK_THRESHOLD - 2)) {
         if ((uint32_t)wait_phase_duration < CONFIG_GNRC_GOMACH_CP_DURATION_US) {
-            wait_phase_duration = (wait_phase_duration + GNRC_GOMACH_SUPERFRAME_DURATION_US) -
+            wait_phase_duration = (wait_phase_duration +
+                                   CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US) -
                                   CONFIG_GNRC_GOMACH_CP_DURATION_US;
         }
         else {
@@ -484,13 +485,13 @@ static void gomach_t2k_init(gnrc_netif_t *netif)
      *  a little bit, to see if the real phase is behind the original calculated one. */
     if (netif->mac.tx.no_ack_counter == (GNRC_GOMACH_REPHASELOCK_THRESHOLD - 1)) {
         wait_phase_duration = wait_phase_duration + CONFIG_GNRC_GOMACH_CP_DURATION_US;
-        if ((uint32_t)wait_phase_duration > GNRC_GOMACH_SUPERFRAME_DURATION_US) {
-            wait_phase_duration = wait_phase_duration - GNRC_GOMACH_SUPERFRAME_DURATION_US;
+        if ((uint32_t)wait_phase_duration > CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US) {
+            wait_phase_duration = wait_phase_duration - CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US;
         }
     }
 
-    if ((uint32_t)wait_phase_duration > GNRC_GOMACH_SUPERFRAME_DURATION_US) {
-        wait_phase_duration = wait_phase_duration % GNRC_GOMACH_SUPERFRAME_DURATION_US;
+    if ((uint32_t)wait_phase_duration > CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US) {
+        wait_phase_duration = wait_phase_duration % CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US;
     }
     gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_WAIT_CP, (uint32_t)wait_phase_duration);
 
@@ -577,8 +578,7 @@ static void _cp_tx_success(gnrc_netif_t *netif)
             netif->mac.tx.current_neighbor->cp_phase -= CONFIG_GNRC_GOMACH_CP_DURATION_US;
         }
         else {
-            netif->mac.tx.current_neighbor->cp_phase +=
-                GNRC_GOMACH_SUPERFRAME_DURATION_US;
+            netif->mac.tx.current_neighbor->cp_phase += CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US;
             netif->mac.tx.current_neighbor->cp_phase -= CONFIG_GNRC_GOMACH_CP_DURATION_US;
         }
     }
@@ -590,9 +590,9 @@ static void _cp_tx_success(gnrc_netif_t *netif)
             (CONFIG_GNRC_GOMACH_CP_DURATION_US + 20 * US_PER_MS);
 
         if (netif->mac.tx.current_neighbor->cp_phase >=
-            GNRC_GOMACH_SUPERFRAME_DURATION_US) {
+            CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US) {
             netif->mac.tx.current_neighbor->cp_phase -=
-                GNRC_GOMACH_SUPERFRAME_DURATION_US;
+                CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US;
         }
     }
 
@@ -1446,7 +1446,7 @@ static void _gomach_phase_backoff(gnrc_netif_t *netif)
     netif->mac.prot.gomach.last_wakeup = rtt_get_counter();
 
     uint32_t alarm = netif->mac.prot.gomach.last_wakeup +
-                     RTT_US_TO_TICKS(GNRC_GOMACH_SUPERFRAME_DURATION_US);
+                     RTT_US_TO_TICKS(CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US);
 
     rtt_set_alarm(alarm, _gomach_rtt_cb, NULL);
 

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -1474,7 +1474,7 @@ static void gomach_listen_init(gnrc_netif_t *netif)
         }
     }
 
-    if (netif->mac.tx.t2u_fail_count >= GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD) {
+    if (netif->mac.tx.t2u_fail_count >= CONFIG_GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD) {
         netif->mac.tx.t2u_fail_count = 0;
         LOG_DEBUG("[GOMACH]: Re-initialize radio.");
         gomach_reinit_radio(netif);

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -1464,7 +1464,7 @@ static void gomach_listen_init(gnrc_netif_t *netif)
         if (netif->mac.rx.check_dup_pkt.last_nodes[i].node_addr.len != 0) {
             netif->mac.rx.check_dup_pkt.last_nodes[i].life_cycle++;
             if (netif->mac.rx.check_dup_pkt.last_nodes[i].life_cycle >=
-                GNRC_GOMACH_RX_DUPCHK_UNIT_LIFE) {
+                CONFIG_GNRC_GOMACH_RX_DUPCHK_UNIT_LIFE) {
                 netif->mac.rx.check_dup_pkt.last_nodes[i].node_addr.len = 0;
                 netif->mac.rx.check_dup_pkt.last_nodes[i].node_addr.addr[0] = 0;
                 netif->mac.rx.check_dup_pkt.last_nodes[i].node_addr.addr[1] = 0;

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -472,18 +472,18 @@ static void gomach_t2k_init(gnrc_netif_t *netif)
      * Firstly, put the calculated phase ahead, check whether the neighbor's phase has gone ahead
      * of the recorded one */
     if (netif->mac.tx.no_ack_counter == (GNRC_GOMACH_REPHASELOCK_THRESHOLD - 2)) {
-        if ((uint32_t)wait_phase_duration < GNRC_GOMACH_CP_DURATION_US) {
+        if ((uint32_t)wait_phase_duration < CONFIG_GNRC_GOMACH_CP_DURATION_US) {
             wait_phase_duration = (wait_phase_duration + GNRC_GOMACH_SUPERFRAME_DURATION_US) -
-                                  GNRC_GOMACH_CP_DURATION_US;
+                                  CONFIG_GNRC_GOMACH_CP_DURATION_US;
         }
         else {
-            wait_phase_duration = wait_phase_duration - GNRC_GOMACH_CP_DURATION_US;
+            wait_phase_duration = wait_phase_duration - CONFIG_GNRC_GOMACH_CP_DURATION_US;
         }
     }
     /* If this is the last t2k trial, the phase-lock auto-adjust scheme delays the estimated phase
      *  a little bit, to see if the real phase is behind the original calculated one. */
     if (netif->mac.tx.no_ack_counter == (GNRC_GOMACH_REPHASELOCK_THRESHOLD - 1)) {
-        wait_phase_duration = wait_phase_duration + GNRC_GOMACH_CP_DURATION_US;
+        wait_phase_duration = wait_phase_duration + CONFIG_GNRC_GOMACH_CP_DURATION_US;
         if ((uint32_t)wait_phase_duration > GNRC_GOMACH_SUPERFRAME_DURATION_US) {
             wait_phase_duration = wait_phase_duration - GNRC_GOMACH_SUPERFRAME_DURATION_US;
         }
@@ -573,16 +573,13 @@ static void _cp_tx_success(gnrc_netif_t *netif)
      * phase upon success. Here the new phase will be put ahead to the
      * original phase. */
     if (netif->mac.tx.no_ack_counter == (GNRC_GOMACH_REPHASELOCK_THRESHOLD - 2)) {
-        if (netif->mac.tx.current_neighbor->cp_phase >=
-            GNRC_GOMACH_CP_DURATION_US) {
-            netif->mac.tx.current_neighbor->cp_phase -=
-                GNRC_GOMACH_CP_DURATION_US;
+        if (netif->mac.tx.current_neighbor->cp_phase >= CONFIG_GNRC_GOMACH_CP_DURATION_US) {
+            netif->mac.tx.current_neighbor->cp_phase -= CONFIG_GNRC_GOMACH_CP_DURATION_US;
         }
         else {
             netif->mac.tx.current_neighbor->cp_phase +=
                 GNRC_GOMACH_SUPERFRAME_DURATION_US;
-            netif->mac.tx.current_neighbor->cp_phase -=
-                GNRC_GOMACH_CP_DURATION_US;
+            netif->mac.tx.current_neighbor->cp_phase -= CONFIG_GNRC_GOMACH_CP_DURATION_US;
         }
     }
     /* Here is the phase-lock auto-adjust scheme. Use the new adjusted
@@ -590,7 +587,7 @@ static void _cp_tx_success(gnrc_netif_t *netif)
      * phase. */
     if (netif->mac.tx.no_ack_counter == (GNRC_GOMACH_REPHASELOCK_THRESHOLD - 1)) {
         netif->mac.tx.current_neighbor->cp_phase +=
-            (GNRC_GOMACH_CP_DURATION_US + 20 * US_PER_MS);
+            (CONFIG_GNRC_GOMACH_CP_DURATION_US + 20 * US_PER_MS);
 
         if (netif->mac.tx.current_neighbor->cp_phase >=
             GNRC_GOMACH_SUPERFRAME_DURATION_US) {
@@ -1486,10 +1483,9 @@ static void gomach_listen_init(gnrc_netif_t *netif)
 
     /* Set listen period timeout. */
     uint32_t listen_period = random_uint32_range(0, GNRC_GOMACH_CP_RANDOM_END_US) +
-                             GNRC_GOMACH_CP_DURATION_US;
+                             CONFIG_GNRC_GOMACH_CP_DURATION_US;
     gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_CP_END, listen_period);
     gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_CP_MAX, GNRC_GOMACH_CP_DURATION_MAX_US);
-
     gnrc_netif_set_rx_started(netif, false);
     gnrc_gomach_set_pkt_received(netif, false);
     netif->mac.prot.gomach.cp_extend_count = 0;
@@ -1523,14 +1519,16 @@ static void _cp_listen_get_pkt(gnrc_netif_t *netif)
         gnrc_gomach_set_got_preamble(netif, false);
         gnrc_gomach_set_cp_end(netif, false);
         gnrc_gomach_clear_timeout(netif, GNRC_GOMACH_TIMEOUT_CP_END);
-        gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_CP_END, GNRC_GOMACH_CP_DURATION_US);
+        gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_CP_END,
+                                CONFIG_GNRC_GOMACH_CP_DURATION_US);
     }
     else if ((!gnrc_gomach_get_unintd_preamble(netif)) &&
              (!gnrc_gomach_get_quit_cycle(netif))) {
         gnrc_gomach_set_got_preamble(netif, false);
         gnrc_gomach_set_cp_end(netif, false);
         gnrc_gomach_clear_timeout(netif, GNRC_GOMACH_TIMEOUT_CP_END);
-        gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_CP_END, GNRC_GOMACH_CP_DURATION_US);
+        gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_CP_END,
+                                CONFIG_GNRC_GOMACH_CP_DURATION_US);
     }
 }
 

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -1482,7 +1482,7 @@ static void gomach_listen_init(gnrc_netif_t *netif)
     gnrc_gomach_set_enter_new_cycle(netif, false);
 
     /* Set listen period timeout. */
-    uint32_t listen_period = random_uint32_range(0, GNRC_GOMACH_CP_RANDOM_END_US) +
+    uint32_t listen_period = random_uint32_range(0, CONFIG_GNRC_GOMACH_CP_RANDOM_END_US) +
                              CONFIG_GNRC_GOMACH_CP_DURATION_US;
     gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_CP_END, listen_period);
     gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_CP_MAX, GNRC_GOMACH_CP_DURATION_MAX_US);

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -617,7 +617,7 @@ static bool _cp_tx_busy(gnrc_netif_t *netif)
 {
     /* If the channel busy counter is below threshold, retry CSMA immediately,
      * by knowing that the CP will be automatically extended. */
-    if (netif->mac.tx.tx_busy_count < GNRC_GOMACH_TX_BUSY_THRESHOLD) {
+    if (netif->mac.tx.tx_busy_count < CONFIG_GNRC_GOMACH_TX_BUSY_THRESHOLD) {
         netif->mac.tx.tx_busy_count++;
 
         /* Store the TX sequence number for this packet. Always use the same

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -557,7 +557,7 @@ static void gomach_t2k_trans_in_cp(gnrc_netif_t *netif)
         return;
     }
 
-    gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_NO_TX_ISR, GNRC_GOMACH_NO_TX_ISR_US);
+    gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_NO_TX_ISR, CONFIG_GNRC_GOMACH_NO_TX_ISR_US);
 
     netif->mac.tx.t2k_state = GNRC_GOMACH_T2K_WAIT_CPTX_FEEDBACK;
     gnrc_gomach_set_update(netif, false);
@@ -815,7 +815,7 @@ static void gomach_t2k_trans_in_slots(gnrc_netif_t *netif)
         return;
     }
 
-    gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_NO_TX_ISR, GNRC_GOMACH_NO_TX_ISR_US);
+    gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_NO_TX_ISR, CONFIG_GNRC_GOMACH_NO_TX_ISR_US);
 
     netif->mac.tx.vtdma_para.slots_num--;
     netif->mac.tx.t2k_state = GNRC_GOMACH_T2K_WAIT_VTDMA_FEEDBACK;
@@ -1268,7 +1268,7 @@ static void gomach_t2u_send_data(gnrc_netif_t *netif)
         return;
     }
 
-    gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_NO_TX_ISR, GNRC_GOMACH_NO_TX_ISR_US);
+    gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_NO_TX_ISR, CONFIG_GNRC_GOMACH_NO_TX_ISR_US);
 
     netif->mac.tx.t2u_state = GNRC_GOMACH_T2U_WAIT_DATA_TX;
     gnrc_gomach_set_update(netif, false);

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -1035,7 +1035,7 @@ static void gomach_t2u_send_preamble_prepare(gnrc_netif_t *netif)
             gnrc_gomach_set_on_pubchan_1(netif, true);
         }
         gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_MAX_PREAM_INTERVAL,
-                                GNRC_GOMACH_MAX_PREAM_INTERVAL_US);
+                                CONFIG_GNRC_GOMACH_MAX_PREAM_INTERVAL_US);
     }
     else {
         /* Here, for the first preamble, we set the pream_max_interval timeout to
@@ -1043,7 +1043,7 @@ static void gomach_t2u_send_preamble_prepare(gnrc_netif_t *netif)
          * using csma for sending, and csma costs some time before actually sending
          * the packet. */
         gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_MAX_PREAM_INTERVAL,
-                                (5 * GNRC_GOMACH_MAX_PREAM_INTERVAL_US));
+                                (5 * CONFIG_GNRC_GOMACH_MAX_PREAM_INTERVAL_US));
     }
 
     gnrc_gomach_set_max_pream_interv(netif, false);

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -299,7 +299,7 @@ static void gomach_wait_bcast_tx_finish(gnrc_netif_t *netif)
 {
     if (gnrc_gomach_get_tx_finish(netif)) {
         gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_BCAST_INTERVAL,
-                                GNRC_GOMACH_BCAST_INTERVAL_US);
+                                CONFIG_GNRC_GOMACH_BCAST_INTERVAL_US);
         netif->mac.tx.bcast_state = GNRC_GOMACH_BCAST_WAIT_NEXT_TX;
         gnrc_gomach_set_update(netif, false);
     }

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -728,7 +728,7 @@ static void gomach_t2k_wait_beacon(gnrc_netif_t *netif)
                 gnrc_gomach_set_netdev_state(netif, NETOPT_STATE_SLEEP);
 
                 uint32_t wait_slots_duration = netif->mac.tx.vtdma_para.slots_position *
-                                               GNRC_GOMACH_VTDMA_SLOT_SIZE_US;
+                                               CONFIG_GNRC_GOMACH_VTDMA_SLOT_SIZE_US;
                 gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_WAIT_SLOTS,
                                         wait_slots_duration);
 
@@ -1730,7 +1730,7 @@ static void gomach_vtdma_init(gnrc_netif_t *netif)
 
     /* Set the vTDMA period timeout. */
     uint32_t vtdma_duration = netif->mac.rx.vtdma_manag.total_slots_num *
-                              GNRC_GOMACH_VTDMA_SLOT_SIZE_US;
+                              CONFIG_GNRC_GOMACH_VTDMA_SLOT_SIZE_US;
     gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_VTDMA, vtdma_duration);
 
     gnrc_gomach_set_vTDMA_end(netif, false);

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -1159,7 +1159,7 @@ static bool _handle_in_t2u_send_preamble(gnrc_netif_t *netif)
         gnrc_gomach_clear_timeout(netif, GNRC_GOMACH_TIMEOUT_WAIT_RX_END);
 
         gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_WAIT_RX_END,
-                                GNRC_GOMACH_WAIT_RX_END_US);
+                                CONFIG_GNRC_GOMACH_WAIT_RX_END_US);
         return false;
     }
 
@@ -1540,7 +1540,7 @@ static void _cp_listen_end(gnrc_netif_t *netif)
         netif->mac.prot.gomach.cp_extend_count++;
         gnrc_gomach_clear_timeout(netif, GNRC_GOMACH_TIMEOUT_WAIT_RX_END);
         gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_WAIT_RX_END,
-                                GNRC_GOMACH_WAIT_RX_END_US);
+                                CONFIG_GNRC_GOMACH_WAIT_RX_END_US);
     }
     else {
         gnrc_gomach_clear_timeout(netif, GNRC_GOMACH_TIMEOUT_WAIT_RX_END);
@@ -1757,7 +1757,7 @@ static void gomach_vtdma(gnrc_netif_t *netif)
         if (gnrc_gomach_get_netdev_state(netif) == NETOPT_STATE_RX) {
             gnrc_gomach_clear_timeout(netif, GNRC_GOMACH_TIMEOUT_WAIT_RX_END);
             gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_WAIT_RX_END,
-                                    GNRC_GOMACH_WAIT_RX_END_US);
+                                    CONFIG_GNRC_GOMACH_WAIT_RX_END_US);
             return;
         }
 

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -1092,7 +1092,7 @@ static void gomach_t2u_wait_preamble_tx(gnrc_netif_t *netif)
         /* Set preamble interval timeout. This is a very short timeout (1ms),
          * just to catch the rx-start event of receiving possible preamble-ACK. */
         gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_PREAMBLE,
-                                GNRC_GOMACH_PREAMBLE_INTERVAL_US);
+                                CONFIG_GNRC_GOMACH_PREAMBLE_INTERVAL_US);
 
         netif->mac.tx.t2u_state = GNRC_GOMACH_T2U_WAIT_PREAMBLE_ACK;
         gnrc_gomach_set_update(netif, false);

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -1536,7 +1536,7 @@ static void _cp_listen_end(gnrc_netif_t *netif)
 {
     /* If we found ongoing reception, wait for reception complete. */
     if ((gnrc_gomach_get_netdev_state(netif) == NETOPT_STATE_RX) &&
-        (netif->mac.prot.gomach.cp_extend_count < GNRC_GOMACH_CP_EXTEND_THRESHOLD)) {
+        (netif->mac.prot.gomach.cp_extend_count < CONFIG_GNRC_GOMACH_CP_EXTEND_THRESHOLD)) {
         netif->mac.prot.gomach.cp_extend_count++;
         gnrc_gomach_clear_timeout(netif, GNRC_GOMACH_TIMEOUT_WAIT_RX_END);
         gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_WAIT_RX_END,

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -471,7 +471,7 @@ static void gomach_t2k_init(gnrc_netif_t *netif)
      * phase-lock failure due to timer drift.
      * Firstly, put the calculated phase ahead, check whether the neighbor's phase has gone ahead
      * of the recorded one */
-    if (netif->mac.tx.no_ack_counter == (GNRC_GOMACH_REPHASELOCK_THRESHOLD - 2)) {
+    if (netif->mac.tx.no_ack_counter == (CONFIG_GNRC_GOMACH_REPHASELOCK_THRESHOLD - 2)) {
         if ((uint32_t)wait_phase_duration < CONFIG_GNRC_GOMACH_CP_DURATION_US) {
             wait_phase_duration = (wait_phase_duration +
                                    CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US) -
@@ -483,7 +483,7 @@ static void gomach_t2k_init(gnrc_netif_t *netif)
     }
     /* If this is the last t2k trial, the phase-lock auto-adjust scheme delays the estimated phase
      *  a little bit, to see if the real phase is behind the original calculated one. */
-    if (netif->mac.tx.no_ack_counter == (GNRC_GOMACH_REPHASELOCK_THRESHOLD - 1)) {
+    if (netif->mac.tx.no_ack_counter == (CONFIG_GNRC_GOMACH_REPHASELOCK_THRESHOLD - 1)) {
         wait_phase_duration = wait_phase_duration + CONFIG_GNRC_GOMACH_CP_DURATION_US;
         if ((uint32_t)wait_phase_duration > CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US) {
             wait_phase_duration = wait_phase_duration - CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US;
@@ -573,7 +573,7 @@ static void _cp_tx_success(gnrc_netif_t *netif)
     /* Here is the phase-lock auto-adjust scheme. Use the new adjusted
      * phase upon success. Here the new phase will be put ahead to the
      * original phase. */
-    if (netif->mac.tx.no_ack_counter == (GNRC_GOMACH_REPHASELOCK_THRESHOLD - 2)) {
+    if (netif->mac.tx.no_ack_counter == (CONFIG_GNRC_GOMACH_REPHASELOCK_THRESHOLD - 2)) {
         if (netif->mac.tx.current_neighbor->cp_phase >= CONFIG_GNRC_GOMACH_CP_DURATION_US) {
             netif->mac.tx.current_neighbor->cp_phase -= CONFIG_GNRC_GOMACH_CP_DURATION_US;
         }
@@ -585,7 +585,7 @@ static void _cp_tx_success(gnrc_netif_t *netif)
     /* Here is the phase-lock auto-adjust scheme. Use the new adjusted
      * phase upon success. Here the new phase will be put behind the original
      * phase. */
-    if (netif->mac.tx.no_ack_counter == (GNRC_GOMACH_REPHASELOCK_THRESHOLD - 1)) {
+    if (netif->mac.tx.no_ack_counter == (CONFIG_GNRC_GOMACH_REPHASELOCK_THRESHOLD - 1)) {
         netif->mac.tx.current_neighbor->cp_phase +=
             (CONFIG_GNRC_GOMACH_CP_DURATION_US + 20 * US_PER_MS);
 
@@ -647,7 +647,7 @@ static void _cp_tx_default(gnrc_netif_t *netif)
     /* If no_ack_counter reaches the threshold, regarded as phase-lock failed. So
      * retry to send the packet in t2u, i.e., try to phase-lock with the receiver
      * again. */
-    if (netif->mac.tx.no_ack_counter >= GNRC_GOMACH_REPHASELOCK_THRESHOLD) {
+    if (netif->mac.tx.no_ack_counter >= CONFIG_GNRC_GOMACH_REPHASELOCK_THRESHOLD) {
         LOG_DEBUG("[GOMACH] t2k failed, go to t2u.\n");
         /* Here, we don't queue the packet again, but keep it in tx.packet. */
         netif->mac.tx.current_neighbor->mac_type = GNRC_GOMACH_TYPE_UNKNOWN;
@@ -1321,7 +1321,7 @@ static void _t2u_data_tx_fail(gnrc_netif_t *netif)
     }
     else {
         /* Record the MAC sequence of the data, retry t2u in next cycle. */
-        netif->mac.tx.no_ack_counter = GNRC_GOMACH_REPHASELOCK_THRESHOLD;
+        netif->mac.tx.no_ack_counter = CONFIG_GNRC_GOMACH_REPHASELOCK_THRESHOLD;
         netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->dev;
         netif->mac.tx.tx_seq = device_state->seq - 1;
 
@@ -1340,7 +1340,7 @@ static void gomach_t2u_wait_tx_feedback(gnrc_netif_t *netif)
         /* No TX-ISR, go to sleep. */
         netif->mac.tx.t2u_retry_counter++;
 
-        netif->mac.tx.no_ack_counter = GNRC_GOMACH_REPHASELOCK_THRESHOLD;
+        netif->mac.tx.no_ack_counter = CONFIG_GNRC_GOMACH_REPHASELOCK_THRESHOLD;
         netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->dev;
         netif->mac.tx.tx_seq = device_state->seq - 1;
 

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -553,7 +553,7 @@ int gnrc_gomach_send_beacon(gnrc_netif_t *netif)
     }
     else {
         gnrc_gomach_set_timeout(netif, GNRC_GOMACH_TIMEOUT_NO_TX_ISR,
-                                GNRC_GOMACH_NO_TX_ISR_US);
+                                CONFIG_GNRC_GOMACH_NO_TX_ISR_US);
     }
     return res;
 }

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -492,7 +492,7 @@ int gnrc_gomach_send_beacon(gnrc_netif_t *netif)
             j++;
 
             /* If reach the maximum sender ID number limit, stop. */
-            if (total_tdma_node_num >= GNRC_GOMACH_MAX_ALLOC_SENDER_NUM) {
+            if (total_tdma_node_num >= CONFIG_GNRC_GOMACH_MAX_ALLOC_SENDER_NUM){
                 break;
             }
         }

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -465,7 +465,7 @@ int gnrc_gomach_send_beacon(gnrc_netif_t *netif)
     /* Check the maximum number of slots that can be allocated to senders. */
     uint16_t max_slot_num = (CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US -
                              gnrc_gomach_phase_now(netif)) /
-                            GNRC_GOMACH_VTDMA_SLOT_SIZE_US;
+                            CONFIG_GNRC_GOMACH_VTDMA_SLOT_SIZE_US;
 
     for (i = 0; i < GNRC_GOMACH_SLOSCH_UNIT_COUNT; i++) {
         if (netif->mac.rx.slosch_list[i].queue_indicator > 0) {

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -944,15 +944,15 @@ void gnrc_gomach_process_preamble_ack(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     }
 
     if (((uint32_t)phase_us > (CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US -
-                               GNRC_GOMACH_CP_MIN_GAP_US)) ||
-        ((uint32_t)phase_us < GNRC_GOMACH_CP_MIN_GAP_US)) {
+                               CONFIG_GNRC_GOMACH_CP_MIN_GAP_US)) ||
+        ((uint32_t)phase_us < CONFIG_GNRC_GOMACH_CP_MIN_GAP_US)) {
         LOG_DEBUG("[GOMACH] t2u: own phase is close to the neighbor's.\n");
         gnrc_gomach_set_phase_backoff(netif, true);
         /* Set a random phase-backoff value. */
         netif->mac.prot.gomach.backoff_phase_us =
-            random_uint32_range(GNRC_GOMACH_CP_MIN_GAP_US,
+            random_uint32_range(CONFIG_GNRC_GOMACH_CP_MIN_GAP_US,
                                 (CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US -
-                                 GNRC_GOMACH_CP_MIN_GAP_US));
+                                 CONFIG_GNRC_GOMACH_CP_MIN_GAP_US));
     }
 
     netif->mac.tx.current_neighbor->cp_phase = phase_us;

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -463,7 +463,8 @@ int gnrc_gomach_send_beacon(gnrc_netif_t *netif)
     uint8_t slots_list[GNRC_GOMACH_SLOSCH_UNIT_COUNT];
 
     /* Check the maximum number of slots that can be allocated to senders. */
-    uint16_t max_slot_num = (GNRC_GOMACH_SUPERFRAME_DURATION_US - gnrc_gomach_phase_now(netif)) /
+    uint16_t max_slot_num = (CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US -
+                             gnrc_gomach_phase_now(netif)) /
                             GNRC_GOMACH_VTDMA_SLOT_SIZE_US;
 
     for (i = 0; i < GNRC_GOMACH_SLOSCH_UNIT_COUNT; i++) {
@@ -939,17 +940,19 @@ void gnrc_gomach_process_preamble_ack(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
                         gomach_preamble_ack_hdr->phase_in_us;
 
     if (phase_us < 0) {
-        phase_us += GNRC_GOMACH_SUPERFRAME_DURATION_US;
+        phase_us += CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US;
     }
 
-    if (((uint32_t)phase_us > (GNRC_GOMACH_SUPERFRAME_DURATION_US - GNRC_GOMACH_CP_MIN_GAP_US)) ||
+    if (((uint32_t)phase_us > (CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US -
+                               GNRC_GOMACH_CP_MIN_GAP_US)) ||
         ((uint32_t)phase_us < GNRC_GOMACH_CP_MIN_GAP_US)) {
         LOG_DEBUG("[GOMACH] t2u: own phase is close to the neighbor's.\n");
         gnrc_gomach_set_phase_backoff(netif, true);
         /* Set a random phase-backoff value. */
         netif->mac.prot.gomach.backoff_phase_us =
             random_uint32_range(GNRC_GOMACH_CP_MIN_GAP_US,
-                                (GNRC_GOMACH_SUPERFRAME_DURATION_US - GNRC_GOMACH_CP_MIN_GAP_US));
+                                (CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US -
+                                 GNRC_GOMACH_CP_MIN_GAP_US));
     }
 
     netif->mac.tx.current_neighbor->cp_phase = phase_us;
@@ -1393,7 +1396,7 @@ void gnrc_gomach_update_neighbor_phase(gnrc_netif_t *netif)
             long int tmp = netif->mac.tx.neighbors[i].cp_phase -
                            netif->mac.prot.gomach.backoff_phase_us;
             if (tmp < 0) {
-                tmp += GNRC_GOMACH_SUPERFRAME_DURATION_US;
+                tmp += CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US;
 
                 /* Toggle the neighbor's public channel phase if tmp < 0. */
                 if (netif->mac.tx.neighbors[i].pub_chanseq ==


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in GNRC:GOMACH, to Kconfig.

### Testing procedure

1. New documentation was built using doxygen 

The build works fine.

2. Header and macro was introduced to tests/gnrc_gomach/

```

#include "net/gnrc/gomach/gomach.h"

#define STR(x)   #x
#define SHOW_DEFINE(x) printf("%s=%s\n", #x, STR(x))


```
Test files can be found [here](https://github.com/akshaim/RIOT/commit/9e680b7b250330192e35684350b977b4ceb14b13) .
Compiled binaries were uploaded to FIT IoT Test bed.
#### Default State:

##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-638-g333c5-Kconfig_gomach_tests)
CONFIG_GNRC_GOMACH_CP_DURATION_US=(10U * (1000LU))
CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US=(300LU * (1000LU))
CONFIG_GNRC_GOMACH_CP_RANDOM_END_US=(1U * (1000LU))
CONFIG_GNRC_GOMACH_CP_MIN_GAP_US=(25U * (1000LU))
CONFIG_GNRC_GOMACH_WAIT_RX_END_US=(6U * (1000LU))
CONFIG_GNRC_GOMACH_NO_TX_ISR_US=(50U * (1000LU))
CONFIG_GNRC_GOMACH_MAX_PREAM_INTERVAL_US=(6U * (1000LU))
CONFIG_GNRC_GOMACH_PREAMBLE_INTERVAL_US=(2U * (1000LU))
CONFIG_GNRC_GOMACH_BCAST_INTERVAL_US=(1U * (1000LU))
CONFIG_GNRC_GOMACH_VTDMA_SLOT_SIZE_US=(5U * (1000LU))
CONFIG_GNRC_GOMACH_TX_BUSY_THRESHOLD=(5U)
CONFIG_GNRC_GOMACH_CP_EXTEND_THRESHOLD=(5U)
CONFIG_GNRC_GOMACH_RX_DUPCHK_UNIT_LIFE=(30U)
CONFIG_GNRC_GOMACH_MAX_ALLOC_SENDER_NUM=(11U)
CONFIG_GNRC_GOMACH_REPHASELOCK_THRESHOLD=(4U)
CONFIG_GNRC_GOMACH_T2U_RETYR_THRESHOLD=(2U)
CONFIG_GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD=(10U)

#### Usage with menuconfig [default values]

> make menuconfig

##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-638-g333c5-Kconfig_gomach_tests)
CONFIG_GNRC_GOMACH_CP_DURATION_US=10000
CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US=300000
CONFIG_GNRC_GOMACH_CP_RANDOM_END_US=1000
CONFIG_GNRC_GOMACH_CP_MIN_GAP_US=25000
CONFIG_GNRC_GOMACH_WAIT_RX_END_US=6000
CONFIG_GNRC_GOMACH_NO_TX_ISR_US=50000
CONFIG_GNRC_GOMACH_MAX_PREAM_INTERVAL_US=6000
CONFIG_GNRC_GOMACH_PREAMBLE_INTERVAL_US=2000
CONFIG_GNRC_GOMACH_BCAST_INTERVAL_US=1000
CONFIG_GNRC_GOMACH_VTDMA_SLOT_SIZE_US=5000
CONFIG_GNRC_GOMACH_TX_BUSY_THRESHOLD=5
CONFIG_GNRC_GOMACH_CP_EXTEND_THRESHOLD=5
CONFIG_GNRC_GOMACH_RX_DUPCHK_UNIT_LIFE=30
CONFIG_GNRC_GOMACH_MAX_ALLOC_SENDER_NUM=11
CONFIG_GNRC_GOMACH_REPHASELOCK_THRESHOLD=4
CONFIG_GNRC_GOMACH_T2U_RETYR_THRESHOLD=2
CONFIG_GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD=10

#### Usage with menuconfig

> make menuconfig

##### Firmware Output

main(): This is RIOT! (Version: 2020.07-devel-638-g333c5-Kconfig_gomach_tests)
CONFIG_GNRC_GOMACH_CP_DURATION_US=20000
CONFIG_GNRC_GOMACH_SUPERFRAME_DURATION_US=350000
CONFIG_GNRC_GOMACH_CP_RANDOM_END_US=2000
CONFIG_GNRC_GOMACH_CP_MIN_GAP_US=55000
CONFIG_GNRC_GOMACH_WAIT_RX_END_US=5000
CONFIG_GNRC_GOMACH_NO_TX_ISR_US=30000
CONFIG_GNRC_GOMACH_MAX_PREAM_INTERVAL_US=6005
CONFIG_GNRC_GOMACH_PREAMBLE_INTERVAL_US=2005
CONFIG_GNRC_GOMACH_BCAST_INTERVAL_US=1001
CONFIG_GNRC_GOMACH_VTDMA_SLOT_SIZE_US=5000
CONFIG_GNRC_GOMACH_TX_BUSY_THRESHOLD=6
CONFIG_GNRC_GOMACH_CP_EXTEND_THRESHOLD=6
CONFIG_GNRC_GOMACH_RX_DUPCHK_UNIT_LIFE=35
CONFIG_GNRC_GOMACH_MAX_ALLOC_SENDER_NUM=12
CONFIG_GNRC_GOMACH_REPHASELOCK_THRESHOLD=6
CONFIG_GNRC_GOMACH_T2U_RETYR_THRESHOLD=1
CONFIG_GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD=11

**MACROS were successfully configured.**

### Issues/PRs references

#12888 
Merge this only after merging #14086 