### PR TITLE
tinydtls_sock_dtls: save session info after data successfully decrypted

### DIFF
--- a/examples/dtls-sock/dtls-server.c
+++ b/examples/dtls-sock/dtls-server.c
@@ -86,7 +86,6 @@ void *dtls_server_wrapper(void *arg)
     /* Prepare (thread) messages reception */
     msg_init_queue(_reader_queue, READER_QUEUE_SIZE);
 
-    sock_dtls_session_t session;
     sock_dtls_t sock;
     sock_udp_t udp_sock;
     sock_udp_ep_t local = SOCK_IPV6_EP_ANY;
@@ -113,6 +112,7 @@ void *dtls_server_wrapper(void *arg)
             active = false;
         }
         else {
+            sock_dtls_session_t session = { 0 };
             res = sock_dtls_recv(&sock, &session, rcv, sizeof(rcv),
                                   10 * US_PER_SEC);
             if (res >= 0) {
@@ -121,14 +121,13 @@ void *dtls_server_wrapper(void *arg)
                 if (res < 0) {
                     printf("Error resending DTLS message: %d", (int)res);
                 }
+                sock_dtls_session_destroy(&sock, &session);
             }
             else if (res == -SOCK_DTLS_HANDSHAKE) {
                 printf("New client connected\n");
             }
         }
     }
-
-    sock_dtls_session_destroy(&sock, &session);
     sock_dtls_close(&sock);
     sock_udp_close(&udp_sock);
     puts("Terminating");

--- a/pkg/tinydtls/contrib/sock_dtls.c
+++ b/pkg/tinydtls/contrib/sock_dtls.c
@@ -117,7 +117,9 @@ static int _event(struct dtls_context_t *ctx, session_t *session,
             break;
     }
 #endif  /* ENABLE_DEBUG */
-    mbox_put(&sock->mbox, &msg);
+    if (!level && (code != DTLS_EVENT_CONNECT)) {
+        mbox_put(&sock->mbox, &msg);
+    }
     return 0;
 }
 

--- a/pkg/tinydtls/include/sock_dtls_types.h
+++ b/pkg/tinydtls/include/sock_dtls_types.h
@@ -41,9 +41,14 @@ struct sock_dtls {
                                                 handling */
     msg_t mbox_queue[SOCK_DTLS_MBOX_SIZE];  /**< Queue for struct
                                                 sock_dtls::mbox */
-    uint8_t *buf;                           /**< Buffer to pass decrypted data
-                                                back to user */
-    size_t buflen;                          /**< Size of buffer */
+    /**
+     * @brief Buffer used to pass decrypted data and its session information.
+     */
+    struct {
+        uint8_t *data;                      /**< Pointer to the decrypted data */
+        size_t datalen;                     /**< data length */
+        session_t *session;                 /**< Session information */
+    } buffer;
     credman_tag_t tag;                      /**< Credential tag of a registered
                                                 (D)TLS credential */
     dtls_peer_type role;                    /**< DTLS role of the socket */


### PR DESCRIPTION
### Contribution description

This PR fixes a bug (https://github.com/RIOT-OS/RIOT/pull/12907#discussion_r441983334) in the tinydtls implementation of sock dtls where the session information is not saved after the data is successfully decrypted.

### Testing procedure

Test using `examples/dtls-sock` using two native nodes. Try send normal message, empty, etc. The result should be the same with the version in `master`.