### PR TITLE
cpu/kinetis: Move dependencies to Makefile.dep

### DIFF
--- a/cpu/kinetis/Makefile.dep
+++ b/cpu/kinetis/Makefile.dep
@@ -5,4 +5,18 @@ ifneq (,$(filter periph_i2c,$(USEMODULE)))
   USEMODULE += core_thread_flags
 endif
 
+# select kinetis periph drivers
+# As FEATURES_PROVIDED cannot be checked directly, add both to FEATURES_OPTIONAL
+# and check FEATURES_USED instead.
+FEATURES_OPTIONAL += periph_ics
+FEATURES_OPTIONAL += periph_mcg
+
+ifneq (,$(filter periph_ics,$(FEATURES_USED)))
+  USEMODULE += periph_ics
+else ifneq (,$(filter periph_mcg,$(FEATURES_USED)))
+  USEMODULE += periph_mcg
+endif
+
+USEMODULE += periph_wdog
+
 include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/kinetis/Makefile.include
+++ b/cpu/kinetis/Makefile.include
@@ -46,12 +46,4 @@ CFLAGS += \
 # add the CPU specific flash configuration field for the linker
 UNDEF += $(BINDIR)/cpu/fcfield.o
 
-# select kinetis periph drivers
-ifeq (EA,$(KINETIS_SERIES))
-USEMODULE += periph_ics
-else
-USEMODULE += periph_mcg
-endif
-USEMODULE += periph_wdog
-
 include $(RIOTMAKE)/arch/cortexm.inc.mk


### PR DESCRIPTION
### Contribution description
This moves dependencies of `kinetis` to its `Makefile.dep`, and uses the provided features instead of the model to load the modules.

### Testing procedure
- All kinetis-based boards should still use the same modules.
- As we still do not have a board which uses an `EA` series CPU, check that `periph_ics` is used when setting `CPU_MODEL=s9keaz128aclh48`.

### Issues/PRs references
Part of #9913