### PR TITLE
boards/nrf52840dongle: enable automatic reset to bootloader

### DIFF
--- a/boards/nrf52840dongle/Makefile.dep
+++ b/boards/nrf52840dongle/Makefile.dep
@@ -5,13 +5,12 @@ endif
 ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_% slipdev_stdio,$(USEMODULE))))
   # Use stdio_cdc_acm only if no other stdio is requested explicitly.
   USEMODULE += stdio_cdc_acm
-  # This does not *really* hinge on the choice of stdio, but this ensures
-  # compatibility with the test suite that uses stdio_null and would conflict
-  # with bootloader_nrfutil.
-  # (Having the feature in is generally a good thing because as an indicator
-  # that it the resulting program is meant to be flashed using nrfutil).
-  FEATURES_REQUIRED += bootloader_nrfutil
 endif
-# ... and fall back to the UART-based stdio
+
+# enable bootloader reset over USB, requires USB bootloader to be used
+ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
+  FEATURES_REQUIRED += bootloader_nrfutil
+  USEMODULE += usb_board_reset
+endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/nrf52840dongle/Makefile.include
+++ b/boards/nrf52840dongle/Makefile.include
@@ -18,6 +18,8 @@ ifeq (nrfutil,$(PROGRAMMER))
   FLASHDEPS += $(HEXFILE).zip
   FLASHER = nrfutil
   FFLAGS = dfu usb-serial --port=${PORT} --package=$(HEXFILE).zip
+
+  include $(RIOTMAKE)/tools/usb_board_reset.mk
 endif
 
 %.hex.zip: %.hex

--- a/boards/nrf52840dongle/doc.txt
+++ b/boards/nrf52840dongle/doc.txt
@@ -28,9 +28,14 @@ The board is flashed using its on-board boot loader; the
 be installed. That can turn the binary into a suitable zip file and send it to the
 bootloader.
 
-The process is automated in the usual `make flash` target. For that process to
-complete, you need to enter the bootloader manually by pressing the board's
-reset button. Readiness of the bootloader is indicated by LD2 pulsing in red.
+The process is automated in the usual `make flash` target.
+
+If RIOT is already running on the board, it will automatically reset the CPU and enter
+the bootloader.
+If some other firmware is running or RIOT crashed, you need to enter the bootloader
+manually by pressing the board's reset button.
+
+Readiness of the bootloader is indicated by LD2 pulsing in red.
 
 #### nrfutil installation
 

--- a/boards/nrf52840dongle/reset.c
+++ b/boards/nrf52840dongle/reset.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C)  2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840dongle
+ * @{
+ * @file
+ * @brief       Allows reboot into bootloader via hardware reset
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#ifdef MODULE_USB_BOARD_RESET
+
+#include "periph/gpio.h"
+
+/* P0.19 is connected to the RESET line */
+#define BSP_SELF_PINRESET_PIN GPIO_PIN(0, 19)
+
+void usb_board_reset_in_bootloader(void)
+{
+    gpio_init(BSP_SELF_PINRESET_PIN, GPIO_OUT);
+    gpio_clear(BSP_SELF_PINRESET_PIN);
+}
+
+#endif /* MODULE_USB_BOARD_RESET */


### PR DESCRIPTION
### Contribution description

There was a brief discussion about this in #13146. I view it as a great convinience being able to flash a board without any physical interaction.

Now I did not test this since I don't have such a board, but having moved the board reset logic to a common place now, this should just work™ on these boards too.

### Testing procedure

 - flash the board the usual way by pressing the reset button
 - flash the board again using only `make flash`
 - the board should get flashed without having to press any buttons.

Again, I did not test this, so please give this a try.

### Issues/PRs references

requires ddf407e192811a9742c1b6f52ebacfc8c9bd1358 from #14212
