### PR TITLE
sam0_common: Make SPI peripheral DMA compatible

### DIFF
--- a/boards/common/arduino-mkr/include/periph_conf.h
+++ b/boards/common/arduino-mkr/include/periph_conf.h
@@ -74,6 +74,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_3,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM1_DMAC_ID_TX,
+        .rx_trigger = SERCOM1_DMAC_ID_RX,
+#endif
     },
     {
         .dev      = &SERCOM2->SPI,
@@ -86,6 +90,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_3,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM2_DMAC_ID_TX,
+        .rx_trigger = SERCOM2_DMAC_ID_RX,
+#endif
     }
 };
 

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -103,6 +103,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM0_DMAC_ID_TX,
+        .rx_trigger = SERCOM0_DMAC_ID_RX,
+#endif
     }
 };
 

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -219,6 +219,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM4_DMAC_ID_TX,
+        .rx_trigger = SERCOM4_DMAC_ID_RX,
+#endif
     }
 };
 

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -224,6 +224,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM4_DMAC_ID_TX,
+        .rx_trigger = SERCOM4_DMAC_ID_RX,
+#endif
     }
 };
 

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -256,6 +256,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM0_DMAC_ID_TX,
+        .rx_trigger = SERCOM0_DMAC_ID_RX,
+#endif
     },
     {   /* EXT2 */
         .dev      = &SERCOM1->SPI,
@@ -268,6 +272,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM1_DMAC_ID_TX,
+        .rx_trigger = SERCOM1_DMAC_ID_RX,
+#endif
     },
     {   /* EXT3 */
         .dev      = &SERCOM5->SPI,
@@ -280,6 +288,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM5_DMAC_ID_TX,
+        .rx_trigger = SERCOM5_DMAC_ID_RX,
+#endif
     }
 };
 

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -162,6 +162,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_3,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
         .gclk_src = SAM0_GCLK_48MHZ,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM4_DMAC_ID_TX,
+        .rx_trigger = SERCOM4_DMAC_ID_RX,
+#endif
 
     },
     {    /* EXT2, EXT3 */
@@ -175,6 +179,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_3,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
         .gclk_src = SAM0_GCLK_48MHZ,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM6_DMAC_ID_TX,
+        .rx_trigger = SERCOM6_DMAC_ID_RX,
+#endif
     }
 };
 

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -120,6 +120,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM0_DMAC_ID_TX,
+        .rx_trigger = SERCOM0_DMAC_ID_RX,
+#endif
     }
 };
 

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -230,6 +230,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM4_DMAC_ID_TX,
+        .rx_trigger = SERCOM4_DMAC_ID_RX,
+#endif
     },
     {
         .dev      = &SERCOM5->SPI,
@@ -242,6 +246,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM5_DMAC_ID_TX,
+        .rx_trigger = SERCOM5_DMAC_ID_RX,
+#endif
     }
 };
 

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -95,6 +95,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM4_DMAC_ID_TX,
+        .rx_trigger = SERCOM4_DMAC_ID_RX,
+#endif
     },
     {    /* EXT1 & EXT3 Pin Header */
         .dev      = &(SERCOM5->SPI),
@@ -107,6 +111,11 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        /* The SAML21 doesn't support DMA triggers on SERCOM5 */
+        .tx_trigger = DMA_TRIGGER_DISABLED,
+        .rx_trigger = DMA_TRIGGER_DISABLED,
+#endif
     }
 };
 

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -103,6 +103,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM4_DMAC_ID_TX,
+        .rx_trigger = SERCOM4_DMAC_ID_RX,
+#endif
     }
 };
 

--- a/boards/sensebox_samd21/include/periph_conf.h
+++ b/boards/sensebox_samd21/include/periph_conf.h
@@ -173,6 +173,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_3,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM1_DMAC_ID_TX,
+        .rx_trigger = SERCOM1_DMAC_ID_RX,
+#endif
     }
 };
 

