### PR TITLE
pkg/pkg.mk: explicitly exclude state files

### DIFF
--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -82,7 +82,7 @@ gen_dependency_files = $(file >$1,$@: $2)$(foreach f,$2,$(file >>$1,$(f):))
 $(PKG_PATCHED): $(PKG_PATCHED_PREREQUISITES)
 	$(info [INFO] patch $(PKG_NAME))
 	$(call gen_dependency_files,$@.d,$(PKG_PATCHED_PREREQUISITES))
-	$(Q)$(GIT_IN_PKG) clean $(GIT_QUIET) -xdff '**' $(PKG_STATE:$(PKG_BUILDDIR)/%=':!%*')
+	$(Q)$(GIT_IN_PKG) clean $(GIT_QUIET) -xdff '**' -e $(PKG_STATE:$(PKG_BUILDDIR)/%='%*')
 	$(Q)$(GIT_IN_PKG) checkout $(GIT_QUIET) -f $(PKG_VERSION)
 	$(Q)$(GIT_IN_PKG) $(GITFLAGS) am $(GITAMFLAGS) $(PKG_PATCHES) </dev/null
 	@touch $@


### PR DESCRIPTION
### Contribution description

I recently upgraded to `git 2.27` and for some reason how the state files was excluded does not work for me anymore which lead to patching to happen on every compile. Instead I used the explicit `-e` flag for this, which works for me `2.27` and in `2.17` (in docker).

### Testing procedure

- test in docker (git 2.17)


run 1
```
BUILD_IN_DOCKER=1 make -C examples/dtls-sock/ clean all
make: Entering directory '/home/francisco/workspace/RIOT/examples/dtls-sock'
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/home/francisco/workspace/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'        -w '/data/riotbuild/riotbase/examples/dtls-sock/' 'riot/riotbuild:latest' make     all
Building application "dtls_sock" for "native" with MCU "native".

[INFO] updating tinydtls /data/riotbuild/riotbase/examples/dtls-sock/bin/pkg/native/tinydtls/.pkg-state.git-downloaded
echo 7a0420bfe3c041789cc0fe87822832f2fd12d0c3 > /data/riotbuild/riotbase/examples/dtls-sock/bin/pkg/native/tinydtls/.pkg-state.git-downloaded
```
run 2
```
BUILD_IN_DOCKER=1 make -C examples/dtls-sock/ all
make: Entering directory '/home/francisco/workspace/RIOT/examples/dtls-sock'
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/home/francisco/workspace/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'        -w '/data/riotbuild/riotbase/examples/dtls-sock/' 'riot/riotbuild:latest' make     all
Building application "dtls_sock" for "native" with MCU "native".

make[1]: Nothing to be done for 'prepare'.
"make" -C /data/riotbuild/riotbase/pkg/tinydtls
"make" -C /data/riotbuild/riotbase/examples/dtls-sock/bin/pkg/native/tinydtls -f /data/riotbuild/riotbase/examples/dtls-sock/bin/pkg/native/tinydtls/Makefile.riot
```

- test with git 2.27

run 1
```
make -C examples/dtls-sock/ clean all
make: Entering directory '/home/francisco/workspace/RIOT/examples/dtls-sock'
Building application "dtls_sock" for "native" with MCU "native".

[INFO] updating tinydtls /home/francisco/workspace/RIOT/examples/dtls-sock/bin/pkg/native/tinydtls/.pkg-state.git-downloaded
echo 7a0420bfe3c041789cc0fe87822832f2fd12d0c3 > /home/francisco/workspace/RIOT/examples/dtls-sock/bin/pkg/native/tinydtls/.pkg-state.git-downloaded
[INFO] patch tinydtls
"make" -C /home/francisco/workspace/RIOT/pkg/tinydtls
"make" -C /home/francisco/workspace/RIOT/examples/dtls-sock/bin/pkg/native/tinydtls -f /home/francisco/workspace/RIOT/examples/dtls-sock/bin/pkg/native/tinydtls/Makefile.riot
```
run 2
```
make -C examples/dtls-sock/ all
make: Entering directory '/home/francisco/workspace/RIOT/examples/dtls-sock'
Building application "dtls_sock" for "native" with MCU "native".

make[1]: Nothing to be done for 'prepare'.
"make" -C /home/francisco/workspace/RIOT/pkg/tinydtls
"make" -C /home/francisco/workspace/RIOT/examples/dtls-sock/bin/pkg/native/tinydtls -f /home/francisco/workspace/RIOT/examples/dtls-sock/bin/pkg/native/tinydtls/Makefile.riot
"make" -C /home/francisco/workspace/RIOT/examples/dtls-sock/bin/pkg/native/tinydtls/aes -f /home/francisco/workspace/RIOT/examples/dtls-sock/bin/pkg/native/tinydtls/aes/Makefile.riot
"make" -C /home/francisco/workspace/RIOT/examples/dtls-sock/bin/pkg/native/tinydtls/ecc -f /home/francisco/workspace/RIOT/examples/dtls-sock/bin/pkg/native/tinydtls/ecc/Makefile.riot
"make" -C /home/francisco/workspace/RIOT/boards/native
"make" -C /home/francisco/workspace/RIOT/boards/native/driver
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
