### PR TITLE
pkg: fix some typos in pkg.mk

### DIFF
--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -1,5 +1,5 @@
 #
-# Include this file if your Package needs to be checked out by git
+# Include this file if your package needs to be checked out by git
 #
 # A package is up to date when its '.git-prepared' file is up to date.
 # Any change to the package makefile will force updating the repository

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -64,9 +64,9 @@ $(PKG_PREPARED): $(PKG_PATCHED)
 # directory is not a git repository for any reason (clean -xdff or others)
 GIT_IN_PKG = git -C $(PKG_BUILDDIR) --git-dir=.git --work-tree=.
 
-# When $(PKG_PATCHED).d is included $(PKG_PATCHED) pre-requisites will include
-# the old pre-requisites forcing a rebuild on pre-requisite removal, but we do
-# not want to generate $(PKG_PATCHED).d with the old pre-requisites
+# When $(PKG_PATCHED).d is included $(PKG_PATCHED) prerequisites will include
+# the old prerequisites forcing a rebuild on prerequisite removal, but we do
+# not want to generate $(PKG_PATCHED).d with the old prerequisites
 PKG_PATCHED_PRE_REQUISITES = $(PKG_PATCHES) $(PKG_DOWNLOADED) $(MAKEFILE_LIST)
 
 # Generate dependency file. Force rebuilding on dependency deletion

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -67,7 +67,7 @@ GIT_IN_PKG = git -C $(PKG_BUILDDIR) --git-dir=.git --work-tree=.
 # When $(PKG_PATCHED).d is included $(PKG_PATCHED) prerequisites will include
 # the old prerequisites forcing a rebuild on prerequisite removal, but we do
 # not want to generate $(PKG_PATCHED).d with the old prerequisites
-PKG_PATCHED_PRE_REQUISITES = $(PKG_PATCHES) $(PKG_DOWNLOADED) $(MAKEFILE_LIST)
+PKG_PATCHED_PREREQUISITES = $(PKG_PATCHES) $(PKG_DOWNLOADED) $(MAKEFILE_LIST)
 
 # Generate dependency file. Force rebuilding on dependency deletion
 # Warning: It will be evaluated before target execution, so use as first step
@@ -79,9 +79,9 @@ gen_dependency_files = $(file >$1,$@: $2)$(foreach f,$2,$(file >>$1,$(f):))
 # * clean, without removing the 'state' files
 # * checkout the wanted base commit
 # * apply patches if there are any. (If none, it does nothing)
-$(PKG_PATCHED): $(PKG_PATCHED_PRE_REQUISITES)
+$(PKG_PATCHED): $(PKG_PATCHED_PREREQUISITES)
 	$(info [INFO] patch $(PKG_NAME))
-	$(call gen_dependency_files,$@.d,$(PKG_PATCHED_PRE_REQUISITES))
+	$(call gen_dependency_files,$@.d,$(PKG_PATCHED_PREREQUISITES))
 	$(Q)$(GIT_IN_PKG) clean $(GIT_QUIET) -xdff '**' $(PKG_STATE:$(PKG_BUILDDIR)/%=':!%*')
 	$(Q)$(GIT_IN_PKG) checkout $(GIT_QUIET) -f $(PKG_VERSION)
 	$(Q)$(GIT_IN_PKG) $(GITFLAGS) am $(GITAMFLAGS) $(PKG_PATCHES) </dev/null


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a typo on the work "prerequisites" in pkg.mk (pre-requisites in used). The typo is also available in the corresponding variable name which is also renamed.
There's another minor fix on Package instead of package in the middle of a sentence.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock should be enough

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
