### PR TITLE
cpu/stm32: use shorten name in CPU_FAM variable

### DIFF
--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -7,14 +7,14 @@ FEATURES_PROVIDED += puf_sram
 FEATURES_PROVIDED += periph_uart_modecfg
 FEATURES_PROVIDED += periph_wdt
 
-ifneq (,$(filter $(CPU_FAM),stm32f0 stm32f1 stm32f3 stm32l0 stm32l1 stm32l4 stm32wb))
+ifneq (,$(filter $(CPU_FAM),f0 f1 f3 l0 l1 l4 wb))
   ifeq (,$(filter nucleo-f031k6,$(BOARD)))
     FEATURES_PROVIDED += periph_flashpage
     FEATURES_PROVIDED += periph_flashpage_raw
   endif
 endif
 
-ifneq (,$(filter $(CPU_FAM),stm32l0 stm32l1))
+ifneq (,$(filter $(CPU_FAM),l0 l1))
   FEATURES_PROVIDED += periph_eeprom
 endif
 
@@ -23,7 +23,7 @@ ifeq (stm32f1,$(CPU_FAM))
   FEATURES_CONFLICT_MSG += "On the STM32F1, the RTC and RTT map to the same hardware peripheral."
 endif
 
-ifneq (,$(filter $(CPU_FAM),stm32f2 stm32f4 stm32f7 stm32l0 stm32l4 stm32wb))
+ifneq (,$(filter $(CPU_FAM),f2 f4 f7 l0 l4 wb))
   FEATURES_PROVIDED += periph_hwrng
 endif
 
@@ -42,7 +42,7 @@ ifneq (,$(filter $(BOARDS_WITHOUT_HWRNG),$(BOARD)))
   FEATURES_PROVIDED := $(filter-out periph_hwrng,$(FEATURES_PROVIDED))
 endif
 
-ifneq (,$(filter $(CPU_FAM),stm32f2 stm32f4 stm32f7 stm32l1 stm32l4))
+ifneq (,$(filter $(CPU_FAM),f2 f4 f7 l1 l4))
   FEATURES_PROVIDED += cortexm_mpu
 endif
 

--- a/cpu/stm32/Makefile.include
+++ b/cpu/stm32/Makefile.include
@@ -1,4 +1,4 @@
-CFLAGS += -DCPU_FAM_$(call uppercase_and_underscore,$(CPU_FAM))
+CFLAGS += -DCPU_FAM_STM32$(call uppercase_and_underscore,$(CPU_FAM))
 
 # For stm32 cpu's we use the generic stm32.ld linker script
 LINKER_SCRIPT ?= stm32.ld
@@ -43,6 +43,6 @@ ifneq (,$(CCMRAM_LEN))
   LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_ccmram_length=$(CCMRAM_LEN)
 endif
 
-VECTORS_O ?= $(BINDIR)/stm32_vectors/vectors_$(subst stm32,,$(CPU_FAM)).o
+VECTORS_O ?= $(BINDIR)/stm32_vectors/vectors_$(CPU_FAM).o
 
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/stm32/periph/Makefile
+++ b/cpu/stm32/periph/Makefile
@@ -2,21 +2,21 @@ MODULE = periph
 
 # Select the specific implementation for `periph_i2c`
 ifneq (,$(filter periph_i2c,$(USEMODULE)))
-  ifneq (,$(filter $(CPU_FAM),stm32f0 stm32f3 stm32f7 stm32l0 stm32l4 stm32wb))
+  ifneq (,$(filter $(CPU_FAM),f0 f3 f7 l0 l4 wb))
     SRC += i2c_1.c
-  else # stm32f1/f2/f4/l1
+  else # f1/f2/f4/l1
     SRC += i2c_2.c
   endif
 endif
 
 # Select the specific implementation for `periph_adc`
 ifneq (,$(filter periph_adc,$(USEMODULE)))
-  SRC += adc_$(subst stm32,,$(CPU_FAM)).c
+  SRC += adc_$(CPU_FAM).c
 endif
 
 # Select the correct implementation for `periph_gpio`
 ifneq (,$(filter periph_gpio,$(USEMODULE)))
-  ifeq (stm32f1,$(CPU_FAM))
+  ifeq (f1,$(CPU_FAM))
     SRC += gpio_f1.c
   else
     SRC += gpio_all.c
@@ -25,7 +25,7 @@ endif
 
 # Select the correct implementation for `periph_rtc`
 ifneq (,$(filter periph_rtc,$(USEMODULE)))
-  ifeq (stm32f1,$(CPU_FAM))
+  ifeq (f1,$(CPU_FAM))
     SRC += rtc_f1.c
   else
     SRC += rtc_all.c
@@ -34,7 +34,7 @@ endif
 
 # Select the correct implementation for `periph_rtt`
 ifneq (,$(filter periph_rtt,$(USEMODULE)))
