### PR TITLE
cpu/kconfig: Rename CPU classification symbols

### DIFF
--- a/cpu/Kconfig
+++ b/cpu/Kconfig
@@ -10,12 +10,7 @@
 #        || selects
 #        \/
 #  +------------+
-#  | CPU_SERIES |
-#  +------------+
-#        || selects
-#        \/
-#  +------------+
-#  | CPU_FAMILY |
+#  |  CPU_FAM   |
 #  +------------+
 #        || selects
 #        \/
@@ -27,25 +22,25 @@
 #   +----------+
 #   | CPU_ARCH |
 #   +----------+
+
 config CPU
     string
     help
-        Name of the currently selected CPU.
+        Name of the currently selected CPU. This reflects the Makefile variable
+        used by the build system as entry point in the cpu folder.
 
 config CPU_MODEL
     string
     help
         Model of the currently selected CPU.
 
-config CPU_SERIES
+config CPU_FAM
     string
     help
-        Series of the currently selected CPU.
-
-config CPU_FAMILY
-    string
-    help
-        Family of the currently selected CPU.
+        Family of the currently selected CPU. It is an identifier that
+        represents a sub-group of a Manufacturers CPU's. All CPU models
+        belonging to the same family, usually share the same core and have
+        similar register mapping.
 
 config CPU_CORE
     string

--- a/cpu/cc26x0/Kconfig
+++ b/cpu/cc26x0/Kconfig
@@ -5,21 +5,17 @@
 # directory for more details.
 #
 
-config CPU_FAMILY_CC26X0_CC13X0
+config CPU_FAM_CC26X0
     bool
     select CPU_CORE_CORTEX_M3
     select CPU_COMMON_CC26XX_CC13XX
     select HAS_CPU_CC26X0
     select HAS_CORTEXM_MPU
 
-config CPU_SERIES_CC26X0
-    bool
-    select CPU_FAMILY_CC26X0_CC13X0
-
 ## CPU Models
 config CPU_MODEL_CC26X0F128
     bool
-    select CPU_SERIES_CC26X0
+    select CPU_FAM_CC26X0
 
 ## Definition of specific features
 config HAS_CPU_CC26X0
@@ -28,13 +24,13 @@ config HAS_CPU_CC26X0
         Indicates that a 'cc26x0' cpu is being used.
 
 ## Common CPU symbols
-config CPU_FAMILY
-    default "cc26x0_cc13x0" if CPU_FAMILY_CC26X0_CC13X0
-
-config CPU_SERIES
-    default "cc26x0" if CPU_SERIES_CC26X0
+config CPU_FAM
+    default "cc26x0" if CPU_FAM_CC26X0
 
 config CPU_MODEL
     default "cc26x0f128" if CPU_MODEL_CC26X0F128
+
+config CPU
+    default "cc26x0"
 
 source "$(RIOTCPU)/cc26xx_cc13xx/Kconfig"

--- a/cpu/cc26x2_cc13x2/Kconfig
+++ b/cpu/cc26x2_cc13x2/Kconfig
@@ -5,29 +5,25 @@
 # directory for more details.
 #
 
-config CPU_FAMILY_CC26X2_CC13X2
+config CPU_FAM_CC13X2
     bool
-    select CPU_CORE_CORTEX_M4F
     select CPU_COMMON_CC26XX_CC13XX
+    select CPU_CORE_CORTEX_M4F
     select HAS_CPU_CC26X2_CC13X2
     select HAS_CORTEXM_MPU
-
-config CPU_SERIES_CC13X2
-    bool
-    select CPU_FAMILY_CC26X2_CC13X2
 
 ## CPU Models
 config CPU_MODEL_CC1312R1F3
     bool
-    select CPU_SERIES_CC13X2
+    select CPU_FAM_CC13X2
 
 config CPU_MODEL_CC1352R1
     bool
-    select CPU_SERIES_CC13X2
+    select CPU_FAM_CC13X2
 
 config CPU_MODEL_CC1352P1
     bool
