### PR TITLE
tests/lwip: blacklist nucleo-f302r8

### DIFF
--- a/tests/lwip/Makefile.ci
+++ b/tests/lwip/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-f302r8 \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-l031k6 \


### PR DESCRIPTION
### Contribution description

The application is failing to compile for this platform because its too large. It got by murdock because of https://github.com/RIOT-OS/RIOT/issues/14264. So blacklist

### Testing procedure

 `make -Ctests/lwip BOARD=nucleo-f302r8 all` fails on master, won't be built with this PR.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14246 failed because of this: https://ci.riot-os.org/RIOT-OS/RIOT/14246/ac9eeb78ffc98fc715e255465e40fb7e21bbbf3e/output/compile/tests/lwip/nucleo-f302r8:gnu.txt
