### PR TITLE
dist/tools/flatc: compile with ccache (if CCACHE is set)

### DIFF
--- a/dist/tools/flatc/Makefile
+++ b/dist/tools/flatc/Makefile
@@ -17,6 +17,10 @@ CMAKE_OPTIONS = \
     -DFLATBUFFERS_BUILD_FLATLIB=OFF  \
     #
 
+ifneq (, $(CCACHE))
+    CMAKE_OPTIONS += -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+endif
+
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR passes `CCACHE` to flatc's cmake call via `-DCMAKE_CXX_COMPILER_LAUNCHER`.
Apparently 'flatc' builds could be seen in CI worker top output, meaning it took a long time.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Check CI output.
Time used by `tests/pkg_flatbuffers` before:

`runtime: total=3h:35m:34.1s min=42.4s max=1m:48.9s avg=1m:14.3s`.

After:

`runtime: total=37m:01.1s min=2.2s max=1m:11.9s avg=12.8s`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
