### PR TITLE
pkg: add ZBOSS Zigbee stack

### DIFF
--- a/examples/zigbee-zll/Makefile
+++ b/examples/zigbee-zll/Makefile
@@ -1,0 +1,36 @@
+# name of your application
+APPLICATION = zigbee-zll
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= ikea-tradfri
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+# Include packages that pull up and auto-init the link layer.
+# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
+USEMODULE += gnrc_netdev_default
+USEMODULE += auto_init_gnrc_netif
+
+# Add also the shell, some shell commands
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+USEMODULE += netstats_l2
+
+USEPKG += zboss
+# for zboss nv storage
+FEATURES_OPTIONAL += periph_flashpage
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include
+
+# Set a custom channel if needed
+include $(RIOTMAKE)/default-radio-settings.inc.mk

--- a/examples/zigbee-zll/README.md
+++ b/examples/zigbee-zll/README.md
@@ -1,0 +1,4 @@
+# ZBOSS Zigbee ZLL example
+
+This example runs the ZBOSS stack as a ZLL lighting device. A ZLL
+controller can be paired with it and used to toggle the onboard LED.

--- a/examples/zigbee-zll/main.c
+++ b/examples/zigbee-zll/main.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2019 Thomas Stilwell <stilwellt@openlabs.co>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Example ZLL application for demonstrating the ZBOSS Zigbee stack
+ *
+ * @author      Thomas Stilwell <stilwellt@openlabs.co>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "msg.h"
+#include "led.h"
+
+#include "zb_common.h"
+#include "zb_aps.h"
+#include "zb_zcl.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#define MAIN_QUEUE_SIZE     (8)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+/* these commands are provided by the zboss stack */
+extern int zb_input_packet(int argc, char **argv);
+extern int zb_inject_packet(int argc, char **argv);
+extern int cmd_zconfig(int argc, char *argv[]);
+static const shell_command_t shell_commands[] = {
+    { "zconfig",      "ZBOSS configuration",         cmd_zconfig},
+    { "zigp",         "input a zigbee packet like 030806ffffffff07 (first byte is 15.4 FCF; do not include FCS)", zb_input_packet},
+    { "inj",          "inject a raw 802.15.4 packet like 030885ffffffff07 (first byte is 15.4 FCF; do not include FCS)", zb_inject_packet},
+    { NULL, NULL, NULL }
+};
+
+/* handle an indication from the zboss stack that we've received some data */
+void zb_data_indication(zb_uint8_t param)
+{
+    /* get the packet buffer corresponding to param */
+    zb_buf_t *buf = ZB_BUF_FROM_REF(param);
+
+    /* get the indication parameters attached to the packet buffer */
+    zb_apsde_data_indication_t *ind = ZB_GET_BUF_PARAM(buf,
+                                                    zb_apsde_data_indication_t);
+    DEBUG("got indication 0x%04x\n", ind->clusterid);
+
+    /* set pointers to the beginnings of the aps and zcl payloads */
+    zb_uint8_t *aps = ZB_BUF_BEGIN(buf);
+    zb_uint8_t *zcl = aps + zb_aps_full_hdr_size(aps);
+
+    uint8_t zcl_command;
+    switch (ind->clusterid) {
+        case 0x0019: /* zdo start */
+            /* don't free buf */
+            break;
+        case 0x0003: /* identify */
+            puts("got identify request");
+            zb_free_buf(buf);
+            break;
+
+        case 0x0004: /* groups */
+            zb_zcl_handle_group_request(param);
+            break;
+
+        case 0x0006: /* on/off */
+            zcl_command = zcl[2];
+            switch (zcl_command) {
+                case 0x0:
+                    LED0_OFF;
+                    puts("OFF");
+                    break;
+                case 0x1:
+                    LED0_ON;
+                    puts("ON");
+                    break;
+                case 0x2:
+                    LED0_TOGGLE;
+                    puts("TOGGLE");
+                    break;
+                default:
+                    printf("unhandled on/off command: 0x%x\n", zcl_command);
+            }
+            zb_free_buf(buf);
+            break;
+
+        case 0x0008: /* level control */
+            zcl_command = zcl[2];
+            switch (zcl_command) {
+                default:
+                    printf("unhandled level control command: 0x%x\n", zcl_command);
+            }
+            zb_free_buf(buf);
+            break;
+
+        case 0x0005: /* color change */
+            zcl_command = zcl[4];
+            switch (zcl_command) {
+                default:
+                    printf("unhandled color command: 0x%x\n", zcl_command);
+            }
+            zb_free_buf(buf);
+            break;
+
+        default:
+            printf("unhandled cluster: 0x%x\n", ind->clusterid);
+            zb_free_buf(buf);
+    }
+}
+
+int main(void)
+{
+    /* we need a message queue for the thread running the shell in order to
+     * receive potentially fast incoming networking packets */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+    puts("RIOT Zigbee ZLL example application");
+
+    /* start shell */
+    puts("All up, running the shell now");
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    /* should be never reached */
+    return 0;
+}

