### PR TITLE
cpu/esp: implement ESP WiFi SoftAP mode

### DIFF
--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -49,8 +49,9 @@
 8. [Network Interfaces](#esp32_network_interfaces)
     1. [Ethernet MAC Network Interface](#esp32_ethernet_network_interface)
     2. [WiFi Network Interface](#esp32_wifi_network_interface)
-    3. [ESP-NOW Network Interface](#esp32_esp_now_network_interface)
-    4. [Other Network Devices](#esp32_other_network_devices)
+    3. [WiFi SoftAP Network Interface](#esp32_wifi_ap_network_interface)
+    4. [ESP-NOW Network Interface](#esp32_esp_now_network_interface)
+    5. [Other Network Devices](#esp32_other_network_devices)
 10. [Application-Specific Configurations](#esp32_application_specific_configurations)
     1. [Make Variable ```CONFIGS```](#esp32_config_make_variable)
     2. [Application-Specific Board Configuration](#esp32_application_specific_board_configuration)
@@ -124,6 +125,7 @@ Module    | Default  | Short description
 [esp_spi_ram](#esp32_spi_ram) | not used |  enable SPI RAM
 [esp_spiffs](#esp32_spiffs_device) | not used  |  enable SPIFFS for on-board flash memory
 [esp_wifi](#esp32_wifi_network_interface) | not used  | enable the Wifi network device in WPA2 personal mode
+[esp_wifi_ap](#esp32_wifi_ap_network_interface) | not used | enable the WiFi SoftAP network device
 [esp_wifi_enterprise](#esp32_wifi_network_interface) | not used  | enable the Wifi network device in WPA2 enterprise mode
 
 </center>
@@ -425,6 +427,7 @@ esp_rtc_timer_32k | Enable RTC hardware timer with external 32.768 kHz crystal.
 esp_spiffs  | Enable the optional SPIFFS drive in on-board flash memory, see section [SPIFFS Device](#esp32_spiffs_device).
 esp_spi_ram | Enable the optional SPI RAM, see section [SPI RAM Modules](#esp32_spi_ram).
 esp_wifi | Enable the built-in WiFi module as `netdev` network device in WPA2 personal mode, see section [WiFi Network Interface](#esp32_wifi_network_interface).
+esp_wifi_ap | Enable the built-in WiFi SoftAP module as `netdev` network device, see section [WiFi SoftAP Network Interface](#esp32_wifi_ap_network_interface).
 esp_wifi_enterprise | Enable the built-in WiFi module as `netdev` network device in WPA2 enterprise mode, see section [WiFi Network Interface](#esp32_wifi_network_interface).
 
 </center>
@@ -1255,6 +1258,53 @@ a mesh network which uses ESP-NOW.
 In this case the ESP-NOW interface must use the same channel as the AP of the
 infrastructure WiFi network. All ESP-NOW nodes must therefore be compiled with
 the channel of the AP as value for the parameter 'ESP_NOW_CHANNEL'.
+
+\anchor esp32_wifi_ap_network_interface
+## <a name="esp32_wifi_ap_network_interface"> WiFi SoftAP Network Interface </a> &nbsp;[[TOC](#esp32_toc)]
+
+The RIOT port for the ESP32 supports a `netdev` interface for the ESP32 WiFi
+SoftAP mode. Module `esp_wifi_ap` has to be enabled to use it.
+
+The following parameters can be configured:
+
+<center>
+
+Parameter                 | Default                   | Description
+:-------------------------|:--------------------------|:-------------
+#ESP_WIFI_SSID            | "RIOT_AP"                 | Static SSID definition for the SoftAP
+#ESP_WIFI_AP_PREFIX       | "RIOT_AP_"                | Optional prefix for dynamic SSID, if used, the node will create the SSID based on the prefix + mac address (e.g.: "RIOT_AP_aabbccddeeff"). This is disabled by default and `ESP_WIFI_SSID` is used, define this to enable the usage of the SSID prefix.
+#ESP_WIFI_PASS            | none                      | The password for the WiFi SoftAP network interface. If no password is provided, the interface will be "open", otherwise it uses WPA2-PSK authentication mode.
+#ESP_WIFI_SSID_HIDDEN     | 0                         | Whether the SoftAP SSID should be hidden.
+#ESP_WIFI_MAX_CONN        | 4                         | The maximum number of connections for the SoftAP.
+#ESP_WIFI_BEACON_INTERVAL | 100                       | The beacon interval time in milliseconds for the SoftAP.
+#ESP_WIFI_STACKSIZE       | #THREAD_STACKSIZE_DEFAULT | Stack size used for the WiFi netdev driver thread.
+
+</center>
+
+These configuration parameter definitions, as well as enabling the `esp_wifi_ap`
+module, can be done either in the makefile of the project or at make command
+line, for example:
+
+```
+USEMODULE=esp_wifi_ap \
+CFLAGS='-DESP_WIFI_SSID=\"MySSID\" -DESP_WIFI_PASS=\"MyPassphrase\" -DESP_WIFI_MAX_CONN=1 \
+make -C examples/gnrc_networking BOARD=...
+```
+
+@note
+- The `esp_wifi_ap` module is not used by default when `netdev_default` is used.
+- Supports open and WPA2-PSK authentication modes.
+- The ESP-NOW network interface and the WiFi SoftAP network interface can not
+be used simultaneously.
+
+@warning
+The SoftAP may or may not be at all reliable sometimes, this is a known
+problem with the Wi-Fi network interface, even on the official ESP-IDF.
+The problem is that the AP doesn't cache multicast data for connected
+stations, and if stations connected to the AP are power save enabled,
+they may experience multicast packet loss. This affects RIOT, because
+NDP relies on multicast packets to work correctly.
+Refer to the SDK documentation from Espressif on [AP Sleep](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#ap-sleep) for more information.
 
 \anchor esp32_esp_now_network_interface
 ## <a name="esp32_esp_now_network_interface"> ESP-NOW Network Interface </a> &nbsp;[[TOC](#esp32_toc)]

--- a/cpu/esp8266/doc.txt
+++ b/cpu/esp8266/doc.txt
@@ -29,7 +29,8 @@
     8. [Other Peripherals](#esp8266_other_peripherals)
 7. [Network Interfaces](#esp8266_network_interfaces)
     1. [WiFi Network Interface](#esp8266_wifi_network_interface)
-    2. [ESP-NOW Network Interface](#esp8266_esp_now_network_interface)
+    2. [WiFi SoftAP Network Interface](#esp8266_wifi_ap_network_interface)
+    3. [ESP-NOW Network Interface](#esp8266_esp_now_network_interface)
 8. [Preconfigured Devices](#esp8266_preconfigured_devices)
     1. [Network Devices](#esp8266_network_devices)
     2. [SD-Card Device](#esp8266_sd_card_device)
@@ -112,6 +113,7 @@ Module    | Default  | Short description
 [esp_qemu](#esp8266_qemu_mode_and_gdb) | not used  | generate image for `QEMU` and `GDB` debugging
 [esp_spiffs](#esp8266_spiffs_device) | not used  |  enable SPIFFS for on-board flash memory
 [esp_wifi](#esp8266_wifi_network_interface) | not used  | enable the Wifi network device
+[esp_wifi_ap](#esp8266_wifi_ap_network_interface) | not used  | enable the Wifi SoftAP network device
 
 </center>
 
@@ -418,6 +420,7 @@ Module | Description
 [esp_spiffs](#esp8266_spiffs_device) | Enable the SPIFFS drive in on-board flash memory
 [esp_sw_timer](#esp8266_timers) | Enable software timer implementation
 [esp_wifi](#esp8266_wifi_network_interface) | Enable the built-in WiFi module in infrastructure mode as `netdev` network device
+[esp_wifi_ap](#esp8266_wifi_ap_network_interface) | Enable the built-in WiFi SoftAP module as `netdev` network device
 
 </center><br>
 
@@ -713,6 +716,53 @@ border router for a mesh network which uses ESP-NOW.
 In this case the ESP-NOW interface must use the same channel as the AP of the
 infrastructure WiFi network. All ESP-NOW nodes must therefore be compiled with
 the channel of the AP asvalue for the parameter 'ESP_NOW_CHANNEL'.
+
+\anchor esp8266_wifi_ap_network_interface
+## <a name="esp8266_wifi_ap_network_interface"> WiFi SoftAP Network Interface </a> &nbsp;[[TOC](#esp8266_toc)]
+
+The RIOT port for the ESP8266 supports a `netdev` interface for the ESP32 WiFi
+SoftAP mode. Module `esp_wifi_ap` has to be enabled to use it.
+
+The following parameters can be configured:
+
+<center>
+
+Parameter                 | Default                   | Description
+:-------------------------|:--------------------------|:-------------
+#ESP_WIFI_SSID            | "RIOT_AP"                 | Static SSID definition for the SoftAP
+#ESP_WIFI_AP_PREFIX       | "RIOT_AP_"                | Optional prefix for dynamic SSID, if used, the node will create the SSID based on the prefix + mac address (e.g.: "RIOT_AP_aabbccddeeff"). This is disabled by default and `ESP_WIFI_SSID` is used, define this to enable the usage of the SSID prefix.
+#ESP_WIFI_PASS            | none                      | The password for the WiFi SoftAP network interface. If no password is provided, the interface will be "open", otherwise it uses WPA2-PSK authentication mode.
+#ESP_WIFI_SSID_HIDDEN     | 0                         | Whether the SoftAP SSID should be hidden.
+#ESP_WIFI_MAX_CONN        | 4                         | The maximum number of connections for the SoftAP.
+#ESP_WIFI_BEACON_INTERVAL | 100                       | The beacon interval time in milliseconds for the SoftAP.
+#ESP_WIFI_STACKSIZE       | #THREAD_STACKSIZE_DEFAULT | Stack size used for the WiFi netdev driver thread.
+
+</center>
+
+These configuration parameter definitions, as well as enabling the `esp_wifi_ap`
+module, can be done either in the makefile of the project or at make command
+line, for example:
+
+```
+USEMODULE=esp_wifi_ap \
+CFLAGS='-DESP_WIFI_SSID=\"MySSID\" -DESP_WIFI_PASS=\"MyPassphrase\" -DESP_WIFI_MAX_CONN=1 \
+make -C examples/gnrc_networking BOARD=...
+```
+
+@note
+- The `esp_wifi_ap` module is not used by default when `netdev_default` is used.
+- Supports open and WPA2-PSK authentication modes.
+- The ESP-NOW network interface and the WiFi SoftAP network interface can not
+be used simultaneously.
+
+@warning
+The SoftAP may or may not be at all reliable sometimes, this is a known
+problem with the Wi-Fi network interface, even on the official ESP-IDF.
+The problem is that the AP doesn't cache multicast data for connected
+stations, and if stations connected to the AP are power save enabled,
+they may experience multicast packet loss. This affects RIOT, because
+NDP relies on multicast packets to work correctly.
+Refer to the SDK documentation from Espressif on [AP Sleep](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#ap-sleep) for more information.
 
 \anchor esp8266_esp_now_network_interface
 ## <a name="esp8266_esp_now_network_interface"> ESP-NOW Network Interface </a> &nbsp;[[TOC](#esp8266_toc)]

--- a/cpu/esp_common/Kconfig
+++ b/cpu/esp_common/Kconfig
@@ -15,6 +15,7 @@ config CPU_COMMON_ESP
     select HAS_ESP_NOW
     select HAS_ESP_SPIFFS
     select HAS_ESP_WIFI
+    select HAS_ESP_WIFI_AP
     select HAS_LIBSTDCPP
     select HAS_PERIPH_CPUID
     select HAS_PERIPH_HWRNG
@@ -33,6 +34,11 @@ config HAS_ESP_WIFI
     bool
     help
         Indicates that an ESP WiFi radio is present.
+
+config HAS_ESP_WIFI_AP
+    bool
+    help
+        Indicates that ESP WiFi SoftAP support is present.
 
 config HAS_ESP_NOW
     bool

--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -24,6 +24,11 @@ USEMODULE += xtensa
 
 FEATURES_REQUIRED += cpp # Vendor code uses C++
 
+ifneq (,$(filter esp_wifi_ap,$(USEMODULE)))
+  FEATURES_REQUIRED += esp_wifi_ap
+  USEMODULE += esp_wifi
+endif
+
 ifneq (,$(filter esp_wifi_enterprise,$(USEMODULE)))
   FEATURES_REQUIRED += esp_wifi_enterprise
   USEMODULE += esp_wifi

--- a/cpu/esp_common/Makefile.features
+++ b/cpu/esp_common/Makefile.features
@@ -7,6 +7,7 @@ FEATURES_PROVIDED += arch_esp
 FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += esp_now
 FEATURES_PROVIDED += esp_spiffs
+FEATURES_PROVIDED += esp_wifi_ap
 FEATURES_PROVIDED += esp_wifi
 FEATURES_PROVIDED += libstdcpp
 FEATURES_PROVIDED += periph_cpuid
@@ -14,3 +15,6 @@ FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pm
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += ssp
+
+FEATURES_CONFLICT += esp_wifi_ap:esp_now
+FEATURES_CONFLICT_MSG += "ESP_NOW and ESP_WIFI_AP can not be used at the same time."

--- a/cpu/esp_common/Makefile.include
+++ b/cpu/esp_common/Makefile.include
@@ -14,6 +14,7 @@ PSEUDOMODULES += esp_log_startup
 PSEUDOMODULES += esp_qemu
 PSEUDOMODULES += esp_spiffs
 PSEUDOMODULES += esp_wifi_any
+PSEUDOMODULES += esp_wifi_ap
 
 # Common includes
 

--- a/cpu/esp_common/esp-wifi/esp_wifi_netdev.h
+++ b/cpu/esp_common/esp-wifi/esp_wifi_netdev.h
@@ -56,10 +56,14 @@ typedef struct
     uint8_t tx_buf[ETHERNET_MAX_LEN];  /**< transmit buffer */
 
     uint8_t event_recv;                /**< number of frame received events */
+#ifdef MODULE_ESP_WIFI_AP
+    uint8_t sta_connected;             /**< number of connected stations */
+#else /* MODULE_ESP_WIFI_AP */
     uint8_t event_conn;                /**< number of pending connect events */
     uint8_t event_disc;                /**< number of pending disc events */
 
     bool connected;                    /**< indicates whether connected to AP */
+#endif /* MODULE_ESP_WIFI_AP */
 
     mutex_t dev_lock;                  /**< device is already in use */
 

--- a/cpu/esp_common/esp-wifi/esp_wifi_params.h
+++ b/cpu/esp_common/esp-wifi/esp_wifi_params.h
@@ -44,8 +44,15 @@
 /**
  * @brief   SSID of the AP to be used.
  */
-#ifndef ESP_WIFI_SSID
+#if !defined(ESP_WIFI_SSID) && !defined(ESP_WIFI_AP_PREFIX)
 #define ESP_WIFI_SSID       "RIOT_AP"
+#endif
+
+/**
+ * @brief   Prefix to be used as part of the SSID (e.g.: RIOT_AP_aabbccddeeff)
+ */
+#if !defined(ESP_WIFI_SSID) && !defined(ESP_WIFI_AP_PREFIX) || defined(DOXYGEN)
+#define ESP_WIFI_AP_PREFIX "RIOT_AP_"
 #endif
 
 /**
@@ -54,6 +61,31 @@
 #ifdef DOXYGEN
 #define ESP_WIFI_PASS       "ThisistheRIOTporttoESP"
 #endif
+
+#if defined(MODULE_ESP_WIFI_AP) || defined(DOXYGEN)
+
+/**
+ * @brief   Whether SoftAP SSID should be hidden.
+ */
+#ifndef ESP_WIFI_SSID_HIDDEN
+#define ESP_WIFI_SSID_HIDDEN (0)
+#endif
+
+/**
+ * @brief   WiFi SoftAP maximum connections (max. 4).
+ */
+#ifndef ESP_WIFI_MAX_CONN
+#define ESP_WIFI_MAX_CONN    (4)
+#endif
+
+/**
+ * @brief   WiFi SoftAP beacon interval, in milliseconds.
+ */
+#ifndef ESP_WIFI_BEACON_INTERVAL
+#define ESP_WIFI_BEACON_INTERVAL (100)
+#endif
+
+#endif /* defined(ESP_WIFI_AP) || defined(DOXYGEN) */
 
 /**@}*/
 


### PR DESCRIPTION
### Contribution description

This is an implementation of the ESP32 SoftAP mode using the `esp_wifi_ap` pseudomodule.

The clients connected to the AP work normally (they are reachable with `ping6`). As DHCP isn't implemented most OSes will struggle trying to get an IP from the ESP32 SoftAP.

### Testing procedure

- Use `gnrc_networking` example and add `USEMODULE += esp_wifi_ap`. Upon ESP32 initialization a WiFi AP is started with the default SSID `RIOT_AP`.
- Use two ESP nodes, one ESP32 as AP and one ESP32/ESP8266 as station. Flash them `gnrc_networking`, for example
   ```
   USEMODULE=esp_wifi_ap make BOARD=esp32-wroom-32 -C examples/gnrc_networking flash PORT=/dev/ttyUSB0
   USEMODULE=esp_wifi make BOARD=esp8266 -C examples/gnrc_networking flash PORT=/dev/ttyUSB1
   ```
   The ESP32/ESP8266 in station mode should be able to connect, shown by message `STA connected` on the ESP32 AP. After that, it should be possible to ping in both directions.

### Issues/PRs references

#14114 
