### PR TITLE
cpu/stm32: restore default attribute names in exti structure for l4 and wb

### DIFF
--- a/cpu/stm32/include/vendor/stm32l412xx.h
+++ b/cpu/stm32/include/vendor/stm32l412xx.h
@@ -292,12 +292,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t IMR;        /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
-  __IO uint32_t EMR;        /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
-  __IO uint32_t RTSR;       /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
-  __IO uint32_t FTSR;       /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
-  __IO uint32_t SWIER;      /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
-  __IO uint32_t PR;         /*!< EXTI Pending register 1,                    Address offset: 0x14 */
+  __IO uint32_t IMR1;        /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
+  __IO uint32_t EMR1;        /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
+  __IO uint32_t RTSR1;       /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
+  __IO uint32_t FTSR1;       /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
+  __IO uint32_t SWIER1;      /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
+  __IO uint32_t PR1;         /*!< EXTI Pending register 1,                    Address offset: 0x14 */
   uint32_t      RESERVED1;   /*!< Reserved, 0x18                                                   */
   uint32_t      RESERVED2;   /*!< Reserved, 0x1C                                                   */
   __IO uint32_t IMR2;        /*!< EXTI Interrupt mask register 2,             Address offset: 0x20 */

--- a/cpu/stm32/include/vendor/stm32l432xx.h
+++ b/cpu/stm32/include/vendor/stm32l432xx.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -404,12 +404,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t IMR;        /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
-  __IO uint32_t EMR;        /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
-  __IO uint32_t RTSR;       /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
-  __IO uint32_t FTSR;       /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
-  __IO uint32_t SWIER;      /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
-  __IO uint32_t PR;         /*!< EXTI Pending register 1,                    Address offset: 0x14 */
+  __IO uint32_t IMR1;        /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
+  __IO uint32_t EMR1;        /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
+  __IO uint32_t RTSR1;       /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
+  __IO uint32_t FTSR1;       /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
+  __IO uint32_t SWIER1;      /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
+  __IO uint32_t PR1;         /*!< EXTI Pending register 1,                    Address offset: 0x14 */
   uint32_t      RESERVED1;   /*!< Reserved, 0x18                                                   */
   uint32_t      RESERVED2;   /*!< Reserved, 0x1C                                                   */
   __IO uint32_t IMR2;        /*!< EXTI Interrupt mask register 2,             Address offset: 0x20 */

--- a/cpu/stm32/include/vendor/stm32l433xx.h
+++ b/cpu/stm32/include/vendor/stm32l433xx.h
@@ -410,12 +410,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t IMR;        /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
-  __IO uint32_t EMR;        /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
-  __IO uint32_t RTSR;       /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
-  __IO uint32_t FTSR;       /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
-  __IO uint32_t SWIER;      /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
-  __IO uint32_t PR;         /*!< EXTI Pending register 1,                    Address offset: 0x14 */
+  __IO uint32_t IMR1;        /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
+  __IO uint32_t EMR1;        /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
+  __IO uint32_t RTSR1;       /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
+  __IO uint32_t FTSR1;       /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
+  __IO uint32_t SWIER1;      /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
+  __IO uint32_t PR1;         /*!< EXTI Pending register 1,                    Address offset: 0x14 */
   uint32_t      RESERVED1;   /*!< Reserved, 0x18                                                   */
   uint32_t      RESERVED2;   /*!< Reserved, 0x1C                                                   */
   __IO uint32_t IMR2;        /*!< EXTI Interrupt mask register 2,             Address offset: 0x20 */

