### PR TITLE
makefiles/info-global.inc.mk: add info-boards-features-blacklisted

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -174,7 +174,14 @@ include $(RIOTMAKE)/boards.inc.mk
 # Debug targets for build system migration
 include $(RIOTMAKE)/dependencies_debug.inc.mk
 
-GLOBAL_GOALS += buildtest buildtest-indocker info-boards-supported info-boards-features-missing info-buildsizes info-buildsizes-diff
+GLOBAL_GOALS += buildtest \
+                buildtest-indocker \
+                info-boards-features-blacklisted \
+                info-boards-features-missing \
+                info-boards-supported \
+                info-buildsizes info-buildsizes-diff \
+                #
+
 ifneq (, $(filter $(GLOBAL_GOALS), $(MAKECMDGOALS)))
   BOARD=none
 endif

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -1,5 +1,9 @@
-.PHONY: info-buildsizes info-buildsizes-diff info-features-missing \
-        info-boards-features-missing
+.PHONY: info-buildsizes \
+        info-buildsizes-diff \
+        info-boards-supported \
+        info-boards-features-missing \
+        info-boards-features-blacklisted \
+        #
 
 # Perform dependency resolution without having included
 # $(RIOTBASE)/Makefile.features for now. This results in no optional modules and
@@ -125,6 +129,9 @@ info-boards-supported:
 
 info-boards-features-missing:
 	@for f in $(BOARDS_FEATURES_MISSING); do echo $${f}; done | column -t
+
+info-boards-features-blacklisted:
+	@for f in $(BOARDS_FEATURES_USED_BLACKLISTED); do echo $${f}; done | column -t
 
 # Reset BOARDSDIR so unchanged for makefiles included after, for now only
 # needed for buildtests.inc.mk


### PR DESCRIPTION
### Contribution description

Adds `info-boards-feautes-blacklisted`.

### Testing procedure

```
make -C examples/hello-world info-boards-features-blacklisted --no-print-directory
adafruit-clue        bootloader_nrfutil
arduino-mkr1000      bootloader_arduino
arduino-mkrfox1200   bootloader_arduino
arduino-mkrwan1300   bootloader_arduino
arduino-mkrzero      bootloader_arduino
arduino-nano-33-ble  bootloader_arduino
feather-m0           bootloader_arduino
nrf52840dongle       bootloader_nrfutil
serpente             bootloader_arduino
sodaq-autonomo       bootloader_arduino
sodaq-explorer       bootloader_arduino
sodaq-one            bootloader_arduino
sodaq-sara-aff       bootloader_arduino

```
### Issues/PRs references

Usefull for testing issue mentioned in https://github.com/RIOT-OS/RIOT/pull/13738#issuecomment-633412414
