### PR TITLE
cpu/stm32: add non blocking uart

### DIFF
--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -12,4 +12,8 @@ ifneq (,$(filter bootloader_stm32,$(FEATURES_USED)))
   USEMODULE += bootloader_stm32
 endif
 
+ifneq (,$(filter periph_uart_nonblocking,$(USEMODULE)))
+  USEMODULE += tsrb
+endif
+
 include $(RIOTCPU)/cortexm_common/Makefile.dep

--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -6,6 +6,7 @@ FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += puf_sram
 FEATURES_PROVIDED += periph_uart_modecfg
+FEATURES_PROVIDED += periph_uart_nonblocking
 FEATURES_PROVIDED += periph_wdt
 
 ifneq (,$(filter $(CPU_FAM),f0 f1 f3 l0 l1 l4 wb))

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -547,6 +547,13 @@ typedef enum {
     STM32_LPUART,           /**< STM32 Low-power UART (LPUART) module type */
 } uart_type_t;
 
+/**
+ * @brief   Size of the UART TX buffer for non-blocking mode.
+ */
+#ifndef STM32_UART_TXBUF_SIZE
+#define STM32_UART_TXBUF_SIZE    (64)
+#endif
+
 #ifndef DOXYGEN
 /**
  * @brief   Invalid UART mode mask


### PR DESCRIPTION
### Contribution description

This PR adds `periph_uart_nonblocking` to stm32f1. It probably works for other stm32, but I did it on purpose only for `stm32f1` so that only one platform needs to be tested.

### Testing procedure

`BOARD=iotlab-m3 make -C tests/periph_uart_nonblocking/ flash test`

```
...
Join us now and share the software;
You'll be free, hackers, you'll be free.
Join us now and share the software;
You'll be free, hackers, you'll be free.

== printed in 2101449/2100000 µs ==
[SUCCESS]
```
