### PR TITLE
cpu/stm32/Makefile.features: capture whole family

### DIFF
--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -24,7 +24,7 @@ ifeq (stm32f1,$(CPU_FAM))
 endif
 
 # Not all F4 and L0 parts implement a RNG.
-CPU_MODELS_WITHOUT_HWRNG = stm32f401re% stm32f411re% stm32f446re% stm32f446ze% stm32l031k6%
+CPU_MODELS_WITHOUT_HWRNG = stm32f401% stm32f411% stm32f446% stm32l031%
 ifneq (,$(filter $(CPU_FAM),f2 f4 f7 l0 l4 wb))
   ifeq (,$(filter $(CPU_MODELS_WITHOUT_HWRNG),$(CPU_MODEL)))
     FEATURES_PROVIDED += periph_hwrng


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

All members of the stm32f401* family (etc) don't have the HWRNG peripheral.
Apply a broader wildcard so we don't have to touch this file when adding new boards with slightly different MCUs.

### Testing procedure

The output of

    make -C tests/periph_hwrng info-boards-supported | wc -w

remains the same.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
