### PR TITLE
tests/thread_flood: account for all threads already in use

### DIFF
--- a/tests/thread_flood/main.c
+++ b/tests/thread_flood/main.c
@@ -39,6 +39,7 @@ int main(void)
 {
     kernel_pid_t thr_id = KERNEL_PID_UNDEF;
     unsigned thr_cnt = 0;
+    unsigned thr_in_use = sched_num_threads;
 
     puts("[START] Spawning threads");
     do {
@@ -54,12 +55,11 @@ int main(void)
     /* decrease by 1 because last thread_create failed */
     --thr_cnt;
 
-    /* expect (MAXTHREADS - 2), as main and idle thread take a PID each */
-    if (thr_cnt == (MAXTHREADS - 2)) {
+    if (thr_cnt == (MAXTHREADS - thr_in_use)) {
         printf("[SUCCESS]");
     }
     else {
-        printf("[ERROR] expected %u,", (MAXTHREADS - 2));
+        printf("[ERROR] expected %u,", (MAXTHREADS - thr_in_use));
     }
     printf(" created %u\n", thr_cnt);
 


### PR DESCRIPTION
Before there were only two: "main" and "idle". But now there can also be
a thread for "usbus". The code will now first count how many there are in
use when the tests starts. It subtracts that number from MAXTHREADS.

This resolves issue #14180 (fixes #14180)