### PR TITLE
pkg/fatfs/fatfs_vfs: fix flag translation in _open

### DIFF
--- a/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
+++ b/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
@@ -151,7 +151,12 @@ static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode,
         fatfs_flags |= FA_CREATE_ALWAYS;
     }
     if ((flags & O_CREAT) == O_CREAT) {
-        fatfs_flags |= FA_CREATE_NEW;
+        if ((flags & O_EXCL) == O_EXCL) {
+            fatfs_flags |= FA_CREATE_NEW;
+        }
+        else {
+            fatfs_flags |= FA_OPEN_ALWAYS;
+        }
     }
     else {
         fatfs_flags |= FA_OPEN_EXISTING;


### PR DESCRIPTION
### Contribution description

When using `fatfs_vfs` with `newlib`, `fopen` will fail in append-mode (`"a"`) if the file you want to open already exists.
Using `vfs_open(..., O_WRONLY | O_CREAT, 0)` on an existing file will also fail.

This PR extends the `test_create`-test case and provides a new test case for `fopen` etc.
It fixes the mode flag translation to FatFs's `FA_`-flags. The translation should be as in the table:

| POSIX | `O_`-flags                | FatFs `FA_`-flags |
|--------|----------------------|--------------------|
|"r"   | O_RDONLY                    | FA_READ |
|"r+"  | O_RDWR                      | FA_READ,FA_WRITE |
|"w"   | O_WRONLY, O_CREAT, O_TRUNC      |      FA_WRITE, FA_CREATE_ALWAYS |
|"w+"  | O_RDWR,   O_CREAT, O_TRUNC      | FA_READ,FA_WRITE, FA_CREATE_ALWAYS |
|"a"   | O_WRONLY, O_CREAT, O_APPEND     |             FA_OPEN_APPEND |
|"a+"  | O_RDWR,   O_CREAT, O_APPEND     | FA_READ,       FA_OPEN_APPEND |
|"wx"  | O_WRONLY, O_CREAT, O_TRUNC,O_EXCL |      FA_WRITE, FA_CREATE_NEW |
|"w+x" | O_RDWR,   O_CREAT, O_TRUNC,O_EXCL | FA_READ,FA_WRITE, FA_CREATE_NEW |
| ?       | O_WRONLY, O_CREAT | FA_WRITE,FA_OPEN_ALWAYS |

Compare flag-table [here](http://elm-chan.org/fsw/ff/doc/open.html).

### Testing procedure

Run [these tests](https://github.com/RIOT-OS/RIOT/tree/master/tests/pkg_fatfs_vfs) on your hardware with an SD-card as described in the REAME.
