### PR TITLE
net/sock/dns: move non-sock code to net/dns.h

### DIFF
--- a/sys/include/net/dns.h
+++ b/sys/include/net/dns.h
@@ -20,9 +20,44 @@
 #ifndef NET_DNS_H
 #define NET_DNS_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/**
+ * @brief   DNS internal structure
+ * @see [RFC 6195, section 2]
+ *      (https://tools.ietf.org/html/rfc6195#section-2)
+ * @see [RFC 1035, section 4.1.1]
+ *      (https://tools.ietf.org/html/rfc1035#section-4.1.1)
+ */
+typedef struct {
+    uint16_t id;       /**< Identifier */
+    uint16_t flags;    /**< Flags */
+    uint16_t qdcount;  /**< Number of entries in the question section */
+    uint16_t ancount;  /**< Number of resource records in the answer section */
+    uint16_t nscount;  /**< Number of name server resource records */
+    uint16_t arcount;  /**< Number of resource records in the additional records
+                            section */
+    uint8_t payload[]; /**< Payload */
+} dns_hdr_t;
+
+/**
+ * @name    DNS Record Types
+ * @{
+ */
+#define DNS_TYPE_A          (1)
+#define DNS_TYPE_AAAA       (28)
+/** @} */
+
+/**
+ * @name    DNS Class types
+ * @{
+ */
+#define DNS_CLASS_IN        (1)
+/** @} */
 
 /**
  * @name    Field lengths

--- a/sys/include/net/sock/dns.h
+++ b/sys/include/net/sock/dns.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#include "net/dns.h"
 #include "net/sock/udp.h"
 
 #ifdef __cplusplus
@@ -34,31 +35,14 @@ extern "C" {
 #endif
 
 /**
- * @brief DNS internal structure
- */
-typedef struct {
-    uint16_t id;        /**< read           */
-    uint16_t flags;     /**< DNS            */
-    uint16_t qdcount;   /**< RFC            */
-    uint16_t ancount;   /**< for            */
-    uint16_t nscount;   /**< detailed       */
-    uint16_t arcount;   /**< explanations   */
-    uint8_t payload[];  /**< !!             */
-} sock_dns_hdr_t;
-
-/**
- * @name DNS defines
+ * @name Sock DNS defines
  * @{
  */
-#define DNS_TYPE_A              (1)
-#define DNS_TYPE_AAAA           (28)
-#define DNS_CLASS_IN            (1)
-
 #define SOCK_DNS_PORT           (53)
 #define SOCK_DNS_RETRIES        (2)
 
 #define SOCK_DNS_BUF_LEN        (128)       /* we're in embedded context. */
-#define SOCK_DNS_MAX_NAME_LEN   (SOCK_DNS_BUF_LEN - sizeof(sock_dns_hdr_t) - 4)
+#define SOCK_DNS_MAX_NAME_LEN   (SOCK_DNS_BUF_LEN - sizeof(dns_hdr_t) - 4)
 /** @} */
 
 /**

--- a/sys/net/application_layer/dns/dns.c
+++ b/sys/net/application_layer/dns/dns.c
@@ -19,7 +19,6 @@
 #include <string.h>
 #include <stdio.h>
 
-#include "net/dns.h"
 #include "net/sock/udp.h"
 #include "net/sock/dns.h"
 
@@ -28,7 +27,7 @@
 #endif
 
 /* min domain name length is 1, so minimum record length is 7 */
-#define DNS_MIN_REPLY_LEN   (unsigned)(sizeof(sock_dns_hdr_t ) + 7)
+#define DNS_MIN_REPLY_LEN   (unsigned)(sizeof(dns_hdr_t ) + 7)
 
 /* global DNS server UDP endpoint */
 sock_udp_ep_t sock_dns_server;
@@ -105,7 +104,7 @@ static ssize_t _skip_hostname(const uint8_t *buf, size_t len, uint8_t *bufpos)
 static int _parse_dns_reply(uint8_t *buf, size_t len, void* addr_out, int family)
 {
     const uint8_t *buflim = buf + len;
-    sock_dns_hdr_t *hdr = (sock_dns_hdr_t*) buf;
+    dns_hdr_t *hdr = (dns_hdr_t*) buf;
     uint8_t *bufpos = buf + sizeof(*hdr);
 
     /* skip all queries that are part of the reply */
@@ -191,7 +190,7 @@ int sock_dns_query(const char *domain_name, void *addr_out, int family)
     for (int i = 0; i < SOCK_DNS_RETRIES; i++) {
         uint8_t *buf = dns_buf;
 
-        sock_dns_hdr_t *hdr = (sock_dns_hdr_t*) buf;
+        dns_hdr_t *hdr = (dns_hdr_t*) buf;
         memset(hdr, 0, sizeof(*hdr));
         hdr->id = id;
         hdr->flags = htons(0x0120);


### PR DESCRIPTION
### Contribution description

Just moves code around from `net/sock/dns.h` to `net/dns.h`, this to be able to use those definitions without depending on `sock_dns`.

Please let me know if this is not desired and makes more sense to have it on `net/sock/dns.h`.

### Testing procedure

- Green CI
- `tests/gnrc_sock_dns` working as before.

### Issues/PRs references
