### PR TITLE
drivers/soft_uart: add software based UART implementation

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -760,6 +760,11 @@ ifneq (,$(filter soft_spi,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter soft_uart,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio_irq
+  FEATURES_REQUIRED += periph_timer_periodic
+endif
+
 ifneq (,$(filter sps30,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
   USEMODULE += checksum

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -364,6 +364,10 @@ ifneq (,$(filter soft_spi,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/soft_spi/include
 endif
 
+ifneq (,$(filter soft_uart,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/soft_uart/include
+endif
+
 ifneq (,$(filter sps30,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/sps30/include
 endif

--- a/drivers/include/soft_uart.h
+++ b/drivers/include/soft_uart.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_soft_uart Software UART
+ * @ingroup     drivers_soft_periph
+ * @brief       Software implemented UART
+ *
+ * This module provides a software implemented Universal Asynchronous Receiver Transmitter.
+ * It is intended to be used in situation where hardware UART is not available.
+ * The signatures of the functions are similar to the functions declared in uart.h
+ *
+ * Currently sending and receiving is not possible at the same time, so loopback operation
+ * is not possible.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Software UART port descriptor definition
+ *
+ * @author      Benjamin Valentin <benjjamin.valentin@ml-pa.com>
+ */
+
+#ifndef SOFT_UART_H
+#define SOFT_UART_H
+
+#include "periph/gpio.h"
+#include "periph/uart.h"
+#include "periph/timer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Software UART port descriptor
+ */
+typedef struct {
+    gpio_t rx_pin;          /**< RX pin */
+    gpio_t tx_pin;          /**< TX pin */
+    tim_t rx_timer;         /**< Hardware timer used for RX */
+    tim_t tx_timer;         /**< Hardware timer used for TX */
+    uint32_t timer_freq;    /**< Operating frequency of the timer.
+                                 Should be a multiple of baudrate */
+} soft_uart_conf_t;
+
+/**
+ * @brief Software UART type definition
+ */
+typedef unsigned soft_uart_t;
+
+/**
+ * @brief   Initialize a given UART device
+ *
+ * The UART device will be initialized with the following configuration:
+ * - 8 data bits
+ * - no parity
+ * - 1 stop bit
+ * - baudrate as given
+ *
+ * If no callback parameter is given (rx_cb := NULL), the UART will be
+ * initialized in TX only mode.
+ *
+ * @param[in] uart          UART device to initialize
+ * @param[in] baudrate      desired symbol rate in baud
+ * @param[in] rx_cb         receive callback, executed in interrupt context once
+ *                          for every byte that is received (RX buffer filled),
+ *                          set to NULL for TX only mode
+ * @param[in] arg           optional context passed to the callback functions
+ *
+ * @return                  UART_OK on success
+ * @return                  UART_NODEV on invalid UART device
+ * @return                  UART_NOBAUD on inapplicable baudrate
+ * @return                  UART_INTERR on other errors
+ */
+int soft_uart_init(soft_uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg);
+
+/**
+ * @brief   Setup parity, data and stop bits for a given UART device
+ *
+ * @param[in] uart          UART device to configure
+ * @param[in] data_bits     number of data bits in a UART frame
+ * @param[in] parity        parity mode
+ * @param[in] stop_bits     number of stop bits in a UART frame
+ *
+ * @return                  UART_OK on success
+ * @return                  UART_NOMODE on other errors
+ */
+int soft_uart_mode(soft_uart_t uart, uart_data_bits_t data_bits, uart_parity_t parity,
+                   uart_stop_bits_t stop_bits);
+
+/**
+ * @brief   Write data from the given buffer to the specified UART device
+ *
+ * This function is blocking, as it will only return after @p len bytes from the
+ * given buffer have been send. The way this data is send is up to the
+ * implementation: active waiting, interrupt driven, DMA, etc.
+ *
+ * @param[in] uart          UART device to use for transmission
+ * @param[in] data          data buffer to send
+ * @param[in] len           number of bytes to send
+ *
+ */
+void soft_uart_write(soft_uart_t uart, const uint8_t *data, size_t len);
+
+/**
+ * @brief   Power on the given UART device
+ *
+ * @param[in] uart          the UART device to power on
+ */
+void soft_uart_poweron(soft_uart_t uart);
+
+/**
+ * @brief Power off the given UART device
+ *
+ * @param[in] uart          the UART device to power off
+ */
+void soft_uart_poweroff(soft_uart_t uart);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SOFT_UART_H */
+/** @} */

--- a/drivers/include/soft_uart.h
+++ b/drivers/include/soft_uart.h
@@ -38,6 +38,16 @@ extern "C" {
 #endif
 
 /**
+ * @brief invert the level of the TX signal
+ */
+#define SOFT_UART_FLAG_INVERT_TX    0x1
+
+/**
+ * @brief invert the level of the RX signal
+ */
+#define SOFT_UART_FLAG_INVERT_RX    0x2
+
+/**
  * @brief Software UART port descriptor
  */
 typedef struct {
@@ -47,6 +57,7 @@ typedef struct {
     tim_t tx_timer;         /**< Hardware timer used for TX */
     uint32_t timer_freq;    /**< Operating frequency of the timer.
                                  Should be a multiple of baudrate */
+    uint8_t flags;          /**< Soft UART flags */
 } soft_uart_conf_t;
 
 /**

--- a/drivers/soft_uart/Makefile
+++ b/drivers/soft_uart/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/soft_uart/include/soft_uart_params.h
+++ b/drivers/soft_uart/include/soft_uart_params.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_soft_uart
+ * @{
+ *
+ * @file
+ * @brief       Software UART configuration
+ *
+ * @author      Benjamin Valentin <benjjamin.valentin@ml-pa.com>
+ */
+
+#ifndef SOFT_UART_PARAMS_H
+#define SOFT_UART_PARAMS_H
+
+#include "soft_uart.h"
+#include "macros/units.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef SOFT_UART_PARAM_RX
+#define SOFT_UART_PARAM_RX          GPIO_UNDEF
+#endif
+#ifndef SOFT_UART_PARAM_TX
+#define SOFT_UART_PARAM_TX          GPIO_UNDEF
+#endif
+#ifndef SOFT_UART_PARAM_TIMER_RX
+#define SOFT_UART_PARAM_TIMER_RX    (0)
+#endif
+#ifndef SOFT_UART_PARAM_TIMER_TX
+#define SOFT_UART_PARAM_TIMER_TX    (1)
+#endif
+#ifndef SOFT_UART_PARAM_FREQ
+#define SOFT_UART_PARAM_FREQ        MHZ(1)
+#endif
+
+#ifndef SOFT_UART_PARAMS
+#define SOFT_UART_PARAMS     { .rx_pin = SOFT_UART_PARAM_RX,    \
+                               .tx_pin = SOFT_UART_PARAM_TX,    \
+                               .rx_timer = SOFT_UART_PARAM_TIMER_RX, \
+                               .tx_timer = SOFT_UART_PARAM_TIMER_TX, \
+                               .timer_freq = SOFT_UART_PARAM_FREQ }
+#endif
+
+/**
+ * @brief   Sotware UART port descriptor array
+ */
+static const soft_uart_conf_t soft_uart_config[] = {
+    SOFT_UART_PARAMS,
+};
+
+#define SOFT_UART_NUMOF             ARRAY_SIZE(soft_uart_config)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SOFT_UART_PARAMS_H */
+/** @} */

--- a/drivers/soft_uart/include/soft_uart_params.h
+++ b/drivers/soft_uart/include/soft_uart_params.h
@@ -41,13 +41,18 @@ extern "C" {
 #ifndef SOFT_UART_PARAM_FREQ
 #define SOFT_UART_PARAM_FREQ        MHZ(1)
 #endif
+#ifndef SOFT_UART_PARAM_FLAGS
+#define SOFT_UART_PARAM_FLAGS       (0)
+#endif
 
 #ifndef SOFT_UART_PARAMS
 #define SOFT_UART_PARAMS     { .rx_pin = SOFT_UART_PARAM_RX,    \
                                .tx_pin = SOFT_UART_PARAM_TX,    \
                                .rx_timer = SOFT_UART_PARAM_TIMER_RX, \
                                .tx_timer = SOFT_UART_PARAM_TIMER_TX, \
-                               .timer_freq = SOFT_UART_PARAM_FREQ }
+                               .timer_freq = SOFT_UART_PARAM_FREQ, \
+                               .flags = SOFT_UART_PARAM_FLAGS, \
+                             }
 #endif
 
 /**

--- a/drivers/soft_uart/soft_uart.c
+++ b/drivers/soft_uart/soft_uart.c
@@ -1,0 +1,329 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_soft_uart
+ * @{
+ *
+ * @file
+ * @brief       Software UART implementation
+ *
+ * @author      Benjamin Valentin <benjjamin.valentin@ml-pa.com>
+ */
+
+#include <stdio.h>
+#include <assert.h>
+
+#include "mutex.h"
+#include "soft_uart.h"
+#include "soft_uart_params.h"
+
+enum {
+    STATE_RX_IDLE,
+    STATE_RX_HIGH,
+    STATE_RX_LOW
+};
+
+enum {
+    PARITY_NONE,
+    PARITY_EVEN,
+    PARITY_ODD,
+    PARITY_MARK,
+    PARITY_SPACE,
+};
+
+struct uart_ctx {
+    mutex_t lock;       /**< UART mutex          */
+    mutex_t sync;       /**< TX byte done signal */
+    uart_rx_cb_t rx_cb; /**< RX callback         */
+    void* rx_cb_arg;    /**< RX callback arg     */
+    uint32_t bit_time;  /**< timer ticks per bit */
+    uint16_t byte_tx;   /**< current TX byte     */
+    uint16_t byte_rx;   /**< curretn RX byte     */
+    uint8_t bits_tx;    /**< TX bit pos          */
+    uint8_t state_rx;   /**< RX state            */
+#ifdef MODULE_SOFT_UART_MODECFG
+    uint8_t data_bits;  /**< number of data bits */
+    uint8_t stop_bits;  /**< number of stop bits */
+    uint8_t parity;     /**< parity mode         */
+#endif
+} soft_uart_ctx[SOFT_UART_NUMOF];
+
+#ifdef MODULE_SOFT_UART_MODECFG
+#define BITS_DATA(ctx)      (ctx)->data_bits
+#define BITS_STOP(ctx)      (ctx)->stop_bits
+#define BITS_PARITY(ctx)    ((ctx)->parity != PARITY_NONE)
+#else
+#define BITS_DATA(ctx)      8
+#define BITS_STOP(ctx)      1
+#define BITS_PARITY(ctx)    0
+#endif
+
+static void _tx_timer_cb(void *arg, int chan)
+{
+    soft_uart_t uart = (soft_uart_t)arg;
+
+    const soft_uart_conf_t *cfg = &soft_uart_config[uart];
+    struct uart_ctx *ctx = &soft_uart_ctx[uart];
+
+    gpio_write(cfg->tx_pin, ctx->byte_tx & 1);
+    ctx->byte_tx >>= 1;
+
+    if (--ctx->bits_tx == 0) {
+        timer_clear(cfg->tx_timer, chan);
+        mutex_unlock(&ctx->sync);
+    }
+}
+
+static void _rx_timer_cb(void *arg, int chan)
+{
+    soft_uart_t uart = (soft_uart_t)arg;
+
+    const soft_uart_conf_t *cfg = &soft_uart_config[uart];
+    struct uart_ctx *ctx = &soft_uart_ctx[uart];
+
+    (void)chan;
+
+    timer_stop(cfg->rx_timer);
+
+    /* ignore spurious interrupts */
+    if (ctx->state_rx == STATE_RX_IDLE) {
+        return;
+    }
+
+    ctx->state_rx = STATE_RX_IDLE;
+    ctx->rx_cb(ctx->rx_cb_arg, ctx->byte_rx);
+}
+
+static void _rx_gpio_cb(void *arg)
+{
+    soft_uart_t uart = (soft_uart_t)arg;
+
+    const soft_uart_conf_t *cfg = &soft_uart_config[uart];
+    struct uart_ctx *ctx = &soft_uart_ctx[uart];
+
+    /* TODO: use Timer Capture feature */
+    const uint32_t now = timer_read(cfg->rx_timer);
+
+    if (ctx->state_rx == STATE_RX_IDLE) {
+        timer_start(cfg->rx_timer);
+        ctx->state_rx = STATE_RX_LOW;
+        ctx->byte_rx = 0;
+        return;
+    }
+
+    /* we only get interrupts on flanks, so all bits
+     * till the next interrupt will have the same level. */
+    uint8_t bit = now / ctx->bit_time;
+    uint8_t mask = 0xff << bit;
+
+    if (ctx->state_rx == STATE_RX_HIGH) {
+        ctx->byte_rx &= ~mask;
+        ctx->state_rx = STATE_RX_LOW;
+    } else {
+        ctx->byte_rx |= mask;
+        ctx->state_rx = STATE_RX_HIGH;
+    }
+}
+
+int soft_uart_init(soft_uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
+{
+    if (uart >= SOFT_UART_NUMOF) {
+        return UART_NODEV;
+    }
+
+    const soft_uart_conf_t *cfg = &soft_uart_config[uart];
+    struct uart_ctx *ctx = &soft_uart_ctx[uart];
+
+    mutex_init(&ctx->lock);
+    static const mutex_t init_locked = MUTEX_INIT_LOCKED;
+    ctx->sync = init_locked;
+
+    ctx->bit_time = (cfg->timer_freq + baudrate / 2) / baudrate;
+
+    unsigned accuracy = (100 * cfg->timer_freq / ctx->bit_time) / baudrate;
+    if (accuracy > 110 || accuracy < 90) {
+        return UART_NOBAUD;
+    }
+
+    if (cfg->rx_pin == GPIO_UNDEF) {
+        rx_cb = NULL;
+    }
+
+#ifdef MODULE_SOFT_UART_MODECFG
+    ctx->data_bits = 8;
+    ctx->stop_bits = 1;
+    ctx->parity    = PARITY_NONE;
+#endif
+
+    ctx->rx_cb = rx_cb;
+    ctx->rx_cb_arg = arg;
+
+    ctx->state_rx = STATE_RX_IDLE;
+
+    if (cfg->tx_pin != GPIO_UNDEF) {
+        timer_init(cfg->tx_timer, cfg->timer_freq, _tx_timer_cb, (void *)uart);
+        gpio_write(cfg->tx_pin, !(cfg->flags & SOFT_UART_FLAG_INVERT_TX));
+        gpio_init(cfg->tx_pin, GPIO_OUT);
+    }
+
+    if (rx_cb) {
+        timer_init(cfg->rx_timer, cfg->timer_freq, _rx_timer_cb, (void *)uart);
+        timer_stop(cfg->rx_timer);
+        /* timer should fire at the end of the byte */
+        timer_set_periodic(cfg->rx_timer, 0, ctx->bit_time * (BITS_DATA(ctx) + BITS_PARITY(ctx) + 1),
+                           TIM_FLAG_RESET_ON_MATCH | TIM_FLAG_RESET_ON_SET);
+        gpio_init_int(cfg->rx_pin, GPIO_IN, GPIO_BOTH, _rx_gpio_cb, (void*) uart);
+    }
+
+    return 0;
+}
+
+#ifdef MODULE_SOFT_UART_MODECFG
+int soft_uart_mode(soft_uart_t uart, uart_data_bits_t data_bits, uart_parity_t parity,
+                   uart_stop_bits_t stop_bits)
+{
+    if (uart >= SOFT_UART_NUMOF) {
+        return UART_NODEV;
+    }
+
+    struct uart_ctx *ctx = &soft_uart_ctx[uart];
+
+    switch (data_bits) {
+    case UART_DATA_BITS_5:
+        ctx->data_bits = 5;
+        break;
+    case UART_DATA_BITS_6:
+        ctx->data_bits = 6;
+        break;
+    case UART_DATA_BITS_7:
+        ctx->data_bits = 7;
+        break;
+    default:
+    case UART_DATA_BITS_8:
+        ctx->data_bits = 8;
+        break;
+    }
+
+    switch (parity) {
+    case UART_PARITY_EVEN:
+        ctx->parity = PARITY_EVEN;
+        break;
+    case UART_PARITY_ODD:
+        ctx->parity = PARITY_ODD;
+        break;
+    case UART_PARITY_MARK:
+        ctx->parity = PARITY_MARK;
+        break;
+    case UART_PARITY_SPACE:
+        ctx->parity = PARITY_SPACE;
+        break;
+    default:
+    case UART_PARITY_NONE:
+        ctx->parity = PARITY_NONE;
+        break;
+    }
+
+    switch (stop_bits) {
+    case UART_STOP_BITS_2:
+        ctx->stop_bits = 2;
+        break;
+    default:
+    case UART_STOP_BITS_1:
+        ctx->stop_bits = 1;
+        break;
+    }
+
+    return 0;
+}
+#endif /* MODULE_SOFT_UART_MODECF */
+
+static void soft_uart_write_byte(soft_uart_t uart, uint8_t data)
+{
+    const soft_uart_conf_t *cfg = &soft_uart_config[uart];
+    struct uart_ctx *ctx = &soft_uart_ctx[uart];
+
+    /* start bit (LOW) + data bits */
+    ctx->bits_tx = 1 + BITS_DATA(ctx);
+    ctx->byte_tx = data << 1;
+
+#ifdef MODULE_SOFT_UART_MODECFG
+    if (ctx->parity != PARITY_NONE) {
+        uint8_t parity = 0;
+
+        switch (ctx->parity) {
+        case PARITY_EVEN:
+            parity = __builtin_parity(data);
+            break;
+        case PARITY_ODD:
+            parity = !__builtin_parity(data);
+            break;
+        case PARITY_MARK:
+            parity = 1;
+            break;
+        case PARITY_SPACE:
+            parity = 0;
+            break;
+        }
+
+        ctx->byte_tx |= parity << ctx->bits_tx++;
+    }
+#endif
+
+    for (int i = 0; i < BITS_STOP(ctx); ++i) {
+        ctx->byte_tx |= 1 << ctx->bits_tx++;
+    }
+
+    if (cfg->flags & SOFT_UART_FLAG_INVERT_TX) {
+        ctx->byte_tx = ~ctx->byte_tx;
+    }
+
+    timer_set_periodic(cfg->tx_timer, 0, ctx->bit_time,
+                       TIM_FLAG_RESET_ON_MATCH | TIM_FLAG_RESET_ON_SET);
+    mutex_lock(&ctx->sync);
+}
+
+void soft_uart_write(uart_t uart, const uint8_t *data, size_t len)
+{
+    const soft_uart_conf_t *cfg = &soft_uart_config[uart];
+    struct uart_ctx *ctx = &soft_uart_ctx[uart];
+
+    const uint8_t *end = data + len;
+
+    mutex_lock(&ctx->lock);
+    timer_start(cfg->tx_timer);
+
+    while (data != end) {
+        soft_uart_write_byte(uart, *data++);
+    }
+
+    timer_stop(cfg->tx_timer);
+    mutex_unlock(&soft_uart_ctx[uart].lock);
+}
+
+void soft_uart_poweron(soft_uart_t uart)
+{
+    const soft_uart_conf_t *cfg = &soft_uart_config[uart];
+    struct uart_ctx *ctx = &soft_uart_ctx[uart];
+
+    if (ctx->rx_cb) {
+        gpio_irq_enable(cfg->rx_pin);
+    }
+}
+
+void soft_uart_poweroff(soft_uart_t uart)
+{
+    const soft_uart_conf_t *cfg = &soft_uart_config[uart];
+    struct uart_ctx *ctx = &soft_uart_ctx[uart];
+
+    if (ctx->rx_cb) {
+        gpio_irq_disable(cfg->rx_pin);
+    }
+
+    /* timers are already stopped after RX/TX */
+}

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -105,6 +105,7 @@ PSEUDOMODULES += sock_dtls
 PSEUDOMODULES += sock_ip
 PSEUDOMODULES += sock_tcp
 PSEUDOMODULES += sock_udp
+PSEUDOMODULES += soft_uart_modecfg
 PSEUDOMODULES += stdin
 PSEUDOMODULES += stdio_ethos
 PSEUDOMODULES += stdio_cdc_acm

--- a/tests/driver_soft_uart/Makefile
+++ b/tests/driver_soft_uart/Makefile
@@ -1,0 +1,15 @@
+include ../Makefile.tests_common
+
+USEMODULE += soft_uart
+USEMODULE += soft_uart_modecfg
+
+USEMODULE += shell
+
+ifneq (,$(PIN_RX))
+  CFLAGS += "-DSOFT_UART_PARAM_RX=$(PIN_RX)"
+endif
+ifneq (,$(PIN_TX))
+  CFLAGS += "-DSOFT_UART_PARAM_TX=$(PIN_TX)"
+endif
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_soft_uart/Makefile.ci
+++ b/tests/driver_soft_uart/Makefile.ci
@@ -1,0 +1,7 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    #

--- a/tests/driver_soft_uart/main.c
+++ b/tests/driver_soft_uart/main.c
@@ -1,0 +1,288 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Manual test application for UART peripheral drivers
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "board.h"
+#include "shell.h"
+#include "thread.h"
+#include "msg.h"
+#include "ringbuffer.h"
+#include "soft_uart.h"
+#include "soft_uart_params.h"
+
+#ifndef SHELL_BUFSIZE
+#define SHELL_BUFSIZE       (128U)
+#endif
+#ifndef UART_BUFSIZE
+#define UART_BUFSIZE        (128U)
+#endif
+
+#define PRINTER_PRIO        (THREAD_PRIORITY_MAIN - 1)
+#define PRINTER_TYPE        (0xabcd)
+
+typedef struct {
+    char rx_mem[UART_BUFSIZE];
+    ringbuffer_t rx_buf;
+} uart_ctx_t;
+
+static uart_ctx_t ctx[SOFT_UART_NUMOF];
+
+static kernel_pid_t printer_pid;
+static char printer_stack[THREAD_STACKSIZE_MAIN];
+
+#ifdef MODULE_SOFT_UART_MODECFG
+static uart_data_bits_t data_bits_lut[] = { UART_DATA_BITS_5, UART_DATA_BITS_6,
+                                            UART_DATA_BITS_7, UART_DATA_BITS_8 };
+static int data_bits_lut_len = ARRAY_SIZE(data_bits_lut);
+
+static uart_stop_bits_t stop_bits_lut[] = { UART_STOP_BITS_1, UART_STOP_BITS_2 };
+static int stop_bits_lut_len = ARRAY_SIZE(stop_bits_lut);
+#endif
+
+static int parse_dev(char *arg)
+{
+    unsigned dev = atoi(arg);
+    if (dev >= SOFT_UART_NUMOF) {
+        printf("Error: Invalid UART_DEV device specified (%u).\n", dev);
+        return -1;
+    }
+
+    return dev;
+}
+
+static void rx_cb(void *arg, uint8_t data)
+{
+    uart_t dev = (uart_t)arg;
+
+    ringbuffer_add_one(&(ctx[dev].rx_buf), data);
+    if (data == '\n' || ringbuffer_full(&(ctx[dev].rx_buf))) {
+        msg_t msg;
+        msg.content.value = (uint32_t)dev;
+        msg_send(&msg, printer_pid);
+    }
+}
+
+static void *printer(void *arg)
+{
+    (void)arg;
+    msg_t msg;
+    msg_t msg_queue[8];
+    msg_init_queue(msg_queue, 8);
+
+    while (1) {
+        msg_receive(&msg);
+        uart_t dev = (uart_t)msg.content.value;
+        int c;
+
+        printf("Success: UART_DEV(%i) RX: \n[", dev);
+        do {
+            c = ringbuffer_get_one(&(ctx[dev].rx_buf));
+            if (c == '\n') {
+                puts("]\\n");
+            }
+            else if (c >= ' ' && c <= '~') {
+                printf("%c", c);
+            }
+            else {
+                printf("\\x%02x", (unsigned char)c);
+            }
+        } while (c >= 0 && c != '\n');
+        puts("");
+    }
+
+    /* this should never be reached */
+    return NULL;
+}
+
+static void sleep_test(int num, uart_t uart)
+{
+    printf("UARD_DEV(%i): test uart_poweron() and uart_poweroff()  ->  ", num);
+    soft_uart_poweroff(uart);
+    soft_uart_poweron(uart);
+    puts("[OK]");
+}
+
+static int cmd_init(int argc, char **argv)
+{
+    int dev, res;
+    uint32_t baud;
+
+    if (argc < 3) {
+        printf("usage: %s <dev> <baudrate>\n", argv[0]);
+        return 1;
+    }
+    /* parse parameters */
+    dev = parse_dev(argv[1]);
+    if (dev < 0) {
+        return 1;
+    }
+    baud = strtol(argv[2], NULL, 0);
+
+    /* initialize UART */
+    res = soft_uart_init(dev, baud, rx_cb, (void *)dev);
+    if (res == UART_NOBAUD) {
+        printf("Error: Given baudrate (%u) not possible\n", (unsigned int)baud);
+        return 1;
+    }
+    else if (res != UART_OK) {
+        puts("Error: Unable to initialize UART device");
+        return 1;
+    }
+    printf("Success: Initialized UART_DEV(%i) at BAUD %"PRIu32"\n", dev, baud);
+
+    /* also test if poweron() and poweroff() work (or at least don't break
+     * anything) */
+    sleep_test(dev, UART_DEV(dev));
+
+    return 0;
+}
+
+#ifdef MODULE_SOFT_UART_MODECFG
+static int cmd_mode(int argc, char **argv)
+{
+    int dev, data_bits_arg, stop_bits_arg;
+    uart_data_bits_t data_bits;
+    uart_parity_t  parity;
+    uart_stop_bits_t  stop_bits;
+
+    if (argc < 5) {
+        printf("usage: %s <dev> <data bits> <parity> <stop bits>\n", argv[0]);
+        return 1;
+    }
+
+    dev = parse_dev(argv[1]);
+    if (dev < 0) {
+        return 1;
+    }
+
+    data_bits_arg = atoi(argv[2]) - 5;
+    if (data_bits_arg >= 0 && data_bits_arg < data_bits_lut_len) {
+        data_bits = data_bits_lut[data_bits_arg];
+    }
+    else {
+        printf("Error: Invalid number of data_bits (%i).\n", data_bits_arg + 5);
+        return 1;
+    }
+
+    argv[3][0] &= ~0x20;
+    switch (argv[3][0]) {
+        case 'N':
+            parity = UART_PARITY_NONE;
+            break;
+        case 'E':
+            parity = UART_PARITY_EVEN;
+            break;
+        case 'O':
+            parity = UART_PARITY_ODD;
+            break;
+        case 'M':
+            parity = UART_PARITY_MARK;
+            break;
+        case 'S':
+            parity = UART_PARITY_SPACE;
+            break;
+        default:
+            printf("Error: Invalid parity (%c).\n", argv[3][0]);
+            return 1;
+    }
+
+    stop_bits_arg = atoi(argv[4]) - 1;
+    if (stop_bits_arg >= 0 && stop_bits_arg < stop_bits_lut_len) {
+        stop_bits = stop_bits_lut[stop_bits_arg];
+    }
+    else {
+        printf("Error: Invalid number of stop bits (%i).\n", stop_bits_arg + 1);
+        return 1;
+    }
+
+    if (soft_uart_mode(dev, data_bits, parity, stop_bits) != UART_OK) {
+        puts("Error: Unable to apply UART settings");
+        return 1;
+    }
+    printf("Success: Successfully applied UART_DEV(%i) settings\n", dev);
+
+    return 0;
+}
+#endif /* MODULE_PERIPH_UART_MODECFG */
+
+static int cmd_send(int argc, char **argv)
+{
+    int dev;
+    uint8_t endline = (uint8_t)'\n';
+
+    if (argc < 3) {
+        printf("usage: %s <dev> <data (string)>\n", argv[0]);
+        return 1;
+    }
+    /* parse parameters */
+    dev = parse_dev(argv[1]);
+    if (dev < 0) {
+        return 1;
+    }
+
+    printf("UART_DEV(%i) TX: %s\n", dev, argv[2]);
+    soft_uart_write(dev, (uint8_t *)argv[2], strlen(argv[2]));
+    soft_uart_write(dev, &endline, 1);
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "init", "Initialize a UART device with a given baudrate", cmd_init },
+#ifdef MODULE_SOFT_UART_MODECFG
+    { "mode", "Setup data bits, stop bits and parity for a given UART device", cmd_mode },
+#endif
+    { "send", "Send a string through given UART device", cmd_send },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("\nManual UART driver test application");
+    puts("===================================");
+    puts("When receiving data on one of the software UART interfaces, this\n"
+         "data will be outputted via STDIO.\n"
+         "Unfortunately full-duplex operation is not possible, so you can't\n"
+         "simply connect RX and TX in loopback mode, but have to connect an\n"
+         "external UART interface (e.g. USB-UART adapter).\n"
+         "Then you can send data on that interface and you should see the data\n"
+         "being printed to STDOUT\n\n"
+         "NOTE: all strings need to be '\\n' terminated!\n");
+
+
+    puts("\nUART INFO:");
+    printf("Available devices:               %i\n", SOFT_UART_NUMOF);
+
+    /* initialize ringbuffers */
+    for (unsigned i = 0; i < SOFT_UART_NUMOF; i++) {
+        ringbuffer_init(&(ctx[i].rx_buf), ctx[i].rx_mem, UART_BUFSIZE);
+    }
+
+    /* start the printer thread */
+    printer_pid = thread_create(printer_stack, sizeof(printer_stack),
+                                PRINTER_PRIO, 0, printer, NULL, "printer");
+
+    /* run the shell */
+    char line_buf[SHELL_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_BUFSIZE);
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

This adds a software based UART implementation similar to `soft_spi`.
It uses a hardware timer for TX and another one for RX per software UART.

UART does not use a clock signal and is therefore very sensitive to timings. Unfortunately that means the RX isr will mess with the TX isr enough that both can't be used at the same time.

This could possibly be solved by adjusting interrupt priorities or using the Timer Capture mode, but we don't have a platform independent solution for this yet.

### Testing procedure

Run `tests/driver_soft_uart` with e.g. `PIN_TX=GPIO_PIN\(PA,22\) PIN_RX=GPIO_PIN\(PA,23\)`

Unfortunately loop-back mode does not work, so you have to connect RX and TX to a separate UART adapter. 

### Issues/PRs references

requires #14320 to work properly on samd21 based platforms
