### PR TITLE
boards/dwm1001: add support to Decawave DWM1001 dev board

### DIFF
--- a/boards/dwm1001/Makefile
+++ b/boards/dwm1001/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/dwm1001/Makefile.dep
+++ b/boards/dwm1001/Makefile.dep
@@ -1,0 +1,6 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += lis2dh12
+endif
+
+# include common nrf52 dependencies
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/dwm1001/Makefile.features
+++ b/boards/dwm1001/Makefile.features
@@ -1,0 +1,8 @@
+CPU_MODEL = nrf52832xxaa
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/dwm1001/Makefile.include
+++ b/boards/dwm1001/Makefile.include
@@ -1,0 +1,2 @@
+# include common configuration for nrf52 based boards
+include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/dwm1001/board.c
+++ b/boards/dwm1001/board.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_dwm1001
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the DWM1001 dev board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+
+    /* initialize the boards LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_set(LED0_PIN);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_set(LED1_PIN);
+    gpio_init(LED2_PIN, GPIO_OUT);
+    gpio_set(LED2_PIN);
+    gpio_init(LED3_PIN, GPIO_OUT);
+    gpio_set(LED3_PIN);
+}

--- a/boards/dwm1001/doc.txt
+++ b/boards/dwm1001/doc.txt
@@ -1,0 +1,40 @@
+/**
+@defgroup    boards_dwm1001 Decawave DWM1001
+@ingroup     boards
+@brief       Support for the Decawave DWM1001 development board
+
+## Overview
+
+The [Devawave DWM1001 development board](https://www.decawave.com/product/dwm1001-development-board/)
+includes a DWM1001 module which is based on a Nordic nRF51832 microcontroller.
+This microcontroller is an ARM Cortex-M4 with 64KB of RAM and 512KB of flash
+memory. It also provides in integrated BLE radio.
+The DWM1001 module also contains an UWB tranceiver connected to the
+microcontroller via SPI (not supported yet).
+
+## Flash the board
+
+This board can be flashed using OpenOCD or JLink. Jlink is the default programmer.
+To program this board, plug it to your computer via USB and run the following
+command:
+
+```
+make BOARD=dwm1001 -C examples/hello-world flash
+```
+
+To program the board with OpenOCD, use:
+
+```
+PROGRAMMER=openocd make BOARD=dwm1001 -C examples/hello-world flash
+```
+
+## Accessing STDIO via UART
+
+The STDIO is directly accessible via the USB port. On a Linux host, it's
+generally mapped to `/dev/ttyACM0`.
+
+Use the `term` target to connect to the board serial port<br/>
+```
+make BOARD=dwm1001 -C examples/hello-world term
+```
+ */

