### PR TITLE
makefiles/stlink: fix path to default stm32 openocd config files

### DIFF
--- a/makefiles/tools/openocd-adapters/stlink.inc.mk
+++ b/makefiles/tools/openocd-adapters/stlink.inc.mk
@@ -28,6 +28,6 @@ ifeq (,$(OPENOCD_CONFIG))
   # if no openocd default configuration is provided by the board,
   # use the STM32 common one
   ifeq (0,$(words $(wildcard $(BOARDDIR)/dist/openocd.cfg)))
-    OPENOCD_CONFIG = $(RIOTBASE)/boards/common/stm32/dist/$(CPU_FAM).cfg
+    OPENOCD_CONFIG = $(RIOTBASE)/boards/common/stm32/dist/stm32$(CPU_FAM).cfg
   endif
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a regression with the default openocd configuration files used with stm32 boards. This change was missing in #14141.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Flashing/resetting/debugging a nucleo board should work. It's broken on master

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Bug introduced in #14141 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
