### PR TITLE
pkg/lwip: enable IPv4/IPv6 dual stack mode

### DIFF
--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -155,8 +155,8 @@ static struct netif *_netif_add(struct netif *netif, void *state,
                                 netif_init_fn init, netif_input_fn input)
 {
 #if IS_USED(MODULE_LWIP_IPV4)
-    return netif_add(netif, IP4_ADDR_ANY, IP4_ADDR_ANY, IP4_ADDR_ANY,
-                     state, init, input);
+    return netif_add(netif, ip_2_ip4(IP4_ADDR_ANY), ip_2_ip4(IP4_ADDR_ANY),
+                     ip_2_ip4(IP4_ADDR_ANY), state, init, input);
 #else /* IS_USED(MODULE_LWIP_IPV4) */
     return netif_add(netif, state, init, input);
 #endif  /* IS_USED(MODULE_LWIP_IPV4) */

--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -330,11 +330,6 @@ static int _create(int type, int proto, uint16_t flags, struct netconn **out)
         return -ENOMEM;
     }
     netconn_set_callback_arg(*out, NULL);
-#if LWIP_IPV4 && LWIP_IPV6
-    if (type & NETCONN_TYPE_IPV6) {
-        netconn_set_ipv6only(*out, 1);
-    }
-#endif
 #if SO_REUSE
     if (flags & SOCK_FLAGS_REUSE_EP) {
         ip_set_option((*out)->pcb.ip, SOF_REUSEADDR);

--- a/sys/include/net/sock/util.h
+++ b/sys/include/net/sock/util.h
@@ -29,22 +29,56 @@
 #include <stdint.h>
 
 #include "net/sock/udp.h"
+#include "net/sock/tcp.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @brief   Format UDP endpoint to string and port
+ * @brief   Format common IP-based transport layer endpoint to string and port
  *
  * @param[in]   endpoint    endpoint to format
  * @param[out]  addr_str    where to write address as string
- * @param[out]  port        where to write prt number as uint16_t
+ * @param[out]  port        where to write port number as uint16_t
  *
  * @returns     number of bytes written to @p addr_str on success
  * @returns     <0 otherwise
  */
-int sock_udp_ep_fmt(const sock_udp_ep_t *endpoint, char *addr_str, uint16_t *port);
+int sock_tl_ep_fmt(const struct _sock_tl_ep *endpoint,
+                   char *addr_str, uint16_t *port);
+
+/**
+ * @brief   Format TCP endpoint to string and port
+ *
+ * @param[in]   endpoint    endpoint to format
+ * @param[out]  addr_str    where to write address as string
+ * @param[out]  port        where to write port number as uint16_t
+ *
+ * @returns     number of bytes written to @p addr_str on success
+ * @returns     <0 otherwise
+ */
+static inline int sock_tcp_ep_fmt(const sock_tcp_ep_t *endpoint,
+                                  char *addr_str, uint16_t *port)
+{
+    return sock_tl_ep_fmt(endpoint, addr_str, port);
+}
+
+/**
+ * @brief   Format UDP endpoint to string and port
+ *
+ * @param[in]   endpoint    endpoint to format
+ * @param[out]  addr_str    where to write address as string
+ * @param[out]  port        where to write port number as uint16_t
+ *
+ * @returns     number of bytes written to @p addr_str on success
+ * @returns     <0 otherwise
+ */
+static inline int sock_udp_ep_fmt(const sock_udp_ep_t *endpoint,
+                                  char *addr_str, uint16_t *port)
+{
+    return sock_tl_ep_fmt(endpoint, addr_str, port);
+}
 
 /**
  * @brief    Split url to host:port and url path
@@ -69,6 +103,37 @@ int sock_udp_ep_fmt(const sock_udp_ep_t *endpoint, char *addr_str, uint16_t *por
 int sock_urlsplit(const char *url, char *hostport, char *urlpath);
 
 /**
+ * @brief    Convert string to common IP-based transport layer endpoint
+ *
+ * Takes eg., "[2001:db8::1]:1234" and converts it into the corresponding UDP
+ * endpoint structure.
+ *
+ * @param[out]  ep_out  endpoint structure to fill
+ * @param[in]   str     string to read from
+ *
+ * @returns     0 on success
+ * @returns     <0 otherwise
+ */
+int sock_tl_str2ep(struct _sock_tl_ep *ep_out, const char *str);
+
+/**
+ * @brief    Convert string to TCP endpoint
+ *
+ * Takes eg., "[2001:db8::1]:1234" and converts it into the corresponding UDP
+ * endpoint structure.
+ *
+ * @param[out]  ep_out  endpoint structure to fill
+ * @param[in]   str     string to read from
+ *
+ * @returns     0 on success
+ * @returns     <0 otherwise
+ */
+static inline int sock_tcp_str2ep(sock_tcp_ep_t *ep_out, const char *str)
+{
+    return sock_tl_str2ep(ep_out, str);
+}
+
+/**
  * @brief    Convert string to UDP endpoint
  *
  * Takes eg., "[2001:db8::1]:1234" and converts it into the corresponding UDP
@@ -80,7 +145,45 @@ int sock_urlsplit(const char *url, char *hostport, char *urlpath);
  * @returns     0 on success
  * @returns     <0 otherwise
  */
-int sock_udp_str2ep(sock_udp_ep_t *ep_out, const char *str);
+static inline int sock_udp_str2ep(sock_udp_ep_t *ep_out, const char *str)
+{
+    return sock_tl_str2ep(ep_out, str);
+}
+
+/**
+ * @brief   Compare the two given common IP-based transport layer endpoints
+ *
+ * The given endpoint identifiers are compared by checking their address family,
+ * their addresses, and their port value.
+ *
+ * @param[in] a     Endpoint A
+ * @param[in] b     Endpoint B
+ *
+ * @return  true if given endpoint identifiers point to the same destination
+ * @return  false if given endpoint identifiers do not point to the same
+ *          destination, or if the address family is unknown
+ */
+bool sock_tl_ep_equal(const struct _sock_tl_ep *a,
+                      const struct _sock_tl_ep *b);
+
+/**
+ * @brief   Compare the two given TCP endpoints
+ *
+ * The given endpoint identifiers are compared by checking their address family,
+ * their addresses, and their port value.
+ *
+ * @param[in] a     Endpoint A
+ * @param[in] b     Endpoint B
+ *
+ * @return  true if given endpoint identifiers point to the same destination
+ * @return  false if given endpoint identifiers do not point to the same
+ *          destination, or if the address family is unknown
+ */
+static inline bool sock_tcp_ep_equal(const sock_tcp_ep_t *a,
+                                     const sock_tcp_ep_t *b)
+{
+    return sock_tl_ep_equal(a, b);
+}
 
 /**
  * @brief   Compare the two given UDP endpoints
@@ -95,7 +198,11 @@ int sock_udp_str2ep(sock_udp_ep_t *ep_out, const char *str);
  * @return  false if given endpoint identifiers do not point to the same
  *          destination, or if the address family is unknown
  */
-bool sock_udp_ep_equal(const sock_udp_ep_t *a, const sock_udp_ep_t *b);
+static inline bool sock_udp_ep_equal(const sock_udp_ep_t *a,
+                                     const sock_udp_ep_t *b)
+{
+    return sock_tl_ep_equal(a, b);
+}
 
 /**
  * @defgroup    net_sock_util_conf SOCK utility functions compile configurations

--- a/sys/net/sock/sock_util.c
+++ b/sys/net/sock/sock_util.c
@@ -36,7 +36,8 @@
 #define PORT_STR_LEN    (5)
 #define NETIF_STR_LEN   (5)
 
-int sock_udp_ep_fmt(const sock_udp_ep_t *endpoint, char *addr_str, uint16_t *port)
+int sock_tl_ep_fmt(const struct _sock_tl_ep *endpoint,
+                   char *addr_str, uint16_t *port)
 {
     void *addr_ptr;
     *addr_str = '\0';
@@ -187,7 +188,7 @@ int _parse_netif(sock_udp_ep_t *ep_out, char *netifstart)
     return (netifend - netifstart);
 }
 
-int sock_udp_str2ep(sock_udp_ep_t *ep_out, const char *str)
+int sock_tl_str2ep(struct _sock_tl_ep *ep_out, const char *str)
 {
     unsigned brackets_flag;
     char *hoststart = (char*)str;
@@ -253,7 +254,8 @@ int sock_udp_str2ep(sock_udp_ep_t *ep_out, const char *str)
     return -EINVAL;
 }
 
-bool sock_udp_ep_equal(const sock_udp_ep_t *a, const sock_udp_ep_t *b)
+bool sock_tl_ep_equal(const struct _sock_tl_ep *a,
+                      const struct _sock_tl_ep *b)
 {
     assert(a && b);
 

--- a/sys/net/sock/sock_util.c
+++ b/sys/net/sock/sock_util.c
@@ -42,13 +42,11 @@ int sock_udp_ep_fmt(const sock_udp_ep_t *endpoint, char *addr_str, uint16_t *por
     *addr_str = '\0';
 
     switch (endpoint->family) {
-#if defined(SOCK_HAS_IPV4)
         case AF_INET:
             {
                 addr_ptr = (void*)&endpoint->addr.ipv4;
                 break;
             }
-#endif
 #if defined(SOCK_HAS_IPV6)
         case AF_INET6:
             {

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -10,10 +10,14 @@ ifneq (0, $(LWIP_IPV4))
   CFLAGS += -DETHARP_SUPPORT_STATIC_ENTRIES=1
   LWIP_IPV6 ?= 0
 else
+  # use IPv6 as default IP protocol when IPv4 is not explicitly selected
+  LWIP_IPV6 ?= 1
+endif
+
+ifneq (0, $(LWIP_IPV6))
   USEMODULE += ipv6_addr
   USEMODULE += lwip_ipv6
   USEMODULE += lwip_ipv6_autoconfig
-  LWIP_IPV6 ?= 1
 endif
 
 # including lwip_ipv6_mld would currently break this test on at86rf2xx radios
@@ -22,6 +26,7 @@ USEMODULE += lwip_udp lwip_sock_udp
 USEMODULE += lwip_tcp lwip_sock_tcp
 USEMODULE += lwip_sock_async
 USEMODULE += sock_async_event
+USEMODULE += sock_util
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps

--- a/tests/lwip/Makefile.ci
+++ b/tests/lwip/Makefile.ci
@@ -1,6 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
     airfy-beacon \
     blackpill \
+    bluepill \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/lwip/common.h
+++ b/tests/lwip/common.h
@@ -21,8 +21,18 @@
 #include <stdint.h>
 #include <sys/types.h>
 
+#include "kernel_defines.h"
+
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+#if IS_USED(MODULE_LWIP_IPV6)
+#include "net/ipv6.h"
+#define SOCK_IP_EP_ANY  SOCK_IPV6_EP_ANY
+#elif IS_USED(MODULE_LWIP_IPV4)
+#include "net/ipv4.h"
+#define SOCK_IP_EP_ANY  SOCK_IPV4_EP_ANY
 #endif
 
 /**

--- a/tests/lwip/main.c
+++ b/tests/lwip/main.c
@@ -32,24 +32,36 @@
 #endif
 #include "shell.h"
 
+#define IFCONFIG_FILLER     "       "
+
 static int ifconfig(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
     for (struct netif *iface = netif_list; iface != NULL; iface = iface->next) {
         printf("%s_%02u: ", iface->name, iface->num);
-#ifdef MODULE_LWIP_IPV6
+#if IS_USED(MODULE_LWIP_IPV6)
         char addrstr[IPV6_ADDR_MAX_STR_LEN];
+#elif IS_USED(MODULE_LWIP_IPV4)
+        char addrstr[IPV4_ADDR_MAX_STR_LEN];
+#endif
+#ifdef MODULE_LWIP_IPV6
         for (int i = 0; i < LWIP_IPV6_NUM_ADDRESSES; i++) {
             if (!ipv6_addr_is_unspecified((ipv6_addr_t *)&iface->ip6_addr[i])) {
-                printf(" inet6 %s\n", ipv6_addr_to_str(addrstr, (ipv6_addr_t *)&iface->ip6_addr[i],
-                                                       sizeof(addrstr)));
+                printf("%s inet6 %s\n", (i == 0) ? "" : IFCONFIG_FILLER,
+                       ipv6_addr_to_str(addrstr,
+                                        (ipv6_addr_t *)&iface->ip6_addr[i],
+                                        sizeof(addrstr)));
             }
         }
 #endif
 #ifdef MODULE_LWIP_IPV4
-        char addrstr[IPV4_ADDR_MAX_STR_LEN];
-        printf(" inet %s\n", ipv4_addr_to_str(addrstr, (ipv4_addr_t *)&iface->ip_addr,
+        if (IS_USED(MODULE_LWIP_IPV6)) {
+            /* insert spaces to be aligned with inet6 */
+            printf(IFCONFIG_FILLER);
+        }
+        printf(" inet %s\n", ipv4_addr_to_str(addrstr,
+                                              (ipv4_addr_t *)&iface->ip_addr,
                                               sizeof(addrstr)));
 #endif
         puts("");
