### PR TITLE
cpu/cortexm_common: use mpu stack guard if DEVELHELP is enabled

### DIFF
--- a/cpu/cortexm_common/Makefile.dep
+++ b/cpu/cortexm_common/Makefile.dep
@@ -18,3 +18,8 @@ FEATURES_OPTIONAL += cortexm_fpu
 ifneq (,$(filter cortexm_fpu,$(FEATURES_USED)))
   DEFAULT_MODULE += cortexm_fpu
 endif
+
+# Enable the MPU stack guard if develhelp is enabled
+ifeq (1, $(DEVELHELP))
+  FEATURES_OPTIONAL += cortexm_mpu
+endif

--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -33,3 +33,8 @@ USEMODULE += $(filter cortexm_svc, $(FEATURES_USED))
 ifeq (, $(filter no_idle_thread, $(FEATURES_USED)))
   USEMODULE += core_idle_thread
 endif
+
+# use mpu_stack_guard if the feature is used
+ifneq (,$(filter cortexm_mpu,$(FEATURES_USED)))
+  USEMODULE += mpu_stack_guard
+endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

the stack guard only minimally reduces context switch performance, but is a tremendous help while developing.
So this PR enables it if DEVELHELP is enabled, for platforms that support it.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
