### PR TITLE
cpu/stm32: don't include usbdev_stm32.h in periph_cpu_common.h

### DIFF
--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -917,10 +917,6 @@ int dma_configure(dma_t dma, int chan, const volatile void *src, volatile void *
 #include "candev_stm32.h"
 #endif
 
-#ifdef MODULE_PERIPH_USBDEV
-#include "usbdev_stm32.h"
-#endif
-
 /**
  * @brief STM32 Ethernet configuration mode
  */


### PR DESCRIPTION
#### Contribution description

`usbdev_stm32.h` will pull in `usb.h` which causes an error for each file that includes `periph_cpu_common.h` but does not set `USB_H_USER_IS_RIOT_INTERNAL`.

Turns out this include is not needed, so just drop it.

This will make working with (currently out-of-tree) stm32 boards that use CDC ACM for stdio possible.

### Testing procedure

Enable `stdio_cdc_acm` on any stm32 board

### Issues/PRs references

split off #14122, #12778 & #13382
