### PR TITLE
sys: add `dbgpin` module for debugging and profiling

### DIFF
--- a/cpu/arm7_common/arm7_init.c
+++ b/cpu/arm7_common/arm7_init.c
@@ -124,6 +124,10 @@ void bootloader(void)
     puf_sram_init((uint8_t *) &_sheap, SEED_RAM_LEN);
 #endif
 
+#ifdef MODULE_DBGPIN
+    dbgpin_init();
+#endif
+
     /* cpu specific setup of clocks, peripherals */
     cpu_init();
 

--- a/cpu/atmega_common/startup.c
+++ b/cpu/atmega_common/startup.c
@@ -71,6 +71,11 @@ __attribute__((used)) void reset_handler(void)
 #ifdef MODULE_PUF_SRAM
     puf_sram_init((uint8_t *)RAMEND-SEED_RAM_LEN, SEED_RAM_LEN);
 #endif
+
+#ifdef MODULE_DBGPIN
+    dbgpin_init();
+#endif
+
     /* initialize the board and startup the kernel */
     board_init();
     /* startup the kernel */

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -172,6 +172,10 @@ void reset_handler_default(void)
 
     post_startup();
 
+#ifdef MODULE_DBGPIN
+    dbgpin_init();
+#endif
+
     /* initialize the board (which also initiates CPU initialization) */
     board_init();
 

--- a/cpu/esp32/startup.c
+++ b/cpu/esp32/startup.c
@@ -142,6 +142,10 @@ NORETURN void IRAM call_start_cpu0 (void)
         memset(&_rtc_bss_rtc_start, 0, (&_rtc_bss_rtc_end - &_rtc_bss_rtc_start));
     }
 
+#ifdef MODULE_DBGPIN
+    dbgpin_init();
+#endif
+
     uint8_t cpu_id[CPUID_LEN];
     cpuid_get ((void*)cpu_id);
 

--- a/cpu/esp8266/startup.c
+++ b/cpu/esp8266/startup.c
@@ -74,6 +74,10 @@ void esp_riot_init(void)
         system_update_cpu_freq(ESP8266_CPU_FREQUENCY);
     }
 
+#ifdef MODULE_DBGPIN
+    dbgpin_init();
+#endif
+
     ets_printf("\n");
 #ifdef MODULE_ESP_LOG_STARTUP
     ets_printf("Starting ESP8266 CPU with ID: %08x\n", system_get_chip_id());

