### PR TITLE
tests/netstats_l2: disable test run for esp32-wroom-32

### DIFF
--- a/tests/netstats_l2/Makefile
+++ b/tests/netstats_l2/Makefile
@@ -20,4 +20,7 @@ USEMODULE += netstats_l2
 #   open(/dev/net/tun): No such file or directory
 TEST_ON_CI_BLACKLIST += native
 
+# sometimes fails on esp32, see #14237.
+TEST_ON_CI_BLACKLIST += esp32-wroom-32
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Test is flakey. Let's disable it until the solution is found.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/14237

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
