### PR TITLE
sys/arduino: include arduino_sketches in Makefile.dep

### DIFF
--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -2,6 +2,8 @@ ifneq (,$(filter arduino,$(USEMODULE)))
   FEATURES_OPTIONAL += periph_i2c
   FEATURES_OPTIONAL += periph_spi
   FEATURES_REQUIRED += periph_uart
+  SKETCH_MODULE ?= arduino_sketches
+  USEMODULE += $(SKETCH_MODULE)
 endif
 
 ifneq (,$(filter eepreg,$(USEMODULE)))

--- a/sys/arduino/Makefile.include
+++ b/sys/arduino/Makefile.include
@@ -4,14 +4,14 @@ SKETCHES = $(wildcard $(APPDIR)/*.sketch)
 
 ifneq (,$(SKETCHES))
   # Define application sketches module, it will be generated into $(BINDIR)
-  SKETCH_MODULE     ?= arduino_sketches
   SKETCH_MODULE_DIR ?= $(BINDIR)/$(SKETCH_MODULE)
   include $(RIOTBASE)/sys/arduino/sketches.inc.mk
 
   # Depends on module
-  USEMODULE += $(SKETCH_MODULE)
   DIRS      += $(SKETCH_MODULE_DIR)
   BUILDDEPS += $(SKETCH_GENERATED_FILES)
+else
+  PSEUDOMODULES += $(SKETCH_MODULE)
 endif
 
 # include the Arduino headers


### PR DESCRIPTION
### Contribution description

`SKETCH_MODULE` is currently declared in `Makefile.include` which lead to its inclusion as a module to also happen there. Strictly speaking it is not needed for #9913 ince `sys/Makefile.include` is already included after `dependency resolution`, for consistency modules should not be included in `Makefile.include`

In this PR I though to remove the option of changing `SKETCH_MODULE` name, I'm not sure its useful in any way. But to make the change simpler I just moved it to Makefile.dep.


### Testing procedure

- application with no sketches compile fine

`USEMODULE=arduino BOARD=nucleo-l152re make -C examples/hello-world/
`

- `make -C tests/sys_arduino test` passes

```
main(): This is RIOT! (Version: 2020.07-devel-1416-ga9849-pr_sketch_module)
Hello Arduino!
wrang
UNK
echo quite long string echoing on arduino module test
ECHO: quite long string echoing on arduino module test
numb 4242
4242 4242 1092 10222
time
5145589 5182366 5219138 OK END
print
print(int, BIN): 11111111111111111111101011000111
println(int, BIN): 11111111111111111111101011000111
print(int, OCT): 37777775307
println(int, OCT): 37777775307
print(int, DEC): -1337
println(int, DEC): -1337
print(int, HEX): fffffac7
println(int, HEX): fffffac7
print(unsigned int, BIN): 101010
println(unsigned int, BIN): 101010
print(unsigned int, OCT): 52
println(unsigned int, OCT): 52
print(unsigned int, DEC): 42
println(unsigned int, DEC): 42
print(unsigned int, HEX): 2a
println(unsigned int, HEX): 2a
print(long, BIN): 10110110011010011111110100101110
println(long, BIN): 10110110011010011111110100101110
print(long, OCT): 26632376456
println(long, OCT): 26632376456
print(long, DEC): -1234567890
println(long, DEC): -1234567890
print(long, HEX): b669fd2e
println(long, HEX): b669fd2e
print(unsigned long, BIN): 1001001100101100000001011010010
println(unsigned long, BIN): 1001001100101100000001011010010
print(unsigned long, OCT): 11145401322
println(unsigned long, OCT): 11145401322
print(unsigned long, DEC): 1234567890
println(unsigned long, DEC): 1234567890
print(unsigned long, HEX): 499602d2
println(unsigned long, HEX): 499602d2
```

### Issues/PRs references

#9913
