### PR TITLE
pkg/gecko_sdk: update to v2.7.6

### DIFF
--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=gecko_sdk
 PKG_URL=https://github.com/basilfx/RIOT-gecko-sdk
-PKG_VERSION=ec942b9f430193b5b3ddaf4cf2a85fc29e44696a
+PKG_VERSION=31a7f247e19fca16dc961427c53f27f777f7b557
 PKG_LICENSE=Zlib
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
### Contribution description
This PR upgrades the Gecko SDK from version 2.7 to 2.7.6. The package is used by all EFM32 chips. Unfortunately, there are no release notes provided by Silicon Labs, but the whole diff can be found [here](https://github.com/basilfx/RIOT-gecko-sdk/commit/31a7f247e19fca16dc961427c53f27f777f7b557).

It also adds a new GPIO function to initialize GPIO without changing its state (as required by the GPIO peripheral driver). This is for an upcoming PR to fix the root cause of the problem in #12380.

Tested this on the SLSTK3402a and the STK3600.

### Testing procedure
* Any example runs and compiles just fine.
* Murdock is green.

### Issues/PRs references
None