### PR TITLE
core/include: don't use 64 bit for MHZ & MiB macros

### DIFF
--- a/core/include/macros/units.h
+++ b/core/include/macros/units.h
@@ -26,7 +26,7 @@
 /**
  * @brief   A macro to return the bytes in x KiB
  */
-#define KiB(x) ((unsigned long long)(x) << 10)
+#define KiB(x) ((unsigned long)(x) << 10)
 
 /**
  * @brief   A macro to return the bytes in x MiB
@@ -36,17 +36,22 @@
 /**
  * @brief   A macro to return the bytes in x GiB
  */
-#define GiB(x) (MiB(x) << 10)
+#define GiB(x) ((unsigned long long)MiB(x) << 10)
 
 /**
  * @brief   A macro to return the Hz in x kHz
  */
-#define KHZ(x)    ((x) * 1000ULL)
+#define KHZ(x)    ((x) * 1000UL)
 
 /**
  * @brief   A macro to return the Hz in x MHz
  */
-#define MHZ(x) (KHZ(x) * 1000ULL)
+#define MHZ(x) (KHZ(x) * 1000UL)
+
+/**
+ * @brief   A macro to return the Hz in x GHz
+ */
+#define GHZ(x) (MHZ(x) * 1000ULL)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Those macros are all about convenience. However, always using 64 bit makes casts
nececcary that goes against the idea of having a convenience macro.

E.g. when printing a frequency in KHZ one might want to do

```C
printf("freq: %lu kHz\n", freq / KHZ(1));
```

leads to an error

> error: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'long long unsigned int'

Now we would have to cast - `%llu` is not available with newlib-nano and wholly
uneccecary.

Only use 64 bit artithmetic where necessary (GHZ, GiB), not for smaller units.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
