### PR TITLE
cpu/sam0_common: i2c: fix BAUD handling & cleanup

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -383,6 +383,15 @@ typedef enum {
 
 /**
  * @brief   I2C device configuration
+ *          The frequency f() of the clock `gclk_src` must fulfill the condition
+ *
+ *              4 * speed ≤ f(gclk_src) ≤ 512 * speed
+ *
+ *          if speed ≤ 1 MHz and
+ *
+ *             12 * speed ≤ f(gclk_src) ≤ 520 * speed
+ *
+ *          if speed > 1 MHz
  */
 typedef struct {
     SercomI2cm *dev;        /**< pointer to the used I2C device */

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -125,23 +125,16 @@ void i2c_init(i2c_t dev)
     /* Find and set baudrate. Read speed configuration. Set transfer
      * speed: SERCOM_I2CM_CTRLA_SPEED(0): Standard-mode (Sm) up to 100
      * kHz and Fast-mode (Fm) up to 400 kHz */
-    switch (i2c_config[dev].speed) {
-        case I2C_SPEED_NORMAL:
-        case I2C_SPEED_FAST:
-            bus(dev)->CTRLA.reg |= SERCOM_I2CM_CTRLA_SPEED(0);
-            break;
-        case I2C_SPEED_HIGH:
-            bus(dev)->CTRLA.reg |= SERCOM_I2CM_CTRLA_SPEED(2);
-            break;
-        default:
-            DEBUG("BAD BAUDRATE\n");
-            return;
+    if (i2c_config[dev].speed > I2C_SPEED_FAST) {
+        bus(dev)->CTRLA.reg |= SERCOM_I2CM_CTRLA_SPEED(2);
+    } else {
+        bus(dev)->CTRLA.reg |= SERCOM_I2CM_CTRLA_SPEED(0);
     }
     /* Get the baudrate */
     tmp_baud = (int32_t)(((sam0_gclk_freq(i2c_config[dev].gclk_src) +
                (2 * (i2c_config[dev].speed)) - 1) /
                (2 * (i2c_config[dev].speed))) -
-               (i2c_config[dev].speed == I2C_SPEED_HIGH ? 1 : 5));
+               (i2c_config[dev].speed > I2C_SPEED_FAST ? 1 : 5));
     /* Ensure baudrate is within limits */
     if (tmp_baud < 255 && tmp_baud > 0) {
         bus(dev)->BAUD.reg = SERCOM_I2CM_BAUD_BAUD(tmp_baud);

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -80,6 +80,9 @@ void i2c_init(i2c_t dev)
 
     assert(dev < I2C_NUMOF);
 
+    const uint32_t fSCL = i2c_config[dev].speed;
+    const uint32_t fGCLK = sam0_gclk_freq(i2c_config[dev].gclk_src);
+
     /* Initialize mutex */
     mutex_init(&locks[dev]);
     /* DISABLE I2C MASTER */
@@ -123,9 +126,9 @@ void i2c_init(i2c_t dev)
     bus(dev)->CTRLB.reg = SERCOM_I2CM_CTRLB_SMEN;
 
     /* Set SPEED */
-    if (i2c_config[dev].speed > I2C_SPEED_FAST_PLUS) {
+    if (fSCL > I2C_SPEED_FAST_PLUS) {
         bus(dev)->CTRLA.reg |= SERCOM_I2CM_CTRLA_SPEED(2);
-    } else if (i2c_config[dev].speed > I2C_SPEED_FAST) {
+    } else if (fSCL > I2C_SPEED_FAST) {
         bus(dev)->CTRLA.reg |= SERCOM_I2CM_CTRLA_SPEED(1);
     } else {
         bus(dev)->CTRLA.reg |= SERCOM_I2CM_CTRLA_SPEED(0);
@@ -134,15 +137,14 @@ void i2c_init(i2c_t dev)
     /* Get the baudrate */
     /* fSCL = fGCLK / (10 + 2 * BAUD)  -> BAUD   = fGCLK / (2 * fSCL) - 5 */
     /* fSCL = fGCLK / (2 + 2 * HSBAUD) -> HSBAUD = fGCLK / (2 * fSCL) - 1 */
-    tmp_baud = (((sam0_gclk_freq(i2c_config[dev].gclk_src) +
-               (2 * (i2c_config[dev].speed)) - 1) / /* round up */
-               (2 * (i2c_config[dev].speed))) -
-               (i2c_config[dev].speed > I2C_SPEED_FAST_PLUS ? 1 : 5));
+    tmp_baud = (fGCLK + (2 * fSCL) - 1) /* round up */
+             / (2 * fSCL)
+             - (fSCL > I2C_SPEED_FAST_PLUS ? 1 : 5);
 
     /* Ensure baudrate is within limits */
     assert(tmp_baud < 255 && tmp_baud > 0);
 
-    if (i2c_config[dev].speed > I2C_SPEED_FAST_PLUS) {
+    if (fSCL > I2C_SPEED_FAST_PLUS) {
         bus(dev)->BAUD.reg = SERCOM_I2CM_BAUD_HSBAUD(tmp_baud);
     } else {
         bus(dev)->BAUD.reg = SERCOM_I2CM_BAUD_BAUD(tmp_baud);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The Atmel I2C peripheral supports arbitrary I2C frequencies.
Since the `i2c_speed_t` enum just encodes the raw frequency values,
we can just use them in the peripheral definition.

We just have to remove the switch-case block that will generate an error for values outside of `i2c_speed_t`.

While doing so we can also clean up the code a bit and fix the omission of Fast Mode+ handling. I also noticed that the BAUD register would always be rounded up.
This is not correct. It should be rounded to the next integer. 

### Testing procedure

```patch
--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -26,6 +26,7 @@
 
 #include "cpu.h"
 #include "periph_cpu.h"
+#include "macros/units.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -259,7 +260,7 @@ static const spi_conf_t spi_config[] = {
 static const i2c_conf_t i2c_config[] = {
     {
         .dev      = &(SERCOM3->I2CM),
-        .speed    = I2C_SPEED_NORMAL,
+        .speed    = KHZ(50),
         .scl_pin  = GPIO_PIN(PA, 17),
         .sda_pin  = GPIO_PIN(PA, 16),
         .mux      = GPIO_MUX_D,
```

should allow you to set an I2C frequency of 50 kbit/s (if your I2C slave device supports that).
But normal I2C operation should keep working. 
Also Fast Mode+ should now work.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
