### PR TITLE
boards/samr21-xpro: increase CONFIG_ZTIMER_USEC_MIN

### DIFF
--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -43,7 +43,8 @@ extern "C" {
  */
 #define CONFIG_ZTIMER_USEC_TYPE    ZTIMER_TYPE_PERIPH_TIMER
 #define CONFIG_ZTIMER_USEC_DEV     TIMER_DEV(1)
-#define CONFIG_ZTIMER_USEC_MIN     (8)
+/* timer_set() may underflow for values smaller than 9, set 10 as margin */
+#define CONFIG_ZTIMER_USEC_MIN     (10)
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

If `tests/periph_timer_short_relative_set` is ran a couple of times you should see that it sometimes fails when setting an interval at 8.

```
2020-06-10 13:29:34,362 # interval 14 ok
2020-06-10 13:29:34,363 # interval 13 ok
2020-06-10 13:29:34,365 # interval 12 ok
2020-06-10 13:29:34,366 # interval 11 ok
2020-06-10 13:29:34,368 # interval 10 ok
2020-06-10 13:29:34,369 # interval 9 ok
2020-06-10 13:29:34,375 # ERROR: too long delay, aborted after 1005 (TEST_MAX_DIFF=1000)
2020-06-10 13:29:34,377 # TEST FAILED
```

### Testing procedure

Run `BOARD=samr21-xpro make -C tests/periph_timer_short_relative_set/ flash term -j3` a couple of times

