### PR TITLE
tests/cond_order: refactor the test to avoid knowing the thread IDs

### DIFF
--- a/tests/cond_order/tests/01-run.py
+++ b/tests/cond_order/tests/01-run.py
@@ -10,28 +10,31 @@
 import os
 import sys
 
-thread_prio = {
-        3:  6,
-        4:  4,
-        5:  0,
-        6:  2,
-        7:  1
-        }
-first_group_size = 3
+NUM_THREADS = 5
 
 
 def testfunc(child):
+    # First collect the thread info how they are created
+    # A number of lines with:
+    #  T4 (prio 6): waiting on condition variable now
+    thread_prios = {}
+    for _ in range(NUM_THREADS):
+        child.expect(r"T(\d+) \(prio (\d+)\): waiting on condition variable now")
+        thread_id = int(child.match.group(1))
+        thread_prio = int(child.match.group(2))
+        thread_prios[thread_id] = thread_prio
 
-    for k in thread_prio.keys():
-        child.expect_exact("T{} (prio {}): waiting on condition variable now"
-                           .format(k, thread_prio[k]))
-    count = 0
-    last = -1
     child.expect_exact("First batch was signaled")
-    for _ in range(len(thread_prio)):
-        child.expect(r"T\d+ \(prio (\d+)\): condition variable was signaled now")
-        assert(int(child.match.group(1)) > last)
-        last = int(child.match.group(1))
+
+    count = 0
+    last_prio = -1
+    for _ in range(len(thread_prios)):
+        child.expect(r"T(\d+) \(prio (\d+)\): condition variable was signaled now")
+        thread_id = int(child.match.group(1))
+        thread_prio = int(child.match.group(2))
+        assert thread_prios[thread_id] == thread_prio
+        assert thread_prio > last_prio
+        last_prio = thread_prio
         count += 1
         if count == 3:
             child.expect_exact("First batch has woken up")


### PR DESCRIPTION
### Contribution description

When CDC ACM is used as stdio the first thread in the test may have a
different ID than #3. The test code will now look at the printed thread
information (id, prio) as they are created. This avoids the need for a
table with ID/prio.

### Testing procedure

Run `tests/cond_order` with `compile_and_test_for_board`. Choose a board which uses CDC ACM as stdio. That means there are three threads active when the test starts. The test should succeed.

Run `tests/cond_order` with `compile_and_test_for_board`. Choose a board which uses standard UART for stdio (no CDC ACM). That means there are two threads active when the test starts. The test should succeed.

### Issues/PRs references

A similar problem was solved in #14181 