### PR TITLE
boards/esp-based: Model features in Kconfig

### DIFF
--- a/boards/common/esp32/Kconfig
+++ b/boards/common/esp32/Kconfig
@@ -1,0 +1,12 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_COMMON_ESP32
+    bool
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_UART_MODECFG

--- a/boards/common/esp32/Makefile.features
+++ b/boards/common/esp32/Makefile.features
@@ -6,8 +6,3 @@ FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_gpio_irq
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_uart_modecfg
-
-# other features provided by all boards
-FEATURES_PROVIDED += esp_spiffs
-FEATURES_PROVIDED += esp_wifi
-FEATURES_PROVIDED += esp_now

--- a/boards/common/esp32/Makefile.features
+++ b/boards/common/esp32/Makefile.features
@@ -1,5 +1,4 @@
 CPU = esp32
-CPU_MODEL = esp32
 
 # additional features provided by all boards are GPIOs and at least one UART
 FEATURES_PROVIDED += periph_gpio

--- a/boards/common/esp8266/Kconfig
+++ b/boards/common/esp8266/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_COMMON_ESP8266
+    bool
+    select HAS_ARDUINO
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_UART_MODECFG

--- a/boards/common/esp8266/Makefile.features
+++ b/boards/common/esp8266/Makefile.features
@@ -1,5 +1,4 @@
 CPU = esp8266
-CPU_MODEL = esp8266
 
 # MCU defined peripheral features provided by all boards in alphabetical order
 

--- a/boards/esp32-heltec-lora32-v2/Kconfig
+++ b/boards/esp32-heltec-lora32-v2/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32-heltec-lora32-v2" if BOARD_ESP32_HELTEC_LORA32_V2
+
+config BOARD_ESP32_HELTEC_LORA32_V2
+    bool
+    default y
+    select BOARD_COMMON_ESP32
+    select CPU_MODEL_ESP32_D0WD
+    select HAS_ARDUINO
+    select HAS_ESP_RTC_TIMER_32K
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+
+source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-heltec-lora32-v2/Makefile.features
+++ b/boards/esp32-heltec-lora32-v2/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = esp32-d0wd
+
 # common board and CPU features
 include $(RIOTBOARD)/common/esp32/Makefile.features
 

--- a/boards/esp32-mh-et-live-minikit/Kconfig
+++ b/boards/esp32-mh-et-live-minikit/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32-mh-et-live-minikit" if BOARD_ESP32_MH_ET_LIVE_MINIKIT
+
+config BOARD_ESP32_MH_ET_LIVE_MINIKIT
+    bool
+    default y
+    select BOARD_COMMON_ESP32
+    select CPU_MODEL_ESP32_WROOM_32
+    select HAS_ARDUINO
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+
+source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-mh-et-live-minikit/Makefile.features
+++ b/boards/esp32-mh-et-live-minikit/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = esp32-wroom_32
+
 # common board and CPU features
 include $(RIOTBOARD)/common/esp32/Makefile.features
 

--- a/boards/esp32-olimex-evb/Kconfig
+++ b/boards/esp32-olimex-evb/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32-olimex-evb" if BOARD_ESP32_OLIMEX_EVB
+
+config BOARD_ESP32_OLIMEX_EVB
+    bool
+    default y
+    select BOARD_COMMON_ESP32
+    select CPU_MODEL_ESP32_WROOM_32
+    select HAS_ARDUINO
+    select HAS_PERIPH_ADC if MODULE_OLIMEX_ESP32_GATEWAY
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_ETH
+    select HAS_PERIPH_CAN
+    select HAS_PERIPH_IR
+
+source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-olimex-evb/Makefile.features
+++ b/boards/esp32-olimex-evb/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = esp32-wroom_32
+
 # common board and CPU features
 include $(RIOTBOARD)/common/esp32/Makefile.features
 

--- a/boards/esp32-ttgo-t-beam/Kconfig
+++ b/boards/esp32-ttgo-t-beam/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32-ttgo-t-beam" if BOARD_ESP32_TTGO_T_BEAM
+
+config BOARD_ESP32_TTGO_T_BEAM
+    bool
+    default y
+    select BOARD_COMMON_ESP32
+    select CPU_MODEL_ESP32_D0WD
+    select HAS_ARDUINO
+    select HAS_ESP_SPI_RAM
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-ttgo-t-beam/Makefile.features
+++ b/boards/esp32-ttgo-t-beam/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = esp32-d0wd
+
 # common board and CPU features
 include $(RIOTBOARD)/common/esp32/Makefile.features
 

