### PR TITLE
sys/hashes: add sha224 and reuse sha256 code

### DIFF
--- a/sys/hashes/sha224.c
+++ b/sys/hashes/sha224.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_hashes
+ *
+ * @{
+ * @file
+ * @brief       SHA224 hash function implementation
+ *
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+#include <assert.h>
+
+#include "hashes/sha224.h"
+#include "hashes/sha2xx_common.h"
+
+/* SHA-224 initialization.  Begins a SHA-224 operation. */
+void sha224_init(sha224_context_t *ctx)
+{
+    /* Zero bits processed so far */
+    ctx->count[0] = ctx->count[1] = 0;
+
+    /* Magic initialization constants */
+    ctx->state[0] = 0xC1059ED8;
+    ctx->state[1] = 0x367CD507;
+    ctx->state[2] = 0x3070DD17;
+    ctx->state[3] = 0xF70E5939;
+    ctx->state[4] = 0xFFC00B31;
+    ctx->state[5] = 0x68581511;
+    ctx->state[6] = 0x64F98FA7;
+    ctx->state[7] = 0xBEFA4FA4;
+}
+
+/* Add bytes into the hash */
+void sha224_update(sha224_context_t *ctx, const void *data, size_t len)
+{
+    sha2xx_update(ctx, data, len);
+}
+
+/*
+ * SHA-224 finalization.  Pads the input data, exports the hash value,
+ * and clears the context state.
+ */
+void sha224_final(sha224_context_t *ctx, void *dst)
+{
+    sha2xx_final(ctx, dst, SHA224_DIGEST_LENGTH);
+}
+
+void *sha224(const void *data, size_t len, void *digest)
+{
+    sha224_context_t c;
+    static unsigned char m[SHA224_DIGEST_LENGTH];
+
+    if (digest == NULL) {
+        digest = m;
+    }
+
+    sha224_init(&c);
+    sha224_update(&c, data, len);
+    sha224_final(&c, digest);
+
+    return digest;
+}

--- a/sys/hashes/sha224.c
+++ b/sys/hashes/sha224.c
@@ -41,21 +41,6 @@ void sha224_init(sha224_context_t *ctx)
     ctx->state[7] = 0xBEFA4FA4;
 }
 