--- a/cpu/stm32/include/vendor/stm32l452xx.h
+++ b/cpu/stm32/include/vendor/stm32l452xx.h
@@ -445,12 +445,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t IMR;        /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
-  __IO uint32_t EMR;        /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
-  __IO uint32_t RTSR;       /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
-  __IO uint32_t FTSR;       /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
-  __IO uint32_t SWIER;      /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
-  __IO uint32_t PR;         /*!< EXTI Pending register 1,                    Address offset: 0x14 */
+  __IO uint32_t IMR1;        /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
+  __IO uint32_t EMR1;        /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
+  __IO uint32_t RTSR1;       /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
+  __IO uint32_t FTSR1;       /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
+  __IO uint32_t SWIER1;      /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
+  __IO uint32_t PR1;         /*!< EXTI Pending register 1,                    Address offset: 0x14 */
   uint32_t      RESERVED1;   /*!< Reserved, 0x18                                                   */
   uint32_t      RESERVED2;   /*!< Reserved, 0x1C                                                   */
   __IO uint32_t IMR2;        /*!< EXTI Interrupt mask register 2,             Address offset: 0x20 */

--- a/cpu/stm32/include/vendor/stm32l475xx.h
+++ b/cpu/stm32/include/vendor/stm32l475xx.h
@@ -447,12 +447,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t IMR;         /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
-  __IO uint32_t EMR;         /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
-  __IO uint32_t RTSR;        /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
-  __IO uint32_t FTSR;        /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
-  __IO uint32_t SWIER;       /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
-  __IO uint32_t PR;          /*!< EXTI Pending register 1,                    Address offset: 0x14 */
+  __IO uint32_t IMR1;        /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
+  __IO uint32_t EMR1;        /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
+  __IO uint32_t RTSR1;       /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
+  __IO uint32_t FTSR1;       /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
+  __IO uint32_t SWIER1;      /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
+  __IO uint32_t PR1;         /*!< EXTI Pending register 1,                    Address offset: 0x14 */
   uint32_t      RESERVED1;   /*!< Reserved, 0x18                                                   */
   uint32_t      RESERVED2;   /*!< Reserved, 0x1C                                                   */
   __IO uint32_t IMR2;        /*!< EXTI Interrupt mask register 2,             Address offset: 0x20 */

--- a/cpu/stm32/include/vendor/stm32l476xx.h
+++ b/cpu/stm32/include/vendor/stm32l476xx.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -448,12 +448,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t IMR;         /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
-  __IO uint32_t EMR ;        /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
-  __IO uint32_t RTSR;        /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
-  __IO uint32_t FTSR;        /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
-  __IO uint32_t SWIER;       /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
-  __IO uint32_t PR;          /*!< EXTI Pending register 1,                    Address offset: 0x14 */
+  __IO uint32_t IMR1;        /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
+  __IO uint32_t EMR1;        /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
+  __IO uint32_t RTSR1;       /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
+  __IO uint32_t FTSR1;       /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
+  __IO uint32_t SWIER1;      /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
+  __IO uint32_t PR1;         /*!< EXTI Pending register 1,                    Address offset: 0x14 */
   uint32_t      RESERVED1;   /*!< Reserved, 0x18                                                   */
   uint32_t      RESERVED2;   /*!< Reserved, 0x1C                                                   */
   __IO uint32_t IMR2;        /*!< EXTI Interrupt mask register 2,             Address offset: 0x20 */

--- a/cpu/stm32/include/vendor/stm32l496xx.h
+++ b/cpu/stm32/include/vendor/stm32l496xx.h
@@ -9,7 +9,7 @@
   *          This file contains:
   *           - Data structures and the address mapping for all peripherals
   *           - Peripheral's registers declarations and bits definition
-  *           - Macros to access peripheral’s registers hardware
+  *           - Macros to access peripheralï¿½s registers hardware
   *
   ******************************************************************************
   * @attention
