### PR TITLE
drivers/at86rf215: make reset pulse width configurable

### DIFF
--- a/drivers/at86rf215/Kconfig
+++ b/drivers/at86rf215/Kconfig
@@ -38,6 +38,17 @@ config AT86RF215_TRIM_VAL
         26 MHz the best.
         For more information Refer Table 6-25 TRIM in Datasheet
 
+config AT86RF215_RESET_PULSE_WIDTH_US
+    int "Width of the reset pulse (µs)"
+    range 16 1000
+    default 16
+    help
+        If your board design includes a filtering capacitor on the reset line, this raises
+        the rise time of the reset pulse.
+        To accommodate for this, select a larger reset pulse width here.
+
+        If unsure, leave this at the default value of 16 µs.
+
 choice
     prompt "Default Modulation"
 

--- a/drivers/at86rf215/at86rf215_internal.c
+++ b/drivers/at86rf215/at86rf215_internal.c
@@ -49,7 +49,7 @@ int at86rf215_hardware_reset(at86rf215_t *dev)
 
     /* trigger hardware reset */
     gpio_clear(dev->params.reset_pin);
-    xtimer_usleep(AT86RF215_RESET_PULSE_WIDTH_US);
+    xtimer_usleep(CONFIG_AT86RF215_RESET_PULSE_WIDTH_US);
     gpio_set(dev->params.reset_pin);
     xtimer_usleep(AT86RF215_RESET_DELAY_US);
 

--- a/drivers/at86rf215/include/at86rf215_internal.h
+++ b/drivers/at86rf215/include/at86rf215_internal.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include "at86rf215.h"
 #include "at86rf215_registers.h"
+#include "board.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,7 +31,9 @@ extern "C" {
 /**
  * @brief Minimum reset pulse width (tRST) in µs
  */
-#define AT86RF215_RESET_PULSE_WIDTH_US  (16U)
+#ifndef CONFIG_AT86RF215_RESET_PULSE_WIDTH_US
+#define CONFIG_AT86RF215_RESET_PULSE_WIDTH_US  (16U)
+#endif
 
 /**
  * @brief The typical transition time to TRX_OFF after reset (tPOWERON) in µs


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Some hardware designers like to include filtering capacitors into reset lines in order to protect against ESD or other pulses.

This increases the raise time of the reset signal. To still reach the required 16 µs reset pulse width, we thus have to increase the reset pulse width via board config.

### Testing procedure

The easiest way to test if your board is affected is by setting both interfaces to sleep, then reboot.
If the reset was not executed properly, the radio will not be able to start properly. after a the reboot.

This does not affect any of the reference boards but only a custom board with the at86rf215 chip.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
