### PR TITLE
sys/shell/commands: alias ping=ping6

### DIFF
--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -216,6 +216,7 @@ const shell_command_t _shell_command_list[] = {
 #ifdef MODULE_GNRC_ICMPV6_ECHO
 #ifdef MODULE_XTIMER
     { "ping6", "Ping via ICMPv6", _gnrc_icmpv6_ping },
+    { "ping", "Ping via ICMPv6", _gnrc_icmpv6_ping },
 #endif
 #endif
 #ifdef MODULE_RANDOM


### PR DESCRIPTION

### Contribution description

On most other platforms it hasn't been necessary to type `ping6` for several years. Riot is the only modern shell I know of that doesn't accept just `ping`. Must we be so pedantic about it, or would anyone object to making this small change to save ourselves the frustration of always forgetting to type the 6?