@@ -517,12 +517,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t IMR;        /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
-  __IO uint32_t EMR;        /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
-  __IO uint32_t RTSR;       /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
-  __IO uint32_t FTSR;       /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
-  __IO uint32_t SWIER;      /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
-  __IO uint32_t PR;         /*!< EXTI Pending register 1,                    Address offset: 0x14 */
+  __IO uint32_t IMR1;        /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
+  __IO uint32_t EMR1;        /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
+  __IO uint32_t RTSR1;       /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
+  __IO uint32_t FTSR1;       /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
+  __IO uint32_t SWIER1;      /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
+  __IO uint32_t PR1;         /*!< EXTI Pending register 1,                    Address offset: 0x14 */
   uint32_t      RESERVED1;   /*!< Reserved, 0x18                                                   */
   uint32_t      RESERVED2;   /*!< Reserved, 0x1C                                                   */
   __IO uint32_t IMR2;        /*!< EXTI Interrupt mask register 2,             Address offset: 0x20 */

--- a/cpu/stm32/include/vendor/stm32l4r5xx.h
+++ b/cpu/stm32/include/vendor/stm32l4r5xx.h
@@ -527,12 +527,12 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t IMR;        /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
-  __IO uint32_t EMR;        /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
-  __IO uint32_t RTSR;       /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
-  __IO uint32_t FTSR;       /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
-  __IO uint32_t SWIER;      /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
-  __IO uint32_t PR;         /*!< EXTI Pending register 1,                    Address offset: 0x14 */
+  __IO uint32_t IMR1;        /*!< EXTI Interrupt mask register 1,             Address offset: 0x00 */
+  __IO uint32_t EMR1;        /*!< EXTI Event mask register 1,                 Address offset: 0x04 */
+  __IO uint32_t RTSR1;       /*!< EXTI Rising trigger selection register 1,   Address offset: 0x08 */
+  __IO uint32_t FTSR1;       /*!< EXTI Falling trigger selection register 1,  Address offset: 0x0C */
+  __IO uint32_t SWIER1;      /*!< EXTI Software interrupt event register 1,   Address offset: 0x10 */
+  __IO uint32_t PR1;         /*!< EXTI Pending register 1,                    Address offset: 0x14 */
   uint32_t      RESERVED1;   /*!< Reserved, 0x18                                                   */
   uint32_t      RESERVED2;   /*!< Reserved, 0x1C                                                   */
   __IO uint32_t IMR2;        /*!< EXTI Interrupt mask register 2,             Address offset: 0x20 */

