### PR TITLE
gnrc/icmpv6: conditional definition of the MIN macro

### DIFF
--- a/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
+++ b/sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c
@@ -27,6 +27,7 @@
 #define ICMPV6_ERROR_SET_VALUE(data, value) \
     ((icmpv6_error_pkt_too_big_t *)(data))->mtu = byteorder_htonl(value)
 
+#undef MIN
 #define MIN(a, b)   ((a) < (b)) ? (a) : (b)
 
 /**


### PR DESCRIPTION
### Contribution description

While implementing the inlined version of `irq_*` functions according to PR https://github.com/RIOT-OS/RIOT/pull/13999 and issue https://github.com/RIOT-OS/RIOT/issues/14356, I ran into a compilation problem with the `MIN` macro definition in `sys/net/gnrc/network_layer/icmpv6/error/gnrc_icmpv6_error.c`.

Since `min(a,b)` is a very frequently used function, several libraries such as the ESP8266 SDK define their own `MIN` macro in their header files. Therefore the `MIN` macro in `gnrc/icmpv6` should only be defined if it has not been defined anywhere else before.

### Testing procedure

Compilation in Murdock should succeed.

### Issues/PRs references