### PR TITLE
boards/common/iotlab: don't enforce BAUD

### DIFF
--- a/boards/common/iotlab/Makefile.include
+++ b/boards/common/iotlab/Makefile.include
@@ -3,7 +3,7 @@ PORT_LINUX ?= /dev/ttyUSB1
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*B)))
 
 # setup serial terminal
-BAUD = 500000
+BAUD ?= 500000
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # Using connect_assert_srst removes errors on flash from invalid state


### PR DESCRIPTION
### Contribution description

This PR simply relaxes the enforcement of the baudrate for iotlab-m3, allowing it to be set
elsewhere that as a make command argument.

### Testing procedure

The following now works:

```
BAUD=115200 BOARD=iotlab-m3 make -C examples/hello-world/ term
make: Entering directory '/home/francisco/workspace/RIOT3/examples/hello-world'
/home/francisco/workspace/RIOT3/dist/tools/pyterm/pyterm -p "/dev/riot/tty-iotlab-m3" -b "115200"
2020-06-10 13:35:54,240 # Connect to serial port /dev/riot/tty-iotlab-m3
Welcome to pyterm!
Type '/exit' to exit.
```

In master:

```
BAUD=115200 BOARD=iotlab-m3 make -C examples/hello-world/ term
make: Entering directory '/home/francisco/workspace/RIOT/examples/hello-world'
/home/francisco/workspace/RIOT/dist/tools/pyterm/pyterm -p "/dev/riot/tty-iotlab-m3" -b "500000" 
2020-06-10 13:36:39,241 # Connect to serial port /dev/riot/tty-iotlab-m3
Welcome to pyterm!
Type '/exit' to exit.
```
