### PR TITLE
boards/common/saml1x: configure UART on EXT1

### DIFF
--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -77,12 +77,28 @@ static const uart_conf_t uart_config[] = {
         .tx_pad   = UART_PAD_TX_2,
         .flags    = UART_FLAG_NONE,
         .gclk_src = SAM0_GCLK_MAIN,
+    },
+    {    /* EXT1 */
+        .dev      = &SERCOM1->USART,
+        .rx_pin   = GPIO_PIN(PA, 9),
+        .tx_pin   = GPIO_PIN(PA, 8),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_C,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_MAIN,
     }
 };
 
 /* interrupt function name mapping */
 #define UART_0_ISR          isr_sercom2_2
 #define UART_0_ISR_TX       isr_sercom2_0
+#define UART_1_ISR          isr_sercom1_2
+#define UART_1_ISR_TX       isr_sercom1_0
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */


### PR DESCRIPTION
### Contribution description

This adds the configuration for the UART found on EXT1

### Testing procedure

Connect PA8 & PA9 in loopback mode.
Initialize uart 1 and send some data. You should receive the sent data back.

```
> 2020-06-19 00:37:54,481 #  main(): This is RIOT! (Version: 2020.07-devel-1284-gdcda5-cpu/sam0_common/periph/uart-rxonly)
2020-06-19 00:37:54,481 # 
2020-06-19 00:37:54,484 # Manual UART driver test application
2020-06-19 00:37:54,487 # ===================================
2020-06-19 00:37:54,492 # This application is intended for testing additional UART
2020-06-19 00:37:54,498 # interfaces, that might be defined for a board. The 'primary' UART
2020-06-19 00:37:54,504 # interface is tested implicitly, as it is running the shell...
2020-06-19 00:37:54,504 # 
2020-06-19 00:37:54,510 # When receiving data on one of the additional UART interfaces, this
2020-06-19 00:37:54,515 # data will be outputted via STDIO. So the easiest way to test an 
2020-06-19 00:37:54,521 # UART interface, is to simply connect the RX with the TX pin. Then 
2020-06-19 00:37:54,527 # you can send data on that interface and you should see the data 
2020-06-19 00:37:54,529 # being printed to STDOUT
2020-06-19 00:37:54,529 # 
2020-06-19 00:37:54,533 # NOTE: all strings need to be '\n' terminated!
2020-06-19 00:37:54,533 # 
2020-06-19 00:37:54,788 # UARD_DEV(0): test uart_poweron() and uart_poweroff()  ->  [OK]
2020-06-19 00:37:54,788 # 
2020-06-19 00:37:54,789 # UART INFO:
2020-06-19 00:37:54,792 # Available devices:               2
2020-06-19 00:37:54,796 # UART used for STDIO (the shell): UART_DEV(0)
2020-06-19 00:37:54,797 # 
init 1 115200
2020-06-19 00:37:58,652 #  init 1 115200
2020-06-19 00:37:58,656 # Success: Initialized UART_DEV(1) at BAUD 115200
2020-06-19 00:37:58,911 # UARD_DEV(1): test uart_poweron() and uart_poweroff()  ->  [OK]
send 1 hello
2020-06-19 00:38:00,867 #  send 1 hello
2020-06-19 00:38:00,870 # UART_DEV(1) TX: hello
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
