### PR TITLE
cpu/saml21: adjust RTT_MIN_OFFSET

### DIFF
--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -81,6 +81,8 @@ typedef enum {
 #define RTT_CLOCK_FREQUENCY (32768U)                      /* in Hz */
 #define RTT_MIN_FREQUENCY   (RTT_CLOCK_FREQUENCY / 512U)  /* in Hz */
 #define RTT_MAX_FREQUENCY   (RTT_CLOCK_FREQUENCY)         /* in Hz */
+/* determined by tests/ztimer_underflow */
+#define RTT_MIN_OFFSET      (8U)
 /** @} */
 
 #ifdef __cplusplus

--- a/tests/ztimer_underflow/Makefile
+++ b/tests/ztimer_underflow/Makefile
@@ -1,0 +1,14 @@
+include ../Makefile.tests_common
+
+TEST_ZTIMER_CLOCK ?= ZTIMER_USEC
+
+USEMODULE += ztimer
+USEMODULE += ztimer_usec
+ifeq ($(TEST_ZTIMER_CLOCK), ZTIMER_MSEC)
+  USEMODULE += ztimer_msec
+  USEMODULE += ztimer_periph_rtt
+endif
+
+CFLAGS += -DTEST_ZTIMER_CLOCK=$(TEST_ZTIMER_CLOCK)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/ztimer_underflow/Makefile.ci
+++ b/tests/ztimer_underflow/Makefile.ci
@@ -1,0 +1,9 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    nucleo-f031k6 \
+    stm32f030f4-demo \
+    #

--- a/tests/ztimer_underflow/README.md
+++ b/tests/ztimer_underflow/README.md
@@ -1,0 +1,16 @@
+# Introduction
+
+This test application underflows ztimer clocks by setting a time offset of zero.
+The tests succeeds if the board running the test does not get stuck.
+
+
+## ZTIMER_USEC
+
+Set the environment variable `TEST_ZTIMER_CLOCK=ZTIMER_USEC`. If the test gets
+stuck, increase `CONFIG_ZTIMER_USEC_MIN`.
+
+
+## ZTIMER_MSEC
+
+Set the environment variable `TEST_ZTIMER_CLOCK=ZTIMER_MSEC`. If the test gets
+stuck, increase `RTT_MIN_OFFSET`.

--- a/tests/ztimer_underflow/main.c
+++ b/tests/ztimer_underflow/main.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 SSV Software Systems GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief    ztimer test application
+ *
+ * @author   Juergen Fitschen <jfi@ssv-embedded.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "ztimer.h"
+
+#ifndef TEST_ZTIMER_CLOCK
+#error Please define TEST_ZTIMER_CLOCK
+#endif
+
+#define LOOPS (1000U)
+
+#define xstr(s) str(s)
+#define str(s) #s
+
+int main(void)
+{
+    printf("Looping over ztimer clock %s\n", xstr(TEST_ZTIMER_CLOCK));
+
+    for (unsigned i = 0; i < LOOPS; i++) {
+        printf("Loop %u\n", i);
+        ztimer_sleep(TEST_ZTIMER_CLOCK, 0);
+    }
+
+    printf("SUCCESS!\n");
+
+    return 0;
+}

--- a/tests/ztimer_underflow/tests/01-run.py
+++ b/tests/ztimer_underflow/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2020 SSV Software Systems GmbH
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact("SUCCESS!")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

The `samr30-xpro` board requires *some* cycles to set the RTT and may miss the RTT clock alarm.

### Testing procedure

A test for `ztimer` underflows has been added.

`make -C tests/ztimer_underflow BOARD=samr30-xpro TEST_ZTIMER_CLOCK=ZTIMER_MSEC flash test`

### Issues/PRs references

The added test may be handy testing out #14244.
Waiting for #14259.