### PR TITLE
boards/pinetime: remove useless makefile.dep include

### DIFF
--- a/boards/pinetime/Makefile.dep
+++ b/boards/pinetime/Makefile.dep
@@ -8,5 +8,4 @@ ifneq (,$(filter mtd,$(USEMODULE)))
 endif
 
 # include common nrf52 dependencies
-include $(RIOTBOARD)/common/nrf52/nrf52832/Makefile.dep
 include $(RIOTBOARD)/common/nrf52/Makefile.dep


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Not very important but this PR removes a redundant Makefile.dep include in the pinetime board.

The common `Makefile.nrf52832.dep` is already included in the main `common/nrf52/Makefile.dep` file, based on the CPU_MODEL defined.

https://github.com/RIOT-OS/RIOT/blob/f63066974cb0cf21e133c0e191f337aa26160a8e/boards/common/nrf52/Makefile.dep#L5-L7

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Check the USEMODULE list of a build for the pinetime:

<details><summary>this PR</summary>

```
make BOARD=pinetime -C examples/gnrc_networking info-build |grep USEMODULE
USEMODULE:      auto_init_gnrc_netif auto_init_gnrc_rpl bluetil_ad bluetil_addr core_thread_flags cortexm_common cortexm_common_periph cpu_common div event event_callback evtimer fmt gnrc gnrc_icmpv6 gnrc_icmpv6_echo gnrc_icmpv6_error gnrc_ipv6 gnrc_ipv6_hdr gnrc_ipv6_nib gnrc_ipv6_nib_6ln gnrc_ipv6_nib_6lr gnrc_ipv6_nib_router gnrc_ipv6_router gnrc_ipv6_router_default gnrc_ndp gnrc_netapi gnrc_netdev_default gnrc_netif gnrc_netif_6lo gnrc_netif_hdr gnrc_netif_init_devs gnrc_netif_ipv6 gnrc_netreg gnrc_nettype_icmpv6 gnrc_nettype_ipv6 gnrc_nettype_sixlowpan gnrc_nettype_udp gnrc_pkt gnrc_pktbuf gnrc_pktbuf_static gnrc_pktdump gnrc_rpl gnrc_sixlowpan gnrc_sixlowpan_ctx gnrc_sixlowpan_iphc gnrc_sixlowpan_iphc_nhc gnrc_sixlowpan_nd gnrc_udp icmpv6 inet_csum ipv6_addr ipv6_hdr l2util luid netdev_default netif netstats netstats_ipv6 netstats_l2 netstats_rpl newlib newlib_nano newlib_syscalls_default nimble_addr nimble_controller nimble_drivers_nrf5x nimble_host nimble_host_store_ram nimble_host_util nimble_netif nimble_npl_riot nimble_porting_nimble nimble_riot_contrib nimble_scanlist nimble_scanner nimble_svc_ipss nimble_tinycrypt nimble_transport_ram nrf5x_common_periph od periph periph_common periph_cpuid periph_gpio periph_hwrng periph_pm periph_timer posix_headers posix_semaphore prng prng_tinymt32 ps random sema shell shell_commands sixlowpan stdin stdio_rtt tinymt32 trickle udp xtimer
FEATURES_PROVIDED (by the board or USEMODULE'd drivers):
```

</details>

<details><summary>master</summary>

```
make BOARD=pinetime -C examples/gnrc_networking info-build |grep USEMODULE
USEMODULE:      auto_init_gnrc_netif auto_init_gnrc_rpl bluetil_ad bluetil_addr core_thread_flags cortexm_common cortexm_common_periph cpu_common div event event_callback evtimer fmt gnrc gnrc_icmpv6 gnrc_icmpv6_echo gnrc_icmpv6_error gnrc_ipv6 gnrc_ipv6_hdr gnrc_ipv6_nib gnrc_ipv6_nib_6ln gnrc_ipv6_nib_6lr gnrc_ipv6_nib_router gnrc_ipv6_router gnrc_ipv6_router_default gnrc_ndp gnrc_netapi gnrc_netdev_default gnrc_netif gnrc_netif_6lo gnrc_netif_hdr gnrc_netif_init_devs gnrc_netif_ipv6 gnrc_netreg gnrc_nettype_icmpv6 gnrc_nettype_ipv6 gnrc_nettype_sixlowpan gnrc_nettype_udp gnrc_pkt gnrc_pktbuf gnrc_pktbuf_static gnrc_pktdump gnrc_rpl gnrc_sixlowpan gnrc_sixlowpan_ctx gnrc_sixlowpan_iphc gnrc_sixlowpan_iphc_nhc gnrc_sixlowpan_nd gnrc_udp icmpv6 inet_csum ipv6_addr ipv6_hdr l2util luid netdev_default netif netstats netstats_ipv6 netstats_l2 netstats_rpl newlib newlib_nano newlib_syscalls_default nimble_addr nimble_controller nimble_drivers_nrf5x nimble_host nimble_host_store_ram nimble_host_util nimble_netif nimble_npl_riot nimble_porting_nimble nimble_riot_contrib nimble_scanlist nimble_scanner nimble_svc_ipss nimble_tinycrypt nimble_transport_ram nrf5x_common_periph od periph periph_common periph_cpuid periph_gpio periph_hwrng periph_pm periph_timer posix_headers posix_semaphore prng prng_tinymt32 ps random sema shell shell_commands sixlowpan stdin stdio_rtt tinymt32 trickle udp xtimer
FEATURES_PROVIDED (by the board or USEMODULE'd drivers):
```

</details>
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
