### PR TITLE
boards: Fix incorrect units and alignment

### DIFF
--- a/boards/6lowpan-clicker/doc.txt
+++ b/boards/6lowpan-clicker/doc.txt
@@ -21,8 +21,8 @@ found in the [manual](https://download.mikroe.com/documents/starter-boards/click
 |:---------- |:-------------------- |
 | Family     | PIC32MX (MIPS M4K)   |
 | Vendor     | Microchip            |
-| RAM        | 128Kb                |
-| Flash      | 512Kb                |
+| RAM        | 128KiB               |
+| Flash      | 512KiB               |
 | Frequency  | 120MHz               |
 | FPU        | no                   |
 | Timers     | 5 (all 16-bit)       |

--- a/boards/airfy-beacon/doc.txt
+++ b/boards/airfy-beacon/doc.txt
@@ -6,7 +6,7 @@
 ## Overview
 
 The Airfy Beacon is utilizing a Nordics NRF51822QFAA SoC.
-The SoC features 16Kb of RAM, 256Kb of flash ROM and comes on top of the
+The SoC features 16KiB of RAM, 256KiB of flash ROM and comes on top of the
 usual micro-controller peripherals with a 2.4GHz radio that supports both
 Nordics proprietary ShockBurst as well as Bluetooth Low Energy (BLE).
 
@@ -19,22 +19,22 @@ The board was available via
 ![airfy-beacon]
 (https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/airfy-beacon.jpg)
 
-| MCU        | NRF51822QFAA      |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M0     |
-| Vendor | Nordic Semiconductor  |
-| RAM        | 16Kb  |
-| Flash      | 256Kb             |
-| Frequency  | 16MHz |
-| FPU        | no                |
-| Timers | 3 (2x 16-bit, 1x 32-bit [TIMER0]) |
-| ADCs       | 1x 10-bit (8 channels)        |
-| UARTs      | 1                 |
-| SPIs       | 2                 |
-| I2Cs       | 2                 |
-| Vcc        | 1.8V - 3.6V           |
+| MCU                   | NRF51822QFAA                      |
+|:--------------------- |:--------------------------------- |
+| Family                | ARM Cortex-M0                     |
+| Vendor                | Nordic Semiconductor              |
+| RAM                   | 16KiB                             |
+| Flash                 | 256KiB                            |
+| Frequency             | 16MHz                             |
+| FPU                   | no                                |
+| Timers                | 3 (2x 16-bit, 1x 32-bit [TIMER0]) |
+| ADCs                  | 1x 10-bit (8 channels)            |
+| UARTs                 | 1                                 |
+| SPIs                  | 2                                 |
+| I2Cs                  | 2                                 |
+| Vcc                   | 1.8V - 3.6V                       |
 | Product Specification | [Product Specification](https://infocenter.nordicsemi.com/pdf/nRF51822_PS_v3.3.pdf) |
-| Reference Manual | [Reference Manual](https://infocenter.nordicsemi.com/pdf/nRF51_RM_v3.0.1.pdf) |
+| Reference Manual      | [Reference Manual](https://infocenter.nordicsemi.com/pdf/nRF51_RM_v3.0.1.pdf) |
 
 ## Unlocking the flash memory
 

--- a/boards/arduino-zero/doc.txt
+++ b/boards/arduino-zero/doc.txt
@@ -6,8 +6,8 @@
 ## Overview
 
 The `Arduino Zero` is a board by Arduino/Genuino featuring a ATSAMD21G18A.
-The SAMD21 is a ARM Cortex-M0+ micro-controller.  It has 256Kb of flash memory
-and 32Kb of RAM.
+The SAMD21 is a ARM Cortex-M0+ micro-controller.  It has 256KiB of flash memory
+and 32KiB of RAM.
 
 This board is available [here](https://store.arduino.cc/product/GBX00003).
 
@@ -17,28 +17,28 @@ This board is available [here](https://store.arduino.cc/product/GBX00003).
 
 
 ### MCU
-| MCU        | ATSAMD21G18A      |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M0+        |
-| Vendor        | Atmel                 |
-| RAM        | 32Kb                  |
-| Flash      | 256Kb             |
-| Frequency  | up to 48MHz |
-| FPU        | no                |
-| Timers | 6 (1x 16-bit, 2x 24-bit, 3x 32-bit)   |
-| ADCs       | 6x 12-bit channels)           |
-| UARTs      | 2                 |
-| SPIs       | max 6 (see UART)                  |
-| I2Cs       | max 6 (see UART)              |
-| Vcc        | 1.8V - 3.6V           |
-| Datasheet  | [Datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM_D21_DA1_Family_Data%20Sheet_DS40001882E.pdf) |
+| MCU           | ATSAMD21G18A                          |
+|:------------- |:------------------------------------- |
+| Family        | ARM Cortex-M0+                        |
+| Vendor        | Atmel                                 |
+| RAM           | 32KiB                                 |
+| Flash         | 256KiB                                |
+| Frequency     | up to 48MHz                           |
+| FPU           | no                                    |
+| Timers        | 6 (1x 16-bit, 2x 24-bit, 3x 32-bit)   |
+| ADCs          | 6x 12-bit channels)                   |
+| UARTs         | 2                                     |
+| SPIs          | max 6 (see UART)                      |
+| I2Cs          | max 6 (see UART)                      |
+| Vcc           | 1.8V - 3.6V                           |
+| Datasheet     | [Datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM_D21_DA1_Family_Data%20Sheet_DS40001882E.pdf) |
 
 ### User Interface
 
 1 LED:
 
-| Device | PIN |
-|:------ |:--- |
+| Device | PIN  |
+|:------ |:---- |
 | LED0   | PA17 |
 
 

--- a/boards/cc1312-launchpad/doc.txt
+++ b/boards/cc1312-launchpad/doc.txt
@@ -13,22 +13,22 @@ Cortex-M4F microcontroller alongside a dedicated Cortex-M0 to control radio.
 
 ![LAUNCHXL-CC1312R1](http://www.ti.com/diagrams/launchxl-cc1312r1_cc1312r1-top-prof1.jpg)
 
-| MCU          | CC1312R1          |
-|:------------ |:----------------- |
-| Family       | ARM Cortex-M4F    |
-| Vendor       | Texas Instruments |
-| RAM          | 80 Kb             |
-| Flash        | 352 Kb            |
-| Frequency    | 48 MHz            |
-| FPU          | yes               |
-| Timers       | 4                 |
-| ADCs         | 1x 12-bt (channels) |
-| UARTs        | 2                 |
-| SPIs         | 2                 |
-| I2Cs         | 1                 |
-| Vcc          | 1.8V - 3.8V       |
-| Datasheet    | [Datasheet](http://www.ti.com/lit/ds/symlink/cc1312r.pdf) (pdf file) |
-| Reference Manual | [Reference Manual](http://www.ti.com/lit/ug/swcu185d/swcu185d.pdf) |
+| MCU               | CC1312R1              |
+|:----------------- |:--------------------- |
+| Family            | ARM Cortex-M4F        |
+| Vendor            | Texas Instruments     |
+| RAM               | 80KiB                 |
+| Flash             | 352KiB                |
+| Frequency         | 48MHz                 |
+| FPU               | yes                   |
+| Timers            | 4                     |
+| ADCs              | 1x 12-bit (channels)  |
+| UARTs             | 2                     |
+| SPIs              | 2                     |
+| I2Cs              | 1                     |
+| Vcc               | 1.8V - 3.8V           |
+| Datasheet         | [Datasheet](http://www.ti.com/lit/ds/symlink/cc1312r.pdf) (pdf file) |
+| Reference Manual  | [Reference Manual](http://www.ti.com/lit/ug/swcu185d/swcu185d.pdf) |
 
 ## Board pinout
 

--- a/boards/cc2538dk/doc.txt
+++ b/boards/cc2538dk/doc.txt
@@ -13,22 +13,22 @@ microcontroller with an IEEE802.15.4 radio.
 
 ![cc2538dk](http://www.ti.com/diagrams/cc2538dk_cc2538dk_web_1.jpg)
 
-| MCU        | CC2538SF53        |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M3     |
-| Vendor | Texas Instruments |
-| RAM        | 32Kb  |
-| Flash      | 512Kb             |
-| Frequency  | 32MHz |
-| FPU        | no                |
-| Timers | 4 |
-| ADCs       | 1x 12-bit (8 channels)        |
-| UARTs      | 2                 |
-| SPIs       | 2                 |
-| I2Cs       | 1                 |
-| Vcc        | 2V - 3.6V         |
-| Datasheet  | [Datasheet](http://www.ti.com/lit/gpn/cc2538) (pdf file) |
-| Reference Manual | [Reference Manual](http://www.ti.com/lit/pdf/swru319) |
+| MCU               | CC2538SF53                |
+|:----------------- |:------------------------- |
+| Family            | ARM Cortex-M3             |
+| Vendor            | Texas Instruments         |
+| RAM               | 32KiB                     |
+| Flash             | 512KiB                    |
+| Frequency         | 32MHz                     |
+| FPU               | no                        |
+| Timers            | 4                         |
+| ADCs              | 1x 12-bit (8 channels)    |
+| UARTs             | 2                         |
+| SPIs              | 2                         |
+| I2Cs              | 1                         |
+| Vcc               | 2V - 3.6V                 |
+| Datasheet         | [Datasheet](http://www.ti.com/lit/gpn/cc2538) (pdf file) |
+| Reference Manual  | [Reference Manual](http://www.ti.com/lit/pdf/swru319) |
 
 
 ##  Flashing and Debugging

--- a/boards/cc2650stk/doc.txt
+++ b/boards/cc2650stk/doc.txt
@@ -16,23 +16,23 @@ Use `BOARD=cc2650stk` for building RIOT for this platform.
 
 ## Components
 
-| MCU        | CC2650f128        |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M3     |
-| Vendor | Texas Instruments |
-| RAM        | 20KB  |
-| Flash      | 128KB             |
-| Frequency - Standby    | 31.26kHz, 32kHz or 32.768kHz |
-| Frequency - Active / Idle  | 48MHz |
-| RF core    | ARM Cortex-M0 CPU, 4KB RAM                |
-| Timers | 4x 32-bit |
-| ADCs       | 1x 12-bit (8 channels)        |
-| UARTs      | 2                 |
-| SPIs       | 2                 |
-| I2C        | 1                 |
-| I2S        | 1                 |
-| Datasheet  | [Datasheet](http://www.ti.com/lit/ds/symlink/cc2650.pdf) |
-| Reference Manual | [Reference Manual](https://www.ti.com/lit/ug/swcu117h/swcu117h.pdf) |
+| MCU                       | CC2650f128                    |
+|:------------------------- |:----------------------------- |
+| Family                    | ARM Cortex-M3                 |
+| Vendor                    | Texas Instruments             |
+| RAM                       | 20KiB                         |
+| Flash                     | 128KiB                        |
+| Frequency - Standby       | 31.26kHz, 32kHz or 32.768kHz  |
+| Frequency - Active / Idle | 48MHz                         |
+| RF core                   | ARM Cortex-M0 CPU, 4KiB RAM   |
+| Timers                    | 4x 32-bit                     |
+| ADCs                      | 1x 12-bit (8 channels)        |
+| UARTs                     | 2                             |
+| SPIs                      | 2                             |
+| I2C                       | 1                             |
+| I2S                       | 1                             |
+| Datasheet                 | [Datasheet](http://www.ti.com/lit/ds/symlink/cc2650.pdf) |
+| Reference Manual          | [Reference Manual](https://www.ti.com/lit/ug/swcu117h/swcu117h.pdf) |
 
 ## Implementation Status
 

--- a/boards/chronos/doc.txt
+++ b/boards/chronos/doc.txt
@@ -9,23 +9,23 @@
 (http://riot-os.org/images/hardware-watch-riot.png)
 
 # MCU
-| MCU        | TI CC430F6137     |
-|:------------- |:--------------------- |
-| Family | MSP430    |
-| Vendor | Texas Instruments |
-| Package       | 64VQFN |
-| RAM        | 4Kb   |
-| Flash      | 32Kb          |
-| Frequency  | 20MHz |
-| FPU        | no                |
-| Timers | 2 (2x 16bit)  |
-| ADCs       | 1x 8 channel 12-bit           |
-| UARTs      | 1                 |
-| SPIs       | 2 |
-| I2Cs       | 1     |
-| Vcc        | 2.0V - 3.6V           |
-| Datasheet / Reference Manual   | [Datasheet](http://www.ti.com/lit/gpn/cc430f6137) |
-| Board Manual   | [User Guide](http://www.ti.com/lit/pdf/slau292)|
+| MCU                           | TI CC430F6137         |
+|:----------------------------- |:--------------------- |
+| Family                        | MSP430                |
+| Vendor                        | Texas Instruments     |
+| Package                       | 64VQFN                |
+| RAM                           | 4KiB                  |
+| Flash                         | 32KiB                 |
+| Frequency                     | 20MHz                 |
+| FPU                           | no                    |
+| Timers                        | 2 (2x 16bit)          |
+| ADCs                          | 1x 8 channel 12-bit   |
+| UARTs                         | 1                     |
+| SPIs                          | 2                     |
+| I2Cs                          | 1                     |
+| Vcc                           | 2.0V - 3.6V           |
+| Datasheet / Reference Manual  | [Datasheet](http://www.ti.com/lit/gpn/cc430f6137) |
+| Board Manual                  | [User Guide](http://www.ti.com/lit/pdf/slau292)|
 
 ## Flashing RIOT
 

--- a/boards/firefly/doc.txt
+++ b/boards/firefly/doc.txt
@@ -11,8 +11,8 @@ Zolertia Firefly platform
 @image html "http://i.imgur.com/m2acovV.png?1" "Firefly"
 
 The Firefly platform (Revision A) is a IoT Hardware development platform based
-on TI's CC2538 system on chip (SoC), featuring an ARM Cortex-M3 with 512KB
-flash, 32Kb RAM, double RF interface (Sub-1GHz CC1200 RF transceiver), and the
+on TI's CC2538 system on chip (SoC), featuring an ARM Cortex-M3 with 512KiB
+flash, 32KiB RAM, double RF interface (Sub-1GHz CC1200 RF transceiver), and the
 following goodies:
 
 - ISM 2.4-GHz IEEE 802.15.4 & Zigbee compliant.

--- a/boards/fox/doc.txt
+++ b/boards/fox/doc.txt
@@ -5,28 +5,28 @@
 
 ## Components
 
-| MCU    | [ST2M32F103REY](http://www.st.com/web/catalog/mmc/FM141/SC1169/SS1031/LN1565/PF164485) – 32-bits|
-|-------|-----------------------------------------------------------------------------------------------------|
-| RAM | 64Kb |
-| Flash | 512Kb |
-| radio chipset   | [AT86RF231](http://www.atmel.com/images/doc8111.pdf) |
-| | a IEEE802.15.4-compliant radio at 2.4 GHz |
+| MCU           | [ST2M32F103REY](http://www.st.com/web/catalog/mmc/FM141/SC1169/SS1031/LN1565/PF164485) – 32-bits  |
+|:------------- |:------------------------------------------------------------------------------------------------- |
+| RAM           | 64KiB                                                                                             |
+| Flash         | 512KiB                                                                                            |
+| radio chipset | [AT86RF231](http://www.atmel.com/images/doc8111.pdf)                                              |
+|               | a IEEE802.15.4-compliant radio at 2.4 GHz                                                         |
 
 ## Implementation Status
 
-| Device | ID        | Supported | Comments  |
-|:------------- |:------------- |:------------- |:------------- |
-| MCU        | [STM23F103REY](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/reference_manual/CD00171190.pdf) | partly    | Energy saving modes not fully utilized |
-| Low-level driver | GPIO    | yes       | |
-|        | PWM       | no        | |
-|        | UART      | full      | |
-|        | I2C       | yes       | |
-|        | SPI       | yes       | one SPI device for now    |
-|        | USB       | no        | |
-|        | RTT       | yes       | in progress |
-|        | RNG       | no        | no HW module |
-|        | Timer     | full      | |
-| Radio Chip | AT86RF231 | partly        | will be remodelled soon |
+| Device            | ID            | Supported | Comments                  |
+|:----------------- |:------------- |:----------|:------------------------- |
+| MCU               | [STM23F103REY](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/reference_manual/CD00171190.pdf) | partly    | Energy saving modes not fully utilized |
+| Low-level driver  | GPIO          | yes       |                           |
+|                   | PWM           | no        |                           |
+|                   | UART          | full      |                           |
+|                   | I2C           | yes       |                           |
+|                   | SPI           | yes       | one SPI device for now    |
+|                   | USB           | no        |                           |
+|                   | RTT           | yes       | in progress               |
+|                   | RNG           | no        | no HW module              |
+|                   | Timer         | full      |                           |
+| Radio Chip        | AT86RF231     | partly    |   will be remodelled soon |
 
 
 ##### Note on at86rf231 radio driver

--- a/boards/frdm-k64f/doc.txt
+++ b/boards/frdm-k64f/doc.txt
@@ -10,25 +10,25 @@ The board has a K64F Kinetis MCU and is supported by `cpu/kinetis_common`.
 
 ![frdm-k64f](https://www.nxp.com/assets/images/en/dev-board-image/BOARD-FRDM-K64F-PRODUCT-SHOT.png)
 
-| MCU        | MK64FN1M0VLL12        |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M4F    |
-| Vendor | Freescale |
-| RAM        | 256Kb |
-| Flash      | 1024Kb                |
-| Frequency  | 120MHz |
-| FPU        | yes               |
-| Timers | yes   |
-| ADCs       | yes       |
-| UARTs      | yes           |
-| SPIs       | yes               |
-| I2Cs       | yes           |
-| Ethernet   | WIP           |
-| USB        | WIP           |
-| LPM        | TODO          |
-| DAC        | TODO          |
-| Vcc        | TODO          |
-| Reference Manual | TODO |
+| MCU               | MK64FN1M0VLL12        |
+|:----------------- |:--------------------- |
+| Family            | ARM Cortex-M4F        |
+| Vendor            | Freescale             |
+| RAM               | 256KiB                |
+| Flash             | 1024KiB               |
+| Frequency         | 120MHz                |
+| FPU               | yes                   |
+| Timers            | yes                   |
+| ADCs              | yes                   |
+| UARTs             | yes                   |
+| SPIs              | yes                   |
+| I2Cs              | yes                   |
+| Ethernet          | WIP                   |
+| USB               | WIP                   |
+| LPM               | TODO                  |
+| DAC               | TODO                  |
+| Vcc               | TODO                  |
+| Reference Manual  | TODO                  |
 
 The board has an integrated debugger adapter (k20dx128) with the firmware from
 ARMmbed.

--- a/boards/ikea-tradfri/doc.txt
+++ b/boards/ikea-tradfri/doc.txt
@@ -18,8 +18,8 @@ More information about the module can be found on this
 | Family          | ARM Cortex-M4F                                                                          |
 | Vendor          | Silicon Labs                                                                            |
 | Vendor Family   | EFR32 Mighty Gecko 1P                                                                   |
-| RAM             | 32.0KB (1.0KB reserved)                                                                 |
-| Flash           | 256.0KB                                                                                 |
+| RAM             | 32.0KiB (1.0KiB reserved)                                                               |
+| Flash           | 256.0KiB                                                                                |
 | EEPROM          | no                                                                                      |
 | Frequency       | up to 38.4 MHz                                                                          |
 | FPU             | yes                                                                                     |

--- a/boards/im880b/doc.txt
+++ b/boards/im880b/doc.txt
@@ -9,24 +9,24 @@
 
 
 ### MCU
-| MCU        | stm32l151cb-a |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M3     |
-| Vendor | ST Microelectronics   |
-| RAM        | 16Kb  |
-| Flash      | 128Kb             |
-| Frequency  | 32MHz (no external oscilator connected) |
-| FPU        | no                |
-| Timers | 10 (8x 16-bit, 2x watchdog timers)   |
-| ADCs       | 1x 24-channel 12-bit          |
-| UARTs      | 3                 |
-| SPIs       | 2                 |
-| I2Cs       | 2                 |
-| Vcc        | 1.65V - 3.6V          |
-| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32l151cb-a.pdf) |
-| Reference Manual | [Reference Manual](https://www.st.com/content/ccc/resource/technical/document/reference_manual/cc/f9/93/b2/f0/82/42/57/CD00240193.pdf/files/CD00240193.pdf/jcr:content/translations/en.CD00240193.pdf) |
-| Programming Manual | [Programming Manual](https://www.st.com/content/ccc/resource/technical/document/programming_manual/5b/ca/8d/83/56/7f/40/08/CD00228163.pdf/files/CD00228163.pdf/jcr:content/translations/en.CD00228163.pdf) |
-| Board Manual   | [Board Manual](https://cdn.sos.sk/productdata/29/eb/a68245ed/im880b-l-lorawan.pdf)|
+| MCU                   | stm32l151cb-a                             |
+|:--------------------- |:----------------------------------------- |
+| Family                | ARM Cortex-M3                             |
+| Vendor                | ST Microelectronics                       |
+| RAM                   | 16KiB                                     |
+| Flash                 | 128KiB                                    |
+| Frequency             | 32MHz (no external oscillator connected)  |
+| FPU                   | no                                        |
+| Timers                | 10 (8x 16-bit, 2x watchdog timers)        |
+| ADCs                  | 1x 24-channel 12-bit                      |
+| UARTs                 | 3                                         |
+| SPIs                  | 2                                         |
+| I2Cs                  | 2                                         |
+| Vcc                   | 1.65V - 3.6V                              |
+| Datasheet             | [Datasheet](https://www.st.com/resource/en/datasheet/stm32l151cb-a.pdf) |
+| Reference Manual      | [Reference Manual](https://www.st.com/content/ccc/resource/technical/document/reference_manual/cc/f9/93/b2/f0/82/42/57/CD00240193.pdf/files/CD00240193.pdf/jcr:content/translations/en.CD00240193.pdf) |
+| Programming Manual    | [Programming Manual](https://www.st.com/content/ccc/resource/technical/document/programming_manual/5b/ca/8d/83/56/7f/40/08/CD00228163.pdf/files/CD00228163.pdf/jcr:content/translations/en.CD00228163.pdf) |
+| Board Manual          | [Board Manual](https://cdn.sos.sk/productdata/29/eb/a68245ed/im880b-l-lorawan.pdf)|
 
 ### User Interface
 

--- a/boards/iotlab-m3/doc.txt
+++ b/boards/iotlab-m3/doc.txt
@@ -5,16 +5,16 @@
 
 ## Components
 
-| MCU    | [ST2M32F103REY](http://www.st.com/web/catalog/mmc/FM141/SC1169/SS1031/LN1565/PF164485) – 32-bits, 64kB RAM |
-|-------|-------------------------------------------------------------------------------------------------------------------|
-|sensors | Light ([ISL29020](https://www.renesas.com/kr/en/products/sensors/ambient-light-sensors/light-to-digital-sensors/device/ISL29020.html)) |
-| | Pressure ([LPS331AP](http://www.st.com/web/catalog/sense_power/FM89/SC1316/PF251601)) |
-| | Tri-axis accelerometer/magnetometer ([LSM303DLHC](http://www.st.com/web/catalog/sense_power/FM89/SC1449/PF251940)) |
-| | Tri-axis gyrometer ([L3G4200D](http://www.st.com/web/catalog/sense_power/FM89/SC1288/PF250373)) |
-| external memory    | 128 Mbits external Nor flash ([N25Q128A13E1240F](https://www.micron.com/-/media/client/global/documents/products/data-sheet/nor-flash/serial-nor/n25q/n25q_128mb_3v_65nm.pdf)) |
-| power  | 3,7V LiPo battery – 650 mAh ([063040](http://www.gmbattery.com/Datasheet/LIPO/LIPO-063040.pdf)) |
-| radio chipset   | [AT86RF231](http://www.atmel.com/images/doc8111.pdf) |
-| | a IEEE802.15.4-compliant radio at 2.4 GHz |
+| MCU               | [ST2M32F103REY](http://www.st.com/web/catalog/mmc/FM141/SC1169/SS1031/LN1565/PF164485) – 32-bits, 64KiB RAM                               |
+|:----------------- |:----------------------------------------------------------------------------------------------------------------------------------------- |
+|sensors            | Light ([ISL29020](https://www.renesas.com/kr/en/products/sensors/ambient-light-sensors/light-to-digital-sensors/device/ISL29020.html))    |
+|                   | Pressure ([LPS331AP](http://www.st.com/web/catalog/sense_power/FM89/SC1316/PF251601))                                                     |
+|                   | Tri-axis accelerometer/magnetometer ([LSM303DLHC](http://www.st.com/web/catalog/sense_power/FM89/SC1449/PF251940))                        |
+|                   | Tri-axis gyrometer ([L3G4200D](http://www.st.com/web/catalog/sense_power/FM89/SC1288/PF250373))                                           |
+| external memory   | 128 Mbits external Nor flash ([N25Q128A13E1240F](https://www.micron.com/-/media/client/global/documents/products/data-sheet/nor-flash/serial-nor/n25q/n25q_128mb_3v_65nm.pdf)) |
+| power             | 3,7V LiPo battery – 650 mAh ([063040](http://www.gmbattery.com/Datasheet/LIPO/LIPO-063040.pdf))                                           |
+| radio chipset     | [AT86RF231](http://www.atmel.com/images/doc8111.pdf)                                                                                      |
+|                   | a IEEE802.15.4-compliant radio at 2.4 GHz                                                                                                 |
 
 ## Board HW overview
 
@@ -31,23 +31,23 @@
 
 ## Implementation Status
 
-| Device | ID        | Supported | Comments  |
-|:------------- |:------------- |:------------- |:------------- |
-| MCU        | [STM23F103REY](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/reference_manual/CD00171190.pdf) | partly    | Energy saving modes not fully utilized |
-| Low-level driver | GPIO    | yes       | |
-|        | PWM       | no        | #4227|
-|        | UART      | yes       | |
-|        | I2C       | yes       | |
-|        | SPI       | yes       | |
-|        | USB       | no        | |
-|        | RTT       | yes       | |
-|        | Timer     | yes       | |
-| Radio Chip | AT86RF231 | yes       | |
-| Accelerometer  | L3G4200D  | yes       | |
-| Magnetometer   | L3G4200D  | yes       | |
-| Gyroscope  | LSM303DLHC    | yes       | |
-| Pressure Sensor | LPS331AP | yes       |  |
-| Light Sensor   | ISL29020  | yes       | |
+| Device            | ID            | Supported     | Comments              |
+|:----------------- |:------------- |:------------- |:--------------------- |
+| MCU               | [STM23F103REY](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/reference_manual/CD00171190.pdf) | partly    | Energy saving modes not fully utilized |
+| Low-level driver  | GPIO          | yes           |                       |
+|                   | PWM           | no            | periph config missing |
+|                   | UART          | yes           |                       |
+|                   | I2C           | yes           |                       |
+|                   | SPI           | yes           |                       |
+|                   | USB           | no            |                       |
+|                   | RTT           | yes           |                       |
+|                   | Timer         | yes           |                       |
+| Radio Chip        | AT86RF231     | yes           |                       |
+| Accelerometer     | L3G4200D      | yes           |                       |
+| Magnetometer      | L3G4200D      | yes           |                       |
+| Gyroscope         | LSM303DLHC    | yes           |                       |
+| Pressure Sensor   | LPS331AP      | yes           |                       |
+| Light Sensor      | ISL29020      | yes           |                       |
 
 ## Toolchains
 

--- a/boards/limifrog-v1/doc.txt
+++ b/boards/limifrog-v1/doc.txt
@@ -16,32 +16,32 @@ features a variety of sensors as well as an OLED Display and a BLE
 ![limifrog-v1 pinout](https://raw.githubusercontent.com/wiki/RIOT-OS/RIOT/images/limifrog-v1_pinout.png)
 
 ### MCU
-| MCU        | STM32L151RC |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M3     |
-| Vendor | ST Microelectronics   |
-| RAM        | 32Kb  |
-| Flash      | 256Kb             |
-| Frequency  | 32MHz (no external oscilator connected) |
-| FPU        | no                |
-| Timers | 8 (8x 16-bit, 1x 32-bit [TIM5])   |
-| ADCs       | 1x 42-channel 12-bit          |
-| UARTs      | 3                 |
-| SPIs       | 2                 |
-| I2Cs       | 2                 |
-| Vcc        | 1.65V - 3.6V          |
-| Datasheet  | [Datasheet](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00048356.pdf) |
-| Reference Manual | [Reference Manual](http://www.st.com/web/en/resource/technical/document/reference_manual/CD00240193.pdf) |
-| Programming Manual | [Programming Manual](http://www.st.com/web/en/resource/technical/document/programming_manual/CD00228163.pdf) |
+| MCU                   | STM32L151RC                               |
+|:--------------------- |:----------------------------------------- |
+| Family                | ARM Cortex-M3                             |
+| Vendor                | ST Microelectronics                       |
+| RAM                   | 32KiB                                     |
+| Flash                 | 256KiB                                    |
+| Frequency             | 32MHz (no external oscillator connected)  |
+| FPU                   | no                                        |
+| Timers                | 8 (8x 16-bit, 1x 32-bit [TIM5])           |
+| ADCs                  | 1x 42-channel 12-bit                      |
+| UARTs                 | 3                                         |
+| SPIs                  | 2                                         |
+| I2Cs                  | 2                                         |
+| Vcc                   | 1.65V - 3.6V                              |
+| Datasheet             | [Datasheet](http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00048356.pdf) |
+| Reference Manual      | [Reference Manual](http://www.st.com/web/en/resource/technical/document/reference_manual/CD00240193.pdf) |
+| Programming Manual    | [Programming Manual](http://www.st.com/web/en/resource/technical/document/programming_manual/CD00228163.pdf) |
 
 ## User Inferface
 
 2 Buttons:
 
-| PIN    |
-|:----- |
+| PIN       |
+|:--------- |
 | PA15 (IN) |
-| PC8 (IN) |
+| PC8 (IN)  |
 
 1 LED:
 
@@ -52,23 +52,23 @@ features a variety of sensors as well as an OLED Display and a BLE
 
 ## Implementation Status
 
-| Device | ID        | Supported | Comments  |
-|:------------- |:------------- |:------------- |:------------- |
-| MCU        | STM32L151RC   | partly    | Energy saving modes not fully utilized |
-| Low-level driver | GPIO    | yes       | |
-|        | PWM       | yes       | |
-|        | UART      | yes       | |
-|        | I2C       | yes       | |
-|        | SPI       | yes       | |
-|        | Timer     | yes       | |
-| Ambient Light Sensor| ST VL6180X | no      | planned|
-| Accelerometer  | ST LSM6DS3    | no        | planned |
-| Magnetometer   | ST LIS3MDL    | no        | planned |
-| Gyroscope  | ST LSM6DS3    | no        | planned |
-| atmospheric pressure (and altitude) sensor | ST SLPS25H    | no        | planned |
-| Microphone | Knowles SPU0414HR5H-SB    | no        | planned |
-| OLED Display   | Densitron DD-160128FC-1A  | no        | planned |
-| BLE    | Panasonic PAN1740 | no        | planned |
+| Device                                        | ID                        | Supported | Comments                                  |
+|:--------------------------------------------- |:------------------------- |:--------- |:----------------------------------------- |
+| MCU                                           | STM32L151RC               | partly    | Energy saving modes not fully utilized    |
+| Low-level driver                              | GPIO                      | yes       |                                           |
+|                                               | PWM                       | yes       |                                           |
+|                                               | UART                      | yes       |                                           |
+|                                               | I2C                       | yes       |                                           |
+|                                               | SPI                       | yes       |                                           |
+|                                               | Timer                     | yes       |                                           |
+| Ambient Light Sensor                          | ST VL6180X                | no        | planned                                   |
+| Accelerometer                                 | ST LSM6DS3                | no        | planned                                   |
+| Magnetometer                                  | ST LIS3MDL                | no        | planned                                   |
+| Gyroscope                                     | ST LSM6DS3                | no        | planned                                   |
+| atmospheric pressure (and altitude) sensor    | ST SLPS25H                | no        | planned                                   |
+| Microphone                                    | Knowles SPU0414HR5H-SB    | no        | planned                                   |
+| OLED Display                                  | Densitron DD-160128FC-1A  | no        | planned                                   |
+| BLE                                           | Panasonic PAN1740         | no        | planned                                   |
 
 ## Flashing and Debugging the device
 

--- a/boards/lobaro-lorabox/doc.txt
+++ b/boards/lobaro-lorabox/doc.txt
@@ -9,24 +9,24 @@
 
 
 ### MCU
-| MCU        | stm32l151cb-a |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M3     |
-| Vendor | ST Microelectronics   |
-| RAM        | 16Kb  |
-| Flash      | 128Kb             |
-| Frequency  | 32MHz (no external oscilator connected) |
-| FPU        | no                |
-| Timers | 10 (8x 16-bit, 2x watchdog timers)   |
-| ADCs       | 1x 24-channel 12-bit          |
-| UARTs      | 3                 |
-| SPIs       | 2                 |
-| I2Cs       | 2                 |
-| Vcc        | 1.65V - 3.6V          |
-| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32l151cb-a.pdf) |
-| Reference Manual | [Reference Manual](https://www.st.com/content/ccc/resource/technical/document/reference_manual/cc/f9/93/b2/f0/82/42/57/CD00240193.pdf/files/CD00240193.pdf/jcr:content/translations/en.CD00240193.pdf) |
-| Programming Manual | [Programming Manual](https://www.st.com/content/ccc/resource/technical/document/programming_manual/5b/ca/8d/83/56/7f/40/08/CD00228163.pdf/files/CD00228163.pdf/jcr:content/translations/en.CD00228163.pdf) |
-| Board Manual   | [Board Manual](https://www.lobaro.com/download/7250/)|
+| MCU                   | stm32l151cb-a                             |
+|:--------------------- |:----------------------------------------- |
+| Family                | ARM Cortex-M3                             |
+| Vendor                | ST Microelectronics                       |
+| RAM                   | 16KiB                                     |
+| Flash                 | 128KiB                                    |
+| Frequency             | 32MHz (no external oscillator connected)  |
+| FPU                   | no                                        |
+| Timers                | 10 (8x 16-bit, 2x watchdog timers)        |
+| ADCs                  | 1x 24-channel 12-bit                      |
+| UARTs                 | 3                                         |
+| SPIs                  | 2                                         |
+| I2Cs                  | 2                                         |
+| Vcc                   | 1.65V - 3.6V                              |
+| Datasheet             | [Datasheet](https://www.st.com/resource/en/datasheet/stm32l151cb-a.pdf) |
+| Reference Manual      | [Reference Manual](https://www.st.com/content/ccc/resource/technical/document/reference_manual/cc/f9/93/b2/f0/82/42/57/CD00240193.pdf/files/CD00240193.pdf/jcr:content/translations/en.CD00240193.pdf) |
+| Programming Manual    | [Programming Manual](https://www.st.com/content/ccc/resource/technical/document/programming_manual/5b/ca/8d/83/56/7f/40/08/CD00228163.pdf/files/CD00228163.pdf/jcr:content/translations/en.CD00228163.pdf) |
+| Board Manual          | [Board Manual](https://www.lobaro.com/download/7250/)|
 
 ### User Interface
 

--- a/boards/mbed_lpc1768/doc.txt
+++ b/boards/mbed_lpc1768/doc.txt
@@ -21,24 +21,24 @@ about the board.
 
 ### MCU
 
-| MCU             | LPC1768FDB100  |
-|:--------------- |:-------------- |
-| Family          | ARM Cortex-M3  |
-| Vendor          | NXP            |
-| RAM             | 64kB SRAM      |
-| Flash           | 512kB          |
-| Frequency       | up to 100MHz   |
-| Timers          | 4              |
-| UARTs           | 4              |
-| SPIs            | 2              |
-| I2Cs            | 3              |
-| CAN             | 2              |
-| PWM             | 6              |
-| USB Host/Device | 1              |
-| Ethernet        | 1              |
-| RTC             | 1              |
-| ADC             | 8 (all 12-bit) |
-| Vcc             | 2.4V - 3.6V    |
+| MCU             | LPC1768FDB100   |
+|:--------------- |:--------------- |
+| Family          | ARM Cortex-M3   |
+| Vendor          | NXP             |
+| RAM             | 64KiB SRAM      |
+| Flash           | 512KiB          |
+| Frequency       | up to 100MHz    |
+| Timers          | 4               |
+| UARTs           | 4               |
+| SPIs            | 2               |
+| I2Cs            | 3               |
+| CAN             | 2               |
+| PWM             | 6               |
+| USB Host/Device | 1               |
+| Ethernet        | 1               |
+| RTC             | 1               |
+| ADC             | 8 (all 12-bit)  |
+| Vcc             | 2.4V - 3.6V     |
 | Datasheet       | [Datasheet](http://www.nxp.com/documents/data_sheet/LPC1769_68_67_66_65_64_63.pdf) |
 | User Manual     | [User Manual](http://www.nxp.com/documents/user_manual/UM10360.pdf)|
 

--- a/boards/mcb2388/doc.txt
+++ b/boards/mcb2388/doc.txt
@@ -11,8 +11,8 @@
 
 | MCU:      | LPC2388 ARM7-TDMI |
 |-----------|-------------------|
-| RAM:      | 96kb              |
-| Flash:    | 512kb             |
+| RAM:      | 96KiB             |
+| Flash:    | 512KiB            |
 
 # More info
 

--- a/boards/microbit/doc.txt
+++ b/boards/microbit/doc.txt
@@ -9,7 +9,7 @@ The [micro:bit](https://www.microbit.co.uk/) was designed by the BBC and
 released in 2015. The boards was distributed to all 11-12 year old children
 throughout the UK.
 
-The board is based on the Nordic nRF51822 SoC, featuring 16Kb of RAM, 256Kb
+The board is based on the Nordic nRF51822 SoC, featuring 16KiB of RAM, 256KiB
 of ROM, and a 2.4GHz radio, that supports Bluetooth Low Energy (BLE) as well as
 a Nordic proprietary radio mode.
 
@@ -21,21 +21,21 @@ Additionally the boards features 2 buttons, a 5x5 LED matrix, a MAG3110
 
 ![micro:bit](https://github.com/RIOT-OS/RIOT/wiki/images/board_microbit.png)
 
-| MCU        | NRF51822QFAA      |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M0     |
-| Vendor | Nordic Semiconductor  |
-| RAM        | 16Kb  |
-| Flash      | 256Kb             |
-| Frequency  | 16MHz |
-| FPU        | no                |
-| Timers | 3 (2x 16-bit, 1x 32-bit [TIMER0]) |
-| ADCs       | 1x 10-bit (8 channels)        |
-| UARTs      | 1                 |
-| SPIs       | 2                 |
-| I2Cs       | 2                 |
-| Vcc        | 1.8V - 3.6V           |
-| Reference Manual | [Reference Manual](http://infocenter.nordicsemi.com/pdf/nRF51_RM_v3.0.pdf) |
+| MCU               | NRF51822QFAA                      |
+|:----------------- |:--------------------------------- |
+| Family            | ARM Cortex-M0                     |
+| Vendor            | Nordic Semiconductor              |
+| RAM               | 16KiB                             |
+| Flash             | 256KiB                            |
+| Frequency         | 16MHz                             |
+| FPU               | no                                |
+| Timers            | 3 (2x 16-bit, 1x 32-bit [TIMER0]) |
+| ADCs              | 1x 10-bit (8 channels)            |
+| UARTs             | 1                                 |
+| SPIs              | 2                                 |
+| I2Cs              | 2                                 |
+| Vcc               | 1.8V - 3.6V                       |
+| Reference Manual  | [Reference Manual](http://infocenter.nordicsemi.com/pdf/nRF51_RM_v3.0.pdf) |
 
 
 ##  Flashing and Debugging

--- a/boards/msb-430h/doc.txt
+++ b/boards/msb-430h/doc.txt
@@ -8,37 +8,37 @@
 ![ScatterWeb MSB-430H](http://riot-os.org/images/msb-430h_2.png)
 
 ## MCU
-| MCU        | TI MSP430F1612        |
-|:------------- |:--------------------- |
-| Family | MSP430    |
-| Vendor | Texas Instruments |
-| Package       | 64 QFN |
-| RAM        | 5Kb   |
-| Flash      | 55Kb          |
-| Frequency  | 8MHz |
-| FPU        | no                |
-| Timers | 2 (2x 16bit)  |
-| ADCs       | 1x 8 channel 12-bit           |
-| UARTs      | 2                 |
-| SPIs       | 2 |
-| I2Cs       | 1     |
-| Vcc        | 2.0V - 3.6V           |
-| Datasheet / Reference Manual   | [Datasheet](https://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/ScatterWeb/moduleComponents/msp430f1612.pdf) |
-| User Guide | [User Guide](https://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/ScatterWeb/moduleComponents/MSP430slau049f.pdf)|
+| MCU                           | TI MSP430F1612        |
+|:----------------------------- |:--------------------- |
+| Family                        | MSP430                |
+| Vendor                        | Texas Instruments     |
+| Package                       | 64 QFN                |
+| RAM                           | 5KiB                  |
+| Flash                         | 55KiB                 |
+| Frequency                     | 8MHz                  |
+| FPU                           | no                    |
+| Timers                        | 2 (2x 16bit)          |
+| ADCs                          | 1x 8 channel 12-bit   |
+| UARTs                         | 2                     |
+| SPIs                          | 2                     |
+| I2Cs                          | 1                     |
+| Vcc                           | 2.0V - 3.6V           |
+| Datasheet / Reference Manual  | [Datasheet](https://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/ScatterWeb/moduleComponents/msp430f1612.pdf) |
+| User Guide                    | [User Guide](https://www.mi.fu-berlin.de/inf/groups/ag-tech/projects/ScatterWeb/moduleComponents/MSP430slau049f.pdf)|
 
 ## Radio
 
-| RF Chip           | Texas Instruments® CC1100 |
-|:-------------------- |:------------------------- |
-| Frequency Band       | 300-348MHz, 400-464 MHz, and 800-928 MHz |
-| Standard compliance  | DASH7 compliant |
-| Receive Sensitivity  | -94dBm typ |
-| Transfer Rate         | 500kBaud |
-| RF Power          | -30dBm ~ 10dBm  |
-| Current Draw          | RX: 14.4mA TX: 16.9mA Sleep mode: 400nA |
-| RF Power Supply      | 2.1V ~ 3.6V |
-| Antenna           | Dipole Antenna / PCB Antenna    |
-| Datasheet            | [Datasheet](http://www.ti.com/lit/gpn/cc1100) |
+| RF Chip               | Texas Instruments® CC1100                     |
+|:--------------------- |:--------------------------------------------- |
+| Frequency Band        | 300-348MHz, 400-464 MHz, and 800-928 MHz      |
+| Standard compliance   | DASH7 compliant                               |
+| Receive Sensitivity   | -94dBm typ                                    |
+| Transfer Rate         | 500kBaud                                      |
+| RF Power              | -30dBm ~ 10dBm                                |
+| Current Draw          | RX: 14.4mA TX: 16.9mA Sleep mode: 400nA       |
+| RF Power Supply       | 2.1V ~ 3.6V                                   |
+| Antenna               | Dipole Antenna / PCB Antenna                  |
+| Datasheet             | [Datasheet](http://www.ti.com/lit/gpn/cc1100) |
 
 ## Flashing RIOT
 

--- a/boards/msba2/doc.txt
+++ b/boards/msba2/doc.txt
@@ -12,8 +12,8 @@
 
 | MCU:      | LPC2387 ARM7-TDMI |
 |-----------|-------------------|
-| RAM:      | 96kb              |
-| Flash:    | 512kb             |
+| RAM:      | 96KiB             |
+| Flash:    | 512KiB            |
 
 
 # More info

--- a/boards/mulle/doc.txt
+++ b/boards/mulle/doc.txt
@@ -21,14 +21,14 @@ Use `BOARD=mulle` for building RIOT for this platform.
 https://github.com/eistec/mulle/wiki/Datasheets contains a list of relevant
 documentation for the components.
 
-| MCU    | MK60DN512VLL10 – Cortex-M4 |
-|-------|-----------------------------------|
-| RAM    | 64kB |
-| Flash  | 512kB|
-| radio chipset   | AT86RF212B, sub-GHz IEEE802.15.4 transceiver, similar to the AT86RF233 |
-| external flash memory  | Micron M25P16 16 Mbits external NOR flash, used for storing configuration, measurements and other slow changing non-volatile data |
-| external FRAM memory   | Cypress/Ramtron FM25L04B 4 Kbits external F-RAM, used for storing counters and other rapidly changing non-volatile data |
-| accelerometer  | ST micro LIS3DH MEMS accelerometer,  |
+| MCU                   | MK60DN512VLL10 – Cortex-M4                                                                                                        |
+|:--------------------- |:--------------------------------------------------------------------------------------------------------------------------------- |
+| RAM                   | 64KiB                                                                                                                             |
+| Flash                 | 512KiB                                                                                                                            |
+| radio chipset         | AT86RF212B, sub-GHz IEEE802.15.4 transceiver, similar to the AT86RF233                                                            |
+| external flash memory | Micron M25P16 2 MiB external NOR flash, used for storing configuration, measurements and other slow changing non-volatile data    |
+| external FRAM memory  | Cypress/Ramtron FM25L04B 512B external F-RAM, used for storing counters and other rapidly changing non-volatile data              |
+| accelerometer         | ST micro LIS3DH MEMS accelerometer                                                                                                |
 
 
 ## Layout
@@ -40,23 +40,23 @@ documentation for the components.
 The Mulle board is supported by mainline RIOT. See the below table for
 software support status for the different components.
 
-| Device | ID        | Supported | Comments  |
-|:------------- |:------------- |:------------- |:------------- |
-| MCU        | MK60DN512VLL10    | partly    | See below |
-| Low-level driver | GPIO    | yes       | |
-|        | PWM       | yes       | |
-|        | UART      | yes       | |
-|        | I2C       | yes       | |
-|        | SPI       | yes       |Master mode works, slave mode unsupported |
-|        | USB       | no        | [PR#3890](https://github.com/RIOT-OS/RIOT/pull/3890) |
-|        | RTT       | yes       | |
-|        | RNG       | yes       | |
-|        | timer     | yes       | uses LPTMR module for TIMER_0 (used by xtimer), 32.768 kHz tick rate. PIT for additional timers, F_BUS tick rate (48 MHz default) |
-|        | PM/LLWU   | in progress   | [PR#2605](https://github.com/RIOT-OS/RIOT/pull/2605) |
-| Radio Chip | AT86RF212B    | yes       | |
-| Accelerometer  | LIS3DH    | yes       | |
-| Flash  | M25P16    | in progress   | [PR#6762](https://github.com/RIOT-OS/RIOT/pull/6762) |
-| FRAM   | FM25L04B  | yes       | |
+| Device            | ID                | Supported     | Comments                                              |
+|:----------------- |:----------------- |:------------- |:----------------------------------------------------- |
+| MCU               | MK60DN512VLL10    | partly        | See below                                             |
+| Low-level driver  | GPIO              | yes           |                                                       |
+|                   | PWM               | yes           |                                                       |
+|                   | UART              | yes           |                                                       |
+|                   | I2C               | yes           |                                                       |
+|                   | SPI               | yes           | Slave mode unsupported                                |
+|                   | USB               | no            | [PR#3890](https://github.com/RIOT-OS/RIOT/pull/3890)  |
+|                   | RTT               | yes           |                                                       |
+|                   | RNG               | yes           |                                                       |
+|                   | timer             | yes           | uses LPTMR module for TIMER_0 (used by xtimer), 32.768 kHz tick rate. PIT for additional timers, F_BUS tick rate (48 MHz default) |
+|                   | PM/LLWU           | in progress   | [PR#2605](https://github.com/RIOT-OS/RIOT/pull/2605)  |
+| Radio Chip        | AT86RF212B        | yes           |                                                       |
+| Accelerometer     | LIS3DH            | yes           |                                                       |
+| Flash             | M25P16            | yes           |                                                       |
+| FRAM              | FM25L04B          | yes           |                                                       |
 
 ## Toolchains
 

--- a/boards/nrf51dongle/doc.txt
+++ b/boards/nrf51dongle/doc.txt
@@ -6,7 +6,7 @@
 ## Overview:
 The nRF51822 is a multi-protocol SoC ideally suited for Bluetooth® low energy
 and 2.4GHz ultra low-power wireless applications from Nordic Semiconductor. The
-nRF51822 is built around a 32-bit ARM® Cortex™ M0 CPU with 256kB flash + 16kB
+nRF51822 is built around a 32-bit ARM® Cortex™ M0 CPU with 256KiB flash + 16KiB
 RAM. The embedded 2.4GHz transceiver supports Bluetooth low energy as well as
 2.4GHz operation.
 
@@ -21,23 +21,23 @@ have to be flashed/debugged using the (included) external J-Link device.
 ![Nordic Semiconductor nrF51822 Development Kit]
 (https://www.nordicsemi.com/-/media/Images/Products/DevKits/nRF51-Series/nRF51-Dongle-promo.png)
 
-| MCU        | NRF51822QFAA      |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M0     |
-| Vendor | Nordic Semiconductor  |
-| RAM        | 16Kb  |
-| Flash      | 256Kb             |
-| Frequency  | 16MHz |
-| FPU        | no                |
-| Timers | 3 (2x 16-bit, 1x 32-bit [TIMER0]) |
-| ADCs       | 1x 10-bit (8 channels)        |
-| UARTs      | 1                 |
-| SPIs       | 2                 |
-| I2Cs       | 2                 |
-| Radio         | 2.4GHz BLE compatiple, +4dBm to -20 dBm output, -93 dBm RX sensitivity |
-| Vcc        | 1.8V - 3.6V           |
-| Datasheet  | [Datasheet](https://infocenter.nordicsemi.com/pdf/nRF51822_PS_v3.3.pdf) |
-| Reference Manual | [Reference Manual](https://infocenter.nordicsemi.com/pdf/nRF51_RM_v3.0.1.pdf) |
+| MCU               | NRF51822QFAA                                                                  |
+|:----------------- |:----------------------------------------------------------------------------- |
+| Family            | ARM Cortex-M0                                                                 |
+| Vendor            | Nordic Semiconductor                                                          |
+| RAM               | 16KiB                                                                         |
+| Flash             | 256KiB                                                                        |
+| Frequency         | 16MHz                                                                         |
+| FPU               | no                                                                            |
+| Timers            | 3 (2x 16-bit, 1x 32-bit [TIMER0])                                             |
+| ADCs              | 1x 10-bit (8 channels)                                                        |
+| UARTs             | 1                                                                             |
+| SPIs              | 2                                                                             |
+| I2Cs              | 2                                                                             |
+| Radio             | 2.4GHz BLE compatiple, +4dBm to -20 dBm output, -93 dBm RX sensitivity        |
+| Vcc               | 1.8V - 3.6V                                                                   |
+| Datasheet         | [Datasheet](https://infocenter.nordicsemi.com/pdf/nRF51822_PS_v3.3.pdf)       |
+| Reference Manual  | [Reference Manual](https://infocenter.nordicsemi.com/pdf/nRF51_RM_v3.0.1.pdf) |
 
 
 ## Flashing the Device:

--- a/boards/nrf52dk/doc.txt
+++ b/boards/nrf52dk/doc.txt
@@ -10,8 +10,8 @@ KEY), two LED’s (Pin 30, 31), a voltage regulator and a current messurment shu
 on board. A serial connection and flashing must be provided by external
 Hardware.
 
-The nRF52832 is a SoC with a 32-bit ARM® Cortex™-M4F CPU with 512kB Flash and
-64kB RAM. The embedded 2.4GHz transceiver supports Bluetooth low energy, ANT and
+The nRF52832 is a SoC with a 32-bit ARM® Cortex™-M4F CPU with 512KiB Flash and
+64KiB RAM. The embedded 2.4GHz transceiver supports Bluetooth low energy, ANT and
 proprietary 2.4 GHz protocol stack. It is on air compatible with the nRF51
 Series, nRF24L and nRF24AP Series products from Nordic Semiconductor.
 
@@ -19,26 +19,26 @@ Series, nRF24L and nRF24AP Series products from Nordic Semiconductor.
 ![nRF52 minimal development
 board](https://github.com/d00616/temp/raw/master/nrf52-minidev.jpg)
 
-| MCU        | NRF52832      |
-|:------------- |:--------------------- |
-| Family | ARM Cortex-M4F    |
-| Vendor | Nordic Semiconductor  |
-| RAM        | 64Kb  |
-| Flash      | 512Kb             |
-| Frequency  | 64MHz |
-| FPU        | yes               |
-| Timers | 5 (32-bit)    |
-| RTC    | 3 |
-| ADCs       | 1x 12-bit (8 channels)        |
-| UARTs      | 1                 |
-| SPIs       | 3                 |
-| I2Cs       | 2                 |
-| I2S        | 1                 |
-| PWM        | 3*4 Channels              |
-| Radio         | 2.4GHz BLE compatiple, -20 dBm to +4 dBm output, -96 dBm RX sensitivity |
-| Vcc        | 1.7V - 3.6V           |
-| Datasheet  | [Datasheet](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF52832) |
-| Reference Manual | [Reference Manual](https://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.4.pdf) |
+| MCU               | NRF52832                                                                              |
+|:----------------- |:------------------------------------------------------------------------------------- |
+| Family            | ARM Cortex-M4F                                                                        |
+| Vendor            | Nordic Semiconductor                                                                  |
+| RAM               | 64KiB                                                                                 |
+| Flash             | 512KiB                                                                                |
+| Frequency         | 64MHz                                                                                 |
+| FPU               | yes                                                                                   |
+| Timers            | 5 (32-bit)                                                                            |
+| RTC               | 3                                                                                     |
+| ADCs              | 1x 12-bit (8 channels)                                                                |
+| UARTs             | 1                                                                                     |
+| SPIs              | 3                                                                                     |
+| I2Cs              | 2                                                                                     |
+| I2S               | 1                                                                                     |
+| PWM               | 3*4 Channels                                                                          |
+| Radio             | 2.4GHz BLE compatiple, -20 dBm to +4 dBm output, -96 dBm RX sensitivity               |
+| Vcc               | 1.7V - 3.6V                                                                           |
+| Datasheet         | [Datasheet](https://www.nordicsemi.com/eng/Products/Bluetooth-low-energy/nRF52832)    |
+| Reference Manual  | [Reference Manual](https://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.4.pdf)        |
 
 ##Pin layout
 

--- a/boards/nucleo-f030r8/doc.txt
+++ b/boards/nucleo-f030r8/doc.txt
@@ -16,21 +16,21 @@ STM32F030R8 microcontroller with 8Kb of SRAM and 64Kb of ROM Flash.
 
 
 ### MCU
-| MCU        | STM32F030R8       |
-|:---------- |:----------------- |
-| Family     | ARM Cortex-M0     |
-| Vendor     | ST Microelectronics |
-| RAM        | 8Kb               |
-| Flash      | 64Kb              |
-| Frequency  | up to 48MHz       |
-| FPU        | no                |
-| Timers     | 10 (2x watchdog, 1 SysTick, 7x 16-bit)    |
-| ADCs       | 1x 12-bit         |
-| UARTs      | 2                 |
-| SPIs       | 2                 |
-| I2Cs       | 2                 |
-| RTC        | 1                 |
-| Vcc        | 2.4V - 3.6V       |
+| MCU        | STM32F030R8                                                          |
+|:---------- |:-------------------------------------------------------------------- |
+| Family     | ARM Cortex-M0                                                        |
+| Vendor     | ST Microelectronics                                                  |
+| RAM        | 8KiB                                                                 |
+| Flash      | 64KiB                                                                |
+| Frequency  | up to 48MHz                                                          |
+| FPU        | no                                                                   |
+| Timers     | 10 (2x watchdog, 1 SysTick, 7x 16-bit)                               |
+| ADCs       | 1x 12-bit                                                            |
+| UARTs      | 2                                                                    |
+| SPIs       | 2                                                                    |
+| I2Cs       | 2                                                                    |
+| RTC        | 1                                                                    |
+| Vcc        | 2.4V - 3.6V                                                          |
 | Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f030r8.pdf) |
 | Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/dm00091010.pdf) |
 | Programming Manual | [Programming Manual](http://www.st.com/resource/en/programming_manual/dm00051352.pdf) |

--- a/boards/nucleo-f070rb/doc.txt
+++ b/boards/nucleo-f070rb/doc.txt
@@ -16,26 +16,26 @@ STM32F070RB microcontroller with 16Kb of SRAM and 128Kb of ROM Flash.
 
 
 ### MCU
-| MCU        | STM32F070RB           |
-|:---------- |:--------------------- |
-| Family     | ARM Cortex-M0         |
-| Vendor     | ST Microelectronics   |
-| RAM        | 16Kb                  |
-| Flash      | 128Kb                 |
-| Frequency  | up to 48MHz           |
-| FPU        | no                    |
-| Timers     | 11 (2x watchdog, 1 SysTick, 8x 16-bit) |
-| ADCs       | 1x 12-bit (16 channels) |
-| UARTs      | 4                     |
-| SPIs       | 2                     |
-| I2Cs       | 2                     |
-| RTC        | 1                     |
-| USB        | 1                     |
-| Vcc        | 2.4V - 3.6V           |
-| Datasheet  | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f070rb.pdf) |
-| Reference Manual | [Reference Manual](https://www.st.com/resource/en/reference_manual/dm00091010.pdf) |
-| Programming Manual | [Programming Manual](http://www.st.com/resource/en/programming_manual/dm00051352.pdf) |
-| Board Manual | [Board Manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf) |
+| MCU                   | STM32F070RB                                                                           |
+|:--------------------- |:------------------------------------------------------------------------------------- |
+| Family                | ARM Cortex-M0                                                                         |
+| Vendor                | ST Microelectronics                                                                   |
+| RAM                   | 16KiB                                                                                 |
+| Flash                 | 128KiB                                                                                |
+| Frequency             | up to 48MHz                                                                           |
+| FPU                   | no                                                                                    |
+| Timers                | 11 (2x watchdog, 1 SysTick, 8x 16-bit)                                                |
+| ADCs                  | 1x 12-bit (16 channels)                                                               |
+| UARTs                 | 4                                                                                     |
+| SPIs                  | 2                                                                                     |
+| I2Cs                  | 2                                                                                     |
+| RTC                   | 1                                                                                     |
+| USB                   | 1                                                                                     |
+| Vcc                   | 2.4V - 3.6V                                                                           |
+| Datasheet             | [Datasheet](http://www.st.com/resource/en/datasheet/stm32f070rb.pdf)                  |
+| Reference Manual      | [Reference Manual](https://www.st.com/resource/en/reference_manual/dm00091010.pdf)    |
+| Programming Manual    | [Programming Manual](http://www.st.com/resource/en/programming_manual/dm00051352.pdf) |
+| Board Manual          | [Board Manual](http://www.st.com/resource/en/user_manual/dm00105823.pdf)              |
 
 
 


### PR DESCRIPTION
### Contribution description

- In the doc RAM / Flash size is often given as "kb" (kilo bit = 1000 bit) or (kB = 1000 Byte) (kilo byte) or even Kb (which is not even a unit). Correct is in most case KiB (kibi byte = 1024 byte). This fixes the use in many board docs
- The alignment of tables is messed up. This annoys me way more than it should. This PR fixes it for many tables

### Testing procedure

Read the doc

### Issues/PRs references

None