-    select CPU_SERIES_CC13X2
+    select CPU_FAM_CC13X2
 
 ## Definition of specific features
 config HAS_CPU_CC26X2_CC13X2
@@ -36,15 +32,15 @@ config HAS_CPU_CC26X2_CC13X2
         Indicates that a 'cc26x2_cc13x2' cpu is being used.
 
 ## Common CPU symbols
-config CPU_FAMILY
-    default "cc26x2_cc13x2" if CPU_FAMILY_CC26X2_CC13X2
-
-config CPU_SERIES
-    default "cc13x2" if CPU_SERIES_CC13X2
+config CPU_FAM
+    default "cc13x2" if CPU_FAM_CC13X2
 
 config CPU_MODEL
     default "cc1312r1f3" if CPU_MODEL_CC1312R1F3
     default "cc1352r1" if CPU_MODEL_CC1352R1
     default "cc1352p1" if CPU_MODEL_CC1352P1
+
+config CPU
+    default "cc26x2_cc13x2"
 
 source "$(RIOTCPU)/cc26xx_cc13xx/Kconfig"

--- a/cpu/samd21/Kconfig
+++ b/cpu/samd21/Kconfig
@@ -5,37 +5,33 @@
 # directory for more details.
 #
 
-config CPU_FAMILY_SAMD2X
+config CPU_FAM_SAMD21
     bool
-    select CPU_CORE_CORTEX_M0PLUS
     select CPU_COMMON_SAM0
-
-config CPU_SERIES_SAMD21
-    bool
-    select CPU_FAMILY_SAMD2X
+    select CPU_CORE_CORTEX_M0PLUS
     select HAS_CPU_SAMD21
     select HAS_PUF_SRAM
 
 ## CPU Models
 config CPU_MODEL_SAMD21E18A
     bool
-    select CPU_SERIES_SAMD21
+    select CPU_FAM_SAMD21
 
 config CPU_MODEL_SAMD21G18A
     bool
-    select CPU_SERIES_SAMD21
+    select CPU_FAM_SAMD21
 
 config CPU_MODEL_SAMD21J18A
     bool
-    select CPU_SERIES_SAMD21
+    select CPU_FAM_SAMD21
 
 config CPU_MODEL_SAMR21E18A
     bool
-    select CPU_SERIES_SAMD21
+    select CPU_FAM_SAMD21
 
 config CPU_MODEL_SAMR21G18A
     bool
-    select CPU_SERIES_SAMD21
+    select CPU_FAM_SAMD21
 
 ## Definition of specific features
 config HAS_CPU_SAMD21
@@ -44,11 +40,8 @@ config HAS_CPU_SAMD21
         Indicates that a 'samd21' cpu is being used.
 
 ## Common CPU symbols
-config CPU_FAMILY
-    default "samd2x" if CPU_FAMILY_SAMD2X
-
-config CPU_SERIES
-    default "samd21" if CPU_SERIES_SAMD21
+config CPU_FAM
+    default "samd21" if CPU_FAM_SAMD21
 
 config CPU_MODEL
     default "samd21e18a" if CPU_MODEL_SAMD21E18A
@@ -56,5 +49,8 @@ config CPU_MODEL
     default "samd21j18a" if CPU_MODEL_SAMD21J18A
     default "samr21e18a" if CPU_MODEL_SAMR21E18A
     default "samr21g18a" if CPU_MODEL_SAMR21G18A
+
+config CPU
+    default "samd21"
 
 source "$(RIOTCPU)/sam0_common/Kconfig"


### PR DESCRIPTION
### Contribution description
This removes the `CPU_FAMILY` and `CPU_SERIES` common CPU symbols and adds `CPU_FAM` instead. The changes are based on the discussion in #14176.

### Testing procedure
- Check the new symbol structure
- `tests/kconfig_features` should still pass for whitelisted boards

### Issues/PRs references
#14176
