### PR TITLE
posix_sockets: use sin6_scope_id of struct sockaddr_in6

### DIFF
--- a/sys/posix/sockets/posix_sockets.c
+++ b/sys/posix/sockets/posix_sockets.c
@@ -238,6 +238,9 @@ static int _sockaddr_to_ep(const struct sockaddr *address, socklen_t address_len
             out->family = AF_INET6;
             memcpy(&out->addr.ipv6, &in6_addr->sin6_addr, sizeof(out->addr.ipv6));
             out->port = ntohs(in6_addr->sin6_port);
+            if (in6_addr->sin6_scope_id != 0) {
+                out->netif = (uint16_t) in6_addr->sin6_scope_id;
+            }
             break;
 #endif
         default:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This PR improves the POSIX compatibilitiy regarding scoped IPv6 addresses ([RFC4007](https://tools.ietf.org/html/rfc4007)).

Scoped IPv6 addresses are known by their `%`-notation especially with link-local addresses. The scope (aka netif id) can be mapped to the `sin6_scope_id` field of `struct sockaddr_in6` that is specified in [`<netinet/in.h>`](https://pubs.opengroup.org/onlinepubs/009695399/basedefs/netinet/in.h.html).

The PR includes a modified `posix_sockets` example that now accepts netif definitions like `fe80::x:x:x:x%5`. It can therefore, for example, be used on the `native` target that requires link-local addresses.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


Initialize tap interace(s). Open a netcat receiver:

```
netcat -vu6 -l 5555
```

Run posix_sockets example in another terminal on native:

```
make -C examples/posix_sockets
make -C examples/posix_sockets term
udp send IPV6ADDR 5555 hello
```
IPV6ADDR be the host link-local address, potentially with appended scope definition `...%netif`.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #14207 