### PR TITLE
boards/atmega256rfr2-based: Model features in Kconfig

### DIFF
--- a/boards/atmega256rfr2-xpro/Kconfig
+++ b/boards/atmega256rfr2-xpro/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "atmega256rfr2-xpro" if BOARD_ATMEGA256RFR2_XPRO
+
+config BOARD_ATMEGA256RFR2_XPRO
+    bool
+    default y
+    select CPU_MODEL_ATMEGA256RFR2
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/avr-rss2/Kconfig
+++ b/boards/avr-rss2/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "avr-rss2" if BOARD_AVR_RSS2
+
+config BOARD_AVR_RSS2
+    bool
+    default y
+    select CPU_MODEL_ATMEGA256RFR2
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/derfmega256/Kconfig
+++ b/boards/derfmega256/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "derfmega256" if BOARD_DERFMEGA256
+
+config BOARD_DERFMEGA256
+    bool
+    default y
+    select CPU_MODEL_ATMEGA256RFR2
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/cpu/atmega256rfr2/Kconfig
+++ b/cpu/atmega256rfr2/Kconfig
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_FAM_ATMEGA256RF
+    bool
+    select CPU_COMMON_ATMEGA
+
+## CPU Models
+config CPU_MODEL_ATMEGA256RFR2
+    bool
+    select CPU_FAM_ATMEGA256RF
+    select HAS_ATMEGA_PCINT1
+    select HAS_CPU_ATMEGA256RFR2
+
+## Definition of specific features
+config HAS_CPU_ATMEGA256RFR2
+    bool
+    help
+        Indicates that a 'atmega256rfr2' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "atmega256rf" if CPU_FAM_ATMEGA256RF
+
+config CPU_MODEL
+    default "atmega256rfr2" if CPU_MODEL_ATMEGA256RFR2
+
+config CPU
+    default "atmega256rfr2" if CPU_MODEL_ATMEGA256RFR2
+
+source "$(RIOTCPU)/atmega_common/Kconfig"

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -6,13 +6,16 @@ BOARD_WHITELIST += arduino-duemilanove \
                    arduino-nano \
                    arduino-uno \
                    atmega1284p \
+                   atmega256rfr2-xpro \
                    atmega328p \
+                   avr-rss2 \
                    cc1312-launchpad \
                    cc1352-launchpad \
                    cc1352p-launchpad \
                    cc2650-launchpad \
                    cc2650stk \
                    derfmega128 \
+                   derfmega256 \
                    ikea-tradfri \
                    mega-xplained \
                    microduino-corerf \


### PR DESCRIPTION
### Contribution description
This models the features in Kconfig for all the boards based on the atmega256rfr2 CPU.
~~The first commit is from #14176, included for testing.~~

### Testing procedure
- `tests/kconfig_features` should pass for:
   - `atmega256rfr2-xpro`
   - `avr-rss2`
   - `derfmega256`

### Issues/PRs references
~~Depends on #14176~~