### PR TITLE
tests/periph_spi: add benchmark for acquire / release

### DIFF
--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -486,6 +486,25 @@ int cmd_bench(int argc, char **argv)
     sum += (stop - start);
     sched_sum += sched_diff_us;
 
+    /* 15 - release & acquire the bus 1000 times */
+    sched_start = _sched_ticks();
+    start = xtimer_now_usec();
+    for (int i = 0; i < BENCH_REDOS; i++) {
+        spi_release(spiconf.dev);
+        if (spi_acquire(spiconf.dev, spiconf.cs, spiconf.mode, spiconf.clk) != SPI_OK) {
+            puts("ERROR - spi_acquire() failed.");
+            break;
+        }
+    }
+    stop = xtimer_now_usec();
+    sched_stop = _sched_ticks();
+    sched_diff_us = _xtimer_diff_usec(sched_stop, sched_start);
+    printf("15 - acquire/release %i times:\t\t", BENCH_REDOS);
+    printf("%"PRIu32"\t%"PRIu32"\n", (stop - start), sched_diff_us);
+    sum += (stop - start);
+    sched_sum += sched_diff_us;
+
+
     xtimer_sleep(1);
 
     printf("-- - SUM:\t\t\t\t\t%"PRIu32"\t%"PRIu32"\n", sum, sched_sum);

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -80,6 +80,11 @@ static xtimer_ticks32_t _sched_ticks(void)
     return runtime_ticks;
 }
 
+static uint32_t _xtimer_diff_usec(xtimer_ticks32_t stop, xtimer_ticks32_t start)
+{
+    return xtimer_usec_from_ticks(xtimer_diff(stop, start));
+}
+
 void print_bytes(char* title, uint8_t* data, size_t len)
 {
     printf("%4s\n", title);
@@ -280,8 +285,7 @@ int cmd_bench(int argc, char **argv)
     }
     stop = xtimer_now_usec();
     sched_stop = _sched_ticks();
-    sched_diff_us = xtimer_usec_from_ticks(xtimer_diff(sched_stop,
-                                                       sched_start));
+    sched_diff_us = _xtimer_diff_usec(sched_stop, sched_start);
     printf(" 1 - write %i times %i byte:", BENCH_REDOS, 1);
     printf("\t\t\t%"PRIu32"\t%"PRIu32"\n", (stop - start), sched_diff_us);
     sum += (stop - start);
@@ -296,8 +300,7 @@ int cmd_bench(int argc, char **argv)
     }
     stop = xtimer_now_usec();
     sched_stop = _sched_ticks();
-    sched_diff_us = xtimer_usec_from_ticks(xtimer_diff(sched_stop,
-                                                       sched_start));
+    sched_diff_us = _xtimer_diff_usec(sched_stop, sched_start);
     printf(" 2 - write %i times %i byte:", BENCH_REDOS, BENCH_SMALL);
     printf("\t\t\t%"PRIu32"\t%"PRIu32"\n", (stop - start), sched_diff_us);
     sum += (stop - start);
@@ -312,8 +315,7 @@ int cmd_bench(int argc, char **argv)
     }
     stop = xtimer_now_usec();
     sched_stop = _sched_ticks();
-    sched_diff_us = xtimer_usec_from_ticks(xtimer_diff(sched_stop,
-                                                       sched_start));
+    sched_diff_us = _xtimer_diff_usec(sched_stop, sched_start);
     printf(" 3 - write %i times %i byte:", BENCH_REDOS, BENCH_LARGE);
     printf("\t\t%"PRIu32"\t%"PRIu32"\n", (stop - start), sched_diff_us);
     sum += (stop - start);
@@ -328,8 +330,7 @@ int cmd_bench(int argc, char **argv)
     }
     stop = xtimer_now_usec();
     sched_stop = _sched_ticks();
-    sched_diff_us = xtimer_usec_from_ticks(xtimer_diff(sched_stop,
-                                                       sched_start));
+    sched_diff_us = _xtimer_diff_usec(sched_stop, sched_start);
     printf(" 4 - write %i times %i byte to register:", BENCH_REDOS, 1);
     printf("\t%"PRIu32"\t%"PRIu32"\n", (stop - start), sched_diff_us);
     sum += (stop - start);
