### PR TITLE
board+cpu: remove left-over RTC_NUMOF

### DIFF
--- a/boards/im880b/include/periph_conf.h
+++ b/boards/im880b/include/periph_conf.h
@@ -178,13 +178,6 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @name    RTC configuration
- * @{
- */
-#define RTC_NUMOF           (1U)
-/** @} */
-
-/**
  * @name    ADC configuration
  * @{
  */

--- a/cpu/kinetis/doc.txt
+++ b/cpu/kinetis/doc.txt
@@ -121,7 +121,6 @@ seconds.
 
 ### RTC configuration example (for periph_conf.h) ###
 
-    #define RTC_NUMOF           (1U)
     #define RTC_DEV             RTC
     #define RTC_UNLOCK()        (SIM->SCGC6 |= (SIM_SCGC6_RTC_MASK))
 


### PR DESCRIPTION
### Contribution description
There were still two places that mentioned `RTC_NUMOF`, although these defines were removed in #12673.

### Testing procedure
* Murdock is still green.

### Issues/PRs references
#12673