--- a/boards/esp32-wemos-lolin-d32-pro/Kconfig
+++ b/boards/esp32-wemos-lolin-d32-pro/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32-wemos-lolin-d32-pro" if BOARD_ESP32_WEMOS_LOLIN_D32_PRO
+
+config BOARD_ESP32_WEMOS_LOLIN_D32_PRO
+    bool
+    default y
+    select BOARD_COMMON_ESP32
+    select CPU_MODEL_ESP32_WROVER
+    select HAS_ARDUINO
+    select HAS_ESP_SPI_RAM
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+
+source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-wemos-lolin-d32-pro/Makefile.features
+++ b/boards/esp32-wemos-lolin-d32-pro/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = esp32-wrover
+
 # common board and CPU features
 include $(RIOTBOARD)/common/esp32/Makefile.features
 

--- a/boards/esp32-wroom-32/Kconfig
+++ b/boards/esp32-wroom-32/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32-wroom-32" if BOARD_ESP32_WROOM_32
+
+config BOARD_ESP32_WROOM_32
+    bool
+    default y
+    select BOARD_COMMON_ESP32
+    select CPU_MODEL_ESP32_WROOM_32
+    select HAS_ARDUINO
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+
+source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-wroom-32/Makefile.features
+++ b/boards/esp32-wroom-32/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = esp32-wroom_32
+
 # common board and CPU features
 include $(RIOTBOARD)/common/esp32/Makefile.features
 

--- a/boards/esp32-wrover-kit/Kconfig
+++ b/boards/esp32-wrover-kit/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32-wrover-kit" if BOARD_ESP32_WROVER_KIT
+
+config BOARD_ESP32_WROVER_KIT
+    bool
+    default y
+    select BOARD_COMMON_ESP32
+    select CPU_MODEL_ESP32_WROVER
+    select HAS_ARDUINO
+    select HAS_ESP_RTC_TIMER_32K
+    select HAS_ESP_SPI_RAM
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_SDCARD_SPI
+
+source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-wrover-kit/Makefile.features
+++ b/boards/esp32-wrover-kit/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = esp32-wrover
+
 # common board and CPU features
 include $(RIOTBOARD)/common/esp32/Makefile.features
 

--- a/boards/esp8266-esp-12x/Kconfig
+++ b/boards/esp8266-esp-12x/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp8266-esp-12x" if BOARD_ESP8266_ESP_12X
+
+config BOARD_ESP8266_ESP_12X
+    bool
+    default y
+    select BOARD_COMMON_ESP8266
+    select CPU_MODEL_ESP8266_ESP_12X
+
+source "$(RIOTBOARD)/common/esp8266/Kconfig"

--- a/boards/esp8266-esp-12x/Makefile.features
+++ b/boards/esp8266-esp-12x/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = esp8266-esp-12x
+
 # Board provides all common peripheral features defined for all ESP8266 boards
 
 include $(RIOTBOARD)/common/esp8266/Makefile.features

--- a/boards/esp8266-olimex-mod/Kconfig
+++ b/boards/esp8266-olimex-mod/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp8266-olimex-mod" if BOARD_ESP8266_OLIMEX_MOD
+
+config BOARD_ESP8266_OLIMEX_MOD
+    bool
+    default y
+    select BOARD_COMMON_ESP8266
+    select CPU_MODEL_ESP8266_ESP_12X
+
+source "$(RIOTBOARD)/common/esp8266/Kconfig"

--- a/boards/esp8266-olimex-mod/Makefile.features
+++ b/boards/esp8266-olimex-mod/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = esp8266-esp-12x
+
 # Board provides all common peripheral features defined for all ESP8266 boards
 
 include $(RIOTBOARD)/common/esp8266/Makefile.features

--- a/boards/esp8266-sparkfun-thing/Kconfig
+++ b/boards/esp8266-sparkfun-thing/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp8266-sparkfun-thing" if BOARD_ESP8266_SPARKFUN_THING
+
+config BOARD_ESP8266_SPARKFUN_THING
+    bool
+    default y
+    select BOARD_COMMON_ESP8266
+    select CPU_MODEL_ESP8266EX
+
+source "$(RIOTBOARD)/common/esp8266/Kconfig"

