### PR TITLE
cpu/stm32/qdec: test null callback pointer

### DIFF
--- a/cpu/stm32/periph/qdec.c
+++ b/cpu/stm32/periph/qdec.c
@@ -115,13 +115,10 @@ int32_t qdec_init(qdec_t qdec, qdec_mode_t mode, qdec_cb_t cb, void *arg)
     isr_ctx[qdec].arg = arg;
 
     /* Enable the qdec's interrupt only if there is a callback provided */
-    if (cb)
-    {
+    if (cb) {
         NVIC_EnableIRQ(qdec_config[qdec].irqn);
         dev(qdec)->DIER |= TIM_DIER_UIE;
-    }
-    else
-    {
+    } else {
         dev(qdec)->DIER &= ~TIM_DIER_UIE;
     }
 

--- a/cpu/stm32/periph/qdec.c
+++ b/cpu/stm32/periph/qdec.c
@@ -114,9 +114,16 @@ int32_t qdec_init(qdec_t qdec, qdec_mode_t mode, qdec_cb_t cb, void *arg)
     isr_ctx[qdec].cb = cb;
     isr_ctx[qdec].arg = arg;
 
-    /* Enable the qdec's interrupt */
-    NVIC_EnableIRQ(qdec_config[qdec].irqn);
-    dev(qdec)->DIER |= TIM_DIER_UIE;
+    /* Enable the qdec's interrupt only if there is a callback provided */
+    if (cb)
+    {
+        NVIC_EnableIRQ(qdec_config[qdec].irqn);
+        dev(qdec)->DIER |= TIM_DIER_UIE;
+    }
+    else
+    {
+        dev(qdec)->DIER &= ~TIM_DIER_UIE;
+    }
 
     /* Reset counter and start qdec */
     qdec_start(qdec);


### PR DESCRIPTION
#### Contribution description

This PR is a fix to test callback pointer in case it is NULL.
Thanks to @Yanok35 for pointing this out.

#### Testing procedure

make -C tests/periph_qdec/ BOARD=native

#### Issues/PRs references

None