### PR TITLE
cpu/sam0_common: UART: implement inverted RX & TX

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -168,6 +168,8 @@ typedef enum {
     UART_FLAG_NONE            = 0x0,    /**< No flags set */
     UART_FLAG_RUN_STANDBY     = 0x1,    /**< run SERCOM in standby mode */
     UART_FLAG_WAKEUP          = 0x2,    /**< wake from sleep on receive */
+    UART_FLAG_RXINV           = 0x4,    /**< invert RX signal */
+    UART_FLAG_TXINV           = 0x8,    /**< invert TX signal */
 } uart_flag_t;
 
 #ifndef DOXYGEN

--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -114,6 +114,18 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     if (uart_config[uart].flags & UART_FLAG_RUN_STANDBY) {
         dev(uart)->CTRLA.reg |= SERCOM_USART_CTRLA_RUNSTDBY;
     }
+#ifdef SERCOM_USART_CTRLA_RXINV
+    /* COM100-61: The TXINV and RXINV bits in the CTRLA register have inverted functionality. */
+    if (uart_config[uart].flags & UART_FLAG_TXINV) {
+        dev(uart)->CTRLA.reg |= SERCOM_USART_CTRLA_RXINV;
+    }
+#endif
+#ifdef SERCOM_USART_CTRLA_TXINV
+    /* COM100-61: The TXINV and RXINV bits in the CTRLA register have inverted functionality. */
+    if (uart_config[uart].flags & UART_FLAG_RXINV) {
+        dev(uart)->CTRLA.reg |= SERCOM_USART_CTRLA_TXINV;
+    }
+#endif
 
     /* calculate and set baudrate */
     uint32_t baud = (((sam0_gclk_freq(uart_config[uart].gclk_src) * 8) / baudrate) / 16);


### PR DESCRIPTION
### Contribution description

The UART TX and TX lines on SAMD5x and SAML1x can be inverted.
However, the flags don't do exactly what one would expect.

See errata [2.18.5: SERCOM-UART: TXINV and RXINV Bits Reference](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-D5X-E5X-Family-Silicon-Errata-and-Data-Sheet-Clarification-80000748F.pdf#page=35):

> The TXINV and RXINV bits in the CTRLA register have inverted functionality.
>
> Workaround:
> In software interpret the TXINV bit as a functionality of RXINV, and conversely,
> interpret the RXINV bit as a functionality of TXINV.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