--- a/boards/esp8266-sparkfun-thing/Makefile.features
+++ b/boards/esp8266-sparkfun-thing/Makefile.features
@@ -1,3 +1,5 @@
+CPU_MODEL = esp8266ex
+
 # Board provides all common peripheral features defined for all ESP8266 boards
 
 include $(RIOTBOARD)/common/esp8266/Makefile.features

--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -1,0 +1,84 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config CPU_CORE_XTENSA_LX6
+    bool
+    select CPU_ARCH_XTENSA
+
+config CPU_FAM_ESP32
+    bool
+    select CPU_CORE_XTENSA_LX6
+    select CPU_COMMON_ESP
+    select HAS_ARCH_ESP32
+    select HAS_CPU_ESP32
+    select HAS_ESP_WIFI_ENTERPRISE
+    select HAS_PERIPH_ADC_CTRL
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+
+## CPU Models
+config CPU_MODEL_ESP32_WROOM_32
+    bool
+    select CPU_FAM_ESP32
+
+config CPU_MODEL_ESP32_WROVER
+    bool
+    select CPU_FAM_ESP32
+
+config CPU_MODEL_ESP32_D0WD
+    bool
+    select CPU_FAM_ESP32
+
+## Definition of specific features
+config HAS_ARCH_ESP32
+    bool
+    help
+        Indicates that the current architecture is ESP32.
+
+config HAS_CPU_ESP32
+    bool
+    help
+        Indicates that the current CPU is 'esp32'.
+
+config HAS_ESP_RTC_TIMER_32K
+    bool
+    help
+        Indicates that an external 32.768 kHz crystal is connected to the ESP32
+        in the board.
+
+config HAS_ESP_SPI_RAM
+    bool
+    help
+        Indicates that an external RAM is connected via the FSPI interface in
+        the board.
+
+config HAS_ESP_WIFI_ENTERPRISE
+    bool
+    help
+        Indicates that the platform supports WPA2 enterprise mode for the WiFi
+        interface.
+
+config HAS_PERIPH_ADC_CTRL
+    bool
+    help
+        Indicates that an ESP32 ADC controller peripheral is present.
+
+## Common CPU symbols
+config CPU_CORE
+    default "xtensa-lx6" if CPU_CORE_XTENSA_LX6
+
+config CPU_FAM
+    default "esp32" if CPU_FAM_ESP32
+
+config CPU_MODEL
+    default "esp32-wroom_32" if CPU_MODEL_ESP32_WROOM_32
+    default "esp32-wrover" if CPU_MODEL_ESP32_WROVER
+    default "esp32-d0wd" if CPU_MODEL_ESP32_D0WD
+
+config CPU
+    default "esp32" if CPU_FAM_ESP32
+
+source "$(RIOTCPU)/esp_common/Kconfig"

--- a/cpu/esp32/Makefile.features
+++ b/cpu/esp32/Makefile.features
@@ -1,3 +1,5 @@
+CPU_FAM = esp32
+
 # MCU defined features that are provided independent on board definitions
 
 include $(RIOTCPU)/esp_common/Makefile.features

--- a/cpu/esp8266/Kconfig
+++ b/cpu/esp8266/Kconfig
@@ -1,0 +1,54 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config CPU_CORE_XTENSA_L106
+    bool
+    select CPU_ARCH_XTENSA
+
+config CPU_FAM_ESP8266
+    bool
+    select CPU_CORE_XTENSA_L106
+    select CPU_COMMON_ESP
+    select HAS_ARCH_ESP8266
+    select HAS_CPU_ESP8266
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_RTC
+
+## CPU Models
+config CPU_MODEL_ESP8266EX
+    bool
+    select CPU_FAM_ESP8266
+
+config CPU_MODEL_ESP8266_ESP_12X
+    bool
+    select CPU_FAM_ESP8266
+
+## Definition of specific features
+config HAS_ARCH_ESP8266
+    bool
+    help
+        Indicates that the current architecture is ESP8266.
+
+config HAS_CPU_ESP8266
+    bool
+    help
+        Indicates that the current CPU is 'esp8266'.
+
+## Common CPU symbols
+config CPU_CORE
+    default "xtensa-l106" if CPU_CORE_XTENSA_L106
+
+config CPU_FAM
+    default "esp8266" if CPU_FAM_ESP8266
+
+config CPU_MODEL
+    default "esp8266ex" if CPU_MODEL_ESP8266EX
+    default "esp8266-esp-12x" if CPU_MODEL_ESP8266_ESP_12X
+
+config CPU
+    default "esp8266" if CPU_FAM_ESP8266
+
+source "$(RIOTCPU)/esp_common/Kconfig"

