### PR TITLE
cpu/sam0: unified rtt configuration

### DIFF
--- a/boards/common/arduino-mkr/include/periph_conf_common.h
+++ b/boards/common/arduino-mkr/include/periph_conf_common.h
@@ -190,23 +190,12 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @name RTC configuration
- * @{
- */
-#define RTC_DEV             RTC->MODE2
-/** @} */
-
-/**
  * @name RTT configuration
  * @{
  */
-#define RTT_DEV             RTC->MODE0
-#define RTT_IRQ             RTC_IRQn
-#define RTT_IRQ_PRIO        10
-#define RTT_ISR             isr_rtc
-#define RTT_MAX_VALUE       (0xffffffff)
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
-#define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
+#endif
 /** @} */
 
 /**

--- a/boards/common/arduino-zero/include/periph_conf.h
+++ b/boards/common/arduino-zero/include/periph_conf.h
@@ -268,23 +268,12 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @name RTC configuration
- * @{
- */
-#define RTC_DEV             RTC->MODE2
-/** @} */
-
-/**
  * @name RTT configuration
  * @{
  */
-#define RTT_DEV             RTC->MODE0
-#define RTT_IRQ             RTC_IRQn
-#define RTT_IRQ_PRIO        10
-#define RTT_ISR             isr_rtc
-#define RTT_MAX_VALUE       (0xffffffff)
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
-#define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
+#endif
 /** @} */
 
 /**

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -145,8 +145,9 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTT configuration
  * @{
  */
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (32768U)
-#define RTT_MAX_VALUE       (0xffffffffU)
+#endif
 /** @} */
 
 /**

--- a/boards/common/sodaq/include/cfg_rtt_default.h
+++ b/boards/common/sodaq/include/cfg_rtt_default.h
@@ -32,13 +32,9 @@ extern "C" {
  * @name RTT configuration
  * @{
  */
-#define RTT_DEV             RTC->MODE0
-#define RTT_IRQ             RTC_IRQn
-#define RTT_IRQ_PRIO        10
-#define RTT_ISR             isr_rtc
-#define RTT_MAX_VALUE       (0xffffffff)
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
-#define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
+#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -248,23 +248,12 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @name    RTC configuration
+ * @name RTT configuration
  * @{
  */
-#define RTC_DEV             RTC->MODE2
-/** @} */
-
-/**
- * @name    RTT configuration
- * @{
- */
-#define RTT_DEV             RTC->MODE0
-#define RTT_IRQ             RTC_IRQn
-#define RTT_IRQ_PRIO        10
-#define RTT_ISR             isr_rtc
-#define RTT_MAX_VALUE       (0xffffffff)
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
-#define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
+#endif
 /** @} */
 
 /**

--- a/boards/hamilton/include/periph_conf.h
+++ b/boards/hamilton/include/periph_conf.h
@@ -88,23 +88,12 @@ extern "C" {
 /** @} */
 
 /**
- * @name    RTC configuration
+ * @name RTT configuration
  * @{
  */
-#define RTC_DEV             RTC->MODE2
-/** @} */
-
-/**
- * @name    RTT configuration
- * @{
- */
-#define RTT_DEV             RTC->MODE0
-#define RTT_IRQ             RTC_IRQn
-#define RTT_IRQ_PRIO        10
-#define RTT_ISR             isr_rtc
-#define RTT_MAX_VALUE       (0xffffffff)
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
-#define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
+#endif
 /** @} */
 
 /**

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -317,23 +317,12 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @name RTC configuration
- * @{
- */
-#define RTC_DEV             RTC->MODE2
-/** @} */
-
-/**
  * @name RTT configuration
  * @{
  */
-#define RTT_DEV             RTC->MODE0
-#define RTT_IRQ             RTC_IRQn
-#define RTT_IRQ_PRIO        10
-#define RTT_ISR             isr_rtc
-#define RTT_MAX_VALUE       (0xffffffff)
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
-#define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
+#endif
 /** @} */
 
 /**

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -231,8 +231,9 @@ static const i2c_conf_t i2c_config[] = {
  * @name RTT configuration
  * @{
  */
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (32768U)
-#define RTT_MAX_VALUE       (0xffffffffU)
+#endif
 /** @} */
 
 /**

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -162,8 +162,9 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTT configuration
  * @{
  */
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (32768U)
-#define RTT_MAX_VALUE       (0xffffffffU)
+#endif
 /** @} */
 
 /**

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -283,24 +283,13 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @name    RTC configuration
+ * @name RTT configuration
  * @{
  */
-#define RTC_DEV             RTC->MODE2
-/** @} */
-
-/**
- * @name    RTT configuration
- * @{
- */
-#define RTT_DEV             RTC->MODE0
-#define RTT_IRQ             RTC_IRQn
-#define RTT_IRQ_PRIO        10
-#define RTT_ISR             isr_rtc
-#define RTT_MAX_VALUE       (0xffffffff)
-#define RTT_MIN_OFFSET      (10U)
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
-#define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
+#endif
+#define RTT_MIN_OFFSET      (10U)
 /** @} */
 
 /**

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -153,9 +153,11 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_FREQUENCY                           (32768U)
-#define RTT_MAX_VALUE                           (0xffffffffU)
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (32768U)
+#endif
 /** @} */
+
 
 /**
  * @name ADC Configuration

--- a/boards/samr34-xpro/include/periph_conf.h
+++ b/boards/samr34-xpro/include/periph_conf.h
@@ -144,8 +144,9 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_FREQUENCY                           (32768U)
-#define RTT_MAX_VALUE                           (0xffffffffU)
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (32768U)
+#endif
 /** @} */
 
 /**

--- a/boards/serpente/include/periph_conf.h
+++ b/boards/serpente/include/periph_conf.h
@@ -212,8 +212,9 @@ static const i2c_conf_t i2c_config[] = {
  * @name    RTT configuration
  * @{
  */
-#define RTT_MAX_VALUE       (0xffffffff)
+#ifndef RTT_FREQUENCY
 #define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
+#endif
 /** @} */
 
 /**

--- a/cpu/sam0_common/periph/rtt.c
+++ b/cpu/sam0_common/periph/rtt.c
@@ -47,17 +47,17 @@
 #endif
 
 static rtt_cb_t _overflow_cb;
-static void* _overflow_arg;
+static void *_overflow_arg;
 
 static rtt_cb_t _cmp0_cb;
-static void* _cmp0_arg;
+static void *_cmp0_arg;
 
 static void _wait_syncbusy(void)
 {
 #ifdef REG_RTC_MODE0_SYNCBUSY
     while (RTC->MODE0.SYNCBUSY.reg) {}
 #else
-    while(RTC->MODE0.STATUS.bit.SYNCBUSY) {}
+    while (RTC->MODE0.STATUS.bit.SYNCBUSY) {}
 #endif
 }
 
@@ -76,7 +76,8 @@ static inline void _rtt_reset(void)
 static void _rtt_clock_setup(void)
 {
     /* Setup clock GCLK2 with OSC32K */
-    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN(SAM0_GCLK_32KHZ) | GCLK_CLKCTRL_ID_RTC;
+    GCLK->CLKCTRL.reg = GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN(SAM0_GCLK_32KHZ) |
+                        GCLK_CLKCTRL_ID_RTC;
     while (GCLK->STATUS.bit.SYNCBUSY) {}
 }
 #else
@@ -98,6 +99,7 @@ static void _rtt_clock_setup(void)
 #else
 #error "No clock source for RTT selected. "
 #endif
+
 }
 #endif /* !CPU_SAMD21 - Clock Setup */
 
