### PR TITLE
cpu/sam0_common/spi: move clk pin muxing into spi_acquire / spi_release

### DIFF
--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -94,7 +94,7 @@ void spi_init_pins(spi_t bus)
     gpio_init(spi_config[bus].clk_pin, GPIO_OUT);
     gpio_init_mux(spi_config[bus].miso_pin, spi_config[bus].miso_mux);
     gpio_init_mux(spi_config[bus].mosi_pin, spi_config[bus].mosi_mux);
-    gpio_init_mux(spi_config[bus].clk_pin, spi_config[bus].clk_mux);
+    /* clk_pin will be muxed during acquire / release */
 }
 
 int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
@@ -141,11 +141,18 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     dev(bus)->CTRLA.reg |= SERCOM_SPI_CTRLA_ENABLE;
     while (dev(bus)->SYNCBUSY.reg & SERCOM_SPI_SYNCBUSY_ENABLE) {}
 
+    /* mux clk_pin to SPI peripheral */
+    gpio_init_mux(spi_config[bus].clk_pin, spi_config[bus].clk_mux);
+
     return SPI_OK;
 }
 
 void spi_release(spi_t bus)
 {
+    /* Demux clk_pin back to GPIO_OUT function. Otherwise it will get HIGH-Z
+     * and lead to unexpected current draw by SPI salves. */
+    gpio_disable_mux(spi_config[bus].clk_pin);
+
     /* disable the device */
     dev(bus)->CTRLA.reg &= ~(SERCOM_SPI_CTRLA_ENABLE);
     while (dev(bus)->SYNCBUSY.reg & SERCOM_SPI_SYNCBUSY_ENABLE) {}


### PR DESCRIPTION

### Contribution description

When the MCU disables the SPI peripheral, the out pins will get HIGH-Z if they are still muxed to the SPI peripheral. This may leads to unwanted current consumption by the attached SPI slave.

High-Z causes floating on the SCK line which leads to undefined voltage levels. Connected slaves feed their clock system from SCK. If SCK is not gated by the CS line, they start to draw current, unexpectedly.

### Testing procedure

Use a `sam0_common`-based board and flash the `periph_spi` example. Without this patch, the SCK line is High-Z. With this patch, it should be LOW all the time.

---

Alternative test: Grab a `samr30-xpro` board and observe the current draw of the board with `examples/default`:

```
$ make BOARD=samr30-xpro flash term
2020-05-20 14:25:40,931 # main(): This is RIOT! (Version: 2020.04-devel-2669-g03322-fix/sam0_spi_deep-sleep)
2020-05-20 14:25:40,932 # Welcome to RIOT!
> ifconfig 4 set state SLEEP
2020-05-20 14:25:55,728 #  ifconfig 4 set state SLEEP
2020-05-20 14:25:55,732 # success: set state of interface 4 to SLEEP
> pm set 1
2020-05-20 14:26:03,830 #  pm set 1
2020-05-20 14:26:03,833 # CPU is entering power mode 1.
2020-05-20 14:26:03,836 # Now waiting for a wakeup event...
```

Without this patch, the board draws ~600uA. With this patch, it drops down to ~4uA.
