### PR TITLE
cpu/atmega*: Clean up timer configs

### DIFF
--- a/boards/common/atmega/include/periph_conf_atmega_common.h
+++ b/boards/common/atmega/include/periph_conf_atmega_common.h
@@ -53,21 +53,6 @@ extern "C" {
  *
  * @details Only the 16 bit timers are used by xtimer
  *
- * ATmega256RFR2
- * =============
- * The timer driver only supports the four 16-bit timers
- * (Timer1, TST, Timer3, Timer4, Timer5), so those are the Timer we can use here.
- * Timer 1, TST, PORT B5/6/7 Out, Port D4/6 In,  Analog Comparator Input Capture, Output Compare Modulator, PWM
- * Timer 3, TST, PORT E3/4/5 Out, Port E/6/7 In, Input or Output Compare and PWM Output
- * Timer 4, TST, It can not be connected to any I/O Pin,
- * Timer 5, TST, It can not be connected to any I/O Pin,
- *
- * Using Atmel Timer 4 and 5 seems to be the best choice
- * Using Atmel Timer 4 as Xtimer
- * and Atmel Timer 5 as timer available for the the application seems to be the best choice,
- * as the special functions of the other timer are not lost.
- * Atmel Timer1 to be used as PWM timer for RGB LED
- *
  * ATmega328p
  * ==========
  * The timer driver only supports the 16-bit timer (Timer1)
@@ -96,31 +81,7 @@ extern "C" {
  * @{
  */
 #ifndef TIMER_NUMOF
-#if defined(CPU_ATMEGA128RFA1) || defined(CPU_ATMEGA256RFR2)
-    #define TIMER_NUMOF         (3U)
-    #define TIMER_CHANNELS      (3)
-
-    #define TIMER_0             MEGA_TIMER4
-    #define TIMER_0_MASK        &TIMSK4
-    #define TIMER_0_FLAG        &TIFR4
-    #define TIMER_0_ISRA        TIMER4_COMPA_vect
-    #define TIMER_0_ISRB        TIMER4_COMPB_vect
-    #define TIMER_0_ISRC        TIMER4_COMPC_vect
-
-    #define TIMER_1             MEGA_TIMER5
-    #define TIMER_1_MASK        &TIMSK5
-    #define TIMER_1_FLAG        &TIFR5
-    #define TIMER_1_ISRA        TIMER5_COMPA_vect
-    #define TIMER_1_ISRB        TIMER5_COMPB_vect
-    #define TIMER_1_ISRC        TIMER5_COMPC_vect
-
-    #define TIMER_2             MEGA_TIMER1
-    #define TIMER_2_MASK        &TIMSK1
-    #define TIMER_2_FLAG        &TIFR1
-    #define TIMER_2_ISRA        TIMER1_COMPA_vect
-    #define TIMER_2_ISRB        TIMER1_COMPB_vect
-    #define TIMER_2_ISRC        TIMER1_COMPC_vect
-#elif defined(CPU_ATMEGA328P)
+#if defined(CPU_ATMEGA328P)
     #define TIMER_NUMOF         (1U)
     #define TIMER_CHANNELS      (2)
 

--- a/boards/common/atmega/include/periph_conf_atmega_common.h
+++ b/boards/common/atmega/include/periph_conf_atmega_common.h
@@ -53,11 +53,6 @@ extern "C" {
  *
  * @details Only the 16 bit timers are used by xtimer
  *
- * ATmega328p
- * ==========
- * The timer driver only supports the 16-bit timer (Timer1)
- * so this is the only one we can use here.
- *
  * ATmega1281
  * ==========
  * The ATmega1281 has 6 timers. Timer0 and Timer2 are 8 Bit Timers,
@@ -81,16 +76,7 @@ extern "C" {
  * @{
  */
 #ifndef TIMER_NUMOF
-#if defined(CPU_ATMEGA328P)
-    #define TIMER_NUMOF         (1U)
-    #define TIMER_CHANNELS      (2)
-
-    #define TIMER_0             MEGA_TIMER1
-    #define TIMER_0_MASK        &TIMSK1
-    #define TIMER_0_FLAG        &TIFR1
-    #define TIMER_0_ISRA        TIMER1_COMPA_vect
-    #define TIMER_0_ISRB        TIMER1_COMPB_vect
-#elif defined(CPU_ATMEGA1284P)
+#if defined(CPU_ATMEGA1284P)
     #define TIMER_NUMOF         (2U)
     #define TIMER_CHANNELS      (2)
 

--- a/boards/common/atmega/include/periph_conf_atmega_common.h
+++ b/boards/common/atmega/include/periph_conf_atmega_common.h
@@ -49,50 +49,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name    Timer configuration
- *
- * @details Only the 16 bit timers are used by xtimer
- *
- * ATmega1281
- * ==========
- * The ATmega1281 has 6 timers. Timer0 and Timer2 are 8 Bit Timers,
- * Timer0 has special uses too and therefore we'll avoid using it.
- *
- * The timer driver only supports the four 16-bit timers (Timer1, Timer3,
- * Timer4, Timer5), so those are the only ones we can use here.
- *
- * ATmega2560
- * ==========
- * The timer driver only supports the four 16-bit timers (Timer1, Timer3,
- * Timer4, Timer5), so those are the only ones we can use here.
- *
- * @{
- */
-#ifndef TIMER_NUMOF
-#if defined(CPU_ATMEGA2560) || defined(CPU_ATMEGA1281)
-    #define TIMER_NUMOF         (2U)
-    #define TIMER_CHANNELS      (3)
-
-    #define TIMER_0             MEGA_TIMER1
-    #define TIMER_0_MASK        &TIMSK1
-    #define TIMER_0_FLAG        &TIFR1
-    #define TIMER_0_ISRA        TIMER1_COMPA_vect
-    #define TIMER_0_ISRB        TIMER1_COMPB_vect
-    #define TIMER_0_ISRC        TIMER1_COMPC_vect
-
-    #define TIMER_1             MEGA_TIMER4
-    #define TIMER_1_MASK        &TIMSK4
-    #define TIMER_1_FLAG        &TIFR4
-    #define TIMER_1_ISRA        TIMER4_COMPA_vect
-    #define TIMER_1_ISRB        TIMER4_COMPB_vect
-    #define TIMER_1_ISRC        TIMER4_COMPC_vect
-#else
-    #define TIMER_NUMOF         (0U)
-#endif
-#endif /* TIMER_NUMOF */
-/** @} */
-
-/**
  * @name    UART configuration
  *
  * The UART devices have fixed pin mappings, so all we need to do, is to specify

--- a/boards/common/atmega/include/periph_conf_atmega_common.h
+++ b/boards/common/atmega/include/periph_conf_atmega_common.h
@@ -93,35 +93,10 @@ extern "C" {
  * The timer driver only supports the four 16-bit timers (Timer1, Timer3,
  * Timer4, Timer5), so those are the only ones we can use here.
  *
- *
- * ATmega32U4
- * ==========
- * The ATmega32U4 has 4 timers. Timer0 and Timer2 are 8 Bit Timers.
- *
- * The timer driver only supports the two 16-bit timers (Timer1 and
- * Timer3), so those are the only ones we can use here.
- *
  * @{
  */
 #ifndef TIMER_NUMOF
-#if defined(CPU_ATMEGA32U4)
-    #define TIMER_NUMOF         (2U)
-    #define TIMER_CHANNELS      (3)
-
-    #define TIMER_0             MEGA_TIMER1
-    #define TIMER_0_MASK        &TIMSK1
-    #define TIMER_0_FLAG        &TIFR1
-    #define TIMER_0_ISRA        TIMER1_COMPA_vect
-    #define TIMER_0_ISRB        TIMER1_COMPB_vect
-    #define TIMER_0_ISRC        TIMER1_COMPC_vect
-
-    #define TIMER_1             MEGA_TIMER3
-    #define TIMER_1_MASK        &TIMSK3
-    #define TIMER_1_FLAG        &TIFR3
-    #define TIMER_1_ISRA        TIMER3_COMPA_vect
-    #define TIMER_1_ISRB        TIMER3_COMPB_vect
-    #define TIMER_1_ISRC        TIMER3_COMPC_vect
-#elif defined(CPU_ATMEGA128RFA1) || defined(CPU_ATMEGA256RFR2)
+#if defined(CPU_ATMEGA128RFA1) || defined(CPU_ATMEGA256RFR2)
     #define TIMER_NUMOF         (3U)
     #define TIMER_CHANNELS      (3)
 

--- a/boards/common/atmega/include/periph_conf_atmega_common.h
+++ b/boards/common/atmega/include/periph_conf_atmega_common.h
@@ -61,13 +61,6 @@ extern "C" {
  * The timer driver only supports the four 16-bit timers (Timer1, Timer3,
  * Timer4, Timer5), so those are the only ones we can use here.
  *
- * ATmega1284P
- * ===========
- * The ATmega1284P has 4 timers. Timer0 and Timer2 are 8 Bit Timers.
- *
- * The timer driver only supports the two 16-bit timers (Timer1 and
- * Timer3), so those are the only ones we can use here.
- *
  * ATmega2560
  * ==========
  * The timer driver only supports the four 16-bit timers (Timer1, Timer3,
@@ -76,22 +69,7 @@ extern "C" {
  * @{
  */
 #ifndef TIMER_NUMOF
-#if defined(CPU_ATMEGA1284P)
-    #define TIMER_NUMOF         (2U)
-    #define TIMER_CHANNELS      (2)
-
-    #define TIMER_0             MEGA_TIMER1
-    #define TIMER_0_MASK        &TIMSK1
-    #define TIMER_0_FLAG        &TIFR1
-    #define TIMER_0_ISRA        TIMER1_COMPA_vect
-    #define TIMER_0_ISRB        TIMER1_COMPB_vect
-
-    #define TIMER_1             MEGA_TIMER3
-    #define TIMER_1_MASK        &TIMSK3
-    #define TIMER_1_FLAG        &TIFR3
-    #define TIMER_1_ISRA        TIMER3_COMPA_vect
-    #define TIMER_1_ISRB        TIMER3_COMPB_vect
-#elif defined(CPU_ATMEGA2560) || defined(CPU_ATMEGA1281)
+#if defined(CPU_ATMEGA2560) || defined(CPU_ATMEGA1281)
     #define TIMER_NUMOF         (2U)
     #define TIMER_CHANNELS      (3)
 

--- a/cpu/atmega1281/include/default_timer_config.h
+++ b/cpu/atmega1281/include/default_timer_config.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 HAW Hamburg
+ *               2016 Freie Universität Berlin
+ *               2016 INRIA
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_atmega1281
+ * @{
+ *
+ * @file
+ * @brief           Default timer configuration
+ *
+ * @author          René Herthel <rene-herthel@outlook.de>
+ * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author          Francisco Acosta <francisco.acosta@inria.fr>
+ */
+
+#ifndef DEFAULT_TIMER_CONFIG_H
+#define DEFAULT_TIMER_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef TIMER_NUMOF
+#define TIMER_NUMOF         (2U)
+#define TIMER_CHANNELS      (3)
+
+#define TIMER_0             MEGA_TIMER1
+#define TIMER_0_MASK        &TIMSK1
+#define TIMER_0_FLAG        &TIFR1
+#define TIMER_0_ISRA        TIMER1_COMPA_vect
+#define TIMER_0_ISRB        TIMER1_COMPB_vect
+#define TIMER_0_ISRC        TIMER1_COMPC_vect
+
+#define TIMER_1             MEGA_TIMER4
+#define TIMER_1_MASK        &TIMSK4
+#define TIMER_1_FLAG        &TIFR4
+#define TIMER_1_ISRA        TIMER4_COMPA_vect
+#define TIMER_1_ISRB        TIMER4_COMPB_vect
+#define TIMER_1_ISRC        TIMER4_COMPC_vect
+#endif /* TIMER_NUMOF */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEFAULT_TIMER_CONFIG_H */
+/** @} */

--- a/cpu/atmega1281/include/periph_cpu.h
+++ b/cpu/atmega1281/include/periph_cpu.h
@@ -75,5 +75,8 @@ enum {
 }
 #endif
 
+#include "periph_conf.h"
+#include "default_timer_config.h"
+
 #endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/atmega1284p/include/default_timer_config.h
+++ b/cpu/atmega1284p/include/default_timer_config.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_atmega1284p
+ * @{
+ *
+ * @file
+ * @brief           Default timer configuration
+ *
+ * @author          Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef DEFAULT_TIMER_CONFIG_H
+#define DEFAULT_TIMER_CONFIG_H
+
+#include "periph_cpu_common.h"
+#include "periph_conf.h" /* <- Allow overwriting timer config from board */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef TIMER_NUMOF
+#define TIMER_NUMOF         (2U)
+#define TIMER_CHANNELS      (2)
+
+#define TIMER_0             MEGA_TIMER1
+#define TIMER_0_MASK        &TIMSK1
+#define TIMER_0_FLAG        &TIFR1
+#define TIMER_0_ISRA        TIMER1_COMPA_vect
+#define TIMER_0_ISRB        TIMER1_COMPB_vect
+
+#define TIMER_1             MEGA_TIMER3
+#define TIMER_1_MASK        &TIMSK3
+#define TIMER_1_FLAG        &TIFR3
+#define TIMER_1_ISRA        TIMER3_COMPA_vect
+#define TIMER_1_ISRB        TIMER3_COMPB_vect
+#endif /* TIMER_NUMOF */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEFAULT_TIMER_CONFIG_H */
+/** @} */

--- a/cpu/atmega1284p/include/periph_cpu.h
+++ b/cpu/atmega1284p/include/periph_cpu.h
@@ -72,5 +72,8 @@ enum {
 }
 #endif
 
+#include "periph_conf.h"
+#include "default_timer_config.h"
+
 #endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/atmega128rfa1/include/default_timer_config.h
+++ b/cpu/atmega128rfa1/include/default_timer_config.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) Josua Arndt, Steffen Robertz 2017 RWTH Aachen
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_atmega128rfa1
+ * @{
+ *
+ * @file
+ * @brief           Default timer configuration
+ *
+ * @author          Josua Arndt <jarndt@ias.rwth-aachen.de>
+ * @author          Steffen Robertz <steffen.robertz@rwth-aachen.de>
+ */
+
+#ifndef DEFAULT_TIMER_CONFIG_H
+#define DEFAULT_TIMER_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef TIMER_NUMOF
+#define TIMER_NUMOF         (3U)
+#define TIMER_CHANNELS      (3)
+
+#define TIMER_0             MEGA_TIMER4
+#define TIMER_0_MASK        &TIMSK4
+#define TIMER_0_FLAG        &TIFR4
+#define TIMER_0_ISRA        TIMER4_COMPA_vect
+#define TIMER_0_ISRB        TIMER4_COMPB_vect
+#define TIMER_0_ISRC        TIMER4_COMPC_vect
+
+#define TIMER_1             MEGA_TIMER5
+#define TIMER_1_MASK        &TIMSK5
+#define TIMER_1_FLAG        &TIFR5
+#define TIMER_1_ISRA        TIMER5_COMPA_vect
+#define TIMER_1_ISRB        TIMER5_COMPB_vect
+#define TIMER_1_ISRC        TIMER5_COMPC_vect
+
+#define TIMER_2             MEGA_TIMER1
+#define TIMER_2_MASK        &TIMSK1
+#define TIMER_2_FLAG        &TIFR1
+#define TIMER_2_ISRA        TIMER1_COMPA_vect
+#define TIMER_2_ISRB        TIMER1_COMPB_vect
+#define TIMER_2_ISRC        TIMER1_COMPC_vect
+#endif /* TIMER_NUMOF */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEFAULT_TIMER_CONFIG_H */
+/** @} */

--- a/cpu/atmega128rfa1/include/periph_cpu.h
+++ b/cpu/atmega128rfa1/include/periph_cpu.h
@@ -73,5 +73,8 @@ enum {
 }
 #endif
 
+#include "periph_conf.h"
+#include "default_timer_config.h"
+
 #endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/atmega2560/include/default_timer_config.h
+++ b/cpu/atmega2560/include/default_timer_config.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 HAW Hamburg
+ *               2016 Freie Universität Berlin
+ *               2016 INRIA
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_atmega2560
+ * @{
+ *
+ * @file
+ * @brief           Default timer configuration
+ *
+ * @author          René Herthel <rene-herthel@outlook.de>
+ * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author          Francisco Acosta <francisco.acosta@inria.fr>
+ */
+
+#ifndef DEFAULT_TIMER_CONFIG_H
+#define DEFAULT_TIMER_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef TIMER_NUMOF
+#define TIMER_NUMOF         (2U)
+#define TIMER_CHANNELS      (3)
+
+#define TIMER_0             MEGA_TIMER1
+#define TIMER_0_MASK        &TIMSK1
+#define TIMER_0_FLAG        &TIFR1
+#define TIMER_0_ISRA        TIMER1_COMPA_vect
+#define TIMER_0_ISRB        TIMER1_COMPB_vect
+#define TIMER_0_ISRC        TIMER1_COMPC_vect
+
+#define TIMER_1             MEGA_TIMER4
+#define TIMER_1_MASK        &TIMSK4
+#define TIMER_1_FLAG        &TIFR4
+#define TIMER_1_ISRA        TIMER4_COMPA_vect
+#define TIMER_1_ISRB        TIMER4_COMPB_vect
+#define TIMER_1_ISRC        TIMER4_COMPC_vect
+#endif /* TIMER_NUMOF */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEFAULT_TIMER_CONFIG_H */
+/** @} */

--- a/cpu/atmega2560/include/periph_cpu.h
+++ b/cpu/atmega2560/include/periph_cpu.h
@@ -77,5 +77,8 @@ enum {
 }
 #endif
 
+#include "periph_conf.h"
+#include "default_timer_config.h"
+
 #endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/atmega256rfr2/include/default_timer_config.h
+++ b/cpu/atmega256rfr2/include/default_timer_config.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) Josua Arndt, Steffen Robertz 2017 RWTH Aachen
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_atmega256rfr2
+ * @{
+ *
+ * @file
+ * @brief           Default timer configuration
+ *
+ * @author          Josua Arndt <jarndt@ias.rwth-aachen.de>
+ * @author          Steffen Robertz <steffen.robertz@rwth-aachen.de>
+ */
+
+#ifndef DEFAULT_TIMER_CONFIG_H
+#define DEFAULT_TIMER_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef TIMER_NUMOF
+#define TIMER_NUMOF         (3U)
+#define TIMER_CHANNELS      (3)
+
+#define TIMER_0             MEGA_TIMER4
+#define TIMER_0_MASK        &TIMSK4
+#define TIMER_0_FLAG        &TIFR4
+#define TIMER_0_ISRA        TIMER4_COMPA_vect
+#define TIMER_0_ISRB        TIMER4_COMPB_vect
+#define TIMER_0_ISRC        TIMER4_COMPC_vect
+
+#define TIMER_1             MEGA_TIMER5
+#define TIMER_1_MASK        &TIMSK5
+#define TIMER_1_FLAG        &TIFR5
+#define TIMER_1_ISRA        TIMER5_COMPA_vect
+#define TIMER_1_ISRB        TIMER5_COMPB_vect
+#define TIMER_1_ISRC        TIMER5_COMPC_vect
+
+#define TIMER_2             MEGA_TIMER1
+#define TIMER_2_MASK        &TIMSK1
+#define TIMER_2_FLAG        &TIFR1
+#define TIMER_2_ISRA        TIMER1_COMPA_vect
+#define TIMER_2_ISRB        TIMER1_COMPB_vect
+#define TIMER_2_ISRC        TIMER1_COMPC_vect
+#endif /* TIMER_NUMOF */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEFAULT_TIMER_CONFIG_H */
+/** @} */

--- a/cpu/atmega256rfr2/include/periph_cpu.h
+++ b/cpu/atmega256rfr2/include/periph_cpu.h
@@ -73,5 +73,8 @@ enum {
 }
 #endif
 
+#include "periph_conf.h"
+#include "default_timer_config.h"
+
 #endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/atmega328p/include/default_timer_config.h
+++ b/cpu/atmega328p/include/default_timer_config.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015 HAW Hamburg
+ *               2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_atmega328p
+ * @{
+ *
+ * @file
+ * @brief           Default timer configuration
+ *
+ * @author          René Herthel <rene-herthel@outlook.de>
+ * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef DEFAULT_TIMER_CONFIG_H
+#define DEFAULT_TIMER_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef TIMER_NUMOF
+#define TIMER_NUMOF         (1U)
+#define TIMER_CHANNELS      (2)
+
+#define TIMER_0             MEGA_TIMER1
+#define TIMER_0_MASK        &TIMSK1
+#define TIMER_0_FLAG        &TIFR1
+#define TIMER_0_ISRA        TIMER1_COMPA_vect
+#define TIMER_0_ISRB        TIMER1_COMPB_vect
+#endif /* TIMER_NUMOF */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEFAULT_TIMER_CONFIG_H */
+/** @} */

--- a/cpu/atmega328p/include/periph_cpu.h
+++ b/cpu/atmega328p/include/periph_cpu.h
@@ -68,5 +68,8 @@ enum {
 }
 #endif
 
+#include "periph_conf.h"
+#include "default_timer_config.h"
+
 #endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/atmega32u4/include/default_timer_config.h
+++ b/cpu/atmega32u4/include/default_timer_config.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2017 Thomas Perrot <thomas.perrot@tupi.fr>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_atmega32u4
+ * @{
+ *
+ * @file
+ * @brief           Default ATmega32U4 Timer Config
+ *
+ * @author          Thomas Perrot <thomas.perrot@tupi.fr>
+ *
+ */
+
+#ifndef DEFAULT_TIMER_CONFIG_H
+#define DEFAULT_TIMER_CONFIG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef TIMER_NUMOF
+#define TIMER_NUMOF         (2U)
+#define TIMER_CHANNELS      (3)
+
+#define TIMER_0             MEGA_TIMER1
+#define TIMER_0_MASK        &TIMSK1
+#define TIMER_0_FLAG        &TIFR1
+#define TIMER_0_ISRA        TIMER1_COMPA_vect
+#define TIMER_0_ISRB        TIMER1_COMPB_vect
+#define TIMER_0_ISRC        TIMER1_COMPC_vect
+
+#define TIMER_1             MEGA_TIMER3
+#define TIMER_1_MASK        &TIMSK3
+#define TIMER_1_FLAG        &TIFR3
+#define TIMER_1_ISRA        TIMER3_COMPA_vect
+#define TIMER_1_ISRB        TIMER3_COMPB_vect
+#define TIMER_1_ISRC        TIMER3_COMPC_vect
+#endif /* TIMER_NUMOF */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEFAULT_TIMER_CONFIG_H */
+/** @} */

--- a/cpu/atmega32u4/include/periph_cpu.h
+++ b/cpu/atmega32u4/include/periph_cpu.h
@@ -66,5 +66,8 @@ enum {
 }
 #endif
 
+#include "periph_conf.h"
+#include "default_timer_config.h"
+
 #endif /* PERIPH_CPU_H */
 /** @} */

--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -90,7 +90,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     DEBUG_TIMER_DDR |= (1 << DEBUG_TIMER_PIN);
     DEBUG_TIMER_PORT &= ~(1 << DEBUG_TIMER_PIN);
     DEBUG("Debug Pin: DDR 0x%02x Port 0x%02x Pin 0x%02x\n",
-           &DEBUG_TIMER_DDR , &DEBUG_TIMER_PORT,(1<<DEBUG_TIMER_PIN));
+          &DEBUG_TIMER_DDR, &DEBUG_TIMER_PORT, (1 << DEBUG_TIMER_PIN));
 #endif
 
     DEBUG("timer.c: freq = %ld\n", freq);


### PR DESCRIPTION
### Contribution description

This PR moves the default configurations of `periph_timer` from `boards/common/atmega` to `cpu/<ATMEGA_CPU>`. This allows getting rid of many instances of `#if defined(CPU_ATEMGA<FOO>)`. 

With the current periph code 16 bit timers can only be used for `periph_timer`, and 8 bit timers only for `periph_pwm`. So there is nothing for the board to decide on anyway. Still, this PR allows overwriting the timer config from a boards `periph_conf.h` just by defining `TIMER_NUMOF` there.

### Testing procedure

`tests/periph_timer` should still compile and pass for ATmega boards.

### Issues/PRs references

None