@@ -344,8 +345,7 @@ int cmd_bench(int argc, char **argv)
     }
     stop = xtimer_now_usec();
     sched_stop = _sched_ticks();
-    sched_diff_us = xtimer_usec_from_ticks(xtimer_diff(sched_stop,
-                                                       sched_start));
+    sched_diff_us = _xtimer_diff_usec(sched_stop, sched_start);
     printf(" 5 - write %i times %i byte to register:", BENCH_REDOS, BENCH_SMALL);
     printf("\t%"PRIu32"\t%"PRIu32"\n", (stop - start), sched_diff_us);
     sum += (stop - start);
@@ -360,8 +360,7 @@ int cmd_bench(int argc, char **argv)
     }
     stop = xtimer_now_usec();
     sched_stop = _sched_ticks();
-    sched_diff_us = xtimer_usec_from_ticks(xtimer_diff(sched_stop,
-                                                       sched_start));
+    sched_diff_us = _xtimer_diff_usec(sched_stop, sched_start);
     printf(" 6 - write %i times %i byte to register:", BENCH_REDOS, BENCH_LARGE);
     printf("\t%"PRIu32"\t%"PRIu32"\n", (stop - start), sched_diff_us);
     sum += (stop - start);
@@ -376,8 +375,7 @@ int cmd_bench(int argc, char **argv)
     }
     stop = xtimer_now_usec();
     sched_stop = _sched_ticks();
-    sched_diff_us = xtimer_usec_from_ticks(xtimer_diff(sched_stop,
-                                                       sched_start));
+    sched_diff_us = _xtimer_diff_usec(sched_stop, sched_start);
     printf(" 7 - read %i times %i byte:", BENCH_REDOS, BENCH_SMALL);
     printf("\t\t\t%"PRIu32"\t%"PRIu32"\n", (stop - start), sched_diff_us);
     sum += (stop - start);
@@ -392,8 +390,7 @@ int cmd_bench(int argc, char **argv)
     }
     stop = xtimer_now_usec();
     sched_stop = _sched_ticks();
-    sched_diff_us = xtimer_usec_from_ticks(xtimer_diff(sched_stop,
-                                                       sched_start));
+    sched_diff_us = _xtimer_diff_usec(sched_stop, sched_start);
     printf(" 8 - read %i times %i byte:", BENCH_REDOS, BENCH_LARGE);
     printf("\t\t%"PRIu32"\t%"PRIu32"\n", (stop - start), sched_diff_us);
     sum += (stop - start);
@@ -408,8 +405,7 @@ int cmd_bench(int argc, char **argv)
     }
     stop = xtimer_now_usec();
     sched_stop = _sched_ticks();
-    sched_diff_us = xtimer_usec_from_ticks(xtimer_diff(sched_stop,
-                                                       sched_start));
+    sched_diff_us = _xtimer_diff_usec(sched_stop, sched_start);
     printf(" 9 - read %i times %i byte from register:", BENCH_REDOS, BENCH_SMALL);
     printf("\t%"PRIu32"\t%"PRIu32"\n", (stop - start), sched_diff_us);
     sum += (stop - start);
@@ -424,8 +420,7 @@ int cmd_bench(int argc, char **argv)
     }
     stop = xtimer_now_usec();
     sched_stop = _sched_ticks();
-    sched_diff_us = xtimer_usec_from_ticks(xtimer_diff(sched_stop,
-                                                       sched_start));
+    sched_diff_us = _xtimer_diff_usec(sched_stop, sched_start);
     printf("10 - read %i times %i byte from register:", BENCH_REDOS, BENCH_LARGE);
     printf("\t%"PRIu32"\t%"PRIu32"\n", (stop - start), sched_diff_us);
     sum += (stop - start);
@@ -440,8 +435,7 @@ int cmd_bench(int argc, char **argv)
     }
     stop = xtimer_now_usec();
     sched_stop = _sched_ticks();
-    sched_diff_us = xtimer_usec_from_ticks(xtimer_diff(sched_stop,
-                                                       sched_start));
+    sched_diff_us = _xtimer_diff_usec(sched_stop, sched_start);
     printf("11 - transfer %i times %i byte:", BENCH_REDOS, BENCH_SMALL);
     printf("\t\t%"PRIu32"\t%"PRIu32"\n", (stop - start), sched_diff_us);
     sum += (stop - start);
