### PR TITLE
cpu/sam0_common/spi: demux SPI output pins before entering deep sleep

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -380,6 +380,20 @@ void cpu_pm_cb_enter(int deep);
 void cpu_pm_cb_leave(int deep);
 
 /**
+ * @brief   Called before the power management enters a power mode
+ *
+ * @param[in] deep
+ */
+void spi_pm_cb_enter(int deep);
+
+/**
+ * @brief   Called after the power management left a power mode
+ *
+ * @param[in] deep
+ */
+void spi_pm_cb_leave(int deep);
+
+/**
  * @brief   Wrapper for cortexm_sleep calling power management callbacks
  *
  * @param[in] deep
@@ -390,11 +404,19 @@ static inline void sam0_cortexm_sleep(int deep)
     gpio_pm_cb_enter(deep);
 #endif
 
+#ifdef MODULE_PERIPH_SPI
+    spi_pm_cb_enter(deep);
+#endif
+
     cpu_pm_cb_enter(deep);
 
     cortexm_sleep(deep);
 
     cpu_pm_cb_leave(deep);
+
+#ifdef MODULE_PERIPH_SPI
+    spi_pm_cb_leave(deep);
+#endif
 
 #ifdef MODULE_PERIPH_GPIO
     gpio_pm_cb_leave(deep);

--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -184,3 +184,25 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
         gpio_set((gpio_t)cs);
     }
 }
+
+void spi_pm_cb_enter(int deep)
+{
+    if (deep) {
+        for (size_t i = 0; i < SPI_NUMOF; i++) {
+            spi_t bus = SPI_DEV(i);
+            gpio_disable_mux(spi_config[bus].mosi_pin);
+            gpio_disable_mux(spi_config[bus].clk_pin);
+        }
+    }
+}
+
+void spi_pm_cb_leave(int deep)
+{
+    if (deep) {
+        for (size_t i = 0; i < SPI_NUMOF; i++) {
+            spi_t bus = SPI_DEV(i);
+            gpio_init_mux(spi_config[bus].mosi_pin, spi_config[bus].mosi_mux);
+            gpio_init_mux(spi_config[bus].clk_pin, spi_config[bus].clk_mux);
+        }
+    }
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The output pins of `periph_spi` becomes HIGH-Z when entering a deep sleep power mode. 

If no external pull resistors are present, this will lead to undefined voltage levels and will create unwanted current draw by connected SPI slaves.
This can be observed with the `samr30` CPU as it has a sub-GHz transceiver inside its package that disables its pull resistor once it has been initialized.

### Testing procedure

Grab a `samr30-xpro` board and observe the current draw of the board with `examples/default`:

```
$ make BOARD=samr30-xpro flash term
2020-05-20 14:25:40,931 # main(): This is RIOT! (Version: 2020.04-devel-2669-g03322-fix/sam0_spi_deep-sleep)
2020-05-20 14:25:40,932 # Welcome to RIOT!
> ifconfig 4 set state SLEEP
2020-05-20 14:25:55,728 #  ifconfig 4 set state SLEEP
2020-05-20 14:25:55,732 # success: set state of interface 4 to SLEEP
> pm set 1
2020-05-20 14:26:03,830 #  pm set 1
2020-05-20 14:26:03,833 # CPU is entering power mode 1.
2020-05-20 14:26:03,836 # Now waiting for a wakeup event...
```

Without this patch, the board draws ~600uA. With this patch, it drops down to ~4uA.

If you want to test it with another `sam0_common`-based board, call `pm set 1` and try to pull the SPI pins with a resistor to VCC and GND. If this works, you verified these pins to be HIGH-Z.

