### PR TITLE
cortexm_common: Remove read in ICSR register read-modify-write operations

### DIFF
--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -280,7 +280,7 @@ void thread_yield_higher(void)
 {
     /* trigger the PENDSV interrupt to run scheduler and schedule new thread if
      * applicable */
-    SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;
+    SCB->ICSR = SCB_ICSR_PENDSVSET_Msk;
 }
 
 void __attribute__((naked)) __attribute__((used)) isr_pendsv(void) {
@@ -432,7 +432,7 @@ static void __attribute__((used)) _svc_dispatch(unsigned int *svc_args)
 
     switch (svc_number) {
         case 1: /* SVC number used by cpu_switch_context_exit */
-            SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;
+            SCB->ICSR = SCB_ICSR_PENDSVSET_Msk;
             break;
         default:
             DEBUG("svc: unhandled SVC #%u\n", svc_number);
@@ -443,6 +443,6 @@ static void __attribute__((used)) _svc_dispatch(unsigned int *svc_args)
 #else /* MODULE_CORTEXM_SVC */
 void __attribute__((used)) isr_svc(void)
 {
-    SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;
+    SCB->ICSR = SCB_ICSR_PENDSVSET_Msk;
 }
 #endif /* MODULE_CORTEXM_SVC */


### PR DESCRIPTION

### Contribution description

All bits in the ICSR register in the cortexm system control block are
either read-only or don't have an effect when writing a zero. A
read-modify-write cycle is thus not required when writing bit flags in
the register. This commit removes the reads in the read-modify-store
patterns for this register.

On the same54-xpro this changes the `isr_svc` instructions from:
```
00000000 <isr_svc>:
   0:   4a02            ldr     r2, [pc, #8]    ; (c <isr_svc+0xc>)
   2:   6853            ldr     r3, [r2, #4]
   4:   f043 5380       orr.w   r3, r3, #268435456      ; 0x10000000
   8:   6053            str     r3, [r2, #4]
   a:   4770            bx      lr
   c:   e000ed00        and     lr, r0, r0, lsl #26
```
to:
```
00000000 <isr_svc>:
   0:   4b02            ldr     r3, [pc, #8]    ; (c <isr_svc+0xc>)
   2:   f04f 5280       mov.w   r2, #268435456  ; 0x10000000
   6:   605a            str     r2, [r3, #4]
   8:   4770            bx      lr
   a:   bf00            nop
   c:   e000ed00        and     lr, r0, r0, lsl #26
```

### Testing procedure

- Test on the common cortex architectures with the bench tests.
-  Verify with the documentation for the [cortex-m0](https://developer.arm.com/docs/dui0497/a/cortex-m0-peripherals/system-control-block/interrupt-control-and-state-register), [cortex-m3](https://developer.arm.com/docs/dui0552/a/cortex-m3-peripherals/system-control-block/interrupt-control-and-state-register), [cortex-m4](https://developer.arm.com/docs/dui0553/latest/cortex-m4-peripherals/system-control-block/interrupt-control-and-state-register), [cortex-m7](https://developer.arm.com/docs/dui0646/c/cortex-m7-peripherals/system-control-block/interrupt-control-and-state-register), [cortex-m23](https://developer.arm.com/docs/dui1095/a/cortex-m23-peripherals/system-control-space/interrupt-control-and-state-register)

### Issues/PRs references

Discovered while reviewing #14224 

### Bench marks

Using `tests/bench_thread_yield_pingpong`:

<details>
  <summary>same54-xpro</summary>

Master:
```
2020-06-23 12:01:52,842 # START
2020-06-23 12:01:52,848 # main(): This is RIOT! (Version: 2020.07-devel-1415-gae95e-HEAD)
2020-06-23 12:01:52,849 # main starting
2020-06-23 12:01:53,851 # { "result" : 398670 }
```

with this PR:
```
2020-06-23 11:58:46,587 # START
2020-06-23 11:58:46,596 # main(): This is RIOT! (Version: 2020.07-devel-1416-gd7c15-pr/cortexm_common/thread_arch_remove_pipe)
2020-06-23 11:58:46,597 # main starting
2020-06-23 11:58:47,599 # { "result" : 404039 }
```

</details>


<details>
  <summary>samr21-xpro</summary>

Master:
```
2020-06-23 12:01:26,734 # START
2020-06-23 12:01:26,740 # main(): This is RIOT! (Version: 2020.07-devel-1415-gae95e-HEAD)
2020-06-23 12:01:26,741 # main starting
2020-06-23 12:01:27,742 # { "result" : 90566 }
```

with this PR:
```
2020-06-23 12:00:43,632 # START
2020-06-23 12:00:43,641 # main(): This is RIOT! (Version: 2020.07-devel-1416-gd7c15-pr/cortexm_common/thread_arch_remove_pipe)
2020-06-23 12:00:43,642 # main starting
2020-06-23 12:00:44,644 # { "result" : 92307 }
```
</details>