--- a/cpu/fe310/cpu.c
+++ b/cpu/fe310/cpu.c
@@ -93,6 +93,10 @@ void flash_init(void)
  */
 void cpu_init(void)
 {
+#ifdef MODULE_DBGPIN
+    dbgpin_init();
+#endif
+
     /* Initialize clock */
     clock_init();
 

--- a/cpu/mips32r2_common/cpu.c
+++ b/cpu/mips32r2_common/cpu.c
@@ -64,6 +64,10 @@ void software_init_hook(void)
 
 void mips_start(void)
 {
+#ifdef MODULE_DBGPIN
+    dbgpin_init();
+#endif
+
     board_init();
 
     /* kernel_init */

--- a/cpu/msp430_common/startup.c
+++ b/cpu/msp430_common/startup.c
@@ -34,13 +34,13 @@ __attribute__((constructor)) static void startup(void)
 {
     board_init();
 
+#ifdef MODULE_DBGPIN
+    dbgpin_init();
+#endif
+
 #ifdef MODULE_NEWLIB
     void _init(void);
     _init();
-#endif
-
-#ifdef MODULE_DBGPIN
-    dbgpin_init();
 #endif
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */

--- a/cpu/msp430_common/startup.c
+++ b/cpu/msp430_common/startup.c
@@ -39,6 +39,10 @@ __attribute__((constructor)) static void startup(void)
     _init();
 #endif
 
+#ifdef MODULE_DBGPIN
+    dbgpin_init();
+#endif
+
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
     stdio_init();
     /* trigger static peripheral initialization */

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -47,6 +47,10 @@
 #include "periph/init.h"
 #include "periph/pm.h"
 
+#if IS_USED(MODULE_DBGPIN)
+#include "dbgpin.h"
+#endif
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -433,6 +437,7 @@ static void _reset_handler(void)
 __attribute__((constructor)) static void startup(int argc, char **argv, char **envp)
 {
     _native_init_syscalls();
+
     /* initialize stdio as early as possible */
     stdio_init();
 
@@ -565,6 +570,10 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
         /* not enough ZEPs given */
         usage_exit(EXIT_FAILURE);
     }
+#endif
+
+#if IS_USED(MODULE_DBGPIN)
+    dbgpin_init();
 #endif
 
     if (dmn) {

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -46,4 +46,12 @@ ifneq (,$(filter shell_commands,$(USEMODULE)))
   endif
 endif
 
+ifneq (,$(filter dbgpin,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  # XXX native segfaults when not using the mock module
+  ifeq (native,$(BOARD))
+    USEMODULE += periph_gpio_mock
+  endif
+endif
+
 include $(RIOTBASE)/sys/test_utils/Makefile.dep

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -126,3 +126,7 @@ endif
 ifneq (,$(filter prng,$(USEMODULE)))
   include $(RIOTBASE)/sys/random/Makefile.include
 endif
+
+ifneq (,$(filter dbgpin,$(USEMODULE)))
+  INCLUDES += -include $(RIOTBASE)/sys/include/dbgpin.h
+endif

--- a/sys/dbgpin/Makefile
+++ b/sys/dbgpin/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/dbgpin/dbgpin.c
+++ b/sys/dbgpin/dbgpin.c
@@ -1,0 +1,18 @@
+
+
+#include "dbgpin.h"
+
+const gpio_t dbgpin_pins[] = { DBGPIN_PINS };
+
+unsigned dbgpin_cnt(void)
+{
+    return ARRAY_SIZE(dbgpin_pins);
+}
+
+void dbgpin_init(void)
+{
+    for (unsigned i = 0; i < ARRAY_SIZE(dbgpin_pins); i++) {
+        gpio_init(dbgpin_pins[i], GPIO_OUT);
+        gpio_clear(dbgpin_pins[i]);
+    }
+}

--- a/sys/dbgpin/dbgpin.c
+++ b/sys/dbgpin/dbgpin.c
@@ -4,7 +4,7 @@
 
 const gpio_t dbgpin_pins[] = { DBGPIN_PINS };
 
-unsigned dbgpin_cnt(void)
+unsigned dbgpin_count(void)
 {
     return ARRAY_SIZE(dbgpin_pins);
 }

--- a/sys/include/dbgpin.h
+++ b/sys/include/dbgpin.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_dbgpin Direct pin control for debugging/profiling
+ * @ingroup     sys
+ *
+ * @warning     This module does not verify the given pin number, so make sure
+ *              the pin numbers you use are actually configured!
+ *
+ * @{
+ * @file
+ * @brief       GPIO wrapper for debugging/profiling purposes
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef DBGPIN_H
+#define DBGPIN_H
+
+#include "kernel_defines.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifndef DBGPIN_PINS
+#error Please specify the pins to use with the dbgpin module (DBGPIN_PINS)
+#endif
+
+extern const gpio_t dbgpin_pins[];
+
+static inline void dbgpin_set(unsigned pin)
+{
+    gpio_set(dbgpin_pins[pin]);
+}
+
+static inline void dbgpin_clr(unsigned pin)
+{
+    gpio_clear(dbgpin_pins[pin]);
+}
+
+static inline void dbgpin_tgl(unsigned pin)
+{
+    gpio_toggle(dbgpin_pins[pin]);
+}
+
+static inline void dbgpin_pulse(unsigned pin)
+{
+    dbgpin_tgl(pin);
+    dbgpin_tgl(pin);
+}
+
+static inline void dbgpin_sig(unsigned pin, unsigned num)
+{
+    for (unsigned i = 0; i < num; i++) {
+        dbgpin_pulse(pin);
+    }
+}
+
+unsigned dbgpin_cnt(void);
+
+void dbgpin_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DBGPIN_H */
+/** @} **/

--- a/sys/include/dbgpin.h
+++ b/sys/include/dbgpin.h
@@ -37,36 +37,75 @@ extern "C"
 
 extern const gpio_t dbgpin_pins[];
 
+/**
+ * @brief   Set the given debug pin to HIGH
+ *
+ * @param[in] pin       pin to set, pin number is offset to the list of defined
+ *                      debug pins in DBGPIN_PINS
+ */
 static inline void dbgpin_set(unsigned pin)
 {
     gpio_set(dbgpin_pins[pin]);
 }
 
-static inline void dbgpin_clr(unsigned pin)
+/**
+ * @brief   Set the given debug pin to LOW
+ *
+ * @param[in] pin       pin to set, pin number is offset to the list of defined
+ *                      debug pins in DBGPIN_PINS
+ */
+static inline void dbgpin_clear(unsigned pin)
 {
     gpio_clear(dbgpin_pins[pin]);
 }
 
-static inline void dbgpin_tgl(unsigned pin)
+/**
+ * @brief   Toggle the given debug pin
+ *
+ * @param[in] pin       pin to set, pin number is offset to the list of defined
+ *                      debug pins in DBGPIN_PINS
+ */
+static inline void dbgpin_toggle(unsigned pin)
 {
     gpio_toggle(dbgpin_pins[pin]);
 }
 
+/**
+ * @brief   Output a pulse (2 time toggle) on the given debug pin
+ *
+ * @param[in] pin       pin to set, pin number is offset to the list of defined
+ *                      debug pins in DBGPIN_PINS
+ */
 static inline void dbgpin_pulse(unsigned pin)
 {
-    dbgpin_tgl(pin);
-    dbgpin_tgl(pin);
+    dbgpin_toggle(pin);
+    dbgpin_toggle(pin);
 }
 
-static inline void dbgpin_sig(unsigned pin, unsigned num)
+/**
+ * @brief   Output a specified number of pulses on the given debug pin
+ *
+ * @param[in] pin       pin to set, pin number is offset to the list of defined
+ *                      debug pins in DBGPIN_PINS
+ * @param[in] num       number of pulses to output
+ */
+static inline void dbgpin_signal(unsigned pin, unsigned num)
 {
     for (unsigned i = 0; i < num; i++) {
         dbgpin_pulse(pin);
     }
 }
 
-unsigned dbgpin_cnt(void);
+/**
+ * @brief   Get the number of configured debug pins
+ *
+ * @return  number of configured debug pins
+ */
+unsigned dbgpin_count(void);
 
+/**
+ * @brief   Initialize the configured input pins
+ */
 void dbgpin_init(void);
 
 #ifdef __cplusplus

--- a/tests/dbgpin/Makefile
+++ b/tests/dbgpin/Makefile
@@ -1,0 +1,9 @@
+include ../Makefile.tests_common
+
+USEMODULE += dbgpin
+USEMODULE += xtimer
+
+DBGPIN_PINS ?= GPIO_PIN(0,0)
+CFLAGS += -DDBGPIN_PINS="$(DBGPIN_PINS)"
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/dbgpin/main.c
+++ b/tests/dbgpin/main.c
@@ -26,22 +26,22 @@
 
 int main(void)
 {
-    printf("Found %i configured debug pin(s)\n", dbgpin_cnt());
+    printf("Found %i configured debug pin(s)\n", dbgpin_count());
 
-    for (unsigned p = 0; p < dbgpin_cnt(); p++) {
+    for (unsigned p = 0; p < dbgpin_count(); p++) {
         printf("Testing pin %u\n", p);
         dbgpin_set(p);
         xtimer_usleep(TICK);
-        dbgpin_clr(p);
+        dbgpin_clear(p);
         xtimer_usleep(TICK);
-        dbgpin_tgl(p);
+        dbgpin_toggle(p);
         xtimer_usleep(2 * TICK);
-        dbgpin_tgl(p);
+        dbgpin_toggle(p);
         xtimer_usleep(TICK);
         dbgpin_pulse(p);
         xtimer_usleep(TICK);
         for (unsigned i = 2; i <= 5; i++) {
-            dbgpin_sig(p, i);
+            dbgpin_signal(p, i);
             xtimer_usleep(TICK);
         }
     }

--- a/tests/dbgpin/main.c
+++ b/tests/dbgpin/main.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test for the dbgpin module
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "xtimer.h"
+
+#define TICK        (5 * US_PER_MS)     /* -> 5ms */
+
+int main(void)
+{
+    printf("Found %i configured debug pin(s)\n", dbgpin_cnt());
+
+    for (unsigned p = 0; p < dbgpin_cnt(); p++) {
+        printf("Testing pin %u\n", p);
+        dbgpin_set(p);
+        xtimer_usleep(TICK);
+        dbgpin_clr(p);
+        xtimer_usleep(TICK);
+        dbgpin_tgl(p);
+        xtimer_usleep(2 * TICK);
+        dbgpin_tgl(p);
+        xtimer_usleep(TICK);
+        dbgpin_pulse(p);
+        xtimer_usleep(TICK);
+        for (unsigned i = 2; i <= 5; i++) {
+            dbgpin_sig(p, i);
+            xtimer_usleep(TICK);
+        }
+    }
+
+    puts("Test successful.");
+
+    return 0;
+}

--- a/tests/dbgpin/tests/01-run.py
+++ b/tests/dbgpin/tests/01-run.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact('Test successful.')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description
Rework of #7352

Gave the `dbgpin` thing another approach (as I currently need this functionality to debug some real-time issues with NimBLE...):
- changed my mind on toggling the pins on a instruction level: by now I am pretty much convinced that simply wrapping the periph/gpio module should yield sufficient timings for most cases -> subsequently this new version of the code is much simpler

Benefits of this approach:
- no more dependencies to specific CPU models. Right now, only the init function is called from the startup code of each supported architecture. This enables us to use the `dbgpin` functionality to debug startup code etc. 
- Alternative could be to call `dbgpin_init` from `kernel_init` -> only one call systemwide to `dbgpin_init`, but the module is not usable to debug board init code.
- the `dbgpin.h` is provided directly to the compiler using the `-include` directive: this means that the `dbgpin_x()` functions can be called anywhere in the code without the need to include the header in the code of that compilation unit
- to configure custom pins, one can simply pass a comma separated list of pins using the `DBGPIN_PARAMS` macro:
e.g.
```
CFLAGS="-DDBGPIN_PARAMS=GPIO_PIN\(0,24\),GPIO_PIN\(0,25\),GPIO_PIN\(0,26\),GPIO_PIN\(0,31\)" make flash term
```
As alternative (same as the configuration for other device drivers), one could simply define a custom `dbgpin_params.h` file and include it into the include path, just take care its in a position before `sys/include`.

TODO:
the initialization is only included for `native` and `cortexm` for now, will adopt all the other architectures once we agree to proceed with this PR...

### Testing procedure
- Compile the `tests/dbgpin` application.
- flash it to any board of your choice
- connect a logic analyzer or scope to the configured dbg pin(s)
- see if you can see the pins toggling around on those pins

### Issues/PRs references
Rework of #7352