### PR TITLE
tests/periph_uart_nonblocking: relax time requirement a bit

### DIFF
--- a/tests/periph_uart_nonblocking/tests/01-run.py
+++ b/tests/periph_uart_nonblocking/tests/01-run.py
@@ -10,12 +10,15 @@ import sys
 from testrunner import run
 
 
+PRECISION = 1.002
+
+
 def testfunc(child):
     child.expect(r'== printed in (\d+)/(\d+) µs ==')
     time_actual = int(child.match.group(1))
     time_expect = int(child.match.group(2))
 
-    assert time_actual / time_expect < 1.0015
+    assert time_actual / time_expect < PRECISION
 
     child.expect_exact("[SUCCESS]")
 


### PR DESCRIPTION
### Contribution description

With SAMD21 + CDC ACM the test reports
    == printed in 2103454/2100000 µs ==
Which failed to match the requirement of <1.0015, because it computes to 1.0016109523809524.

This commit relaxes the requirement to <1.002

### Testing procedure

Run `tests/periph_uart_nonblocking` with `compile_and_test_for_board`. Choose a SAMD21 board, e.g. sodaq-autonomo. It will fail because it takes slightly longer than what is required by
```
    assert time_actual / time_expect < 1.0015
```
In this commit the precision is relaxed a little bit to 1.002
