### PR TITLE
sys/test_utils/dummy_thread: initial commit

### DIFF
--- a/sys/Makefile
+++ b/sys/Makefile
@@ -31,6 +31,9 @@ endif
 ifneq (,$(filter test_utils_interactive_sync,$(USEMODULE)))
   DIRS += test_utils/interactive_sync
 endif
+ifneq (,$(filter dummy_thread,$(USEMODULE)))
+  DIRS += test_utils/dummy_thread
+endif
 ifneq (,$(filter net_help,$(USEMODULE)))
   DIRS += net/crosslayer/net_help
 endif

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -49,6 +49,10 @@ void auto_init(void)
         extern void init_schedstatistics(void);
         init_schedstatistics();
     }
+    if (IS_USED(MODULE_DUMMY_THREAD)) {
+        extern void dummy_thread_create(void);
+        dummy_thread_create();
+    }
     if (IS_USED(MODULE_EVENT_THREAD)) {
         LOG_DEBUG("Auto init event threads.\n");
         extern void auto_init_event_thread(void);

--- a/sys/test_utils/dummy_thread/Makefile
+++ b/sys/test_utils/dummy_thread/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/test_utils/dummy_thread/dummy_thread.c
+++ b/sys/test_utils/dummy_thread/dummy_thread.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ *                    Freie Universität Berlin
+ *                    Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys
+ * @{
+ *
+ * @file
+ * @brief       Module creating a dummy thread
+ *
+ * This module can be used to mess up the number of threads a bit, e.g., for
+ * testing test scripts.
+ *
+ * This module can be used by manually adding it to the command line when
+ * building, e.g.,
+ *
+ *     USEMODULE+=dummy_thread make -C tests/rmutex
+ *     make -C tests/rmutex test
+ *
+ * Note how the output of the test changes compared to a build without
+ * dummy_thread.
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include "thread.h"
+
+static char _dummy_stack[THREAD_STACKSIZE_IDLE];
+
+static void *_dummy_thread(void *arg)
+{
+    (void)arg;
+    while (1) {
+        thread_sleep();
+    }
+
+    return NULL;
+}
+
+void dummy_thread_create(void)
+{
+    thread_create(_dummy_stack, sizeof(_dummy_stack),
+                  THREAD_PRIORITY_IDLE,
+                  THREAD_CREATE_WOUT_YIELD \
+                  | THREAD_CREATE_STACKTEST \
+                  | THREAD_CREATE_SLEEPING,
+                  _dummy_thread, NULL, "dummy");
+}

--- a/tests/test_tools/Makefile
+++ b/tests/test_tools/Makefile
@@ -10,4 +10,7 @@ CFLAGS += -DSHELL_NO_ECHO=1 -DSHELL_NO_PROMPT=1
 # synchronizes by itself through `shellping` command.
 DISABLE_MODULE += test_utils_interactive_sync
 
+# include sys/test_utils/dummy_thread
+USEMODULE += dummy_thread
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While looking at # #14181, I needed a quick way to add a thread. So this dummy thread module was born. If used, the module will start a dummy thread that only sleeps, in auto_init().

Use like this, to trick tests that assume a constant number of threads:

`USEMODULE+=dummy_thread make -Ctests/rmutex flash test`.

This module is not used otherwise.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
