### PR TITLE
ztimer: convert_frac: use self->scale_now for max_value

### DIFF
--- a/sys/ztimer/convert_frac.c
+++ b/sys/ztimer/convert_frac.c
@@ -100,7 +100,7 @@ void ztimer_convert_frac_init(ztimer_convert_frac_t *self,
 
     ztimer_convert_frac_compute_scale(self, freq_self, freq_lower);
     if (freq_self < freq_lower) {
-        self->super.super.max_value = frac_scale(&self->scale_set, UINT32_MAX);
+        self->super.super.max_value = frac_scale(&self->scale_now, UINT32_MAX);
         ztimer_init_extend(&self->super.super);
     }
     else {


### PR DESCRIPTION
### Contribution description

When using convert_frac to slow down a timer, the extension machinery is
used to prevent converting values that would be larger than, after
conversion, 2**32. In order to calculate the maximum value, UINT32_MAX
is converted.

Previously, this was mistakenly converted by multiplying with the
fraction used to scale up a value. E.g., when using convert_frac to
slow down a 1us timer to provide a 1ms timer, UINT32_MAX was multiplied
by 1000. As the result is used % UINT32_MAX, this lead to a wrong value
close to UINT32_MAX, as ((UINT32_MAX * N) % UINT32_MAX = (UINT32_MAX - N - 1)).

This PR fixes the calculation so max_value is determined by multiplying
with the fraction used to scale down a value.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
