### PR TITLE
gcoap: Process CON responses

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -459,10 +459,11 @@ extern "C" {
  * @{
  */
 #define GCOAP_MEMO_UNUSED       (0)     /**< This memo is unused */
-#define GCOAP_MEMO_WAIT         (1)     /**< Request sent; awaiting response */
-#define GCOAP_MEMO_RESP         (2)     /**< Got response */
-#define GCOAP_MEMO_TIMEOUT      (3)     /**< Timeout waiting for response */
-#define GCOAP_MEMO_ERR          (4)     /**< Error processing response packet */
+#define GCOAP_MEMO_RETRANSMIT   (1)     /**< Request sent, retransmitting until response arrives */
+#define GCOAP_MEMO_WAIT         (2)     /**< Request sent; awaiting response */
+#define GCOAP_MEMO_RESP         (3)     /**< Got response */
+#define GCOAP_MEMO_TIMEOUT      (4)     /**< Timeout waiting for response */
+#define GCOAP_MEMO_ERR          (5)     /**< Error processing response packet */
 /** @} */
 
 /**

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -170,11 +170,9 @@ static void _on_sock_evt(sock_udp_t *sock, sock_async_flags_t type, void *arg)
                 /* ping request */
                 if (coap_get_type(&pdu) == COAP_TYPE_CON) {
                     messagelayer_emptyresponse_type = COAP_TYPE_RST;
-                } else if (coap_get_type(&pdu) == COAP_TYPE_NON) {
-                    DEBUG("gcoap: empty NON msg\n");
-                }
-                else {
-                    goto empty_as_response;
+                    DEBUG("gcoap: Answering empty CON request with RST\n");
+                } else {
+                    DEBUG("gcoap: Ignoring empty non-CON request\n");
                 }
             }
             /* normal request */
@@ -194,10 +192,6 @@ static void _on_sock_evt(sock_udp_t *sock, sock_async_flags_t type, void *arg)
                 DEBUG("gcoap: illegal request type: %u\n", coap_get_type(&pdu));
             }
             break;
-
-empty_as_response:
-            DEBUG("gcoap: empty ack/reset not handled yet\n");
-            return;
 
         /* incoming response */
         case COAP_CLASS_SUCCESS:


### PR DESCRIPTION
This generalizes the existing code for answering CoAP pings into general
message-layer responses. Such responses are now also sent as a reaction
to CON responses, which can otherwise follow the same code path as
existing other responses.

As a side effect, issues that would crop up when responding to odd empty
requests that have token length set are resolved.

### Testing procedure

\[edit: further down on https://github.com/RIOT-OS/RIOT/pull/14178#issuecomment-651213208 ]

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/14169 (eventually; currently it only addresses the first parts).