### PR TITLE
boards/stm32: remove useless #ifdef MODULE_PERIPH_DMA

### DIFF
--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -33,7 +33,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 1  }, /* channel 2 */
     { .stream = 2  }, /* channel 3 */
@@ -48,7 +47,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_SHARED_ISR_1_STREAMS    { 2, 3, 4 } /* Indexes 2, 3 and 4 of dma_config share the same isr */
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-#endif
 /** @} */
 
 /**

--- a/boards/b-l475e-iot01a/include/periph_conf.h
+++ b/boards/b-l475e-iot01a/include/periph_conf.h
@@ -31,7 +31,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 1 },    /* DMA1 Channel 2 - SPI1_RX */
     { .stream = 2 },    /* DMA1 Channel 3 - SPI1_TX */
@@ -45,7 +44,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_3_ISR  isr_dma2_channel3
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-#endif
 /** @} */
 
 /**

--- a/boards/common/iotlab/include/periph_conf_common.h
+++ b/boards/common/iotlab/include/periph_conf_common.h
@@ -72,7 +72,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 3 },    /* DMA1 Channel 4 - USART1_TX */
     { .stream = 5 },    /* DMA1 Channel 6 - USART2_TX */
@@ -82,7 +81,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_1_ISR  isr_dma1_channel6
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-#endif
 /** @} */
 
 /**

--- a/boards/lsn50/include/periph_conf.h
+++ b/boards/lsn50/include/periph_conf.h
@@ -32,7 +32,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 1  }, /* channel 2 */
     { .stream = 2  }, /* channel 3 */
@@ -47,7 +46,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_SHARED_ISR_1_STREAMS    { 2, 3, 4 } /* Indexes 2, 3 and 4 of dma_config share the same isr */
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-#endif
 /** @} */
 
 /**

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -31,7 +31,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
     { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
@@ -41,8 +40,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_1_ISR           isr_dma2_stream2
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-
-#endif /* MODULE_PERIPH_DMA */
 /** @} */
 
 /**

--- a/boards/nucleo-f091rc/include/periph_conf.h
+++ b/boards/nucleo-f091rc/include/periph_conf.h
@@ -58,7 +58,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 1  },
     { .stream = 2  },
@@ -68,7 +67,7 @@ static const dma_conf_t dma_config[] = {
 #define DMA_SHARED_ISR_0_STREAMS    { 0, 1 } /* Indexes 0 and 1 of dma_config share the same isr */
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-#endif
+/** @} */
 
 /**
  * @name   Timer configuration

--- a/boards/nucleo-f207zg/include/periph_conf.h
+++ b/boards/nucleo-f207zg/include/periph_conf.h
@@ -34,7 +34,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
     { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
@@ -54,7 +53,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_6_ISR  isr_dma2_stream0
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-#endif
 /** @} */
 
 /**

--- a/boards/nucleo-f401re/include/periph_conf.h
+++ b/boards/nucleo-f401re/include/periph_conf.h
@@ -32,7 +32,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
     { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
@@ -50,8 +49,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_5_ISR           isr_dma1_stream0
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-
-#endif /* MODULE_PERIPH_DMA */
 /** @} */
 
 /**

--- a/boards/nucleo-f410rb/include/periph_conf.h
+++ b/boards/nucleo-f410rb/include/periph_conf.h
@@ -32,7 +32,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
     { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
@@ -42,8 +41,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_1_ISR           isr_dma2_stream2
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-
-#endif /* MODULE_PERIPH_DMA */
 /** @} */
 
 /**

--- a/boards/nucleo-f411re/include/periph_conf.h
+++ b/boards/nucleo-f411re/include/periph_conf.h
@@ -32,7 +32,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
     { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
@@ -42,8 +41,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_1_ISR           isr_dma2_stream2
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-
-#endif /* MODULE_PERIPH_DMA */
 /** @} */
 
 /**

--- a/boards/nucleo-f412zg/include/periph_conf.h
+++ b/boards/nucleo-f412zg/include/periph_conf.h
@@ -35,7 +35,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
     { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
@@ -45,8 +44,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_1_ISR           isr_dma2_stream2
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-
-#endif /* MODULE_PERIPH_DMA */
 /** @} */
 
 /**

--- a/boards/nucleo-f413zh/include/periph_conf.h
+++ b/boards/nucleo-f413zh/include/periph_conf.h
@@ -36,7 +36,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
     { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
@@ -46,7 +45,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_1_ISR           isr_dma2_stream2
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-#endif
 /** @} */
 
 /**

--- a/boards/nucleo-f429zi/include/periph_conf.h
+++ b/boards/nucleo-f429zi/include/periph_conf.h
@@ -34,7 +34,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
     { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
@@ -44,8 +43,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_1_ISR           isr_dma2_stream2
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-
-#endif /* MODULE_PERIPH_DMA */
 /** @} */
 
 /**

--- a/boards/nucleo-f446re/include/periph_conf.h
+++ b/boards/nucleo-f446re/include/periph_conf.h
@@ -33,7 +33,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
     { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
@@ -51,8 +50,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_5_ISR           isr_dma1_stream0
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-
-#endif /* MODULE_PERIPH_DMA */
 /** @} */
 
 /**

--- a/boards/nucleo-f446ze/include/periph_conf.h
+++ b/boards/nucleo-f446ze/include/periph_conf.h
@@ -34,7 +34,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
     { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
@@ -44,8 +43,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_1_ISR           isr_dma2_stream2
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-
-#endif /* MODULE_PERIPH_DMA */
 /** @} */
 
 /**

--- a/boards/nucleo-f767zi/include/periph_conf.h
+++ b/boards/nucleo-f767zi/include/periph_conf.h
@@ -35,7 +35,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 4 },    /* DMA1 Stream 4 - USART3_TX */
     { .stream = 14 },   /* DMA2 Stream 6 - USART6_TX */
