### PR TITLE
usbus/cdc/acm: correct return expression of stdio_write

### DIFF
--- a/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
@@ -67,7 +67,7 @@ ssize_t stdio_write(const void* buffer, size_t len)
         buffer = (char *)buffer + n;
         len -= n;
     } while (len);
-    return start - (char *)buffer;
+    return (char *)buffer - start;
 }
 
 static void _cdc_acm_rx_pipe(usbus_cdcacm_device_t *cdcacm,


### PR DESCRIPTION
### Contribution description

This is a correction of `stdio_write` in `cdc_acm_stdio.c` where the expression in the return had the operands reversed.

### Testing procedure

Use a board that uses USB for stdio. And run `tests/periph_gpio`. Enter "bench 0 0" and see that the output ends with:
```
2020-06-07 12:00:39,142 #                 gpio_read:     49946us  ---   0.049us per call  ---   20021623 calls per sec
2020-06-07 12:00:39,143 #                gpio_write:     32148us  ---   0.032us per call  ---   31106134 calls per sec
2020-06-07 12:00:39,143 # 
> 
```
There is a missing "-- DONE -- "

With this bugfix, the output is:
```
2020-06-07 11:58:27,082 #                 gpio_read:     49946us  ---   0.049us per call  ---   20021623 calls per sec
2020-06-07 11:58:27,084 #                gpio_write:     32149us  ---   0.032us per call  ---   31105166 calls per sec
2020-06-07 11:58:27,084 # 
2020-06-07 11:58:27,084 #  --- DONE ---
> 
```

### Issues/PRs references

Fixes #14184
