### PR TITLE
drivers/at: Add at_urc_isr module to process URCs upon arrival

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -43,6 +43,14 @@ ifneq (,$(filter at,$(USEMODULE)))
   USEMODULE += fmt
   USEMODULE += isrpipe
   USEMODULE += isrpipe_read_timeout
+
+  _AT_ISR_MODULE := $(filter at_urc_isr_%,$(USEMODULE))
+  ifneq (,$(_AT_ISR_MODULE))
+    # pull in the correspondant event_thread_<priority> module
+    USEMODULE += $(_AT_ISR_MODULE:at_urc_isr_%=event_thread_%)
+    USEMODULE += at_urc
+    USEMODULE += at_urc_isr
+  endif
 endif
 
 ifneq (,$(filter at24c%,$(USEMODULE)))

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -1,4 +1,8 @@
 PSEUDOMODULES += at_urc
+PSEUDOMODULES += at_urc_isr
+PSEUDOMODULES += at_urc_isr_low
+PSEUDOMODULES += at_urc_isr_medium
+PSEUDOMODULES += at_urc_isr_highest
 PSEUDOMODULES += at24c%
 PSEUDOMODULES += base64url
 PSEUDOMODULES += can_mbox

--- a/tests/driver_at/Makefile
+++ b/tests/driver_at/Makefile
@@ -2,6 +2,9 @@ include ../Makefile.tests_common
 
 USEMODULE += shell
 USEMODULE += at
-USEMODULE += at_urc
+USEMODULE += at_urc_isr_medium
+
+# we are printing from the event thread, we need more stack
+CFLAGS += -DEVENT_THREAD_MEDIUM_STACKSIZE=1024
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description
This adds the `at_urc_isr` pseudomodule to the AT driver. This module allows to trigger the processing of registered URCs when  `AT_EOL_RECV_2` character is detected (and no response is pending). It makes use of event threads to process the buffer and call the callback function.

### Testing procedure
- Use the `tests/driver_at` application and register an URC. When the URC arrives the notification should be displayed without having to manually process it. All the other functionalities of the driver should still work as usual.
- Change `at_urc_isr` by `at_urc` in the application and now manually processing should be needed.

### Issues/PRs references
None.
