### PR TITLE
tests/kconfig_features: Fix target dependencies

### DIFF
--- a/dist/tools/kconfiglib/Makefile
+++ b/dist/tools/kconfiglib/Makefile
@@ -7,6 +7,10 @@ PKG_BUILDDIR=$(CURDIR)/bin
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:
-	cp $(PKG_BUILDDIR)/kconfiglib.py $(PKG_BUILDDIR)/menuconfig.py \
+	$(Q)cp $(PKG_BUILDDIR)/kconfiglib.py $(PKG_BUILDDIR)/menuconfig.py \
 	   $(PKG_BUILDDIR)/genconfig.py $(PKG_BUILDDIR)/examples/merge_config.py \
 	   .
+
+remove:
+	$(Q)$(RM) -r $(PKG_BUILDDIR) kconfiglib.py menuconfig.py genconfig.py \
+	       merge_config.py

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -2,11 +2,11 @@ include ../Makefile.tests_common
 
 BOARD_WHITELIST += samr21-xpro
 
-kconfig-features:
-	@bash -c 'diff <($(MAKE) info-features-provided) \
-	    <($(MAKE) dependency-debug-features-provided-kconfig) || \
-	    (echo "ERROR: Kconfig features mismatch" && exit 1)'
-
 all: kconfig-features
 
 include $(RIOTBASE)/Makefile.include
+
+kconfig-features: $(KCONFIG_OUT_CONFIG)
+	@bash -c 'diff <($(MAKE) info-features-provided) \
+	    <($(MAKE) dependency-debug-features-provided-kconfig) || \
+	    (echo "ERROR: Kconfig features mismatch" && exit 1)'


### PR DESCRIPTION
### Contribution description
This fixes a bug in the `tests/kconfig_features` application, which causes to fail the CI builds sometimes. There seems to be a race condition when the kconfiglib tool needs to be downloaded, which causes the features check to fail because `out.config` is not generated.

This adds `KCONFIG_OUT_CONFIG` as a dependency for `kconfig_features`, so it waits for the tool to be downloaded and run before checking features.

Also, now the `bin` folder from `kconfiglib` is removed after downloading the tool because it is not actually needed.

### Testing procedure
- To reproduce the issue in master:
   1. Remove all downloaded files from `dist/tools/kconfiglib`
   2. Run: ` env BOARD=samr21-xpro make -C tests/kconfig_features -j clean all`

- With this it should not fail
- CI should pass (let's run it a couple of times to be sure)

### Issues/PRs references
Test introduced in #13404
