### PR TITLE
tests/pkg_cryptoauthlib_internal: blacklist atmega256rfr2 boards

### DIFF
--- a/tests/pkg_cryptoauthlib_internal-tests/Makefile.ci
+++ b/tests/pkg_cryptoauthlib_internal-tests/Makefile.ci
@@ -12,8 +12,11 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega1284p \
+    atmega256rfr2-xpro \
     atmega328p \
+    avr-rss2 \
     derfmega128 \
+    derfmega256 \
     mega-xplained \
     microduino-corerf \
     saml10-xpro \


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The test is right on the edge with these boards, so slight toolchain changes make it overflow the RAM, causing CI issues.


### Testing procedure

CI should stop failing on this test.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