-/* Add bytes into the hash */
-void sha224_update(sha224_context_t *ctx, const void *data, size_t len)
-{
-    sha2xx_update(ctx, data, len);
-}
-
-/*
- * SHA-224 finalization.  Pads the input data, exports the hash value,
- * and clears the context state.
- */
-void sha224_final(sha224_context_t *ctx, void *dst)
-{
-    sha2xx_final(ctx, dst, SHA224_DIGEST_LENGTH);
-}
-
 void *sha224(const void *data, size_t len, void *digest)
 {
     sha224_context_t c;

--- a/sys/hashes/sha256.c
+++ b/sys/hashes/sha256.c
@@ -49,143 +49,8 @@
 #include <assert.h>
 
 #include "hashes/sha256.h"
+#include "hashes/sha2xx_common.h"
 
-#ifdef __BIG_ENDIAN__
-/* Copy a vector of big-endian uint32_t into a vector of bytes */
-#define be32enc_vect memcpy
-
-/* Copy a vector of bytes into a vector of big-endian uint32_t */
-#define be32dec_vect memcpy
-
-#else /* !__BIG_ENDIAN__ */
-
-/*
- * Encode a length len/4 vector of (uint32_t) into a length len vector of
- * (unsigned char) in big-endian form.  Assumes len is a multiple of 4.
- */
-static void be32enc_vect(void *dst_, const void *src_, size_t len)
-{
-    if ((uintptr_t)dst_ % sizeof(uint32_t) == 0 &&
-        (uintptr_t)src_ % sizeof(uint32_t) == 0) {
-        uint32_t *dst = dst_;
-        const uint32_t *src = src_;
-        for (size_t i = 0; i < len / 4; i++) {
-            dst[i] = __builtin_bswap32(src[i]);
-        }
-    }
-    else {
-        uint8_t *dst = dst_;
-        const uint8_t *src = src_;
-        for (size_t i = 0; i < len; i += 4) {
-            dst[i] = src[i + 3];
-            dst[i + 1] = src[i + 2];
-            dst[i + 2] = src[i + 1];
-            dst[i + 3] = src[i];
-        }
-    }
-}
-
-/*
- * Decode a big-endian length len vector of (unsigned char) into a length
- * len/4 vector of (uint32_t).  Assumes len is a multiple of 4.
- */
-#define be32dec_vect be32enc_vect
-
-#endif /* __BYTE_ORDER__ != __ORDER_BIG_ENDIAN__ */
-
-/* Elementary functions used by SHA256 */
-#define Ch(x, y, z) ((x & (y ^ z)) ^ z)
-#define Maj(x, y, z)    ((x & (y | z)) | (y & z))
-#define SHR(x, n)   (x >> n)
-#define ROTR(x, n)  ((x >> n) | (x << (32 - n)))
-#define S0(x)       (ROTR(x, 2) ^ ROTR(x, 13) ^ ROTR(x, 22))
-#define S1(x)       (ROTR(x, 6) ^ ROTR(x, 11) ^ ROTR(x, 25))
-#define s0(x)       (ROTR(x, 7) ^ ROTR(x, 18) ^ SHR(x, 3))
-#define s1(x)       (ROTR(x, 17) ^ ROTR(x, 19) ^ SHR(x, 10))
-
-static const uint32_t K[64] = {
-    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
-    0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
-    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
-    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
-    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
-    0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
-    0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
-    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
-    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
-    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
-    0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
-    0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
-    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
-};
-
-/*
- * SHA256 block compression function.  The 256-bit state is transformed via
- * the 512-bit input block to produce a new state.
- */
-static void sha256_transform(uint32_t *state, const unsigned char block[64])
-{
-    uint32_t W[64];
-    uint32_t S[8];
-
-    /* 1. Prepare message schedule W. */
-    be32dec_vect(W, block, 64);
-    for (int i = 16; i < 64; i++) {
-        W[i] = s1(W[i - 2]) + W[i - 7] + s0(W[i - 15]) + W[i - 16];
-    }
-
-    /* 2. Initialize working variables. */
-    memcpy(S, state, 32);
-
-    /* 3. Mix. */
-    for (int i = 0; i < 64; ++i) {
-        uint32_t e = S[(68 - i) % 8], f = S[(69 - i) % 8];
-        uint32_t g = S[(70 - i) % 8], h = S[(71 - i) % 8];
-        uint32_t t0 = h + S1(e) + Ch(e, f, g) + W[i] + K[i];
-
-        uint32_t a = S[(64 - i) % 8], b = S[(65 - i) % 8];
-        uint32_t c = S[(66 - i) % 8], d = S[(67 - i) % 8];
-        uint32_t t1 = S0(a) + Maj(a, b, c);
-
-        S[(67 - i) % 8] = d + t0;
-        S[(71 - i) % 8] = t0 + t1;
-    }
-
-    /* 4. Mix local working variables into global state */
-    for (int i = 0; i < 8; i++) {
-        state[i] += S[i];
-    }
-}
-
-static unsigned char PAD[64] = {
-    0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-};
-
-/* Add padding and terminating bit-count. */
-static void sha256_pad(sha256_context_t *ctx)
-{
-    /*
-     * Convert length to a vector of bytes -- we do this now rather
-     * than later because the length will change after we pad.
-     */
-    unsigned char len[8];
-
-    be32enc_vect(len, ctx->count, 8);
-
-    /* Add 1--64 bytes so that the resulting length is 56 mod 64 */
-    uint32_t r = (ctx->count[1] >> 3) & 0x3f;
-    uint32_t plen = (r < 56) ? (56 - r) : (120 - r);
-    sha256_update(ctx, PAD, (size_t) plen);
-
-    /* Add the terminating bit-count */
-    sha256_update(ctx, len, 8);
-}
 
 /* SHA-256 initialization.  Begins a SHA-256 operation. */
 void sha256_init(sha256_context_t *ctx)
@@ -207,45 +72,7 @@ void sha256_init(sha256_context_t *ctx)
 /* Add bytes into the hash */
 void sha256_update(sha256_context_t *ctx, const void *data, size_t len)
 {
-    /* Number of bytes left in the buffer from previous updates */
-    uint32_t r = (ctx->count[1] >> 3) & 0x3f;
-
-    /* Convert the length into a number of bits */
-    uint32_t bitlen1 = ((uint32_t) len) << 3;
-    uint32_t bitlen0 = ((uint32_t) len) >> 29;
-
-    /* Update number of bits */
-    if ((ctx->count[1] += bitlen1) < bitlen1) {
-        ctx->count[0]++;
-    }
-
-    ctx->count[0] += bitlen0;
-
-    /* Handle the case where we don't need to perform any transforms */
-    if (len < 64 - r) {
-        if (len > 0) {
-            memcpy(&ctx->buf[r], data, len);
-        }
-        return;
-    }
-
-    /* Finish the current block */
-    const unsigned char *src = data;
-
-    memcpy(&ctx->buf[r], src, 64 - r);
-    sha256_transform(ctx->state, ctx->buf);
-    src += 64 - r;
-    len -= 64 - r;
-
-    /* Perform complete blocks */
-    while (len >= 64) {
-        sha256_transform(ctx->state, src);
-        src += 64;
-        len -= 64;
-    }
-
-    /* Copy left over data into buffer */
-    memcpy(ctx->buf, src, len);
+    sha2xx_update(ctx, data, len);
 }
 
 /*
@@ -254,14 +81,7 @@ void sha256_update(sha256_context_t *ctx, const void *data, size_t len)
  */
 void sha256_final(sha256_context_t *ctx, void *dst)
 {
-    /* Add padding */
-    sha256_pad(ctx);
-
-    /* Write the hash */
-    be32enc_vect(dst, ctx->state, 32);
-
-    /* Clear the context state */
-    memset((void *) ctx, 0, sizeof(*ctx));
+    sha2xx_final(ctx, dst, SHA256_DIGEST_LENGTH);
 }
 
 void *sha256(const void *data, size_t len, void *digest)
@@ -274,7 +94,7 @@ void *sha256(const void *data, size_t len, void *digest)
     }
 
     sha256_init(&c);
-    sha256_update(&c, data, len);
+    sha2xx_update(&c, data, len);
     sha256_final(&c, digest);
 
     return digest;
@@ -312,20 +132,20 @@ void hmac_sha256_init(hmac_context_t *ctx, const void *key, size_t key_length)
      * tmp = hash(i_key_pad CONCAT message)
      */
     sha256_init(&ctx->c_in);
-    sha256_update(&ctx->c_in, i_key_pad, SHA256_INTERNAL_BLOCK_SIZE);
+    sha2xx_update(&ctx->c_in, i_key_pad, SHA256_INTERNAL_BLOCK_SIZE);
 
     /*
      * Initiate calculation of the outer hash
      * result = hash(o_key_pad CONCAT tmp)
      */
     sha256_init(&ctx->c_out);
-    sha256_update(&ctx->c_out, o_key_pad, SHA256_INTERNAL_BLOCK_SIZE);
+    sha2xx_update(&ctx->c_out, o_key_pad, SHA256_INTERNAL_BLOCK_SIZE);
 
 }
 
 void hmac_sha256_update(hmac_context_t *ctx, const void *data, size_t len)
 {
-    sha256_update(&ctx->c_in, data, len);
+    sha2xx_update(&ctx->c_in, data, len);
 }
 
 void hmac_sha256_final(hmac_context_t *ctx, void *digest)
