### PR TITLE
boards/samd21-based: Model features in Kconfig

### DIFF
--- a/boards/arduino-mkr1000/Kconfig
+++ b/boards/arduino-mkr1000/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "arduino-mkr1000" if BOARD_ARDUINO_MKR1000
+
+config BOARD_ARDUINO_MKR1000
+    bool
+    default y
+    select BOARD_COMMON_ARDUINO_MKR
+
+source "$(RIOTBOARD)/common/arduino-mkr/Kconfig"

--- a/boards/arduino-mkrfox1200/Kconfig
+++ b/boards/arduino-mkrfox1200/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "arduino-mkrfox1200" if BOARD_ARDUINO_MKRFOX1200
+
+config BOARD_ARDUINO_MKRFOX1200
+    bool
+    default y
+    select BOARD_COMMON_ARDUINO_MKR
+
+source "$(RIOTBOARD)/common/arduino-mkr/Kconfig"

--- a/boards/arduino-mkrwan1300/Kconfig
+++ b/boards/arduino-mkrwan1300/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "arduino-mkrwan1300" if BOARD_ARDUINO_MKRWAN1300
+
+config BOARD_ARDUINO_MKRWAN1300
+    bool
+    default y
+    select BOARD_COMMON_ARDUINO_MKR
+
+source "$(RIOTBOARD)/common/arduino-mkr/Kconfig"

--- a/boards/arduino-mkrzero/Kconfig
+++ b/boards/arduino-mkrzero/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "arduino-mkrzero" if BOARD_ARDUINO_MKRZERO
+
+config BOARD_ARDUINO_MKRZERO
+    bool
+    default y
+    select BOARD_COMMON_ARDUINO_MKR
+
+source "$(RIOTBOARD)/common/arduino-mkr/Kconfig"

--- a/boards/arduino-zero/Kconfig
+++ b/boards/arduino-zero/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "arduino-zero" if BOARD_ARDUINO_ZERO
+
+config BOARD_ARDUINO_ZERO
+    bool
+    default y
+    select BOARD_COMMON_ARDUINO_ZERO
+
+source "$(RIOTBOARD)/common/arduino-zero/Kconfig"

--- a/boards/common/arduino-mkr/Kconfig
+++ b/boards/common/arduino-mkr/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_COMMON_ARDUINO_MKR
+    bool
+    select CPU_MODEL_SAMD21G18A
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_ARDUINO
+    select HAS_ARDUINO_PWM
+    select HAS_BOOTLOADER_ARDUINO

--- a/boards/common/arduino-zero/Kconfig
+++ b/boards/common/arduino-zero/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_COMMON_ARDUINO_ZERO
+    bool
+    select CPU_MODEL_SAMD21G18A
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_ARDUINO
+    select HAS_ARDUINO_PWM

--- a/boards/common/sodaq/Kconfig
+++ b/boards/common/sodaq/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_COMMON_SODAQ
+    bool
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_ARDUINO
+    select HAS_BOOTLOADER_ARDUINO

--- a/boards/feather-m0/Kconfig
+++ b/boards/feather-m0/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "feather-m0" if BOARD_FEATHER_M0
+
+config BOARD_FEATHER_M0
+    bool
+    default y
+    select CPU_MODEL_SAMD21G18A
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_BOOTLOADER_ARDUINO

--- a/boards/hamilton/Kconfig
+++ b/boards/hamilton/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "hamilton" if BOARD_HAMILTON
+
+config BOARD_HAMILTON
+    bool
+    default y
+    select CPU_MODEL_SAMR21E18A
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER

--- a/boards/samd21-xpro/Kconfig
+++ b/boards/samd21-xpro/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "samd21-xpro" if BOARD_SAMD21_XPRO
+
+config BOARD_SAMD21_XPRO
+    bool
+    default y
+    select CPU_MODEL_SAMD21J18A
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/sensebox_samd21/Kconfig
+++ b/boards/sensebox_samd21/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "sensebox_samd21" if BOARD_SENSEBOX_SAMD21
+
+config BOARD_SENSEBOX_SAMD21
+    bool
+    default y
+    select CPU_MODEL_SAMD21G18A
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV

