### PR TITLE
pkg/pkg.mk: silent prepare target when there's nothing to prepare

### DIFF
--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -53,7 +53,10 @@ PKG_DOWNLOADED = $(PKG_STATE)-downloaded
 
 # Declare 'all' first to have it being the default target
 all: $(PKG_PREPARED)
+
+# Add noop builtin to avoid "Nothing to be done for prepare" message
 prepare: $(PKG_PREPARED)
+	@:
 
 # Allow packages to add a custom step to be `prepared`.
 # It should be a dependency of `$(PKG_PREPARED)` and depend on `$(PKG_PATCHED)`

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -52,7 +52,7 @@ PKG_PATCHED    = $(PKG_STATE)-patched
 PKG_DOWNLOADED = $(PKG_STATE)-downloaded
 
 # Declare 'all' first to have it being the default target
-all: $(PKG_PREPARED)
+all: prepare
 
 # Add noop builtin to avoid "Nothing to be done for prepare" message
 prepare: $(PKG_PREPARED)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Looking at pkg.mk, it seems that the `all` and `prepare` target are redundant. Even more, only `prepare` is useful since `all` is defined in all packages Makefiles.

`prepare` is called anyway when building packages:

https://github.com/RIOT-OS/RIOT/blob/20276d9d01e9b681a30f0e5d9617421a529b36a8/Makefile.include#L552

https://github.com/RIOT-OS/RIOT/blob/20276d9d01e9b681a30f0e5d9617421a529b36a8/Makefile.include#L673-L674

So there's no need to recall it from `all` and thus, my analysis is that `all` could be removed.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
