### PR TITLE
boards/samr30-xpro: add SPI dev for ext pin header

### DIFF
--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -85,7 +85,7 @@ static const uart_conf_t uart_config[] = {
  * @{
  */
 static const spi_conf_t spi_config[] = {
-    {
+    {    /* Internal AT86RF212B */
         .dev      = &(SERCOM4->SPI),
         .miso_pin = GPIO_PIN(PC, 19),
         .mosi_pin = GPIO_PIN(PB, 30),
@@ -107,7 +107,7 @@ static const spi_conf_t spi_config[] = {
  * @{
  */
 static const i2c_conf_t i2c_config[] = {
-    {
+    {    /* EXT1 & EXT3 Pin Header */
         .dev      = &(SERCOM1->I2CM),
         .speed    = I2C_SPEED_NORMAL,
         .scl_pin  = GPIO_PIN(PA, 17),

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -96,6 +96,18 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+    },
+    {    /* EXT1 & EXT3 Pin Header */
+        .dev      = &(SERCOM5->SPI),
+        .miso_pin = GPIO_PIN(PB, 2),
+        .mosi_pin = GPIO_PIN(PB, 22),
+        .clk_pin  = GPIO_PIN(PB, 23),
+        .miso_mux = GPIO_MUX_D,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux  = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -115,7 +115,7 @@ static const i2c_conf_t i2c_config[] = {
         .mux      = GPIO_MUX_C,
         .gclk_src = SAM0_GCLK_MAIN,
         .flags    = I2C_FLAG_NONE
-     }
+    }
 };
 #define I2C_NUMOF          ARRAY_SIZE(i2c_config)
 /** @} */


### PR DESCRIPTION
### Contribution description

While testing #14107 I needed a SPI dev on the exposed pin header of the board.

### Testing procedure

Connect a SPI slave to:
* SCK: PB23
* MOSI: PB22
* MISO: PB02

Try to communicate with that slave using the `tests/periph_spi` example.