### PR TITLE
boards/atmega128x-based: Model features in Kconfig

### DIFF
--- a/boards/atmega1284p/Kconfig
+++ b/boards/atmega1284p/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "atmega1284p" if BOARD_ATMEGA1284P
+
+config BOARD_ATMEGA1284P
+    bool
+    default y
+    select CPU_MODEL_ATMEGA1284P
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/mega-xplained/Kconfig
+++ b/boards/mega-xplained/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "mega-xplained" if BOARD_MEGA_XPLAINED
+
+config BOARD_MEGA_XPLAINED
+    bool
+    default y
+    select CPU_MODEL_ATMEGA1284P
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/waspmote-pro/Kconfig
+++ b/boards/waspmote-pro/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "waspmote-pro" if BOARD_WASPMOTE_PRO
+
+config BOARD_WASPMOTE_PRO
+    bool
+    default y
+    select CPU_MODEL_ATMEGA1281
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/cpu/atmega1281/Kconfig
+++ b/cpu/atmega1281/Kconfig
@@ -1,0 +1,29 @@
+
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+## CPU Models
+config CPU_MODEL_ATMEGA1281
+    bool
+    select CPU_FAM_ATMEGA128
+    select HAS_ATMEGA_PCINT1
+    select HAS_ATMEGA_PCINT2
+    select HAS_CPU_ATMEGA1281
+
+## Definition of specific features
+config HAS_CPU_ATMEGA1281
+    bool
+    help
+        Indicates that a 'atmega1281' cpu is being used.
+
+## Common CPU symbols
+config CPU_MODEL
+    default "atmega1281" if CPU_MODEL_ATMEGA1281
+
+config CPU
+    default "atmega1281" if CPU_MODEL_ATMEGA1281
+
+source "$(RIOTCPU)/atmega_common/Kconfig"

--- a/cpu/atmega1284p/Kconfig
+++ b/cpu/atmega1284p/Kconfig
@@ -1,0 +1,29 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+## CPU Models
+config CPU_MODEL_ATMEGA1284P
+    bool
+    select CPU_FAM_ATMEGA128
+    select HAS_ATMEGA_PCINT1
+    select HAS_ATMEGA_PCINT2
+    select HAS_ATMEGA_PCINT3
+    select HAS_CPU_ATMEGA1284P
+
+## Definition of specific features
+config HAS_CPU_ATMEGA1284P
+    bool
+    help
+        Indicates that a 'atmega1284p' cpu is being used.
+
+## Common CPU symbols
+config CPU_MODEL
+    default "atmega1284p" if CPU_MODEL_ATMEGA1284P
+
+config CPU
+    default "atmega1284p" if CPU_MODEL_ATMEGA1284P
+
+source "$(RIOTCPU)/atmega_common/Kconfig"

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -4,6 +4,7 @@ BOARD_WHITELIST += arduino-duemilanove \
                    arduino-mega2560 \
                    arduino-nano \
                    arduino-uno \
+                   atmega1284p \
                    atmega328p \
                    cc1312-launchpad \
                    cc1352-launchpad \
@@ -12,6 +13,7 @@ BOARD_WHITELIST += arduino-duemilanove \
                    cc2650stk \
                    derfmega128 \
                    ikea-tradfri \
+                   mega-xplained \
                    microduino-corerf \
                    samr21-xpro \
                    slstk3401a \
@@ -20,7 +22,8 @@ BOARD_WHITELIST += arduino-duemilanove \
                    slwstk6000b-slwrb4150a \
                    slwstk6000b-slwrb4162a \
                    stk3600 \
-                   stk3700
+                   stk3700 \
+                   waspmote-pro
 
 
 all: checks


### PR DESCRIPTION
### Contribution description
This models the features in Kconfig for all the boards based on the `atmega1281` and `atmega1284p` CPUs.
~~The first commit is from #14176, included for testing.~~

### Testing procedure
- `tests/kconfig_features` should pass for:
   - `atmega1284p`
   - `mega-xplained`
   - `waspmote-pro`

### Issues/PRs references
~~Depends on #14176~~