### PR TITLE
boards/cc26xx_cc13xx-based: model features in Kconfig

### DIFF
--- a/boards/cc1312-launchpad/Kconfig
+++ b/boards/cc1312-launchpad/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 Locha Inc
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "cc1312-launchpad" if BOARD_CC1312_LAUNCHPAD
+
+config BOARD_CC1312_LAUNCHPAD
+    bool
+    default y
+    select CPU_MODEL_CC1312R1F3
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/cc1352-launchpad/Kconfig
+++ b/boards/cc1352-launchpad/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 Locha Inc
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "cc1352-launchpad" if BOARD_CC1352_LAUNCHPAD
+
+config BOARD_CC1352_LAUNCHPAD
+    bool
+    default y
+    select CPU_MODEL_CC1352R1
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/cc1352p-launchpad/Kconfig
+++ b/boards/cc1352p-launchpad/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 Locha Inc
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "cc1352p-launchpad" if BOARD_CC1352P_LAUNCHPAD
+
+config BOARD_CC1352P_LAUNCHPAD
+    bool
+    default y
+    select CPU_MODEL_CC1352P1
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/cc2650-launchpad/Kconfig
+++ b/boards/cc2650-launchpad/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 Locha Inc
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "cc2650-launchpad" if BOARD_CC2650_LAUNCHPAD
+
+config BOARD_CC2650_LAUNCHPAD
+    bool
+    default y
+    select CPU_MODEL_CC26X0F128
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/cc2650stk/Kconfig
+++ b/boards/cc2650stk/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 Locha Inc
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "cc2650stk" if BOARD_CC2650STK
+
+config BOARD_CC2650STK
+    bool
+    default y
+    select CPU_MODEL_CC26X0F128
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/cpu/cc26x0/Kconfig
+++ b/cpu/cc26x0/Kconfig
@@ -1,0 +1,40 @@
+# Copyright (c) 2020 Locha Inc
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_FAMILY_CC26X0_CC13X0
+    bool
+    select CPU_CORE_CORTEX_M3
+    select CPU_COMMON_CC26XX_CC13XX
+    select HAS_CPU_CC26X0
+    select HAS_CORTEXM_MPU
+
+config CPU_SERIES_CC26X0
+    bool
+    select CPU_FAMILY_CC26X0_CC13X0
+
+## CPU Models
+config CPU_MODEL_CC26X0F128
+    bool
+    select CPU_SERIES_CC26X0
+
+## Definition of specific features
+config HAS_CPU_CC26X0
+    bool
+    help
+        Indicates that a 'cc26x0' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAMILY
+    default "cc26x0_cc13x0" if CPU_FAMILY_CC26X0_CC13X0
+
+config CPU_SERIES
+    default "cc26x0" if CPU_SERIES_CC26X0
+
+config CPU_MODEL
+    default "cc26x0f128" if CPU_MODEL_CC26X0F128
+
+source "$(RIOTCPU)/cc26xx_cc13xx/Kconfig"

--- a/cpu/cc26x2_cc13x2/Kconfig
+++ b/cpu/cc26x2_cc13x2/Kconfig
@@ -1,0 +1,50 @@
+# Copyright (c) 2020 Locha Inc
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_FAMILY_CC26X2_CC13X2
+    bool
+    select CPU_CORE_CORTEX_M4F
+    select CPU_COMMON_CC26XX_CC13XX
+    select HAS_CPU_CC26X2_CC13X2
+    select HAS_CORTEXM_MPU
+
+config CPU_SERIES_CC13X2
+    bool
+    select CPU_FAMILY_CC26X2_CC13X2
+
+## CPU Models
+config CPU_MODEL_CC1312R1F3
+    bool
+    select CPU_SERIES_CC13X2
+
+config CPU_MODEL_CC1352R1
+    bool
+    select CPU_SERIES_CC13X2
+
+config CPU_MODEL_CC1352P1
+    bool
+    select CPU_SERIES_CC13X2
+
+## Definition of specific features
+config HAS_CPU_CC26X2_CC13X2
+    bool
+    help
+        Indicates that a 'cc26x2_cc13x2' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAMILY
+    default "cc26x2_cc13x2" if CPU_FAMILY_CC26X2_CC13X2
+
+config CPU_SERIES
+    default "cc13x2" if CPU_SERIES_CC13X2
+
+config CPU_MODEL
+    default "cc1312r1f3" if CPU_MODEL_CC1312R1F3
+    default "cc1352r1" if CPU_MODEL_CC1352R1
+    default "cc1352p1" if CPU_MODEL_CC1352P1
+
+source "$(RIOTCPU)/cc26xx_cc13xx/Kconfig"

--- a/cpu/cc26xx_cc13xx/Kconfig
+++ b/cpu/cc26xx_cc13xx/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 Locha Inc
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_COMMON_CC26XX_CC13XX
+    bool
+    select HAS_PERIPH_CPUID
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_UART_MODECFG
+
+source "$(RIOTCPU)/cortexm_common/Kconfig"

--- a/cpu/cortexm_common/Kconfig
+++ b/cpu/cortexm_common/Kconfig
@@ -94,3 +94,8 @@ config HAS_CORTEXM_FPU
     bool
     help
         Indicates that a ARM Cortex-M FPU is present.
+
+config HAS_CORTEXM_MPU
+    bool
+    help
+        Indicates that a ARM Cortex-M MPU is present.

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -1,6 +1,12 @@
 include ../Makefile.tests_common
 
-BOARD_WHITELIST += samr21-xpro
+BOARD_WHITELIST += cc1312-launchpad \
+                   cc1352-launchpad \
+                   cc1352p-launchpad \
+                   cc2650-launchpad \
+                   cc2650stk \
+                   samr21-xpro
+
 
 all: kconfig-features
 


### PR DESCRIPTION
### Contribution description

This adds Kconfig symbol definitions for the `cc26xx_c13xx` CPUs and for boards based on that CPU.

### Testing procedure

- Green CI.
- `tests/kconfig_features` should pass.

### Issues/PRs references

#14148 