@@ -67,7 +79,7 @@ static const shell_command_t shell_commands[] = {
 #ifdef MODULE_SOCK_UDP
     { "udp", "Send UDP messages and listen for messages on UDP port", udp_cmd },
 #endif
-    { "ifconfig", "Shows assigned IPv6 addresses", ifconfig },
+    { "ifconfig", "Shows assigned IP addresses", ifconfig },
     { NULL, NULL, NULL }
 };
 

--- a/tests/lwip/tests/01-run.py
+++ b/tests/lwip/tests/01-run.py
@@ -235,7 +235,7 @@ def test_udpv6_send(board_group, application, env=None):
         receiver.sendline(u"udp server start %d" % port)
         # wait for neighbor discovery to be done
         time.sleep(5)
-        sender.sendline(u"udp send %s %d ab:cd:ef" % (receiver_ip, port))
+        sender.sendline(u"udp send [%s]:%d ab:cd:ef" % (receiver_ip, port))
         sender.expect_exact("Success: send 3 byte over UDP to [{}]:{}"
                             .format(receiver_ip, port))
         receiver.expect(u"00000000  AB  CD  EF")
@@ -261,7 +261,7 @@ def test_tcpv6_send(board_group, application, env=None):
         server.sendline(u"tcp server start %d" % port)
         # wait for neighbor discovery to be done
         time.sleep(5)
