### PR TITLE
cpu/fe310: migrate to inlined irq API

### DIFF
--- a/cpu/fe310/include/cpu_conf.h
+++ b/cpu/fe310/include/cpu_conf.h
@@ -39,6 +39,11 @@
  */
 #define HAVE_HEAP_STATS
 
+/**
+ * @brief   This arch uses the inlined irq API.
+ */
+#define IRQ_API_INLINED     (1)
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/fe310/include/irq_arch.h
+++ b/cpu/fe310/include/irq_arch.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2017 Ken Rabold
+ *               2020 Inria
+ *               2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup         cpu_fe310
+ * @{
+ *
+ * @file
+ * @brief           Implementation of the kernels irq interface
+ *
+ * @author          Ken Rabold
+ * @author          Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author          Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef IRQ_ARCH_H
+#define IRQ_ARCH_H
+
+#include <stdint.h>
+#include "irq.h"
+#include "cpu_conf.h"
+#include "cpu.h"
+
+#include "vendor/encoding.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern volatile int fe310_in_isr;
+
+/**
+ * @brief Enable all maskable interrupts
+ */
+static inline __attribute__((always_inline)) unsigned int irq_enable(void)
+{
+    /* Enable all interrupts */
+    unsigned state;
+    __asm__ volatile (
+        "csrrs %[dest], mstatus, %[mask]"
+        : [dest]    "=r"(state)
+        : [mask]    "i"(MSTATUS_MIE)
+        : "memory"
+    );
+    return state;
+}
+
+/**
+ * @brief Disable all maskable interrupts
+ */
+static inline __attribute__((always_inline)) unsigned int irq_disable(void)
+{
+
+    unsigned int state;
+    __asm__ volatile (
+        "csrrc %[dest], mstatus, %[mask]"
+        : [dest]    "=r"(state)
+        : [mask]    "i"(MSTATUS_MIE)
+        : "memory"
+    );
+
+    return state;
+}
+
+/**
+ * @brief Restore the state of the IRQ flags
+ */
+static inline __attribute__((always_inline)) void irq_restore(unsigned int state)
+{
+    /* Restore all interrupts to given state */
+    __asm__ volatile (
+        "csrw mstatus, %[state]"
+        : /* no outputs */
+        : [state]   "r"(state)
+        : "memory"
+    );
+}
+
+/**
+ * @brief See if the current context is inside an ISR
+ */
+static inline __attribute__((always_inline)) int irq_is_in(void)
+{
+    return fe310_in_isr;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* IRQ_ARCH_H */
+/** @} */

--- a/cpu/fe310/irq_arch.c
+++ b/cpu/fe310/irq_arch.c
@@ -23,6 +23,7 @@
 
 #include "cpu.h"
 #include "irq.h"
+#include "irq_arch.h"
 #include "panic.h"
 #include "sched.h"
 
@@ -72,45 +73,6 @@ void irq_init(void)
 
     /*  Set default state of mstatus */
     set_csr(mstatus, MSTATUS_DEFAULT);
-}
-
-/**
- * @brief Enable all maskable interrupts
- */
-unsigned int irq_enable(void)
-{
-    /* Enable all interrupts */
-    set_csr(mstatus, MSTATUS_MIE);
-    return read_csr(mstatus);
-}
-
-/**
- * @brief Disable all maskable interrupts
- */
-unsigned int irq_disable(void)
-{
-    unsigned int state = read_csr(mstatus);
-
-    /* Disable all interrupts */
-    clear_csr(mstatus, MSTATUS_MIE);
-    return state;
-}
-
-/**
- * @brief Restore the state of the IRQ flags
- */
-void irq_restore(unsigned int state)
-{
-    /* Restore all interrupts to given state */
-    write_csr(mstatus, state);
-}
-
-/**
- * @brief See if the current context is inside an ISR
- */
-int irq_is_in(void)
-{
-    return fe310_in_isr;
 }
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR migrates the irq functions implemented for the FE310 cpu (RISCV) to the inlined API.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- fe310 based boards are still working, so the command  below shouldn't report critical issues:

```
BUILD_IN_DOCKER=1 ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . hifive1b --with-test-only --jobs=8
```
  I will report my results when the command is complete.


- verify that code has decreased a bit. With `examples/default` there are 42B saved on flash:

<details><summary>this PR</summary>

```
RIOT_VERSION=test make -C examples/default BOARD=hifive1b --no-print-directory 
Building application "default" for "hifive1b" with MCU "fe310".

"make" -C /work/riot/RIOT/boards/hifive1b
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/fe310
"make" -C /work/riot/RIOT/cpu/fe310/nano
"make" -C /work/riot/RIOT/cpu/fe310/periph
"make" -C /work/riot/RIOT/cpu/fe310/vendor
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/drivers/saul
"make" -C /work/riot/RIOT/drivers/saul/init_devs
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/fmt
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/phydat
"make" -C /work/riot/RIOT/sys/ps
"make" -C /work/riot/RIOT/sys/saul_reg
"make" -C /work/riot/RIOT/sys/shell
"make" -C /work/riot/RIOT/sys/shell/commands
"make" -C /work/riot/RIOT/sys/stdio_uart
"make" -C /work/riot/RIOT/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  28376	    600	   2540	  31516	   7b1c	/work/riot/RIOT/examples/default/bin/hifive1b/default.elf
```

</details>

<details><summary>master</summary>

```
RIOT_VERSION=test make -C examples/default BOARD=hifive1b --no-print-directory 
Building application "default" for "hifive1b" with MCU "fe310".

"make" -C /work/riot/RIOT-review/boards/hifive1b
"make" -C /work/riot/RIOT-review/core
"make" -C /work/riot/RIOT-review/cpu/fe310
"make" -C /work/riot/RIOT-review/cpu/fe310/nano
"make" -C /work/riot/RIOT-review/cpu/fe310/periph
"make" -C /work/riot/RIOT-review/cpu/fe310/vendor
"make" -C /work/riot/RIOT-review/drivers
"make" -C /work/riot/RIOT-review/drivers/periph_common
"make" -C /work/riot/RIOT-review/drivers/saul
"make" -C /work/riot/RIOT-review/drivers/saul/init_devs
"make" -C /work/riot/RIOT-review/sys
"make" -C /work/riot/RIOT-review/sys/auto_init
"make" -C /work/riot/RIOT-review/sys/fmt
"make" -C /work/riot/RIOT-review/sys/isrpipe
"make" -C /work/riot/RIOT-review/sys/phydat
"make" -C /work/riot/RIOT-review/sys/ps
"make" -C /work/riot/RIOT-review/sys/saul_reg
"make" -C /work/riot/RIOT-review/sys/shell
"make" -C /work/riot/RIOT-review/sys/shell/commands
"make" -C /work/riot/RIOT-review/sys/stdio_uart
"make" -C /work/riot/RIOT-review/sys/tsrb
   text	   data	    bss	    dec	    hex	filename
  28418	    600	   2540	  31558	   7b46	/work/riot/RIOT-review/examples/default/bin/hifive1b/default.elf
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick an item in #14356

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
