### PR TITLE
gnrc_tcp: add retransmission timer

### DIFF
--- a/sys/include/net/gnrc/tcp/tcb.h
+++ b/sys/include/net/gnrc/tcp/tcb.h
@@ -67,8 +67,10 @@ typedef struct _transmission_control_block {
     int32_t srtt;          /**< Smoothed round trip time */
     int32_t rto;           /**< Retransmission timeout duration */
     uint8_t retries;       /**< Number of retransmissions */
-    xtimer_t tim_tout;     /**< Timer struct for timeouts */
-    msg_t msg_tout;        /**< Message, sent on timeouts */
+    xtimer_t timer_retransmit; /**< Retransmission timer */
+    xtimer_t timer_misc;       /**< General purpose timer */
+    msg_t msg_retransmit;      /**< Retransmission timer message */
+    msg_t msg_misc;            /**< General purpose timer message */
     gnrc_pktsnip_t *pkt_retransmit;   /**< Pointer to packet in "retransmit queue" */
     mbox_t *mbox;            /**< TCB mbox for synchronization */
     uint8_t *rcv_buf_raw;    /**< Pointer to the receive buffer */

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
@@ -85,7 +85,7 @@ static int _clear_retransmit(gnrc_tcp_tcb_t *tcb)
 {
     if (tcb->pkt_retransmit != NULL) {
         gnrc_pktbuf_release(tcb->pkt_retransmit);
-        xtimer_remove(&(tcb->tim_tout));
+        xtimer_remove(&(tcb->timer_retransmit));
         tcb->pkt_retransmit = NULL;
     }
     return 0;
@@ -100,10 +100,11 @@ static int _clear_retransmit(gnrc_tcp_tcb_t *tcb)
  */
 static int _restart_timewait_timer(gnrc_tcp_tcb_t *tcb)
 {
-    xtimer_remove(&tcb->tim_tout);
-    tcb->msg_tout.type = MSG_TYPE_TIMEWAIT;
-    tcb->msg_tout.content.ptr = (void *)tcb;
-    xtimer_set_msg(&tcb->tim_tout, 2 * CONFIG_GNRC_TCP_MSL, &tcb->msg_tout, gnrc_tcp_pid);
+    xtimer_remove(&tcb->timer_retransmit);
+    tcb->msg_retransmit.type = MSG_TYPE_TIMEWAIT;
+    tcb->msg_retransmit.content.ptr = (void *)tcb;
+    xtimer_set_msg(&(tcb->timer_retransmit), 2 * CONFIG_GNRC_TCP_MSL, &(tcb->msg_retransmit),
+                   gnrc_tcp_pid);
     return 0;
 }
 

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_pkt.c
@@ -412,9 +412,9 @@ int _pkt_setup_retransmit(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *pkt, const bool r
     }
 
     /* Setup retransmission timer, msg to TCP thread with ptr to TCB */
-    tcb->msg_tout.type = MSG_TYPE_RETRANSMISSION;
-    tcb->msg_tout.content.ptr = (void *) tcb;
-    xtimer_set_msg(&tcb->tim_tout, tcb->rto, &tcb->msg_tout, gnrc_tcp_pid);
+    tcb->msg_retransmit.type = MSG_TYPE_RETRANSMISSION;
+    tcb->msg_retransmit.content.ptr = (void *) tcb;
+    xtimer_set_msg(&tcb->timer_retransmit, tcb->rto, &tcb->msg_retransmit, gnrc_tcp_pid);
     return 0;
 }
 
@@ -438,7 +438,7 @@ int _pkt_acknowledge(gnrc_tcp_tcb_t *tcb, const uint32_t ack)
 
     /* If segment can be acknowledged -> stop timer, release packet from pktbuf and update rto. */
     if (LSS_32_BIT(seg, ack)) {
-        xtimer_remove(&(tcb->tim_tout));
+        xtimer_remove(&(tcb->timer_retransmit));
         gnrc_pktbuf_release(tcb->pkt_retransmit);
         tcb->pkt_retransmit = NULL;
 


### PR DESCRIPTION
Hi,

This PR adds a dedicated retransmission timer to the TCB next to the generall purpose timer.

Just like #14222 and #14291 this is a preparation for an API change in gnrc_tcp (implements a listen/accept scheme) to simplify sock_tcp integration. I have tested this PR on native and it should work on MCUs.

This PR does not introduce new features, testing by executing the test scripts in "tests/gnrc_tcp" should be sufficient.

Cheer Simon