-        client.sendline(u"tcp connect %s %d" % (server_ip, port))
+        client.sendline(u"tcp connect [%s]:%d" % (server_ip, port))
         server.expect(u"TCP client \\[%s\\]:[0-9]+ connected" % client_ip)
         client.sendline(u"tcp send affe:abe")
         client.expect_exact(u"Success: send 4 byte over TCP to server")
@@ -301,14 +301,14 @@ def test_tcpv6_multiconnect(board_group, application, env=None):
         server.sendline(u"tcp server start %d" % port)
         # wait for neighbor discovery to be done
         time.sleep(5)
-        client.sendline(u"tcp connect %s %d" % (server_ip, port))
+        client.sendline(u"tcp connect [%s]:%d" % (server_ip, port))
         server.expect(u"TCP client \\[%s\\]:[0-9]+ connected" % client_ip)
         with socket.socket(socket.AF_INET6) as sock:
             sock.connect(connect_addr)
             server.expect(u"Error on TCP accept \\[-[0-9]+\\]")
         client.sendline(u"tcp disconnect")
         server.expect(u"TCP connection to \\[%s\\]:[0-9]+ reset" % client_ip)
-        client.sendline(u"tcp connect %s %d" % (server_ip, port))
+        client.sendline(u"tcp connect [%s]:%d" % (server_ip, port))
         server.expect(u"TCP client \\[%s\\]:[0-9]+ connected" % client_ip)
         client.sendline(u"tcp disconnect")
         server.expect(u"TCP connection to \\[%s\\]:[0-9]+ reset" % client_ip)
