### PR TITLE
tests/periph_rtt: fix small issue with RTT_FREQUENCY for stm32f1

### DIFF
--- a/tests/periph_rtt/Makefile
+++ b/tests/periph_rtt/Makefile
@@ -8,9 +8,11 @@ DISABLE_MODULE += periph_init_rtt
 include $(RIOTBASE)/Makefile.include
 
 # Put board specific dependencies here
-ifneq (,$(filter-out stm32f1,$(filter stm32%,$(CPU))))
-  # all stm32% but stm32f1 RTT are based on a 16 bit LPTIM, if using the default
-  # 32768KHz configuration TICKS_TO_WAIT will overflow
-  RTT_FREQUENCY ?= 1024
-  CFLAGS += -DRTT_FREQUENCY=$(RTT_FREQUENCY)
+ifeq (stm32,$(CPU))
+  ifneq (f1,$(CPU_FAM))
+    # all stm32% but stm32f1 RTT are based on a 16 bit LPTIM, if using the default
+    # 32768KHz configuration TICKS_TO_WAIT will overflow
+    RTT_FREQUENCY ?= 1024
+    CFLAGS += -DRTT_FREQUENCY=$(RTT_FREQUENCY)
+  endif
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes an issue with the `periph_rtt` test application that was probably introduced by #14021. Now the `$(CPU)` variable contains `stm32` for all stm32 cpus, so the condition is always met.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Verify that the specific RTT_FREQUENCY value is not set on stm32f1 CPUs:

<details><summary>this PR</summary>

- nucleo-f103rb:

```
$ make BOARD=nucleo-f103rb -C tests/periph_rtt --no-print-directory info-build | grep RTT_FREQUENCY
```

=> empty output

- nucleo-l073rz:

```
make BOARD=nucleo-l073rz -C tests/periph_rtt --no-print-directory info-build | grep RTT_FREQUENCY
	-DRTT_FREQUENCY=1024
```

</details>

<details><summary>master</summary>

- nucleo-f103rb:

```
make BOARD=nucleo-f103rb -C tests/periph_rtt --no-print-directory info-build | grep RTT_FREQUENCY
	-DRTT_FREQUENCY=1024
```

RTT_FREQUENCY is set but shouldn't

- nucleo-l073rz:

```
make BOARD=nucleo-l073rz -C tests/periph_rtt --no-print-directory info-build | grep RTT_FREQUENCY
	-DRTT_FREQUENCY=1024
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Introduced by a combination of #14021 and #14141 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