--- a/boards/serpente/Kconfig
+++ b/boards/serpente/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "serpente" if BOARD_SERPENTE
+
+config BOARD_SERPENTE
+    bool
+    default y
+    select CPU_MODEL_SAMD21E18A
+    select HAS_BOOTLOADER_ARDUINO
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV

--- a/boards/sodaq-autonomo/Kconfig
+++ b/boards/sodaq-autonomo/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "sodaq-autonomo" if BOARD_SODAQ_AUTONOMO
+
+config BOARD_SODAQ_AUTONOMO
+    bool
+    default y
+    select BOARD_COMMON_SODAQ
+    select CPU_MODEL_SAMD21J18A
+    select HAS_PERIPH_PWM
+    select HAS_ARDUINO_PWM
+
+source "$(RIOTBOARD)/common/sodaq/Kconfig"

--- a/boards/sodaq-explorer/Kconfig
+++ b/boards/sodaq-explorer/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "sodaq-explorer" if BOARD_SODAQ_EXPLORER
+
+config BOARD_SODAQ_EXPLORER
+    bool
+    default y
+    select BOARD_COMMON_SODAQ
+    select CPU_MODEL_SAMD21J18A
+
+source "$(RIOTBOARD)/common/sodaq/Kconfig"

--- a/boards/sodaq-one/Kconfig
+++ b/boards/sodaq-one/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "sodaq-one" if BOARD_SODAQ_ONE
+
+config BOARD_SODAQ_ONE
+    bool
+    default y
+    select BOARD_COMMON_SODAQ
+    select CPU_MODEL_SAMD21G18A
+
+source "$(RIOTBOARD)/common/sodaq/Kconfig"

--- a/boards/sodaq-sara-aff/Kconfig
+++ b/boards/sodaq-sara-aff/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "sodaq-sara-aff" if BOARD_SODAQ_SARA_AFF
+
+config BOARD_SODAQ_SARA_AFF
+    bool
+    default y
+    select BOARD_COMMON_SODAQ
+    select CPU_MODEL_SAMD21J18A
+
+source "$(RIOTBOARD)/common/sodaq/Kconfig"

--- a/boards/sodaq-sara-sff/Kconfig
+++ b/boards/sodaq-sara-sff/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "sodaq-sara-sff" if BOARD_SODAQ_SARA_SFF
+
+config BOARD_SODAQ_SARA_SFF
+    bool
+    default y
+    select BOARD_COMMON_SODAQ
+    select CPU_MODEL_SAMD21G18A
+
+source "$(RIOTBOARD)/common/sodaq/Kconfig"

--- a/boards/wemos-zero/Kconfig
+++ b/boards/wemos-zero/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "wemos-zero" if BOARD_WEMOS_ZERO
+
+config BOARD_WEMOS_ZERO
+    bool
+    default y
+    select BOARD_COMMON_ARDUINO_ZERO
+    select HAS_BOOTLOADER_ARDUINO
+
+source "$(RIOTBOARD)/common/arduino-zero/Kconfig"

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -165,6 +165,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    sodaq-autonomo \
                    sodaq-explorer \
                    sodaq-one \
+                   sodaq-sara-aff \
                    spark-core \
                    stk3600 \
                    stk3700 \

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -154,6 +154,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    samr30-xpro \
                    samr34-xpro \
                    seeeduino_arch-pro \
+                   sensebox_samd21 \
                    slstk3401a \
                    slstk3402a \
                    sltb001a \

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -166,6 +166,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    sodaq-explorer \
                    sodaq-one \
                    sodaq-sara-aff \
