### PR TITLE
 net/gnrc/netif: add option for non-std 6lo MTU 

### DIFF
--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -152,6 +152,18 @@ extern "C" {
 #define CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US   (0U)
 #endif
 
+/**
+ * @brief   Enable the usage of non standard MTU for 6LoWPAN network interfaces
+ *
+ * @experimental
+ *
+ * This feature is non compliant with RFC 4944 and might not be supported by
+ * other implementations.
+ */
+#ifndef CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU
+#define CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU 0
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/netif/Kconfig
+++ b/sys/net/gnrc/netif/Kconfig
@@ -36,4 +36,12 @@ config GNRC_NETIF_MIN_WAIT_AFTER_SEND_US
         This value is expressed in microseconds. It is purely meant as a debugging
         feature to slow down a radios sending.
 
+config GNRC_NETIF_NONSTANDARD_6LO_MTU
+    bool "Enable usage of non standard MTU for 6LoWPAN network interfaces"
+    depends on MODULE_GNRC_NETIF_6LO
+    help
+        Enables the usage of non standard MTU for 6LoWPAN network interfaces.
+        This is non compliant with RFC 4944 and might not be supported by other
+        implementations.
+
 endif # KCONFIG_MODULE_GNRC_NETIF

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1304,7 +1304,11 @@ static void _test_options(gnrc_netif_t *netif)
                    (IEEE802154_LONG_ADDRESS_LEN == netif->l2addr_len));
 #if IS_USED(MODULE_GNRC_NETIF_IPV6)
 #if IS_USED(MODULE_GNRC_NETIF_6LO)
+#if IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU)
             assert(netif->ipv6.mtu >= IPV6_MIN_MTU);
+#else /* IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU) */
+            assert(netif->ipv6.mtu == IPV6_MIN_MTU);
+#endif /* IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU) */
             assert(netif->sixlo.max_frag_size > 0);
             assert(-ENOTSUP != netif->dev->driver->get(netif->dev, NETOPT_PROTO,
                                                        &tmp, sizeof(tmp)));

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1309,7 +1309,6 @@ static void _test_options(gnrc_netif_t *netif)
 #else /* IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU) */
             assert(netif->ipv6.mtu == IPV6_MIN_MTU);
 #endif /* IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU) */
-            assert(netif->sixlo.max_frag_size > 0);
             assert(-ENOTSUP != netif->dev->driver->get(netif->dev, NETOPT_PROTO,
                                                        &tmp, sizeof(tmp)));
 #else   /* IS_USED(MODULE_GNRC_NETIF_6LO) */

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -26,8 +26,12 @@
 #include "net/ethernet.h"
 #include "net/ieee802154.h"
 #include "net/l2util.h"
+#if IS_USED(MODULE_GNRC_NETIF_6LO)
+#include "net/sixlowpan.h"
+#endif
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 netopt_t gnrc_netif_get_l2addr_opt(const gnrc_netif_t *netif)
 {
@@ -145,7 +149,7 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
             assert(res == sizeof(tmp));
 #if IS_USED(MODULE_GNRC_NETIF_6LO)
             netif->ipv6.mtu = MAX(IPV6_MIN_MTU, tmp);
-            netif->sixlo.max_frag_size = tmp;
+            netif->sixlo.max_frag_size = MIN(SIXLOWPAN_FRAG_MAX_LEN, tmp);
 #else   /* IS_USED(MODULE_GNRC_NETIF_6LO) */
             netif->ipv6.mtu = tmp;
 #endif  /* IS_USED(MODULE_GNRC_NETIF_6LO) */

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -148,7 +148,11 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
                                    &tmp, sizeof(tmp));
             assert(res == sizeof(tmp));
 #if IS_USED(MODULE_GNRC_NETIF_6LO)
+#if IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU)
             netif->ipv6.mtu = MAX(IPV6_MIN_MTU, tmp);
+#else /* IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU) */
+            netif->ipv6.mtu = IPV6_MIN_MTU;
+#endif /* IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU) */
             netif->sixlo.max_frag_size = MIN(SIXLOWPAN_FRAG_MAX_LEN, tmp);
 #else   /* IS_USED(MODULE_GNRC_NETIF_6LO) */
             netif->ipv6.mtu = tmp;

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -153,7 +153,15 @@ void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
 #else /* IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU) */
             netif->ipv6.mtu = IPV6_MIN_MTU;
 #endif /* IS_ACTIVE(CONFIG_GNRC_NETIF_NONSTANDARD_6LO_MTU) */
-            netif->sixlo.max_frag_size = MIN(SIXLOWPAN_FRAG_MAX_LEN, tmp);
+            if (tmp >= netif->ipv6.mtu) {
+                /* When the L2-PDU is higher or equal to the IPv6 MTU, disable
+                 * 6Lo fragmentation, this generally applies to 802.15.4g
+                 * devices with a big L2-PDU */
+                netif->sixlo.max_frag_size = 0;
+            }
+            else {
+                netif->sixlo.max_frag_size = MIN(SIXLOWPAN_FRAG_MAX_LEN, tmp);
+            }
 #else   /* IS_USED(MODULE_GNRC_NETIF_6LO) */
             netif->ipv6.mtu = tmp;
 #endif  /* IS_USED(MODULE_GNRC_NETIF_6LO) */


### PR DESCRIPTION
### Contribution description

This adds a new configuration option for `net/gnrc/netif` to enable the usage of non-standard MTU sizes (>1280).

Also adds an upper limit for 6LoWPAN `max_frag_size` as it's only 11-bits (2047 is the max length).

### Testing procedure

- Green CI
- MTU should still be compliant with the standard, this option is disabled by default.
- `make menuconfig`, navigate to GNRC configuration and enable it. This way 6lowpan interfaces will have a >1280 MTU when the L2-PDU is larger than that.

### Issues/PRs references

See also #14190 , #14164 , #14172 
