### PR TITLE
drivers/kw41zrf: fix wrong endianness in short_addr get/set

### DIFF
--- a/drivers/kw41zrf/kw41zrf_getset.c
+++ b/drivers/kw41zrf/kw41zrf_getset.c
@@ -116,9 +116,11 @@ void kw41zrf_set_pan(kw41zrf_t *dev, uint16_t pan)
 void kw41zrf_set_addr_short(kw41zrf_t *dev, const network_uint16_t *addr)
 {
     (void) dev;
+    /* radio hardware stores this in little endian */
     ZLL->MACSHORTADDRS0 = (ZLL->MACSHORTADDRS0
                             & ~ZLL_MACSHORTADDRS0_MACSHORTADDRS0_MASK) |
-                            ZLL_MACSHORTADDRS0_MACSHORTADDRS0(addr->u16);
+                            ZLL_MACSHORTADDRS0_MACSHORTADDRS0(byteorder_swaps(
+                                                                addr->u16));
 }
 
 void kw41zrf_set_addr_long(kw41zrf_t *dev, const eui64_t *addr)
@@ -133,6 +135,8 @@ void kw41zrf_get_addr_short(kw41zrf_t *dev, network_uint16_t *addr)
     (void) dev;
     addr->u16 = (ZLL->MACSHORTADDRS0 & ZLL_MACSHORTADDRS0_MACSHORTADDRS0_MASK) >>
                         ZLL_MACSHORTADDRS0_MACSHORTADDRS0_SHIFT;
+    /* radio hardware stores this in little endian */
+    addr->u16 = byteorder_swaps(addr->u16);
 }
 
 void kw41zrf_get_addr_long(kw41zrf_t *dev, eui64_t *addr)


### PR DESCRIPTION
### Contribution description
Originally I used this endianness here because it worked with the zboss stack, and I never double-checked it, but after testing zboss with other radio drivers I realized that I had the endianness wrong in zboss and it only worked with kw41zrf because the endianness was wrong there too. Indeed the reference manual does confirm that the address is stored in little endian.

### Testing procedure
I don't know of a way to test packets with short addresses other than zboss. I'm using [this](https://github.com/benemorius/RIOT/commits/openlabs) branch for testing.

