### PR TITLE
boards/msp430-based: Model features in Kconfig

### DIFF
--- a/boards/chronos/Kconfig
+++ b/boards/chronos/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "chronos" if BOARD_CHRONOS
+
+config BOARD_CHRONOS
+    bool
+    default y
+    select CPU_MODEL_CC430F6137
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_RTC

--- a/boards/common/msb-430/Kconfig
+++ b/boards/common/msb-430/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD_COMMON_MSB_430
+    bool
+    default y
+    select CPU_MODEL_MSP430F1612

--- a/boards/common/wsn430/Kconfig
+++ b/boards/common/wsn430/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "wsn430" if BOARD_WSN430
+
+config BOARD_COMMON_WSN430
+    bool
+    default y
+    select CPU_MODEL_MSP430F1611
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART

--- a/boards/msb-430/Kconfig
+++ b/boards/msb-430/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "msb-430" if BOARD_MSB_430
+
+config BOARD_MSB_430
+    bool
+    default y
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select BOARD_COMMON_MSB_430
+
+source "$(RIOTBOARD)/common/msb-430/Kconfig"

--- a/boards/msb-430h/Kconfig
+++ b/boards/msb-430h/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "msb-430h" if BOARD_MSB_430H
+
+config BOARD_MSB_430H
+    bool
+    default y
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select BOARD_COMMON_MSB_430
+
+source "$(RIOTBOARD)/common/msb-430/Kconfig"

--- a/boards/telosb/Kconfig
+++ b/boards/telosb/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "telosb" if BOARD_TELOSB
+
+config BOARD_TELOSB
+    bool
+    default y
+    select CPU_MODEL_MSP430F1611
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/wsn430-v1_3b/Kconfig
+++ b/boards/wsn430-v1_3b/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "wsn430-v1_3b" if BOARD_WSN430_V1_3B
+
+config BOARD_WSN430_V1_3B
+    bool
+    default y
+    select BOARD_COMMON_WSN430
+
+source "$(RIOTBOARD)/common/wsn430/Kconfig"

--- a/boards/wsn430-v1_4/Kconfig
+++ b/boards/wsn430-v1_4/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "wsn430-v1_4" if BOARD_WSN430_V1_4
+
+config BOARD_WSN430_V1_4
+    bool
+    default y
+    select BOARD_COMMON_WSN430
+
+source "$(RIOTBOARD)/common/wsn430/Kconfig"

--- a/boards/z1/Kconfig
+++ b/boards/z1/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "z1" if BOARD_Z1
+
+config BOARD_Z1
+    bool
+    default y
+    select CPU_MODEL_MSP430F2617
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/cpu/cc430/Kconfig
+++ b/cpu/cc430/Kconfig
@@ -1,1 +1,35 @@
+# Copyright (c) 2020 Freie Universität Berlin
+#               2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_FAM_CC430
+    bool
+    select CPU_CORE_MSP430
+    select HAS_CPU_CC430
+
+## CPU Models
+config CPU_MODEL_CC430F6137
+    bool
+    select CPU_FAM_CC430
+
+## Definition of specific features
+config HAS_CPU_CC430
+    bool
+    help
+        Indicates that a 'cc430' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "cc430" if CPU_FAM_CC430
+
+config CPU_MODEL
+    default "cc430f6137" if CPU_MODEL_CC430F6137
+
+config CPU
+    default "cc430" if CPU_FAM_CC430
+
 source "$(RIOTCPU)/msp430_common/Kconfig"

--- a/cpu/cc430/Makefile.features
+++ b/cpu/cc430/Makefile.features
@@ -1,1 +1,3 @@
--include $(RIOTCPU)/msp430_common/Makefile.features
+CPU_FAM = cc430
+
+include $(RIOTCPU)/msp430_common/Makefile.features

--- a/cpu/msp430_common/Kconfig
+++ b/cpu/msp430_common/Kconfig
@@ -1,9 +1,37 @@
 # Copyright (c) 2020 Freie Universitaet Berlin
