### PR TITLE
shell_commands: provide command to reboot to bootloader

### DIFF
--- a/sys/shell/commands/sc_sys.c
+++ b/sys/shell/commands/sc_sys.c
@@ -32,6 +32,20 @@ int _reboot_handler(int argc, char **argv)
     return 0;
 }
 
+#ifdef MODULE_USB_BOARD_RESET
+void usb_board_reset_in_bootloader(void);
+
+int _bootloader_handler(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+
+    usb_board_reset_in_bootloader();
+
+    return 0;
+}
+#endif
+
 int _version_handler(int argc, char **argv)
 {
     (void) argc;

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -175,9 +175,16 @@ extern int _suit_handler(int argc, char **argv);
 extern int _cryptoauth(int argc, char **argv);
 #endif
 
+#ifdef MODULE_USB_BOARD_RESET
+extern int _bootloader_handler(int argc, char **argv);
+#endif
+
 const shell_command_t _shell_command_list[] = {
     {"reboot", "Reboot the node", _reboot_handler},
     {"version", "Prints current RIOT_VERSION", _version_handler},
+#ifdef MODULE_USB_BOARD_RESET
+    {"bootloader", "Reboot to bootloader", _bootloader_handler},
+#endif
 #ifdef MODULE_CONFIG
     {"id", "Gets or sets the node's id.", _id_handler},
 #endif


### PR DESCRIPTION
Make the triggering of the bootloader available as a shell command.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

We provide a way to reset the board to the bootloader by opening the CDC ACM device with a special baudrate.
Not all devices with a bootloader might use usb, and for testing it's neat to have a shell command to trigger the same action.

### Testing procedure

Flash on a board that provides `usb_board_reset`.
The `bootloader` command should restart the board in bootloader mode.


### Issues/PRs references

suggested in https://github.com/RIOT-OS/RIOT/pull/14119#discussion_r434368271
