### PR TITLE
Revert "gnrc_netif: relax 6lo MTU assertion for 802.15.4g"

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1304,7 +1304,7 @@ static void _test_options(gnrc_netif_t *netif)
                    (IEEE802154_LONG_ADDRESS_LEN == netif->l2addr_len));
 #if IS_USED(MODULE_GNRC_NETIF_IPV6)
 #if IS_USED(MODULE_GNRC_NETIF_6LO)
-            assert(netif->ipv6.mtu >= IPV6_MIN_MTU);
+            assert(netif->ipv6.mtu == IPV6_MIN_MTU);
             assert(netif->sixlo.max_frag_size > 0);
             assert(-ENOTSUP != netif->dev->driver->get(netif->dev, NETOPT_PROTO,
                                                        &tmp, sizeof(tmp)));


### PR DESCRIPTION
Reverts RIOT-OS/RIOT#14172

The change breaks standard compliance without even checking the upper bound. See https://github.com/RIOT-OS/RIOT/pull/14172#issuecomment-637570848