--- a/cpu/esp8266/Makefile.features
+++ b/cpu/esp8266/Makefile.features
@@ -1,3 +1,5 @@
+CPU_FAM = esp8266
+
 # MCU defined features that are provided independent on board definitions
 
 include $(RIOTCPU)/esp_common/Makefile.features

--- a/cpu/esp_common/Kconfig
+++ b/cpu/esp_common/Kconfig
@@ -1,0 +1,48 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config CPU_ARCH_XTENSA
+    bool
+    select HAS_ARCH_32BIT
+    select HAS_ARCH_ESP
+
+config CPU_COMMON_ESP
+    bool
+    select HAS_CPP
+    select HAS_ESP_NOW
+    select HAS_ESP_SPIFFS
+    select HAS_ESP_WIFI
+    select HAS_PERIPH_CPUID
+    select HAS_PERIPH_HWRNG
+    select HAS_PERIPH_PM
+    select HAS_PERIPH_TIMER
+    select HAS_SSP
+
+## Declaration of specific features
+config HAS_ESP_SPIFFS
+    bool
+    help
+        Indicates that a Serial Peripheral Interface Flash File System can be
+        used.
+
+config HAS_ESP_WIFI
+    bool
+    help
+        Indicates that an ESP WiFi radio is present.
+
+config HAS_ESP_NOW
+    bool
+    help
+        Indicates that an ESP NOW-compatible radio is present.
+
+config HAS_ARCH_ESP
+    bool
+    help
+        Indicates that an 'ESP' architecture is being used.
+
+## Common CPU symbols
+config CPU_ARCH
+    default "xtensa" if CPU_ARCH_XTENSA

--- a/cpu/esp_common/Makefile.features
+++ b/cpu/esp_common/Makefile.features
@@ -1,3 +1,5 @@
+CPU_ARCH = xtensa
+
 # MCU defined features that are provided independent on board definitions
 
 FEATURES_PROVIDED += arch_32bit

--- a/cpu/esp_common/Makefile.features
+++ b/cpu/esp_common/Makefile.features
@@ -3,6 +3,9 @@
 FEATURES_PROVIDED += arch_32bit
 FEATURES_PROVIDED += arch_esp
 FEATURES_PROVIDED += cpp
+FEATURES_PROVIDED += esp_now
+FEATURES_PROVIDED += esp_spiffs
+FEATURES_PROVIDED += esp_wifi
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pm

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -18,6 +18,16 @@ BOARD_WHITELIST += arduino-duemilanove \
                    chronos \
                    derfmega128 \
                    derfmega256 \
+                   esp32-heltec-lora32-v2 \
+                   esp32-mh-et-live-minikit \
+                   esp32-olimex-evb \
+                   esp32-ttgo-t-beam \
+                   esp32-wemos-lolin-d32-pro \
+                   esp32-wroom-32 \
+                   esp32-wrover-kit \
+                   esp8266-esp-12x \
+                   esp8266-olimex-mod \
+                   esp8266-sparkfun-thing \
                    firefly \
                    frdm-k22f \
                    frdm-k64f \


### PR DESCRIPTION
### Contribution description
This models in Kconfig all the features of the esp8266 and esp32 boards:
- esp32-heltec-lora32-v2
- esp32-mh-et-live-minikit
- esp32-olimex-evb
- esp32-ttgo-t-beam
- esp32-wemos-lolin-d32-pro
- esp32-wroom-32
- esp32-wrover-kit
- esp8266-esp-12x
- esp8266-olimex-mod
- esp8266-sparkfun-thing

### Testing procedure
- Check the symbol organization
- Green CI
- `tests/kconfig_features` should pass for all boards. Which means that `make info-features-provided` and `make dependency-debug-features-provided-kconfig` should return the same list.

### Issues/PRs references
Part of #14148