### PR TITLE
makefiles/info-global: Remove dependency resolution cache

### DIFF
--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -5,16 +5,6 @@
         info-boards-features-blacklisted \
         #
 
-# Perform dependency resolution without having included
-# $(RIOTBASE)/Makefile.features for now. This results in no optional modules and
-# no architecture specific handling being done. The result will be a subset of
-# used modules and requirements that is present in for *all* boards, so this can
-# be cached to speed up individual dependency checks
-include $(RIOTMAKE)/defaultmodules.inc.mk
-# add default modules
-USEMODULE += $(filter-out $(DISABLE_MODULE),$(DEFAULT_MODULE))
-include $(RIOTMAKE)/dependency_resolution.inc.mk
-
 BOARDDIR_GLOBAL := $(BOARDDIR)
 USEMODULE_GLOBAL := $(USEMODULE)
 USEPKG_GLOBAL := $(USEPKG)


### PR DESCRIPTION
### Contribution description
This removes a preliminar dependency resolution that is performed without including features, to skip a full dependency resolution when boards can be proven to be unsupported on an earlier stage.

This was introducing issues on some boards since the blacklisting of some features depends on board information which is not available at the time of performing this resolution.

#### Some time measurements

Running `make info-boards-supported` 50 times on my computer results in:

| Application | Time with cache | Time without cache |
| -------------- | ---------------------- | -------------------------- |
| `hello_world` | `873.0 ms ±  20.5 ms` |`851.7 ms ±  26.3 ms` |
| `tests/driver_ws281x` (proposed [here](https://github.com/RIOT-OS/RIOT/pull/13349#issuecomment-605950720)) | `266.4 ms ±  11.6 ms` | ` 263.0 ms ±  18.6 ms` |

### Testing procedure

- `make info-boards-supported` should work properly now (it was pointed out in the mailing list that the sodaq boards are not showing up in the list in current master, for instance)


### Issues/PRs references
Spotted by @fjmolinas [here](https://github.com/RIOT-OS/RIOT/pull/13738#issuecomment-633432857)
