### PR TITLE
boards/arduino-mega2560: Model features in Kconfig

### DIFF
--- a/boards/arduino-mega2560/Kconfig
+++ b/boards/arduino-mega2560/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "arduino-mega2560" if BOARD_ARDUINO_MEGA2560
+
+config BOARD_ARDUINO_MEGA2560
+    bool
+    default y
+    select CPU_MODEL_ATMEGA2560
+    select BOARD_COMMON_ARDUINO_ATMEGA
+
+source "$(RIOTBOARD)/common/arduino-atmega/Kconfig"

--- a/cpu/atmega2560/Kconfig
+++ b/cpu/atmega2560/Kconfig
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config CPU_FAM_ATMEGA256
+    bool
+    select CPU_COMMON_ATMEGA
+
+## CPU Models
+config CPU_MODEL_ATMEGA2560
+    bool
+    select CPU_FAM_ATMEGA256
+    select HAS_ATMEGA_PCINT1
+    select HAS_ATMEGA_PCINT2
+    select HAS_CPU_ATMEGA2560
+
+## Definition of specific features
+config HAS_CPU_ATMEGA2560
+    bool
+    help
+        Indicates that a 'atmega2560' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "atmega256" if CPU_FAM_ATMEGA256
+
+config CPU_MODEL
+    default "atmega2560" if CPU_MODEL_ATMEGA2560
+
+config CPU
+    default "atmega2560" if CPU_FAM_ATMEGA256
+
+source "$(RIOTCPU)/atmega_common/Kconfig"

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
 BOARD_WHITELIST += arduino-duemilanove \
+                   arduino-mega2560 \
                    arduino-nano \
                    arduino-uno \
                    atmega328p \


### PR DESCRIPTION
### Contribution description
This models the features in Kconfig for the arduino-mega2560. ~~The first 2 commits are from #14176, they are included for testing.~~

### Testing procedure
- `tests/kconfig_features` should pass for `arduino-mega2560`.
- Check that the symbol organization is correct

### Issues/PRs references
~~Depends on #14176~~
