### PR TITLE
examples/lua*: adapt to the blob mechanism

### DIFF
--- a/examples/lua_REPL/Makefile
+++ b/examples/lua_REPL/Makefile
@@ -25,28 +25,7 @@ CFLAGS += -DTHREAD_STACKSIZE_MAIN='(THREAD_STACKSIZE_DEFAULT+7000)'
 
 USEPKG += lua
 
-LUA_PATH = $(BINDIR)/lua
-
-# add directory of generated *.lua.h files to include path
-CFLAGS += -I$(LUA_PATH)
-
 # generate .lua.h header files of .lua files
-LUA = $(wildcard *.lua)
-
-LUA_H = $(LUA:%.lua=$(LUA_PATH)/%.lua.h)
-
-BUILDDEPS += $(LUA_H) $(LUA_PATH)/
+BLOBS += $(wildcard *.lua)
 
 include $(RIOTBASE)/Makefile.include
-
-# The code below generates a header file from any .lua scripts in the
-# example directory. The header file contains a byte array of the
-# ASCII characters in the .lua script.
-
-$(LUA_PATH)/:
-	$(Q)mkdir -p $@
-
-# FIXME: This way of embedding lua code is not robust. A proper script will
-#        be included later.
-$(LUA_H): $(LUA_PATH)/%.lua.h: %.lua | $(LUA_PATH)/
-	$(Q)xxd -i $< | sed 's/^unsigned/const unsigned/g' > $@

--- a/examples/lua_REPL/main.c
+++ b/examples/lua_REPL/main.c
@@ -23,7 +23,7 @@
 
 #include "lua_run.h"
 #include "lua_builtin.h"
