### PR TITLE
netdev: remove NETOPT_IPV6_IID support for network devices

### DIFF
--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -187,14 +187,6 @@ uint16_t nrfmin_get_addr(void)
     return my_addr;
 }
 
-void nrfmin_get_iid(uint16_t *iid)
-{
-    iid[0] = 0;
-    iid[1] = 0xff00;
-    iid[2] = 0x00fe;
-    iid[3] = my_addr;
-}
-
 uint16_t nrfmin_get_channel(void)
 {
     return (uint16_t)(NRF_RADIO->FREQUENCY >> 2);
@@ -506,10 +498,6 @@ static int nrfmin_get(netdev_t *dev, netopt_t opt, void *val, size_t max_len)
             assert(max_len >= sizeof(uint16_t));
             *((uint16_t *)val) = NETDEV_TYPE_NRFMIN;
             return sizeof(uint16_t);
-        case NETOPT_IPV6_IID:
-            assert(max_len >= sizeof(uint64_t));
-            nrfmin_get_iid((uint16_t *)val);
-            return sizeof(uint64_t);
         default:
             return -ENOTSUP;
     }

--- a/drivers/cc110x/cc110x_netdev.c
+++ b/drivers/cc110x/cc110x_netdev.c
@@ -506,26 +506,6 @@ static int cc110x_send(netdev_t *netdev, const iolist_t *iolist)
 }
 
 /**
- * @brief   Generate an IPv6 interface identifier for a CC110X transceiver
- *
- * @param   dev     Transceiver to create the IPv6 interface identifier (IID)
- * @param   iid     Store the generated IID here
- *
- * @return  Returns the size of @ref eui64_t to confirm with the API
- *          in @ref netdev_driver_t::get
- */
-static int cc110x_get_iid(cc110x_t *dev, eui64_t *iid)
-{
-    static const eui64_t empty_iid = {
-        .uint8 = { 0x00, 0x00, 0x00, 0xff, 0xfe, 0x00, 0x00, 0x00 }
-    };
-
-    *iid = empty_iid;
-    iid->uint8[7] = dev->addr;
-    return sizeof(eui64_t);
-}
-
-/**
  * @brief   Checks if the CC110x's address filter is disabled
  * @param   dev     Transceiver to check if in promiscuous mode
  * @param   dest    Store the result here
@@ -551,6 +531,7 @@ static int cc110x_get(netdev_t *netdev, netopt_t opt,
 {
     cc110x_t *dev = (cc110x_t *)netdev;
 
+    (void)max_len;  /* only used in assert() */
     switch (opt) {
         case NETOPT_DEVICE_TYPE:
             assert(max_len == sizeof(uint16_t));
@@ -574,11 +555,6 @@ static int cc110x_get(netdev_t *netdev, netopt_t opt,
             assert(max_len >= CC1XXX_ADDR_SIZE);
             *((uint8_t *)val) = dev->addr;
             return CC1XXX_ADDR_SIZE;
-        case NETOPT_IPV6_IID:
-            if (max_len < sizeof(eui64_t)) {
-                return -EOVERFLOW;
-            }
-            return cc110x_get_iid(dev, val);
         case NETOPT_CHANNEL:
             assert(max_len == sizeof(uint16_t));
             *((uint16_t *)val) = dev->channel;

--- a/drivers/netdev_eth/netdev_eth.c
+++ b/drivers/netdev_eth/netdev_eth.c
@@ -29,23 +29,14 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static int _get_iid(netdev_t *netdev, eui64_t *value, size_t max_len)
-{
-    if (max_len < sizeof(eui64_t)) {
-        return -EOVERFLOW;
-    }
-
-    eui48_t mac;
-    netdev->driver->get(netdev, NETOPT_ADDRESS, mac.uint8, sizeof(eui48_t));
-    eui48_to_ipv6_iid(value, &mac);
-
-    return sizeof(eui64_t);
-}
-
 int netdev_eth_get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
 {
     int res = 0;
 
+#ifndef MODULE_L2FILTER
+    (void)dev;
+#endif
+    (void)max_len;  /* only used in assert() */
     switch (opt) {
         case NETOPT_DEVICE_TYPE:
             {
@@ -75,10 +66,6 @@ int netdev_eth_get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
             {
                 res = 1;
                 break;
-            }
-        case NETOPT_IPV6_IID:
-            {
-                return _get_iid(dev, value, max_len);
             }
 #ifdef MODULE_L2FILTER
         case NETOPT_L2FILTER:

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -29,30 +29,6 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static int _get_iid(netdev_ieee802154_t *dev, eui64_t *value, size_t max_len)
-{
-    (void)max_len;
-
-    uint8_t addr[IEEE802154_LONG_ADDRESS_LEN];
-    uint16_t addr_len;
-
-    assert(max_len >= sizeof(eui64_t));
-
-    dev->netdev.driver->get(&dev->netdev, NETOPT_SRC_LEN, &addr_len,
-                            sizeof(addr_len));
-    if (addr_len == IEEE802154_LONG_ADDRESS_LEN) {
-        dev->netdev.driver->get(&dev->netdev, NETOPT_ADDRESS_LONG, addr,
-                                addr_len);
-    }
-    else {
-        dev->netdev.driver->get(&dev->netdev, NETOPT_ADDRESS, addr,
-                                addr_len);
-    }
-    ieee802154_get_iid(value, addr, addr_len);
-
-    return sizeof(eui64_t);
-}
-
 void netdev_ieee802154_reset(netdev_ieee802154_t *dev)
 {
     /* Only the least significant byte of the random value is used */
@@ -106,6 +82,7 @@ int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,
 {
     int res = -ENOTSUP;
 
+    (void)max_len;  /* only used in assert() */
     switch (opt) {
         case NETOPT_ADDRESS:
             assert(max_len >= sizeof(dev->short_addr));
@@ -169,9 +146,6 @@ int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,
             assert(max_len == sizeof(uint16_t));
             *((uint16_t *)value) = NETDEV_TYPE_IEEE802154;
             res = sizeof(uint16_t);
-            break;
-        case NETOPT_IPV6_IID:
-            res = _get_iid(dev, value, max_len);
             break;
 #ifdef MODULE_L2FILTER
         case NETOPT_L2FILTER:

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -763,19 +763,6 @@ static int xbee_get(netdev_t *ndev, netopt_t opt, void *value, size_t max_len)
             assert(max_len == sizeof(uint16_t));
             *((uint16_t *)value) = NETDEV_TYPE_IEEE802154;
             return sizeof(uint16_t);
-        case NETOPT_IPV6_IID:
-            if (max_len < sizeof(eui64_t)) {
-                return -EOVERFLOW;
-            }
-            if (dev->addr_flags & XBEE_ADDR_FLAGS_LONG) {
-                ieee802154_get_iid(value, dev->addr_long.uint8,
-                                   IEEE802154_LONG_ADDRESS_LEN);
-            }
-            else {
-                ieee802154_get_iid(value, dev->addr_short,
-                                   IEEE802154_SHORT_ADDRESS_LEN);
-            }
-            return sizeof(eui64_t);
         case NETOPT_CHANNEL:
             return _get_channel(dev, (uint8_t *)value, max_len);
         case NETOPT_MAX_PDU_SIZE:

--- a/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
+++ b/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
@@ -221,10 +221,6 @@ static int _netdev_get(netdev_t *netdev, netopt_t opt,
             *((uint16_t *)value) = NETDEV_TYPE_BLE;
             res = sizeof(uint16_t);
             break;
-        case NETOPT_IPV6_IID:
-            eui48_to_ipv6_iid((eui64_t *)value, (eui48_t *)_ble_netif->l2addr);
-            res = sizeof(uint64_t);
-            break;
         default:
             break;
     }

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -120,10 +120,9 @@ typedef enum {
      *          RFC 4291, section 2.5.1
      *      </a>
      *
-     * @deprecated  Do not implement this in a network device. Other APIs
-     *              utilizing [netopt](@ref net_netopt) may still implement it.
-     *              Existing support of drivers will be dropped after the
-     *              2019.07 release.
+     * @note    Do not implement this in a network device driver. Other APIs
+     *          utilizing [netopt](@ref net_netopt) such as @ref net_gnrc_netif
+     *          or @ref net_netif may still implement it.
      *
      * The generation of the interface identifier is dependent on the link-layer.
      * Please refer to the appropriate IPv6 over `<link>` specification for

--- a/tests/gnrc_ipv6_nib_6ln/main.c
+++ b/tests/gnrc_ipv6_nib_6ln/main.c
@@ -1327,12 +1327,6 @@ int _mock_netif_get(gnrc_netapi_opt_t *opt)
                 *val = sizeof(_loc_l2);
                 return sizeof(uint16_t);
             }
-        case NETOPT_IPV6_IID:
-            if (opt->data_len < sizeof(_loc_iid)) {
-                return -EOVERFLOW;
-            }
-            memcpy(opt->data, _loc_iid, sizeof(_loc_iid));
-            return sizeof(_loc_iid);
         case NETOPT_IS_WIRED:
             return 1;
         case NETOPT_MAX_PDU_SIZE: {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This option is handled in the `gnrc_netif`-layer without any access to the driver's option since #10569.

The implementation on the device driver is deprecated and was slated for removal in [2019.07 already](https://doc.riot-os.org/group__net__netopt.html#gga19e30424c1ab107c9c84dc0cb29d9906a74f1c2aac469e1132c28cb902007ecfe), so let's get rid of them.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Auto-generated IPv6 addresses do not change compared to master in `examples/gnrc_networking` on

- [x] Ethernet-based boards (e.g. `native`)
- [x] IEEE-802.15.4-based boards including `xbee`. (e.g. `samr21-xpro` and `arduino-due` + `xbee`)
- [x] `nrfmin`-based boards (e.g. `nrf51dk`)
- [ ] `cc110x`-based boards (e.g. `msba2`)

Same for `tests/nordic_softdevice`.

Tests still pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Very late follow-up on https://github.com/RIOT-OS/RIOT/pull/10569 and https://github.com/RIOT-OS/RIOT/pull/10595
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
