### PR TITLE
sock_dtls: provide getter function for UDP sock

### DIFF
--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -259,6 +259,12 @@ int sock_dtls_create(sock_dtls_t *sock, sock_udp_t *udp_sock,
     return 0;
 }
 
+sock_udp_t *sock_dtls_get_udp_sock(sock_dtls_t *sock)
+{
+    assert(sock);
+    return sock->udp_sock;
+}
+
 int sock_dtls_session_init(sock_dtls_t *sock, const sock_udp_ep_t *ep,
                            sock_dtls_session_t *remote)
 {

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -570,6 +570,17 @@ int sock_dtls_create(sock_dtls_t *sock, sock_udp_t *udp_sock,
                      credman_tag_t tag, unsigned version, unsigned role);
 
 /**
+ * @brief   Get underlying UDP sock.
+ *
+ * @pre `sock != NULL`.
+ *
+ * @param[in] sock  DTLS sock to get UDP sock from.
+ *
+ * @return  The underlying UDP sock.
+ */
+sock_udp_t *sock_dtls_get_udp_sock(sock_dtls_t *sock);
+
+/**
  * @brief Initialize session handshake.
  *
  * Sends a ClientHello message to initialize the handshake. Call

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -557,7 +557,7 @@ void sock_dtls_init(void);
  *
  * @param[out] sock     The resulting DTLS sock object
  * @param[in] udp_sock  Existing UDP sock initialized with
- *                      @ref sock_udp_create()to be used underneath.
+ *                      @ref sock_udp_create() to be used underneath.
  * @param[in] tag       Credential tag of @p sock. The sock will only use
  *                      credentials with the same tag given here.
  * @param[in] version   [DTLS version](@ref sock_dtls_prot_version) to use.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This way a user does not have to store the UDP sock (e.g. to use with `sock_async`) somewhere else.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Mostly just a simple API enhancement, so just read ;-).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See https://github.com/RIOT-OS/RIOT/pull/12907#issuecomment-634203050
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
