### PR TITLE
cpu/sam0_common/rt%: use READREQUEST when accessing CLOCK/COUNT regs

### DIFF
--- a/cpu/sam0_common/periph/rtc.c
+++ b/cpu/sam0_common/periph/rtc.c
@@ -52,6 +52,14 @@ static void _wait_syncbusy(void)
 #endif
 }
 
+static void _rtt_read_req(void)
+{
+#ifdef RTC_READREQ_RREQ
+    RTC->MODE0.READREQ.reg = RTC_READREQ_RREQ;
+    _wait_syncbusy();
+#endif
+}
+
 static inline void _rtc_set_enabled(bool on)
 {
 #ifdef REG_RTC_MODE2_CTRLA
@@ -145,6 +153,7 @@ int rtc_get_time(struct tm *time)
     RTC_MODE2_CLOCK_Type clock;
 
     /* Read register in one time */
+    _rtt_read_req();
     clock.reg = RTC->MODE2.CLOCK.reg;
 
     time->tm_year = clock.bit.YEAR + reference_year;

--- a/cpu/sam0_common/periph/rtt.c
+++ b/cpu/sam0_common/periph/rtt.c
@@ -51,6 +51,14 @@ static void _wait_syncbusy(void)
 #endif
 }
 
+static void _rtt_read_req(void)
+{
+#ifdef RTC_READREQ_RREQ
+    RTC->MODE0.READREQ.reg = RTC_READREQ_RREQ;
+    _wait_syncbusy();
+#endif
+}
+
 static inline void _rtt_reset(void)
 {
 #ifdef RTC_MODE0_CTRL_SWRST
@@ -136,6 +144,7 @@ void rtt_clear_overflow_cb(void)
 uint32_t rtt_get_counter(void)
 {
     _wait_syncbusy();
+    _rtt_read_req();
     return RTC->MODE0.COUNT.reg;
 }
 


### PR DESCRIPTION
### Contribution description

> [1] Reading a read-synchronized core register will cause the peripheral bus to stall immediately until the read- synchronization is complete.

>[2] If an operation that requires synchronization is executed while STATUS.SYNCBUSY is one, the bus will be stalled. All operations will complete successfully, but the CPU will be stalled and interrupts will be pending as long as the bus is stalled.

Using READREQUEST allows us to wait for the `SYNCBUSY` to be unset, this avoids stalling the bus and an ISR can be therefore handled while synchronization is ongoing.

### Testing procedure

- `tests/periph_rtt` should still work

- reviewing the datasheet, for samr21 

### References

[1] samr21 datasheet 17.6.9 Synchronization, p.231
[2] samr21 datasheet  12.3.1.5 Read Request, p.85