--- a/boards/serpente/include/periph_conf.h
+++ b/boards/serpente/include/periph_conf.h
@@ -164,6 +164,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_2,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM1_DMAC_ID_TX,
+        .rx_trigger = SERCOM1_DMAC_ID_RX,
+#endif
     },
     {   /* D0 … D2 (user pins) */
         .dev      = &SERCOM0->SPI,
@@ -176,6 +180,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_2,
         .mosi_pad = SPI_PAD_MOSI_0_SCK_1,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM0_DMAC_ID_TX,
+        .rx_trigger = SERCOM0_DMAC_ID_RX,
+#endif
     },
 };
 

--- a/boards/sodaq-one/include/periph_conf.h
+++ b/boards/sodaq-one/include/periph_conf.h
@@ -128,6 +128,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM0_DMAC_ID_TX,
+        .rx_trigger = SERCOM0_DMAC_ID_RX,
+#endif
     }
 };
 

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -39,8 +39,10 @@ extern "C" {
  */
 #define PERIPH_SPI_NEEDS_INIT_CS
 #define PERIPH_SPI_NEEDS_TRANSFER_BYTE
+#ifndef MODULE_PERIPH_DMA
 #define PERIPH_SPI_NEEDS_TRANSFER_REG
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
+#endif
 /** @} */
 
 /**
@@ -275,6 +277,10 @@ typedef struct {
     spi_misopad_t miso_pad; /**< pad to use for MISO line */
     spi_mosipad_t mosi_pad; /**< pad to use for MOSI and CLK line */
     uint8_t gclk_src;       /**< GCLK source which supplys SERCOM */
+#ifdef MODULE_PERIPH_DMA
+    uint8_t tx_trigger;     /**< DMA trigger */
+    uint8_t rx_trigger;     /**< DMA trigger */
+#endif
 } spi_conf_t;
 /** @} */
 

--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -29,6 +29,7 @@
 #include "mutex.h"
 #include "assert.h"
 #include "periph/spi.h"
+#include "pm_layered.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -37,6 +38,18 @@
  * @brief Array holding one pre-initialized mutex for each SPI device
  */
 static mutex_t locks[SPI_NUMOF];
+
+#ifdef MODULE_PERIPH_DMA
+struct dma_state {
+    dma_t tx_dma;
+    dma_t rx_dma;
+};
+
+static struct dma_state _dma_state[SPI_NUMOF];
+
+static DmacDescriptor DMA_DESCRIPTOR_ATTRS tx_desc[SPI_NUMOF];
+static DmacDescriptor DMA_DESCRIPTOR_ATTRS rx_desc[SPI_NUMOF];
+#endif
 
 /**
  * @brief   Shortcut for accessing the used SPI SERCOM device
@@ -54,6 +67,17 @@ static inline void poweron(spi_t bus)
 static inline void poweroff(spi_t bus)
 {
     sercom_clk_dis(dev(bus));
+}
+
+static inline bool _use_dma(spi_t bus)
+{
+#ifdef MODULE_PERIPH_DMA
+    return (spi_config[bus].tx_trigger != DMA_TRIGGER_DISABLED) &&
+           (spi_config[bus].rx_trigger != DMA_TRIGGER_DISABLED);
+#else
+    (void)bus;
+    return false;
+#endif
 }
 
 void spi_init(spi_t bus)
@@ -82,8 +106,23 @@ void spi_init(spi_t bus)
      * no synchronization needed, as SERCOM device is not enabled */
     dev(bus)->CTRLB.reg = (SERCOM_SPI_CTRLB_CHSIZE(0) | SERCOM_SPI_CTRLB_RXEN);
 
+#ifdef MODULE_PERIPH_DMA
+    if (_use_dma(bus)) {
+        _dma_state[bus].rx_dma = dma_acquire_channel();
+        _dma_state[bus].tx_dma = dma_acquire_channel();
+        dma_setup(_dma_state[bus].tx_dma,
+                  spi_config[bus].tx_trigger, 0, false);
+        dma_setup(_dma_state[bus].rx_dma,
+                  spi_config[bus].rx_trigger, 1, true);
+        dma_prepare(_dma_state[bus].rx_dma, DMAC_BTCTRL_BEATSIZE_BYTE_Val,
+                    (void*)&dev(bus)->DATA.reg, NULL, 1, 0);
+        dma_prepare(_dma_state[bus].tx_dma, DMAC_BTCTRL_BEATSIZE_BYTE_Val,
+                    NULL, (void*)&dev(bus)->DATA.reg, 0, 0);
+    }
+#endif
     /* put device back to sleep */
     poweroff(bus);