@@ -342,7 +342,7 @@ def test_triple_send(board_group, application, env=None):
         receiver.sendline(u"tcp server start %d" % tcp_port)
         # wait for neighbor discovery to be done
         time.sleep(5)
-        sender.sendline(u"udp send %s %d 01:23" % (receiver_ip, udp_port))
+        sender.sendline(u"udp send [%s]:%d 01:23" % (receiver_ip, udp_port))
         sender.expect_exact(u"Success: send 2 byte over UDP to [%s]:%d" %
                             (receiver_ip, udp_port))
         receiver.expect(u"00000000  01  23")
@@ -351,7 +351,7 @@ def test_triple_send(board_group, application, env=None):
         sender.expect_exact(u"Success: send 4 byte over IPv6 to %s (next header: %d)" %
                             (receiver_ip, ipprot))
         receiver.expect(u"00000000  01  02  03  04")
-        sender.sendline(u"tcp connect %s %d" % (receiver_ip, tcp_port))
+        sender.sendline(u"tcp connect [%s]:%d" % (receiver_ip, tcp_port))
         receiver.expect(u"TCP client \\[%s\\]:[0-9]+ connected" % sender_ip)
         sender.sendline(u"tcp send dead:beef")
         sender.expect_exact(u"Success: send 4 byte over TCP to server")


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This enables lwIP and the `tests/lwip` application to run in IPv4/IPv6 dual stack mode. Piggy-backed in this is an extension for `sock_util` for `sock_tcp` and a fix for `sock_util` for IPv4. I can move them to their own PR, but they are required for this change (particularly the test adaptation).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile and run `tests/lwip` with any combination of `LWIP_IPV6={0,1}` and `LWIP_IPV4={0,1}` (`LWIP_IPV6=1` is preferred if no IP protocol is selected).