@@ -339,7 +159,7 @@ void hmac_sha256_final(hmac_context_t *ctx, void *digest)
     }
 
     sha256_final(&ctx->c_in, tmp);
-    sha256_update(&ctx->c_out, tmp, SHA256_DIGEST_LENGTH);
+    sha2xx_update(&ctx->c_out, tmp, SHA256_DIGEST_LENGTH);
     sha256_final(&ctx->c_out, digest);
 }
 
@@ -367,7 +187,7 @@ static inline void sha256_inplace(unsigned char element[SHA256_DIGEST_LENGTH])
     sha256_context_t ctx;
 
     sha256_init(&ctx);
-    sha256_update(&ctx, element, SHA256_DIGEST_LENGTH);
+    sha2xx_update(&ctx, element, SHA256_DIGEST_LENGTH);
     sha256_final(&ctx, element);
 }
 
@@ -419,7 +239,7 @@ void *sha256_chain_with_waypoints(const void *seed,
         for (size_t i = 1; i < elements; ++i) {
             sha256_context_t ctx;
             sha256_init(&ctx);
-            sha256_update(&ctx, waypoints[(i - 1)].element, SHA256_DIGEST_LENGTH);
+            sha2xx_update(&ctx, waypoints[(i - 1)].element, SHA256_DIGEST_LENGTH);
             sha256_final(&ctx, waypoints[i].element);
             waypoints[i].index = i;
         }

--- a/sys/hashes/sha256.c
+++ b/sys/hashes/sha256.c
@@ -69,21 +69,6 @@ void sha256_init(sha256_context_t *ctx)
     ctx->state[7] = 0x5BE0CD19;
 }
 
