### PR TITLE
cpu/Kconfig: Add a common symbol for the CPU Core

### DIFF
--- a/cpu/Kconfig
+++ b/cpu/Kconfig
@@ -19,6 +19,11 @@
 #  +------------+
 #        || selects
 #        \/
+#  +------------+
+#  |  CPU_CORE  |
+#  +------------+
+#        || selects
+#        \/
 #   +----------+
 #   | CPU_ARCH |
 #   +----------+
@@ -41,6 +46,11 @@ config CPU_FAMILY
     string
     help
         Family of the currently selected CPU.
+
+config CPU_CORE
+    string
+    help
+        Core of the currently selected CPU.
 
 config CPU_ARCH
     string


### PR DESCRIPTION
### Contribution description
In #13715 common symbols were added to Kconfig for each CPU to assign a value when used. The hierarchies proposed there seem to be limiting when trying to adjust every CPU model that we support in RIOT to it. Introducing a `CPU_CORE` should help to be more precise in the categorization.

### Testing procedure
- Green CI
- With any board selected, run make menuconfig. Using the search function (/) you should be able to find these hidden symbols. Check that they are displayed correctly.

### Issues/PRs references
Extends #13715 