### PR TITLE
gnrc/[gomach,lwmac]: Remove unused queue size option

### DIFF
--- a/sys/include/net/gnrc/gomach/gomach.h
+++ b/sys/include/net/gnrc/gomach/gomach.h
@@ -349,30 +349,7 @@ extern "C" {
 #ifndef CONFIG_GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD
 #define CONFIG_GNRC_GOMACH_MAX_T2U_RETYR_THRESHOLD          (10U)
 #endif
-
-/**
- * @brief Default message queue size to use for the GoMacH thread (as exponent
- *        of 2^n).
- *
- * As the queue size ALWAYS needs to be power of two, this option represents the
- * exponent of 2^n, which will be used as the size of the queue.
- *
- * The value of this macro should be enough for supporting the manipulation of
- * GoMacH.
- */
-#ifndef CONFIG_GNRC_GOMACH_IPC_MSG_QUEUE_SIZE_EXP
-#define CONFIG_GNRC_GOMACH_IPC_MSG_QUEUE_SIZE_EXP        (3U)
-#endif
 /** @} */
-
-/**
- * @brief Message queue size to use for the GoMacH thread.
- */
-#ifndef GNRC_GOMACH_IPC_MSG_QUEUE_SIZE
-#define GNRC_GOMACH_IPC_MSG_QUEUE_SIZE  (1 << CONFIG_GNRC_GOMACH_IPC_MSG_QUEUE_SIZE_EXP)
-#endif
-/** @} */
-
 
 /**
  * @brief   Creates an IEEE 802.15.4 GoMacH network interface

--- a/sys/include/net/gnrc/lwmac/lwmac.h
+++ b/sys/include/net/gnrc/lwmac/lwmac.h
@@ -290,29 +290,7 @@ extern "C" {
 #ifndef GNRC_LWMAC_BROADCAST_CSMA_RETRIES
 #define GNRC_LWMAC_BROADCAST_CSMA_RETRIES    (3U)
 #endif
-
-/**
- * @brief Default message queue size to use for the LWMAC thread (as exponent of
- *        2^n).
- *
- * As the queue size ALWAYS needs to be power of two, this option represents the
- * exponent of 2^n, which will be used as the size of the queue.
- *
- * The value of this macro should be enough for supporting the manipulation of
- * LWMAC.
- *
- */
-#ifndef CONFIG_GNRC_LWMAC_IPC_MSG_QUEUE_SIZE_EXP
-#define CONFIG_GNRC_LWMAC_IPC_MSG_QUEUE_SIZE_EXP        (3U)
-#endif
 /** @} */
-
-/**
- * @brief Message queue size to use for the LWMAC thread.
- */
-#ifndef GNRC_LWMAC_IPC_MSG_QUEUE_SIZE
-#define GNRC_LWMAC_IPC_MSG_QUEUE_SIZE       (1 << CONFIG_GNRC_LWMAC_IPC_MSG_QUEUE_SIZE_EXP)
-#endif
 
 /**
  * @brief   Creates an IEEE 802.15.4 LWMAC network interface


### PR DESCRIPTION
### Contribution description
This removes the IPC message queue size configuration options from GoMacH and LWMAC modules as they are not used:
- `CONFIG_GNRC_GOMACH_IPC_MSG_QUEUE_SIZE_EXP`
- `GNRC_GOMACH_IPC_MSG_QUEUE_SIZE`
- `CONFIG_GNRC_LWMAC_IPC_MSG_QUEUE_SIZE_EXP`
- `GNRC_LWMAC_IPC_MSG_QUEUE_SIZE`


### Testing procedure
- Green CI
- Test applications should compile and work as usual as the parameters are not used at all


### Issues/PRs references
Spotted while reviewing #14104 