### PR TITLE
tests/mutex_order: refactor the test to avoid knowing the thread IDs

### DIFF
--- a/tests/mutex_order/tests/01-run.py
+++ b/tests/mutex_order/tests/01-run.py
@@ -10,26 +10,29 @@
 import sys
 from testrunner import run
 
-
-thread_prio = {
-        3:  6,
-        4:  4,
-        5:  0,
-        6:  2,
-        7:  1
-        }
+NUM_THREADS = 5
 
 
 def testfunc(child):
-    for k in thread_prio.keys():
-        child.expect_exact("T{} (prio {}): trying to lock mutex now"
-                           .format(k, thread_prio[k]))
 
-    last = -1
-    for i in range(len(thread_prio)):
-        child.expect(r"T\d+ \(prio (\d+)\): locked mutex now")
-        assert(int(child.match.group(1)) > last)
-        last = int(child.match.group(1))
+    # First collect the thread info how they are created
+    # A number of lines with:
+    #  T4 (prio 6): waiting on condition variable now
+    thread_prios = {}
+    for nr in range(NUM_THREADS):
+        child.expect(r"T(\d+) \(prio (\d+)\): trying to lock mutex now")
+        thread_id = int(child.match.group(1))
+        thread_prio = int(child.match.group(2))
+        thread_prios[thread_id] = thread_prio
+
+    last_prio = -1
+    for _ in range(len(thread_prios)):
+        child.expect(r"T(\d+) \(prio (\d+)\): locked mutex now")
+        thread_id = int(child.match.group(1))
+        thread_prio = int(child.match.group(2))
+        assert thread_prios[thread_id] == thread_prio
+        assert thread_prio > last_prio
+        last_prio = thread_prio
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description

When CDC ACM is used as stdio the first thread in the test may have a
different ID than #3. The test code will now look at the printed thread
information (id, prio) as they are created. This avoids the need for a
table with ID/prio.

### Testing procedure
Run `tests/mutex_order` with `compile_and_test_for_board`. Choose a board which uses CDC ACM as stdio. That means there are three threads active when the test starts. The test should succeed.

Run `tests/mutex_order` with `compile_and_test_for_board`. Choose a board which uses standard UART for stdio (no CDC ACM). That means there are two threads active when the test starts. The test should succeed.

### Issues/PRs references
A similar problem was solved in #14181