### PR TITLE
.gitignore: Ignore temporary vim files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ fuzzing/**/findings/
 # Backup files
 *~
 *.orig
+.*.swn
+.*.swo
 .*.swp
 \#*\#
 cachegrind.out*


### PR DESCRIPTION
### Contribution description

When the editor Vim opens file `foo`, a temporary file `.foo.swp`/`.foo.swo`/`.foo.swn` is created to allow restoring previous states in case of crashes / power loss etc. The chances that someone on purpose wants to commit a file name `\..*\.sw[pon]` is pretty much zero, so we can just add them to `.gitignore`

### Testing procedure

You could create such file and verify that `git status` doesn't show them. Or just read the diff.

### Issues/PRs references

Noticed during https://github.com/RIOT-OS/RIOT/pull/12363