@@ -49,7 +48,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_3_ISR  isr_dma2_stream0
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-#endif
 /** @} */
 
 /**

--- a/boards/nucleo-l152re/include/periph_conf.h
+++ b/boards/nucleo-l152re/include/periph_conf.h
@@ -65,7 +65,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 1 },    /* DMA1 Channel 2 - SPI1_RX / USART3_TX */
     { .stream = 2 },    /* DMA1 Channel 3 - SPI1_TX */
@@ -79,7 +78,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_3_ISR  isr_dma1_ch4
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-#endif
 /** @} */
 
 /**

--- a/boards/nucleo-l476rg/include/periph_conf.h
+++ b/boards/nucleo-l476rg/include/periph_conf.h
@@ -36,7 +36,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 1 },    /* DMA1 Channel 2 - SPI1_RX | USART3_TX */
     { .stream = 2 },    /* DMA1 Channel 3 - SPI1_TX */
@@ -50,7 +49,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_3_ISR  isr_dma1_channel7
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-#endif /* MODULE_PERIPH_DMA */
 /** @} */
 
 

--- a/boards/pyboard/include/periph_conf.h
+++ b/boards/pyboard/include/periph_conf.h
@@ -63,7 +63,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
     { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
@@ -73,8 +72,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_1_ISR           isr_dma2_stream2
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-
-#endif /* MODULE_PERIPH_DMA */
 /** @} */
 
 /**

--- a/boards/stm32f429i-disc1/include/periph_conf.h
+++ b/boards/stm32f429i-disc1/include/periph_conf.h
@@ -33,7 +33,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 14 },   /* DMA2 Stream 6 - SPI5_TX */
     { .stream = 13 },   /* DMA2 Stream 5 - SPI5_RX */
@@ -43,8 +42,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_1_ISR           isr_dma2_stream5
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-
-#endif /* MODULE_PERIPH_DMA */
 /** @} */
 
 /**

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -33,7 +33,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 11 },   /* DMA2 Stream 3 - SPI1_TX */
     { .stream = 10 },   /* DMA2 Stream 2 - SPI1_RX */
@@ -47,8 +46,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_3_ISR           isr_dma1_stream3
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-
-#endif /* MODULE_PERIPH_DMA */
 /** @} */
 
 /**

--- a/boards/ublox-c030-u201/include/periph_conf.h
+++ b/boards/ublox-c030-u201/include/periph_conf.h
@@ -61,7 +61,6 @@ extern "C" {
  * @name    DMA streams configuration
  * @{
  */
-#ifdef MODULE_PERIPH_DMA
 static const dma_conf_t dma_config[] = {
     { .stream = 9 },   /* DMA2 Stream 1 - SPI4_TX */
     { .stream = 8 },   /* DMA2 Stream 0 - SPI4_RX */
@@ -71,8 +70,6 @@ static const dma_conf_t dma_config[] = {
 #define DMA_1_ISR           isr_dma2_stream0
 
 #define DMA_NUMOF           ARRAY_SIZE(dma_config)
-
-#endif /* MODULE_PERIPH_DMA */
 /** @} */
 
 /**

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -366,7 +366,6 @@ typedef enum {
 /** @} */
 #endif /* ndef DOXYGEN */
 
-#ifdef MODULE_PERIPH_DMA
 /**
  * @brief   DMA configuration
  */
@@ -429,7 +428,6 @@ typedef enum {
 #define DMA_DATA_WIDTH_MASK      (0x0C)
 #define DMA_DATA_WIDTH_SHIFT     (2)
 /** @} */
-#endif /* MODULE_PERIPH_DMA */
 
 /**
  * @brief   Available number of ADC devices


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR removes not needed preprocessor ifdef related to DMA in STM32 based boards.
Since we don't use this for configuring other CPU features, why use it only for DMA ?

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock should be enough.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while reviewing #14093 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
