### PR TITLE
pkg/lwip: add support for nrf802154

### DIFF
--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -55,6 +55,10 @@
 #include "stm32_eth.h"
 #endif
 
+#ifdef MODULE_NRF802154
+#include "nrf802154.h"
+#endif
+
 #include "lwip.h"
 
 #define ENABLE_DEBUG    (0)
@@ -89,6 +93,10 @@
 #endif
 
 #ifdef MODULE_STM32_ETH
+#define LWIP_NETIF_NUMOF        (1)
+#endif
+
+#ifdef MODULE_NRF802154
 #define LWIP_NETIF_NUMOF        (1)
 #endif
 
@@ -129,6 +137,10 @@ extern void esp_wifi_setup(esp_wifi_netdev_t *dev);
 #ifdef MODULE_STM32_ETH
 static netdev_t stm32_eth;
 extern void stm32_eth_netdev_setup(netdev_t *netdev);
+#endif
+
+#ifdef MODULE_NRF802154
+extern netdev_ieee802154_t nrf802154_dev;
 #endif
 
 void lwip_bootstrap(void)
@@ -233,6 +245,12 @@ void lwip_bootstrap(void)
         return;
     }
 #endif /* MODULE_LWIP_IPV4 */
+#elif defined(MODULE_NRF802154)
+    if (netif_add(&netif[0], &nrf802154_dev, lwip_netdev_init,
+                tcpip_6lowpan_input) == NULL) {
+        DEBUG("Could not add nrf802154 device\n");
+        return;
+    }
 #endif
     if (netif[0].state != NULL) {
         /* state is set to a netdev_t in the netif_add() functions above */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds the missing support for nrf802154 radios in the lwip package. Without this PR, no interface is automatically configured when building and running `tests/lwip`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build and flash `tests/lwip` on an nrf52840 CPU based board and check the interface is configured using the `ifconfig` provided by the shell:

<details><summary>this PR:</summary>

```
make BOARD=nrf52840-mdk -C tests/lwip flash term --no-print-directory 
Building application "tests_lwip" for "nrf52840-mdk" with MCU "nrf52".

make[1]: Nothing to be done for 'prepare'.
"make" -C /work/riot/RIOT/pkg/lwip
"make" -f /work/riot/RIOT/Makefile.base MODULE=lwip_api -C /work/riot/RIOT/tests/lwip/bin/pkg/nrf52840-mdk/lwip/src/api
"make" -f /work/riot/RIOT/Makefile.base MODULE=lwip_core -C /work/riot/RIOT/tests/lwip/bin/pkg/nrf52840-mdk/lwip/src/core
"make" -f /work/riot/RIOT/Makefile.base MODULE=lwip_ipv6 -C /work/riot/RIOT/tests/lwip/bin/pkg/nrf52840-mdk/lwip/src/core/ipv6
"make" -f /work/riot/RIOT/Makefile.base MODULE=lwip_netif -C /work/riot/RIOT/tests/lwip/bin/pkg/nrf52840-mdk/lwip/src/netif
"make" -f /work/riot/RIOT/Makefile.base MODULE=lwip -C /work/riot/RIOT/tests/lwip/bin/pkg/nrf52840-mdk/lwip
"make" -C /work/riot/RIOT/boards/nrf52840-mdk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/nrf52
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf52/periph
"make" -C /work/riot/RIOT/cpu/nrf52/radio/nrf802154
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/netdev_ieee802154
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/pkg/lwip/contrib
"make" -C /work/riot/RIOT/pkg/lwip/contrib/netdev
"make" -C /work/riot/RIOT/pkg/lwip/contrib/sock
"make" -C /work/riot/RIOT/pkg/lwip/contrib/sock/ip
"make" -C /work/riot/RIOT/pkg/lwip/contrib/sock/tcp
"make" -C /work/riot/RIOT/pkg/lwip/contrib/sock/udp
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/event
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/luid
"make" -C /work/riot/RIOT/sys/net/link_layer/ieee802154
"make" -C /work/riot/RIOT/sys/net/link_layer/l2util
"make" -C /work/riot/RIOT/sys/net/network_layer/ipv6/addr
"make" -C /work/riot/RIOT/sys/net/sock/async/event
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/od
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/random
"make" -C /work/riot/RIOT/sys/random/tinymt32
"make" -C /work/riot/RIOT/sys/sema
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  91700	    192	  19040	 110932	  1b154	/work/riot/RIOT/tests/lwip/bin/nrf52840-mdk/tests_lwip.elf
/work/riot/RIOT/dist/tools/pyocd/pyocd.sh flash /work/riot/RIOT/tests/lwip/bin/nrf52840-mdk/tests_lwip.hex
### Flashing Target ###
[====================] 100%
0007156:INFO:loader:Erased 0 bytes (0 sectors), programmed 0 bytes (0 pages), skipped 94208 bytes (23 pages) at 13.77 kB/s
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-06-08 09:39:34,158 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
help
2020-06-08 09:39:36,842 # help
2020-06-08 09:39:36,844 # Command              Description
2020-06-08 09:39:36,848 # ---------------------------------------
2020-06-08 09:39:36,854 # ip                   Send IP packets and listen for packets of certain type
2020-06-08 09:39:36,861 # tcp                  Send TCP messages and listen for messages on TCP port
2020-06-08 09:39:36,867 # udp                  Send UDP messages and listen for messages on UDP port
2020-06-08 09:39:36,872 # ifconfig             Shows assigned IPv6 addresses
2020-06-08 09:39:36,875 # reboot               Reboot the node
2020-06-08 09:39:36,879 # version              Prints current RIOT_VERSION
2020-06-08 09:39:36,884 # pm                   interact with layered PM subsystem
2020-06-08 09:39:36,890 # ps                   Prints information about running threads.
2020-06-08 09:39:36,893 # random_init          initializes the PRNG
2020-06-08 09:39:36,899 # random_get           returns 32 bit of pseudo randomness
> ifconfig
2020-06-08 09:39:39,242 #  ifconfig
2020-06-08 09:39:39,246 # L6_00:  inet6 fe80::2eb:6d8f:e39c:8a0a
2020-06-08 09:39:39,246 # 
> 2020-06-08 09:39:41,599 # Exiting Pyterm
```

</details>

<details><summary>master:</summary>

```
make BOARD=nrf52840-mdk -C tests/lwip flash term --no-print-directory 
Building application "tests_lwip" for "nrf52840-mdk" with MCU "nrf52".

make[1]: Nothing to be done for 'prepare'.
"make" -C /work/riot/RIOT/pkg/lwip
"make" -f /work/riot/RIOT/Makefile.base MODULE=lwip_api -C /work/riot/RIOT/tests/lwip/bin/pkg/nrf52840-mdk/lwip/src/api
"make" -f /work/riot/RIOT/Makefile.base MODULE=lwip_core -C /work/riot/RIOT/tests/lwip/bin/pkg/nrf52840-mdk/lwip/src/core
"make" -f /work/riot/RIOT/Makefile.base MODULE=lwip_ipv6 -C /work/riot/RIOT/tests/lwip/bin/pkg/nrf52840-mdk/lwip/src/core/ipv6
"make" -f /work/riot/RIOT/Makefile.base MODULE=lwip_netif -C /work/riot/RIOT/tests/lwip/bin/pkg/nrf52840-mdk/lwip/src/netif
"make" -f /work/riot/RIOT/Makefile.base MODULE=lwip -C /work/riot/RIOT/tests/lwip/bin/pkg/nrf52840-mdk/lwip
"make" -C /work/riot/RIOT/boards/nrf52840-mdk
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/nrf52
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf52/periph
"make" -C /work/riot/RIOT/cpu/nrf52/radio/nrf802154
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/netdev_ieee802154
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/pkg/lwip/contrib
"make" -C /work/riot/RIOT/pkg/lwip/contrib/netdev
"make" -C /work/riot/RIOT/pkg/lwip/contrib/sock
"make" -C /work/riot/RIOT/pkg/lwip/contrib/sock/ip
"make" -C /work/riot/RIOT/pkg/lwip/contrib/sock/tcp
"make" -C /work/riot/RIOT/pkg/lwip/contrib/sock/udp
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/sys/event
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/luid
"make" -C /work/riot/RIOT/sys/net/link_layer/ieee802154
"make" -C /work/riot/RIOT/sys/net/link_layer/l2util
"make" -C /work/riot/RIOT/sys/net/network_layer/ipv6/addr
"make" -C /work/riot/RIOT/sys/net/sock/async/event
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/od
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/random
"make" -C /work/riot/RIOT/sys/random/tinymt32
"make" -C /work/riot/RIOT/sys/sema
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  64948	    140	  15724	  80812	  13bac	/work/riot/RIOT/tests/lwip/bin/nrf52840-mdk/tests_lwip.elf
/work/riot/RIOT/dist/tools/pyocd/pyocd.sh flash /work/riot/RIOT/tests/lwip/bin/nrf52840-mdk/tests_lwip.hex
### Flashing Target ###
[====================] 100%
0006129:INFO:loader:Erased 65536 bytes (16 sectors), programmed 65536 bytes (16 pages), skipped 0 bytes (0 pages) at 11.27 kB/s
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-06-08 09:40:23,931 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
help
2020-06-08 09:40:27,346 # help
2020-06-08 09:40:27,349 # Command              Description
2020-06-08 09:40:27,352 # ---------------------------------------
2020-06-08 09:40:27,359 # ip                   Send IP packets and listen for packets of certain type
2020-06-08 09:40:27,365 # tcp                  Send TCP messages and listen for messages on TCP port
2020-06-08 09:40:27,372 # udp                  Send UDP messages and listen for messages on UDP port
2020-06-08 09:40:27,376 # ifconfig             Shows assigned IPv6 addresses
2020-06-08 09:40:27,379 # reboot               Reboot the node
2020-06-08 09:40:27,384 # version              Prints current RIOT_VERSION
2020-06-08 09:40:27,389 # pm                   interact with layered PM subsystem
2020-06-08 09:40:27,394 # ps                   Prints information about running threads.
2020-06-08 09:40:27,398 # random_init          initializes the PRNG
2020-06-08 09:40:27,403 # random_get           returns 32 bit of pseudo randomness
> ifconfig
2020-06-08 09:40:29,603 #  ifconfig
> 2020-06-08 09:40:31,272 # Exiting Pyterm
```

</details>

**Side note:** if the board is behind a border router (also nrf52840 based), a global ipv6 address is also correctly configured with this PR but ping doesn't work neither from the host nor from the BR itself. Should this work as well ? If yes, what is missing then ?

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

I wanted to try #12647 on a nrf52840 based setup.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