`make test` only works if `LWIP_IPV6` is compiled in and it only tests IPv6 behavior (I will fix that once https://github.com/RIOT-OS/riotctrl/ goes public and https://github.com/RIOT-OS/RIOT/pull/11406 is merged). I tested that however for `LWIP_IPV6=1` and `LWIP_IPV6=1 LWIP_IPV4=1`.

#### Manual IPv4 testing
<details><summary>IPv4 I tested by hand on `native`, using `netcat`, as I was too lazy to configure proper routing on my laptop ;-P.</summary>

##### Setting up a DHCP server using `dnsmasq`
```sh
sudo dist/tools/tapsetup/tapsetup -d
sudo dist/tools/tapsetup/tapsetup
sudo ip addr add 10.1.194.1/24 dev tapbr0
sudo dnsmasq --no-daemon --log-queries --dhcp-range=10.1.194.2,10.1.194.128,1h -i tapbr0
```
##### Testing interaction
###### RIOT
```
> ifconfig
ifconfig
ET_00:  inet6 fe80::e0bc:7dff:fecb:f550
        inet 10.1.194.77

> tcp server start 1337
tcp server start 1337
Success: started TCP server on port 1337
```
###### Host
```sh
echo "test" | nc -4 10.1.194.77 1337
^C
```
###### RIOT
```
> TCP client [10.1.194.1]:47664 connected
Received TCP data from client [10.1.194.1]:47664
00000000  74  65  73  74  0A
TCP connection to [10.1.194.1]:47664 reset
udp server start 1338
udp server start 1338
Success: started UDP server on port 1338
```
###### Host
```sh
echo "test" | nc -4u 10.1.194.77 1338
^C
nc -4l 10.1.194.1 1234
```
###### RIOT
```
> tcp connect 10.1.194.1:1234
tcp connect 10.1.194.1:1234
> tcp send 31323435
tcp send 31323435
Success: send 4 byte over TCP to server
```
###### Host
```sh
1245^C
nc -4lu 1235
```
###### RIOT
```
> udp send 10.1.194.1:1235 61626364656a
udp send 10.1.194.1:1235 61626364656a
Success: send 6 byte over UDP to 10.1.194.1:1235
```
###### Host
```
abcdej^C
```

</details>

(IP raw sockets were not tested as `netcat` does not support them, but one could maybe test using e.g. `scapy`)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Issue came up in #12647
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
