### PR TITLE
makefiles/boards/sam0.inc.mk: dap: use OpenOCD for debugging

### DIFF
--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -43,6 +43,8 @@ endif
 ifeq ($(PROGRAMMER),edbg)
   # use edbg for flashing
   include $(RIOTMAKE)/tools/edbg.inc.mk
+  # use openocd for debugging
+  include $(RIOTMAKE)/tools/openocd.inc.mk
 else ifeq ($(PROGRAMMER),jlink)
   # this board uses J-Link for debug and possibly flashing
   include $(RIOTMAKE)/tools/jlink.inc.mk


### PR DESCRIPTION



<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`ebdg` can only be used for flashing, we still have to use OpenOCD for debugging.

### Testing procedure

make debug` should work again on e.g. `samr21-xpro`.


### Issues/PRs references

fixes #14328
