### PR TITLE
pkg/cryptoauthlib: cleanup build system integration

### DIFF
--- a/pkg/cryptoauthlib/Makefile
+++ b/pkg/cryptoauthlib/Makefile
@@ -40,15 +40,10 @@ $(TOOLCHAIN_FILE): git-download
 	$(RIOTTOOLS)/cmake/generate-xcompile-toolchain.sh > $(TOOLCHAIN_FILE)
 
 build_tests:
-	cp $(PKG_TESTINCLDIR)/*.c $(PKG_BUILDDIR)
-	cp $(PKG_TESTINCLDIR)/jwt/*.c $(PKG_BUILDDIR)
-	cp $(PKG_TESTINCLDIR)/tng/*.c $(PKG_BUILDDIR)
-	cp $(PKG_TESTINCLDIR)/atcacert/*.c $(PKG_BUILDDIR)
-
-	echo "MODULE = $(PKG_TEST_NAME)" > $(PKG_BUILDDIR)/Makefile
-	echo "include \$$(RIOTBASE)/Makefile.base" >> $(PKG_BUILDDIR)/Makefile
-
-	"$(MAKE)" -C $(PKG_BUILDDIR)
+	"$(MAKE)" MODULE=$(PKG_TEST_NAME) -C $(PKG_BUILDDIR)/test -f $(RIOTBASE)/Makefile.base
+	"$(MAKE)" MODULE=$(PKG_TEST_NAME)_jwt -C $(PKG_BUILDDIR)/test/jwt -f $(RIOTBASE)/Makefile.base
+	"$(MAKE)" MODULE=$(PKG_TEST_NAME)_tng -C $(PKG_BUILDDIR)/test/tng -f $(RIOTBASE)/Makefile.base
+	"$(MAKE)" MODULE=$(PKG_TEST_NAME)_atcacert -C $(PKG_BUILDDIR)/test/atcacert -f $(RIOTBASE)/Makefile.base
 
 git-download: | ..cmake_version_supported
 

--- a/pkg/cryptoauthlib/Makefile
+++ b/pkg/cryptoauthlib/Makefile
@@ -3,11 +3,13 @@ PKG_URL=https://github.com/MicrochipTech/cryptoauthlib
 PKG_VERSION=af8187776cd3f3faf8bed412eaf6ff7221862e19
 PKG_LICENSE=LGPL-2.1
 PKG_TEST_NAME=cryptoauthlib_test
-PKG_TESTINCLDIR = $(PKG_BUILDDIR)/test
 
 include $(RIOTBASE)/pkg/pkg.mk
 
 .PHONY: all..cmake_version_supported
+
+CRYPTOAUTHLIB_SOURCE_DIR = $(PKG_BUILDDIR)
+CRYPTOAUTHLIB_BUILD_DIR = $(PKG_BUILDDIR)/build
 
 CMAKE_MINIMAL_VERSION = 3.6.0
 
@@ -17,7 +19,7 @@ CFLAGS += -Wno-type-limits -Wno-strict-aliasing -Wno-unused-variable -DATCA_HAL_
 CFLAGS += -Wno-unused-parameter -Wno-sign-compare -Wno-overflow -Wno-pointer-to-int-cast
 CFLAGS += -Wno-char-subscripts
 
-TOOLCHAIN_FILE=$(PKG_BUILDDIR)/xcompile-toolchain.cmake
+TOOLCHAIN_FILE=$(CRYPTOAUTHLIB_SOURCE_DIR)/xcompile-toolchain.cmake
 
 ifneq (,$(filter $(PKG_TEST_NAME),$(USEMODULE)))
     all: cryptoauth build_tests
@@ -25,25 +27,25 @@ else
     all: cryptoauth
 endif
 
-cryptoauth: $(PKG_BUILDDIR)/lib/Makefile
-	$(MAKE) -C $(PKG_BUILDDIR)/lib
-	cp $(PKG_BUILDDIR)/lib/libcryptoauth.a $(BINDIR)/$(PKG_NAME).a
+cryptoauth: $(CRYPTOAUTHLIB_BUILD_DIR)/Makefile
+	$(MAKE) -C $(CRYPTOAUTHLIB_BUILD_DIR)
+	cp $(CRYPTOAUTHLIB_BUILD_DIR)/libcryptoauth.a $(BINDIR)/$(PKG_NAME).a
 
-$(PKG_BUILDDIR)/lib/Makefile: $(TOOLCHAIN_FILE)
-	cd $(PKG_BUILDDIR)/lib && \
+$(CRYPTOAUTHLIB_BUILD_DIR)/Makefile: $(TOOLCHAIN_FILE)
 	cmake -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE) \
 		  -Wno-dev \
-		  -DBUILD_TESTS=OFF \
-		  -DATCA_HAL_I2C:BOOL=TRUE .
+		  -DATCA_HAL_I2C:BOOL=TRUE \
+		  -B$(CRYPTOAUTHLIB_BUILD_DIR) \
+		  -H$(CRYPTOAUTHLIB_SOURCE_DIR)/lib
 
 $(TOOLCHAIN_FILE): git-download
 	$(RIOTTOOLS)/cmake/generate-xcompile-toolchain.sh > $(TOOLCHAIN_FILE)
 
 build_tests:
-	"$(MAKE)" MODULE=$(PKG_TEST_NAME) -C $(PKG_BUILDDIR)/test -f $(RIOTBASE)/Makefile.base
-	"$(MAKE)" MODULE=$(PKG_TEST_NAME)_jwt -C $(PKG_BUILDDIR)/test/jwt -f $(RIOTBASE)/Makefile.base
-	"$(MAKE)" MODULE=$(PKG_TEST_NAME)_tng -C $(PKG_BUILDDIR)/test/tng -f $(RIOTBASE)/Makefile.base
-	"$(MAKE)" MODULE=$(PKG_TEST_NAME)_atcacert -C $(PKG_BUILDDIR)/test/atcacert -f $(RIOTBASE)/Makefile.base
+	"$(MAKE)" -C $(CRYPTOAUTHLIB_SOURCE_DIR)/test -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_TEST_NAME)
+	"$(MAKE)" -C $(CRYPTOAUTHLIB_SOURCE_DIR)/test/jwt -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_TEST_NAME)_jwt
+	"$(MAKE)" -C $(CRYPTOAUTHLIB_SOURCE_DIR)/test/tng -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_TEST_NAME)_tng
+	"$(MAKE)" -C $(CRYPTOAUTHLIB_SOURCE_DIR)/test/atcacert -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_TEST_NAME)_atcacert
 
 git-download: | ..cmake_version_supported
 

--- a/pkg/cryptoauthlib/Makefile.dep
+++ b/pkg/cryptoauthlib/Makefile.dep
@@ -3,3 +3,9 @@ FEATURES_REQUIRED += periph_i2c
 FEATURES_OPTIONAL += periph_i2c_reconfigure
 DEFAULT_MODULE += auto_init_security
 USEMODULE += cryptoauthlib_contrib
+
+ifneq (,$(filter cryptoauthlib_test,$(USEMODULE)))
+  USEMODULE += cryptoauthlib_test_jwt
+  USEMODULE += cryptoauthlib_test_tng
+  USEMODULE += cryptoauthlib_test_atcacert
+endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR cleans up how the cryptoauthlib package is built:
- it removes the need to move around source files within the package source: for this we can directly use RIOT's build system module functionality.
- it modifies the way CMake is used to perform an [out-of-source build](https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#what-is-an-out-of-source-build) . This is a recommended usage with CMake: all files generated by the configuration and build are located outside the original source code.

There's also a minor change: the `BUILD_TESTS` doesn't exists in the variables defined by the project. The actual build generates the following warning:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_TESTS
```
This PR simply removes it to drop the warning.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- The `test/pkg_cryptoauthlib_internal-tests` still builds and works fine

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
