### PR TITLE
sam0_common/dma: Mark src parameter as const

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -760,8 +760,8 @@ void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, bool irq);
  * @param   len     Number of beats to transfer
  * @param   incr    Which of the addresses to increment after a beat
  */
-void dma_prepare(dma_t dma, uint8_t width, void *src, void *dst, size_t len,
-                 dma_incr_t incr);
+void dma_prepare(dma_t dma, uint8_t width, const void *src, void *dst,
+                 size_t len, dma_incr_t incr);
 
 /**
  * @brief   Prepare a transfer without modifying the destination address
@@ -780,7 +780,7 @@ void dma_prepare(dma_t dma, uint8_t width, void *src, void *dst, size_t len,
  * @param   len     Number of beats to transfer
  * @param   incr    Whether to increment the source address after a beat
  */
-void dma_prepare_src(dma_t dma, void *src, size_t len, bool incr);
+void dma_prepare_src(dma_t dma, const void *src, size_t len, bool incr);
 
 /**
  * @brief   Prepare a transfer without modifying the source address
@@ -817,7 +817,7 @@ void dma_prepare_dst(dma_t dma, void *dst, size_t len, bool incr);
  * @param   incr        Which of the addresses to increment after a beat
  */
 void dma_append(dma_t dma, DmacDescriptor *descriptor, uint8_t width,
-                void *src, void *dst, size_t len, dma_incr_t incr);
+                const void *src, void *dst, size_t len, dma_incr_t incr);
 
 /**
  * @brief   Append a second transfer descriptor after the default channel
@@ -833,8 +833,8 @@ void dma_append(dma_t dma, DmacDescriptor *descriptor, uint8_t width,
  * @param   len     Number of beats to transfer
  * @param   incr    Whether to increment the source address after a beat
  */
-void dma_append_src(dma_t dma, DmacDescriptor *next, void *src, size_t len,
-                    bool incr);
+void dma_append_src(dma_t dma, DmacDescriptor *next, const void *src,
+                    size_t len, bool incr);
 
 /**
  * @brief   Append a second transfer descriptor after the default channel

--- a/cpu/sam0_common/periph/dma.c
+++ b/cpu/sam0_common/periph/dma.c
@@ -124,7 +124,7 @@ void dma_release_channel(dma_t dma)
     irq_restore(state);
 }
 
-static inline void _set_source(DmacDescriptor *descr, void *src)
+static inline void _set_source(DmacDescriptor *descr, const void *src)
 {
     descr->SRCADDR.reg = (uint32_t)src;
 }
@@ -170,7 +170,7 @@ void dma_setup(dma_t dma, unsigned trigger, uint8_t prio, bool irq)
 #endif
 }
 
-void dma_prepare(dma_t dma, uint8_t width, void *src, void *dst, size_t len,
+void dma_prepare(dma_t dma, uint8_t width, const void *src, void *dst, size_t len,
                  uint8_t incr)
 {
     DEBUG("[DMA]: Prepare %u, len: %u\n", dma, (unsigned)len);
@@ -184,7 +184,7 @@ void dma_prepare(dma_t dma, uint8_t width, void *src, void *dst, size_t len,
                         DMAC_BTCTRL_VALID;
 }
 
-void dma_prepare_src(dma_t dma, void *src, size_t len,
+void dma_prepare_src(dma_t dma, const void *src, size_t len,
                      bool incr)
 {
     DEBUG("[dma]: %u: prep src %p, %u, %u\n", dma, src, (unsigned)len, incr);
@@ -209,7 +209,7 @@ void dma_prepare_dst(dma_t dma, void *dst, size_t len,
 }
 
 void _fmt_append(DmacDescriptor *descr, DmacDescriptor *next,
-                 void *src, void *dst, size_t len)
+                 const void *src, void *dst, size_t len)
 {
     /* Configure the full descriptor besides the BTCTRL data */
     _set_next_descriptor(descr, next);
@@ -220,7 +220,7 @@ void _fmt_append(DmacDescriptor *descr, DmacDescriptor *next,
 }
 
 void dma_append(dma_t dma, DmacDescriptor *next, uint8_t width,
-                void *src, void *dst, size_t len, dma_incr_t incr)
+                const void *src, void *dst, size_t len, dma_incr_t incr)
 {
     DmacDescriptor *descr = &descriptors[dma];
 
@@ -230,8 +230,8 @@ void dma_append(dma_t dma, DmacDescriptor *next, uint8_t width,
     _fmt_append(descr, next, src, dst, len);
 }
 
-void dma_append_src(dma_t dma, DmacDescriptor *next, void *src, size_t len,
-                    bool incr)
+void dma_append_src(dma_t dma, DmacDescriptor *next, const void *src,
+                    size_t len, bool incr)
 {
     DmacDescriptor *descr = &descriptors[dma];
 


### PR DESCRIPTION
### Contribution description

This PR marks the src argument of the DMA functions as const. The DMA should only read from this location and never write to them.

### Testing procedure

Successful compilation should be enough here, the resulting code is not changed, only how the compiler treats it.

### Issues/PRs references

Missed in #14260 