-/* Add bytes into the hash */
-void sha256_update(sha256_context_t *ctx, const void *data, size_t len)
-{
-    sha2xx_update(ctx, data, len);
-}
-
-/*
- * SHA-256 finalization.  Pads the input data, exports the hash value,
- * and clears the context state.
- */
-void sha256_final(sha256_context_t *ctx, void *dst)
-{
-    sha2xx_final(ctx, dst, SHA256_DIGEST_LENGTH);
-}
-
 void *sha256(const void *data, size_t len, void *digest)
 {
     sha256_context_t c;

--- a/sys/hashes/sha2xx_common.c
+++ b/sys/hashes/sha2xx_common.c
@@ -1,0 +1,223 @@
+/*-
+ * Copyright 2005 Colin Percival
+ * Copyright 2013 Christian Mehlis & René Kijewski
+ * Copyright 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ * Copyright 2016 OTA keys S.A.
+ * Copyright 2020 HAW Hamburg
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD: src/lib/libmd/sha256.h,v 1.1.2.1 2005/06/24 13:32:25 cperciva Exp $
+ */
+
+/**
+ * @ingroup     sys_hashes
+ * @{
+ *
+ * @file
+ * @brief       Common code for SHA2XX hash functions
+ *
+ * @author      Colin Percival
+ * @author      Christian Mehlis
+ * @author      Rene Kijewski
+ * @author      Martin Landsmann
+ * @author      Hermann Lelong
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <assert.h>
+
+#include "hashes/sha2xx_common.h"
+
+
+#ifdef __BIG_ENDIAN__
+/* Copy a vector of big-endian uint32_t into a vector of bytes */
+#define be32enc_vect memcpy
+
+/* Copy a vector of bytes into a vector of big-endian uint32_t */
+#define be32dec_vect memcpy
+#else /* !__BIG_ENDIAN__ */
+
+/*
+ * Encode a length len/4 vector of (uint32_t) into a length len vector of
+ * (unsigned char) in big-endian form.  Assumes len is a multiple of 4.
+ */
+static void be32enc_vect(void *dst_, const void *src_, size_t len)
+{
+    /* Assert if len is not a multiple of 4 */
+    assert(!(len & 3));
+
+    if ((uintptr_t)dst_ % sizeof(uint32_t) == 0 &&
+        (uintptr_t)src_ % sizeof(uint32_t) == 0) {
+        uint32_t *dst = dst_;
+        const uint32_t *src = src_;
+        for (size_t i = 0; i < len / 4; i++) {
+            dst[i] = __builtin_bswap32(src[i]);
+        }
+    }
+    else {
+        uint8_t *dst = dst_;
+        const uint8_t *src = src_;
+        for (size_t i = 0; i < len; i += 4) {
+            dst[i] = src[i + 3];
+            dst[i + 1] = src[i + 2];
+            dst[i + 2] = src[i + 1];
+            dst[i + 3] = src[i];
+        }
+    }
+}
+
+/*
+ * Decode a big-endian length len vector of (unsigned char) into a length
+ * len/4 vector of (uint32_t).  Assumes len is a multiple of 4.
+ */
+#define be32dec_vect be32enc_vect
+
+#endif /* __BYTE_ORDER__ != __ORDER_BIG_ENDIAN__ */
+
+/*
+ * SHA256 block compression function.  The 256-bit state is transformed via
+ * the 512-bit input block to produce a new state.
+ */
+static void sha2xx_transform(uint32_t *state, const unsigned char block[64])
+{
+    uint32_t W[64];
+    uint32_t S[8];
+
+    /* 1. Prepare message schedule W. */
+    be32dec_vect(W, block, 64);
+    for (int i = 16; i < 64; i++) {
+        W[i] = s1(W[i - 2]) + W[i - 7] + s0(W[i - 15]) + W[i - 16];
+    }
+
+    /* 2. Initialize working variables. */
+    memcpy(S, state, 32);
+
+    /* 3. Mix. */
+    for (int i = 0; i < 64; ++i) {
+        uint32_t e = S[(68 - i) % 8], f = S[(69 - i) % 8];
+        uint32_t g = S[(70 - i) % 8], h = S[(71 - i) % 8];
+        uint32_t t0 = h + S1(e) + Ch(e, f, g) + W[i] + K[i];
+
+        uint32_t a = S[(64 - i) % 8], b = S[(65 - i) % 8];
+        uint32_t c = S[(66 - i) % 8], d = S[(67 - i) % 8];
+        uint32_t t1 = S0(a) + Maj(a, b, c);
+
+        S[(67 - i) % 8] = d + t0;
+        S[(71 - i) % 8] = t0 + t1;
+    }
+
+    /* 4. Mix local working variables into global state */
+    for (int i = 0; i < 8; i++) {
+        state[i] += S[i];
+    }
+}
+
+static unsigned char PAD[64] = {
+    0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+};
+
+/* Add padding and terminating bit-count. */
+void sha2xx_pad(sha2xx_context_t *ctx)
+{
+    /*
+     * Convert length to a vector of bytes -- we do this now rather
+     * than later because the length will change after we pad.
+     */
+    unsigned char len[8];
+
+    be32enc_vect(len, ctx->count, 8);
+
+    /* Add 1--64 bytes so that the resulting length is 56 mod 64 */
+    uint32_t r = (ctx->count[1] >> 3) & 0x3f;
+    uint32_t plen = (r < 56) ? (56 - r) : (120 - r);
+    sha2xx_update(ctx, PAD, (size_t) plen);
+
+    /* Add the terminating bit-count */
+    sha2xx_update(ctx, len, 8);
+}
+
+/* Add bytes into the hash */
+void sha2xx_update(sha2xx_context_t *ctx, const void *data, size_t len)
+{
+    /* Number of bytes left in the buffer from previous updates */
+    uint32_t r = (ctx->count[1] >> 3) & 0x3f;
+
+    /* Convert the length into a number of bits */
+    uint32_t bitlen1 = ((uint32_t) len) << 3;
+    uint32_t bitlen0 = ((uint32_t) len) >> 29;
+
+    /* Update number of bits */
+    if ((ctx->count[1] += bitlen1) < bitlen1) {
+        ctx->count[0]++;
+    }
+
+    ctx->count[0] += bitlen0;
+
+    /* Handle the case where we don't need to perform any transforms */
+    if (len < 64 - r) {
+        if (len > 0) {
+            memcpy(&ctx->buf[r], data, len);
+        }
+        return;
+    }
+
+    /* Finish the current block */
+    const unsigned char *src = data;
+
+    memcpy(&ctx->buf[r], src, 64 - r);
+    sha2xx_transform(ctx->state, ctx->buf);
+    src += 64 - r;
+    len -= 64 - r;
+
+    /* Perform complete blocks */
+    while (len >= 64) {
+        sha2xx_transform(ctx->state, src);
+        src += 64;
+        len -= 64;
+    }
+
+    /* Copy left over data into buffer */
+    memcpy(ctx->buf, src, len);
+}
+
+/*
+ * SHA-224 finalization.  Pads the input data, exports the hash value,
+ * and clears the context state.
+ */
+void sha2xx_final(sha2xx_context_t *ctx, void *dst, size_t dig_len)
+{
+    /* Add padding */
+    sha2xx_pad(ctx);
+
+    /* Write the hash */
+    be32enc_vect(dst, ctx->state, dig_len);
+
+    /* Clear the context state */
+    memset((void *) ctx, 0, sizeof(*ctx));
+}

--- a/sys/include/hashes/sha224.h
+++ b/sys/include/hashes/sha224.h
@@ -1,0 +1,119 @@
+/*-
+ * Copyright 2005 Colin Percival
+ * Copyright 2013 Christian Mehlis & René Kijewski
+ * Copyright 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ * Copyright 2016 OTA keys S.A.
+ * Copyright 2020 HAW Hamburg
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD: src/lib/libmd/sha256.h,v 1.1.2.1 2005/06/24 13:32:25 cperciva Exp $
+ */
+
+
+/**
+ * @defgroup    sys_hashes_sha224 SHA-224
+ * @ingroup     sys_hashes_unkeyed
+ * @brief       Implementation of the SHA-224 hashing function
+ * @{
+ *
+ * @file
+ * @brief       Header definitions for the SHA224 hash function
+ *
+ * @author      Colin Percival
+ * @author      Christian Mehlis
+ * @author      Rene Kijewski
+ * @author      Hermann Lelong
+ * @author      Peter Kietzmann
+ */
+
+#ifndef HASHES_SHA224_H
+#define HASHES_SHA224_H
+
+#include <inttypes.h>
+#include <stddef.h>
+
+#include "hashes/sha2xx_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Length of SHA224 digests in bytes
+ */
+#define SHA224_DIGEST_LENGTH (28)
+
+/**
+ * @brief 512 Bit (64 Byte) internally used block size for sha224
+ */
+#define SHA224_INTERNAL_BLOCK_SIZE (64)
+
+/**
+ * @brief Context for cipher operations based on sha224
+ */
+typedef sha2xx_context_t sha224_context_t;
+
+/**
+ * @brief SHA-224 initialization.  Begins a SHA-224 operation.
+ *
+ * @param ctx  sha224_context_t handle to init
+ */
+void sha224_init(sha224_context_t *ctx);
+
+/**
+ * @brief Add bytes into the hash
+ *
+ * @param ctx      sha224_context_t handle to use
+ * @param[in] data Input data
+ * @param[in] len  Length of @p data
+ */
+void sha224_update(sha224_context_t *ctx, const void *data, size_t len);
+
+/**
+ * @brief SHA-224 finalization.  Pads the input data, exports the hash value,
+ * and clears the context state.
+ *
+ * @param ctx    sha224_context_t handle to use
+ * @param digest resulting digest, this is the hash of all the bytes
+ */
+void sha224_final(sha224_context_t *ctx, void *digest);
+
+/**
+ * @brief A wrapper function to simplify the generation of a hash, this is
+ * useful for generating sha224 for one buffer
+ *
+ * @param[in] data   pointer to the buffer to generate hash from
+ * @param[in] len    length of the buffer
+ * @param[out] digest optional pointer to an array for the result, length must
+ *                    be SHA224_DIGEST_LENGTH
+ *                    if digest == NULL, one static buffer is used
+ */
+void *sha224(const void *data, size_t len, void *digest);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* HASHES_SHA224_H */

--- a/sys/include/hashes/sha224.h
+++ b/sys/include/hashes/sha224.h
@@ -88,7 +88,10 @@ void sha224_init(sha224_context_t *ctx);
  * @param[in] data Input data
  * @param[in] len  Length of @p data
  */
-void sha224_update(sha224_context_t *ctx, const void *data, size_t len);
+static inline void sha224_update(sha224_context_t *ctx, const void *data, size_t len)
+{
+    sha2xx_update(ctx, data, len);
+}
 
 /**
  * @brief SHA-224 finalization.  Pads the input data, exports the hash value,
@@ -97,7 +100,10 @@ void sha224_update(sha224_context_t *ctx, const void *data, size_t len);
  * @param ctx    sha224_context_t handle to use
  * @param digest resulting digest, this is the hash of all the bytes
  */
-void sha224_final(sha224_context_t *ctx, void *digest);
+static inline void sha224_final(sha224_context_t *ctx, void *digest)
+{
+    sha2xx_final(ctx, digest, SHA224_DIGEST_LENGTH);
+}
 
 /**
  * @brief A wrapper function to simplify the generation of a hash, this is

--- a/sys/include/hashes/sha256.h
+++ b/sys/include/hashes/sha256.h
@@ -51,6 +51,8 @@
 #include <inttypes.h>
 #include <stddef.h>
 
+#include "hashes/sha2xx_common.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -68,14 +70,7 @@ extern "C" {
 /**
  * @brief Context for cipher operations based on sha256
  */
-typedef struct {
-    /** global state */
-    uint32_t state[8];
-    /** processed bytes counter */
-    uint32_t count[2];
-    /** data buffer */
-    unsigned char buf[64];
-} sha256_context_t;
+typedef sha2xx_context_t sha256_context_t;
 
 /**
  * @brief Context for HMAC operations based on sha256

--- a/sys/include/hashes/sha256.h
+++ b/sys/include/hashes/sha256.h
@@ -106,7 +106,10 @@ void sha256_init(sha256_context_t *ctx);
  * @param[in] data Input data
  * @param[in] len  Length of @p data
  */
-void sha256_update(sha256_context_t *ctx, const void *data, size_t len);
+static inline void sha256_update(sha256_context_t *ctx, const void *data, size_t len)
+{
+    sha2xx_update(ctx, data, len);
+}
 
 /**
  * @brief SHA-256 finalization.  Pads the input data, exports the hash value,
@@ -115,7 +118,10 @@ void sha256_update(sha256_context_t *ctx, const void *data, size_t len);
  * @param ctx    sha256_context_t handle to use
  * @param digest resulting digest, this is the hash of all the bytes
  */
-void sha256_final(sha256_context_t *ctx, void *digest);
+static inline void sha256_final(sha256_context_t *ctx, void *digest)
+{
+    sha2xx_final(ctx, digest, SHA256_DIGEST_LENGTH);
+}
 
 /**
  * @brief A wrapper function to simplify the generation of a hash, this is

--- a/sys/include/hashes/sha2xx_common.h
+++ b/sys/include/hashes/sha2xx_common.h
@@ -1,0 +1,137 @@
+/*-
+ * Copyright 2005 Colin Percival
+ * Copyright 2013 Christian Mehlis & René Kijewski
+ * Copyright 2016 Martin Landsmann <martin.landsmann@haw-hamburg.de>
+ * Copyright 2016 OTA keys S.A.
+ * Copyright 2020 HAW Hamburg
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD: src/lib/libmd/sha256.h,v 1.1.2.1 2005/06/24 13:32:25 cperciva Exp $
+ */
+
+
+/**
+ * @defgroup    sys_hashes_sha2xx_common SHA-2xx common
+ * @ingroup     sys_hashes_unkeyed
+ * @brief       Implementation of common functionality for SHA-224/256 hashing functions
+ * @{
+ *
+ * @file
+ * @brief       Common definitions for the SHA-224/256 hash functions
+ *
+ * @author      Colin Percival
+ * @author      Christian Mehlis
+ * @author      Rene Kijewski
+ * @author      Hermann Lelong
+ * @author      Peter Kietzmann
+ */
+
+#ifndef HASHES_SHA2XX_COMMON_H
+#define HASHES_SHA2XX_COMMON_H
+
+#include <string.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    Structure to hold the SHA-2XX context.
+ */
+typedef struct {
+    /** global state */
+    uint32_t state[8];
+    /** processed bytes counter */
+    uint32_t count[2];
+    /** data buffer */
+    unsigned char buf[64];
+} sha2xx_context_t;
+
+/**
+ * @brief    Elementary functions used by SHA2XX
+ * @{
+ */
+#define Ch(x, y, z) ((x & (y ^ z)) ^ z)
+#define Maj(x, y, z)    ((x & (y | z)) | (y & z))
+#define SHR(x, n)   (x >> n)
+#define ROTR(x, n)  ((x >> n) | (x << (32 - n)))
+#define S0(x)       (ROTR(x, 2) ^ ROTR(x, 13) ^ ROTR(x, 22))
+#define S1(x)       (ROTR(x, 6) ^ ROTR(x, 11) ^ ROTR(x, 25))
+#define s0(x)       (ROTR(x, 7) ^ ROTR(x, 18) ^ SHR(x, 3))
+#define s1(x)       (ROTR(x, 17) ^ ROTR(x, 19) ^ SHR(x, 10))
+/** @} */
+
+/** @brief SHA-224 and SHA-256 Constants */
+static const uint32_t K[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
+    0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+    0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+    0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3,
+    0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5,
+    0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+};
+
+/**
+ * @brief SHA-2XX initialization.  Begins a SHA-2XX operation.
+ *
+ * @param ctx  sha2xx_context_t handle to init
+ */
+void sha2xx_pad(sha2xx_context_t *ctx);
+
+/**
+ * @brief Add bytes into the hash
+ *
+ * @param ctx      sha2xx_context_t handle to use
+ * @param[in] data Input data
+ * @param[in] len  Length of @p data
+ */
+void sha2xx_update(sha2xx_context_t *ctx, const void *data, size_t len);
+
+/**
+ * @brief SHA-2XX finalization.  Pads the input data, exports the hash value,
+ * and clears the context state.
+ *
+ * @param ctx     sha2xx_context_t handle to use
+ * @param digest  resulting digest, this is the hash of all the bytes
+ * @param dig_len Length of @p digest
+ */
+void sha2xx_final(sha2xx_context_t *ctx, void *digest, size_t dig_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* HASHES_SHA2XX_COMMON_H */

--- a/tests/unittests/tests-hashes/tests-hashes-sha224.c
+++ b/tests/unittests/tests-hashes/tests-hashes-sha224.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2020 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+ /**
+ * @ingroup     unittests
+ * @{
+ *
+ * @file
+ * @brief       testcases for the sha224 implementation
+ *
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <limits.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "embUnit/embUnit.h"
+
+#include "hashes/sha224.h"
+
+#include "tests-hashes.h"
+
+/**
+ * @brief expected hash for test 01
+ * i.e. 3eda9ffe5537a588f54d0b2a453e5fa932986d0bc0f9556924f5c2379b2c91b0
+ *
+ * converted using:
+ * s=$(echo '<hash string>' | sed -e 's/../0x&, /g' | sed 's/, $//'); echo {$s}\;
+ *
+ * where <hash string> is the above sequence of characters 3e...b0
+ */
+
+/**
+ * @brief expected hash for test empty
+ * i.e. d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f
+ */
+static const unsigned char hempty[] =
+                                   {0xd1, 0x4a, 0x02, 0x8c, 0x2a, 0x3a, 0x2b, 0xc9, 0x47,
+                                    0x61, 0x02, 0xbb, 0x28, 0x82, 0x34, 0xc4, 0x15, 0xa2,
+                                    0xb0, 0x1f, 0x82, 0x8e, 0xa6, 0x2a, 0xc5, 0xb3, 0xe4,
+                                    0x2f};
+
+/**
+ * @brief expected hash for "abc"
+ *        (from FIPS 180-2 Appendix B.1)
+ */
+static const unsigned char h_abc[] =
+                                   {0x23, 0x09, 0x7d, 0x22, 0x34, 0x05, 0xd8, 0x22, 0x86,
+                                    0x42, 0xa4, 0x77, 0xbd, 0xa2, 0x55, 0xb3, 0x2a, 0xad,
+                                    0xbc, 0xe4, 0xbd, 0xa0, 0xb3, 0xf7, 0xe3, 0x6c, 0x9d,
+                                    0xa7};
+/**
+ * @brief expected hash for "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+ *        (from FIPS 180-2 Appendix B.2)
+ */
+static const unsigned char h_abc_long[] =
+                                    {0x75, 0x38, 0x8b, 0x16, 0x51, 0x27, 0x76, 0xcc, 0x5d,
+                                     0xba, 0x5d, 0xa1, 0xfd, 0x89, 0x01, 0x50, 0xb0, 0xc6,
+                                     0x45, 0x5c, 0xb4, 0xf5, 0x8b, 0x19, 0x52, 0x52, 0x25,
+                                     0x25};
+
+/**
+ * @brief expected hash for test long_sequence
+ * i.e. 34674aab568a93190425d9f9d7e96ff835635630e3d2638218a9103b
+ */
+static const unsigned char hlong_sequence[] =
+                                     {0x34, 0x67, 0x4a, 0xab, 0x56, 0x8a, 0x93, 0x19, 0x04,
+                                      0x25, 0xd9, 0xf9, 0xd7, 0xe9, 0x6f, 0xf8, 0x35, 0x63,
+                                      0x56, 0x30, 0xe3, 0xd2, 0x63, 0x82, 0x18, 0xa9, 0x10,
+                                      0x3b};
+
+static int calc_and_compare_hash(const char *str, const unsigned char *expected)
+{
+    static unsigned char hash[28];
+    sha224_context_t sha224;
+
+    sha224_init(&sha224);
+    sha224_update(&sha224, (uint8_t*)str, strlen(str));
+    sha224_final(&sha224, hash);
+
+    return (memcmp(expected, hash, 28) == 0);
+}
+
+static int calc_and_compare_hash_wrapper(const char *str, const unsigned char *expected)
+{
+    static unsigned char hash[SHA224_DIGEST_LENGTH];
+
+    sha224((uint8_t*)str, strlen(str), hash);
+
+    return (memcmp(expected, hash, SHA224_DIGEST_LENGTH) == 0);
+}
+
+static void test_hashes_sha224_hash_sequence_empty(void)
+{
+    const char *teststring = "";
+    TEST_ASSERT(calc_and_compare_hash(teststring, hempty));
+    TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, hempty));
+}
+
+static void test_hashes_sha224_hash_sequence_abc(void)
+{
+    char *teststring = "abc";
+    TEST_ASSERT(calc_and_compare_hash(teststring, h_abc));
+    TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, h_abc));
+}
+
+static void test_hashes_sha224_hash_sequence_abc_long(void)
+{
+    char *teststring = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+    TEST_ASSERT(calc_and_compare_hash(teststring, h_abc_long));
+    TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, h_abc_long));
+}
+
+static void test_hashes_sha256_hash_long_sequence(void)
+{
+    char *teststring = {"RIOT is an open-source microkernel-based operating system, designed"
+                       " to match the requirements of Internet of Things (IoT) devices and"
+                       " other embedded devices. These requirements include a very low memory"
+                       " footprint (on the order of a few kilobytes), high energy efficiency"
+                       ", real-time capabilities, communication stacks for both wireless and"
+                       " wired networks, and support for a wide range of low-power hardware."};
+    TEST_ASSERT(calc_and_compare_hash(teststring, hlong_sequence));
+    TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, hlong_sequence));
+}
+
+Test *tests_hashes_sha224_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_hashes_sha224_hash_sequence_empty),
+        new_TestFixture(test_hashes_sha224_hash_sequence_abc),
+        new_TestFixture(test_hashes_sha224_hash_sequence_abc_long),
+        new_TestFixture(test_hashes_sha256_hash_long_sequence),
+    };
+
+    EMB_UNIT_TESTCALLER(hashes_sha224_tests, NULL, NULL,
+                        fixtures);
+
+    return (Test *)&hashes_sha224_tests;
+}

