### PR TITLE
tests/kconfig_features: Add check for common variable values

### DIFF
--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -12,11 +12,22 @@ BOARD_WHITELIST += arduino-duemilanove \
                    samr21-xpro
 
 
-all: kconfig-features
+all: checks
 
 include $(RIOTBASE)/Makefile.include
+
+# List of variables to compare between Makefile and Kconfig
+_VARS_TO_CHECK = BOARD CPU CPU_MODEL CPU_FAM CPU_CORE CPU_ARCH
+
+# Only compare variables that have a value in Makefile
+checks: kconfig-features $(foreach v,$(_VARS_TO_CHECK), $(if $($(v)),check-value-$(v)))
 
 kconfig-features: $(KCONFIG_OUT_CONFIG)
 	@bash -c 'diff <($(MAKE) info-features-provided) \
 	    <($(MAKE) dependency-debug-features-provided-kconfig) || \
 	    (echo "ERROR: Kconfig features mismatch" && exit 1)'
+
+check-value-%: $(KCONFIG_OUT_CONFIG)
+	@bash -c '(diff <($(MAKE) info-debug-variable-$*) \
+	    <($(MAKE) info-debug-variable-CONFIG_$*) && echo "SUCCESS: $* values match") || \
+	    (echo "ERROR: The value for $* in Kconfig does not match the one in the Makefile" && exit 1)'

--- a/tests/kconfig_features/README.md
+++ b/tests/kconfig_features/README.md
@@ -4,6 +4,9 @@ The objective of this test is to control the synchronization of features
 provided by boards via `Makefile.features` and `Kconfig` files during the
 migration process.
 
+It also checks that multiple common variables (e.g. CPU_MODEL) have the same
+value in the Makefiles and in Kconfig.
+
 The test checks during compilation that both lists of features provided by
 the board match. The `BOARD_WHITELIST` is used to test only the boards that have
 their features modelled in Kconfig.


### PR DESCRIPTION
### Contribution description
This adds a check to `tests/kconfig_features` which verifies that the following variables have the same value in the Kconfig counterpart (only when defined in Makefile):
- `BOARD`
- `CPU`
- `CPU_MODEL`
- `CPU_FAM`
- `CPU_CORE`
- `CPU_ARCH`

### Testing procedure
- Green CI, as the checks are done when building

### Issues/PRs references
Suggested by @fjmolinas [here](https://github.com/RIOT-OS/RIOT/pull/13404#discussion_r437280145).