### PR TITLE
tests/lwip: add blackpill to BOARD_INSUFFICIENT_MEMORY

### DIFF
--- a/tests/lwip/Makefile.ci
+++ b/tests/lwip/Makefile.ci
@@ -1,5 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     airfy-beacon \
+    blackpill \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Somehow this doesn't link on master anymore (test go too large), so blacklist it.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

 `make -Ctests/lwip BOARD=blackpill all` fails on master, won't be built with this PR.
 
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Popped up e.g, here: https://ci.riot-os.org/RIOT-OS/RIOT/14205/3dea09894deea99e8a6739939e52799b680c2313/output/compile/tests/lwip/blackpill:gnu.txt
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
