### PR TITLE
tests/thread_msg_seq: better guarantee sequence of output lines

### DIFF
--- a/tests/thread_msg_seq/main.c
+++ b/tests/thread_msg_seq/main.c
@@ -57,17 +57,16 @@ int main(void)
     p_main = sched_active_pid;
 
     p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
-                       THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
-                       sub_thread, "nr1", "nr1");
-    p2 = thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN - 1,
-                       THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
-                       sub_thread, "nr2", "nr2");
-    p3 = thread_create(t3_stack, sizeof(t3_stack), THREAD_PRIORITY_MAIN - 1,
-                       THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
-                       sub_thread, "nr3", "nr3");
+                       THREAD_CREATE_STACKTEST, sub_thread, "nr1", "nr1");
 
+    p2 = thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN - 1,
+                       THREAD_CREATE_STACKTEST, sub_thread, "nr2", "nr2");
+
+    p3 = thread_create(t3_stack, sizeof(t3_stack), THREAD_PRIORITY_MAIN - 1,
+                       THREAD_CREATE_STACKTEST, sub_thread, "nr3", "nr3");
     puts("THREADS CREATED\n");
-    for(int i = 0; i < 3; i++) {
+
+    for (int i = 0; i < 3; i++) {
         msg_receive(&msg);
         printf("Got msg from pid %" PRIkernel_pid ": \"%s\"\n", msg.sender_pid, (char *)msg.content.ptr);
     }

--- a/tests/thread_msg_seq/tests/01-run.py
+++ b/tests/thread_msg_seq/tests/01-run.py
@@ -3,19 +3,26 @@
 import sys
 from testrunner import run
 
+THREAD_NAMES = ("nr1", "nr2", "nr3")
+
 
 def testfunc(child):
     child.expect_exact("START")
+    # Collect pids
+    thread_pids = []
+    for name in THREAD_NAMES:
+        child.expect(r"THREAD {} \(pid:(\d+)\) start".format(name))
+        thread_pids.append(int(child.match.group(1)))
     child.expect_exact("THREADS CREATED")
-    child.expect_exact("THREAD nr1 (pid:3) start")
-    child.expect_exact("THREAD nr1 (pid:3) end.")
-    child.expect_exact("THREAD nr2 (pid:4) start")
-    child.expect_exact("THREAD nr3 (pid:5) start")
-    child.expect_exact("Got msg from pid 3: \"nr1\"")
-    child.expect_exact("THREAD nr2 (pid:4) end.")
-    child.expect_exact("Got msg from pid 4: \"nr2\"")
-    child.expect_exact("THREAD nr3 (pid:5) end.")
-    child.expect_exact("Got msg from pid 5: \"nr3\"")
+
+    for index, name in enumerate(THREAD_NAMES):
+        child.expect(r"THREAD {} \(pid:(\d+)\) end.".format(name))
+        thread_pid = int(child.match.group(1))
+        assert thread_pid == thread_pids[index]
+        child.expect(r'Got msg from pid (\d+): "{}"'.format(name))
+        thread_pid = int(child.match.group(1))
+        assert thread_pid == thread_pids[index]
+
     child.expect_exact("SUCCESS")
 
 


### PR DESCRIPTION
### Contribution description

Due to timing the sequence of the output lines were less predictable than originally assumed. This became clear with testing `thread_msg_seq` on a board with CDC ACM as stdio.

This commit also changes to expectations of the test script. It does not rely
on fixed thread IDs anymore, because boards with CDC ACM as stdio have
a different first thread then boards with "normal" stdio via UART.

### Testing procedure

Run `tests/thread_msg_seq` with `compile_and_test_for_board`. Choose a board which uses CDC ACM as stdio. That means there are three threads active when the test starts. The test should succeed.

Run `tests/thread_msg_seq` with `compile_and_test_for_board`. Choose a board which uses standard UART for stdio (no CDC ACM). That means there are two threads active when the test starts. The test should succeed.

### Issues/PRs references

Fixes #14256