### PR TITLE
make: call compilers with --file-prefix-map set to RIOTBASE

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -106,19 +106,19 @@ endif
 
 $(OBJC): $(BINDIR)/$(MODULE)/%.o: %.c $(OBJ_DEPS)
 	$(Q)$(CCACHE) $(CC) \
-		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
+		--file-prefix-map=$(RIOTBASE)=. \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
 
 $(GENOBJC): %.o: %.c $(OBJ_DEPS)
 	$(Q) $(CCACHE) $(CC) \
-		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$<)\" \
+		--file-prefix-map=$(RIOTBASE)=. \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $<
 
 $(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.$(SRCXXEXT) $(OBJ_DEPS)
 	$(Q)$(CCACHE) $(CXX) \
-		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
+		--file-prefix-map=$(RIOTBASE)=. \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CXXFLAGS) $(CXXINCLUDES) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
 

--- a/Makefile.base
+++ b/Makefile.base
@@ -105,28 +105,31 @@ ifneq (,$(SHOULD_RUN_KCONFIG))
 endif
 
 $(OBJC): $(BINDIR)/$(MODULE)/%.o: %.c $(OBJ_DEPS)
-	$(Q)$(CCACHE) $(CC) \
-		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
+	$(Q) RELPATH=$$(realpath --relative-base $(RIOTBASE) $(abspath $<)) ; \
+	    cd $(RIOTBASE) && $(CCACHE) $(CC) \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
-		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
+		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ "$${RELPATH}"
 
 $(GENOBJC): %.o: %.c $(OBJ_DEPS)
