### PR TITLE
tests/periph_spi_dma: Add test for SPI with DMA

### DIFF
--- a/tests/periph_spi/Makefile
+++ b/tests/periph_spi/Makefile
@@ -1,7 +1,7 @@
 BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_spi
+FEATURES_REQUIRED += periph_spi
 
 USEMODULE += xtimer
 USEMODULE += shell

--- a/tests/periph_spi_dma/Makefile
+++ b/tests/periph_spi_dma/Makefile
@@ -1,0 +1,3 @@
+FEATURES_REQUIRED += periph_dma
+# Include everything else from the periph_spi test
+include ../periph_spi/Makefile

--- a/tests/periph_spi_dma/Makefile.ci
+++ b/tests/periph_spi_dma/Makefile.ci
@@ -1,0 +1,5 @@
+# Boards not able to accomodate the regular SPI test will not be able to link
+# this test.
+include ../periph_spi/Makefile.ci
+BOARD_INSUFFICIENT_MEMORY += \
+    #

--- a/tests/periph_spi_dma/README.md
+++ b/tests/periph_spi_dma/README.md
@@ -1,0 +1,14 @@
+Expected result
+===============
+You should be presented with the RIOT shell, providing you with commands to initialize a board
+as master or slave, and to send and receive data via SPI.
+
+Background
+==========
+Test for the low-level SPI driver in combination with the DMA peripheral.
+
+## Default SPI CS pin
+
+To overwrite the optional default cs pin CFLAGS can be used:
+
+`CFLAGS="-DDEFAULT_SPI_CS_PORT=<my_port_int> -DDEFAULT_SPI_CS_PIN=<my_pin_int>" BOARD=<my_board> make flash term`

--- a/tests/periph_spi_dma/main.c
+++ b/tests/periph_spi_dma/main.c
@@ -1,0 +1,1 @@
+../periph_spi/main.c


### PR DESCRIPTION
### Contribution description

This new test inherits everything from the regular periph_spi test, but
with DMA enabled

### Testing procedure

Test the test I guess :man_shrugging: 

### Issues/PRs references

As requested in #14261 