### PR TITLE
drivers/wdt: Add feature to indicate a configurable warning period

### DIFF
--- a/cpu/sam0_common/Makefile.features
+++ b/cpu/sam0_common/Makefile.features
@@ -7,6 +7,6 @@ FEATURES_PROVIDED += periph_i2c_reconfigure
 FEATURES_PROVIDED += periph_timer_periodic # implements timer_set_periodic()
 FEATURES_PROVIDED += periph_uart_modecfg
 FEATURES_PROVIDED += periph_uart_nonblocking
-FEATURES_PROVIDED += periph_wdt periph_wdt_cb
+FEATURES_PROVIDED += periph_wdt periph_wdt_cb periph_wdt_warning_period
 
 -include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/drivers/include/periph/wdt.h
+++ b/drivers/include/periph/wdt.h
@@ -112,9 +112,10 @@
  * for details on its constraints.
  *
  * The callback will be executed CONFIG_WDT_WARNING_PERIOD before the actual reboot.
- * The value of CONFIG_WDT_WARNING_PERIOD may be configurable or a fixed value. But is
- * in any case defined at compile time. Specific platform implementation should
- * assert improper values.
+ * The value of CONFIG_WDT_WARNING_PERIOD may be configurable or a fixed value. If
+ * a platform allows this value to be configured, the feature
+ * `periph_wdt_warning_period` is provided. But is in any case defined at
+ * compile time. Specific platform implementation should assert improper values.
  *
  *
  * In the code snippet and diagram `time` is an arbitrary value such that


### PR DESCRIPTION
### Contribution description
This adds the feature `periph_wdt_warning_period` that indicates that a platform WDT driver implementation supports a configurable `CONFIG_WDT_WARNING_PERIOD`.

### Testing procedure
- Check that `sam0_common`-based boards provide the new feature.

### Issues/PRs references
Proposed by @MrKevinWeiss in #13404
