### PR TITLE
unittests: Qualifier cast for pktsnip test initializers

### DIFF
--- a/tests/unittests/tests-pkt/tests-pkt.c
+++ b/tests/unittests/tests-pkt/tests-pkt.c
@@ -27,10 +27,10 @@
 #include "tests-pkt.h"
 
 #define _INIT_ELEM(len, _data, _next) \
-    { .users = 1, .next = (_next), .data = (_data), \
+    { .users = 1, .next = (_next), .data = (void *)(_data), \
       .size = (len), .type = GNRC_NETTYPE_UNDEF \
     }
-#define _INIT_ELEM_STATIC_DATA(data, next) _INIT_ELEM(sizeof(data), data, next)
+#define _INIT_ELEM_STATIC_DATA(data, next) _INIT_ELEM(sizeof(data), (void *)(data), (next))
 
 #define _INIT_ELEM_STATIC_TYPE(_type, _next) \
     { .users = 1, .next = (_next), .data = NULL, .size = 0, .type = (_type) }

--- a/tests/unittests/tests-pktbuf/tests-pktbuf.c
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.c
@@ -709,7 +709,7 @@ static void test_pktbuf_hold__pkt_null(void)
 
 static void test_pktbuf_hold__pkt_external(void)
 {
-    gnrc_pktsnip_t pkt = { NULL, TEST_STRING8, sizeof(TEST_STRING8), 1, GNRC_NETTYPE_TEST };
+    gnrc_pktsnip_t pkt = { NULL, (void *)TEST_STRING8, sizeof(TEST_STRING8), 1, GNRC_NETTYPE_TEST };
 
     gnrc_pktbuf_hold(&pkt, 1);
     TEST_ASSERT(gnrc_pktbuf_is_empty());

--- a/tests/unittests/tests-pktqueue/tests-pktqueue.c
+++ b/tests/unittests/tests-pktqueue/tests-pktqueue.c
@@ -22,8 +22,8 @@
 #include "tests-pktqueue.h"
 
 #define PKT_INIT_ELEM(len, data, next) \
-    { (next), (data), (len), 1, GNRC_NETTYPE_UNDEF }
-#define PKT_INIT_ELEM_STATIC_DATA(data, next) PKT_INIT_ELEM(sizeof(data), data, next)
+    { (next), (void *)(data), (len), 1, GNRC_NETTYPE_UNDEF }
+#define PKT_INIT_ELEM_STATIC_DATA(data, next) PKT_INIT_ELEM(sizeof(data), (void *)(data), (next))
 #define PKTQUEUE_INIT_ELEM(pkt) { NULL, pkt }
 
 static gnrc_pktqueue_t *root;

--- a/tests/unittests/tests-priority_pktqueue/tests-priority_pktqueue.c
+++ b/tests/unittests/tests-priority_pktqueue/tests-priority_pktqueue.c
@@ -23,8 +23,8 @@
 #include "tests-priority_pktqueue.h"
 
 #define PKT_INIT_ELEM(len, data, next) \
-    { (next), (data), (len), 1, GNRC_NETTYPE_UNDEF }
-#define PKT_INIT_ELEM_STATIC_DATA(data, next) PKT_INIT_ELEM(sizeof(data), data, next)
+    { (next), (void *)(data), (len), 1, GNRC_NETTYPE_UNDEF }
+#define PKT_INIT_ELEM_STATIC_DATA(data, next) PKT_INIT_ELEM(sizeof(data), (void *)(data), (next))
 #define PKTQUEUE_INIT_ELEM(pkt) { NULL, pkt }
 
 static gnrc_priority_pktqueue_t pkt_queue;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This takes the remainder of https://github.com/RIOT-OS/RIOT/pull/10022 after https://github.com/RIOT-OS/RIOT/pull/14357 was merged. This ensures that warning about disregarding `const` qualifiers in those tests are ignored.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/unittests` should still pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Taken over from https://github.com/RIOT-OS/RIOT/pull/10022.
Follow-up on https://github.com/RIOT-OS/RIOT/pull/14357
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
