### PR TITLE
boards/cc2538-based: Model features in Kconfig

### DIFF
--- a/boards/cc2538dk/Kconfig
+++ b/boards/cc2538dk/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "cc2538dk" if BOARD_CC2538DK
+
+config BOARD_CC2538DK
+    bool
+    default y
+    select CPU_MODEL_CC2538NF53
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_EMULATOR_RENODE

--- a/boards/common/remote/Kconfig
+++ b/boards/common/remote/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD_COMMON_REMOTE
+    bool
+    default y
+    select CPU_MODEL_CC2538SF53
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/firefly/Kconfig
+++ b/boards/firefly/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "firefly" if BOARD_FIREFLY
+
+config BOARD_FIREFLY
+    bool
+    default y
+    select BOARD_COMMON_REMOTE
+
+source "$(RIOTBOARD)/common/remote/Kconfig"

--- a/boards/openmote-b/Kconfig
+++ b/boards/openmote-b/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "openmote-b" if BOARD_OPENMOTE_B
+
+config BOARD_OPENMOTE_B
+    bool
+    default y
+    select CPU_MODEL_CC2538SF53
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/openmote-cc2538/Kconfig
+++ b/boards/openmote-cc2538/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "openmote-cc2538" if BOARD_OPENMOTE_CC2538
+
+config BOARD_OPENMOTE_CC2538
+    bool
+    default y
+    select CPU_MODEL_CC2538SF53
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/remote-pa/Kconfig
+++ b/boards/remote-pa/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "remote-pa" if BOARD_REMOTE_PA
+
+config BOARD_REMOTE_PA
+    bool
+    default y
+    select BOARD_COMMON_REMOTE
+
+source "$(RIOTBOARD)/common/remote/Kconfig"

--- a/boards/remote-reva/Kconfig
+++ b/boards/remote-reva/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "remote-reva" if BOARD_REMOTE_REVA
+
+config BOARD_REMOTE_REVA
+    bool
+    default y
+    select BOARD_COMMON_REMOTE
+
+source "$(RIOTBOARD)/common/remote/Kconfig"

--- a/boards/remote-revb/Kconfig
+++ b/boards/remote-revb/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "remote-revb" if BOARD_REMOTE_REVB
+
+config BOARD_REMOTE_REVB
+    bool
+    default y
+    select BOARD_COMMON_REMOTE
+
+source "$(RIOTBOARD)/common/remote/Kconfig"

--- a/cpu/cc2538/Kconfig
+++ b/cpu/cc2538/Kconfig
@@ -1,0 +1,46 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_FAM_CC2538
+    bool
+    select CPU_CORE_CORTEX_M3
+    select HAS_CPU_CC2538
+    select HAS_PERIPH_CPUID
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_HWRNG
+    select HAS_PERIPH_UART_MODECFG
+    select HAS_CORTEXM_MPU
+    select HAS_PUF_SRAM
+
+## CPU Models
+config CPU_MODEL_CC2538NF53
+    bool
+    select CPU_FAM_CC2538
+
+config CPU_MODEL_CC2538SF53
+    bool
+    select CPU_FAM_CC2538
+
+## Definition of specific features
+config HAS_CPU_CC2538
+    bool
+    help
+        Indicates that a 'cc2538' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "cc2538" if CPU_FAM_CC2538
+
+config CPU_MODEL
+    default "cc2538nf53" if CPU_MODEL_CC2538NF53
+    default "cc2538sf53" if CPU_MODEL_CC2538SF53
+
+config CPU
+    default "cc2538" if CPU_FAM_CC2538
+
+source "$(RIOTCPU)/cortexm_common/Kconfig"

--- a/cpu/cc2538/Makefile.features
+++ b/cpu/cc2538/Makefile.features
@@ -1,4 +1,5 @@
 CPU_CORE = cortex-m3
+CPU_FAM = cc2538
 
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
@@ -8,4 +9,4 @@ FEATURES_PROVIDED += periph_uart_modecfg
 FEATURES_PROVIDED += cortexm_mpu
 FEATURES_PROVIDED += puf_sram
 
--include $(RIOTCPU)/cortexm_common/Makefile.features
+include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -57,6 +57,11 @@ config HAS_CPU_CHECK_ADDRESS
     help
         Indicates that address validity check is supported.
 
+config HAS_EMULATOR_RENODE
+    bool
+    help
+        Indicates that the platform is compatible with the Renode emulator.
+
 config HAS_ETHERNET
     bool
     help

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -12,11 +12,13 @@ BOARD_WHITELIST += arduino-duemilanove \
                    cc1312-launchpad \
                    cc1352-launchpad \
                    cc1352p-launchpad \
+                   cc2538dk \
                    cc2650-launchpad \
                    cc2650stk \
                    chronos \
                    derfmega128 \
                    derfmega256 \
+                   firefly \
                    hifive1 \
                    hifive1b \
                    ikea-tradfri \
@@ -24,6 +26,11 @@ BOARD_WHITELIST += arduino-duemilanove \
                    microduino-corerf \
                    msb-430 \
                    msb-430h \
+                   openmote-b \
+                   openmote-cc2538 \
+                   remote-pa \
+                   remote-reva \
+                   remote-revb \
                    samr21-xpro \
                    slstk3401a \
                    slstk3402a \


### PR DESCRIPTION
### Contribution description
This PR models in Kconfig the features for all the `cc2538`-based boards:

- `cc2538dk`
- `firefly`
- `openmote-b`
- `openmote-cc2538`
- `remote-pa`
- `remote-reva`
- `remote-revb`

### Testing procedure
- Check the Kconfig symbol organization
- Green CI: `tests/kconfig_features` should pass for all boards

### Issues/PRs references
Part of #14148 
