### PR TITLE
sys/shell: terminate shell on Ctrl-D

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -38,7 +38,8 @@
 #include "shell.h"
 #include "shell_commands.h"
 
-#define ETX '\x03'  /** ASCII "End-of-Text", or ctrl-C */
+#define ETX '\x03'  /** ASCII "End-of-Text", or Ctrl-C */
+#define EOT '\x04'  /** ASCII "End-of-Transmission", or Ctrl-D */
 #define BS  '\x08'  /** ASCII "Backspace" */
 #define DEL '\x7f'  /** ASCII "Delete" */
 
@@ -411,6 +412,9 @@ static int readline(char *buf, size_t size)
 
         switch (c) {
 
+            case EOT:
+                /* Ctrl-D terminates the current shell instance. */
+                /* fall-thru */
             case EOF:
                 return EOF;
 

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -97,13 +97,18 @@ static const shell_command_t shell_commands[] = {
 
 int main(void)
 {
-
     printf("test_shell.\n");
 
     /* define buffer to be used by the shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];
 
     /* define own shell commands */
+    shell_run_once(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    puts("shell exited");
+
+    /* Restart the shell after the previous one exits, so that we can test
+     * Ctrl-D exit */
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
 
     /* or use only system shell commands */

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -45,8 +45,9 @@ CONTROL_D = DLE+'\x04'
 PROMPT = '> '
 
 CMDS = (
-    # test start
     ('start_test', '[TEST_START]'),
+
+    # test empty line input
     ('\n', PROMPT),
 
     # test simple word separation
@@ -54,10 +55,7 @@ CMDS = (
     ('echo   multiple   spaces   between   argv', '"echo""multiple""spaces""between""argv"'),
     ('echo \t tabs\t\t processed \t\tlike\t \t\tspaces', '"echo""tabs""processed""like""spaces"'),
 
-    # test long line
-    ('123456789012345678901234567890123456789012345678901234567890',
-     'shell: command not found: '
-     '123456789012345678901234567890123456789012345678901234567890'),
+    # test unknown commands
     ('unknown_command', 'shell: command not found: unknown_command'),
 
     # test leading/trailing BLANK
@@ -98,8 +96,9 @@ CMDS = (
     ('ps', EXPECTED_PS),
     ('help', EXPECTED_HELP),
 
-    # test end
+    # test reboot
     ('reboot', 'test_shell.'),
+
     ('end_test', '[TEST_END]'),
 )
 
@@ -110,6 +109,16 @@ CMDS_CLEANTERM = {
 CMDS_REGEX = {'ps'}
 
 BOARD = os.environ['BOARD']
+
+# there's an issue with some boards' serial that causes lost characters.
+LINE_EXCEEDED_BLACKLIST = {
+    # There is an issue with nrf52dk when the Virtual COM port is connected
+    # and sending more than 64 bytes over UART. If no terminal is connected
+    # to the Virtual COM and interfacing directly to the nrf52832 UART pins
+    # the issue is not present. See issue #10639 on GitHub.
+    'nrf52dk',
+    'z1',
+}
 
 
 def print_error(message):
@@ -140,17 +149,6 @@ def check_and_get_bufsize(child):
     bufsize = int(child.match.group(1))
 
     return bufsize
-
-
-# there's an issue with some boards' serial that causes lost characters.
-LINE_EXCEEDED_BLACKLIST = {
-    # There is an issue with nrf52dk when the Virtual COM port is connected
-    # and sending more than 64 bytes over UART. If no terminal is connected
-    # to the Virtual COM and interfacing directly to the nrf52832 UART pins
-    # the issue is not present. See issue #10639 on GitHub.
-    'nrf52dk',
-    'z1',
-}
 
 
 def check_line_exceeded(child, longline):

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -182,6 +182,19 @@ def check_erase_long_line(child, longline):
         child.expect_exact('"echo"')
 
 
+def check_control_d(child):
+    # The current shell instance was initiated by shell_run_once(). The shell will exit.
+    child.sendline(CONTROL_D)
+    child.expect_exact('shell exited')
+
+    # The current shell instance was initiated by shell_run(). The shell will respawn
+    # automatically except on native. On native, RIOT is shut down completely,
+    # therefore exclude this part.
+    if BOARD != 'native':
+        child.sendline(CONTROL_D)
+        child.expect_exact(PROMPT)
+
+
 def testfunc(child):
     # avoid sending an extra empty line on native.
     if BOARD == 'native':
@@ -198,6 +211,8 @@ def testfunc(child):
         print("skipping check_line_canceling()")
 
     check_erase_long_line(child, longline)
+
+    check_control_d(child)
 
     # loop other defined commands and expected output
     for cmd, expected in CMDS:


### PR DESCRIPTION
Ctrl-D was not caught in a special case so it was interpreted as a standard character. Handle it now the same way like EOF and terminate the shell instance.

Related to #10788