+#               2020 HAW Hamburg
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 #
+
+config CPU_ARCH_MSP430
+    bool
+    select HAS_ARCH_16BIT
+    select HAS_ARCH_MSP430
+    select HAS_PERIPH_FLASHPAGE
+    select HAS_PERIPH_FLASHPAGE_RAW
+    select HAS_PERIPH_PM
+
+config CPU_CORE_MSP430
+    bool
+    select CPU_ARCH_MSP430
+
+## Common CPU symbols
+config CPU_ARCH
+    default "msp430" if CPU_ARCH_MSP430
+
+config CPU_CORE
+    default "msp430" if CPU_CORE_MSP430
+
+## Definition of specific features
+config HAS_ARCH_MSP430
+    bool
+    help
+        Indicates that the current architecture is MSP430.
+
+## Specific default configuration values
 config GNRC_PKTBUF_SIZE
     default 2560
     depends on KCONFIG_MODULE_GNRC_PKTBUF_STATIC

--- a/cpu/msp430_common/Makefile.features
+++ b/cpu/msp430_common/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = msp430
+CPU_CORE = msp430
+
 FEATURES_PROVIDED += arch_16bit
 FEATURES_PROVIDED += arch_msp430
 FEATURES_PROVIDED += periph_flashpage

--- a/cpu/msp430fxyz/Kconfig
+++ b/cpu/msp430fxyz/Kconfig
@@ -1,1 +1,45 @@
+# Copyright (c) 2020 Freie Universität Berlin
+#               2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_FAM_MSP430F
+    bool
+    select CPU_CORE_MSP430
+    select HAS_CPU_MSP430FXYZ
+
+## CPU Models
+config CPU_MODEL_MSP430F1611
+    bool
+    select CPU_FAM_MSP430F
+
+config CPU_MODEL_MSP430F1612
+    bool
+    select CPU_FAM_MSP430F
+
+config CPU_MODEL_MSP430F2617
+    bool
+    select CPU_FAM_MSP430F
+
+## Definition of specific features
+config HAS_CPU_MSP430FXYZ
+    bool
+    help
+        Indicates that an 'msp430fxyz' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "msp430f" if CPU_FAM_MSP430F
+
+config CPU_MODEL
+    default "msp430f1611" if CPU_MODEL_MSP430F1611
+    default "msp430f1612" if CPU_MODEL_MSP430F1612
+    default "msp430f2617" if CPU_MODEL_MSP430F2617
+
+config CPU
+    default "msp430fxyz" if CPU_FAM_MSP430F
+
 source "$(RIOTCPU)/msp430_common/Kconfig"

--- a/cpu/msp430fxyz/Makefile.features
+++ b/cpu/msp430fxyz/Makefile.features
@@ -1,1 +1,3 @@
--include $(RIOTCPU)/msp430_common/Makefile.features
+CPU_FAM = msp430f
+
+include $(RIOTCPU)/msp430_common/Makefile.features

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -12,10 +12,13 @@ BOARD_WHITELIST += arduino-duemilanove \
                    cc1352p-launchpad \
                    cc2650-launchpad \
                    cc2650stk \
+                   chronos \
                    derfmega128 \
                    ikea-tradfri \
                    mega-xplained \
                    microduino-corerf \
+                   msb-430 \
+                   msb-430h \
                    samr21-xpro \
                    slstk3401a \
                    slstk3402a \
@@ -24,8 +27,12 @@ BOARD_WHITELIST += arduino-duemilanove \
                    slwstk6000b-slwrb4162a \
                    stk3600 \
                    stk3700 \
-                   waspmote-pro
-
+                   telosb \
+                   waspmote-pro \
+                   wsn430-v1_3b \
+                   wsn430-v1_4 \
+                   z1
+                   #
 
 all: checks
 


### PR DESCRIPTION
### Contribution description
This PR models the features of all msp430-based boards in Kconfig. Also, common variables (`CPU_FAM`, `CPU_CORE`, `CPU_ARCH`) are defined in `Makefile.features`.

### Testing procedure
- Check the symbol organization
- Green CI, `tests/kconfig_features` should test everything

### Issues/PRs references
Part of #14148