### PR TITLE
drivers/periph/rtt: introduce RTT_MIN_OFFSET

### DIFF
--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -286,6 +286,7 @@ static const i2c_conf_t i2c_config[] = {
 #define RTT_IRQ_PRIO        10
 #define RTT_ISR             isr_rtc
 #define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_MIN_OFFSET      (10U)
 #define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
 #define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
 /** @} */

--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -61,6 +61,24 @@ extern "C" {
 #define RTT_MAX_VALUE
 #endif
 
+/**
+ * @def     RTT_MIN_OFFSET
+ *
+ * @brief   The minimum offset to correctly set an rtt callback.
+ *
+ * If the callback is taking into account rtt_get_counter() then the rtt
+ * might advance right between the call to rtt_get_counter() and
+ * rtt_set_alarm(). If that happens with val==1, the alarm would be
+ * set to the current time, which would then underflow. To avoid this,
+ * the alarm should be set at least two ticks in the future.
+ *
+ * This value can vary depending on the platform.
+ *
+ */
+#ifndef RTT_MIN_OFFSET
+#define RTT_MIN_OFFSET (2U)
+#endif
+
 #ifndef RTT_FREQUENCY
 /* Allow mock-RTT for unit tests */
 #ifdef MOCK_RTT_FREQUENCY

--- a/sys/ztimer/periph_rtt.c
+++ b/sys/ztimer/periph_rtt.c
@@ -26,10 +26,6 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-#ifndef RTT_MIN_VALUE
-#define RTT_MIN_VALUE (2U)
-#endif
-
 static void _ztimer_periph_rtt_callback(void *arg)
 {
     ztimer_handler((ztimer_clock_t *)arg);
@@ -37,17 +33,17 @@ static void _ztimer_periph_rtt_callback(void *arg)
 
 static void _ztimer_periph_rtt_set(ztimer_clock_t *clock, uint32_t val)
 {
-    if (val < RTT_MIN_VALUE) {
+    if (val < RTT_MIN_OFFSET) {
         /* the rtt might advance right between the call to rtt_get_counter()
          * and rtt_set_alarm(). If that happens with val==1, we'd set an alarm
          * to the current time, which would then underflow.  To avoid this, we
          * set the alarm at least two ticks in the future.  TODO: confirm this
          * is sufficient, or conceive logic to lower this value.
          *
-         * @note RTT_MIN_VALUE defaults to 2, but some platforms might have
+         * @note RTT_MIN_OFFSET defaults to 2, but some platforms might have
          * different values.
          */
-        val = RTT_MIN_VALUE;
+        val = RTT_MIN_OFFSET;
     }
 
     unsigned state = irq_disable();


### PR DESCRIPTION
### Contribution description

This PR moves the definition of `RTT_MIN_VALUE` to the header file and changes it name to avoid confusion with `RTT_MAX_VALUE`.

IMO it should be available since any application using RTT should be aware of values that could cause an underflow.

This PR also adds a board defining a non default value for `samr21-xpro`, see https://github.com/RIOT-OS/RIOT/pull/14146  for how the value was obtained.

### Testing procedure

https://github.com/RIOT-OS/RIOT/pull/14146 can be used to see that this value can vary.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14146