### PR TITLE
gnrc_netif: relax 6lo MTU assertion for 802.15.4g

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1304,7 +1304,7 @@ static void _test_options(gnrc_netif_t *netif)
                    (IEEE802154_LONG_ADDRESS_LEN == netif->l2addr_len));
 #if IS_USED(MODULE_GNRC_NETIF_IPV6)
 #if IS_USED(MODULE_GNRC_NETIF_6LO)
-            assert(netif->ipv6.mtu == IPV6_MIN_MTU);
+            assert(netif->ipv6.mtu >= IPV6_MIN_MTU);
             assert(netif->sixlo.max_frag_size > 0);
             assert(-ENOTSUP != netif->dev->driver->get(netif->dev, NETOPT_PROTO,
                                                        &tmp, sizeof(tmp)));


### PR DESCRIPTION



<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

802.15.4g devices have a 2047 byte PDU.
So the assertion `netif->ipv6.mtu == IPV6_MIN_MTU` is too strict here.

This is only enforced on init, so changing the modulation at run-time did not catch this bug.



### Testing procedure

To test, use e.g. `at86rf215` with 

    CFLAGS += -DAT86RF215_DEFAULT_PHY_MODE=IEEE802154_PHY_MR_OQPSK

and flash `examples/gnrc_networking`.
On `master` the this leads to a failed `assert()`.

### Issues/PRs references

fixes #14164
