### PR TITLE
pkg/nimble/netif: simplify mbuf pool initialization

### DIFF
--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -38,6 +38,7 @@
 #include "nimble_riot.h"
 #include "host/ble_gap.h"
 #include "host/util/util.h"
+#include "mem/mem.h"
 
 #define ENABLE_DEBUG            (0)
 #include "debug.h"
@@ -522,9 +523,8 @@ void nimble_netif_init(void)
     nimble_netif_conn_init();
 
     /* initialize of BLE related buffers */
-    res = os_mempool_init(&_mem_pool, MBUF_CNT, MBUF_SIZE, _mem, "nim_gnrc");
-    assert(res == 0);
-    res = os_mbuf_pool_init(&_mbuf_pool, &_mem_pool, MBUF_SIZE, MBUF_CNT);
+    res = mem_init_mbuf_pool(_mem, &_mem_pool, &_mbuf_pool,
+                             MBUF_CNT, MBUF_SIZE, "nim_gnrc");
     assert(res == 0);
 
     res = ble_l2cap_create_server(NIMBLE_NETIF_CID, MTU_SIZE,


### PR DESCRIPTION
### Contribution description
Minor code simplification: as I discovered, NimBLE already includes a function that initializes an mbuf pool as well as the underlying mempool, so there is no need to do this manually in `nimble_netif`.

### Testing procedure
A compile test should do. But if you want to run something, flash two `nrf52dk` nodes with the `gnrc_networking` example and make sure they can ping each other.

### Issues/PRs references
none