-  ifeq (stm32f1,$(CPU_FAM))
+  ifeq (f1,$(CPU_FAM))
     SRC += rtt_f1.c
   else
     SRC += rtt_all.c

--- a/cpu/stm32/stm32_info.mk
+++ b/cpu/stm32/stm32_info.mk
@@ -10,20 +10,20 @@ STM32_PINCOUNT = $(word 6, $(STM32_INFO))
 STM32_ROMSIZE  = $(word 7, $(STM32_INFO))
 STM32_RAMMOD   = $(word 8, $(STM32_INFO))
 
-CPU_FAM = $(CPU)$(call lowercase,$(STM32_TYPE)$(STM32_FAMILY))
+CPU_FAM = $(call lowercase,$(STM32_TYPE)$(STM32_FAMILY))
 
-ifeq (stm32f0,$(CPU_FAM))
+ifeq (f0,$(CPU_FAM))
   CPU_ARCH = cortex-m0
-else ifneq (,$(filter $(CPU_FAM),stm32f1 stm32f2 stm32l1))
+else ifneq (,$(filter $(CPU_FAM),f1 f2 l1))
   CPU_ARCH = cortex-m3
-else ifneq (,$(filter $(CPU_FAM),stm32f3 stm32f4 stm32l4))
+else ifneq (,$(filter $(CPU_FAM),f3 f4 l4))
   CPU_ARCH = cortex-m4f
-else ifeq (stm32wb,$(CPU_FAM))
+else ifeq (wb,$(CPU_FAM))
   CPU_ARCH = cortex-m4
-else ifeq (stm32f7,$(CPU_FAM))
+else ifeq (f7,$(CPU_FAM))
   CPU_ARCH = cortex-m7
-else ifeq (stm32l0,$(CPU_FAM))
+else ifeq (l0,$(CPU_FAM))
   CPU_ARCH = cortex-m0plus
 else
-  $(error Not supported CPU family: '$(CPU_FAM)')
+  $(error Not supported CPU family: 'stm32$(CPU_FAM)')
 endif

--- a/cpu/stm32/stm32_riotboot.mk
+++ b/cpu/stm32/stm32_riotboot.mk
@@ -1,8 +1,8 @@
-ifneq (,$(filter $(CPU_FAM),stm32f2 stm32f4 stm32f7))
+ifneq (,$(filter $(CPU_FAM),f2 f4 f7))
   # STM32F2/4/7 uses sectors instead of pages, where the minimum sector length is 16KB
   # or 32KB (the first sector), depending on the CPU_MODEL. Therefore RIOTBOOT_LEN must
   # be 16KB or 32kB to cover a whole sector.
-  ifneq (,$(filter $(CPU_FAM),stm32f2 stm32f4))
+  ifneq (,$(filter $(CPU_FAM),f2 f4))
     RIOTBOOT_LEN ?= 0x4000
   else ifneq (,$(filter stm32f722ze,$(CPU_MODEL)))
     RIOTBOOT_LEN ?= 0x4000

--- a/cpu/stm32/stmclk/Makefile
+++ b/cpu/stm32/stmclk/Makefile
@@ -2,12 +2,11 @@ MODULE = stm32_clk
 
 SRC = stmclk_common.c
 
-_CPU_FAM_SHORT = $(subst stm32,,$(CPU_FAM))
-ifneq (,$(filter f%,$(_CPU_FAM_SHORT)))
+ifneq (,$(filter f%,$(CPU_FAM)))
   SRC += stmclk_fx.c
-else ifneq (,$(filter $(_CPU_FAM_SHORT),l0 l1))
+else ifneq (,$(filter $(CPU_FAM),l0 l1))
   SRC += stmclk_l0l1.c
-else ifneq (,$(filter $(_CPU_FAM_SHORT),l4 wb))
+else ifneq (,$(filter $(CPU_FAM),l4 wb))
   SRC += stmclk_l4wb.c
 endif
 

--- a/cpu/stm32/vectors/Makefile
+++ b/cpu/stm32/vectors/Makefile
@@ -2,7 +2,7 @@ MODULE = stm32_vectors
 
 NO_AUTO_SRC = 1
 
-SRC_FILE = vectors_$(subst stm32,,$(CPU_FAM)).c
+SRC_FILE = vectors_$(CPU_FAM).c
 
 SRCS += $(SRC_FILE)
 # (file triggers compiler bug. see #5775)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

For stm32, the CPU_FAM variable contains stm32f1, stm32f2, etc. This PR introduces a new CPU_FAM_SHORT variable which only contains f1, f2, etc, and make use of it where possible.

For accessing the variable from periph/stmclk/vectors Makefile, the variable has to be exported.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Builds should be unchanged.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