--- a/tests/unittests/tests-hashes/tests-hashes-sha256.c
+++ b/tests/unittests/tests-hashes/tests-hashes-sha256.c
@@ -146,70 +146,90 @@ static int calc_and_compare_hash(const char *str, const unsigned char *expected)
     return (memcmp(expected, hash, SHA256_DIGEST_LENGTH) == 0);
 }
 
+static int calc_and_compare_hash_wrapper(const char *str, const unsigned char *expected)
+{
+    static unsigned char hash[SHA256_DIGEST_LENGTH];
+
+    sha256((uint8_t*)str, strlen(str), hash);
+
+    return (memcmp(expected, hash, SHA256_DIGEST_LENGTH) == 0);
+}
+
 static void test_hashes_sha256_hash_sequence_01(void)
 {
-    TEST_ASSERT(calc_and_compare_hash("1234567890_1", h01));
+    const char *teststring = "1234567890_1";
+    TEST_ASSERT(calc_and_compare_hash(teststring, h01));
+    TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, h01));
 }
 
 static void test_hashes_sha256_hash_sequence_02(void)
 {
-    TEST_ASSERT(calc_and_compare_hash("1234567890_2", h02));
+    const char *teststring = "1234567890_2";
+    TEST_ASSERT(calc_and_compare_hash(teststring, h02));
+    TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, h02));
 }
 
 static void test_hashes_sha256_hash_sequence_03(void)
 {
-    TEST_ASSERT(calc_and_compare_hash("1234567890_3", h03));
+    const char *teststring = "1234567890_3";
+    TEST_ASSERT(calc_and_compare_hash(teststring, h03));
+    TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, h03));
 }
 
 static void test_hashes_sha256_hash_sequence_04(void)
 {
-    TEST_ASSERT(calc_and_compare_hash("1234567890_4", h04));
+    const char *teststring = "1234567890_4";
+    TEST_ASSERT(calc_and_compare_hash(teststring, h04));
+    TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, h04));
 }
 
 static void test_hashes_sha256_hash_sequence_digits_letters(void)
 {
-    TEST_ASSERT(calc_and_compare_hash(
-                    "0123456789abcde-0123456789abcde-0123456789abcde-0123456789abcde-",
-                    hdigits_letters));
+    const char *teststring = "0123456789abcde-0123456789abcde-0123456789abcde-0123456789abcde-";
+    TEST_ASSERT(calc_and_compare_hash(teststring, hdigits_letters));
+    TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, hdigits_letters));
 }
 
 static void test_hashes_sha256_hash_sequence_pangramm(void)
 {
-    TEST_ASSERT(calc_and_compare_hash(
-                    "Franz jagt im komplett verwahrlosten Taxi quer durch Bayern",
-                    hpangramm));
+    const char *teststring = "Franz jagt im komplett verwahrlosten Taxi quer durch Bayern";
+    TEST_ASSERT(calc_and_compare_hash(teststring, hpangramm));
+    TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, hpangramm));
 }
 
 static void test_hashes_sha256_hash_sequence_pangramm_no_more(void)
 {
     /* exchanged `z` with `k` of the first word `Fran[z|k]` */
-    TEST_ASSERT(calc_and_compare_hash(
-                    "Frank jagt im komplett verwahrlosten Taxi quer durch Bayern",
-                    hpangramm_no_more));
+    const char *teststring = "Frank jagt im komplett verwahrlosten Taxi quer durch Bayern";
+    TEST_ASSERT(calc_and_compare_hash(teststring, hpangramm_no_more));
+    TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, hpangramm_no_more));
 }
 
 static void test_hashes_sha256_hash_sequence_empty(void)
 {
-    TEST_ASSERT(calc_and_compare_hash("", hempty));
+    const char *teststring = "";
+    TEST_ASSERT(calc_and_compare_hash(teststring, hempty));
+    TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, hempty));
 }
 
 static void test_hashes_sha256_hash_sequence_failing_compare(void)
 {
     /* failing compare (sha256 switched last byte of expected hash from `3b` to `3c`) */
-    TEST_ASSERT(!calc_and_compare_hash("This test fails!",
-                    hfailing_compare));
+    char *teststring = "This test fails!";
+    TEST_ASSERT(!calc_and_compare_hash(teststring, hfailing_compare));
+    TEST_ASSERT(!calc_and_compare_hash_wrapper(teststring, hfailing_compare));
 }
 
 static void test_hashes_sha256_hash_long_sequence(void)
 {
-    TEST_ASSERT(calc_and_compare_hash(
-                    "RIOT is an open-source microkernel-based operating system, designed"
-                    " to match the requirements of Internet of Things (IoT) devices and"
-                    " other embedded devices. These requirements include a very low memory"
-                    " footprint (on the order of a few kilobytes), high energy efficiency"
-                    ", real-time capabilities, communication stacks for both wireless and"
-                    " wired networks, and support for a wide range of low-power hardware.",
-                    hlong_sequence));
+    char *teststring = {"RIOT is an open-source microkernel-based operating system, designed"
+                       " to match the requirements of Internet of Things (IoT) devices and"
+                       " other embedded devices. These requirements include a very low memory"
+                       " footprint (on the order of a few kilobytes), high energy efficiency"
+                       ", real-time capabilities, communication stacks for both wireless and"
+                       " wired networks, and support for a wide range of low-power hardware."};
+    TEST_ASSERT(calc_and_compare_hash(teststring, hlong_sequence));
+    TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, hlong_sequence));
 }
 
 Test *tests_hashes_sha256_tests(void)

