### PR TITLE
cpu/stm32: cleanup timer structure in vendor headers

### DIFF
--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -84,6 +84,11 @@ extern "C" {
 #define TIMER_CHAN          (4U)
 
 /**
+ * @brief   Define a macro for accessing a timer channel
+ */
+#define TIM_CHAN(tim, chan) *(&dev(tim)->CCR1 + chan)
+
+/**
  * @brief   All STM QDEC timers have 2 capture channels
  */
 #define QDEC_CHAN           (2U)

--- a/cpu/stm32/include/vendor/stm32f030x4.h
+++ b/cpu/stm32/include/vendor/stm32f030x4.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -391,7 +391,10 @@ typedef struct
   __IO uint32_t PSC;          /*!< TIM prescaler register,              Address offset: 0x28 */
   __IO uint32_t ARR;          /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;             /*!< TIM  repetition counter register,            Address offset: 0x30 */
-  __IO uint32_t CCR[4];       /*!< TIM capture/compare register 1-4,    Address offset: 0x34 */
+  __IO uint32_t CCR1;         /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;         /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;         /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;         /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;            /*!< TIM break and dead-time register,            Address offset: 0x44 */
   __IO uint32_t DCR;          /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;            /*!< TIM DMA address for full transfer register,  Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f030x8.h
+++ b/cpu/stm32/include/vendor/stm32f030x8.h
@@ -11,7 +11,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -399,7 +399,10 @@ typedef struct
   __IO uint32_t PSC;          /*!< TIM prescaler register,              Address offset: 0x28 */
   __IO uint32_t ARR;          /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;             /*!< TIM  repetition counter register,            Address offset: 0x30 */
-  __IO uint32_t CCR[4];       /*!< TIM capture/compare register 1-4,    Address offset: 0x34 */
+  __IO uint32_t CCR1;         /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;         /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;         /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;         /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;            /*!< TIM break and dead-time register,            Address offset: 0x44 */
   __IO uint32_t DCR;          /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;            /*!< TIM DMA address for full transfer register,  Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f030xc.h
+++ b/cpu/stm32/include/vendor/stm32f030xc.h
@@ -419,13 +419,10 @@ typedef struct
   __IO uint32_t PSC;          /*!< TIM prescaler register,              Address offset: 0x28 */
   __IO uint32_t ARR;          /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;             /*!< TIM  repetition counter register,            Address offset: 0x30 */
-#if 0
   __IO uint32_t CCR1;         /*!< TIM capture/compare register 1,      Address offset: 0x34 */    
   __IO uint32_t CCR2;         /*!< TIM capture/compare register 2,      Address offset: 0x38 */    
   __IO uint32_t CCR3;         /*!< TIM capture/compare register 3,      Address offset: 0x3C */
   __IO uint32_t CCR4;         /*!< TIM capture/compare register 4,      Address offset: 0x40 */
-#endif
-  __IO uint32_t CCR[4];       /*!< TIM capture/compare register 1-4,    Address offset: 0x34 */
   __IO uint32_t BDTR;            /*!< TIM break and dead-time register,            Address offset: 0x44 */
   __IO uint32_t DCR;          /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;            /*!< TIM DMA address for full transfer register,  Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f031x6.h
+++ b/cpu/stm32/include/vendor/stm32f031x6.h
@@ -11,7 +11,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -402,7 +402,10 @@ typedef struct
   __IO uint32_t PSC;          /*!< TIM prescaler register,              Address offset: 0x28 */
   __IO uint32_t ARR;          /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;             /*!< TIM  repetition counter register,            Address offset: 0x30 */
-  __IO uint32_t CCR[4];          /*!< TIM capture/compare register 1-4,            Address offset: 0x34 */
+  __IO uint32_t CCR1;         /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;         /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;         /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;         /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;            /*!< TIM break and dead-time register,            Address offset: 0x44 */
   __IO uint32_t DCR;          /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;            /*!< TIM DMA address for full transfer register,  Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f042x6.h
+++ b/cpu/stm32/include/vendor/stm32f042x6.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripherals registers hardware
   *  
   ******************************************************************************
   * @attention
@@ -475,7 +475,10 @@ typedef struct
   __IO uint32_t PSC;          /*!< TIM prescaler register,              Address offset: 0x28 */
   __IO uint32_t ARR;          /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;             /*!< TIM  repetition counter register,            Address offset: 0x30 */
-  __IO uint32_t CCR[4];         /*!< TIM capture/compare register 1,      Address offset: 0x34 */    
+  __IO uint32_t CCR1;         /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;         /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;         /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;         /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;            /*!< TIM break and dead-time register,            Address offset: 0x44 */
   __IO uint32_t DCR;          /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;            /*!< TIM DMA address for full transfer register,  Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f051x8.h
+++ b/cpu/stm32/include/vendor/stm32f051x8.h
@@ -444,7 +444,10 @@ typedef struct
   __IO uint32_t PSC;          /*!< TIM prescaler register,              Address offset: 0x28 */
   __IO uint32_t ARR;          /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;             /*!< TIM  repetition counter register,            Address offset: 0x30 */
-  __IO uint32_t CCR[4];         /*!< TIM capture/compare register 1,      Address offset: 0x34 */    
+  __IO uint32_t CCR1;         /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;         /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;         /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;         /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;            /*!< TIM break and dead-time register,            Address offset: 0x44 */
   __IO uint32_t DCR;          /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;            /*!< TIM DMA address for full transfer register,  Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f070xb.h
+++ b/cpu/stm32/include/vendor/stm32f070xb.h
@@ -11,7 +11,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -404,7 +404,10 @@ typedef struct
   __IO uint32_t PSC;          /*!< TIM prescaler register,              Address offset: 0x28 */
   __IO uint32_t ARR;          /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;             /*!< TIM  repetition counter register,            Address offset: 0x30 */
-  __IO uint32_t CCR[4];       /*!< TIM capture/compare register 1-4,    Address offset: 0x34 */
+  __IO uint32_t CCR1;         /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;         /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;         /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;         /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;            /*!< TIM break and dead-time register,            Address offset: 0x44 */
   __IO uint32_t DCR;          /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;            /*!< TIM DMA address for full transfer register,  Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f072xb.h
+++ b/cpu/stm32/include/vendor/stm32f072xb.h
@@ -543,7 +543,10 @@ typedef struct
   __IO uint32_t PSC;          /*!< TIM prescaler register,              Address offset: 0x28 */
   __IO uint32_t ARR;          /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;             /*!< TIM  repetition counter register,            Address offset: 0x30 */
-  __IO uint32_t CCR[4];         /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR1;         /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;         /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;         /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;         /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;            /*!< TIM break and dead-time register,            Address offset: 0x44 */
   __IO uint32_t DCR;          /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;            /*!< TIM DMA address for full transfer register,  Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f091xc.h
+++ b/cpu/stm32/include/vendor/stm32f091xc.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -544,7 +544,10 @@ typedef struct
   __IO uint32_t PSC;          /*!< TIM prescaler register,              Address offset: 0x28 */
   __IO uint32_t ARR;          /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;             /*!< TIM  repetition counter register,            Address offset: 0x30 */
-  __IO uint32_t CCR[4];       /*!< TIM capture/compare register 1-4,      Address offset: 0x34 */
+  __IO uint32_t CCR1;         /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;         /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;         /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;         /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;            /*!< TIM break and dead-time register,            Address offset: 0x44 */
   __IO uint32_t DCR;          /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;            /*!< TIM DMA address for full transfer register,  Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f103xb.h
+++ b/cpu/stm32/include/vendor/stm32f103xb.h
@@ -9,8 +9,8 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
-  *  
+  *           - Macros to access peripheral's registers hardware
+  *
   ******************************************************************************
   * @attention
   *
@@ -488,7 +488,10 @@ typedef struct
   __IO uint32_t PSC;             /*!< TIM prescaler register,                      Address offset: 0x28 */
   __IO uint32_t ARR;             /*!< TIM auto-reload register,                    Address offset: 0x2C */
   __IO uint32_t RCR;             /*!< TIM  repetition counter register,            Address offset: 0x30 */
-  __IO uint32_t CCR[4];            /*!< TIM capture/compare register 1,              Address offset: 0x34 */
+  __IO uint32_t CCR1;            /*!< TIM capture/compare register 1,              Address offset: 0x34 */
+  __IO uint32_t CCR2;            /*!< TIM capture/compare register 2,              Address offset: 0x38 */
+  __IO uint32_t CCR3;            /*!< TIM capture/compare register 3,              Address offset: 0x3C */
+  __IO uint32_t CCR4;            /*!< TIM capture/compare register 4,              Address offset: 0x40 */
   __IO uint32_t BDTR;            /*!< TIM break and dead-time register,            Address offset: 0x44 */
   __IO uint32_t DCR;             /*!< TIM DMA control register,                    Address offset: 0x48 */
   __IO uint32_t DMAR;            /*!< TIM DMA address for full transfer register,  Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f103xe.h
+++ b/cpu/stm32/include/vendor/stm32f103xe.h
@@ -9,8 +9,8 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
-  *  
+  *           - Macros to access peripheral's registers hardware
+  *
   ******************************************************************************
   * @attention
   *
@@ -533,7 +533,10 @@ typedef struct
   __IO uint32_t PSC;             /*!< TIM prescaler register,                      Address offset: 0x28 */
   __IO uint32_t ARR;             /*!< TIM auto-reload register,                    Address offset: 0x2C */
   __IO uint32_t RCR;             /*!< TIM  repetition counter register,            Address offset: 0x30 */
-  __IO uint32_t CCR[4];            /*!< TIM capture/compare register 1,              Address offset: 0x34 */
+  __IO uint32_t CCR1;            /*!< TIM capture/compare register 1,              Address offset: 0x34 */
+  __IO uint32_t CCR2;            /*!< TIM capture/compare register 2,              Address offset: 0x38 */
+  __IO uint32_t CCR3;            /*!< TIM capture/compare register 3,              Address offset: 0x3C */
+  __IO uint32_t CCR4;            /*!< TIM capture/compare register 4,              Address offset: 0x40 */
   __IO uint32_t BDTR;            /*!< TIM break and dead-time register,            Address offset: 0x44 */
   __IO uint32_t DCR;             /*!< TIM DMA control register,                    Address offset: 0x48 */
   __IO uint32_t DMAR;            /*!< TIM DMA address for full transfer register,  Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f205xx.h
+++ b/cpu/stm32/include/vendor/stm32f205xx.h
@@ -7,7 +7,7 @@
   *          This file contains :  
   *           - Data structures and the address mapping for all peripherals
   *           - Peripherals registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention
@@ -641,7 +641,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f207xx.h
+++ b/cpu/stm32/include/vendor/stm32f207xx.h
@@ -737,7 +737,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f215xx.h
+++ b/cpu/stm32/include/vendor/stm32f215xx.h
@@ -7,7 +7,7 @@
   *          This file contains :  
   *           - Data structures and the address mapping for all peripherals
   *           - Peripherals registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention
@@ -642,7 +642,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f217xx.h
+++ b/cpu/stm32/include/vendor/stm32f217xx.h
@@ -7,7 +7,7 @@
   *          This file contains :  
   *           - Data structures and the address mapping for all peripherals
   *           - Peripherals registers declarations and bits definition
-  *           - Macros to access peripheral�s registers hardware
+  *           - Macros to access peripheral's registers hardware
   *
   ******************************************************************************
   * @attention
@@ -738,7 +738,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f302x8.h
+++ b/cpu/stm32/include/vendor/stm32f302x8.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -592,7 +592,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f303x8.h
+++ b/cpu/stm32/include/vendor/stm32f303x8.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -582,7 +582,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare 4 registers,     Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f303xc.h
+++ b/cpu/stm32/include/vendor/stm32f303xc.h
@@ -603,7 +603,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f303xe.h
+++ b/cpu/stm32/include/vendor/stm32f303xe.h
@@ -678,7 +678,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f334x8.h
+++ b/cpu/stm32/include/vendor/stm32f334x8.h
@@ -666,7 +666,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f401xe.h
+++ b/cpu/stm32/include/vendor/stm32f401xe.h
@@ -499,7 +499,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1-4,    Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f405xx.h
+++ b/cpu/stm32/include/vendor/stm32f405xx.h
@@ -660,7 +660,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1-4,    Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f407xx.h
+++ b/cpu/stm32/include/vendor/stm32f407xx.h
@@ -755,7 +755,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1-4,    Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f410rx.h
+++ b/cpu/stm32/include/vendor/stm32f410rx.h
@@ -505,7 +505,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1-4,    Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f411xe.h
+++ b/cpu/stm32/include/vendor/stm32f411xe.h
@@ -500,7 +500,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1-4,    Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f412zx.h
+++ b/cpu/stm32/include/vendor/stm32f412zx.h
@@ -683,7 +683,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f413xx.h
+++ b/cpu/stm32/include/vendor/stm32f413xx.h
@@ -744,7 +744,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare registes,        Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f415xx.h
+++ b/cpu/stm32/include/vendor/stm32f415xx.h
@@ -661,7 +661,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1-4,    Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f423xx.h
+++ b/cpu/stm32/include/vendor/stm32f423xx.h
@@ -745,7 +745,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare registes,        Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f429xx.h
+++ b/cpu/stm32/include/vendor/stm32f429xx.h
@@ -875,7 +875,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1-4,    Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f437xx.h
+++ b/cpu/stm32/include/vendor/stm32f437xx.h
@@ -829,7 +829,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1-4,    Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f446xx.h
+++ b/cpu/stm32/include/vendor/stm32f446xx.h
@@ -775,7 +775,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1-4,    Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f722xx.h
+++ b/cpu/stm32/include/vendor/stm32f722xx.h
@@ -710,7 +710,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f723xx.h
+++ b/cpu/stm32/include/vendor/stm32f723xx.h
@@ -710,7 +710,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f746xx.h
+++ b/cpu/stm32/include/vendor/stm32f746xx.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -937,7 +937,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1 - 4,  Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f767xx.h
+++ b/cpu/stm32/include/vendor/stm32f767xx.h
@@ -983,7 +983,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32f769xx.h
+++ b/cpu/stm32/include/vendor/stm32f769xx.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -984,7 +984,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                       Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,            Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,     Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,    Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l010x4.h
+++ b/cpu/stm32/include/vendor/stm32l010x4.h
@@ -413,7 +413,10 @@ typedef struct
   __IO uint32_t PSC;       /*!< TIM prescaler register,                       Address offset: 0x28 */
   __IO uint32_t ARR;       /*!< TIM auto-reload register,                     Address offset: 0x2C */
   uint32_t      RESERVED12;/*!< Reserved                                      Address offset: 0x30 */
-  __IO uint32_t CCR[4];    /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR1;      /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR2;      /*!< TIM capture/compare register 2,               Address offset: 0x38 */
+  __IO uint32_t CCR3;      /*!< TIM capture/compare register 3,               Address offset: 0x3C */
+  __IO uint32_t CCR4;      /*!< TIM capture/compare register 4,               Address offset: 0x40 */
   uint32_t      RESERVED17;/*!< Reserved,                                     Address offset: 0x44 */
   __IO uint32_t DCR;       /*!< TIM DMA control register,                     Address offset: 0x48 */
   __IO uint32_t DMAR;      /*!< TIM DMA address for full transfer register,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l010x6.h
+++ b/cpu/stm32/include/vendor/stm32l010x6.h
@@ -413,7 +413,10 @@ typedef struct
   __IO uint32_t PSC;       /*!< TIM prescaler register,                       Address offset: 0x28 */
   __IO uint32_t ARR;       /*!< TIM auto-reload register,                     Address offset: 0x2C */
   uint32_t      RESERVED12;/*!< Reserved                                      Address offset: 0x30 */
-  __IO uint32_t CCR[4];    /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR1;      /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR2;      /*!< TIM capture/compare register 2,               Address offset: 0x38 */
+  __IO uint32_t CCR3;      /*!< TIM capture/compare register 3,               Address offset: 0x3C */
+  __IO uint32_t CCR4;      /*!< TIM capture/compare register 4,               Address offset: 0x40 */
   uint32_t      RESERVED17;/*!< Reserved,                                     Address offset: 0x44 */
   __IO uint32_t DCR;       /*!< TIM DMA control register,                     Address offset: 0x48 */
   __IO uint32_t DMAR;      /*!< TIM DMA address for full transfer register,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l010x8.h
+++ b/cpu/stm32/include/vendor/stm32l010x8.h
@@ -413,7 +413,10 @@ typedef struct
   __IO uint32_t PSC;       /*!< TIM prescaler register,                       Address offset: 0x28 */
   __IO uint32_t ARR;       /*!< TIM auto-reload register,                     Address offset: 0x2C */
   uint32_t      RESERVED12;/*!< Reserved                                      Address offset: 0x30 */
-  __IO uint32_t CCR[4];    /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR1;      /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR2;      /*!< TIM capture/compare register 2,               Address offset: 0x38 */
+  __IO uint32_t CCR3;      /*!< TIM capture/compare register 3,               Address offset: 0x3C */
+  __IO uint32_t CCR4;      /*!< TIM capture/compare register 4,               Address offset: 0x40 */
   uint32_t      RESERVED17;/*!< Reserved,                                     Address offset: 0x44 */
   __IO uint32_t DCR;       /*!< TIM DMA control register,                     Address offset: 0x48 */
   __IO uint32_t DMAR;      /*!< TIM DMA address for full transfer register,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l010xb.h
+++ b/cpu/stm32/include/vendor/stm32l010xb.h
@@ -414,7 +414,10 @@ typedef struct
   __IO uint32_t PSC;       /*!< TIM prescaler register,                       Address offset: 0x28 */
   __IO uint32_t ARR;       /*!< TIM auto-reload register,                     Address offset: 0x2C */
   uint32_t      RESERVED12;/*!< Reserved                                      Address offset: 0x30 */
-  __IO uint32_t CCR[4];    /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR1;      /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR2;      /*!< TIM capture/compare register 2,               Address offset: 0x38 */
+  __IO uint32_t CCR3;      /*!< TIM capture/compare register 3,               Address offset: 0x3C */
+  __IO uint32_t CCR4;      /*!< TIM capture/compare register 4,               Address offset: 0x40 */
   uint32_t      RESERVED17;/*!< Reserved,                                     Address offset: 0x44 */
   __IO uint32_t DCR;       /*!< TIM DMA control register,                     Address offset: 0x48 */
   __IO uint32_t DMAR;      /*!< TIM DMA address for full transfer register,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l031xx.h
+++ b/cpu/stm32/include/vendor/stm32l031xx.h
@@ -447,7 +447,10 @@ typedef struct
   __IO uint32_t PSC;       /*!< TIM prescaler register,                       Address offset: 0x28 */
   __IO uint32_t ARR;       /*!< TIM auto-reload register,                     Address offset: 0x2C */
   uint32_t      RESERVED12;/*!< Reserved                                      Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR1;      /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR2;      /*!< TIM capture/compare register 2,               Address offset: 0x38 */
+  __IO uint32_t CCR3;      /*!< TIM capture/compare register 3,               Address offset: 0x3C */
+  __IO uint32_t CCR4;      /*!< TIM capture/compare register 4,               Address offset: 0x40 */
   uint32_t      RESERVED17;/*!< Reserved,                                     Address offset: 0x44 */
   __IO uint32_t DCR;       /*!< TIM DMA control register,                     Address offset: 0x48 */
   __IO uint32_t DMAR;      /*!< TIM DMA address for full transfer register,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l052xx.h
+++ b/cpu/stm32/include/vendor/stm32l052xx.h
@@ -511,7 +511,10 @@ typedef struct
   __IO uint32_t PSC;       /*!< TIM prescaler register,                       Address offset: 0x28 */
   __IO uint32_t ARR;       /*!< TIM auto-reload register,                     Address offset: 0x2C */
   uint32_t      RESERVED12;/*!< Reserved                                      Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR1;      /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR2;      /*!< TIM capture/compare register 2,               Address offset: 0x38 */
+  __IO uint32_t CCR3;      /*!< TIM capture/compare register 3,               Address offset: 0x3C */
+  __IO uint32_t CCR4;      /*!< TIM capture/compare register 4,               Address offset: 0x40 */
   uint32_t      RESERVED17;/*!< Reserved,                                     Address offset: 0x44 */
   __IO uint32_t DCR;       /*!< TIM DMA control register,                     Address offset: 0x48 */
   __IO uint32_t DMAR;      /*!< TIM DMA address for full transfer register,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l053xx.h
+++ b/cpu/stm32/include/vendor/stm32l053xx.h
@@ -525,7 +525,10 @@ typedef struct
   __IO uint32_t PSC;       /*!< TIM prescaler register,                       Address offset: 0x28 */
   __IO uint32_t ARR;       /*!< TIM auto-reload register,                     Address offset: 0x2C */
   uint32_t      RESERVED12;/*!< Reserved                                      Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR1;      /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR2;      /*!< TIM capture/compare register 2,               Address offset: 0x38 */
+  __IO uint32_t CCR3;      /*!< TIM capture/compare register 3,               Address offset: 0x3C */
+  __IO uint32_t CCR4;      /*!< TIM capture/compare register 4,               Address offset: 0x40 */
   uint32_t      RESERVED17;/*!< Reserved,                                     Address offset: 0x44 */
   __IO uint32_t DCR;       /*!< TIM DMA control register,                     Address offset: 0x48 */
   __IO uint32_t DMAR;      /*!< TIM DMA address for full transfer register,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l072xx.h
+++ b/cpu/stm32/include/vendor/stm32l072xx.h
@@ -524,7 +524,10 @@ typedef struct
   __IO uint32_t PSC;       /*!< TIM prescaler register,                       Address offset: 0x28 */
   __IO uint32_t ARR;       /*!< TIM auto-reload register,                     Address offset: 0x2C */
   uint32_t      RESERVED12;/*!< Reserved                                      Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR1;      /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR2;      /*!< TIM capture/compare register 2,               Address offset: 0x38 */
+  __IO uint32_t CCR3;      /*!< TIM capture/compare register 3,               Address offset: 0x3C */
+  __IO uint32_t CCR4;      /*!< TIM capture/compare register 4,               Address offset: 0x40 */
   uint32_t      RESERVED17;/*!< Reserved,                                     Address offset: 0x44 */
   __IO uint32_t DCR;       /*!< TIM DMA control register,                     Address offset: 0x48 */
   __IO uint32_t DMAR;      /*!< TIM DMA address for full transfer register,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l073xx.h
+++ b/cpu/stm32/include/vendor/stm32l073xx.h
@@ -538,7 +538,10 @@ typedef struct
   __IO uint32_t PSC;       /*!< TIM prescaler register,                       Address offset: 0x28 */
   __IO uint32_t ARR;       /*!< TIM auto-reload register,                     Address offset: 0x2C */
   uint32_t      RESERVED12;/*!< Reserved                                      Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR1;      /*!< TIM capture/compare register 1,               Address offset: 0x34 */
+  __IO uint32_t CCR2;      /*!< TIM capture/compare register 2,               Address offset: 0x38 */
+  __IO uint32_t CCR3;      /*!< TIM capture/compare register 3,               Address offset: 0x3C */
+  __IO uint32_t CCR4;      /*!< TIM capture/compare register 4,               Address offset: 0x40 */
   uint32_t      RESERVED17;/*!< Reserved,                                     Address offset: 0x44 */
   __IO uint32_t DCR;       /*!< TIM DMA control register,                     Address offset: 0x48 */
   __IO uint32_t DMAR;      /*!< TIM DMA address for full transfer register,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l151xb.h
+++ b/cpu/stm32/include/vendor/stm32l151xb.h
@@ -479,7 +479,10 @@ typedef struct
   __IO uint32_t PSC;          /*!< TIM prescaler register,              Address offset: 0x28 */
   __IO uint32_t ARR;          /*!< TIM auto-reload register,            Address offset: 0x2C */
   uint32_t      RESERVED12;   /*!< Reserved, 0x30                                            */
-  __IO uint32_t CCR[4];       /*!< TIM capture/compare registers 1-4,   Address offset: 0x34 */
+  __IO uint32_t CCR1;         /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;         /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;         /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;         /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   uint32_t      RESERVED17;   /*!< Reserved, 0x44                                            */
   __IO uint32_t DCR;          /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;         /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l151xba.h
+++ b/cpu/stm32/include/vendor/stm32l151xba.h
@@ -479,7 +479,10 @@ typedef struct
   __IO uint32_t PSC;          /*!< TIM prescaler register,              Address offset: 0x28 */
   __IO uint32_t ARR;          /*!< TIM auto-reload register,            Address offset: 0x2C */
   uint32_t      RESERVED12;   /*!< Reserved, 0x30                                            */
-  __IO uint32_t CCR[4];       /*!< TIM capture/compare registers 1-4,   Address offset: 0x34 */
+  __IO uint32_t CCR1;         /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;         /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;         /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;         /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   uint32_t      RESERVED17;   /*!< Reserved, 0x44                                            */
   __IO uint32_t DCR;          /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;         /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l151xc.h
+++ b/cpu/stm32/include/vendor/stm32l151xc.h
@@ -537,7 +537,10 @@ typedef struct
   __IO uint32_t PSC;          /*!< TIM prescaler register,              Address offset: 0x28 */
   __IO uint32_t ARR;          /*!< TIM auto-reload register,            Address offset: 0x2C */
   uint32_t      RESERVED12;   /*!< Reserved, 0x30                                            */
-  __IO uint32_t CCR[4];       /*!< TIM capture/compare registers 1-4,   Address offset: 0x34 */
+  __IO uint32_t CCR1;         /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;         /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;         /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;         /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   uint32_t      RESERVED17;   /*!< Reserved, 0x44                                            */
   __IO uint32_t DCR;          /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;         /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l152xe.h
+++ b/cpu/stm32/include/vendor/stm32l152xe.h
@@ -561,7 +561,10 @@ typedef struct
   __IO uint32_t PSC;          /*!< TIM prescaler register,              Address offset: 0x28 */
   __IO uint32_t ARR;          /*!< TIM auto-reload register,            Address offset: 0x2C */
   uint32_t      RESERVED12;   /*!< Reserved, 0x30                                            */
-  __IO uint32_t CCR[4];       /*!< TIM capture/compare registers 1-4,   Address offset: 0x34 */
+  __IO uint32_t CCR1;         /*!< TIM capture/compare register 1,      Address offset: 0x34 */
+  __IO uint32_t CCR2;         /*!< TIM capture/compare register 2,      Address offset: 0x38 */
+  __IO uint32_t CCR3;         /*!< TIM capture/compare register 3,      Address offset: 0x3C */
+  __IO uint32_t CCR4;         /*!< TIM capture/compare register 4,      Address offset: 0x40 */
   uint32_t      RESERVED17;   /*!< Reserved, 0x44                                            */
   __IO uint32_t DCR;          /*!< TIM DMA control register,            Address offset: 0x48 */
   __IO uint32_t DMAR;         /*!< TIM DMA address for full transfer,   Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l412xx.h
+++ b/cpu/stm32/include/vendor/stm32l412xx.h
@@ -673,7 +673,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                            Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,                 Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,          Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,           Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,           Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,           Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,         Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l432xx.h
+++ b/cpu/stm32/include/vendor/stm32l432xx.h
@@ -803,7 +803,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                            Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,                 Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,          Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,           Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,           Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,           Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,         Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l433xx.h
+++ b/cpu/stm32/include/vendor/stm32l433xx.h
@@ -852,7 +852,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                            Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,                 Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,          Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,           Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,           Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,           Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,         Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l452xx.h
+++ b/cpu/stm32/include/vendor/stm32l452xx.h
@@ -853,7 +853,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                            Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,                 Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,          Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1-4,         Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,           Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,           Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,           Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,         Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l475xx.h
+++ b/cpu/stm32/include/vendor/stm32l475xx.h
@@ -911,7 +911,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                            Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,                 Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,          Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1-4,           Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,           Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,           Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,           Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,         Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l476xx.h
+++ b/cpu/stm32/include/vendor/stm32l476xx.h
@@ -926,7 +926,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                            Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,                 Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,          Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare registers 1-4,        Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,           Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,           Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,           Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,         Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l496xx.h
+++ b/cpu/stm32/include/vendor/stm32l496xx.h
@@ -999,7 +999,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                            Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,                 Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,          Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,           Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,           Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,           Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,         Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32l4r5xx.h
+++ b/cpu/stm32/include/vendor/stm32l4r5xx.h
@@ -1019,7 +1019,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler,                            Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,                 Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,          Address offset: 0x30 */
-  __IO uint32_t CCR[4];        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,           Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,           Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,           Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,         Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x4C */

--- a/cpu/stm32/include/vendor/stm32wb55xx.h
+++ b/cpu/stm32/include/vendor/stm32wb55xx.h
@@ -622,7 +622,10 @@ typedef struct
   __IO uint32_t PSC;         /*!< TIM prescaler register,                   Address offset: 0x28 */
   __IO uint32_t ARR;         /*!< TIM auto-reload register,                 Address offset: 0x2C */
   __IO uint32_t RCR;         /*!< TIM repetition counter register,          Address offset: 0x30 */
-  __IO uint32_t CCR[4];      /*!< TIM capture/compare register 1-4,         Address offset: 0x34 */
+  __IO uint32_t CCR1;        /*!< TIM capture/compare register 1,           Address offset: 0x34 */
+  __IO uint32_t CCR2;        /*!< TIM capture/compare register 2,           Address offset: 0x38 */
+  __IO uint32_t CCR3;        /*!< TIM capture/compare register 3,           Address offset: 0x3C */
+  __IO uint32_t CCR4;        /*!< TIM capture/compare register 4,           Address offset: 0x40 */
   __IO uint32_t BDTR;        /*!< TIM break and dead-time register,         Address offset: 0x44 */
   __IO uint32_t DCR;         /*!< TIM DMA control register,                 Address offset: 0x48 */
   __IO uint32_t DMAR;        /*!< TIM DMA address for full transfer,        Address offset: 0x4C */

--- a/cpu/stm32/periph/pwm.c
+++ b/cpu/stm32/periph/pwm.c
@@ -53,7 +53,7 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
     dev(pwm)->CR1 = 0;
     dev(pwm)->CR2 = 0;
     for (unsigned i = 0; i < TIMER_CHAN; ++i) {
-        dev(pwm)->CCR[i] = 0;
+        TIM_CHAN(pwm, i) = 0;
     }
 
     /* configure the used pins */
@@ -120,7 +120,7 @@ void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
         value = (uint16_t)dev(pwm)->ARR;
     }
     /* set new value */
