### PR TITLE
boards/ikea-tradfri: support EFM32_USE_LEUART=1

### DIFF
--- a/boards/ikea-tradfri/doc.txt
+++ b/boards/ikea-tradfri/doc.txt
@@ -67,6 +67,7 @@ Pin 1 is on the top-left side with only 6 contacts.
 | SPI        | 0       | USART1          | MOSI: PD15, MISO: PD14, CLK: PD13 |                                                     |
 | Timer      | 0       | TIMER0 + TIMER1 |                                   | TIMER0 is used as prescaler (must be adjecent)      |
 | UART       | 0       | USART0          | RX: PB15, TX: PB14                | Default STDIO output                                |
+| LEUART     | 0       | LEUART0         | RX: PB15, TX: PB14                | Alternate to using UART                             |
 
 ### User interface
 | Peripheral | Mapped to | Pin  | Comments |
@@ -91,6 +92,14 @@ Pin 1 is on the top-left side with only 6 contacts.
 | SPI NOR Flash    | IS25LQ020B | yes       | 2MBit flash. Can be used with the the MTD API.                 |
 
 ## Board configuration
+
+### UART selection
+
+By default the UART peripheral is used for the TX/RX pins, however the pinout
+is compatible with LEUART also. You can switch from UART to LEUART by compiling
+with `EFM32_USE_LEUART=1`.
+
+**Note**: LEUART is not working on the ICC-1 module.
 
 ### Clock selection
 There are several clock sources that are available for the different

--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -107,6 +107,31 @@ static const timer_conf_t timer_config[] = {
  * @name    UART configuration
  * @{
  */
+#ifndef EFM32_USE_LEUART
+#define EFM32_USE_LEUART   0
+#endif
+
+#if EFM32_USE_LEUART
+
+#ifndef STDIO_UART_BAUDRATE
+#define STDIO_UART_BAUDRATE (9600)
+#endif
+
+static const uart_conf_t uart_config[] = {
+    {
+        .dev = LEUART0,
+        .rx_pin = GPIO_PIN(PB, 15),
+        .tx_pin = GPIO_PIN(PB, 14),
+        .loc = USART_ROUTELOC0_RXLOC_LOC9 |
+               USART_ROUTELOC0_TXLOC_LOC9,
+        .cmu = cmuClock_LEUART0,
+        .irq = LEUART0_IRQn
+    }
+};
+#define UART_0_ISR_RX       isr_leuart0
+
+#else /* EFM32_USE_LEUART */
+
 static const uart_conf_t uart_config[] = {
     {
         .dev = USART0,
@@ -118,9 +143,10 @@ static const uart_conf_t uart_config[] = {
         .irq = USART0_RX_IRQn
     }
 };
-
-#define UART_NUMOF          ARRAY_SIZE(uart_config)
 #define UART_0_ISR_RX       isr_usart0_rx
+
+#endif /* EFM32_USE_LEUART */
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description
This adds configuration for `ikea-tradfri` to use LEUART instead of UART. The pinout is compatible with either peripheral, and LEUART permits sleep states that UART does not. 

This will help facilitate making firmwares for `ikea-tradfri` that achieve similar battery life compared to the factory firmwares.


### Testing procedure
`CFLAGS="-DEFM32_USE_LEUART=1" make`

Test compiling with both `EFM32_USE_LEUART=1` and `EFM32_USE_LEUART=0` and confirm that the shell still works as intended.

Normally LEUART should work up to 9600 baud, ~but there is currently an issue (resolved in #14233) that prevents LEUART from working reliably at baud rates over 1800 in case LFRCO is used in place of LFXO (tradfri uses LFRCO).~

### Issues/PRs references
The baud issue mentioned above is resolved in ~#14233~
