### PR TITLE
boards/common/sodaq: add XTIMER_DEV and make it equal to other SAMD21

### DIFF
--- a/boards/common/sodaq/include/board_common.h
+++ b/boards/common/sodaq/include/board_common.h
@@ -26,6 +26,14 @@ extern "C" {
 #endif
 
 /**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_DEV          TIMER_DEV(1)
+#define XTIMER_CHAN         (0)
+/** @} */
+
+/**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);


### PR DESCRIPTION

### Contribution description
Add a missing define for `XTIMER_DEV`. For some reason this was looked over a while back (commit 38395fa9bb)

### Testing procedure

Use `tests/periph_timer_periodic`, it should succeed.

### Issues/PRs references

The resolves issue #14217 
