### PR TITLE
boards/weact-f411ce: enable automatic reset to bootloader

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -711,7 +711,7 @@ flash-only: $(FLASHDEPS)
 	$(flash-recipe)
 
 preflash: $(BUILD_BEFORE_FLASH)
-	$(PREFLASHER) $(PREFFLAGS)
+	$(PREFLASHER_PREFIX)$(PREFLASHER) $(PREFFLAGS)
 
 TERMFLASHDEPS ?= $(filter flash flash-only,$(MAKECMDGOALS))
 # Add TERMFLASHDEPS to TERMDEPS so it also applies to `test`

--- a/boards/common/samd21-arduino-bootloader/Makefile.include
+++ b/boards/common/samd21-arduino-bootloader/Makefile.include
@@ -8,21 +8,6 @@ ifeq ($(PROGRAMMER),bossa)
   # such bootloader.
   ROM_OFFSET ?= 0x2000
   BOSSA_ARDUINO_PREFLASH = yes
-  PREFLASH_DELAY = 1
-
-  ifneq (,$(filter reset flash flash-only, $(MAKECMDGOALS)))
-    # By default, add 2 seconds delay before opening terminal: this is required
-    # when opening the terminal right after flashing. In this case, the stdio
-    # over USB needs some time after reset before being ready.
-    TERM_DELAY ?= 2
-    TERMDEPS += term-delay
-  endif
 
   include $(RIOTMAKE)/tools/bossa.inc.mk
 endif
-
-term-delay:
-	sleep $(TERM_DELAY)
-
-TESTRUNNER_CONNECT_DELAY ?= $(TERM_DELAY)
-$(call target-export-variables,test,TESTRUNNER_CONNECT_DELAY)

--- a/boards/weact-f411ce/Makefile.dep
+++ b/boards/weact-f411ce/Makefile.dep
@@ -6,6 +6,12 @@ ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
   USEMODULE += stdio_cdc_acm
 endif
 
+ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
+  # The Mask-ROM bootloader provides USB-DFU capability
+  FEATURES_REQUIRED += bootloader_stm32
+  USEMODULE += usb_board_reset
+endif
+
 ifneq (,$(filter mtd,$(USEMODULE)))
   USEMODULE += mtd_spi_nor
 endif

--- a/boards/weact-f411ce/Makefile.include
+++ b/boards/weact-f411ce/Makefile.include
@@ -6,5 +6,9 @@ DFU_USB_ID ?= 0483:df11
 DFU_FLAGS  ?= -a 0 -s 0x08000000:leave
 ROM_OFFSET ?= 0x0
 
+# CDC ACM is available faster on STM32
+TERM_DELAY ?= 1
+
 # Setup of programmer and serial is shared between STM32 based boards
 include $(RIOTMAKE)/boards/stm32.inc.mk
+include $(RIOTMAKE)/tools/usb_board_reset.mk

--- a/boards/weact-f411ce/doc.txt
+++ b/boards/weact-f411ce/doc.txt
@@ -36,20 +36,24 @@ It is available on sites like AliExpress for less than 4€.
 ## Flashing the device
 The device comes with a bootloader that allows flashing via `dfu-util`.
 
-There are two buttons on the board labeled `BOOT0` and `NRST`.
-
- - Press and hold down `NRST` to reset the CPU
- - Press `BOOT0` while keeping `NRST` held down
- - Release `NRST`, afterwards release `BOOT0`
-
-The board will now show up as `0483:df11` - `STM32 BOOTLOADER` and will accept
-firmware using the DFU protocol.
-
-You can upload your RIOT-firmware by typing
+If RIOT is already running on the board, you can upload your RIOT-firmware by typing
 
 ```
 make BOARD=weact-f411ce flash
 ```
+
+RIOT will make sure to enter the bootloader automatically.
+
+If RIOT crashed or you have the plain board with the stock firmware, you have to enter
+the bootloader manually.
+
+There are two buttons on the board labeled `BOOT0` and `NRST`.
+
+ - Hold down `BOOT0`
+ - Shortly press `NRST` to reset the CPU while keeping `BOOT0` held down
+
+The board will now show up as `0483:df11` - `STM32 BOOTLOADER` and will accept
+firmware using the DFU protocol.
 
 *Note:* You need to have write permissions to the device.
 On Linux you could add yourself to the `plugdev` group and store the following as `/etc/udev/rules.d/99-weact-f411ce.rules`:

