### PR TITLE
cpu/stm32: use TIMER_CHANNEL_NUMOF for consistency

### DIFF
--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -95,7 +95,7 @@ extern "C" {
 /**
  * @brief   All STM timers have 4 capture-compare channels
  */
-#define TIMER_CHAN          (4U)
+#define TIMER_CHANNEL_NUMOF (4U)
 
 /**
  * @brief   Define a macro for accessing a timer channel
@@ -509,8 +509,9 @@ typedef struct {
 typedef struct {
     TIM_TypeDef *dev;               /**< Timer used */
     uint32_t rcc_mask;              /**< bit in clock enable register */
-    pwm_chan_t chan[TIMER_CHAN];    /**< channel mapping, set to {GPIO_UNDEF, 0}
-                                     *   if not used */
+    pwm_chan_t chan[TIMER_CHANNEL_NUMOF]; /**< channel mapping
+                                           *   set to {GPIO_UNDEF, 0}
+                                           *   if not used */
     gpio_af_t af;                   /**< alternate function used */
     uint8_t bus;                    /**< APB bus */
 } pwm_conf_t;

--- a/cpu/stm32/periph/pwm.c
+++ b/cpu/stm32/periph/pwm.c
@@ -52,13 +52,13 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
     /* reset configuration and CC channels */
     dev(pwm)->CR1 = 0;
     dev(pwm)->CR2 = 0;
-    for (unsigned i = 0; i < TIMER_CHAN; ++i) {
+    for (unsigned i = 0; i < TIMER_CHANNEL_NUMOF; ++i) {
         TIM_CHAN(pwm, i) = 0;
     }
 
     /* configure the used pins */
     unsigned i = 0;
-    while ((i < TIMER_CHAN) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
+    while ((i < TIMER_CHANNEL_NUMOF) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
         gpio_init(pwm_config[pwm].chan[i].pin, GPIO_OUT);
         gpio_init_af(pwm_config[pwm].chan[i].pin, pwm_config[pwm].af);
         i++;
@@ -103,7 +103,7 @@ uint8_t pwm_channels(pwm_t pwm)
     assert(pwm < PWM_NUMOF);
 
     unsigned i = 0;
-    while ((i < TIMER_CHAN) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
+    while ((i < TIMER_CHANNEL_NUMOF) && (pwm_config[pwm].chan[i].pin != GPIO_UNDEF)) {
         i++;
     }
     return (uint8_t)i;
@@ -112,7 +112,7 @@ uint8_t pwm_channels(pwm_t pwm)
 void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
 {
     assert((pwm < PWM_NUMOF) &&
-           (channel < TIMER_CHAN) &&
+           (channel < TIMER_CHANNEL_NUMOF) &&
            (pwm_config[pwm].chan[channel].pin != GPIO_UNDEF));
 
     /* norm value to maximum possible value */

--- a/cpu/stm32/periph/timer.c
+++ b/cpu/stm32/periph/timer.c
@@ -70,7 +70,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 
 int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 {
-    if (channel >= (int)TIMER_CHAN) {
+    if (channel >= (int)TIMER_CHANNEL_NUMOF) {
         return -1;
     }
 
@@ -83,7 +83,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 
 int timer_clear(tim_t tim, int channel)
 {
-    if (channel >= (int)TIMER_CHAN) {
+    if (channel >= (int)TIMER_CHANNEL_NUMOF) {
         return -1;
     }
 
@@ -110,7 +110,7 @@ static inline void irq_handler(tim_t tim)
 {
     uint32_t status = (dev(tim)->SR & dev(tim)->DIER);
 
-    for (unsigned int i = 0; i < TIMER_CHAN; i++) {
+    for (unsigned int i = 0; i < TIMER_CHANNEL_NUMOF; i++) {
         if (status & (TIM_SR_CC1IF << i)) {
             dev(tim)->DIER &= ~(TIM_DIER_CC1IE << i);
             isr_ctx[tim].cb(isr_ctx[tim].arg, i);


### PR DESCRIPTION
### Contribution description

To allow for platform independent timer code, all platforms should use the same name for the number of timer channels they offer.
This renames `stm32`'s `TIMER_CHAN` to `TIMER_CHANNEL_NUMOF` for consistency.


### Testing procedure

Only renames code, green Murdock should be enough.


### Issues/PRs references

split off #13900
