### PR TITLE
makefiles/boards/sam0: allways include openocd as backup

### DIFF
--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -43,10 +43,12 @@ endif
 ifeq ($(PROGRAMMER),edbg)
   # use edbg for flashing
   include $(RIOTMAKE)/tools/edbg.inc.mk
-else ifeq ($(PROGRAMMER),jlink)
+endif
+
+ifeq ($(PROGRAMMER),jlink)
   # this board uses J-Link for debug and possibly flashing
   include $(RIOTMAKE)/tools/jlink.inc.mk
-else ifeq ($(PROGRAMMER),openocd)
+else
   # this board uses openocd for debug and possibly flashing
   include $(RIOTMAKE)/tools/openocd.inc.mk
 endif


### PR DESCRIPTION
### Contribution description

In https://github.com/RIOT-OS/RIOT/pull/14198 98824df68ba665e2c54b715a12991ae8e51e7115 the logic was changed and now `openocd` targets are not always included. This has the effect that `debug` does not work out of the box for sam0 which would normally select `edbg`, this a bit annoying. This change reverts that part to how it was before, since everything is defined with `?=` `openocd` will only define targets not set by `edbg`

### Testing procedure

- `flash` uses edbg

```
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004624 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification............................................................................................................                    ....................................................................................................................................................................................................................................... done.
```

- debug uses `openocd`

```
### Starting Debugging ###
Open On-Chip Debugger 0.10.0+dev-01100-g51dd4ce6-dirty (2020-03-03-15:33)
Licensed under GNU GPL v2
For bug reports, read
        http://openocd.org/doc/doxygen/bugs.html
Reading symbols from /home/francisco/workspace/RIOT3/tests/pkg_openwsn/bin/samr21-xpro/tests_pkg_openwsn.elf...
Remote debugging using :3333
sam0_cortexm_sleep (deep=<optimized out>)
    at /home/francisco/workspace/RIOT3/cpu/sam0_common/include/periph_cpu_common.h:409
409         cpu_pm_cb_leave(deep);
```


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14198
