### PR TITLE
use TIMER_CHANNEL_NUMOF instead of TIMER_CHANNELS

### DIFF
--- a/boards/common/esp8266/include/periph_conf_common.h
+++ b/boards/common/esp8266/include/periph_conf_common.h
@@ -193,13 +193,13 @@ static const spi_conf_t spi_config[] = {
 
 /* software timer */
 #define TIMER_NUMOF         (1U)    /**< number of timer devices */
-#define TIMER_CHANNELS      (10U)   /**< number of channels per timer device */
+#define TIMER_CHANNEL_NUMOF (10U)   /**< number of channels per timer device */
 
 #else /* MODULE_ESP_SW_TIMER */
 
 /* hardware timer */
 #define TIMER_NUMOF         (1U)    /**< number of timer devices */
-#define TIMER_CHANNELS      (1U)    /**< number of channels per timer device */
+#define TIMER_CHANNEL_NUMOF (1U)    /**< number of channels per timer device */
 
 #endif /* MODULE_ESP_SW_TIMER */
 /** @} */

--- a/cpu/atmega1281/include/default_timer_config.h
+++ b/cpu/atmega1281/include/default_timer_config.h
@@ -29,7 +29,7 @@ extern "C" {
 
 #ifndef TIMER_NUMOF
 #define TIMER_NUMOF         (2U)
-#define TIMER_CHANNELS      (3)
+#define TIMER_CHANNEL_NUMOF (3)
 
 #define TIMER_0             MEGA_TIMER1
 #define TIMER_0_MASK        &TIMSK1

--- a/cpu/atmega1284p/include/default_timer_config.h
+++ b/cpu/atmega1284p/include/default_timer_config.h
@@ -28,7 +28,7 @@ extern "C" {
 
 #ifndef TIMER_NUMOF
 #define TIMER_NUMOF         (2U)
-#define TIMER_CHANNELS      (2)
+#define TIMER_CHANNEL_NUMOF (2)
 
 #define TIMER_0             MEGA_TIMER1
 #define TIMER_0_MASK        &TIMSK1

--- a/cpu/atmega128rfa1/include/default_timer_config.h
+++ b/cpu/atmega128rfa1/include/default_timer_config.h
@@ -26,7 +26,7 @@ extern "C" {
 
 #ifndef TIMER_NUMOF
 #define TIMER_NUMOF         (3U)
-#define TIMER_CHANNELS      (3)
+#define TIMER_CHANNEL_NUMOF (3)
 
 #define TIMER_0             MEGA_TIMER4
 #define TIMER_0_MASK        &TIMSK4

--- a/cpu/atmega2560/include/default_timer_config.h
+++ b/cpu/atmega2560/include/default_timer_config.h
@@ -29,7 +29,7 @@ extern "C" {
 
 #ifndef TIMER_NUMOF
 #define TIMER_NUMOF         (2U)
-#define TIMER_CHANNELS      (3)
+#define TIMER_CHANNEL_NUMOF (3)
 
 #define TIMER_0             MEGA_TIMER1
 #define TIMER_0_MASK        &TIMSK1

--- a/cpu/atmega256rfr2/include/default_timer_config.h
+++ b/cpu/atmega256rfr2/include/default_timer_config.h
@@ -26,7 +26,7 @@ extern "C" {
 
 #ifndef TIMER_NUMOF
 #define TIMER_NUMOF         (3U)
-#define TIMER_CHANNELS      (3)
+#define TIMER_CHANNEL_NUMOF (3)
 
 #define TIMER_0             MEGA_TIMER4
 #define TIMER_0_MASK        &TIMSK4

--- a/cpu/atmega328p/include/default_timer_config.h
+++ b/cpu/atmega328p/include/default_timer_config.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #ifndef TIMER_NUMOF
 #define TIMER_NUMOF         (1U)
-#define TIMER_CHANNELS      (2)
+#define TIMER_CHANNEL_NUMOF (2)
 
 #define TIMER_0             MEGA_TIMER1
 #define TIMER_0_MASK        &TIMSK1

--- a/cpu/atmega32u4/include/default_timer_config.h
+++ b/cpu/atmega32u4/include/default_timer_config.h
@@ -26,7 +26,7 @@ extern "C" {
 
 #ifndef TIMER_NUMOF
 #define TIMER_NUMOF         (2U)
-#define TIMER_CHANNELS      (3)
+#define TIMER_CHANNEL_NUMOF (3)
 
 #define TIMER_0             MEGA_TIMER1
 #define TIMER_0_MASK        &TIMSK1

--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -78,17 +78,17 @@ static unsigned _oneshot;
 
 static inline void set_oneshot(tim_t tim, int chan)
 {
-    _oneshot |= (1 << chan) << (TIMER_CHANNELS * tim);
+    _oneshot |= (1 << chan) << (TIMER_CHANNEL_NUMOF * tim);
 }
 
 static inline void clear_oneshot(tim_t tim, int chan)
 {
-    _oneshot &= ~((1 << chan) << (TIMER_CHANNELS * tim));
+    _oneshot &= ~((1 << chan) << (TIMER_CHANNEL_NUMOF * tim));
 }
 
 static inline bool is_oneshot(tim_t tim, int chan)
 {
-    return _oneshot & ((1 << chan) << (TIMER_CHANNELS * tim));
+    return _oneshot & ((1 << chan) << (TIMER_CHANNEL_NUMOF * tim));
 }
 
 /**
@@ -150,7 +150,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 
 int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 {
-    if (channel >= TIMER_CHANNELS) {
+    if (channel >= TIMER_CHANNEL_NUMOF) {
         return -1;
     }
 
@@ -168,7 +168,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 
 int timer_set(tim_t tim, int channel, unsigned int timeout)
 {
-    if (channel >= TIMER_CHANNELS) {
+    if (channel >= TIMER_CHANNEL_NUMOF) {
         return -1;
     }
 
@@ -197,7 +197,7 @@ int timer_set_periodic(tim_t tim, int channel, unsigned int value, uint8_t flags
 {
     int res = 0;
 
-    if (channel >= TIMER_CHANNELS) {
+    if (channel >= TIMER_CHANNEL_NUMOF) {
         return -1;
     }
 
@@ -235,7 +235,7 @@ int timer_set_periodic(tim_t tim, int channel, unsigned int value, uint8_t flags
 
 int timer_clear(tim_t tim, int channel)
 {
-    if (channel >= TIMER_CHANNELS) {
+    if (channel >= TIMER_CHANNEL_NUMOF) {
         return -1;
     }
 

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -506,12 +506,12 @@ typedef struct {
  */
 #ifdef MODULE_ESP_HW_COUNTER
 /** hardware ccount/ccompare registers are used for timer implementation */
-#define TIMER_NUMOF     (2)
-#define TIMER_CHANNELS  (1)
+#define TIMER_NUMOF         (2)
+#define TIMER_CHANNEL_NUMOF (1)
 #else
 /** hardware timer modules are used for timer implementation (default) */
-#define TIMER_NUMOF     (3)
-#define TIMER_CHANNELS  (1)
+#define TIMER_NUMOF         (3)
+#define TIMER_CHANNEL_NUMOF (1)
 #endif
 
 /** Timer used for system time */

--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -126,7 +126,7 @@ typedef struct {
 /**
  * @brief   Number of available timer channels
  */
-#define TIMER_CHANNELS      (4U)
+#define TIMER_CHANNEL_NUMOF (4U)
 
 /**
  * @brief   Declare needed generic SPI functions

--- a/cpu/lpc2387/periph/timer.c
+++ b/cpu/lpc2387/periph/timer.c
@@ -42,17 +42,17 @@ static uint32_t _oneshot;
 
 static inline void set_oneshot(tim_t tim, int chan)
 {
-    _oneshot |= (1 << chan) << (TIMER_CHANNELS * tim);
+    _oneshot |= (1 << chan) << (TIMER_CHANNEL_NUMOF * tim);
 }
 
 static inline void clear_oneshot(tim_t tim, int chan)
 {
-    _oneshot &= ~((1 << chan) << (TIMER_CHANNELS * tim));
+    _oneshot &= ~((1 << chan) << (TIMER_CHANNEL_NUMOF * tim));
 }
 
 static inline bool is_oneshot(tim_t tim, int chan)
 {
-    return _oneshot & ((1 << chan) << (TIMER_CHANNELS * tim));
+    return _oneshot & ((1 << chan) << (TIMER_CHANNEL_NUMOF * tim));
 }
 
 /**
@@ -156,7 +156,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 
 int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 {
-    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNELS)) {
+    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNEL_NUMOF)) {
         return -1;
     }
 
@@ -172,7 +172,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 
 int timer_set_periodic(tim_t tim, int channel, unsigned int value, uint8_t flags)
 {
-    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNELS)) {
+    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNEL_NUMOF)) {
         return -1;
     }
 
@@ -202,7 +202,7 @@ int timer_set_periodic(tim_t tim, int channel, unsigned int value, uint8_t flags
 
 int timer_clear(tim_t tim, int channel)
 {
-    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNELS)) {
+    if (((unsigned) tim >= TIMER_NUMOF) || ((unsigned) channel >= TIMER_CHANNEL_NUMOF)) {
         return -1;
     }
     get_dev(tim)->MCR &= ~(1 << (channel * 3));
@@ -242,7 +242,7 @@ static inline void chan_handler(lpc23xx_timer_t *dev, unsigned tim_num, unsigned
 
 static inline void isr_handler(lpc23xx_timer_t *dev, int tim_num)
 {
-    for (unsigned i = 0; i < TIMER_CHANNELS; ++i) {
+    for (unsigned i = 0; i < TIMER_CHANNEL_NUMOF; ++i) {
         chan_handler(dev, tim_num, i);
     }
 

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -353,7 +353,7 @@ typedef struct {
 /**
  * @brief   Number of available timer channels
  */
-#define TIMER_CHANNELS      (2)
+#define TIMER_CHANNEL_NUMOF (2)
 
 /**
  * @brief   Set up alternate function (PMUX setting) for a PORT pin

--- a/cpu/sam0_common/periph/timer.c
+++ b/cpu/sam0_common/periph/timer.c
@@ -41,17 +41,17 @@ static uint32_t _oneshot;
 
 static inline void set_oneshot(tim_t tim, int chan)
 {
-    _oneshot |= (1 << chan) << (TIMER_CHANNELS * tim);
+    _oneshot |= (1 << chan) << (TIMER_CHANNEL_NUMOF * tim);
 }
 
 static inline void clear_oneshot(tim_t tim, int chan)
 {
-    _oneshot &= ~((1 << chan) << (TIMER_CHANNELS * tim));
+    _oneshot &= ~((1 << chan) << (TIMER_CHANNEL_NUMOF * tim));
 }
 
 static inline bool is_oneshot(tim_t tim, int chan)
 {
-    return _oneshot & ((1 << chan) << (TIMER_CHANNELS * tim));
+    return _oneshot & ((1 << chan) << (TIMER_CHANNEL_NUMOF * tim));
 }
 
 static inline TcCount32 *dev(tim_t tim)

--- a/cpu/sam3/include/periph_cpu.h
+++ b/cpu/sam3/include/periph_cpu.h
@@ -68,7 +68,7 @@ typedef uint32_t gpio_t;
 /**
  * @brief   We use 3 channels for each defined timer
  */
-#define TIMER_CHANNELS      (3)
+#define TIMER_CHANNEL_NUMOF (3)
 
 /**
  * @brief   The RTT width is fixed to 32-bit

--- a/cpu/sam3/periph/timer.c
+++ b/cpu/sam3/periph/timer.c
@@ -124,7 +124,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 
 int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 {
-    if (channel >= TIMER_CHANNELS) {
+    if (channel >= TIMER_CHANNEL_NUMOF) {
         return -1;
     }
     (&dev(tim)->TC_CHANNEL[0].TC_RA)[channel] = value;
@@ -135,7 +135,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 
 int timer_clear(tim_t tim, int channel)
 {
-    if (channel >= TIMER_CHANNELS) {
+    if (channel >= TIMER_CHANNEL_NUMOF) {
         return -1;
     }
 
@@ -163,7 +163,7 @@ static inline void isr_handler(tim_t tim)
 {
     uint32_t status = dev(tim)->TC_CHANNEL[0].TC_SR;
 
-    for (int i = 0; i < TIMER_CHANNELS; i++) {
+    for (int i = 0; i < TIMER_CHANNEL_NUMOF; i++) {
         if (status & (TC_SR_CPAS << i)) {
             dev(tim)->TC_CHANNEL[0].TC_IDR = (TC_IDR_CPAS << i);
             isr_ctx[tim].cb(isr_ctx[tim].arg, i);

--- a/tests/periph_timer_periodic/main.c
+++ b/tests/periph_timer_periodic/main.c
@@ -41,7 +41,7 @@
 #define CYCLE_MS    100UL
 #define CYCLES_MAX   10
 
-static unsigned count[TIMER_CHANNELS];
+static unsigned count[TIMER_CHANNEL_NUMOF];
 
 static void cb(void *arg, int chan)
 {
@@ -93,7 +93,7 @@ int main(void)
     puts("\nCycles:");
 
     bool succeeded = true;
-    for (unsigned i = 0; i < TIMER_CHANNELS; ++i) {
+    for (unsigned i = 0; i < TIMER_CHANNEL_NUMOF; ++i) {
         printf("channel %u = %02u\t[%s]\n", i, count[i], _print_ok(i, &succeeded));
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

In #13900 we agreed to make `TIMER_CHANNEL_NUMOF` the new common name for the number of timer channels a platform provides.

So let's start by renaming all instances of `TIMER_CHANNELS`.


### Testing procedure

Murdock should confirm I didn't miss anything.


### Issues/PRs references

alternative to #13900