+
 }
 
 void spi_init_pins(spi_t bus)
@@ -164,27 +203,113 @@ void spi_release(spi_t bus)
     mutex_unlock(&locks[bus]);
 }
 
-void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
-                        const void *out, void *in, size_t len)
+static void _blocking_transfer(spi_t bus, const void *out, void *in, size_t len)
 {
     const uint8_t *out_buf = out;
     uint8_t *in_buf = in;
 
-    assert(out || in);
-
-    if (cs != SPI_CS_UNDEF) {
-        gpio_clear((gpio_t)cs);
-    }
-
     for (int i = 0; i < (int)len; i++) {
         uint8_t tmp = (out_buf) ? out_buf[i] : 0;
-        while (!(dev(bus)->INTFLAG.reg & SERCOM_SPI_INTFLAG_DRE)) {}
         dev(bus)->DATA.reg = tmp;
         while (!(dev(bus)->INTFLAG.reg & SERCOM_SPI_INTFLAG_RXC)) {}
         tmp = (uint8_t)dev(bus)->DATA.reg;
         if (in_buf) {
             in_buf[i] = tmp;
         }
+    }
+}
+
+#ifdef MODULE_PERIPH_DMA
+
+static void _dma_execute(spi_t bus)
+{
+#if defined(CPU_FAM_SAMD21)
+    pm_block(SAMD21_PM_IDLE_1);
+#endif
+    dma_start(_dma_state[bus].rx_dma);
+    dma_start(_dma_state[bus].tx_dma);
+
+    dma_wait(_dma_state[bus].rx_dma);
+#if defined(CPU_FAM_SAMD21)
+    pm_unblock(SAMD21_PM_IDLE_1);
+#endif
+}
+
+static void _dma_transfer(spi_t bus, const uint8_t *out, uint8_t *in,
+                          size_t len)
+{
+    uint8_t tmp = 0;
+    const uint8_t *out_addr = out ? out + len : &tmp;
+    uint8_t *in_addr = in ? in + len : &tmp;
+    dma_prepare_dst(_dma_state[bus].rx_dma, in_addr, len, in ? true : false);
+    dma_prepare_src(_dma_state[bus].tx_dma, out_addr, len, out ? true : false);
+    _dma_execute(bus);
+}
+
+static void _dma_transfer_regs(spi_t bus, uint8_t reg, const uint8_t *out,
+                               uint8_t *in, size_t len)
+{
+    uint8_t tmp;
+    const uint8_t *out_addr = out ? out + len : &tmp;
+    uint8_t *in_addr = in ? in + len : &tmp;
+
+    dma_prepare_dst(_dma_state[bus].rx_dma, &tmp, 1, false);
+    dma_prepare_src(_dma_state[bus].tx_dma, &reg, 1, false);
+
+    dma_append_dst(_dma_state[bus].rx_dma, &rx_desc[bus], in_addr,
+                   len, in ? true : false);
+    dma_append_src(_dma_state[bus].tx_dma, &tx_desc[bus], out_addr,
+                   len, out ? true : false);
+
+    _dma_execute(bus);
+}
+void spi_transfer_regs(spi_t bus, spi_cs_t cs,
+                       uint8_t reg, const void *out, void *in, size_t len)
+{
+    if (cs != SPI_CS_UNDEF) {
+        gpio_clear((gpio_t)cs);
+    }
+
+    if (_use_dma(bus)) {
+        /* The DMA promises not to modify the const out data */
+        _dma_transfer_regs(bus, reg, out, in, len);
+    }
+    else {
+        _blocking_transfer(bus, &reg, NULL, 1);
+        _blocking_transfer(bus, out, in, len);
+    }
+
+    if (cs != SPI_CS_UNDEF) {
+        gpio_set((gpio_t)cs);
+    }
+}
+
+uint8_t spi_transfer_reg(spi_t bus, spi_cs_t cs, uint8_t reg, uint8_t out)
+{
+    uint8_t res;
+    spi_transfer_regs(bus, cs, reg, &out, &res, 1);
+    return res;
+}
+
+#endif /* MODULE_PERIPH_DMA */
+
+
+void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
+                        const void *out, void *in, size_t len)
+{
+    assert(out || in);
+
+    if (cs != SPI_CS_UNDEF) {
+        gpio_clear((gpio_t)cs);
+    }
+    if (_use_dma(bus)) {
+#ifdef MODULE_PERIPH_DMA
+        /* The DMA promises not to modify the const out data */
+        _dma_transfer(bus, out, in, len);
+#endif
+    }
+    else {
+        _blocking_transfer(bus, out, in, len);
     }
 
     if ((!cont) && (cs != SPI_CS_UNDEF)) {


### PR DESCRIPTION
### Contribution description

This adds DMA compatibility to the SPI peripheral on the atsam platform. DMA can be enabled on a per peripheral basis. As the unconfigured DMA option is value zero, leaving the DMA unconfigured with a peripheral while having DMA itself enabled doesn't break the peripheral. (currently the case on the stm32 :cry:). 

A SPI peripheral will claim two DMA channels without releasing them. This prevents having to reconfigure the DMA channel on every transfer and keeps the transfer overhead as low as possible. The receive channel has a higher priority than the transfer channel to keep the transfer channel from starving the receive channel.

SPI register writes are combined in two DMA chained descriptors. This saves considerable time by combining the two transfers into a single blocking transfer.

### Testing procedure

As described in #14260, use `tests/periph_spi` with `periph_dma` in the `FEATURES_REQUIRED`. The benchmark command must work at 10Mhz. It should be tested on:
 - [x] same54-xpro
 - [x] samr21-xpro
 - [x] samr30-xpro/saml21-xpro
 - [x] saml11-xpro/saml10-xpro

### Benchmarks

#### Benchmarks on the samr21-xpro with the SPI peripheral configured at 10Mhz:

<details>
 <summary>With DMA</summary>

```
init 1 0 4 1 3
2020-06-11 11:35:36,424 #  init 1 0 4 1 3
2020-06-11 11:35:36,429 # SPI_DEV(1) initialized: mode: 0, clk: 4, cs_port: 1, cs_pin: 3
bench 3
2020-06-11 11:35:38,088 #  bench
2020-06-11 11:35:38,093 # ### Running some benchmarks, all values in [us] ###
2020-06-11 11:35:38,096 # ### Test                              Transfer time   user time
2020-06-11 11:35:38,097 # 
2020-06-11 11:35:38,122 #  1 - write 1000 times 1 byte:                 22196   22215
2020-06-11 11:35:38,147 #  2 - write 1000 times 2 byte:                 21738   21757
2020-06-11 11:35:38,261 #  3 - write 1000 times 100 byte:               109009  28027
2020-06-11 11:35:38,291 #  4 - write 1000 times 1 byte to register:     25759   25778
2020-06-11 11:35:38,321 #  5 - write 1000 times 2 byte to register:     25217   25236
2020-06-11 11:35:38,440 #  6 - write 1000 times 100 byte to register:   113009  31028
2020-06-11 11:35:38,466 #  7 - read 1000 times 2 byte:                  21884   21903
2020-06-11 11:35:38,578 #  8 - read 1000 times 100 byte:                109009  28027
2020-06-11 11:35:38,609 #  9 - read 1000 times 2 byte from register:    25363   25382
2020-06-11 11:35:38,727 # 10 - read 1000 times 100 byte from register:  113010  31028
2020-06-11 11:35:38,753 # 11 - transfer 1000 times 2 byte:              21800   21819
2020-06-11 11:35:38,867 # 12 - transfer 1000 times 100 byte:            109009  28027
2020-06-11 11:35:38,897 # 13 - transfer 1000 times 2 byte to register:  25300   25319
2020-06-11 11:35:39,016 # 14 - transfer 1000 times 100 byte to register:113338  31028
2020-06-11 11:35:39,030 # 15 - acquire/release 1000 times:              10717   10736
2020-06-11 11:35:40,033 # -- - SUM:                                     866358  377310
2020-06-11 11:35:40,034 # 
2020-06-11 11:35:40,036 # ### All runs complete ###
```
</details>
<details>
 <summary>Without DMA</summary>

```
init 1 0 4 1 3
2020-06-11 11:40:28,612 #  init 1 0 4 1 3
2020-06-11 11:40:28,617 # SPI_DEV(1) initialized: mode: 0, clk: 4, cs_port: 1, cs_pin: 3
bench 3
2020-06-11 11:40:29,736 #  bench
2020-06-11 11:40:29,740 # ### Running some benchmarks, all values in [us] ###
2020-06-11 11:40:29,743 # ### Test                              Transfer time   user time
2020-06-11 11:40:29,743 # 
2020-06-11 11:40:29,751 #  1 - write 1000 times 1 byte:                 4342    4361
2020-06-11 11:40:29,761 #  2 - write 1000 times 2 byte:                 5467    5486
2020-06-11 11:40:29,922 #  3 - write 1000 times 100 byte:               156509  156528
2020-06-11 11:40:29,934 #  4 - write 1000 times 1 byte to register:     8301    8320
2020-06-11 11:40:29,949 #  5 - write 1000 times 2 byte to register:     9488    9507
2020-06-11 11:40:30,115 #  6 - write 1000 times 100 byte to register:   160571  160590
2020-06-11 11:40:30,124 #  7 - read 1000 times 2 byte:                  5551    5570
2020-06-11 11:40:30,285 #  8 - read 1000 times 100 byte:                156675  156694
2020-06-11 11:40:30,299 #  9 - read 1000 times 2 byte from register:    9592    9611
2020-06-11 11:40:30,465 # 10 - read 1000 times 100 byte from register:  160717  160736
2020-06-11 11:40:30,475 # 11 - transfer 1000 times 2 byte:              5530    5549
2020-06-11 11:40:30,638 # 12 - transfer 1000 times 100 byte:            158696  158715
2020-06-11 11:40:30,652 # 13 - transfer 1000 times 2 byte to register:  9509    9528
2020-06-11 11:40:30,821 # 14 - transfer 1000 times 100 byte to register:162738  162757
2020-06-11 11:40:30,835 # 15 - acquire/release 1000 times:              10676   10695
2020-06-11 11:40:31,839 # -- - SUM:                                     1024362 1024647
2020-06-11 11:40:31,839 # 
2020-06-11 11:40:31,842 # ### All runs complete ###
```
</details>

#### Benchmarks on the samr21-xpro with the SPI peripheral configured at 1Mhz:
<details>
 <summary>With DMA</summary>

```
init 1 0 2 1 3
2020-06-11 11:38:18,898 #  init 1 0 2 1 3
2020-06-11 11:38:18,904 # SPI_DEV(1) initialized: mode: 0, clk: 2, cs_port: 1, cs_pin: 3
> bench
2020-06-11 11:38:20,449 #  bench
2020-06-11 11:38:20,454 # ### Running some benchmarks, all values in [us] ###
2020-06-11 11:38:20,457 # ### Test                              Transfer time   user time
2020-06-11 11:38:20,457 # 
2020-06-11 11:38:20,508 #  1 - write 1000 times 1 byte:                 47009   28028
2020-06-11 11:38:20,559 #  2 - write 1000 times 2 byte:                 47008   28027
2020-06-11 11:38:21,395 #  3 - write 1000 times 100 byte:               831006  28027
2020-06-11 11:38:21,451 #  4 - write 1000 times 1 byte to register:     51008   32027
2020-06-11 11:38:21,513 #  5 - write 1000 times 2 byte to register:     58009   31028
2020-06-11 11:38:22,361 #  6 - write 1000 times 100 byte to register:   842009  31028
2020-06-11 11:38:22,412 #  7 - read 1000 times 2 byte:                  47008   28027
2020-06-11 11:38:23,247 #  8 - read 1000 times 100 byte:                831008  28027
2020-06-11 11:38:23,310 #  9 - read 1000 times 2 byte from register:    58009   31028
2020-06-11 11:38:24,158 # 10 - read 1000 times 100 byte from register:  842009  31028
2020-06-11 11:38:24,209 # 11 - transfer 1000 times 2 byte:              47008   28027
2020-06-11 11:38:25,045 # 12 - transfer 1000 times 100 byte:            831008  28027
2020-06-11 11:38:25,108 # 13 - transfer 1000 times 2 byte to register:  58009   31028
2020-06-11 11:38:25,956 # 14 - transfer 1000 times 100 byte to register:842009  31028
2020-06-11 11:38:25,971 # 15 - acquire/release 1000 times:              11363   11382
2020-06-11 11:38:26,975 # -- - SUM:                                     5443480 425767
2020-06-11 11:38:26,976 # 
2020-06-11 11:38:26,978 # ### All runs complete ###
```
</details>
<details>
 <summary>Without DMA</summary>

```
init 1 0 2 1 3
2020-06-11 11:39:36,725 #  init 1 0 2 1 3
2020-06-11 11:39:36,731 # SPI_DEV(1) initialized: mode: 0, clk: 2, cs_port: 1, cs_pin: 3
bench 3
2020-06-11 11:39:37,603 #  bench
2020-06-11 11:39:37,607 # ### Running some benchmarks, all values in [us] ###
2020-06-11 11:39:37,610 # ### Test                              Transfer time   user time
2020-06-11 11:39:37,610 # 
2020-06-11 11:39:37,626 #  1 - write 1000 times 1 byte:                 11780   11799
2020-06-11 11:39:37,651 #  2 - write 1000 times 2 byte:                 20342   20361
2020-06-11 11:39:38,556 #  3 - write 1000 times 100 byte:               900259  900278
2020-06-11 11:39:38,583 #  4 - write 1000 times 1 byte to register:     23175   23194
2020-06-11 11:39:38,620 #  5 - write 1000 times 2 byte to register:     31801   31820
2020-06-11 11:39:39,537 #  6 - write 1000 times 100 byte to register:   911759  911778
2020-06-11 11:39:39,562 #  7 - read 1000 times 2 byte:                  20425   20444
2020-06-11 11:39:40,467 #  8 - read 1000 times 100 byte:                900425  900444
2020-06-11 11:39:40,504 #  9 - read 1000 times 2 byte from register:    31905   31924
2020-06-11 11:39:41,421 # 10 - read 1000 times 100 byte from register:  911905  911924
2020-06-11 11:39:41,446 # 11 - transfer 1000 times 2 byte:              20405   20424
2020-06-11 11:39:42,353 # 12 - transfer 1000 times 100 byte:            902446  902465
2020-06-11 11:39:42,390 # 13 - transfer 1000 times 2 byte to register:  31821   31840
2020-06-11 11:39:43,310 # 14 - transfer 1000 times 100 byte to register:913925  913944
2020-06-11 11:39:43,325 # 15 - acquire/release 1000 times:              11342   11361
2020-06-11 11:39:44,329 # -- - SUM:                                     5643715 5644000
2020-06-11 11:39:44,329 # 
2020-06-11 11:39:44,331 # ### All runs complete ###
```
</details>

Visible is that the overhead of enabling DMA is relative constant, especially at lower SPI clock frequencies. With register writes the peripheral makes use of DMA transfer chaining, making the extra SPI write low overhead. Another notable result is that with large transfers the DMA based config is overal faster than without DMA. At some point, depending on the SPI clock speed, it pays of to always use DMA for the transfer.

### Issues/PRs references

Depends on #14260 