### PR TITLE
boards/atmega128rfa1-based: Model features in Kconfig

### DIFF
--- a/boards/derfmega128/Kconfig
+++ b/boards/derfmega128/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "derfmega128" if BOARD_DERFMEGA128
+
+config BOARD_DERFMEGA128
+    bool
+    default y
+    select CPU_MODEL_ATMEGA128RFA1
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/microduino-corerf/Kconfig
+++ b/boards/microduino-corerf/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+
+config BOARD
+    default "microduino-corerf" if BOARD_MICRODUINO_CORERF
+
+config BOARD_MICRODUINO_CORERF
+    bool
+    default y
+    select CPU_MODEL_ATMEGA128RFA1
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/cpu/atmega128rfa1/Kconfig
+++ b/cpu/atmega128rfa1/Kconfig
@@ -1,0 +1,28 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+## CPU Models
+config CPU_MODEL_ATMEGA128RFA1
+    bool
+    select CPU_FAM_ATMEGA128
+    select HAS_CPU_ATMEGA128RFA1
+    select HAS_ATMEGA_PCINT1
+
+## Definition of specific features
+config HAS_CPU_ATMEGA128RFA1
+    bool
+    help
+        Indicates that a 'atmega128rfa1' cpu is being used.
+
+## Common CPU symbols
+config CPU_MODEL
+    default "atmega128rfa1" if CPU_MODEL_ATMEGA128RFA1
+
+config CPU
+    default "atmega128rfa1" if CPU_MODEL_ATMEGA128RFA1
+
+source "$(RIOTCPU)/atmega_common/Kconfig"

--- a/cpu/atmega_common/Kconfig
+++ b/cpu/atmega_common/Kconfig
@@ -26,12 +26,21 @@ config CPU_COMMON_ATMEGA
     select HAS_PERIPH_WDT
     select HAS_PUF_SRAM
 
+# Define ATMega128 family here as it is used by different CPUs
+config CPU_FAM_ATMEGA128
+    bool
+    select CPU_COMMON_ATMEGA
+    select CPU_CORE_AVR
+
 ## Common CPU symbols
 config CPU_ARCH
     default "avr8" if CPU_ARCH_AVR8
 
 config CPU_CORE
     default "avr" if CPU_CORE_AVR
+
+config CPU_FAM
+    default "atmega128" if CPU_FAM_ATMEGA128
 
 ## Declaration of specific features
 config HAS_ARCH_AVR8

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -10,7 +10,9 @@ BOARD_WHITELIST += arduino-duemilanove \
                    cc1352p-launchpad \
                    cc2650-launchpad \
                    cc2650stk \
+                   derfmega128 \
                    ikea-tradfri \
+                   microduino-corerf \
                    samr21-xpro \
                    slstk3401a \
                    slstk3402a \


### PR DESCRIPTION
### Contribution description
This models the features in Kconfig for all the boards based on the `atmega128rfa1` CPU.
~~The first 2 commits are from #14176, they are included for testing.~~

### Testing procedure
- `tests/kconfig_features` should pass for:
   - `derfmega128`
   - `microduino-corerf`

### Issues/PRs references
~~Depends on #14176~~