### PR TITLE
cc26xx_cc13xx: add periph_i2c implementation

### DIFF
--- a/boards/cc1312-launchpad/Makefile.features
+++ b/boards/cc1312-launchpad/Makefile.features
@@ -2,6 +2,7 @@ CPU = cc26x2_cc13x2
 CPU_MODEL = cc1312r1f3
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_gpio_irq
 FEATURES_PROVIDED += periph_timer

--- a/boards/cc1312-launchpad/include/periph_conf.h
+++ b/boards/cc1312-launchpad/include/periph_conf.h
@@ -105,6 +105,15 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
+/**
+ * @name    I2C configuration
+ * @{
+ */
+#define I2C_NUMOF           (1)
+#define I2C_SCL_PIN         (4)
+#define I2C_SDA_PIN         (5)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/cc1352-launchpad/Makefile.features
+++ b/boards/cc1352-launchpad/Makefile.features
@@ -2,6 +2,7 @@ CPU = cc26x2_cc13x2
 CPU_MODEL = cc1352r1
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_gpio_irq
 FEATURES_PROVIDED += periph_timer

--- a/boards/cc1352-launchpad/include/periph_conf.h
+++ b/boards/cc1352-launchpad/include/periph_conf.h
@@ -99,6 +99,15 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
+/**
+ * @name    I2C configuration
+ * @{
+ */
+#define I2C_NUMOF           (1)
+#define I2C_SCL_PIN         (4)
+#define I2C_SDA_PIN         (5)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/cc1352p-launchpad/Makefile.features
+++ b/boards/cc1352p-launchpad/Makefile.features
@@ -2,6 +2,7 @@ CPU = cc26x2_cc13x2
 CPU_MODEL = cc1352p1
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_gpio_irq
 FEATURES_PROVIDED += periph_timer

--- a/boards/cc1352p-launchpad/include/periph_conf.h
+++ b/boards/cc1352p-launchpad/include/periph_conf.h
@@ -101,6 +101,15 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
+/**
+ * @name    I2C configuration
+ * @{
+ */
+#define I2C_NUMOF           (1)
+#define I2C_SCL_PIN         (21)
+#define I2C_SDA_PIN         (5)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/cc26xx_cc13xx/periph/i2c.c
+++ b/cpu/cc26xx_cc13xx/periph/i2c.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     cpu_cc26x0
+ * @ingroup     cpu_cc26xx_cc13xx
  * @ingroup     drivers_periph_i2c
  * @{
  *


### PR DESCRIPTION
### Contribution description

The CC26xx/CC13xx MCUs have only a single I2C interface, and has not changed between x0/x2 revisions, it's exactly the same (the SDK is using the same exact code).

Only 100 kbit/s mode is supported, fast mode (400 kbit/s) is up to another PR.

### Testing procedure

- `cc26x0` boards should still have a working I2C (no code is touched in reality).
- `cc26x2`/`cc13x2` boards _should_ be able to run `tests/periph_i2c` correctly with a known working device. Please note that this device has weak pull-up resistors.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#13635 

cc @luisan00, could you check if the pins for CC1352P launchpad are good?