### PR TITLE
cpu/cc26x2_cc13x2: rename aux.c to restore Windows compatibility

### DIFF
--- a/cpu/cc26x2_cc13x2/auxiliary.c
+++ b/cpu/cc26x2_cc13x2/auxiliary.c
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) 2020 Locha Inc
  *
@@ -6,6 +5,7 @@
  * Public License v2.1. See the file LICENSE in the top level directory for more
  * details.
  */
+
 /**
  * @ingroup         cpu_cc26x2_cc13x2
  * @{


### PR DESCRIPTION
### Contribution description

AUX.* is a [reserved file name](https://docs.microsoft.com/de-de/windows/win32/fileio/naming-a-file
) on Windows. ([see also](https://www.youtube.com/watch?v=bC6tngl0PTI))


### Testing procedure

Everything should still compile, but you should be able to check out the RIOT repository on a Windows machine again (did not test this) 

@jeandudey are you fine with the new name?

### Issues/PRs references

fixes #14253
