### PR TITLE
kinetis/spi_scalar: Add local ARRAY_SIZE define

### DIFF
--- a/cpu/kinetis/dist/calc_spi_scalers/calc_spi_scalers.c
+++ b/cpu/kinetis/dist/calc_spi_scalers/calc_spi_scalers.c
@@ -28,6 +28,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define ARRAY_SIZE(a) (sizeof((a)) / sizeof((a)[0]))
+
 /**
  * @brief Targeted SPI bus speed values (pre-defined by RIOT)
  */


### PR DESCRIPTION
### Contribution description

The spi scalar calculation tool for the kinetis family is stand-alone
and doesn't use the RIOT headers. It doesn't include the ARRAY_SIZE
macro from the RIOT headers. This commit adds a local definition of the
ARRAY_SIZE macro

### Testing procedure

Verify that `cpu/kinetis/dist/calc_spi_scalars` compiles again.

### Issues/PRs references

None