### PR TITLE
cpu/stm32: implement reset to bootloader

### DIFF
--- a/cpu/stm32/bootloader.c
+++ b/cpu/stm32/bootloader.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_stm32
+ * @{
+ *
+ * @file
+ * @brief       Trigger reset to the bootloader stored in the internal boot ROM
+ *              memory.
+ *
+ *              This will start the DFU bootloader on the USB interface.
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "periph_cpu.h"
+
+#define BOOTLOADER_MAGIC    0xB007AFFE
+
+static uint32_t _magic __attribute__((section(".noinit")));
+
+void pre_startup(void)
+{
+    if (_magic != BOOTLOADER_MAGIC) {
+        return;
+    }
+
+    /* clear magic */
+    _magic = 0;
+
+    /* enable SYSCFG clock */
+    RCC->APB2ENR   = RCC_APB2ENR_SYSCFGEN;
+
+    /* remap ROM at zero */
+    SYSCFG->MEMRMP = SYSCFG_MEMRMP_MEM_MODE_0;
+
+    /* jump to the bootloader */
+    __asm__ volatile("ldr r0, =%0" :: "i" (STM32_LOADER_ADDR));
+    __asm__ volatile("ldr sp, [r0]");
+    __asm__ volatile("ldr pc, [r0, #4]");
+}
+
+void __attribute__((weak)) usb_board_reset_in_bootloader(void)
+{
+    _magic = BOOTLOADER_MAGIC;
+    NVIC_SystemReset();
+}

--- a/cpu/stm32/include/periph/f0/periph_cpu.h
+++ b/cpu/stm32/include/periph/f0/periph_cpu.h
@@ -28,6 +28,21 @@ extern "C" {
  */
 #define CPUID_ADDR          (0x1ffff7ac)
 
+/**
+ * @brief   Starting address of the ROM bootloader
+ *          see application note AN2606
+ */
+#if defined(CPU_LINE_STM32F030x4) || defined(CPU_LINE_STM32F030x6) || \
+    defined(CPU_LINE_STM32F030x8) || defined(CPU_LINE_STM32F031x6) || \
+    defined(CPU_LINE_STM32F051x8)
+#define STM32_LOADER_ADDR   (0x1FFFEC00)
+#elif defined(CPU_LINE_STM32F030xC) || defined(CPU_LINE_STM32F070xB) || \
+      defined(CPU_LINE_STM32F072xB) || defined(CPU_LINE_STM32F091xC)
+#define STM32_LOADER_ADDR   (0x1FFFD800)
+#elif defined(CPU_LINE_STM32F042x6)
+#define STM32_LOADER_ADDR   (0x1FFFC400)
+#endif
+
 #ifndef DOXYGEN
 /**
  * @brief   Override ADC resolution values

--- a/cpu/stm32/include/periph/f1/periph_cpu.h
+++ b/cpu/stm32/include/periph/f1/periph_cpu.h
@@ -29,6 +29,14 @@ extern "C" {
 #define CPUID_ADDR          (0x1ffff7e8)
 
 /**
+ * @brief   Starting address of the ROM bootloader
+ *          see application note AN2606
+ */
+#if defined(CPU_LINE_STM32F103xB) || defined(CPU_LINE_STM32F103xE)
+#define STM32_LOADER_ADDR   (0x1FFFF000)
+#endif
+
+/**
  * @name    Real time counter configuration
  * @{
  */

--- a/cpu/stm32/include/periph/f2/periph_cpu.h
+++ b/cpu/stm32/include/periph/f2/periph_cpu.h
@@ -31,6 +31,12 @@ extern "C" {
 #define CPUID_ADDR          (0x1fff7a10)
 
 /**
+ * @brief   Starting address of the ROM bootloader
+ *          see application note AN2606
+ */
+#define STM32_LOADER_ADDR   (0x1FFF0000)
+
+/**
  * @brief   Available number of ADC devices
  */
 #define ADC_DEVS            (2U)

--- a/cpu/stm32/include/periph/f3/periph_cpu.h
+++ b/cpu/stm32/include/periph/f3/periph_cpu.h
@@ -28,6 +28,12 @@ extern "C" {
  */
 #define CPUID_ADDR          (0x1ffff7ac)
 
+/**
+ * @brief   Starting address of the ROM bootloader
+ *          see application note AN2606
+ */
+#define STM32_LOADER_ADDR   (0x1FFFD800)
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32/include/periph/f4/periph_cpu.h
+++ b/cpu/stm32/include/periph/f4/periph_cpu.h
@@ -29,6 +29,12 @@ extern "C" {
 #define CPUID_ADDR          (0x1fff7a10)
 
 /**
+ * @brief   Starting address of the ROM bootloader
+ *          see application note AN2606
+ */
+#define STM32_LOADER_ADDR   (0x1FFF0000)
+
+/**
  * @brief   Available number of ADC devices
  */
 #if defined(CPU_LINE_STM32F401xE) || defined(CPU_LINE_STM32F410Rx) \

--- a/cpu/stm32/include/periph/f7/periph_cpu.h
+++ b/cpu/stm32/include/periph/f7/periph_cpu.h
@@ -25,6 +25,12 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Starting address of the ROM bootloader
+ *          see application note AN2606
+ */
+#define STM32_LOADER_ADDR   (0x1FF00000)
+
+/**
  * @name    Starting address of the CPU ID
  */
 #if defined(CPU_LINE_STM32F722xx) || defined(CPU_LINE_STM32F723xx)

--- a/cpu/stm32/include/periph/l0/periph_cpu.h
+++ b/cpu/stm32/include/periph/l0/periph_cpu.h
@@ -27,6 +27,12 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Starting address of the ROM bootloader
+ *          see application note AN2606
+ */
+#define STM32_LOADER_ADDR   (0x1FF00000)
+
+/**
  * @brief   Starting address of the CPU ID
  */
 #define CPUID_ADDR          (0x1ff80050)

--- a/cpu/stm32/include/periph/l1/periph_cpu.h
+++ b/cpu/stm32/include/periph/l1/periph_cpu.h
@@ -26,6 +26,12 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Starting address of the ROM bootloader
+ *          see application note AN2606
+ */
+#define STM32_LOADER_ADDR   (0x1FF00000)
+
+/**
  * @name    Starting address of the CPU ID
  */
 #if defined(CPU_MODEL_STM32L151RB_A) || defined(CPU_MODEL_STM32L151CB) || \

--- a/cpu/stm32/include/periph/l4/periph_cpu.h
+++ b/cpu/stm32/include/periph/l4/periph_cpu.h
@@ -25,6 +25,12 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Starting address of the ROM bootloader
+ *          see application note AN2606
+ */
+#define STM32_LOADER_ADDR   (0x1FFF0000)
+
+/**
  * @brief   Starting address of the CPU ID
  */
 #define CPUID_ADDR          (0x1fff7590)

--- a/cpu/stm32/include/periph/wb/periph_cpu.h
+++ b/cpu/stm32/include/periph/wb/periph_cpu.h
@@ -25,6 +25,12 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Starting address of the ROM bootloader
+ *          see application note AN2606
+ */
+#define STM32_LOADER_ADDR   (0x1FFF0000)
+
+/**
  * @brief   Starting address of the CPU ID
  */
 #define CPUID_ADDR          (0x1fff7580)


### PR DESCRIPTION
### Contribution description

The STM32 line of microcontrollers comes with a [bootloader](https://www.st.com/resource/en/application_note/cd00167594-stm32-microcontroller-system-memory-boot-mode-stmicroelectronics.pdf) in the ROM.
It provides the option to flash the device firmware in DFU mode (USB) or via UART or SPI.

To enter the bootloader we have to jump to a specific address in memory, but before reset the CPU to make sure the system is in a known state.

This enables us to use the `usb_board_reset` module on all STM32 platforms.

### Testing procedure

You can use this patch to `examples/default` to add a `dfu` shell command that will restart the board in DFU mode.

```patch
--- a/examples/default/main.c
+++ b/examples/default/main.c
@@ -34,6 +34,24 @@
 #include "net/gnrc.h"
 #endif
 
+extern void usb_board_reset_in_bootloader(void);
+
+static int _dfu_reset(int argc, char** argv)
+{
+    (void) argc;
+    (void) argv;
+
+    usb_board_reset_in_bootloader();
+
+    return 0;
+}
+
+
+static const shell_command_t shell_commands[] = {
+    { "dfu", "enter DFU mode", _dfu_reset},
+    { NULL, NULL, NULL }
+};
+
 int main(void)
 {
 #ifdef MODULE_NETIF
@@ -45,7 +63,7 @@ int main(void)
     (void) puts("Welcome to RIOT!");
 
     char line_buf[SHELL_DEFAULT_BUFSIZE];
-    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     return 0;
 }
```

### Issues/PRs references

Always having to press the reset button is tiring after a while (and ESD seems to get the board in bad states sometimes), so this will make working with #12778 much more comfortable. 