--- a/cpu/stm32/include/vendor/stm32wb55xx.h
+++ b/cpu/stm32/include/vendor/stm32wb55xx.h
@@ -819,10 +819,10 @@ typedef struct
   */
 typedef struct
 {
-  __IO uint32_t RTSR;          /*!< EXTI rising trigger selection register [31:0],            Address offset: 0x00 */
-  __IO uint32_t FTSR;          /*!< EXTI falling trigger selection register [31:0],           Address offset: 0x04 */
-  __IO uint32_t SWIER;         /*!< EXTI software interrupt event register [31:0],            Address offset: 0x08 */
-  __IO uint32_t PR;            /*!< EXTI pending register [31:0],                             Address offset: 0x0C */
+  __IO uint32_t RTSR1;          /*!< EXTI rising trigger selection register [31:0],            Address offset: 0x00 */
+  __IO uint32_t FTSR1;          /*!< EXTI falling trigger selection register [31:0],           Address offset: 0x04 */
+  __IO uint32_t SWIER1;         /*!< EXTI software interrupt event register [31:0],            Address offset: 0x08 */
+  __IO uint32_t PR1;            /*!< EXTI pending register [31:0],                             Address offset: 0x0C */
   __IO uint32_t RESERVED1[4];   /*!< Reserved,                                                 Address offset: 0x10 - 0x1C */
   __IO uint32_t RTSR2;          /*!< EXTI rising trigger selection register [31:0],            Address offset: 0x20 */
   __IO uint32_t FTSR2;          /*!< EXTI falling trigger selection register [31:0],           Address offset: 0x24 */
@@ -831,8 +831,8 @@ typedef struct
   __IO uint32_t RESERVED2[4];   /*!< Reserved,                                                 Address offset: 0x30 - 0x3C */
   __IO uint32_t RESERVED3[8];   /*!< Reserved,                                                 Address offset: 0x40 - 0x5C */
   __IO uint32_t RESERVED4[8];   /*!< Reserved,                                                 Address offset: 0x60 - 0x7C */
-  __IO uint32_t IMR;           /*!< EXTI wakeup with interrupt mask register for cpu1 [31:0], Address offset: 0x80 */
-  __IO uint32_t EMR;           /*!< EXTI wakeup with event mask register for cpu1 [31:0],     Address offset: 0x84 */
+  __IO uint32_t IMR1;           /*!< EXTI wakeup with interrupt mask register for cpu1 [31:0], Address offset: 0x80 */
+  __IO uint32_t EMR1;           /*!< EXTI wakeup with event mask register for cpu1 [31:0],     Address offset: 0x84 */
   __IO uint32_t RESERVED5[2];   /*!< Reserved,                                                 Address offset: 0x88 - 0x8C */
   __IO uint32_t IMR2;           /*!< EXTI wakeup with interrupt mask register for cpu1 [31:0], Address offset: 0x90 */
   __IO uint32_t EMR2;           /*!< EXTI wakeup with event mask register for cpu1 [31:0],     Address offset: 0x94 */

--- a/cpu/stm32/periph/rtc_all.c
+++ b/cpu/stm32/periph/rtc_all.c
@@ -42,6 +42,19 @@
 #define CLKSEL_LSI          (RCC_BDCR_RTCSEL_1)
 #endif
 
+/* map some EXTI register names */
+#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB)
+#define EXTI_REG_RTSR       (EXTI->RTSR1)
+#define EXTI_REG_FTSR       (EXTI->FTSR1)
+#define EXTI_REG_PR         (EXTI->PR1)
+#define EXTI_REG_IMR        (EXTI->IMR1)
+#else
+#define EXTI_REG_RTSR       (EXTI->RTSR)
+#define EXTI_REG_FTSR       (EXTI->FTSR)
+#define EXTI_REG_PR         (EXTI->PR)
+#define EXTI_REG_IMR        (EXTI->IMR)
+#endif
+
 /* interrupt line name mapping */
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0)
 #define IRQN                (RTC_IRQn)
@@ -231,10 +244,10 @@ void rtc_init(void)
 
     /* configure the EXTI channel, as RTC interrupts are routed through it.
      * Needs to be configured to trigger on rising edges. */
-    EXTI->FTSR &= ~(EXTI_FTSR_BIT);
-    EXTI->RTSR |= EXTI_RTSR_BIT;
-    EXTI->IMR  |= EXTI_IMR_BIT;
-    EXTI->PR   = EXTI_PR_BIT;
+    EXTI_REG_FTSR &= ~(EXTI_FTSR_BIT);
+    EXTI_REG_RTSR |= EXTI_RTSR_BIT;
+    EXTI_REG_IMR  |= EXTI_IMR_BIT;
+    EXTI_REG_PR   = EXTI_PR_BIT;
     /* enable global RTC interrupt */
     NVIC_EnableIRQ(IRQN);
 }
@@ -348,6 +361,6 @@ void ISR_NAME(void)
         }
         RTC->ISR &= ~RTC_ISR_ALRAF;
     }
-    EXTI->PR = EXTI_PR_BIT; /* only clear the associated bit */
+    EXTI_REG_PR = EXTI_PR_BIT; /* only clear the associated bit */
     cortexm_isr_end();
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is another cleanup of STM32 CMSIS files, this time for L4 and WB and related to external interrupts.
Instead of patching the CMSIS files for each new added CPUs, the gpio driver is adapted with some ifdefs.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- No functional changes on L4 and WB families (I tried with `tests/buttons` on the p-nucleo-wb55 and can confirm that it still works)
- Code size remains unchanged.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
 