--- a/tests/unittests/tests-hashes/tests-hashes-sha256.c
+++ b/tests/unittests/tests-hashes/tests-hashes-sha256.c
@@ -134,6 +134,25 @@ static const unsigned char hlong_sequence[] =
                                     0x6a, 0x78, 0x21, 0x73, 0x54, 0x89, 0x61, 0x85,
                                     0xb1, 0x4a, 0x3a, 0x84, 0xf7, 0xcd, 0x80, 0x66};
 
+/**
+ * @brief expected hash for "abc"
+ *        (from FIPS 180-2 Appendix B.1)
+ */
+static const unsigned char h_fips_oneblock[] =
+                                   {0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea,
+                                    0x41, 0x41, 0x40, 0xde, 0x5d, 0xae, 0x22, 0x23,
+                                    0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c,
+                                    0xb4, 0x10, 0xff, 0x61, 0xf2, 0x00, 0x15, 0xad};
+/**
+ * @brief expected hash for "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+ *        (from FIPS 180-2 Appendix B.2)
+ */
+static const unsigned char h_fips_multiblock[] =
+                                    {0x24, 0x8d, 0x6a, 0x61, 0xd2, 0x06, 0x38, 0xb8,
+                                     0xe5, 0xc0, 0x26, 0x93, 0x0c, 0x3e, 0x60, 0x39,
+                                     0xa3, 0x3c, 0xe4, 0x59, 0x64, 0xff, 0x21, 0x67,
+                                     0xf6, 0xec, 0xed, 0xd4, 0x19, 0xdb, 0x06, 0xc1};
+
 static int calc_and_compare_hash(const char *str, const unsigned char *expected)
 {
     static unsigned char hash[SHA256_DIGEST_LENGTH];
@@ -232,6 +251,20 @@ static void test_hashes_sha256_hash_long_sequence(void)
     TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, hlong_sequence));
 }
 
