### PR TITLE
tests/periph_rtt_min: add test to figure out RTT_MIN_OFFSET

### DIFF
--- a/tests/periph_rtt_min/Makefile
+++ b/tests/periph_rtt_min/Makefile
@@ -1,0 +1,20 @@
+BOARD ?= samr21-xpro
+include ../Makefile.tests_common
+
+USEMODULE += xtimer
+
+FEATURES_REQUIRED += periph_rtt
+DISABLE_MODULE += periph_init_rtt
+
+SAMPLES ?= 1024
+CFLAGS += -DSAMPLES=$(SAMPLES)
+
+include $(RIOTBASE)/Makefile.include
+
+$(call target-export-variables, test, SAMPLES)
+
+# use highest possible RTT_FREQUENCY for boards that allow it
+ifneq (,$(filter stm32 nrf5%,$(CPU)))
+  RTT_FREQUENCY ?= RTT_MAX_FREQUENCY
+  CFLAGS += -DRTT_FREQUENCY=$(RTT_FREQUENCY)
+endif

--- a/tests/periph_rtt_min/README.md
+++ b/tests/periph_rtt_min/README.md
@@ -1,0 +1,30 @@
+## About
+
+This applications is meant to determine RTT_MIN_OFFSET for a specific BOARD.
+
+The application will iteratively set an alarm starting from 0 ticks offset
+until the alarm actually triggers. Every time the alarm underflows the
+alarm will not be triggered within the expected time, so the application
+will set another one with a larger offset until the alarm successfully triggers.
+
+The rtt might advance between the call to rtt_get_counter() and
+rtt_set_alarm(). If that happens with val=1 then the alarm would be set
+to the current time and underflow. The test is ran over multiple samples
+to make this more likely to happen. Nonetheless its always possible
+that now sample will underflow so a conservatory value would be to
+set RTT_MIN_OFFSET to the value found out with this test + 1tick.
+
+## Usage
+
+Run `BOARD=<board> make -C tests/periph_rtt_min/ flash test` the value will
+be printed as:
+
+```
+Evaluate RTT_MIN_OFFSET over 1024 samples
+........................................................................
+........................................................................
+........................................................................
+........................................................................
+........................................................................
+RTT_MIN_OFFSET for <board>: 2
+```

--- a/tests/periph_rtt_min/main.c
+++ b/tests/periph_rtt_min/main.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test to figure out RTT_MIN_OFFSET
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdatomic.h>
+
+#include "cpu.h"
+#include "periph_conf.h"
+#include "periph/rtt.h"
+
+#include "xtimer.h"
+
+#define US_PER_TICK     (US_PER_SEC / RTT_FREQUENCY)
+/* min. amount of time to wait between set_alarm() */
+#define MIN_WAIT_US     (3 * US_PER_TICK)
+
+#ifndef SAMPLES
+#define SAMPLES 1024LU
+#endif
+
+void cb(void *arg)
+{
+    mutex_unlock(arg);
+}
+
+int main(void)
+{
+    uint32_t value = 0;
+    /* mutex starts out locked, and each time an rtt callback is successfully
+       called it will be locked again for the next iteration */
+    mutex_t lock = MUTEX_INIT_LOCKED;
+
+    rtt_init();
+
+    printf("Evaluate RTT_MIN_OFFSET over %" PRIu32 " samples\n",
+           (uint32_t)SAMPLES);
+
+    for (unsigned i = 0; i < SAMPLES; i++) {
+        uint32_t offset = 0;
+        int ret = -1;
+        while (ret != 0) {
+            offset++;
+            rtt_clear_alarm();
+            uint32_t now = rtt_get_counter();
+            rtt_set_alarm((now + offset) % RTT_MAX_VALUE, cb, &lock);
+            ret = xtimer_mutex_lock_timeout(
+                &lock, offset * US_PER_TICK + MIN_WAIT_US);
+        }
+        if (offset > value) {
+            value = offset;
+        }
+        printf(".");
+        fflush(stdout);
+    }
+    printf("\n");
+
+    printf("RTT_MIN_OFFSET for %s: %" PRIu32 "\n", RIOT_BOARD, value);
+
+    return 0;
+}

--- a/tests/periph_rtt_min/tests/01-run.py
+++ b/tests/periph_rtt_min/tests/01-run.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+from testrunner import run
+
+SAMPLES = int(os.getenv("SAMPLES", "1024"))
+
+
+def testfunc(child):
+    for _ in range(0, SAMPLES):
+        child.expect_exact('.')
+    child.expect(r'RTT_MIN_OFFSET for [a-zA-Z\-\_0-9]+: \d+')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This PR adds a simple test to figure out the correct value for `RTT_MIN_VALUE`

IMO this is also a good reason to make `RTT_MIN_VALUE` public and not only in `ztimer` code.

### Testing procedure

`BOARD=<board>make -C tests/periph_rtt_min/ flash test`

```
main(): This is RIOT! (Version: 2020.07-devel-774-g243984-pr_rtt_min_value_test)
Evaluate RTT_MIN_VALUE over 1024 samples
...............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
RTT_MIN_VALUE for samr21-xpro: 10
```

```
main(): This is RIOT! (Version: 2020.07-devel-774-g243984-pr_rtt_min_value_test)
Evaluate RTT_MIN_VALUE over 1024 samples
...............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
RTT_MIN_VALUE for iotlab-m3: 2

```


You can also see that if in `tests/periph_rtt` `TICKS_TO_WAIT` is set lower than `RTT_MIN_VALUE` the test does not work.

Note hardware specification may suggest a value different than the one resolved by the test, e.g. `cc2538` points out a value of 5. It will also depend on the `RTT_FREQUENCY`, should be ran at the highest possible frequency.

### Issues/PRs references

Figure out while debugging why changing to `ztimer` broke support for `samr21-xpro` in https://github.com/RIOT-OS/RIOT/pull/13824.