--- a/boards/dwm1001/include/board.h
+++ b/boards/dwm1001/include/board.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_dwm1001
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the DWM1001 dev board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 30)  /**< Green LED on D9 */
+#define LED1_PIN            GPIO_PIN(0, 14)  /**< Red LED on D12 */
+#define LED2_PIN            GPIO_PIN(0, 22)  /**< Red LED on D11 */
+#define LED3_PIN            GPIO_PIN(0, 31)  /**< Blue LED on D10 */
+
+#define LED_PORT            (NRF_P0)
+#define LED0_MASK           (1 << 30)
+#define LED1_MASK           (1 << 14)
+#define LED2_MASK           (1 << 22)
+#define LED3_MASK           (1 << 31)
+#define LED_MASK            (LED0_MASK | LED1_MASK | LED2_MASK | LED3_MASK)
+
+#define LED0_ON             (LED_PORT->OUTCLR = LED0_MASK)
+#define LED0_OFF            (LED_PORT->OUTSET = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT->OUT   ^= LED0_MASK)
+
+#define LED1_ON             (LED_PORT->OUTCLR = LED1_MASK)
+#define LED1_OFF            (LED_PORT->OUTSET = LED1_MASK)
+#define LED1_TOGGLE         (LED_PORT->OUT   ^= LED1_MASK)
+
+#define LED2_ON             (LED_PORT->OUTCLR = LED2_MASK)
+#define LED2_OFF            (LED_PORT->OUTSET = LED2_MASK)
+#define LED2_TOGGLE         (LED_PORT->OUT   ^= LED2_MASK)
+
+#define LED3_ON             (LED_PORT->OUTCLR = LED3_MASK)
+#define LED3_OFF            (LED_PORT->OUTSET = LED3_MASK)
+#define LED3_TOGGLE         (LED_PORT->OUT   ^= LED3_MASK)
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(0, 2)
+#define BTN0_MODE           GPIO_IN_PU
+/** @} */
+
+/**
+ * @name    LIS2DH12 driver configuration
+ * @{
+ */
+#define LIS2DH12_PARAM_INT_PIN1     GPIO_PIN(0, 25)
+/** @} */
+
+/**
+ * @name    DW1000 UWB tranceiver
+ * @{
+ */
+#define DW1000_PARAM_SPI_DEV        SPI_DEV(1)
+#define DW1000_PARAM_CS_PIN         GPIO_DEV(0, 17)
+#define DW1000_PARAM_INT_PIN        GPIO_DEV(0, 19)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/dwm1001/include/periph_conf.h
+++ b/boards/dwm1001/include/periph_conf.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_dwm1001
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the DWM1001 dev board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+#define UART_NUMOF          (1U)
+#define UART_PIN_RX         GPIO_PIN(0, 11)
+#define UART_PIN_TX         GPIO_PIN(0, 5)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPIM0,
+        .sclk = GPIO_PIN(0, 4),
+        .mosi = GPIO_PIN(0, 5),
+        .miso = GPIO_PIN(0, 6),
+        .ppi = 0,
+    },
+    {   /* Connected to the DWM1001 UWB tranceiver */
+        .dev  = NRF_SPIM1,
+        .sclk = GPIO_PIN(0, 16),
+        .mosi = GPIO_PIN(0, 20),
+        .miso = GPIO_PIN(0, 18),
+        .ppi = 0,
+    },
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = NRF_TWIM1,
+        .scl = GPIO_PIN(0, 28),
+        .sda = GPIO_PIN(0, 29),
+        .speed = I2C_SPEED_NORMAL
+    }
+};
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @brief Enable the internal DC/DC converter
+ */
+#define NRF5X_ENABLE_DCDC
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -35,7 +35,7 @@ USEMODULE += ps
 USEMODULE += saul_default
 
 BOARD_PROVIDES_NETIF := acd52832 adafruit-clue airfy-beacon atmega256rfr2-xpro \
-        arduino-nano-33-ble avr-rss2 b-l072z-lrwan1 cc2538dk fox \
+        arduino-nano-33-ble avr-rss2 b-l072z-lrwan1 cc2538dk dwm1001 fox \
         derfmega128 derfmega256 hamilton iotlab-m3 iotlab-a8-m3 lobaro-lorabox lsn50 mulle microbit msba2 \
         microduino-corerf native nrf51dk nrf51dongle nrf52dk nrf52840dk nrf52840-mdk nrf6310 \
         nucleo-f207zg nucleo-f767zi openmote-b openmote-cc2538 pba-d-01-kw2x remote-pa \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for the [Decawave DWM1001 dev board](https://www.decawave.com/product/dwm1001-development-board/). This boards runs on a nrf52832 microcontroller and also provides a UWB tranceiver and LIS2DH12 motion sensor.

What has been tested so far:
- UART
- I2C (with lis2dh12)
- compile_and_test_for_board.py is running, just waiting for it to complete but for the moment, things are going well.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- lis2dh12 is initialized and can queried via `examples/saul`
- I'll post there the results of `compile_and_test_for_board.py` when they are done

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
