### PR TITLE
cpu/sam0_common: UART: implement arithmetic BAUD mode

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -210,6 +210,16 @@ typedef enum {
 
 /**
  * @brief   UART device configuration
+ *
+ *          The frequency f() of the clock `gclk_src` must fulfill the condition
+ *
+ *              16 * baud < f(gclk_src) ≤ 2²⁰ * baud
+ *
+ *          in Asynchronous Arithmetic mode and
+ *
+ *              16 * baud < f(gclk_src) ≤ 2¹⁷ * baud
+ *
+ *          in Asynchronous Fractional mode
  */
 typedef struct {
     SercomUsart *dev;       /**< pointer to the used UART device */

--- a/cpu/sam0_common/periph/uart.c
+++ b/cpu/sam0_common/periph/uart.c
@@ -129,7 +129,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     }
 
     /* must disable here first to ensure idempotency */
-    dev(uart)->CTRLA.reg &= ~(SERCOM_USART_CTRLA_ENABLE);
+    dev(uart)->CTRLA.reg = 0;
 
 #ifdef MODULE_PERIPH_UART_NONBLOCKING
     /* set up the TX buffer */


### PR DESCRIPTION
### Contribution description

The SAMD20 line of MCUs is very similar to the SAMD21 line, it just drops several features. One such feature is Asynchronous Fractional Baud Rate calculation used by the UART driver.
Instead we have to use Asynchronous Arithmetic mode which is implemented on every sam0 MCU.

I also factored out pin and baud setup into static functions to tame the sprawling `uart_init()`

### Testing procedure

UART should continue to work both on the default configuration and with 

```Make
CFLAGS += -DCONFIG_SAM0_UART_BAUD_FRAC=0
```
on any member of the sam0 family.

### Issues/PRs references

needed for [samd20](https://github.com/benpicco/RIOT/tree/cpu/samd20) support
