### PR TITLE
cpu/native: Move dependencies to Makefile.dep

### DIFF
--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -4,3 +4,8 @@ endif
 ifeq (,$(filter stdio_%,$(USEMODULE)))
   USEMODULE += stdio_native
 endif
+
+USEMODULE += periph
+
+# UART is needed by startup.c
+USEMODULE += periph_uart

--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -5,7 +5,4 @@ ifeq ($(BUILDOSXNATIVE),1)
   NATIVEINCLUDES += -I$(RIOTCPU)/native/osx-libc-extra
 endif
 
-USEMODULE += periph
-USEMODULE += periph_uart
-
 TOOLCHAINS_SUPPORTED = gnu llvm afl


### PR DESCRIPTION
### Contribution description
This moves the `native` CPU dependencies to its `Makefile.dep`.

### Testing procedure
Green CI should be enough as `periph_uart` is used always on `startup.c`.

### Issues/PRs references
Part of #9913