--- a/makefiles/tools/bossa.inc.mk
+++ b/makefiles/tools/bossa.inc.mk
@@ -13,26 +13,8 @@ FFLAGS  ?= -p $(PROG_DEV) $(FFLAGS_OPTS) -e -i -w -v -b -R $(FLASHFILE)
 # some arduino boards need to toggle the serial interface a little bit to get
 # them ready for flashing...
 ifneq (,$(BOSSA_ARDUINO_PREFLASH))
-  ifeq ($(OS),Linux)
-    STTY_FLAG = -F
-  else ifeq ($(OS),Darwin)
-    STTY_FLAG = -f
-  endif
-
-  PREFLASHER ?= stty
-  PREFFLAGS  ?= $(STTY_FLAG) $(PROG_DEV) raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
-  ifneq (,$(PREFLASH_DELAY))
-    FLASHDEPS += preflash-delay
-  else
-    FLASHDEPS += preflash
-  endif
-
-  RESETFFLASG ?= $(STTY_FLAG) $(PORT) raw ispeed 600 ospeed 600 cs8 -cstopb ignpar eol 255 eof 255
-  RESET ?= $(PREFLASHER) $(RESETFFLASG)
+include $(RIOTMAKE)/tools/usb_board_reset.mk
 endif
-
-preflash-delay: preflash
-	sleep $(PREFLASH_DELAY)
 
 # if we go with the default (BOSSA shipped with RIOT), we download and build
 # the tool if not already done

--- a/makefiles/tools/usb_board_reset.mk
+++ b/makefiles/tools/usb_board_reset.mk
@@ -1,0 +1,35 @@
+TERMDELAYDEPS := $(filter reset flash flash-only, $(MAKECMDGOALS))
+ifneq (,$(TERMDELAYDEPS))
+  # By default, add 2 seconds delay before opening terminal: this is required
+  # when opening the terminal right after flashing. In this case, the stdio
+  # over USB needs some time after reset before being ready.
+  TERM_DELAY ?= 2
+  TERMDEPS += term-delay
+endif
+
+ifeq ($(OS),Linux)
+  STTY_FLAG = -F
+else ifeq ($(OS),Darwin)
+  STTY_FLAG = -f
+endif
+
+# open the ttyACM device at 1200 baud to signal bootloader reset
+PREFLASHER ?= stty
+PREFFLAGS  ?= $(STTY_FLAG) $(PROG_DEV) raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
+PREFLASH_DELAY ?= 1
+# allow preflash to fail - bootloader can be entered manually
+PREFLASHER_PREFIX = -
+FLASHDEPS += preflash-delay
+
+# open the ttyACM device at 600 baud to signal application reset
+RESETFFLASG ?= $(STTY_FLAG) $(PORT) raw ispeed 600 ospeed 600 cs8 -cstopb ignpar eol 255 eof 255
+RESET ?= $(PREFLASHER) $(RESETFFLASG)
+
+TESTRUNNER_CONNECT_DELAY ?= $(TERM_DELAY)
+$(call target-export-variables,test,TESTRUNNER_CONNECT_DELAY)
+
+preflash-delay: preflash
+	sleep $(PREFLASH_DELAY)
+
+term-delay: $(TERMDELAYDEPS)
+	sleep $(TERM_DELAY)


### PR DESCRIPTION
### Contribution description

This enables to reset the `weact-f411ce` in bootloader mode using the same USB CDC ACM sequence already employed by samd/bossa boards.
For this, the usb reset sequence is moved to a common file.

### Testing procedure

Flash any application on the `weact-f411ce`.

A subsequent `make flash` will automatically reset the board in bootloader mode and flash the new application.
You don't have to press any buttons anymore.


### Issues/PRs references

depends on #14119