@@ -120,7 +122,7 @@ void rtt_init(void)
 
     /* initially clear flag */
     RTC->MODE0.INTFLAG.reg = RTC_MODE0_INTFLAG_CMP0
-                           |  RTC_MODE0_INTFLAG_OVF;
+                             |  RTC_MODE0_INTFLAG_OVF;
 
     NVIC_EnableIRQ(RTC_IRQn);
 
@@ -179,7 +181,7 @@ void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
     _wait_syncbusy();
 
     /* enable compare interrupt and clear flag */
-    RTC->MODE0.INTFLAG.reg  = RTC_MODE0_INTFLAG_CMP0;
+    RTC->MODE0.INTFLAG.reg = RTC_MODE0_INTFLAG_CMP0;
     RTC->MODE0.INTENSET.reg = RTC_MODE0_INTENSET_CMP0;
 }
 

--- a/cpu/sam0_common/periph/rtt.c
+++ b/cpu/sam0_common/periph/rtt.c
@@ -36,6 +36,16 @@
 #define RTC_MODE0_CTRLA_COUNTSYNC       (0x1ul << RTC_MODE0_CTRLA_COUNTSYNC_Pos)
 #endif
 
+#ifdef REG_RTC_MODE0_CTRLA
+#define RTC_MODE0_PRESCALER       \
+    (__builtin_ctz(2 * RTT_CLOCK_FREQUENCY / RTT_FREQUENCY) << \
+    RTC_MODE0_CTRLA_PRESCALER_Pos)
+#else
+#define RTC_MODE0_PRESCALER       \
+    (__builtin_ctz(RTT_CLOCK_FREQUENCY / RTT_FREQUENCY) << \
+    RTC_MODE0_CTRL_PRESCALER_Pos)
+#endif
+
 static rtt_cb_t _overflow_cb;
 static void* _overflow_arg;
 
