### PR TITLE
nrf52840dk: move SPI flash to SPIM2 peripheral

### DIFF
--- a/boards/nrf52840dk/include/periph_conf.h
+++ b/boards/nrf52840dk/include/periph_conf.h
@@ -38,7 +38,7 @@ static const spi_conf_t spi_config[] = {
         .miso = GPIO_PIN(1, 14),
     },
     {
-        .dev  = NRF_SPIM1,
+        .dev  = NRF_SPIM2,
         .sclk = GPIO_PIN(0, 19),
         .mosi = GPIO_PIN(0, 20),
         .miso = GPIO_PIN(0, 21),


### PR DESCRIPTION
### Contribution description

The SPIM1 peripheral overlaps with TWIM1. TWIM1 is already configured as
the default peripheral for the I2C interface. This commit moves the
peripheral used for the SPI flash to SPIM2. This peripheral is dedicated
for SPI operations and doesn't conflict with other peripherals

### Testing procedure

`tests/pkg_littlefs2` should still work

### Issues/PRs references

caused by #14052 