### PR TITLE
boards/sodaq: Add DMA config to SPI peripherals

### DIFF
--- a/boards/common/sodaq/include/cfg_spi_default.h
+++ b/boards/common/sodaq/include/cfg_spi_default.h
@@ -44,6 +44,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM3_DMAC_ID_TX,
+        .rx_trigger = SERCOM3_DMAC_ID_RX,
+#endif
     },
 };
 

--- a/boards/sodaq-sara-sff/include/periph_conf.h
+++ b/boards/sodaq-sara-sff/include/periph_conf.h
@@ -127,6 +127,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pad = SPI_PAD_MISO_0,
         .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
         .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM0_DMAC_ID_TX,
+        .rx_trigger = SERCOM0_DMAC_ID_RX,
+#endif
     }
 };
 


### PR DESCRIPTION
### Contribution description

Add the missing DMA config for the common Sodaq SPI peripheral config and for the sodaq-sara-sff board.

### Testing procedure

The added DMA triggers must match the SERCOM device. The `bench` command on `tests/periph_spi_dma` must work

### Issues/PRs references

Follow-up to #12730 and #14261 