### PR TITLE
pkg/nimble/netif: set host thread prio to 1

### DIFF
--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -82,6 +82,12 @@ endif
 ifneq (,$(filter nimble_netif,$(USEMODULE)))
   INCLUDES += -I$(RIOTPKG)/nimble/netif/include
 
+  # when using IP, the host should have a higher prio than the netif thread, but
+  # MUST always have a lower priority then the controller thread. Setting it to
+  # controller prio plus will guarantee the latter while also matching the first
+  # condition as long as the default netif prio is not changed.
+  CFLAGS += -DNIMBLE_HOST_PRIO="(NIMBLE_CONTROLLER_PRIO + 1)"
+
   # configure NimBLE's internals
   NIMBLE_MAX_CONN ?= 3
   CFLAGS += -DMYNEWT_VAL_MSYS_1_BLOCK_SIZE=264


### PR DESCRIPTION
### Contribution description
When using `nimble_netif`, the NimBLE host+controller have pretty much the role of being a transceiver for GNRC. In the current default configuration, the NimBLE host has however a lower priority (prio 5) then the nimble_netif thread (prio 2). This could potentially lead to awkward behavior when sending IP data, as the netif thread might prevent the NimBLE host thread from processing data...

This PR changes the priority for the NimBLE host thread to 1, which is lower than the NimBLE controller thread (prio 0), but higher then the nimble_netif thread (prio 2). 

For all use cases, where NimBLE is used as actual BLE stack without IP, the host thread priority stays untouched.

### Testing procedure
Run `examples/gnrc_networking` on the `nrf52dk` with DEVELHELP enabled:
- run `ps` to check that the NimBLE host thread priority is `1`

### Issues/PRs references
none