### PR TITLE
boards/samr21-xpro: add uart hw cts/rts

### DIFF
--- a/boards/samr21-xpro/Kconfig
+++ b/boards/samr21-xpro/Kconfig
@@ -19,5 +19,6 @@ config BOARD_SAMR21_XPRO
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+    select HAS_PERIPH_UART_HW_FC
     select HAS_PERIPH_USBDEV
     select HAS_RIOTBOOT

--- a/boards/samr21-xpro/Makefile.features
+++ b/boards/samr21-xpro/Makefile.features
@@ -10,6 +10,7 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_uart_hw_fc
 FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)

--- a/boards/samr21-xpro/doc.txt
+++ b/boards/samr21-xpro/doc.txt
@@ -157,6 +157,21 @@ specific board like this:
     BOARD=samr21-xpro SERIAL="ATML2127031800002124" make debug
 
 
+## Accessing STDIO via UART
+
+STDIO is available through the edbg debugger.
+
+Use the `term` target to open a terminal:
+
+    make BOARD=samr21-xpro -C examples/hello-world term
+
+RTS / CTS hardware flow control is available on `UART_DEV(0)` and
+`UART_DEV(1)`. This is unavailable when using STDIO directly through
+the debugger since it does not support it. Therefore to use hardware
+flow control an external FTDI device must be connected to the board's
+rx, tx, cts & rts matching pin headers, eg. for `UART_DEV(0)` to
+`PA5`, `PA4`, `PA6` & `PA7` (respectively) on EXT1 headers.
+
 
 ## Supported Toolchains
 

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -147,12 +147,16 @@ static const uart_conf_t uart_config[] = {
         .rx_pin   = GPIO_PIN(PA,5),
         .tx_pin   = GPIO_PIN(PA,4),
 #ifdef MODULE_PERIPH_UART_HW_FC
-        .rts_pin  = GPIO_UNDEF,
-        .cts_pin  = GPIO_UNDEF,
+        .rts_pin  = GPIO_PIN(PA,6),
+        .cts_pin  = GPIO_PIN(PA,7),
 #endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_1,
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .tx_pad   = UART_PAD_TX_0_RTS_2_CTS_3,
+#else
         .tx_pad   = UART_PAD_TX_0,
+#endif
         .flags    = UART_FLAG_NONE,
         .gclk_src = SAM0_GCLK_MAIN,
     },
@@ -161,12 +165,16 @@ static const uart_conf_t uart_config[] = {
         .rx_pin   = GPIO_PIN(PA,23),
         .tx_pin   = GPIO_PIN(PA,22),
 #ifdef MODULE_PERIPH_UART_HW_FC
-        .rts_pin  = GPIO_UNDEF,
-        .cts_pin  = GPIO_UNDEF,
+        .rts_pin  = GPIO_PIN(PB,22),
+        .cts_pin  = GPIO_PIN(PB,23),
 #endif
         .mux      = GPIO_MUX_D,
         .rx_pad   = UART_PAD_RX_1,
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .tx_pad   = UART_PAD_TX_0_RTS_2_CTS_3,
+#else
         .tx_pad   = UART_PAD_TX_0,
+#endif
         .flags    = UART_FLAG_NONE,
         .gclk_src = SAM0_GCLK_MAIN,
     }


### PR DESCRIPTION
### Contribution description

This PR adds the configuration for HW_FC for `samr21-xpro`. To test you will need to plug in a FTDI device on any of the two serial ports with the matching rts/cts pins connected.

### Testing procedure

- Check pin configuration

![image](https://user-images.githubusercontent.com/23060007/84488067-f34e6480-ac9f-11ea-8420-a1dff766a136.png)

![image](https://user-images.githubusercontent.com/23060007/84488097-fcd7cc80-ac9f-11ea-96e8-cb130f620c25.png)

![image](https://user-images.githubusercontent.com/23060007/84488118-05c89e00-aca0-11ea-88cf-f00cff79bcb6.png)

- I used mini-term to toggle RTS on any application that is continuously printing data.

`BOARD=samr21-xpro CFLAGS=-DSTDIO_UART_DEV="UART_DEV\(1\)" USEMODULE=periph_uart_hw_fc make -C tests/xtimer_drift/ flash term`

```
now=1.023605 (0x000f9e75 ticks), drift=1 us, jitter=1 us
now=2.023603 (0x001ee0b3 ticks), drift=-1 us, jitter=-2 us
now=3.023684 (0x002e2344 ticks), drift=80 us, jitter=81 us
now=4.023605 (0x003d6535 ticks), drift=1 us, jitter=-79 us
now=5.023680 (0x004ca7c0 ticks), drift=76 us, jitter=75 us
now=6.023605 (0x005be9b5 ticks), drift=1 us, jitter=-75 us
now=7.023604 (0x006b2bf4 ticks), drift=0 us, jitter=-1 us
--- RTS inactive ---
--- RTS active ---
now=8.023671 (0x007a6e77 ticks), drift=67 us, jitter=67 us
now=12.051262 (0x00b7e33e ticks), drift=3027658 us, jitter=3027591 us
now=13.051262 (0x00c7257e ticks), drift=3027658 us, jitter=0 us
now=14.051262 (0x00d667be ticks), drift=3027658 us, jitter=0 us
now=15.051262 (0x00e5a9fe ticks), drift=3027658 us, jitter=0 us
now=16.051332 (0x00f4ec84 ticks), drift=3027728 us, jitter=70 us
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
