### PR TITLE
pkg/tinydtls: cleanup build system integration

### DIFF
--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -11,10 +11,9 @@ CFLAGS += -Wno-implicit-fallthrough
 CFLAGS += -D_XOPEN_SOURCE=600
 
 all:
-	@cp $(PKG_BUILDDIR)/Makefile.riot $(PKG_BUILDDIR)/Makefile
-	@cp $(PKG_BUILDDIR)/aes/Makefile.riot $(PKG_BUILDDIR)/aes/Makefile
-	@cp $(PKG_BUILDDIR)/ecc/Makefile.riot $(PKG_BUILDDIR)/ecc/Makefile
-	"$(MAKE)" -C $(PKG_BUILDDIR)
+	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(PKG_BUILDDIR)/Makefile.riot
+	"$(MAKE)" -C $(PKG_BUILDDIR)/aes -f $(PKG_BUILDDIR)/aes/Makefile.riot
+	"$(MAKE)" -C $(PKG_BUILDDIR)/ecc -f $(PKG_BUILDDIR)/ecc/Makefile.riot
 
 ifeq (llvm,$(TOOLCHAIN))
   CFLAGS += -Wno-format-nonliteral

--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -41,14 +41,6 @@ else
   CFLAGS += -DTINYDTLS_LOG_LVL=0
 endif
 
-ifneq (,$(filter tinydtls_aes,$(USEMODULE)))
-  DIRS += $(PKG_BUILDDIR)/aes
-endif
-
-ifneq (,$(filter tinydtls_ecc,$(USEMODULE)))
-  DIRS += $(PKG_BUILDDIR)/ecc
-endif
-
 # For now contrib only contains sock_dtls adaption
 ifneq (,$(filter tinydtls_sock_dtls,$(USEMODULE)))
   DIRS += $(RIOTBASE)/pkg/tinydtls/contrib


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a small cleanup of the tinydtls package integration in the build system: instead of renaming existing RIOT-compatible Makefile in the package code, just use the `-f` option of `make` with the original Makefile.
Then there's also no need to add new `DIRS` from the package source code and it's allows to keep the package code untouched.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- `examples/dtls-echo` is still working

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
