### PR TITLE
boards/atmega328p-based: Model features in Kconfig

### DIFF
--- a/boards/arduino-duemilanove/Kconfig
+++ b/boards/arduino-duemilanove/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_ARDUINO_DUEMILANOVE
+    bool
+    default y
+    select BOARD_COMMON_ARDUINO_ATMEGA
+    select CPU_MODEL_ATMEGA328P
+
+config BOARD
+    default "arduino-duemilanove" if BOARD_ARDUINO_DUEMILANOVE
+
+source "$(RIOTBOARD)/common/arduino-atmega/Kconfig"

--- a/boards/arduino-nano/Kconfig
+++ b/boards/arduino-nano/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_ARDUINO_NANO
+    bool
+    default y
+    select BOARD_COMMON_ARDUINO_ATMEGA
+    select CPU_MODEL_ATMEGA328P
+
+config BOARD
+    default "arduino-nano" if BOARD_ARDUINO_NANO
+
+source "$(RIOTBOARD)/common/arduino-atmega/Kconfig"

--- a/boards/arduino-uno/Kconfig
+++ b/boards/arduino-uno/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_ARDUINO_UNO
+    bool
+    default y
+    select CPU_MODEL_ATMEGA328P
+    select BOARD_COMMON_ARDUINO_ATMEGA
+
+config BOARD
+    default "arduino-uno" if BOARD_ARDUINO_UNO
+
+source "$(RIOTBOARD)/common/arduino-atmega/Kconfig"

--- a/boards/atmega328p/Kconfig
+++ b/boards/atmega328p/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "atmega328p" if BOARD_ATMEGA328P
+
+config BOARD_ATMEGA328P
+    bool
+    default y
+    select CPU_MODEL_ATMEGA328P
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    # Various other features (if any)

--- a/boards/common/arduino-atmega/Kconfig
+++ b/boards/common/arduino-atmega/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_COMMON_ARDUINO_ATMEGA
+    bool
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    # Various other features (if any)
+    select HAS_ARDUINO
+    select HAS_ARDUINO_PWM

--- a/cpu/atmega328p/Kconfig
+++ b/cpu/atmega328p/Kconfig
@@ -1,0 +1,36 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_FAM_ATMEGA328
+    bool
+    select CPU_COMMON_ATMEGA
+    select HAS_ATMEGA_PCINT1
+    select HAS_ATMEGA_PCINT2
+
+## CPU Models
+config CPU_MODEL_ATMEGA328P
+    bool
+    select CPU_FAM_ATMEGA328
+    select HAS_CPU_ATMEGA328P
+
+## Definition of specific features
+config HAS_CPU_ATMEGA328P
+    bool
+    help
+        Indicates that a 'atmega328p' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "atmega328" if CPU_FAM_ATMEGA328
+
+config CPU_MODEL
+    default "atmega328p" if CPU_MODEL_ATMEGA328P
+
+config CPU
+    default "atmega328p" if CPU_FAM_ATMEGA328
+
+source "$(RIOTCPU)/atmega_common/Kconfig"

--- a/cpu/atmega_common/Kconfig
+++ b/cpu/atmega_common/Kconfig
@@ -1,0 +1,60 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+config CPU_ARCH_AVR8
+    bool
+    select HAS_ARCH_8BIT
+    select HAS_ARCH_AVR8
+
+config CPU_CORE_AVR
+    bool
+    select CPU_ARCH_AVR8
+
+config CPU_COMMON_ATMEGA
+    bool
+    select CPU_CORE_AVR
+    select HAS_ATMEGA_PCINT0
+    select HAS_PERIPH_CPUID
+    select HAS_PERIPH_EEPROM
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_PM
+    select HAS_PERIPH_TIMER_PERIODIC
+    select HAS_PERIPH_WDT
+    select HAS_PUF_SRAM
+
+## Common CPU symbols
+config CPU_ARCH
+    default "avr8" if CPU_ARCH_AVR8
+
+config CPU_CORE
+    default "avr" if CPU_CORE_AVR
+
+## Declaration of specific features
+config HAS_ARCH_AVR8
+    bool
+    help
+        Indicates that the current architecture is Atmel AVR8.
+
+config HAS_ATMEGA_PCINT0
+    bool
+    help
+        Indicates that the Pin Change Interrupt bank 0 is present.
+
+config HAS_ATMEGA_PCINT1
+    bool
+    help
+        Indicates that the Pin Change Interrupt bank 1 is present.
+
+config HAS_ATMEGA_PCINT2
+    bool
+    help
+        Indicates that the Pin Change Interrupt bank 2 is present.
+
+config HAS_ATMEGA_PCINT3
+    bool
+    help
+        Indicates that the Pin Change Interrupt bank 3 is present.

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -1,6 +1,10 @@
 include ../Makefile.tests_common
 
-BOARD_WHITELIST += cc1312-launchpad \
+BOARD_WHITELIST += arduino-duemilanove \
+                   arduino-nano \
+                   arduino-uno \
+                   atmega328p \
+                   cc1312-launchpad \
                    cc1352-launchpad \
                    cc1352p-launchpad \
                    cc2650-launchpad \


### PR DESCRIPTION
### Contribution description
Similarly to #13404, this models the symbols for all boards based on the `atmega328p` CPU, and selects the features provided.

### Testing procedure
- Review the symbol organization and the values assigned to the common symbols
- ~~The test provided in #13404 should pass~~
- `tests/kconfig_features` should pass for all the atmega328p-based boards:
   - arduino-duemilanove
   - arduino-nano
   - arduino-uno
   - atmega328p

### Issues/PRs references
~~Depends on #13404~~