### PR TITLE
drivers/edbg_eui: add driver to get MAC address from Atmel EDBG

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -241,6 +241,10 @@ ifneq (,$(filter dynamixel,$(USEMODULE)))
   USEMODULE += uart_half_duplex
 endif
 
+ifneq (,$(filter edbg_eui,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter enc28j60,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_gpio_irq

--- a/drivers/edbg_eui/Makefile
+++ b/drivers/edbg_eui/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/edbg_eui/edbg_eui.c
+++ b/drivers/edbg_eui/edbg_eui.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_edbg_eui
+ *
+ * @{
+ * @file
+ * @brief       Driver for getting a unique ID from the Atmel Embedded Debugger.
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include "edbg_eui.h"
+#include "periph/i2c.h"
+#include "net/l2util.h"
+
+#ifndef EDBG_I2C_DEV
+#define EDBG_I2C_DEV I2C_DEV(0)
+#endif
+
+#define EDBG_ADDR   (0x28)
+#define TOKEN_EUI64 (0xD2)
+#define TOKEN_EXT   (0xE1)
+
+int edbg_get_eui64(eui64_t *addr)
+{
+    int res = 0;
+    i2c_acquire(EDBG_I2C_DEV);
+
+    /* dummy read for another token - following edbg user manual, section 4.3.1
+     * only returns the EUI-64 once, this work-around works reliable though.
+     */
+    if ((res = i2c_read_regs(EDBG_I2C_DEV, EDBG_ADDR, TOKEN_EXT, addr, 2, 0))) {
+        goto out;
+    }
+
+    /* EDBG provides an EUI-64 for the internal radio */
+    if ((res = i2c_read_regs(EDBG_I2C_DEV, EDBG_ADDR, TOKEN_EUI64, addr, sizeof(*addr), 0))) {
+        goto out;
+    }
+
+out:
+    i2c_release(EDBG_I2C_DEV);
+    return res;
+}

--- a/drivers/include/edbg_eui.h
+++ b/drivers/include/edbg_eui.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_edbg_eui Driver for getting MAC address out of Atmel EDBG
+ * @ingroup     drivers_misc
+ * @brief       Device driver interface for the AT24MAC I2C chip
+ * @{
+ *
+ * @file
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef EDBG_EUI_H
+#define EDBG_EUI_H
+
+#include <stdint.h>
+#include "net/eui64.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Get the unique EUI64 address from a Atmel EDBG debugger
+ *
+ * @param[out] addr     memory location to copy the address into.
+ *
+ * @return              0 on success, error otherwise.
+ */
+int edbg_get_eui64(eui64_t *addr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EDBG_EUI_H */
+/** @} */

--- a/tests/driver_edbg_eui/Makefile
+++ b/tests/driver_edbg_eui/Makefile
@@ -1,0 +1,8 @@
+BOARD ?= samr21-xpro
+BOARD_WHITELIST = samr21-xpro
+
+include ../Makefile.tests_common
+
+USEMODULE += edbg_eui
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_edbg_eui/main.c
+++ b/tests/driver_edbg_eui/main.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the EDBG EUI driver
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include "edbg_eui.h"
+
+static int test_get_eui64(void)
+{
+    eui64_t e64;
+    if (edbg_get_eui64(&e64) != 0) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    printf("EUI-64:");
+    for (unsigned i = 0; i < sizeof(e64.uint8); ++i) {
+        printf(" %02x", e64.uint8[i]);
+    }
+    puts("");
+
+    return 0;
+}
+
+int main(void)
+{
+    if (test_get_eui64()) {
+        return -1;
+    }
+
+    puts("[SUCCESS]");
+
+    return 0;
+}


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The EDBG debugger on the `samr21-xpro` contains a unique 64 bit address intended to be used as a MAC address for the internal radio.

This adds a driver to read that EUI-64 from the debugger, it should match with the MAC address printed on the label on the board.

### Testing procedure

Run `tests/driver_edbg_eui`

```
2020-05-25 12:39:28,297 # main(): This is RIOT! (Version: 2020.07-devel-727-gee319a-drivers/edbg_eui)
2020-05-25 12:39:28,302 # EUI-64: 00 04 25 19 18 01 c8 c5
2020-05-25 12:39:28,303 # [SUCCESS]
```

The address should match the one printed on the board.

### Issues/PRs references

split out of #12641
