### PR TITLE
boards/common/iotlab: add CONFIG_ZTIMER_USEC

### DIFF
--- a/boards/common/iotlab/include/board_common.h
+++ b/boards/common/iotlab/include/board_common.h
@@ -53,6 +53,15 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    ztimer configuration
+ * @{
+ */
+#define CONFIG_ZTIMER_USEC_TYPE    ZTIMER_TYPE_PERIPH_TIMER
+#define CONFIG_ZTIMER_USEC_DEV     TIMER_DEV(0)
+#define CONFIG_ZTIMER_USEC_MIN     (2)
+/** @} */
+
+/**
  * @name    Define the interface to the AT86RF231 radio
  *
  * {spi bus, spi speed, cs pin, int pin, reset pin, sleep pin}


### PR DESCRIPTION
### Contribution description

This add configuration values for `iotlab-m3`.

### Testing procedure

I set `CONFIG_ZTIMER_USEC_MIN` with respect to `BOARD=iotlab-m3 make -C tests/periph_timer_short_relative_set flash test` which I ran multiple times.

```
interval 5 ok
interval 4 ok
interval 3 ok
interval 2 ok
ERROR: too long delay, aborted after 1001 (TEST_MAX_DIFF=1000)
TEST FAILED
```

@kaspar030 would you suggest adding a marging?

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
