### PR TITLE
Makefile: add BINFILE to default BUILD_FILES

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -531,8 +531,13 @@ ifeq (,$(FLASHFILE))
   $(error FLASHFILE is not defined for this board: $(FLASHFILE))
 endif
 
-# By default always build ELFFILE and FLASHFILE
-BUILD_FILES += $(ELFFILE) $(FLASHFILE)
+# By default always build ELFFILE, BINFILE and FLASHFILE
+ifeq ($(RIOT_CI_BUILD),1)
+  # Don't build BINFILE on the CI to save some computation time
+  BUILD_FILES += $(ELFFILE) $(FLASHFILE)
+else
+  BUILD_FILES += $(ELFFILE) $(BINFILE) $(FLASHFILE)
+endif
 
 # variables used to compile and link c++
 CPPMIX ?= $(if $(wildcard *.cpp),1,)


### PR DESCRIPTION
### Contribution description

This PR adds `BINFILE` to default `BUILDFILES`, I did not do that in CI, because I saw that it increased build time a bit, see testing results.

I did this because iot-lab now uses the `BINFILE` to flash, and this did not work if I use flash-only on a command previously compiled without any `IOTLAB_%` environment variable, see testing procedure.

This only happens if `iotlabcli>3` is installed since before the elffile was used.

### Testing procedure

1. `BOARD=iotlab-m3 make -C examples/hello-world/ all`
2. iotlab-cli 2.6.0 **sucess**
<details>

IOTLAB_NODE=m3-1.saclay.iot-lab.info BOARD=iotlab-m3 make -C examples/hello-world/ flash-only --no-print-directory
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,m3,1 --update /home/francisco/workspace/RIOT/examples/hello-world/bin/iotlab-m3/hello-world.elf | grep 0
0
</details>

3. iotlab-cli 3.0.0 **Fails** without this PR

```
IOTLAB_NODE=m3-1.saclay.iot-lab.info BOARD=iotlab-m3 make -C examples/hello-world/ flash-only --no-print-directory
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,m3,1 --flash /home/francisco/workspace/RIOT/examples/hello-world/bin/iotlab-m3/hello-world.bin | grep 0
usage: iotlab-node [-h] [-u USERNAME] [-p PASSWORD] [-v] [--jmespath JMESPATH]
                   [--format FORMAT] [-i EXPERIMENT_ID]
                   (-sta | -sto | -r | -fl FIRMWARE_PATH | --flash-idle | --debug-start | --debug-stop | --profile PROFILE_NAME | --profile-load PROFILE_PATH | --profile-reset | --update-idle | -up UP_FIRMWARE_PATH)
                   [-e EXCLUDE_NODES_LIST | -l NODES_LIST]
iotlab-node: error: [Errno 2] No such file or directory: '/home/francisco/workspace/RIOT/examples/hello-world/bin/iotlab-m3/hello-world.bin'
/home/francisco/workspace/RIOT/examples/hello-world/../../Makefile.include:706: recipe for target 'flash-only' failed
make: *** [flash-only] Error 1
```

**Build Time**

- master
```
hyperfine -r 50 -w 1 'RIOT_VERSION= BOARD=iotlab-m3 make -C examples/hello-world/'
Benchmark #1: RIOT_VERSION= BOARD=iotlab-m3 make -C examples/hello-world/
  Time (mean ± σ):     327.8 ms ±   5.9 ms    [User: 269.1 ms, System: 68.7 ms]
  Range (min … max):   315.5 ms … 347.2 ms    50 runs
```

- adding `BINFILE`
```
hyperfine -r 50 -w 1 'RIOT_VERSION= BOARD=iotlab-m3 make -C examples/hello-world/'
Benchmark #1: RIOT_VERSION= BOARD=iotlab-m3 make -C examples/hello-world/
  Time (mean ± σ):     334.6 ms ±   6.2 ms    [User: 271.3 ms, System: 73.1 ms]
  Range (min … max):   321.7 ms … 349.6 ms    50 runs
```