-#include "repl.lua.h"
+#include "blob/repl.lua.h"
 
 /* The basic interpreter+repl needs about 13k ram AT Minimum but we need more
  * memory in order to do interesting stuff.

--- a/examples/lua_basic/Makefile
+++ b/examples/lua_basic/Makefile
@@ -22,28 +22,7 @@ endif
 
 USEPKG += lua
 
-LUA_PATH = $(BINDIR)/lua
-
-# add directory of generated *.lua.h files to include path
-CFLAGS += -I$(LUA_PATH)
-
 # generate .lua.h header files of .lua files
-LUA = $(wildcard *.lua)
-
-LUA_H = $(LUA:%.lua=$(LUA_PATH)/%.lua.h)
-
-BUILDDEPS += $(LUA_H) $(LUA_PATH)/
+BLOBS += $(wildcard *.lua)
 
 include $(RIOTBASE)/Makefile.include
-
-# The code below generates a header file from any .lua scripts in the
-# example directory. The header file contains a byte array of the
-# ASCII characters in the .lua script.
-
-$(LUA_PATH)/:
-	$(Q)mkdir -p $@
-
-# FIXME: This way of embedding lua code is not robust. A proper script will
-#        be included later.
-$(LUA_H): $(LUA_PATH)/%.lua.h: %.lua | $(LUA_PATH)/
-	$(Q)xxd -i $< | sed 's/^unsigned/const unsigned/g' > $@

--- a/examples/lua_basic/main.c
+++ b/examples/lua_basic/main.c
@@ -25,7 +25,7 @@
 #include "lualib.h"
 #include "lua_run.h"
 
-#include "main.lua.h"
+#include "blob/main.lua.h"
 
 #define LUA_MEM_SIZE (11000)
 static char lua_mem[LUA_MEM_SIZE] __attribute__ ((aligned(__BIGGEST_ALIGNMENT__)));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adapts the lua examples so that they now use the blob mechanism available in the build system instead of manually generating the header files containing the lua code.
The approach is already done with micropython and javascript examples.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

lua examples are still functional.

Examples on native:

<details><summary>`examples/lua_basic`</summary>

```
make -C examples/lua_basic/ all term
make: Entering directory '/work/riot/RIOT/examples/lua_basic'
Building application "lua_basic" for "native" with MCU "native".

make[1]: Nothing to be done for 'prepare'.
make[1]: Nothing to be done for 'prepare'.
"make" -C /work/riot/RIOT/pkg/lua
"make" -C /work/riot/RIOT/examples/lua_basic/bin/pkg/native/lua -f /work/riot/RIOT/pkg/lua/Makefile.lua
"make" -C /work/riot/RIOT/pkg/tlsf
"make" -C /work/riot/RIOT/examples/lua_basic/bin/pkg/native/tlsf -f /work/riot/RIOT/Makefile.base
"make" -C /work/riot/RIOT/boards/native
"make" -C /work/riot/RIOT/boards/native/drivers
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/native
"make" -C /work/riot/RIOT/cpu/native/periph
"make" -C /work/riot/RIOT/cpu/native/stdio_native
"make" -C /work/riot/RIOT/cpu/native/vfs
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/pkg/lua/contrib
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
   text	   data	    bss	    dec	    hex	filename
 290708	   2724	  58736	 352168	  55fa8	/work/riot/RIOT/examples/lua_basic/bin/native/lua_basic.elf
/work/riot/RIOT/examples/lua_basic/bin/native/lua_basic.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.07-devel-1406-gd191b)
Lua RIOT build
Hello world, this is lua!
Lua interpreter exited
^C
native: exiting
```

</details>


<details><summary>`examples/lua_REPL`</summary>

```
make -C examples/lua_REPL/ all term
make: Entering directory '/work/riot/RIOT/examples/lua_REPL'
Building application "lua_repl" for "native" with MCU "native".

[INFO] cloning lua
git-cache: cloning from cache. tag=commite354c6355e7f48e087678ec49e340ca0696725b1-443128
[INFO] updating lua /work/riot/RIOT/examples/lua_REPL/bin/pkg/native/lua/.pkg-state.git-downloaded
echo e354c6355e7f48e087678ec49e340ca0696725b1 > /work/riot/RIOT/examples/lua_REPL/bin/pkg/native/lua/.pkg-state.git-downloaded
[INFO] patch lua
[INFO] cloning tlsf
git-cache: cloning from cache. tag=commita1f743ffac0305408b39e791e0ffb45f6d9bc777-443185
[INFO] updating tlsf /work/riot/RIOT/examples/lua_REPL/bin/pkg/native/tlsf/.pkg-state.git-downloaded
echo a1f743ffac0305408b39e791e0ffb45f6d9bc777 > /work/riot/RIOT/examples/lua_REPL/bin/pkg/native/tlsf/.pkg-state.git-downloaded
[INFO] patch tlsf
"make" -C /work/riot/RIOT/pkg/lua
"make" -C /work/riot/RIOT/examples/lua_REPL/bin/pkg/native/lua -f /work/riot/RIOT/pkg/lua/Makefile.lua
"make" -C /work/riot/RIOT/pkg/tlsf
"make" -C /work/riot/RIOT/examples/lua_REPL/bin/pkg/native/tlsf -f /work/riot/RIOT/Makefile.base
"make" -C /work/riot/RIOT/boards/native
"make" -C /work/riot/RIOT/boards/native/drivers
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/native
"make" -C /work/riot/RIOT/cpu/native/periph
"make" -C /work/riot/RIOT/cpu/native/stdio_native
"make" -C /work/riot/RIOT/cpu/native/vfs
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/pkg/lua/contrib
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
   text	   data	    bss	    dec	    hex	filename
 294541	   2780	  90640	 387961	  5eb79	/work/riot/RIOT/examples/lua_REPL/bin/native/lua_repl.elf
/work/riot/RIOT/examples/lua_REPL/bin/native/lua_repl.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.07-devel-1406-gd191b)
Using memory range for Lua heap: 0x565b5090 - 0x565becd0, 4 bytes
This is Lua: starting interactive session

Welcome to the interactive interpreter
L> help
L> h
L> 1 + 2
3
L> ^C
native: exiting
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

closes #11497 (blobs mechanism already available and lua examples are adapted)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
