### PR TITLE
boards/stm32f429i-disco: add support

### DIFF
--- a/boards/stm32f429i-disco/Makefile
+++ b/boards/stm32f429i-disco/Makefile
@@ -1,0 +1,2 @@
+DIRS = $(RIOTBOARD)/stm32f429i-disc1
+include $(RIOTBASE)/Makefile.base

--- a/boards/stm32f429i-disco/Makefile.dep
+++ b/boards/stm32f429i-disco/Makefile.dep
@@ -1,0 +1,5 @@
+ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+  USEMODULE += stdio_cdc_acm
+endif
+
+include $(RIOTBOARD)/stm32f429i-disc1/Makefile.dep

--- a/boards/stm32f429i-disco/Makefile.features
+++ b/boards/stm32f429i-disco/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/stm32f429i-disc1/Makefile.features

--- a/boards/stm32f429i-disco/Makefile.include
+++ b/boards/stm32f429i-disco/Makefile.include
@@ -1,0 +1,4 @@
+STLINK_VERSION ?= 2
+INCLUDES  += -I$(RIOTBOARD)/stm32f429i-disc1/include
+
+include $(RIOTBOARD)/stm32f429i-disc1/Makefile.include

--- a/boards/stm32f429i-disco/doc.txt
+++ b/boards/stm32f429i-disco/doc.txt
@@ -1,0 +1,13 @@
+/**
+ * @defgroup    boards_stm32f429i-disco STM32F429I-DISCO
+ * @ingroup     boards
+ * @brief       Support for the STM32F429I-DISCO board
+ */
+
+### General information
+
+The board is identical to the @ref boards_stm32f429i-disc1 except that it uses
+an older on-board ST-LINK debugger that does not provide a serial UART interface.
+
+To mitigate that, stdio is instead provided through the micro-USB connector using
+RIOT's CDC ACM functionality.


### PR DESCRIPTION
### Contribution description

There is an older version of the `stm32f429i-disc1` called the `stm32f429i-disco`. From what I could gather, they are completely exchangeable. 

The debugger on the `stm32f429i-disco` however does not provide a UART connection.
To spare the user of having to wire up a USB-TTL adapter, enable CDC-ACM on the micro-USB port.

### Testing procedure

Flash any example on the `stm32f429i-disco` board.
You should have a serial console on the micro-USB connector of the board.

### Issues/PRs references

e01a95d43fecac1c6a651c735017bc457b74c3eb is taken from #12778 to allow `stdio_cdc_acm` on stm32