### PR TITLE
cpu/stm32: fix remaining issues related to CPU_FAM variable

### DIFF
--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -1,6 +1,6 @@
 include $(RIOTCPU)/stm32/stm32_info.mk
 
-FEATURES_PROVIDED += cpu_$(CPU_FAM)
+FEATURES_PROVIDED += cpu_stm32$(CPU_FAM)
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += puf_sram

--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -18,7 +18,7 @@ ifneq (,$(filter $(CPU_FAM),l0 l1))
   FEATURES_PROVIDED += periph_eeprom
 endif
 
-ifeq (stm32f1,$(CPU_FAM))
+ifeq (f1,$(CPU_FAM))
   FEATURES_CONFLICT += periph_rtc:periph_rtt
   FEATURES_CONFLICT_MSG += "On the STM32F1, the RTC and RTT map to the same hardware peripheral."
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a couple of issues left over after #14141:
- the cpu feature is not called `cpu_stm32xx` but just `cpu_xx`
- there's still one use of stm32f1 instead of just f1.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- periph_rtc and periph_rtt features cannot be used at the same time on stm32f1. On master, no warning message is displayed, with this PR the warning message about the conflict is displayed as expected:

**master:**

<details><summary>FEATURES_REQUIRED="periph_rtc periph_rtt" make BOARD=nucleo-f103rb -C examples/hello-world --no-print-directory</summary>

``` 
Building application "hello-world" for "nucleo-f103rb" with MCU "stm32".

"make" -C /work/riot/RIOT/boards/nucleo-f103rb
"make" -C /work/riot/RIOT/boards/common/nucleo
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32/periph
"make" -C /work/riot/RIOT/cpu/stm32/stmclk
"make" -C /work/riot/RIOT/cpu/stm32/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8948	    112	   2604	  11664	   2d90	/work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/hello-world.elf
```

</details>

**this PR:**

<details><summary>FEATURES_REQUIRED="periph_rtc periph_rtt" make BOARD=nucleo-f103rb -C examples/hello-world --no-print-directory</summary>

``` 
The following features may conflict: periph_rtc periph_rtt
Rationale: On the STM32F1, the RTC and RTT map to the same hardware peripheral.

EXPECT undesired behaviour!
Building application "hello-world" for "nucleo-f103rb" with MCU "stm32".

"make" -C /work/riot/RIOT/boards/nucleo-f103rb
"make" -C /work/riot/RIOT/boards/common/nucleo
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32/periph
"make" -C /work/riot/RIOT/cpu/stm32/stmclk
"make" -C /work/riot/RIOT/cpu/stm32/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8972	    112	   2604	  11688	   2da8	/work/riot/RIOT/examples/hello-world/bin/nucleo-f103rb/hello-world.elf
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Leftover from #14141 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
