### PR TITLE
cpu/sam0_common: drop prescaler from timer config

### DIFF
--- a/boards/common/arduino-mkr/include/periph_conf_common.h
+++ b/boards/common/arduino-mkr/include/periph_conf_common.h
@@ -91,10 +91,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
     },
@@ -105,10 +103,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
     }

--- a/boards/common/arduino-zero/include/periph_conf.h
+++ b/boards/common/arduino-zero/include/periph_conf.h
@@ -92,10 +92,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
     },
@@ -106,10 +104,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
     }

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -49,7 +49,6 @@ static const tc32_conf_t timer_config[] = {
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER(4),
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
 };

--- a/boards/common/sodaq/include/cfg_timer_default.h
+++ b/boards/common/sodaq/include/cfg_timer_default.h
@@ -40,10 +40,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
     },
@@ -54,10 +52,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
     }

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -86,10 +86,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
     },
@@ -100,10 +98,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
     }

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -119,10 +119,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
     },
@@ -133,10 +131,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
     }

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -105,10 +105,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
     },
@@ -119,10 +117,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
     }

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -43,7 +43,6 @@ static const tc32_conf_t timer_config[] = {
         .mclk_mask      = MCLK_APBAMASK_TC0 | MCLK_APBAMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
         .gclk_src       = SAM0_GCLK_8MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
         .flags          = TC_CTRLA_MODE_COUNT32,
     },
     {   /* Timer 1 */
@@ -53,7 +52,6 @@ static const tc32_conf_t timer_config[] = {
         .mclk_mask      = MCLK_APBBMASK_TC2 | MCLK_APBBMASK_TC3,
         .gclk_id        = TC2_GCLK_ID,
         .gclk_src       = SAM0_GCLK_8MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
 };

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -52,7 +52,6 @@ static const tc32_conf_t timer_config[] = {
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
         .gclk_src       = SAM0_GCLK_8MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER(3),
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
 };

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -105,10 +105,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
     },
@@ -119,10 +117,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
     }

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -42,7 +42,6 @@ static const tc32_conf_t timer_config[] = {
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
         .gclk_src       = SAM0_GCLK_8MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER(3),
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
 };

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -49,7 +49,6 @@ static const tc32_conf_t timer_config[] = {
         .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
         .gclk_id        = TC0_GCLK_ID,
         .gclk_src       = SAM0_GCLK_8MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER(3),
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
 };

--- a/boards/sensebox_samd21/include/periph_conf.h
+++ b/boards/sensebox_samd21/include/periph_conf.h
@@ -87,10 +87,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
     },
@@ -101,10 +99,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
     }

--- a/boards/serpente/include/periph_conf.h
+++ b/boards/serpente/include/periph_conf.h
@@ -86,10 +86,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TCC2_TC3,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT16,
     },
@@ -100,10 +98,8 @@ static const tc32_conf_t timer_config[] = {
         .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
 #if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
         .gclk_src       = SAM0_GCLK_1MHZ,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV1,
 #else
         .gclk_src       = SAM0_GCLK_MAIN,
-        .prescaler      = TC_CTRLA_PRESCALER_DIV8,
 #endif
         .flags          = TC_CTRLA_MODE_COUNT32,
     }

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -339,7 +339,6 @@ typedef struct {
     uint16_t gclk_ctrl;     /**< GCLK_CLKCTRL_ID for the Timer */
 #endif
     uint8_t gclk_src;       /**< GCLK source which supplys Timer */
-    uint16_t prescaler;     /**< prescaler used by the Timer */
     uint16_t flags;         /**< flags for CTRA, e.g. TC_CTRLA_MODE_COUNT32 */
 } tc32_conf_t;
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Since c05984b341ef41b8bc40f93d7fc5acf90e2eee81 the prescaler in the timer config struct is no longer used.

Let's remove it.

### Testing procedure

Everything should still compile.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
