### PR TITLE
dist/tools/mosquitto_rsmb: fix stand-alone build

### DIFF
--- a/dist/tools/mosquitto_rsmb/Makefile
+++ b/dist/tools/mosquitto_rsmb/Makefile
@@ -4,8 +4,6 @@ PKG_VERSION  = 9b99a3be9a26635b93aec8fa2ed744e8c49e7262
 PKG_LICENSE  = EPL-1.0
 PKG_BUILDDIR = $(CURDIR)/bin
 
-include $(RIOTBASE)/pkg/pkg.mk
-
 # set default configuration file
 RSMB_CFG ?= $(CURDIR)/config.cnf
 
@@ -14,7 +12,9 @@ RIOTBASE ?= $(CURDIR)/../../..
 RIOTTOOLS ?= $(CURDIR)/..
 GITCACHE ?= $(RIOTTOOLS)/git/git-cache
 
-$(info $(RIOTBASE))
+# Include pkg.mk after setting RIOTBASE otherwise it is not found when this
+# Makefile is called stand-alone
+include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 # Start mosquitto_rsmb build in a clean environment, so variables set by RIOT's


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a small fix for the mosquitto_rsmb Makefile when it is used stand-alone, when called directly using `make -C dist/tools/mosquitto_rsmb`.

In the Makefile, `pkg.mk` is included before `RIOTBASE` is set so in the stand-alone scenario, this fails.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Run `make -C dist/tools/mosquitto_rsmb`:

<details><summary>master</summary>

```
make -C dist/tools/mosquitto_rsmb --no-print-directory 
/work/riot/RIOT/dist/tools/mosquitto_rsmb/../../..
Makefile:7: /pkg/pkg.mk: No such file or directory
make: *** No rule to make target '/pkg/pkg.mk'.  Stop.
```

</details>

<details><summary>this PR</summary>

```
make -C dist/tools/mosquitto_rsmb --no-print-directory 
[INFO] cloning mosquitto_rsmb
rm -Rf /work/riot/RIOT/dist/tools/mosquitto_rsmb/bin
mkdir -p /work/riot/RIOT/dist/tools/mosquitto_rsmb/bin
/work/riot/RIOT/dist/tools/mosquitto_rsmb/../git/git-cache clone https://github.com/eclipse/mosquitto.rsmb 9b99a3be9a26635b93aec8fa2ed744e8c49e7262 /work/riot/RIOT/dist/tools/mosquitto_rsmb/bin
Cloning into '/work/riot/RIOT/dist/tools/mosquitto_rsmb/bin'...
remote: Enumerating objects: 332, done.
remote: Total 332 (delta 0), reused 0 (delta 0), pack-reused 332
Receiving objects: 100% (332/332), 271.72 KiB | 706.00 KiB/s, done.
Resolving deltas: 100% (180/180), done.
HEAD is now at 9b99a3b Created a Markdown formatted README (#25)
[INFO] updating mosquitto_rsmb /work/riot/RIOT/dist/tools/mosquitto_rsmb/bin/.pkg-state.git-downloaded
git -C /work/riot/RIOT/dist/tools/mosquitto_rsmb/bin --git-dir=.git --work-tree=. fetch  https://github.com/eclipse/mosquitto.rsmb 9b99a3be9a26635b93aec8fa2ed744e8c49e7262
From https://github.com/eclipse/mosquitto.rsmb
 * branch            9b99a3be9a26635b93aec8fa2ed744e8c49e7262 -> FETCH_HEAD
echo 9b99a3be9a26635b93aec8fa2ed744e8c49e7262 > /work/riot/RIOT/dist/tools/mosquitto_rsmb/bin/.pkg-state.git-downloaded
[INFO] patch mosquitto_rsmb
git -C /work/riot/RIOT/dist/tools/mosquitto_rsmb/bin --git-dir=.git --work-tree=. clean  -xdff '**' ':!.pkg-state.git*'
git -C /work/riot/RIOT/dist/tools/mosquitto_rsmb/bin --git-dir=.git --work-tree=. checkout  -f 9b99a3be9a26635b93aec8fa2ed744e8c49e7262
HEAD is now at 9b99a3b Created a Markdown formatted README (#25)
git -C /work/riot/RIOT/dist/tools/mosquitto_rsmb/bin --git-dir=.git --work-tree=. -c user.email=buildsystem@riot -c user.name="RIOT buildsystem" am  --no-gpg-sign --ignore-whitespace --whitespace=nowarn  </dev/null
env -i PATH=/home/aabadie/.local/bin:/work/tools/mips-mti-elf/2016.05-03/bin:/work/tools/avr8-gnu-toolchain-linux_x86_64/bin:/work/tools/riscv-none-gcc/8.2.0-2.2-20190521-0004/bin:/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/:/home/aabadie/.cargo/bin:/home/aabadie/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/work/tools/packer TERM=xterm-256color "make" -C /work/riot/RIOT/dist/tools/mosquitto_rsmb/bin/rsmb/src
make: Entering directory '/work/riot/RIOT/dist/tools/mosquitto_rsmb/bin/rsmb/src'
cc -Wall -Os *.c -o broker
cc -Wall -ggdb *.c -o broker_dbg
cc -DMQTTS -Wall -Os *.c -o broker_mqtts
MQTTProtocolClient.c: In function 'MQTTProtocol_processQueued':
MQTTProtocolClient.c:658:4: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
  658 |    if (client->pendingRegistration == NULL)
      |    ^~
MQTTProtocolClient.c:660:5: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
  660 |     goto exit;
      |     ^~~~
MQTTSProtocol.c: In function 'MQTTSProtocol_handleAdvertises':
MQTTSProtocol.c:273:2: warning: 'ftime' is deprecated [-Wdeprecated-declarations]
  273 |  ftime(&ts);
      |  ^~~~~
In file included from MQTTSProtocol.c:39:
/usr/include/x86_64-linux-gnu/sys/timeb.h:39:12: note: declared here
   39 | extern int ftime (struct timeb *__timebuf)
      |            ^~~~~
perl tools/be/be.pl
make: Leaving directory '/work/riot/RIOT/dist/tools/mosquitto_rsmb/bin/rsmb/src'
cp /work/riot/RIOT/dist/tools/mosquitto_rsmb/bin/rsmb/src/broker_mqtts /work/riot/RIOT/dist/tools/mosquitto_rsmb/mosquitto_rsmb
cp /work/riot/RIOT/dist/tools/mosquitto_rsmb/bin/rsmb/src/Messages.1.* /work/riot/RIOT/dist/tools/mosquitto_rsmb/
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