@@ -100,9 +110,11 @@ void rtt_init(void)
 
     /* set 32bit counting mode & enable the RTC */
 #ifdef REG_RTC_MODE0_CTRLA
-    RTC->MODE0.CTRLA.reg = RTC_MODE0_CTRLA_MODE(0) | RTC_MODE0_CTRLA_ENABLE | RTC_MODE0_CTRLA_COUNTSYNC;
+    RTC->MODE0.CTRLA.reg = RTC_MODE0_CTRLA_MODE(0) | RTC_MODE0_CTRLA_ENABLE |
+                           RTC_MODE0_CTRLA_COUNTSYNC | RTC_MODE0_PRESCALER;
 #else
-    RTC->MODE0.CTRL.reg = RTC_MODE0_CTRL_MODE(0) | RTC_MODE0_CTRL_ENABLE;
+    RTC->MODE0.CTRL.reg = RTC_MODE0_CTRL_MODE(0) | RTC_MODE0_CTRL_ENABLE |
+                          RTC_MODE0_PRESCALER;
 #endif
     _wait_syncbusy();
 

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -127,6 +127,18 @@ typedef enum {
  */
 #define DAC_NUMOF           (1)
 
+/**
+ * @name    Real time counter configuration
+ * @{
+ */
+#define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
+
+#define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_CLOCK_FREQUENCY (32768U)                      /* in Hz */
+#define RTT_MIN_FREQUENCY   (RTT_CLOCK_FREQUENCY / 1024U) /* in Hz */
+#define RTT_MAX_FREQUENCY   (RTT_CLOCK_FREQUENCY)         /* in Hz */
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -79,6 +79,16 @@ enum {
  */
 #define DAC_NUMOF           (2)
 
+/**
+ * @name    Real time counter configuration
+ * @{
+ */
+#define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_CLOCK_FREQUENCY (32768U)                      /* in Hz */
+#define RTT_MIN_FREQUENCY   (RTT_CLOCK_FREQUENCY / 1024U) /* in Hz */
+#define RTT_MAX_FREQUENCY   (RTT_CLOCK_FREQUENCY)         /* in Hz */
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/saml1x/include/periph_cpu.h
+++ b/cpu/saml1x/include/periph_cpu.h
@@ -72,6 +72,16 @@ typedef enum {
  */
 #define DAC_NUMOF           (1)
 
+/**
+ * @name    Real time counter configuration
+ * @{
+ */
+#define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_CLOCK_FREQUENCY (32768U)                      /* in Hz */
+#define RTT_MIN_FREQUENCY   (RTT_CLOCK_FREQUENCY / 1024U)  /* in Hz */
+#define RTT_MAX_FREQUENCY   (RTT_CLOCK_FREQUENCY)         /* in Hz */
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -73,6 +73,16 @@ typedef enum {
  */
 #define DAC_NUMOF           (2)
 
+/**
+ * @name    Real time counter configuration
+ * @{
+ */
+#define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_CLOCK_FREQUENCY (32768U)                      /* in Hz */
+#define RTT_MIN_FREQUENCY   (RTT_CLOCK_FREQUENCY / 512U)  /* in Hz */
+#define RTT_MAX_FREQUENCY   (RTT_CLOCK_FREQUENCY)         /* in Hz */
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

This PR is split from https://github.com/RIOT-OS/RIOT/pull/13874. It unifies `rtt` configuration for `sam0` and make the `RTT_FREQYENCY` configurable.

As in #13874 max and min values for the RTT are documented.

I've notices that `RT&DEV` are unused here, but I would rather remove in a follow up. I did remove `RTT_IRQ_PRIORITY` since it was unused and misleading.

### Testing procedure

Test for one board of every subfamily

- [x] samd21
- [x] saml1x
- [x] saml21
- [x] samd5x

i don't have any board of the other 3 ATM, maybe @benpicco @dylad can help?

- `tests/periph_rtt` should still pass on `sam0` boards with different frequencies


`BOARD=samr21-xpro make -C tests/periph_rtt flash test --no-print-directory -j3`
```
2020-06-17 12:50:59,314 # START
2020-06-17 12:50:59,321 # main(): This is RIOT! (Version: 2020.07-devel-1252-g69761-dev/sam0_unfied_rtt)
2020-06-17 12:50:59,321 #
2020-06-17 12:50:59,323 # RIOT RTT low-level driver test
2020-06-17 12:50:59,328 # This test will display 'Hello' every 5 seconds
2020-06-17 12:50:59,328 #
2020-06-17 12:50:59,330 # Initializing the RTT driver
2020-06-17 12:50:59,332 # RTT now: 2
2020-06-17 12:50:59,335 # Setting initial alarm to now + 5 s (163842)
2020-06-17 12:50:59,340 # Done setting up the RTT, wait for many Hellos
2020-06-17 12:51:04,331 # Hello
2020-06-17 12:51:09,331 # Hello
2020-06-17 12:51:14,331 # Hello
2020-06-17 12:51:19,331 # Hello
2020-06-17 12:51:24,331 # Hello
2020-06-17 12:51:29,331 # Hello
2020-06-17 12:51:34,331 # Hello
2020-06-17 12:51:39,331 # Hello

```

`CFLAGS+=-DRTT_FREQUENCY=1024 BOARD=samr21-xpro make -C tests/periph_rtt clean flash test --no-print-directory -j3`

```
2020-06-17 12:51:46,588 # START
2020-06-17 12:51:46,594 # main(): This is RIOT! (Version: 2020.07-devel-1252-g69761-dev/sam0_unfied_rtt)
2020-06-17 12:51:46,595 #
2020-06-17 12:51:46,597 # RIOT RTT low-level driver test
2020-06-17 12:51:46,601 # This test will display 'Hello' every 5 seconds
2020-06-17 12:51:46,602 #
2020-06-17 12:51:46,604 # Initializing the RTT driver
2020-06-17 12:51:46,605 # RTT now: 0
2020-06-17 12:51:46,609 # Setting initial alarm to now + 5 s (5120)
2020-06-17 12:51:46,613 # Done setting up the RTT, wait for many Hellos
2020-06-17 12:51:51,606 # Hello
2020-06-17 12:51:56,606 # Hello
2020-06-17 12:52:01,606 # Hello
2020-06-17 12:52:06,606 # Hello
2020-06-17 12:52:11,606 # Hello
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