+static void test_hashes_sha256_hash_sequence_abc(void)
+{
+    char *teststring = "abc";
+    TEST_ASSERT(calc_and_compare_hash(teststring, h_fips_oneblock));
+    TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, h_fips_oneblock));
+}
+
+static void test_hashes_sha256_hash_sequence_abc_long(void)
+{
+    char *teststring = "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq";
+    TEST_ASSERT(calc_and_compare_hash(teststring, h_fips_multiblock));
+    TEST_ASSERT(calc_and_compare_hash_wrapper(teststring, h_fips_multiblock));
+}
+
 Test *tests_hashes_sha256_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -247,6 +280,9 @@ Test *tests_hashes_sha256_tests(void)
         new_TestFixture(test_hashes_sha256_hash_sequence_failing_compare),
 
         new_TestFixture(test_hashes_sha256_hash_long_sequence),
+
+        new_TestFixture(test_hashes_sha256_hash_sequence_abc),
+        new_TestFixture(test_hashes_sha256_hash_sequence_abc_long),
     };
 
     EMB_UNIT_TESTCALLER(hashes_sha256_tests, NULL, NULL,

--- a/tests/unittests/tests-hashes/tests-hashes.c
+++ b/tests/unittests/tests-hashes/tests-hashes.c
@@ -25,6 +25,7 @@ void tests_hashes(void)
     TESTS_RUN(tests_hashes_md5_tests());
     TESTS_RUN(tests_hashes_cmac_tests());
     TESTS_RUN(tests_hashes_sha1_tests());
+    TESTS_RUN(tests_hashes_sha224_tests());
     TESTS_RUN(tests_hashes_sha256_tests());
     TESTS_RUN(tests_hashes_sha256_hmac_tests());
     TESTS_RUN(tests_hashes_sha256_chain_tests());

--- a/tests/unittests/tests-hashes/tests-hashes.h
+++ b/tests/unittests/tests-hashes/tests-hashes.h
@@ -52,6 +52,13 @@ Test *tests_hashes_md5_tests(void);
 Test *tests_hashes_sha1_tests(void);
 
 /**
+ * @brief   Generates tests for hashes/sha224.h
+ *
+ * @return  embUnit tests if successful, NULL if not.
+ */
+Test *tests_hashes_sha224_tests(void);
+
+/**
  * @brief   Generates tests for hashes/sha256.h
  *
  * @return  embUnit tests if successful, NULL if not.


### PR DESCRIPTION
### Contribution description
This PR adds the SHA-224 hash function. It is very similar to SHA-256, thus, the common code has to be factored out of the current SHA-256 implementation. The *sha2xx_common* approach requires only few bytes more in text segment.

**master**
```
   text	   data	    bss	    dec	    hex	filename
  40644	    804	   3636	  45084	   b01c	/RIOT/tests/unittests/bin/nucleo-f410rb/tests_unittests.elf
```

**w/ PR**
```
   text	   data	    bss	    dec	    hex	filename
  40676	    804	   3636	  45116	   b03c	/RIOT/tests/unittests/bin/nucleo-f410rb/tests_unittests.elf
```

### Testing procedure

- Build & run *unittests/tests-hashes* 


### Issues/PRs references
 --