--- a/pkg/zboss/Makefile
+++ b/pkg/zboss/Makefile
@@ -1,0 +1,9 @@
+PKG_NAME=zboss
+PKG_URL=https://github.com/benemorius/zboss.git
+PKG_VERSION=9f8fe38db9182a9a29588f1bbb43fad39ae319e7
+PKG_LICENSE=GPL-2
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+all:
+	"$(MAKE)" -C $(PKG_SOURCE_DIR)

--- a/pkg/zboss/Makefile.dep
+++ b/pkg/zboss/Makefile.dep
@@ -1,0 +1,4 @@
+USEMODULE += zboss zboss-aps zboss-common zboss-mac zboss-nwk zboss-secur zboss-zcl zboss-zdo zboss-unix
+
+USEMODULE += memarray
+USEMODULE += xtimer

--- a/pkg/zboss/Makefile.include
+++ b/pkg/zboss/Makefile.include
@@ -1,0 +1,4 @@
+INCLUDES += -isystem$(PKGDIRBASE)/zboss/include
+INCLUDES += -isystem$(PKGDIRBASE)/zboss/osif/include
+
+CFLAGS += -DZB_PLATFORM_RIOT_ARM

--- a/pkg/zboss/doc.txt
+++ b/pkg/zboss/doc.txt
@@ -1,0 +1,6 @@
+/**
+ * @defgroup pkg_zboss  ZBOSS Zigbee stack
+ * @ingroup  pkg
+ * @brief    open-source Zigbee stack for embedded devices
+ * @see      https://github.com/benemorius/zboss
+ */

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -215,6 +215,12 @@ void auto_init(void)
         auto_init_gnrc_rpl();
     }
 
+    if (IS_USED(MODULE_ZBOSS)) {
+        LOG_DEBUG("Auto init ZBOSS.\n");
+        extern void zboss_init(void);
+        zboss_init();
+    }
+
     /* initialize storage devices */
     if (IS_USED(MODULE_AUTO_INIT_STORAGE)) {
         LOG_DEBUG("Auto init STORAGE.\n");

--- a/tests/pkg_zboss/Makefile
+++ b/tests/pkg_zboss/Makefile
@@ -1,0 +1,10 @@
+include ../Makefile.tests_common
+
+USEPKG += zboss
+
+# Include packages that pull up and auto-init the link layer.
+# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
+USEMODULE += gnrc_netdev_default
+USEMODULE += auto_init_gnrc_netif
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_zboss/main.c
+++ b/tests/pkg_zboss/main.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 Thomas Stilwell <stilwellt@openlabs.co>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @file
+ * @brief       Check if the ZBOSS package builds and the ZDO starts.
+ *
+ * @author      Thomas Stilwell <stilwellt@openlabs.co>
+ *
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+
+#include "xtimer.h"
+
+#include "zb_aps.h"
+#include "zb_common.h"
+
+static bool zboss_start_successful;
+
+void zb_data_indication(zb_uint8_t param)
+{
+    zb_buf_t *buf = ZB_BUF_FROM_REF(param);
+    zb_apsde_data_indication_t *ind = ZB_GET_BUF_PARAM(buf,
+                                                    zb_apsde_data_indication_t);
+
+    switch (ind->clusterid) {
+        case 0x0019: /* zdo start */
+            zboss_start_successful = true;
+            /* don't free buf */
+            break;
+
+        default:
+            zb_free_buf(buf);
+    }
+}
+
+int main(void)
+{
+    /* wait for ZDO to start */
+    xtimer_sleep(1);
+
+    if (zboss_start_successful) {
+        puts("SUCCESS: ZBOSS started");
+    } else {
+        puts("FAILED: ZBOSS start not successful");
+    }
+    return 0;
+}

--- a/tests/pkg_zboss/tests/01-run.py
+++ b/tests/pkg_zboss/tests/01-run.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact('SUCCESS: ZBOSS started')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description
This PR adds pkg support for [ZBOSS Zigbee stack](https://github.com/benemorius/zboss).

There are two extra commits that aren't meant to be merged. One adds radio support to the Tradfri platform to facilitate testing.

The other extra commit is the hack I've used to send raw packets. I don't know whether this is appropriate or if there's a better way. Feedback is appreciated.


### Testing procedure
Flash the new `zigbee-zll` example and try to pair a ZLL remote (Tradfri) to the Riot node.

I've tested with `kw41zrf`, `at86rf230`, `efr32`. It may work with other radios. The radio needs to support NETOPT_ACK_PENDING.

### Issues/PRs references
This PR includes #9212 just for testing purposes.