### PR TITLE
[PoC] Reactive SAUL: saul_observer based on msg_bus

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -700,7 +700,11 @@ ifneq (,$(filter saul_adc,$(USEMODULE)))
 endif
 
 ifneq (,$(filter saul_gpio,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
+  ifneq (,$(filter saul_observer,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_gpio_irq
+  else
+    FEATURES_REQUIRED += periph_gpio
+  endif
 endif
 
 ifneq (,$(filter saul,$(USEMODULE)))

--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -274,12 +274,29 @@ typedef int(*saul_read_t)(const void *dev, phydat_t *res);
 typedef int(*saul_write_t)(const void *dev, phydat_t *data);
 
 /**
+ * @brief   Called if a device state change is suspected
+ *
+ * If interested parties should be notified about a device change, which may
+ * results into a `saul_read_t()` call, return 1.
+ *
+ * @param[in] dev       device descriptor of the target device
+ * @param[in] data      data to write to the device
+ *
+ * @return  1 if the decive state has changed significantly
+ * @return  0 if nothing has changed
+ */
+typedef int(*saul_check_change_t)(void *dev);
+
+/**
  * @brief   Definition of the RIOT actuator/sensor interface
  */
 typedef struct {
     saul_read_t read;       /**< read function pointer */
     saul_write_t write;     /**< write function pointer */
     uint8_t type;           /**< device class the device belongs to */
+#if IS_USED(MODULE_SAUL_OBSERVER)
+    saul_check_change_t check; /**< check change function pointer */
+#endif
 } saul_driver_t;
 
 /**

--- a/drivers/saul/gpio_saul.c
+++ b/drivers/saul/gpio_saul.c
@@ -21,6 +21,9 @@
 #include <string.h>
 
 #include "saul.h"
+#if IS_USED(MODULE_SAUL_OBSERVER)
+#include "saul_observer.h"
+#endif
 #include "phydat.h"
 #include "periph/gpio.h"
 #include "saul/periph.h"
@@ -48,14 +51,30 @@ static int write(const void *dev, phydat_t *state)
     return 1;
 }
 
+#if IS_USED(MODULE_SAUL_OBSERVER)
+static int check(void *dev)
+{
+    (void) dev;
+
+    /* just assume the GPIO has changed */
+    return 1;
+}
+#endif
+
 const saul_driver_t gpio_out_saul_driver = {
     .read = read,
     .write = write,
+#if IS_USED(MODULE_SAUL_OBSERVER)
+    .check = check,
+#endif
     .type = SAUL_ACT_SWITCH
 };
 
 const saul_driver_t gpio_in_saul_driver = {
     .read = read,
     .write = saul_notsup,
+#if IS_USED(MODULE_SAUL_OBSERVER)
+    .check = check,
+#endif
     .type = SAUL_SENSE_BTN
 };

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -32,4 +32,9 @@ ifneq (,$(filter rtt_cmd,$(USEMODULE)))
   FEATURES_REQUIRED += periph_rtt
 endif
 
+ifneq (,$(filter saul_observer,$(USEMODULE)))
+  DEFAULT_MODULE += auto_init_saul_observer
+  USEMODULE += core_msg_bus
+endif
+
 include $(RIOTBASE)/sys/test_utils/Makefile.dep

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -200,6 +200,12 @@ void auto_init(void)
         saul_init_devs();
     }
 
+    if (IS_USED(MODULE_AUTO_INIT_SAUL_OBSERVER)) {
+        LOG_DEBUG("Auto init SAUL observer.\n");
+        extern void saul_observer_init(void);
+        saul_observer_init();
+    }
+
     if (IS_USED(MODULE_AUTO_INIT_GNRC_RPL)) {
         LOG_DEBUG("Auto init gnrc_rpl.\n");
         extern void auto_init_gnrc_rpl(void);

--- a/sys/include/saul_observer.h
+++ b/sys/include/saul_observer.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2020 Juergen Fitschen <me@jue.yt>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_saul_observer SAUL observer
+ * @ingroup     sys
+ * @brief       Observer for SAUL device changes
+ *
+ * @see @ref drivers_saul
+ *
+ * @{
+ *
+ * @file
+ * @brief       SAUL observer interface definition
+ *
+ * @author      Juergen Fitschen <me@jue.yt>
+ */
+
+#ifndef SAUL_OBSERVER_H
+#define SAUL_OBSERVER_H
+
+#include <stdint.h>
+
+#include "msg_bus.h"
+#include "saul.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// FIXME
+#define SAUL_OBSERVER_STACK_SIZE            (1024)
+#define SAUL_OBSERVER_PRIO                  (8)
+#define CONFIG_SAUL_OBSERVER_MSG_QUEUE_SIZE (8)
+
+/**
+ * @brief   Requests a check_change call from the SAUL obsevrer thread
+ */
+#define SAUL_OBSERVER_MSG_TYPE_CHECK_DEV  (0x7285)
+
+/**
+ * @brief   Bus ID for change notifications
+ */
+#define SAUL_OBSERVER_MSG_BUS_ID_CHANGE   (0x1)
+
+/**
+ * @brief   Initilize the observer thread
+ */
+void saul_observer_init(void);
+
+/**
+ * @brief   Export the SAUL observer bus
+ */
+extern msg_bus_t saul_observer_bus;
+
+/**
+ * @brief   Export the SAUL observer pid
+ */
+extern kernel_pid_t saul_observer_pid;
+
+/**
+ * @brief   Trigger change check of a SAUL device
+ *
+ * @param[in] dev       pointer to the device's SAUL registry entry
+ */
+void saul_observer_queue_check(saul_reg_t *dev);
+
+/**
+ * @brief   Subscribe to a SAUL device observer
+ *
+ * @param[in] entry     pointer to the attached message bus entry
+ * @param[in] dev       SAUL device to observer
+ */
+static inline void saul_observer_subscribe(msg_bus_entry_t *entry, const saul_reg_t *dev)
+{
+    msg_bus_subscribe(entry, dev->id % 32);
+}
+
+/**
+ * @brief   Unsubscribe from a SAUL device observer
+ *
+ * @param[in] entry     pointer to the attached message bus entry
+ * @param[in] dev       SAUL device to unsubscribe
+ */
+static inline void saul_observer_unsubscribe(msg_bus_entry_t *entry, const saul_reg_t *dev)
+{
+    assert(dev->id < 32);
+    msg_bus_unsubscribe(entry, dev->id);
+}
+
+/**
+ * @brief   Check if a recieved change notification is from a certian SAUL device
+ *
+ * @param[in] dev       SAUL device
+ * @param[in] msg       received message
+ */
+static inline bool saul_observer_dev_has_changed(const saul_reg_t *dev, const msg_t *msg)
+{
+    return msg_is_from_bus(&saul_observer_bus, msg) && \
+           msg_bus_get_type(msg) == (dev->id % 32);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SAUL_OBSERVER_H */
+/** @} */

--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -38,6 +38,7 @@ extern "C" {
  */
 typedef struct saul_reg {
     struct saul_reg *next;          /**< pointer to the next device */
+    uint8_t id;                     /**< device ID */
     void *dev;                      /**< pointer to the device descriptor */
     const char *name;               /**< string identifier for the device */
     saul_driver_t const *driver;    /**< the devices read callback */

--- a/sys/saul_observer/Makefile
+++ b/sys/saul_observer/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/saul_observer/saul_observer.c
+++ b/sys/saul_observer/saul_observer.c
@@ -1,0 +1,63 @@
+#include "thread.h"
+#include "msg.h"
+#include "saul_observer.h"
+
+#if ENABLE_DEBUG
+static char _stack[SAUL_OBSERVER_STACK_SIZE + THREAD_EXTRA_STACKSIZE_PRINTF];
+#else
+static char _stack[SAUL_OBSERVER_STACK_SIZE];
+#endif
+
+kernel_pid_t saul_observer_pid = KERNEL_PID_UNDEF;
+
+msg_bus_t saul_observer_bus;
+
+static void *_event_loop(void *args)
+{
+    msg_t msg, msg_q[CONFIG_SAUL_OBSERVER_MSG_QUEUE_SIZE];
+
+    (void)args;
+    msg_init_queue(msg_q, CONFIG_SAUL_OBSERVER_MSG_QUEUE_SIZE);
+    msg_bus_init(&saul_observer_bus);
+
+    while (1) {
+        msg_receive(&msg);
+        if (msg.type != SAUL_OBSERVER_MSG_TYPE_CHECK_DEV) {
+            continue;
+        }
+
+        saul_reg_t *dev = msg.content.ptr;
+        if (dev->driver->check == NULL || dev->driver->check(dev->dev) <= 0) {
+            continue;
+        }
+
+        msg_bus_post(&saul_observer_bus, dev->id, dev);
+    }
+
+    return NULL;
+}
+
+void saul_observer_init(void)
+{
+    if (saul_observer_pid == KERNEL_PID_UNDEF) {
+        saul_observer_pid = thread_create(_stack, sizeof(_stack), SAUL_OBSERVER_PRIO,
+                                      THREAD_CREATE_STACKTEST,
+                                      _event_loop, NULL, "saul");
+    }
+}
+
+void saul_observer_queue_check(saul_reg_t *dev)
+{
+    /* check if the device is observable */
+    if (dev->driver->check == NULL) {
+        return;
+    }
+
+    if (saul_observer_pid == KERNEL_PID_UNDEF) {
+        return;
+    }
+
+    msg_t m = {.type = SAUL_OBSERVER_MSG_TYPE_CHECK_DEV,
+               .content.ptr = (void *)dev};
+    msg_try_send(&m, saul_observer_pid);
+}

--- a/sys/saul_reg/saul_reg.c
+++ b/sys/saul_reg/saul_reg.c
@@ -30,6 +30,7 @@
  */
 saul_reg_t *saul_reg = NULL;
 
+static uint8_t next_dev_id = 0;
 
 int saul_reg_add(saul_reg_t *dev)
 {
@@ -41,6 +42,7 @@ int saul_reg_add(saul_reg_t *dev)
 
     /* prepare new entry */
     dev->next = NULL;
+    dev->id = next_dev_id++;
     /* add to registry */
     if (saul_reg == NULL) {
         saul_reg = dev;

--- a/tests/saul_observer/Makefile
+++ b/tests/saul_observer/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.tests_common
+
+USEMODULE += saul_default
+USEMODULE += saul_observer
+USEMODULE += shell
+USEMODULE += shell_commands
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/saul_observer/Makefile.ci
+++ b/tests/saul_observer/Makefile.ci
@@ -1,0 +1,7 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    #

--- a/tests/saul_observer/README.md
+++ b/tests/saul_observer/README.md
@@ -1,0 +1,5 @@
+Expected result
+===============
+
+This test application listens for SAUL observer notifications and dumps the
+sensors's / actuator's current state. 

--- a/tests/saul_observer/main.c
+++ b/tests/saul_observer/main.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 Juergen Fitchen <me@jue.yt>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ *
+ * @file
+ * @brief       Test the SAUL observer
+ *
+ * @author      Juergen Fitchen <me@jue.yt>
+ *
+ */
+
+#include <stdio.h>
+
+#include "thread.h"
+#include "phydat.h"
+#include "saul_reg.h"
+#include "saul_observer.h"
+#include "shell.h"
+
+static void *_notify(void *arg)
+{
+    msg_t msg, msgq[4];
+    msg_bus_entry_t sub;
+    saul_reg_t *ptr;
+    phydat_t res;
+    int rc;
+
+    (void) arg;
+    msg_init_queue(msgq, 4);
+    msg_bus_attach(&saul_observer_bus, &sub);
+
+    for (ptr = saul_reg; ptr; ptr = ptr->next) {
+        saul_observer_subscribe(&sub, ptr);
+    }
+
+    while (1) {
+        msg_receive(&msg);
+        saul_reg_t *dev = msg.content.ptr;
+        rc = saul_reg_read(dev, &res);
+        printf("SAUL DEV %d (%s) CHANGED - ", dev->id, dev->name);
+        phydat_dump(&res, rc);
+    }
+
+    return NULL;
+}
+
+char _stack[1024];
+
+int main(void)
+{
+    puts("SAUL observer test application");
+    thread_create(_stack, sizeof(_stack), 8,
+                  THREAD_CREATE_STACKTEST,
+                  _notify, NULL, "saul_observer");
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

After some bikeshedding in #14121, I started implementing a PoC.

This is the first PoC demonstrating an implementation based on `msg_bus`.

Some thoughts from my point-of-view:
- (+) Easy interface - especially if the interested thread wants to monitor many SAUL devices. No special list-item must be held in memory for every subscription.
- (+) Very few lines of code: Only ~50 LoCs are required for the basic functionality.
- (-) If the message-based IPC is used for other purposes, message types (they hold the bus ID and event type) may collide with other messages unrelated to `saul_observer`. Furthermore, message types used by `saul_observer` are not predictable as they encode the bus ID.
- (-) If more than 32 SAUL devices are present, `saul_observer_unsubscribe()` leads to unexpected behavior.

I'll come up with a second PoC show-casing a callback-based approach.

### Testing procedure

Flash `tests/saul_observer` onto a board with `saul_gpio` support and play around with the registered SAUL devices. You should see some change notifications.

```
# make -C tests/saul_observer BOARD=samr30-xpro flash term
> saul
2020-05-31 16:50:28,802 #  saul
2020-05-31 16:50:28,805 # ID	Class		Name
2020-05-31 16:50:28,808 # #0	ACT_SWITCH	LED(green)
2020-05-31 16:50:28,810 # #1	ACT_SWITCH	LED(orange)
2020-05-31 16:50:28,811 # #2	SENSE_BTN	Button(SW0)
> saul write 0 1
2020-05-31 16:50:43,470 #  saul write 0 1
2020-05-31 16:50:43,473 # Writing to device #0 - LED(green)
2020-05-31 16:50:43,475 # Data:	              1 
2020-05-31 16:50:43,478 # data successfully written to device #0
> 2020-05-31 16:50:43,484 #  SAUL DEV 0 (LED(green)) CHANGED - Data:	              1 
2020-05-31 16:50:55,254 # SAUL DEV 2 (Button(SW0)) CHANGED - Data:	              1 
2020-05-31 16:50:55,402 # SAUL DEV 2 (Button(SW0)) CHANGED - Data:	              0 
```

(Of course, no de-bouncing for the switch at the current state. This should be included for a PR that is about to be merged ...)

### Issues/PRs references

#14121 
