### PR TITLE
cpu/efm32: disable default LFRCO options that break LEUART > 1800 baud

### DIFF
--- a/cpu/efm32/cpu.c
+++ b/cpu/efm32/cpu.c
@@ -99,6 +99,12 @@ static void clk_init(void)
         CMU_OscillatorEnable(cmuOsc_HFRCO, false, false);
     }
 
+#ifdef _SILICON_LABS_32B_SERIES_1
+    /* disable LFRCO comparator chopping and dynamic element matching
+     * else LFRCO has too much jitter for LEUART > 1800 baud */
+    CMU->LFRCOCTRL &= ~(CMU_LFRCOCTRL_ENCHOP | CMU_LFRCOCTRL_ENDEM);
+#endif
+
     /* initialize LFXO with board-specific parameters before switching */
     if (CLOCK_LFA == cmuSelect_LFXO || CLOCK_LFB == cmuSelect_LFXO ||
 #ifdef _SILICON_LABS_32B_SERIES_1


### PR DESCRIPTION
### Contribution description
This addresses a problem where LEUART fails to work reliably at baud rates over 1800 in case it's clocked by LFRCO. According to the reference manual, these are two settings that reduce LFRCO power consumption if turned on, at the cost of increased clock jitter. I found that the jitter interferes badly with LEUART, meanwhile the power savings is only about 100nA (out of 4uA total consumption). IMHO the manufacturer should have disabled these options by default. It took literally forever to find the source of the problem.

### Testing procedure
Compile with `CFLAGS="-DSTDIO_UART_BAUDRATE=1800 -DEFM32_USE_LEUART=1" make` and confirm that this patch is necessary to achieve baud rates > 1800 and <= 9600. LEUART only supports up to 9600.

I tested this on `ikea-tradfri`. It's possible that the issue does not occur on other efm32 platforms. I haven't encountered it elsewhere, but I haven't used LFRCO elsewhere.

### Issues/PRs references
This PR includes #14232 for testing purposes. I nearly included both commits in one PR but I wasn't sure which way was preferred.
