### PR TITLE
cpu/mips32r2_common: include newlib_syscalls_mips_uhi in Makefile.dep

### DIFF
--- a/boards/6lowpan-clicker/Makefile.dep
+++ b/boards/6lowpan-clicker/Makefile.dep
@@ -1,3 +1,5 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+USEMODULE += newlib_syscalls_mips_uhi

--- a/boards/6lowpan-clicker/Makefile.include
+++ b/boards/6lowpan-clicker/Makefile.include
@@ -1,5 +1,4 @@
 APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
-USE_UHI_SYSCALLS = 1
 
 # use pic32prog by default to program this board
 PROGRAMMER ?= pic32prog

--- a/boards/pic32-wifire/Makefile.dep
+++ b/boards/pic32-wifire/Makefile.dep
@@ -1,3 +1,5 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+USEMODULE += newlib_syscalls_mips_uhi

--- a/boards/pic32-wifire/Makefile.include
+++ b/boards/pic32-wifire/Makefile.include
@@ -1,5 +1,4 @@
 APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
-USE_UHI_SYSCALLS = 1
 
 PORT_LINUX ?= /dev/ttyUSB0
 include $(RIOTMAKE)/tools/serial.inc.mk

--- a/cpu/mips32r2_common/Makefile.dep
+++ b/cpu/mips32r2_common/Makefile.dep
@@ -5,10 +5,7 @@ USEMODULE += newlib
 # mips32 needs periph_timer for its gettimeofday() implementation
 FEATURES_REQUIRED += periph_timer
 
-ifeq ($(USE_UHI_SYSCALLS),1)
-  #Use UHI to handle syscalls
-  USEMODULE += newlib_syscalls_mips_uhi
-else
-  #Use RIOT to handle syscalls (default)
+#Use RIOT to handle syscalls (default)
+ifeq (,$(filter newlib_syscalls_mips_uhi,$(USEMODULE)))
   USEMODULE += newlib_syscalls_default
 endif

--- a/cpu/mips32r2_common/Makefile.include
+++ b/cpu/mips32r2_common/Makefile.include
@@ -1,7 +1,5 @@
 INCLUDES += -I$(RIOTCPU)/mips32r2_common/include
 
-ifeq ($(USE_UHI_SYSCALLS),1)
-  #Use UHI to handle syscalls
-  LINKFLAGS += -luhi
-  CFLAGS += -DHAVE_HEAP_STATS
-endif
+# NOTE: This can be turned into normal conditional syntax once #9913 is fixed
+CFLAGS += $(if $(filter newlib_syscalls_mips_uhi,$(USEMODULE)),-DHAVE_HEAP_STATS,)
+LINKFLAGS += $(if $(filter newlib_syscalls_mips_uhi,$(USEMODULE)),-luhi,)


### PR DESCRIPTION
### Contribution description

Currently the inclusion of `newlib_syscalls_mips_uhi` depends on a flag set in Makefile.include, this needs to be addressed for #9913. This PR does that.

### Testing procedure

```
for board in 6lowpan-clicker pic32-wifire; do BOARD=${board} make -C examples/hello-world/ info-debug-variable-LINKFLAGS info-debug-variable-CFLAGS info-debug-variable-USEMODULE --no-print-directory > pr.txt; git checkout upstream/master; BOARD=${board} make -C examples/hello-world/ info-debug-variable-LINKFLAGS info-debug-variable-CFLAGS info-debug-variable-USEMODULE --no-print-directory > master.txt; diff pr.txt master.txt; done
#no diff
```

### Issues/PRs references

#9913 
