### PR TITLE
boards/arduino-leonardo: Model features in Kconfig

### DIFF
--- a/boards/arduino-leonardo/Kconfig
+++ b/boards/arduino-leonardo/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "arduino-leonardo" if BOARD_ARDUINO_LEONARDO
+
+config BOARD_ARDUINO_LEONARDO
+    bool
+    default y
+    select BOARD_COMMON_ARDUINO_ATMEGA
+    select CPU_MODEL_ATMEGA32U4
+
+source "$(RIOTBOARD)/common/arduino-atmega/Kconfig"

--- a/cpu/atmega32u4/Kconfig
+++ b/cpu/atmega32u4/Kconfig
@@ -1,0 +1,33 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config CPU_FAM_ATMEGA32
+    bool
+    select CPU_COMMON_ATMEGA
+
+## CPU Models
+config CPU_MODEL_ATMEGA32U4
+    bool
+    select CPU_FAM_ATMEGA32
+    select HAS_CPU_ATMEGA32U4
+
+## Definition of specific features
+config HAS_CPU_ATMEGA32U4
+    bool
+    help
+        Indicates that a 'atmega32u4' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "atmega32" if CPU_FAM_ATMEGA32
+
+config CPU_MODEL
+    default "atmega32u4" if CPU_MODEL_ATMEGA32U4
+
+config CPU
+    default "atmega32u4" if CPU_MODEL_ATMEGA32U4
+
+source "$(RIOTCPU)/atmega_common/Kconfig"

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
 BOARD_WHITELIST += arduino-duemilanove \
+                   arduino-leonardo \
                    arduino-mega2560 \
                    arduino-nano \
                    arduino-uno \


### PR DESCRIPTION
### Contribution description
This PR models the symbols for the `atmega32u4` CPU and the `arduino-leonardo` board (which is the only one so far that uses it).

~~The first 2 commits are from #14176, they are included for testing.~~

### Testing procedure
- `tests/kconfig_features` should pass for the `arduino-leonardo`

### Issues/PRs references
~~Depends on #14176~~