### PR TITLE
gnrc/tcp : Expose configurations to Kconfig

### DIFF
--- a/sys/include/net/gnrc/tcp.h
+++ b/sys/include/net/gnrc/tcp.h
@@ -150,7 +150,7 @@ int gnrc_tcp_open_active(gnrc_tcp_tcb_t *tcb, const gnrc_tcp_ep_t *remote,
  *                    or the address in @p local is invalid.
  * @return   -EISCONN if TCB is already in use.
  * @return   -ENOMEM if the receive buffer for the TCB could not be allocated.
- *            Hint: Increase "GNRC_TCP_RCV_BUFFERS".
+ *            Hint: Increase "CONFIG_GNRC_TCP_RCV_BUFFERS".
  */
 int gnrc_tcp_open_passive(gnrc_tcp_tcb_t *tcb, const gnrc_tcp_ep_t *local);
 

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -27,6 +27,31 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup net_gnrc_tcp_conf GNRC TCP compile configurations
+ * @ingroup net_gnrc_conf
+ *
+ * ## Calculating RTO
+ * To calculate retransmission timeout (RTO), Round Trip Time (RTT) needs to be
+ * taken into account. SRTT (smoothed round-trip time) and RTTVAR (round-trip
+ * time variation) are hence calculated as follows:
+ *
+ *     RTTVAR <- (1 - beta) * RTTVAR + beta * |SRTT - R'|
+ *     SRTT <- (1 - alpha) * SRTT + alpha * R'
+ *
+ * where alpha ( 1 / @ref CONFIG_GNRC_TCP_RTO_A_DIV ) and beta
+ * ( 1 / @ref CONFIG_GNRC_TCP_RTO_B_DIV) are constants, and R' is the
+ * instantaneous RTT value.
+ *
+ * RTO is then calculated as :
+ *
+ *     RTO <- SRTT + max (G, K*RTTVAR)
+ *
+ * where K is a constant, and G is clock granularity in seconds
+ * ( @ref CONFIG_GNRC_TCP_RTO_GRANULARITY).
+ * For more information refer to https://tools.ietf.org/html/rfc6298
+ * @{
+ */
+/**
  * @brief Timeout duration for user calls. Default is 2 minutes.
  */
 #ifndef GNRC_TCP_CONNECTION_TIMEOUT_DURATION
@@ -66,7 +91,10 @@ extern "C" {
 #endif
 
 /**
- * @brief Number of preallocated receive buffers
+ * @brief Number of preallocated receive buffers.
+ *
+ * This value determines how many parallel TCP connections can be active at the
+ * same time.
  */
 #ifndef GNRC_TCP_RCV_BUFFERS
 #define GNRC_TCP_RCV_BUFFERS (1U)
@@ -81,6 +109,10 @@ extern "C" {
 
 /**
  * @brief Lower bound for RTO = 1 sec (see RFC 6298)
+ *
+ * @note Retransmission Timeout (RTO) determines how long TCP waits for
+ * acknowledgment (ACK) of transmitted segment. If the acknowledgment
+ * isn't received within this time it is considered lost.
  */
 #ifndef GNRC_TCP_RTO_LOWER_BOUND
 #define GNRC_TCP_RTO_LOWER_BOUND (1U * US_PER_SEC)
@@ -134,6 +166,7 @@ extern "C" {
 #ifndef GNRC_TCP_PROBE_UPPER_BOUND
 #define GNRC_TCP_PROBE_UPPER_BOUND (60U * US_PER_SEC)
 #endif
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -128,8 +128,8 @@ extern "C" {
 /**
  * @brief Assumes clock granularity for TCP of 10 ms (see RFC 6298)
  */
-#ifndef GNRC_TCP_RTO_GRANULARITY
-#define GNRC_TCP_RTO_GRANULARITY (10U * MS_PER_SEC)
+#ifndef CONFIG_GNRC_TCP_RTO_GRANULARITY
+#define CONFIG_GNRC_TCP_RTO_GRANULARITY (10U * MS_PER_SEC)
 #endif
 
 /**

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -86,8 +86,8 @@ extern "C" {
 /**
  * @brief Default receive window size
  */
-#ifndef GNRC_TCP_DEFAULT_WINDOW
-#define GNRC_TCP_DEFAULT_WINDOW (CONFIG_GNRC_TCP_MSS * CONFIG_GNRC_TCP_MSS_MULTIPLICATOR)
+#ifndef CONFIG_GNRC_TCP_DEFAULT_WINDOW
+#define CONFIG_GNRC_TCP_DEFAULT_WINDOW (CONFIG_GNRC_TCP_MSS * CONFIG_GNRC_TCP_MSS_MULTIPLICATOR)
 #endif
 
 /**
@@ -104,7 +104,7 @@ extern "C" {
  * @brief Default receive buffer size
  */
 #ifndef GNRC_TCP_RCV_BUF_SIZE
-#define GNRC_TCP_RCV_BUF_SIZE (GNRC_TCP_DEFAULT_WINDOW)
+#define GNRC_TCP_RCV_BUF_SIZE (CONFIG_GNRC_TCP_DEFAULT_WINDOW)
 #endif
 
 /**

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -121,8 +121,8 @@ extern "C" {
 /**
  * @brief Upper bound for RTO = 60 sec (see RFC 6298)
  */
-#ifndef GNRC_TCP_RTO_UPPER_BOUND
-#define GNRC_TCP_RTO_UPPER_BOUND (60U * US_PER_SEC)
+#ifndef CONFIG_GNRC_TCP_RTO_UPPER_BOUND
+#define CONFIG_GNRC_TCP_RTO_UPPER_BOUND (60U * US_PER_SEC)
 #endif
 
 /**

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -79,15 +79,15 @@ extern "C" {
 /**
  * @brief MSS Multiplicator = Number of MSS sized packets stored in receive buffer
  */
-#ifndef GNRC_TCP_MSS_MULTIPLICATOR
-#define GNRC_TCP_MSS_MULTIPLICATOR (1U)
+#ifndef CONFIG_GNRC_TCP_MSS_MULTIPLICATOR
+#define CONFIG_GNRC_TCP_MSS_MULTIPLICATOR (1U)
 #endif
 
 /**
  * @brief Default receive window size
  */
 #ifndef GNRC_TCP_DEFAULT_WINDOW
-#define GNRC_TCP_DEFAULT_WINDOW (GNRC_TCP_MSS * GNRC_TCP_MSS_MULTIPLICATOR)
+#define GNRC_TCP_DEFAULT_WINDOW (GNRC_TCP_MSS * CONFIG_GNRC_TCP_MSS_MULTIPLICATOR)
 #endif
 
 /**

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -61,8 +61,8 @@ extern "C" {
 /**
  * @brief Maximum segment lifetime (MSL). Default is 30 seconds.
  */
-#ifndef GNRC_TCP_MSL
-#define GNRC_TCP_MSL (30U * US_PER_SEC)
+#ifndef CONFIG_GNRC_TCP_MSL
+#define CONFIG_GNRC_TCP_MSL (30U * US_PER_SEC)
 #endif
 
 /**

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -135,8 +135,8 @@ extern "C" {
 /**
  * @brief Alpha value for RTO calculation, default is 1/8
  */
-#ifndef GNRC_TCP_RTO_A_DIV
-#define GNRC_TCP_RTO_A_DIV (8U)
+#ifndef CONFIG_GNRC_TCP_RTO_A_DIV
+#define CONFIG_GNRC_TCP_RTO_A_DIV (8U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -96,8 +96,8 @@ extern "C" {
  * This value determines how many parallel TCP connections can be active at the
  * same time.
  */
-#ifndef GNRC_TCP_RCV_BUFFERS
-#define GNRC_TCP_RCV_BUFFERS (1U)
+#ifndef CONFIG_GNRC_TCP_RCV_BUFFERS
+#define CONFIG_GNRC_TCP_RCV_BUFFERS (1U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -54,8 +54,8 @@ extern "C" {
 /**
  * @brief Timeout duration for user calls. Default is 2 minutes.
  */
-#ifndef GNRC_TCP_CONNECTION_TIMEOUT_DURATION
-#define GNRC_TCP_CONNECTION_TIMEOUT_DURATION (120U * US_PER_SEC)
+#ifndef CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION
+#define CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION (120U * US_PER_SEC)
 #endif
 
 /**

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -149,8 +149,8 @@ extern "C" {
 /**
  * @brief K value for RTO calculation, default is 4
  */
-#ifndef GNRC_TCP_RTO_K
-#define GNRC_TCP_RTO_K (4U)
+#ifndef CONFIG_GNRC_TCP_RTO_K
+#define CONFIG_GNRC_TCP_RTO_K (4U)
 #endif
 
 /**

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -68,11 +68,11 @@ extern "C" {
 /**
  * @brief Maximum Segment Size (MSS).
  */
-#ifndef GNRC_TCP_MSS
+#ifndef CONFIG_GNRC_TCP_MSS
 #ifdef  MODULE_GNRC_IPV6
-#define GNRC_TCP_MSS (1220U) /**< If IPv6 is used. Get MSS = 1280 - IPv6 Hdr - TCP Hdr = 1220 */
+#define CONFIG_GNRC_TCP_MSS (1220U) /**< If IPv6 is used. Get MSS = 1280 - IPv6 Hdr - TCP Hdr = 1220 */
 #else
-#define GNRC_TCP_MSS (576U) /**< Default MSS */
+#define CONFIG_GNRC_TCP_MSS (576U) /**< Default MSS */
 #endif
 #endif
 
@@ -87,7 +87,7 @@ extern "C" {
  * @brief Default receive window size
  */
 #ifndef GNRC_TCP_DEFAULT_WINDOW
-#define GNRC_TCP_DEFAULT_WINDOW (GNRC_TCP_MSS * CONFIG_GNRC_TCP_MSS_MULTIPLICATOR)
+#define GNRC_TCP_DEFAULT_WINDOW (CONFIG_GNRC_TCP_MSS * CONFIG_GNRC_TCP_MSS_MULTIPLICATOR)
 #endif
 
 /**

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -114,8 +114,8 @@ extern "C" {
  * acknowledgment (ACK) of transmitted segment. If the acknowledgment
  * isn't received within this time it is considered lost.
  */
-#ifndef GNRC_TCP_RTO_LOWER_BOUND
-#define GNRC_TCP_RTO_LOWER_BOUND (1U * US_PER_SEC)
+#ifndef CONFIG_GNRC_TCP_RTO_LOWER_BOUND
+#define CONFIG_GNRC_TCP_RTO_LOWER_BOUND (1U * US_PER_SEC)
 #endif
 
 /**

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -163,8 +163,8 @@ extern "C" {
 /**
  * @brief Upper bound for the duration between probes
  */
-#ifndef GNRC_TCP_PROBE_UPPER_BOUND
-#define GNRC_TCP_PROBE_UPPER_BOUND (60U * US_PER_SEC)
+#ifndef CONFIG_GNRC_TCP_PROBE_UPPER_BOUND
+#define CONFIG_GNRC_TCP_PROBE_UPPER_BOUND (60U * US_PER_SEC)
 #endif
 /** @} */
 

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -156,8 +156,8 @@ extern "C" {
 /**
  * @brief Lower bound for the duration between probes
  */
-#ifndef GNRC_TCP_PROBE_LOWER_BOUND
-#define GNRC_TCP_PROBE_LOWER_BOUND (1U * US_PER_SEC)
+#ifndef CONFIG_GNRC_TCP_PROBE_LOWER_BOUND
+#define CONFIG_GNRC_TCP_PROBE_LOWER_BOUND (1U * US_PER_SEC)
 #endif
 
 /**

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -142,8 +142,8 @@ extern "C" {
 /**
  * @brief Beta value for RTO calculation, default is 1/4
  */
-#ifndef GNRC_TCP_RTO_B_DIV
-#define GNRC_TCP_RTO_B_DIV (4U)
+#ifndef CONFIG_GNRC_TCP_RTO_B_DIV
+#define CONFIG_GNRC_TCP_RTO_B_DIV (4U)
 #endif
 
 /**

--- a/sys/net/gnrc/Kconfig
+++ b/sys/net/gnrc/Kconfig
@@ -13,5 +13,6 @@ rsource "netif/Kconfig"
 rsource "network_layer/ipv6/Kconfig"
 rsource "network_layer/sixlowpan/Kconfig"
 rsource "routing/rpl/Kconfig"
+rsource "transport_layer/tcp/Kconfig"
 
 endmenu # GNRC Network Stack

--- a/sys/net/gnrc/transport_layer/tcp/Kconfig
+++ b/sys/net/gnrc/transport_layer/tcp/Kconfig
@@ -1,0 +1,115 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_GNRC_TCP
+    bool "Configure GNRC_TCP"
+    depends on MODULE_GNRC_TCP
+    help
+        Configure the GNRC_TCP using Kconfig.
+
+if KCONFIG_MODULE_GNRC_TCP
+
+config GNRC_TCP_CONNECTION_TIMEOUT_DURATION
+    int "Timeout duration for user calls in microseconds"
+    default 120000000
+    help
+        Timeout duration for user calls. Default value is 120000000 microseconds
+        (2 minutes).
+
+config GNRC_TCP_MSL
+    int "Maximum segment lifetime (MSL) in microseconds"
+    default 30000000
+    help
+        Maximum segment lifetime (MSL) in microseconds. Default value is 30
+        seconds.
+
+config GNRC_TCP_MSS
+    int "Maximum Segment Size (MSS)"
+    default 1220 if MODULE_GNRC_IPV6
+    default 576
+
+config GNRC_TCP_MSS_MULTIPLICATOR
+    int "Number of MSS sized packets stored in receive buffer"
+    default 1
+    help
+        Configure MSS Multiplicator i.e. number of MSS sized packets stored in
+        receive buffer.
+
+config GNRC_TCP_DEFAULT_WINDOW_EN
+    bool "Enable configuration of TCP window size"
+    help
+        Enable configuration of TCP window size. If not enabled, TCP window size
+        will default to the product of Maximum Segment Size and the number of
+        MSS sized packets i.e. CONFIG_GNRC_TCP_MSS *
+        CONFIG_GNRC_TCP_MSS_MULTIPLICATOR.
+
+config GNRC_TCP_DEFAULT_WINDOW
+    int "TCP receive window size"
+    default 1220 if MODULE_GNRC_IPV6
+    default 576
+    depends on GNRC_TCP_DEFAULT_WINDOW_EN
+    help
+        Configure TCP receive window size. This value determines the maximum
+        amount of bytes that can be received from the peer at a given moment.
+
+config GNRC_TCP_RCV_BUFFERS
+    int "Number of preallocated receive buffers"
+    default 1
+
+config GNRC_TCP_RTO_LOWER_BOUND
+    int "Lower bound for RTO in microseconds"
+    default 1000000
+    help
+        Lower bound value for retransmission timeout (RTO) in microseconds.
+        Default value is 1000000 microseconds (1 second). Retransmission
+        timeout determines how long TCP waits for acknowledgment (ACK) of
+        transmitted segment. Refer to RFC 6298 for more information.
+
+config GNRC_TCP_RTO_UPPER_BOUND
+    int "Upper bound for RTO in microseconds"
+    default 60000000
+    help
+        Upper bound value for retransmission timeout (RTO) in microseconds.
+        Default value is 60000000 microseconds (60 seconds). Refer to RFC 6298
+        for more information.
+
+config GNRC_TCP_RTO_GRANULARITY
+    int "Clock granularity for RTO in microseconds"
+    default 10000
+    help
+        Clock granularity for retransmission timeout (RTO) for TCP in
+        microseconds. Default value is 10000 microseconds (10 milliseconds).
+        Refer to RFC 6298 for more information.
+
+config GNRC_TCP_RTO_A_DIV
+    int "Alpha value divisor for RTO calculation"
+    default 8
+    help
+        Alpha value divisor to calculate retransmission timeout (RTO). The
+        default value for divisor is 8 which would result in an alpha value of
+        1/8.
+
+config GNRC_TCP_RTO_B_DIV
+    int "Beta value divisor for RTO calculation"
+    default 4
+    help
+        Beta value divisor to calculate retransmission timeout (RTO). The
+        default value for divisor is 4 which would result in a beta value of
+        1/4.
+
+config GNRC_TCP_RTO_K
+    int "K value for RTO calculation"
+    default 4
+
+config GNRC_TCP_PROBE_LOWER_BOUND
+    int "Lower bound for the duration between probes in microseconds"
+    default 1000000
+
+config GNRC_TCP_PROBE_UPPER_BOUND
+    int "Lower bound for the duration between probes in microseconds"
+    default 60000000
+
+endif # KCONFIG_MODULE_GNRC_TCP

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -186,7 +186,7 @@ static int _gnrc_tcp_open(gnrc_tcp_tcb_t *tcb, const gnrc_tcp_ep_t *remote,
         tcb->peer_port = remote->port;
 
         /* Setup connection timeout: Put timeout message in TCBs mbox on expiration */
-        _setup_timeout(&connection_timeout, GNRC_TCP_CONNECTION_TIMEOUT_DURATION,
+        _setup_timeout(&connection_timeout, CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION,
                        _cb_mbox_put_msg, &connection_timeout_arg);
     }
 
@@ -211,7 +211,7 @@ static int _gnrc_tcp_open(gnrc_tcp_tcb_t *tcb, const gnrc_tcp_ep_t *remote,
                  * send SYN+ACK we received upon entering SYN_RCVD is never acknowledged
                  * by the peer. */
                 if ((tcb->state == FSM_STATE_SYN_RCVD) && (tcb->status & STATUS_PASSIVE)) {
-                    _setup_timeout(&connection_timeout, GNRC_TCP_CONNECTION_TIMEOUT_DURATION,
+                    _setup_timeout(&connection_timeout, CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION,
                                    _cb_mbox_put_msg, &connection_timeout_arg);
                 }
                 break;
@@ -493,7 +493,7 @@ ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
     }
 
     /* Setup connection timeout: Put timeout message in tcb's mbox on expiration */
-    _setup_timeout(&connection_timeout, GNRC_TCP_CONNECTION_TIMEOUT_DURATION,
+    _setup_timeout(&connection_timeout, CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION,
                    _cb_mbox_put_msg, &connection_timeout_arg);
 
     /* Setup user specified timeout if timeout_us is greater than zero */
@@ -560,7 +560,7 @@ ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
                 DEBUG("gnrc_tcp.c : gnrc_tcp_send() : NOTIFY_USER\n");
 
                 /* Connection is alive: Reset Connection Timeout */
-                _setup_timeout(&connection_timeout, GNRC_TCP_CONNECTION_TIMEOUT_DURATION,
+                _setup_timeout(&connection_timeout, CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION,
                                _cb_mbox_put_msg, &connection_timeout_arg);
 
                 /* If the window re-opened and we are probing: Stop it */
@@ -633,7 +633,7 @@ ssize_t gnrc_tcp_recv(gnrc_tcp_tcb_t *tcb, void *data, const size_t max_len,
     }
 
     /* Setup connection timeout: Put timeout message in tcb's mbox on expiration */
-    _setup_timeout(&connection_timeout, GNRC_TCP_CONNECTION_TIMEOUT_DURATION,
+    _setup_timeout(&connection_timeout, CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION,
                    _cb_mbox_put_msg, &connection_timeout_arg);
 
     /* Setup user specified timeout */
@@ -714,7 +714,7 @@ void gnrc_tcp_close(gnrc_tcp_tcb_t *tcb)
     }
 
     /* Setup connection timeout: Put timeout message in tcb's mbox on expiration */
-    _setup_timeout(&connection_timeout, GNRC_TCP_CONNECTION_TIMEOUT_DURATION,
+    _setup_timeout(&connection_timeout, CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION,
                    _cb_mbox_put_msg, &connection_timeout_arg);
 
     /* Start connection teardown sequence */

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -548,8 +548,8 @@ ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
                 probe_timeout_duration_us += probe_timeout_duration_us;
 
                 /* Boundary check for time interval between probes */
-                if (probe_timeout_duration_us < GNRC_TCP_PROBE_LOWER_BOUND) {
-                    probe_timeout_duration_us = GNRC_TCP_PROBE_LOWER_BOUND;
+                if (probe_timeout_duration_us < CONFIG_GNRC_TCP_PROBE_LOWER_BOUND) {
+                    probe_timeout_duration_us = CONFIG_GNRC_TCP_PROBE_LOWER_BOUND;
                 }
                 else if (probe_timeout_duration_us > GNRC_TCP_PROBE_UPPER_BOUND) {
                     probe_timeout_duration_us = GNRC_TCP_PROBE_UPPER_BOUND;

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -551,8 +551,8 @@ ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
                 if (probe_timeout_duration_us < CONFIG_GNRC_TCP_PROBE_LOWER_BOUND) {
                     probe_timeout_duration_us = CONFIG_GNRC_TCP_PROBE_LOWER_BOUND;
                 }
-                else if (probe_timeout_duration_us > GNRC_TCP_PROBE_UPPER_BOUND) {
-                    probe_timeout_duration_us = GNRC_TCP_PROBE_UPPER_BOUND;
+                else if (probe_timeout_duration_us > CONFIG_GNRC_TCP_PROBE_UPPER_BOUND) {
+                    probe_timeout_duration_us = CONFIG_GNRC_TCP_PROBE_UPPER_BOUND;
                 }
                 break;
 

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
@@ -222,7 +222,7 @@ static int _fsm_call_open(gnrc_tcp_tcb_t *tcb)
     int ret = 0;
 
     DEBUG("gnrc_tcp_fsm.c : _fsm_call_open()\n");
-    tcb->rcv_wnd = GNRC_TCP_DEFAULT_WINDOW;
+    tcb->rcv_wnd = CONFIG_GNRC_TCP_DEFAULT_WINDOW;
 
     if (tcb->status & STATUS_PASSIVE) {
         /* Passive open, T: CLOSED -> LISTEN */

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
@@ -103,7 +103,7 @@ static int _restart_timewait_timer(gnrc_tcp_tcb_t *tcb)
     xtimer_remove(&tcb->tim_tout);
     tcb->msg_tout.type = MSG_TYPE_TIMEWAIT;
     tcb->msg_tout.content.ptr = (void *)tcb;
-    xtimer_set_msg(&tcb->tim_tout, 2 * GNRC_TCP_MSL, &tcb->msg_tout, gnrc_tcp_pid);
+    xtimer_set_msg(&tcb->tim_tout, 2 * CONFIG_GNRC_TCP_MSL, &tcb->msg_tout, gnrc_tcp_pid);
     return 0;
 }
 

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
@@ -272,7 +272,7 @@ static int _fsm_call_send(gnrc_tcp_tcb_t *tcb, void *buf, size_t len)
     /* Check if window is open and all packets were transmitted */
     if (payload > 0 && tcb->snd_wnd > 0 && tcb->pkt_retransmit == NULL) {
         /* Calculate segment size */
-        payload = (payload < GNRC_TCP_MSS) ? payload : GNRC_TCP_MSS;
+        payload = (payload < CONFIG_GNRC_TCP_MSS) ? payload : CONFIG_GNRC_TCP_MSS;
         payload = (payload < tcb->mss) ? payload : tcb->mss;
         payload = (payload < len) ? payload : len;
 
@@ -307,8 +307,8 @@ static int _fsm_call_recv(gnrc_tcp_tcb_t *tcb, void *buf, size_t len)
     /* Read data into 'buf' up to 'len' bytes from receive buffer */
     size_t rcvd = ringbuffer_get(&(tcb->rcv_buf), buf, len);
 
-    /* If receive buffer can store more than GNRC_TCP_MSS: open window to available buffer size */
-    if (ringbuffer_get_free(&tcb->rcv_buf) >= GNRC_TCP_MSS) {
+    /* If receive buffer can store more than CONFIG_GNRC_TCP_MSS: open window to available buffer size */
+    if (ringbuffer_get_free(&tcb->rcv_buf) >= CONFIG_GNRC_TCP_MSS) {
         tcb->rcv_wnd = ringbuffer_get_free(&(tcb->rcv_buf));
 
         /* Send ACK to anounce window update */

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
@@ -454,10 +454,12 @@ int _pkt_acknowledge(gnrc_tcp_tcb_t *tcb, const uint32_t ack)
             }
             /* If this is a subsequent sample */
             else {
-                tcb->rtt_var = (tcb->rtt_var / GNRC_TCP_RTO_B_DIV) * (GNRC_TCP_RTO_B_DIV-1);
-                tcb->rtt_var += abs(tcb->srtt - rtt) / GNRC_TCP_RTO_B_DIV;
-                tcb->srtt = (tcb->srtt / GNRC_TCP_RTO_A_DIV) * (GNRC_TCP_RTO_A_DIV-1);
-                tcb->srtt += rtt / GNRC_TCP_RTO_A_DIV;
+                tcb->rtt_var = (tcb->rtt_var / GNRC_TCP_RTO_B_DIV) * \
+                    (GNRC_TCP_RTO_B_DIV-1);
+                tcb->rtt_var += abs(tcb->srtt - rtt) / \
+                    GNRC_TCP_RTO_B_DIV;
+                tcb->srtt = (tcb->srtt / CONFIG_GNRC_TCP_RTO_A_DIV) * (CONFIG_GNRC_TCP_RTO_A_DIV-1);
+                tcb->srtt += rtt / CONFIG_GNRC_TCP_RTO_A_DIV;
             }
         }
     }

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
@@ -407,8 +407,8 @@ int _pkt_setup_retransmit(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *pkt, const bool r
     if (tcb->rto < (int32_t) CONFIG_GNRC_TCP_RTO_LOWER_BOUND) {
         tcb->rto = CONFIG_GNRC_TCP_RTO_LOWER_BOUND;
     }
-    else if (tcb->rto > (int32_t) GNRC_TCP_RTO_UPPER_BOUND) {
-        tcb->rto = GNRC_TCP_RTO_UPPER_BOUND;
+    else if (tcb->rto > (int32_t) CONFIG_GNRC_TCP_RTO_UPPER_BOUND) {
+        tcb->rto = CONFIG_GNRC_TCP_RTO_UPPER_BOUND;
     }
 
     /* Setup retransmission timer, msg to TCP thread with ptr to TCB */

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
@@ -201,7 +201,7 @@ int _pkt_build(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t **out_pkt, uint16_t *seq_con,
 
             /* If SYN flag is set: Add MSS option */
             if (ctl & MSK_SYN) {
-                network_uint32_t mss_option = byteorder_htonl(_option_build_mss(GNRC_TCP_MSS));
+                network_uint32_t mss_option = byteorder_htonl(_option_build_mss(CONFIG_GNRC_TCP_MSS));
                 memcpy(opt_ptr, &mss_option, sizeof(mss_option));
             }
             /* Increase opt_ptr and decrease opt_left, if other options are added */

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
@@ -388,7 +388,7 @@ int _pkt_setup_retransmit(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *pkt, const bool r
             tcb->rto = CONFIG_GNRC_TCP_RTO_LOWER_BOUND;
         }
         else {
-            tcb->rto = tcb->srtt + _max(GNRC_TCP_RTO_GRANULARITY,  GNRC_TCP_RTO_K * tcb->rtt_var);
+            tcb->rto = tcb->srtt + _max(CONFIG_GNRC_TCP_RTO_GRANULARITY, GNRC_TCP_RTO_K * tcb->rtt_var);
         }
     }
     else {

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
@@ -388,7 +388,7 @@ int _pkt_setup_retransmit(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *pkt, const bool r
             tcb->rto = CONFIG_GNRC_TCP_RTO_LOWER_BOUND;
         }
         else {
-            tcb->rto = tcb->srtt + _max(CONFIG_GNRC_TCP_RTO_GRANULARITY, GNRC_TCP_RTO_K * tcb->rtt_var);
+            tcb->rto = tcb->srtt + _max(CONFIG_GNRC_TCP_RTO_GRANULARITY, CONFIG_GNRC_TCP_RTO_K * tcb->rtt_var);
         }
     }
     else {

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
@@ -454,10 +454,8 @@ int _pkt_acknowledge(gnrc_tcp_tcb_t *tcb, const uint32_t ack)
             }
             /* If this is a subsequent sample */
             else {
-                tcb->rtt_var = (tcb->rtt_var / GNRC_TCP_RTO_B_DIV) * \
-                    (GNRC_TCP_RTO_B_DIV-1);
-                tcb->rtt_var += abs(tcb->srtt - rtt) / \
-                    GNRC_TCP_RTO_B_DIV;
+                tcb->rtt_var = (tcb->rtt_var / CONFIG_GNRC_TCP_RTO_B_DIV) * (CONFIG_GNRC_TCP_RTO_B_DIV-1);
+                tcb->rtt_var += abs(tcb->srtt - rtt) / CONFIG_GNRC_TCP_RTO_B_DIV;
                 tcb->srtt = (tcb->srtt / CONFIG_GNRC_TCP_RTO_A_DIV) * (CONFIG_GNRC_TCP_RTO_A_DIV-1);
                 tcb->srtt += rtt / CONFIG_GNRC_TCP_RTO_A_DIV;
             }

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
@@ -385,7 +385,7 @@ int _pkt_setup_retransmit(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *pkt, const bool r
     if (!retransmit) {
         /* If this is the first transmission: rto is 1 sec (Lower Bound) */
         if (tcb->srtt == RTO_UNINITIALIZED || tcb->rtt_var == RTO_UNINITIALIZED) {
-            tcb->rto = GNRC_TCP_RTO_LOWER_BOUND;
+            tcb->rto = CONFIG_GNRC_TCP_RTO_LOWER_BOUND;
         }
         else {
             tcb->rto = tcb->srtt + _max(GNRC_TCP_RTO_GRANULARITY,  GNRC_TCP_RTO_K * tcb->rtt_var);
@@ -404,8 +404,8 @@ int _pkt_setup_retransmit(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *pkt, const bool r
     }
 
     /* Perform boundary checks on current RTO before usage */
-    if (tcb->rto < (int32_t) GNRC_TCP_RTO_LOWER_BOUND) {
-        tcb->rto = GNRC_TCP_RTO_LOWER_BOUND;
+    if (tcb->rto < (int32_t) CONFIG_GNRC_TCP_RTO_LOWER_BOUND) {
+        tcb->rto = CONFIG_GNRC_TCP_RTO_LOWER_BOUND;
     }
     else if (tcb->rto > (int32_t) GNRC_TCP_RTO_UPPER_BOUND) {
         tcb->rto = GNRC_TCP_RTO_UPPER_BOUND;

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_rcvbuf.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_rcvbuf.c
@@ -33,7 +33,7 @@ void _rcvbuf_init(void)
 {
     DEBUG("gnrc_tcp_rcvbuf.c : _rcvbuf_init() : entry\n");
     mutex_init(&(_static_buf.lock));
-    for (size_t i = 0; i < GNRC_TCP_RCV_BUFFERS; ++i) {
+    for (size_t i = 0; i < CONFIG_GNRC_TCP_RCV_BUFFERS; ++i) {
         _static_buf.entries[i].used = 0;
     }
 }
@@ -49,7 +49,7 @@ static void* _rcvbuf_alloc(void)
     void *result = NULL;
     DEBUG("gnrc_tcp_rcvbuf.c : _rcvbuf_alloc() : Entry\n");
     mutex_lock(&(_static_buf.lock));
-    for (size_t i = 0; i < GNRC_TCP_RCV_BUFFERS; ++i) {
+    for (size_t i = 0; i < CONFIG_GNRC_TCP_RCV_BUFFERS; ++i) {
         if (_static_buf.entries[i].used == 0) {
             _static_buf.entries[i].used = 1;
             result = (void *)(_static_buf.entries[i].buffer);
@@ -69,7 +69,7 @@ static void _rcvbuf_free(void * const buf)
 {
     DEBUG("gnrc_tcp_rcvbuf.c : _rcvbuf_free() : Entry\n");
     mutex_lock(&(_static_buf.lock));
-    for (size_t i = 0; i < GNRC_TCP_RCV_BUFFERS; ++i) {
+    for (size_t i = 0; i < CONFIG_GNRC_TCP_RCV_BUFFERS; ++i) {
         if ((_static_buf.entries[i].used == 1) && (buf == _static_buf.entries[i].buffer)) {
             _static_buf.entries[i].used = 0;
         }

--- a/sys/net/gnrc/transport_layer/tcp/internal/rcvbuf.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/rcvbuf.h
@@ -42,7 +42,7 @@ typedef struct rcvbuf_entry {
  */
 typedef struct rcvbuf {
     mutex_t lock;                                 /**< Lock for allocation synchronization */
-    rcvbuf_entry_t entries[GNRC_TCP_RCV_BUFFERS]; /**< Maintained receive buffers */
+    rcvbuf_entry_t entries[CONFIG_GNRC_TCP_RCV_BUFFERS]; /**< Maintained receive buffers */
 } rcvbuf_t;
 
 /**

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -14,7 +14,7 @@ TEST_ON_CI_BLACKLIST += all
 
 CFLAGS += -DSHELL_NO_ECHO
 CFLAGS += -DGNRC_TCP_MSL=$(MSL_US)
-CFLAGS += -DGNRC_TCP_CONNECTION_TIMEOUT_DURATION=$(TIMEOUT_US)
+CFLAGS += -DCONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION=$(TIMEOUT_US)
 CFLAGS += -DGNRC_NETIF_SINGLE           # Only one interface used and it makes
                                         # shell commands easier
 

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -13,7 +13,7 @@ TIMEOUT_US ?= 3000000
 TEST_ON_CI_BLACKLIST += all
 
 CFLAGS += -DSHELL_NO_ECHO
-CFLAGS += -DGNRC_TCP_MSL=$(MSL_US)
+CFLAGS += -DCONFIG_GNRC_TCP_MSL=$(MSL_US)
 CFLAGS += -DCONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION=$(TIMEOUT_US)
 CFLAGS += -DGNRC_NETIF_SINGLE           # Only one interface used and it makes
                                         # shell commands easier

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -13,8 +13,6 @@ TIMEOUT_US ?= 3000000
 TEST_ON_CI_BLACKLIST += all
 
 CFLAGS += -DSHELL_NO_ECHO
-CFLAGS += -DCONFIG_GNRC_TCP_MSL=$(MSL_US)
-CFLAGS += -DCONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION=$(TIMEOUT_US)
 CFLAGS += -DGNRC_NETIF_SINGLE           # Only one interface used and it makes
                                         # shell commands easier
 
@@ -45,3 +43,14 @@ ethos:
 	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)/ethos
 
 include $(RIOTBASE)/Makefile.include
+
+# Set CONFIG_GNRC_TCP_MSL via CFLAGS if not being set via Kconfig
+ifndef CONFIG_GNRC_TCP_MSL
+  CFLAGS += -DCONFIG_GNRC_TCP_MSL=$(MSL_US)
+endif
+
+# Set CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION via CFLAGS if not being set
+# via Kconfig
+ifndef CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION
+  CFLAGS += -DCONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION=$(TIMEOUT_US)
+endif


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in GNRC: TCP to Kconfig.

### Testing procedure

1. New documentation was built using Doxygen 

The build works fine.

2. Header and macro was introduced to tests/gnrc_tcp/

```
#include "net/gnrc/tcp/config.h"
#define STR(x)   #x
#define SHOW_DEFINE(x) printf("%s=%s\n", #x, STR(x))

```
The test file can be found [here](https://github.com/akshaim/RIOT/blob/82bdac7d599dd692f3e090a21d9b8468d6419c78/tests/gnrc_tcp/main.c)

Compiled binaries (BOARD=samr21-xpro) were uploaded to FIT IoT Test bed.

#### Default State:

##### Firmware Output

~~}!main(): This is RIOT! (Version: 2020.07-devel-737-g0b75d-Kconfig_tcp_tests)
~~}!CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION=3000000
~~}!CONFIG_GNRC_TCP_MSL=1000000
~~}!CONFIG_GNRC_TCP_MSS_MULTIPLICATOR=(1U)
~~}!CONFIG_GNRC_TCP_RCV_BUFFERS=(1U)
~~}!CONFIG_GNRC_TCP_RTO_LOWER_BOUND=(1U * (1000000LU))
~~}!CONFIG_GNRC_TCP_RTO_UPPER_BOUND=(60U * (1000000LU))
~~}!CONFIG_GNRC_TCP_RTO_GRANULARITY=(10U * (1000LU))
~~}!CONFIG_GNRC_TCP_RTO_A_DIV=(8U)
~~}!CONFIG_GNRC_TCP_RTO_B_DIV=(4U)
~~}!CONFIG_GNRC_TCP_RTO_K=(4U)
~~}!CONFIG_GNRC_TCP_PROBE_LOWER_BOUND=(1U * (1000000LU))
~~}!CONFIG_GNRC_TCP_PROBE_UPPER_BOUND=(60U * (1000000LU))
~~}!RIOT GNRC_TCP test application

#### Usage with menuconfig [default values]

> make menuconfig

##### Firmware Output

!main(): This is RIOT! (Version: 2020.07-devel-737-g82bda-Kconfig_tcp_tests)
~~}!CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION=120000000
~~}!CONFIG_GNRC_TCP_MSL=30000000
~~}!CONFIG_GNRC_TCP_MSS_MULTIPLICATOR=1
~~}!CONFIG_GNRC_TCP_RCV_BUFFERS=1
~~}!CONFIG_GNRC_TCP_RTO_LOWER_BOUND=1000000
~~}!CONFIG_GNRC_TCP_RTO_UPPER_BOUND=60000000
~~}!CONFIG_GNRC_TCP_RTO_GRANULARITY=10000
~~}!CONFIG_GNRC_TCP_RTO_A_DIV=8
~~}!CONFIG_GNRC_TCP_RTO_B_DIV=4
~~}!CONFIG_GNRC_TCP_RTO_K=4
~~}!CONFIG_GNRC_TCP_PROBE_LOWER_BOUND=1000000
~~}!CONFIG_GNRC_TCP_PROBE_UPPER_BOUND=60000000
~~}!RIOT GNRC_TCP test application

#### Usage with menuconfig

> make menuconfig

##### Firmware Output

!main(): This is RIOT! (Version: 2020.07-devel-737-g82bda-Kconfig_tcp_tests)
~~}!CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION=110000000
~~}!CONFIG_GNRC_TCP_MSL=32000000
~~}!CONFIG_GNRC_TCP_MSS_MULTIPLICATOR=2
~~}!CONFIG_GNRC_TCP_RCV_BUFFERS=2
~~}!CONFIG_GNRC_TCP_RTO_LOWER_BOUND=1200000
~~}!CONFIG_GNRC_TCP_RTO_UPPER_BOUND=62000000
~~}!CONFIG_GNRC_TCP_RTO_GRANULARITY=20000
~~}!CONFIG_GNRC_TCP_RTO_A_DIV=4
~~}!CONFIG_GNRC_TCP_RTO_B_DIV=2
~~}!CONFIG_GNRC_TCP_RTO_K=2
~~}!CONFIG_GNRC_TCP_PROBE_LOWER_BOUND=1200000
~~}!CONFIG_GNRC_TCP_PROBE_UPPER_BOUND=50000000
~~}!RIOT GNRC_TCP test application


**MACROS were successfully configured.**

### Issues/PRs references

#12888 