### PR TITLE
sam0_common: Move feature to Makefile.features and add buildsystem check

### DIFF
--- a/cpu/sam0_common/Makefile.dep
+++ b/cpu/sam0_common/Makefile.dep
@@ -5,9 +5,6 @@ endif
 # All SAM0 based CPUs provide PM
 USEMODULE += pm_layered
 
-# the timer implements timer_set_periodic()
-FEATURES_PROVIDED += periph_timer_periodic
-
 # include sam0 common periph drivers
 USEMODULE += sam0_common_periph
 

--- a/cpu/sam0_common/Makefile.features
+++ b/cpu/sam0_common/Makefile.features
@@ -4,6 +4,7 @@ FEATURES_PROVIDED += periph_flashpage_raw
 FEATURES_PROVIDED += periph_flashpage_rwee
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c_reconfigure
+FEATURES_PROVIDED += periph_timer_periodic # implements timer_set_periodic()
 FEATURES_PROVIDED += periph_uart_modecfg
 FEATURES_PROVIDED += periph_uart_nonblocking
 FEATURES_PROVIDED += periph_wdt periph_wdt_cb

--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -60,6 +60,22 @@ check_not_parsing_features() {
         | error_with_message 'Modules should not check the content of FEATURES_PROVIDED/_REQUIRED/OPTIONAL'
 }
 
+# Providing features for boards and CPUs should only be done in
+# Makefile.features
+check_providing_features_only_makefile_features() {
+    local patterns=()
+    local pathspec=()
+
+    patterns+=(-e 'FEATURES_PROVIDED *+= *')
+
+    pathspec+=("boards/*Makefile*" "cpu/*Makefile*")
+
+    pathspec+=(":!*Makefile.features")
+
+    git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}" \
+        | error_with_message 'Features in cpu and boards should only be provided in Makefile.features files'
+}
+
 # Some variables do not need to be exported and even cause issues when being
 # exported because they are evaluated even when not needed.
 #
@@ -259,6 +275,7 @@ error_on_input() {
 
 all_checks() {
     check_not_parsing_features
+    check_providing_features_only_makefile_features
     check_not_exporting_variables
     check_deprecated_vars_patterns
     check_board_do_not_include_cpu_features_dep


### PR DESCRIPTION
### Contribution description
This PR moves a newly introduced feature for `cpu/sam0_common` to its `Makefile.features`. Also, it adds a static check to detect features provided in `boards` and `cpu` on a file that is not `Makefile.features`.

### Testing procedure
- Features provided for any sam0_common-based CPU should still be the same
- The check can be tested by removing the last commit

### Issues/PRs references
None