### PR TITLE
cpu: define TIMER_CHANNEL_NUMOF for constency

### DIFF
--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -290,6 +290,11 @@ typedef struct {
     uint_fast8_t cfg;   /**< timer config word */
 } timer_conf_t;
 
+/**
+ * @brief   Number of available timer channels
+ */
+#define TIMER_CHANNEL_NUMOF     (2U)
+
 #ifndef DOXYGEN
 /**
  * @name   Override resolution options

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -360,6 +360,11 @@ typedef struct {
 /** @} */
 
 /**
+ * @brief   This timer implementation has three available channels
+ */
+#define TIMER_CHANNEL_NUMOF (3U)
+
+/**
  * @brief   UART device configuration.
  */
 #ifndef DOXYGEN

--- a/cpu/efm32/periph/timer.c
+++ b/cpu/efm32/periph/timer.c
@@ -29,11 +29,6 @@
 #include "em_timer_utils.h"
 
 /**
- * @brief   This timer implementation has three available channels
- */
-#define CC_CHANNELS      (3U)
-
-/**
  * @brief   Timer state memory
  */
 static timer_isr_ctx_t isr_ctx[TIMER_NUMOF];
@@ -116,7 +111,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 {
     TIMER_TypeDef *tim;
 
-    if (channel < 0 || channel >= (int) CC_CHANNELS) {
+    if (channel < 0 || channel >= (int) TIMER_CHANNEL_NUMOF) {
         return -1;
     }
 
@@ -158,7 +153,7 @@ void TIMER_0_ISR(void)
 {
     TIMER_TypeDef *tim = timer_config[0].timer.dev;
 
-    for (int i = 0; i < (int) CC_CHANNELS; i++) {
+    for (unsigned i = 0; i < TIMER_CHANNEL_NUMOF; i++) {
         if (tim->IF & (TIMER_IF_CC0 << i)) {
             tim->CC[i].CTRL = _TIMER_CC_CTRL_MODE_OFF;
             tim->IFC = (TIMER_IFC_CC0 << i);

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -130,6 +130,11 @@ typedef uint16_t gpio_t;
 #define PERIPH_TIMER_PROVIDES_SET
 
 /**
+ * @brief   Number of available timer channels
+ */
+#define TIMER_CHANNEL_NUMOF     (1U)
+
+/**
  * @brief   number of usable power modes
  */
 #define PM_NUM_MODES    (1U)

--- a/cpu/kinetis/periph/timer.c
+++ b/cpu/kinetis/periph/timer.c
@@ -628,7 +628,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 
 int timer_set(tim_t dev, int channel, unsigned int timeout)
 {
-    if (channel != 0) {
+    if (channel < 0 || channel >= (int)TIMER_CHANNEL_NUMOF) {
         /* only one channel is supported */
         return -1;
     }
@@ -651,7 +651,7 @@ int timer_set(tim_t dev, int channel, unsigned int timeout)
 
 int timer_set_absolute(tim_t dev, int channel, unsigned int target)
 {
-    if (channel != 0) {
+    if (channel < 0 || channel >= (int)TIMER_CHANNEL_NUMOF) {
         /* only one channel is supported */
         return -1;
     }
@@ -676,7 +676,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int target)
 
 int timer_clear(tim_t dev, int channel)
 {
-    if (channel != 0) {
+    if (channel < 0 || channel >= (int)TIMER_CHANNEL_NUMOF) {
         /* only one channel is supported */
         return -1;
     }

--- a/cpu/lpc1768/include/periph_cpu.h
+++ b/cpu/lpc1768/include/periph_cpu.h
@@ -66,6 +66,11 @@ typedef enum {
 #endif /* ndef DOXYGEN */
 
 /**
+ * @brief   Number of available timer channels
+ */
+#define TIMER_CHANNEL_NUMOF     (4U)
+
+/**
  * @brief   CPU provides own pm_off() function
  */
 #define PROVIDES_PM_LAYERED_OFF


### PR DESCRIPTION
### Contribution description

Add more `TIMER_CHANNEL_NUMOF` definitions to architectures that didn't have that define before.

### Testing procedure

Murdock should confirm nothing breaks.

### Issues/PRs references

alternative to #13900
