### PR TITLE
sam0/stm32: fix possible uart_nonblocking deadlock

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -192,8 +192,8 @@ typedef enum {
 /**
  * @brief   Size of the UART TX buffer for non-blocking mode.
  */
-#ifndef SAM0_UART_TXBUF_SIZE
-#define SAM0_UART_TXBUF_SIZE    (64)
+#ifndef UART_TXBUF_SIZE
+#define UART_TXBUF_SIZE    (64)
 #endif
 
 /**

--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -41,7 +41,7 @@
 #ifdef MODULE_PERIPH_UART_NONBLOCKING
 #include "tsrb.h"
 static tsrb_t uart_tx_rb[UART_NUMOF];
-static uint8_t uart_tx_rb_buf[UART_NUMOF][SAM0_UART_TXBUF_SIZE];
+static uint8_t uart_tx_rb_buf[UART_NUMOF][UART_TXBUF_SIZE];
 #endif
 static uart_isr_ctx_t uart_ctx[UART_NUMOF];
 
@@ -68,7 +68,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 
 #ifdef MODULE_PERIPH_UART_NONBLOCKING
     /* set up the TX buffer */
-    tsrb_init(&uart_tx_rb[uart], uart_tx_rb_buf[uart], SAM0_UART_TXBUF_SIZE);
+    tsrb_init(&uart_tx_rb[uart], uart_tx_rb_buf[uart], UART_TXBUF_SIZE);
 #endif
 
     /* configure pins */

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -550,8 +550,8 @@ typedef enum {
 /**
  * @brief   Size of the UART TX buffer for non-blocking mode.
  */
-#ifndef STM32_UART_TXBUF_SIZE
-#define STM32_UART_TXBUF_SIZE    (64)
+#ifndef UART_TXBUF_SIZE
+#define UART_TXBUF_SIZE    (64)
 #endif
 
 #ifndef DOXYGEN

--- a/cpu/stm32/periph/uart.c
+++ b/cpu/stm32/periph/uart.c
@@ -61,7 +61,7 @@
  * @brief   Allocate for tx ring buffers
  */
 static tsrb_t uart_tx_rb[UART_NUMOF];
-static uint8_t uart_tx_rb_buf[UART_NUMOF][STM32_UART_TXBUF_SIZE];
+static uint8_t uart_tx_rb_buf[UART_NUMOF][UART_TXBUF_SIZE];
 #endif
 
 /**
@@ -168,7 +168,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 
 #ifdef MODULE_PERIPH_UART_NONBLOCKING
     /* set up the TX buffer */
-    tsrb_init(&uart_tx_rb[uart], uart_tx_rb_buf[uart], STM32_UART_TXBUF_SIZE);
+    tsrb_init(&uart_tx_rb[uart], uart_tx_rb_buf[uart], UART_TXBUF_SIZE);
 #endif
 
     uart_init_pins(uart, rx_cb);

--- a/cpu/stm32/periph/uart.c
+++ b/cpu/stm32/periph/uart.c
@@ -207,6 +207,10 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
         dev(uart)->CR1 = (USART_CR1_UE | USART_CR1_TE);
     }
 
+#ifdef MODULE_PERIPH_UART_NONBLOCKING
+    NVIC_EnableIRQ(uart_config[uart].irqn);
+#endif
+
 #ifdef MODULE_PERIPH_UART_HW_FC
     if (uart_config[uart].cts_pin != GPIO_UNDEF) {
         dev(uart)->CR3 |= USART_CR3_CTSE;

--- a/tests/periph_uart_nonblocking/main.c
+++ b/tests/periph_uart_nonblocking/main.c
@@ -30,8 +30,21 @@ static inline uint32_t puts_delay(const char* str)
     return LINE_DELAY_MS * 1000;
 }
 
+static void _irq_disabled_print(void)
+{
+    unsigned state = irq_disable();
+    /* fill the transmit buffer */
+    for (uint8_t i = 0; i < UART_TXBUF_SIZE; i++) {
+        printf(" ");
+    }
+    puts("\nputs with disabled interrupts and a full transmit buffer");
+    irq_restore(state);
+}
+
 int main(void)
 {
+    _irq_disabled_print();
+
     uint32_t total_us = 0;
     xtimer_ticks32_t counter = xtimer_now();
 

--- a/tests/periph_uart_nonblocking/tests/01-run.py
+++ b/tests/periph_uart_nonblocking/tests/01-run.py
@@ -14,6 +14,7 @@ PRECISION = 1.002
 
 
 def testfunc(child):
+    child.expect_exact("puts with disabled interrupts and a full transmit buffer")
     child.expect(r'== printed in (\d+)/(\d+) µs ==')
     time_actual = int(child.match.group(1))
     time_expect = int(child.match.group(2))


### PR DESCRIPTION
### Contribution description

If trying to write to tsrb while ISR are masked or in an ISR then the while loop would block. Avoid blocking if any of those conditions are filled, this might mean bytes are lost.

### Testing procedure

`irq_disable()` in an application printing some output.  I tested in examples hello-world:

```
#include <stdio.h>
#include "irq.h"

int main(void)
{
    unsigned state = irq_disable();
    puts("Hello World!");
    irq_restore(state);
    printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
    printf("This board features a(n) %s MCU.\n", RIOT_MCU);

    return 0;
}
```

```
2020-06-14 20:35:14,805 # main(): This is RIOT! (Version: 2020.07-devel-1126-g5638e-pr_uart_nb_race)
2020-06-14 20:35:14,809 # You are running RIOT on a(n) samr21-xpro board.
2020-06-14 20:35:14,812 # This board features a(n) samd21 MCU.
```

In this example I didn't expect the output to be lost though. Not sure if this is the best solution either.