### PR TITLE
tests/xtimer_now32_overflow: fix active timers going out of scope

### DIFF
--- a/tests/xtimer_now32_overflow/main.c
+++ b/tests/xtimer_now32_overflow/main.c
@@ -27,11 +27,11 @@ static void _callback(void *arg)
     (void)arg;
 }
 
+static xtimer_t t1 = { .callback=_callback };
+static xtimer_t t2 = { .callback=_callback };
+
 int main(void)
 {
-    xtimer_t t1 = { .callback=_callback };
-    xtimer_t t2 = { .callback=_callback };
-
     /* ensure that xtimer_now64() is greater than UINT32_MAX
      * and the upper 32bit of xtimer_now64() equal 1 */
     _xtimer_current_time = (1LLU << 32U);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The test sets up two timer's at 100s, does something else, then exits, with the two timers still being active. When they trigger, they might cause a crash, as their memory is not valid anymore.

This PR moves the timer object definitions to file scope and makes them static.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

1. flash test, open terminal, see `[SUCCESS]` message
2. wait more than 100 seconds, keeping terminal open

On master, it *might* crash. With this PR, it shouldn't.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
