### PR TITLE
Makefile.include: resolve dependencies before Makefile.include

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -363,6 +363,12 @@ include $(RIOTBASE)/Makefile.features
 include $(RIOTMAKE)/pseudomodules.inc.mk
 include $(RIOTMAKE)/defaultmodules.inc.mk
 
+# handle removal of default modules
+USEMODULE += $(filter-out $(DISABLE_MODULE), $(DEFAULT_MODULE))
+
+# process dependencies
+include $(RIOTMAKE)/dependency_resolution.inc.mk
+
 # Include Board and CPU configuration
 INCLUDES += $(addprefix -I,$(wildcard $(BOARDDIR)/include))
 include $(BOARDDIR)/Makefile.include
@@ -384,12 +390,6 @@ include $(RIOTMAKE)/toolchain/$(TOOLCHAIN).inc.mk
 # Non cached builds are not affected in any way.
 # For more information, see http://petereisentraut.blogspot.com/2011/09/ccache-and-clang-part-2.html
 export CCACHE_CPP2=yes
-
-# handle removal of default modules
-USEMODULE += $(filter-out $(DISABLE_MODULE), $(DEFAULT_MODULE))
-
-# process dependencies
-include $(RIOTMAKE)/dependency_resolution.inc.mk
 
 ifeq ($(strip $(MCU)),)
 	MCU = $(CPU)

--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -15,14 +15,6 @@ endif
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-# The following configuration are dependencies specific, specifically they need
-# to know if 'nordic_softdevice_ble' is used. The dependencies are not known
-# because BOARDs Makefile.include are included before Makefile.dep
-# This HACK can be removed either when Makefile.include is included after
-# Makefile.features (see #9913) or if 'nordic_softdevice_ble' is deprecated.
--include $(APPDIR)/Makefile.board.dep
-include $(BOARDDIR)/Makefile.dep
-
 PROGRAMMER ?= jlink
 ifeq (jlink,$(PROGRAMMER))
   # setup JLink for flashing


### PR DESCRIPTION
### Contribution description

This PR moves `BOARD` and `CPU` Makefile includes after dependency resolution.

### Testing procedure

- green murdock

- run `time ./dist/tools/buildsystem_sanity_check/save_all_dependencies_resolution_variables.sh` on this PR and master. There should be no diff. I ran it on a version of this branch rebased on #14350. But I think that shouldn't matter since that module was included after dependency resolution already so result should not be affected by this PR.

I'm ticking it as major since it affects all `BOARD` `CPU`, but IMO the change if fine if no dependencies have changed :)

### Issues/PRs references

Ticks an item in #9913