+                   sodaq-sara-sff \
                    spark-core \
                    stk3600 \
                    stk3700 \

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -8,6 +8,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    arduino-duemilanove \
                    arduino-leonardo \
                    arduino-mega2560 \
+                   arduino-mkr1000 \
                    arduino-nano \
                    arduino-nano-33-ble \
                    arduino-uno \

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -155,6 +155,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    samr34-xpro \
                    seeeduino_arch-pro \
                    sensebox_samd21 \
+                   serpente \
                    slstk3401a \
                    slstk3402a \
                    sltb001a \

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -11,6 +11,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    arduino-mkr1000 \
                    arduino-mkrfox1200 \
                    arduino-mkrwan1300 \
+                   arduino-mkrzero \
                    arduino-nano \
                    arduino-nano-33-ble \
                    arduino-uno \

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -15,6 +15,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    arduino-nano \
                    arduino-nano-33-ble \
                    arduino-uno \
+                   arduino-zero \
                    atmega1284p \
                    atmega256rfr2-xpro \
                    atmega328p \

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -145,6 +145,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    remote-reva \
                    remote-revb \
                    ruuvitag \
+                   samd21-xpro \
                    same54-xpro \
                    saml10-xpro \
                    saml11-xpro \

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -9,6 +9,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    arduino-leonardo \
                    arduino-mega2560 \
                    arduino-mkr1000 \
+                   arduino-mkrfox1200 \
                    arduino-nano \
                    arduino-nano-33-ble \
                    arduino-uno \

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -162,6 +162,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    slwstk6000b-slwrb4150a \
                    slwstk6000b-slwrb4162a \
                    slwstk6220a \
+                   sodaq-autonomo \
                    spark-core \
                    stk3600 \
                    stk3700 \

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -164,6 +164,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    slwstk6220a \
                    sodaq-autonomo \
                    sodaq-explorer \
+                   sodaq-one \
                    spark-core \
                    stk3600 \
                    stk3700 \

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -10,6 +10,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    arduino-mega2560 \
                    arduino-mkr1000 \
                    arduino-mkrfox1200 \
+                   arduino-mkrwan1300 \
                    arduino-nano \
                    arduino-nano-33-ble \
                    arduino-uno \

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -163,6 +163,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    slwstk6000b-slwrb4162a \
                    slwstk6220a \
                    sodaq-autonomo \
+                   sodaq-explorer \
                    spark-core \
                    stk3600 \
                    stk3700 \

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -56,6 +56,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    fox \
                    frdm-k22f \
                    frdm-k64f \
+                   hamilton \
                    hifive1 \
                    hifive1b \
                    ikea-tradfri \

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -188,6 +188,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    usb-kw41z \
                    waspmote-pro \
                    weact-f411ce \
+                   wemos-zero \
                    yunjia-nrf51822 \
                    z1
                    #

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -50,6 +50,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    esp8266-olimex-mod \
                    esp8266-sparkfun-thing \
                    f4vi1 \
+                   feather-m0 \
                    feather-nrf52840 \
                    firefly \
                    fox \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR models the features for samd21 based boards and adds them to the `Kconfig_features` test whitelist.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
It should be enough to check that the `Kconfig_features` test works for all these boards (this means the list of provided features is equivalent):

```bash
BOARD=arduino-mkr1000 make && \
BOARD=arduino-mkrfox1200 make && \
BOARD=arduino-mkrwan1300 make && \
BOARD=arduino-mkrzero make && \
BOARD=arduino-zero make && \
BOARD=feather-m0 make && \
BOARD=hamilton make && \
BOARD=samd21-xpro make && \
BOARD=samr21-xpro make && \
BOARD=sensebox_samd21 make && \
BOARD=serpente make && \
BOARD=sodaq-autonomo make && \
BOARD=sodaq-explorer make && \
BOARD=sodaq-one make && \
BOARD=sodaq-sara-aff &&\
echo "OK"
```

### Issues/PRs references
~Depends on #13404~
#14148 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
