### PR TITLE
Blxxxpill qdec

### DIFF
--- a/boards/common/blxxxpill/Makefile.features
+++ b/boards/common/blxxxpill/Makefile.features
@@ -9,3 +9,4 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_qdec

--- a/boards/common/blxxxpill/include/periph_conf.h
+++ b/boards/common/blxxxpill/include/periph_conf.h
@@ -126,6 +126,44 @@ static const timer_conf_t timer_config[] = {
 /** @} */
 
 /**
+ * @name    QDEC configuration
+ * @{
+ */
+
+static const qdec_conf_t qdec_config[] = {
+    {
+        .dev      = TIM1,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB2ENR_TIM1EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_A, 8),             .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_A, 9),             .cc_chan = 1 } },
+        .bus      = APB2,
+        .irqn     = TIM1_UP_IRQn
+    },
+    {
+        .dev      = TIM3,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB1ENR_TIM3EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_A, 6),             .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_A, 7),             .cc_chan = 1 } },
+        .bus      = APB1,
+        .irqn     = TIM3_IRQn
+    },
+    {
+        .dev      = TIM4,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB1ENR_TIM4EN,
+        .chan     = { { .pin = GPIO_PIN(PORT_B, 6),             .cc_chan = 0 },
+                      { .pin = GPIO_PIN(PORT_B, 7),             .cc_chan = 1 } },
+        .bus      = APB1,
+        .irqn     = TIM4_IRQn
+    }
+};
+
+#define QDEC_NUMOF           ARRAY_SIZE(qdec_config)
+/** @} */
+
+/**
  * @name   UART configuration
  * @{
  */

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -513,7 +513,9 @@ typedef struct {
     uint32_t rcc_mask;              /**< bit in clock enable register */
     qdec_chan_t chan[QDEC_CHAN];    /**< channel mapping, set to {GPIO_UNDEF, 0}
                                      *   if not used */
+#ifndef CPU_FAM_STM32F1
     gpio_af_t af;                   /**< alternate function used */
+#endif
     uint8_t bus;                    /**< APB bus */
     uint8_t irqn;                   /**< global IRQ channel */
 } qdec_conf_t;

--- a/cpu/stm32/periph/qdec.c
+++ b/cpu/stm32/periph/qdec.c
@@ -98,7 +98,9 @@ int32_t qdec_init(qdec_t qdec, qdec_mode_t mode, qdec_cb_t cb, void *arg)
     i = 0;
     while ((i < QDEC_CHAN) && (qdec_config[qdec].chan[i].pin != GPIO_UNDEF)) {
         gpio_init(qdec_config[qdec].chan[i].pin, GPIO_IN);
+#ifndef CPU_FAM_STM32F1
         gpio_init_af(qdec_config[qdec].chan[i].pin, qdec_config[qdec].af);
+#endif
         i++;
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Add qdec support for STM32F1 family. 
Qdec was already implemented for STM32. The changes here make also possible the use of qdec by the F1 family.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
 It was tested with a code similar to tests/periph_qdec on bluepill

