### PR TITLE
cpu/fe310: boards/hifive1*: model features in Kconfig

### DIFF
--- a/boards/hifive1/Kconfig
+++ b/boards/hifive1/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "hifive1" if BOARD_HIFIVE1
+
+config BOARD_HIFIVE1
+    bool
+    default y
+    select CPU_MODEL_FE310_G000
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/hifive1b/Kconfig
+++ b/boards/hifive1b/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "hifive1b" if BOARD_HIFIVE1B
+
+config BOARD_HIFIVE1B
+    bool
+    default y
+    select CPU_MODEL_FE310_G002
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_ARDUINO

--- a/cpu/fe310/Kconfig
+++ b/cpu/fe310/Kconfig
@@ -1,0 +1,63 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_ARCH_RISCV
+    bool
+    select HAS_ARCH_RISCV
+
+config CPU_CORE_RV32M
+    bool
+    select CPU_ARCH_RISCV
+    select HAS_ARCH_32BIT
+
+config CPU_FAM_FE310
+    bool
+    select CPU_CORE_RV32M
+    select HAS_CPU_FE310
+    select HAS_PERIPH_CPUID
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_PM
+    select HAS_PERIPH_WDT
+    select HAS_CPP
+    select HAS_SSP
+
+config CPU_MODEL_FE310_G000
+    bool
+    select CPU_FAM_FE310
+
+config CPU_MODEL_FE310_G002
+    bool
+    select CPU_FAM_FE310
+
+## Definition of specific features
+config HAS_ARCH_RISCV
+    bool
+    help
+        Indicates that the current CPU has a RISC-V.
+
+## Definition of specific features
+config HAS_CPU_FE310
+    bool
+    help
+        Indicates that a 'fe310' cpu is being used.
+
+config CPU_ARCH
+    default "risc-v" if CPU_ARCH_RISCV
+
+config CPU_CORE
+    default "rv32m" if CPU_CORE_RV32M
+
+config CPU_FAM
+    default "fe310" if CPU_FAM_FE310
+
+config CPU_MODEL
+    default "fe310_g000"  if CPU_MODEL_FE310_G000
+    default "fe310_g002"  if CPU_MODEL_FE310_G002
+
+config CPU
+    default "fe310" if CPU_FAM_FE310

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -16,6 +16,8 @@ BOARD_WHITELIST += arduino-duemilanove \
                    cc2650stk \
                    derfmega128 \
                    derfmega256 \
+                   hifive1 \
+                   hifive1b \
                    ikea-tradfri \
                    mega-xplained \
                    microduino-corerf \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is my first attempt to add some Kconfig configuration files so I tried with easy ones: the fe310 cpus and related boards.
I hope there are not too many mistakes :)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- `tests/kconfig_features` work for both boards:

<details><summary>hifive1b</summary>

```
make BOARD=hifive1b -C tests/kconfig_features/ --no-print-directory 
SUCCESS: BOARD values match
SUCCESS: CPU values match
SUCCESS: CPU_MODEL values match
Building application "tests_kconfig_features" for "hifive1b" with MCU "fe310".

"make" -C /work/riot/RIOT/boards/hifive1b
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/fe310
"make" -C /work/riot/RIOT/cpu/fe310/nano
"make" -C /work/riot/RIOT/cpu/fe310/periph
"make" -C /work/riot/RIOT/cpu/fe310/vendor
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8760	    104	   2408	  11272	   2c08	/work/riot/RIOT/tests/kconfig_features/bin/hifive1b/tests_kconfig_features.elf
```

</details>

<details><summary>hifive1</summary>

```
make BOARD=hifive1 -C tests/kconfig_features/ --no-print-directory 
SUCCESS: BOARD values match
SUCCESS: CPU values match
SUCCESS: CPU_MODEL values match
Building application "tests_kconfig_features" for "hifive1" with MCU "fe310".

"make" -C /work/riot/RIOT/boards/hifive1
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/fe310
"make" -C /work/riot/RIOT/cpu/fe310/nano
"make" -C /work/riot/RIOT/cpu/fe310/periph
"make" -C /work/riot/RIOT/cpu/fe310/vendor
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8760	    104	   2408	  11272	   2c08	/work/riot/RIOT/tests/kconfig_features/bin/hifive1/tests_kconfig_features.elf
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Ticks a couple of items in #14148

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