-	$(Q) $(CCACHE) $(CC) \
-		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$<)\" \
+	$(Q) RELPATH=$$(realpath --relative-base $(RIOTBASE) $(abspath $<)) ; \
+	    cd $(RIOTBASE) && $(CCACHE) $(CC) \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
-		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $<
+		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ "$${RELPATH}"
 
 $(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.$(SRCXXEXT) $(OBJ_DEPS)
-	$(Q)$(CCACHE) $(CXX) \
-		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
+	$(Q) RELPATH=$$(realpath --relative-base $(RIOTBASE) $(abspath $<)) ; \
+	    cd $(RIOTBASE) && $(CCACHE) $(CXX) \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
-		$(CXXFLAGS) $(CXXINCLUDES) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
+		$(CXXFLAGS) $(CXXINCLUDES) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ "$${RELPATH}"
 
 $(ASMOBJ): $(BINDIR)/$(MODULE)/%.o: %.s
-	$(Q)$(AS) $(ASFLAGS) -o $@ $(abspath $<)
+	$(Q) RELPATH=$$(realpath --relative-base $(RIOTBASE) $(abspath $<)) ; \
+	    cd $(RIOTBASE) && $(AS) $(ASFLAGS) -o $@ $(abspath $<)
 
 $(ASSMOBJ): $(BINDIR)/$(MODULE)/%.o: %.S $(OBJ_DEPS)
-	$(Q)$(CCAS) $(CCASFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
+	$(Q) RELPATH=$$(realpath --relative-base $(RIOTBASE) $(abspath $<)) ; \
+	    cd $(RIOTBASE) && \
+		$(CCAS) $(CCASFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ "$${RELPATH}"
 
 # pull in dependency info for *existing* .o files
 # deleted header files will be silently ignored

--- a/Makefile.base
+++ b/Makefile.base
@@ -105,31 +105,28 @@ ifneq (,$(SHOULD_RUN_KCONFIG))
 endif
 
 $(OBJC): $(BINDIR)/$(MODULE)/%.o: %.c $(OBJ_DEPS)
-	$(Q) RELPATH=$$(realpath --relative-base $(RIOTBASE) $(abspath $<)) ; \
-	    cd $(RIOTBASE) && $(CCACHE) $(CC) \
+	$(Q)$(CCACHE) $(CC) \
+		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
-		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ "$${RELPATH}"
+		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
 
 $(GENOBJC): %.o: %.c $(OBJ_DEPS)
-	$(Q) RELPATH=$$(realpath --relative-base $(RIOTBASE) $(abspath $<)) ; \
-	    cd $(RIOTBASE) && $(CCACHE) $(CC) \
+	$(Q) $(CCACHE) $(CC) \
+		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$<)\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
-		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ "$${RELPATH}"
+		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $<
 
 $(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.$(SRCXXEXT) $(OBJ_DEPS)
-	$(Q) RELPATH=$$(realpath --relative-base $(RIOTBASE) $(abspath $<)) ; \
-	    cd $(RIOTBASE) && $(CCACHE) $(CXX) \
+	$(Q)$(CCACHE) $(CXX) \
+		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
-		$(CXXFLAGS) $(CXXINCLUDES) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ "$${RELPATH}"
+		$(CXXFLAGS) $(CXXINCLUDES) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
 
 $(ASMOBJ): $(BINDIR)/$(MODULE)/%.o: %.s
-	$(Q) RELPATH=$$(realpath --relative-base $(RIOTBASE) $(abspath $<)) ; \
-	    cd $(RIOTBASE) && $(AS) $(ASFLAGS) -o $@ $(abspath $<)
+	$(Q)$(AS) $(ASFLAGS) -o $@ $(abspath $<)
 
 $(ASSMOBJ): $(BINDIR)/$(MODULE)/%.o: %.S $(OBJ_DEPS)
-	$(Q) RELPATH=$$(realpath --relative-base $(RIOTBASE) $(abspath $<)) ; \
-	    cd $(RIOTBASE) && \
-		$(CCAS) $(CCASFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ "$${RELPATH}"
+	$(Q)$(CCAS) $(CCASFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
 
 # pull in dependency info for *existing* .o files
 # deleted header files will be silently ignored

--- a/sys/include/embUnit/AssertImpl.h
+++ b/sys/include/embUnit/AssertImpl.h
@@ -44,6 +44,10 @@ void addFailure(const char *msg, long line, const char *file);  /*TestCase.c*/
 void assertImplementationLongLong(long long expected,long long actual, long line, const char *file);
 void assertImplementationCStr(const char *expected,const char *actual, long line, const char *file);
 
+#ifndef RIOT_FILE_RELATIVE
+#define RIOT_FILE_RELATIVE  (__FILE__)
+#endif
+
 #define TEST_ASSERT_EQUAL_STRING(expected_, actual_) \
     do { \
         const char *____expected__ = expected_; \

--- a/tests/build_system_relpath/Makefile
+++ b/tests/build_system_relpath/Makefile
@@ -1,0 +1,3 @@
+include ../Makefile.tests_common
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/build_system_relpath/main.c
+++ b/tests/build_system_relpath/main.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       __FILE__ test application
+ *
+ * This test is supposed to check if __FILE__ evaluates to the desired value.
+ * Should evaluate to the relative path of a filename.
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+int main(void)
+{
+    printf("__FILE__: %s\n", __FILE__);
+
+    return 0;
+}

--- a/tests/build_system_relpath/tests/01-run.py
+++ b/tests/build_system_relpath/tests/01-run.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact('__FILE__: ./tests/build_system_relpath/main.c\r\n')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Currently, modules are built by cd'ing into the module folder, then calling gcc with the absolute path. ccache strips absolute paths in order to cache properly.

This leads to different binaries depending on whether ccache has a cache hit or miss, or if it is used at all, if a source file uses e.g., `__FILE__`.

~~This PR changes the build rules for CC, CXX and ASM* so they determine the relative path of a source file (to `$(RIOTBASE)`), use that as agument to compiler/asm, and cd to `$(RIOTBASE)` before calling the compiler.~~

Didn't work, as that invalidates local paths, e.g., `-Ilocal/folder`. Trying --file-prefix-map.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14255

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