-    dev(pwm)->CCR[pwm_config[pwm].chan[channel].cc_chan] = value;
+    TIM_CHAN(pwm, pwm_config[pwm].chan[channel].cc_chan) = value;
 }
 
 void pwm_poweron(pwm_t pwm)

--- a/cpu/stm32/periph/qdec.c
+++ b/cpu/stm32/periph/qdec.c
@@ -65,7 +65,7 @@ int32_t qdec_init(qdec_t qdec, qdec_mode_t mode, qdec_cb_t cb, void *arg)
     dev(qdec)->SMCR = 0;
     dev(qdec)->CCER = 0;
     for (i = 0; i < QDEC_CHAN; i++) {
-        dev(qdec)->CCR[i] = 0;
+        TIM_CHAN(qdec, i) = 0;
     }
 
     /* Count on A (TI1) signal edges, B (TI2) signal edges or both,
@@ -91,7 +91,7 @@ int32_t qdec_init(qdec_t qdec, qdec_mode_t mode, qdec_cb_t cb, void *arg)
 
     /* Reset configuration and CC channels */
     for (i = 0; i < QDEC_CHAN; i++) {
-        dev(qdec)->CCR[i] = 0;
+        TIM_CHAN(qdec, i) = 0;
     }
 
     /* Configure the used pins */

--- a/cpu/stm32/periph/timer.c
+++ b/cpu/stm32/periph/timer.c
@@ -74,7 +74,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
         return -1;
     }
 
-    dev(tim)->CCR[channel] = (value & timer_config[tim].max);
+    TIM_CHAN(tim, channel) = (value & timer_config[tim].max);
     dev(tim)->SR &= ~(TIM_SR_CC1IF << channel);
     dev(tim)->DIER |= (TIM_DIER_CC1IE << channel);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR restores the timer structure in all STM32 vendor headers and adapts the timer peripheral driver accordingly.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Run the timer related tests on STM32 boards to check nothing is broken
- Verify that the code size remains unchanged

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
