### PR TITLE
ztimer: relocate PSEUDOMULDES definitions 

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -253,6 +253,18 @@ check_files_in_boards_not_reference_board_var() {
         | error_with_message 'Code in boards/ should not use $(BOARDS) to reference files since this breaks external BOARDS changing BOARDSDIR"'
 }
 
+check_no_pseudomules_in_makefile_dep() {
+    local patterns=()
+    local pathspec=()
+
+    patterns+=(-e 'PSEUDOMODULES[\t ]*[+:]*=')
+
+    pathspec+=('**/Makefile.dep')
+
+    git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}" \
+        | error_with_message "Don't define PSEUDOMODULES in Makefile.dep"
+}
+
 error_on_input() {
     ! grep ''
 }
@@ -268,6 +280,7 @@ all_checks() {
     checks_tests_application_not_defined_in_makefile
     checks_develhelp_not_defined_via_cflags
     check_files_in_boards_not_reference_board_var
+    check_no_pseudomules_in_makefile_dep
 }
 
 main() {

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -106,6 +106,7 @@ PSEUDOMODULES += stdio_cdc_acm
 PSEUDOMODULES += stdio_uart_rx
 PSEUDOMODULES += suit_transport_%
 PSEUDOMODULES += wakaama_objects_%
+PSEUDOMODULES += xtimer_on_ztimer
 PSEUDOMODULES += zptr
 PSEUDOMODULES += ztimer%
 

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -111,3 +111,9 @@ endif
 ifneq (,$(filter zptr,$(USEMODULE)))
   include $(RIOTBASE)/sys/zptr/Makefile.include
 endif
+
+# Convert xtimer into a pseudo module if its API is already implemented by
+# ztimer's compatibility wrapper
+ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+  PSEUDOMODULES += xtimer
+endif

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -42,7 +42,6 @@ endif
 ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
   USEMODULE += div
   USEMODULE += ztimer_usec
-  PSEUDOMODULES += xtimer
 endif
 
 ifneq (,$(filter ztimer_%,$(USEMODULE)))

--- a/sys/ztimer/Makefile.dep
+++ b/sys/ztimer/Makefile.dep
@@ -35,7 +35,6 @@ endif
 # make xtimer use ztimer_usec as low level timer
 ifneq (,$(filter xtimer_on_ztimer,$(USEMODULE)))
   USEMODULE += ztimer_usec
-  PSEUDOMODULES += xtimer_on_ztimer
 endif
 
 # "ztimer_xtimer_compat" is a wrapper of the xtimer API on ztimer_used


### PR DESCRIPTION
### Contribution description

The discussion in #13661 pointed out that `ztimer` is the only module touching `PSEUDOMUDLES` within its `Makefile.dep`. To be aligned to the current dependency resolution system of RIOT, this PR relocates these definitions.

### Testing procedure

1. `env USEMODULE="ztimer xtimer_on_ztimer" make -C tests/xtimer_msg clean all test`
2. `env USEMODULE="ztimer ztimer_xtimer_compat" make -C tests/xtimer_msg clean all test`
3. `./dist/tools/buildsystem_sanity_check/check.sh`

### Issues/PRs references

#13661 