### PR TITLE
cpu/stm32f1: restore default gpio struct in CMSIS + adapt driver

### DIFF
--- a/cpu/stm32/cpu_init.c
+++ b/cpu/stm32/cpu_init.c
@@ -101,16 +101,16 @@ static void _gpio_init_ain(void)
                 switch (i) {
                     /* preserve JTAG pins on PORTA and PORTB */
                     case 0:
-                        port->CR[0] = GPIO_CRL_CNF;
-                        port->CR[1] = GPIO_CRH_CNF & 0x000FFFFF;
+                        port->CRL = GPIO_CRL_CNF;
+                        port->CRH = GPIO_CRH_CNF & 0x000FFFFF;
                         break;
                     case 1:
-                        port->CR[0] = GPIO_CRL_CNF & 0xFFF00FFF;
-                        port->CR[1] = GPIO_CRH_CNF;
+                        port->CRL = GPIO_CRL_CNF & 0xFFF00FFF;
+                        port->CRH = GPIO_CRH_CNF;
                         break;
                     default:
-                        port->CR[0] = GPIO_CRL_CNF;
-                        port->CR[1] = GPIO_CRH_CNF;
+                        port->CRL = GPIO_CRL_CNF;
+                        port->CRH = GPIO_CRH_CNF;
                         break;
                 }
 #else /* ! defined(CPU_FAM_STM32F1) */
@@ -130,8 +130,8 @@ static void _gpio_init_ain(void)
             }
             else {
 #if defined(CPU_FAM_STM32F1)
-                port->CR[0] = GPIO_CRL_CNF;
-                port->CR[1] = GPIO_CRH_CNF;
+                port->CRL = GPIO_CRL_CNF;
+                port->CRH = GPIO_CRH_CNF;
 #else
                 port->MODER = 0xFFFFFFFF;
 #endif

--- a/cpu/stm32/include/vendor/stm32f103xb.h
+++ b/cpu/stm32/include/vendor/stm32f103xb.h
@@ -356,7 +356,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CR[2];
+  __IO uint32_t CRL;
+  __IO uint32_t CRH;
   __IO uint32_t IDR;
   __IO uint32_t ODR;
   __IO uint32_t BSRR;

--- a/cpu/stm32/include/vendor/stm32f103xe.h
+++ b/cpu/stm32/include/vendor/stm32f103xe.h
@@ -401,7 +401,8 @@ typedef struct
 
 typedef struct
 {
-  __IO uint32_t CR[2];
+  __IO uint32_t CRL;
+  __IO uint32_t CRH;
   __IO uint32_t IDR;
   __IO uint32_t ODR;
   __IO uint32_t BSRR;

--- a/cpu/stm32/periph/gpio_f1.c
+++ b/cpu/stm32/periph/gpio_f1.c
@@ -89,8 +89,8 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     periph_clk_en(APB2, (RCC_APB2ENR_IOPAEN << _port_num(pin)));
 
     /* set pin mode */
-    port->CR[pin_num >> 3] &= ~(0xf << ((pin_num & 0x7) * 4));
-    port->CR[pin_num >> 3] |=  ((mode & MODE_MASK) << ((pin_num & 0x7) * 4));
+    *(uint32_t *)(&port->CRL + (pin_num >> 3)) &= ~(0xf << ((pin_num & 0x7) * 4));
+    *(uint32_t *)(&port->CRL + (pin_num >> 3)) |=  ((mode & MODE_MASK) << ((pin_num & 0x7) * 4));
 
     /* set ODR */
     if (mode == GPIO_IN_PU)
@@ -109,8 +109,8 @@ void gpio_init_af(gpio_t pin, gpio_af_t af)
     /* enable the clock for the selected port */
     periph_clk_en(APB2, (RCC_APB2ENR_IOPAEN << _port_num(pin)));
     /* configure the pin */
-    port->CR[pin_num >> 3] &= ~(0xf << ((pin_num & 0x7) * 4));
-    port->CR[pin_num >> 3] |=  (af << ((pin_num & 0x7) * 4));
+    *(uint32_t *)(&port->CRL + (pin_num >> 3)) &= ~(0xf << ((pin_num & 0x7) * 4));
+    *(uint32_t *)(&port->CRL + (pin_num >> 3)) |=  (af << ((pin_num & 0x7) * 4));
 }
 
 void gpio_init_analog(gpio_t pin)
@@ -120,7 +120,7 @@ void gpio_init_analog(gpio_t pin)
 
     /* map the pin as analog input */
     int pin_num = _pin_num(pin);
-    _port(pin)->CR[pin_num >= 8] &= ~(0xfl << (4 * (pin_num - ((pin_num >= 8) * 8))));
+    *(uint32_t *)(&_port(pin)->CRL + (pin_num >= 8)) &= ~(0xfl << (4 * (pin_num - ((pin_num >= 8) * 8))));
 }
 
 int gpio_read(gpio_t pin)
@@ -128,7 +128,7 @@ int gpio_read(gpio_t pin)
     GPIO_TypeDef *port = _port(pin);
     int pin_num = _pin_num(pin);
 
-    if (port->CR[pin_num >> 3] & (0x3 << ((pin_num & 0x7) << 2))) {
+    if (*(uint32_t *)(&port->CRL + (pin_num >> 3)) & (0x3 << ((pin_num & 0x7) << 2))) {
         /* pin is output */
         return (port->ODR & (1 << pin_num));
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Similar to #14145 and #14144, this PR restores the GPIO structure in the stm32f1 CMSIS headers and adapter the GPIO driver accordingly.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Code size should remain the same
- No functional regression

I tested `examples/default` on iotlab-m3 and could send MAC layer packets between 2 motes.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
