### PR TITLE
cpu/msp430_common: Update to inline-able IRQ API

### DIFF
--- a/cpu/msp430_common/cpu.c
+++ b/cpu/msp430_common/cpu.c
@@ -21,7 +21,7 @@
 __attribute__((naked)) void thread_yield_higher(void)
 {
     __asm__("push r2"); /* save SR */
-    __disable_irq();
+    irq_disable();
 
     __save_context();
 

--- a/cpu/msp430_common/include/cpu.h
+++ b/cpu/msp430_common/include/cpu.h
@@ -46,28 +46,6 @@ extern "C" {
 #define ISR(a,b)        void __attribute__((naked, interrupt (a))) b(void)
 
 /**
- * @brief Globally disable IRQs
- */
-static inline void __attribute__((always_inline)) __disable_irq(void)
-{
-    __asm__ __volatile__("bic  %0, r2" : : "i"(GIE));
-    /* this NOP is needed to handle a "delay slot" that all MSP430 MCUs
-       impose silently after messing with the GIE bit, DO NOT REMOVE IT! */
-    __asm__ __volatile__("nop");
-}
-
-/**
- * @brief Globally enable IRQs
- */
-static inline void __attribute__((always_inline)) __enable_irq(void)
-{
-    __asm__ __volatile__("bis  %0, r2" : : "i"(GIE));
-    /* this NOP is needed to handle a "delay slot" that all MSP430 MCUs
-       impose silently after messing with the GIE bit, DO NOT REMOVE IT! */
-    __asm__ __volatile__("nop");
-}
-
-/**
  * @brief   The current ISR state (inside or not)
  */
 extern volatile int __irq_is_in;

--- a/cpu/msp430_common/include/cpu_conf.h
+++ b/cpu/msp430_common/include/cpu_conf.h
@@ -23,6 +23,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   This arch uses the inlined IRQ API.
+ */
+#define IRQ_API_INLINED     (1)
+
+/**
  * @name   Configure the internal flash memory
  * @{
  */

--- a/cpu/msp430_common/include/irq_arch.h
+++ b/cpu/msp430_common/include/irq_arch.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *               2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_msp430_common
+* @{
+ *
+ * @file
+ * @brief       ISR related functions
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Oliver Hahm <oliver.hahm@inria.fr>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ */
+
+#ifndef IRQ_ARCH_H
+#define IRQ_ARCH_H
+
+#include "irq.h"
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern volatile int __irq_is_in;
+
+__attribute__((always_inline)) static inline unsigned int irq_disable(void)
+{
+    unsigned int state;
+    __asm__ volatile(
+        "mov.w r2, %[state]"                "\n\t"
+        "bic %[gie], r2"                    "\n\t"
+        /*
+         * BEWARE: IRQs remain enabled for one instruction after clearing the
+         * GIE bit in the status register (r2). Thus, the next instruction is
+         * not only used to sanitize the IRQ state, but also delays the actual
+         * critical section by one CPU cycle, so that IRQs are indeed disabled
+         * by then.
+         */
+        "and %[gie], %[state]"              "\n\t"
+        : [state]   "=r"(state)
+        : [gie]     "i"(GIE)
+        : "memory"
+    );
+
+    return state;
+}
+
+__attribute__((always_inline)) static inline unsigned int irq_enable(void)
+{
+    unsigned int state;
+    __asm__ volatile(
+        "mov.w r2, %[state]"                "\n\t"
+        "bis %[gie], r2"                    "\n\t"
+        /*
+         * BEWARE: IRQs remain disabled for one instruction after setting the
+         * GIE bit in the status register (r2). Thus, the next instruction is
+         * not only used to sanitize the IRQ state, but also ensures that the
+         * first instruction after this function is run with IRQs enabled.
+         */
+        "and %[gie], %[state]"              "\n\t"
+        : [state]   "=r"(state)
+        : [gie]     "i"(GIE)
+        : "memory"
+    );
+
+    return state;
+}
+
+__attribute__((always_inline)) static inline void irq_restore(unsigned int state)
+{
+    __asm__ volatile(
+        "bis %[state], r2"                    "\n\t"
+        : /* no outputs */
+        : [state]   "r"(state)
+        : "memory"
+    );
+    /* BEWARE: IRQs remain disabled for up to one CPU cycle after this function
+     * call. But that doesn't seem to be harmful.
+     */
+}
+
+__attribute__((always_inline)) static inline int irq_is_in(void)
+{
+    return __irq_is_in;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* IRQ_ARCH_H */

--- a/cpu/msp430_common/irq.c
+++ b/cpu/msp430_common/irq.c
@@ -7,11 +7,11 @@
  */
 
 /**
- * @ingroup     cpu
+ * @ingroup     cpu_msp430_common
 * @{
  *
  * @file
- * @brief       ISR related functions
+ * @brief       ISR related variables
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
@@ -25,41 +25,3 @@
 volatile int __irq_is_in = 0;
 
 char __isr_stack[ISR_STACKSIZE];
-
-unsigned int irq_disable(void)
-{
-    unsigned int state;
-    __asm__("mov.w r2,%0" : "=r"(state));
-    state &= GIE;
-
-    if (state) {
-        __disable_irq();
-    }
-
-    return state;
-}
-
-unsigned int irq_enable(void)
-{
-    unsigned int state;
-    __asm__("mov.w r2,%0" : "=r"(state));
-    state &= GIE;
-
-    if (!state) {
-        __enable_irq();
-    }
-
-    return state;
-}
-
-void irq_restore(unsigned int state)
-{
-    if (state) {
-        __enable_irq();
-    }
-}
-
-int irq_is_in(void)
-{
-    return __irq_is_in;
-}


### PR DESCRIPTION
### Contribution description

- Updated to inline-able IRQ API
- Improved robustness of functions
    - Added memory barrier to prevent the compiler from moving code outside of
      a critical section guarded by irq_disable() ... irq_restore()
- Reduced overhead of `irq_disable()`
    - After clearing the global interrupt enable (GIE) bit, IRQs remain enabled
      for up to one CPU cycle
    - The previous implementation just added a nop to fill that cycle
    - This implementation uses the cycle for masking the return value
- Reduced overhead of `irq_restore()`
    - Now only one CPU cycle is needed
- `irq_disable()`, `irq_restore()`, and `irq_enable()` work now in constant time

### Testing procedure

#### `tests/irq_disable_restore`

I ran `tests/irq_disable_restore` on a `wsn430-v1_3b` board [in the FIT/IoT-Lab](https://www.iot-lab.info/testbed/experiments/222452):

<details><summary>Console output</summary>

```
s
START
main(): This is RIOT! (Version: 2020.07-devel-1557-g22d44-msp430-irq-inline)
Test for irq_disable() / irq_restore()
======================================

Verifying test works: [SUCCESS]
Test result: [SUCCESS]
```

</details>

#### `tests/tests/bench_mutex_pingpong`

I ran `tests/tests/bench_mutex_pingpong` on the same hardware in the [FIT/IoT-Lab](https://www.iot-lab.info/testbed/experiments/222454)

<details><summary>Console output with `master`</summary>

```
r
READY
s
START
main(): This is RIOT! (Version: 2020.07-devel-1557-g22d44)
main starting
{ "result" : 9222 }
```

</details>

<details><summary>Console output with this PR</summary>

```r
READY
s
START
main(): This is RIOT! (Version: 2020.07-devel-1558-gc5c83-msp430-irq-inline)
main starting
{ "result" : 9910 }
```

</details>

So ~7.5% speedup.

### Issues/PRs references

Follow up of: https://github.com/RIOT-OS/RIOT/pull/13999

Tracked in: https://github.com/RIOT-OS/RIOT/issues/14356