### PR TITLE
ci/build_system_check: fix typo in function name

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -276,7 +276,7 @@ check_files_in_boards_not_reference_board_var() {
         | error_with_message 'Code in boards/ should not use $(BOARDS) to reference files since this breaks external BOARDS changing BOARDSDIR"'
 }
 
-check_no_pseudomules_in_makefile_dep() {
+check_no_pseudomodules_in_makefile_dep() {
     local patterns=()
     local pathspec=()
 
@@ -304,7 +304,7 @@ all_checks() {
     checks_tests_application_not_defined_in_makefile
     checks_develhelp_not_defined_via_cflags
     check_files_in_boards_not_reference_board_var
-    check_no_pseudomules_in_makefile_dep
+    check_no_pseudomodules_in_makefile_dep
 }
 
 main() {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a small typo in one of the function names used by the `build_system_sanity_check` script.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while reviewing #14350 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