@@ -456,8 +450,7 @@ int cmd_bench(int argc, char **argv)
     }
     stop = xtimer_now_usec();
     sched_stop = _sched_ticks();
-    sched_diff_us = xtimer_usec_from_ticks(xtimer_diff(sched_stop,
-                                                       sched_start));
+    sched_diff_us = _xtimer_diff_usec(sched_stop, sched_start);
     printf("12 - transfer %i times %i byte:", BENCH_REDOS, BENCH_LARGE);
     printf("\t\t%"PRIu32"\t%"PRIu32"\n", (stop - start), sched_diff_us);
     sum += (stop - start);
@@ -472,8 +465,7 @@ int cmd_bench(int argc, char **argv)
     }
     stop = xtimer_now_usec();
     sched_stop = _sched_ticks();
-    sched_diff_us = xtimer_usec_from_ticks(xtimer_diff(sched_stop,
-                                                       sched_start));
+    sched_diff_us = _xtimer_diff_usec(sched_stop, sched_start);
     printf("13 - transfer %i times %i byte to register:", BENCH_REDOS, BENCH_SMALL);
     printf("\t%"PRIu32"\t%"PRIu32"\n", (stop - start), sched_diff_us);
     sum += (stop - start);
@@ -488,8 +480,7 @@ int cmd_bench(int argc, char **argv)
     }
     stop = xtimer_now_usec();
     sched_stop = _sched_ticks();
-    sched_diff_us = xtimer_usec_from_ticks(xtimer_diff(sched_stop,
-                                                       sched_start));
+    sched_diff_us = _xtimer_diff_usec(sched_stop, sched_start);
     printf("14 - transfer %i times %i byte to register:", BENCH_REDOS, BENCH_LARGE);
     printf("%"PRIu32"\t%"PRIu32"\n", (stop - start), sched_diff_us);
     sum += (stop - start);


### PR DESCRIPTION
### Contribution description

Add a benchmark to test the performance of `spi_acquire()` / `spi_release()`

Also move the sched diff calculation to a helper function.

### Testing procedure

on `samr21-xpro`:

```
> init 1 0 1 0 0
> bench
2020-05-20 17:54:12,516 # ### Running some benchmarks, all values in [us] ###
2020-05-20 17:54:12,519 # ### Test				Transfer time	user time
2020-05-20 17:54:12,519 # 
2020-05-20 17:54:12,548 #  1 - write 1000 times 1 byte:			24238	24257
2020-05-20 17:54:12,597 #  2 - write 1000 times 2 byte:			45009	45028
2020-05-20 17:54:14,735 #  3 - write 1000 times 100 byte:		2129446	2129465
2020-05-20 17:54:14,788 #  4 - write 1000 times 1 byte to register:	48113	48132
2020-05-20 17:54:14,862 #  5 - write 1000 times 2 byte to register:	68946	68965
2020-05-20 17:54:17,024 #  6 - write 1000 times 100 byte to register:	2153405	2153424
2020-05-20 17:54:17,073 #  7 - read 1000 times 2 byte:			45196	45215
2020-05-20 17:54:19,210 #  8 - read 1000 times 100 byte:		2129634	2129653
2020-05-20 17:54:19,285 #  9 - read 1000 times 2 byte from register:	69134	69153
2020-05-20 17:54:21,448 # 10 - read 1000 times 100 byte from register:	2153509	2153528
2020-05-20 17:54:21,497 # 11 - transfer 1000 times 2 byte:		45134	45153
2020-05-20 17:54:23,635 # 12 - transfer 1000 times 100 byte:		2129613	2129632
2020-05-20 17:54:23,710 # 13 - transfer 1000 times 2 byte to register:	69071	69090
2020-05-20 17:54:25,872 # 14 - transfer 1000 times 100 byte to register:2153530	2153549
2020-05-20 17:54:25,890 # 15 - acquire/release 1000 times:		11321	11340
2020-05-20 17:54:26,893 # -- - SUM:					13275299	13275584
2020-05-20 17:54:26,894 # 
2020-05-20 17:54:26,896 # ### All runs complete ###
```


### Issues/PRs references

useful to test #14107
