### PR TITLE
Fix NDEBUG compilation problems

### DIFF
--- a/cpu/efm32/periph/wdt_series0.c
+++ b/cpu/efm32/periph/wdt_series0.c
@@ -60,7 +60,11 @@ void wdt_stop(void)
 
 void wdt_setup_reboot(uint32_t min_time, uint32_t max_time)
 {
-   /* assert timings */
+    /* avoid compilation errors when NDEBUG is defined */
+    (void)min_time;
+    (void)max_time;
+
+    /* assert timings */
     assert(min_time == 0);
     assert(max_time > NWDT_TIME_LOWER_LIMIT ||
            max_time < NWDT_TIME_UPPER_LIMIT);

--- a/cpu/efm32/periph/wdt_series1.c
+++ b/cpu/efm32/periph/wdt_series1.c
@@ -74,6 +74,9 @@ static WDOG_WinSel_TypeDef _get_illegal_window(uint32_t min_time, uint32_t calcu
 
 static void _init(uint32_t min_time, uint32_t max_time, bool warn)
 {
+    /* avoid compilation errors when NDEBUG is defined */
+    (void)min_time;
+    (void)max_time;
 #ifndef MODULE_PERIPH_WDT_CB
     (void)warn;
 #endif

--- a/pkg/littlefs2/Makefile.include
+++ b/pkg/littlefs2/Makefile.include
@@ -4,3 +4,6 @@ DIRS += $(RIOTBASE)/pkg/littlefs2/fs
 
 # Reduce LFS_NAME_MAX to 31 (as VFS_NAME_MAX default)
 CFLAGS += -DLFS_NAME_MAX=31
+
+# avoid compilation errors when NDEBUG is defined
+CFLAGS += -DLFS_NO_ASSERT

--- a/pkg/qr-code-generator/Makefile
+++ b/pkg/qr-code-generator/Makefile
@@ -7,5 +7,8 @@ include $(RIOTBASE)/pkg/pkg.mk
 
 CFLAGS += -Wno-type-limits
 
+# avoid compilation errors when NDEBUG is defined
+CFLAGS += -Wno-unused-parameter
+
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/c -f $(CURDIR)/$(PKG_NAME).mk

--- a/pkg/u8g2/Makefile.u8g2_csrc
+++ b/pkg/u8g2/Makefile.u8g2_csrc
@@ -2,6 +2,9 @@ MODULE = u8g2_csrc
 
 CFLAGS += -Wno-overlength-strings
 
+# avoid compilation errors when NDEBUG is defined
+CFLAGS += -Wno-unused-variable
+
 ifeq (llvm,$(TOOLCHAIN))
   CFLAGS += -Wno-newline-eof
 endif

--- a/pkg/wakaama/contrib/lwm2m_client.c
+++ b/pkg/wakaama/contrib/lwm2m_client.c
@@ -170,6 +170,8 @@ static void *_lwm2m_client_run(void *arg)
 
         sock_udp_ep_t local;
         int res = sock_udp_get_local(&_client_data->sock, &local);
+        /* avoid compilation errors if NDEBUG is enabled */
+        (void)res;
         assert(res >= 0);
         DEBUG("Waiting for UDP packet on port: %d\n", local.port);
         rcv_len = sock_udp_recv(&_client_data->sock, rcv_buf, sizeof(rcv_buf),

--- a/sys/fuzzing/netdev.c
+++ b/sys/fuzzing/netdev.c
@@ -29,6 +29,7 @@ static int _dev_init(netdev_t *netdev)
 
 static int _dev_get_device_type(netdev_t *netdev, void *value, size_t max_len)
 {
+    (void)max_len;
     assert(max_len == sizeof(uint16_t));
     (void)netdev;
 

--- a/sys/net/gnrc/network_layer/ipv6/ext/opt/gnrc_ipv6_ext_opt.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/opt/gnrc_ipv6_ext_opt.c
@@ -51,6 +51,7 @@ static bool _multicast_dst(gnrc_pktsnip_t *pkt)
 gnrc_pktsnip_t *gnrc_ipv6_ext_opt_process(gnrc_pktsnip_t *pkt,
                                           uint8_t protnum)
 {
+    (void)protnum;
     assert(pkt != NULL);
     assert((protnum == PROTNUM_IPV6_EXT_HOPOPT) ||
            (protnum == PROTNUM_IPV6_EXT_DST));

--- a/tests/bitarithm_timings/main.c
+++ b/tests/bitarithm_timings/main.c
@@ -28,13 +28,13 @@
  * @}
  */
 
-#include <assert.h>
 #include <stdint.h>
 #include <stdatomic.h>
 #include <stdio.h>
 #include <limits.h>
 
 #include "bitarithm.h"
+#include "test_utils/expect.h"
 #include "xtimer.h"
 
 #define TIMEOUT_S (5ul)
@@ -116,8 +116,8 @@ static void run_test_test_and_clear(void)
     xtimer_set(&xtimer, TIMEOUT);
 
     do {
-        assert(do_test_and_clear(TEST_AND_CLEAR_TEST_MASK_0) == TEST_AND_CLEAR_TEST_MASK_0);
-        assert(do_test_and_clear(TEST_AND_CLEAR_TEST_MASK_1) == TEST_AND_CLEAR_TEST_MASK_1);
+        expect(do_test_and_clear(TEST_AND_CLEAR_TEST_MASK_0) == TEST_AND_CLEAR_TEST_MASK_0);
+        expect(do_test_and_clear(TEST_AND_CLEAR_TEST_MASK_1) == TEST_AND_CLEAR_TEST_MASK_1);
         ++count;
     } while (atomic_load(&done) == false);
 

--- a/tests/candev/main.c
+++ b/tests/candev/main.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "shell.h"
+#include "test_utils/expect.h"
 #include "can/device.h"
 
 #if IS_USED(MODULE_PERIPH_CAN)
@@ -220,7 +221,7 @@ int main(void)
     /* add initialization for other candev drivers here */
 #endif
 
-    assert(candev);
+    expect(candev);
 
     candev->event_callback = _can_event_callback;
     candev->isr_arg = NULL;

--- a/tests/gnrc_ipv6_ext_frag/main.c
+++ b/tests/gnrc_ipv6_ext_frag/main.c
@@ -691,7 +691,7 @@ int main(void)
                                     GNRC_NETIF_PRIO, "mock_netif",
                                     &mock_netdev.netdev.netdev);
     mock_netif = &_netif;
-    assert(res == 0);
+    expect(res == 0);
     shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
     return 0;
 }

--- a/tests/gnrc_sixlowpan_frag_minfwd/mockup_netif.c
+++ b/tests/gnrc_sixlowpan_frag_minfwd/mockup_netif.c
@@ -22,6 +22,7 @@
 #include "net/gnrc/netif/internal.h"
 #include "net/netdev_test.h"
 #include "sched.h"
+#include "test_utils/expect.h"
 #include "thread.h"
 
 #define _MSG_QUEUE_SIZE  (2)
@@ -35,7 +36,7 @@ static gnrc_netif_t _netif;
 
 void _common_set_up(void)
 {
-    assert(_mock_netif != NULL);
+    expect(_mock_netif != NULL);
     gnrc_ipv6_nib_init();
     gnrc_netif_acquire(_mock_netif);
     gnrc_ipv6_nib_init_iface(_mock_netif);
@@ -45,14 +46,14 @@ void _common_set_up(void)
 int _get_device_type(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = NETDEV_TYPE_IEEE802154;
     return sizeof(uint16_t);
 }
 
 static int _get_netdev_proto(netdev_t *netdev, void *value, size_t max_len)
 {
-    assert(max_len == sizeof(gnrc_nettype_t));
+    expect(max_len == sizeof(gnrc_nettype_t));
     (void)netdev;
 
     *((gnrc_nettype_t *)value) = GNRC_NETTYPE_SIXLOWPAN;
@@ -62,7 +63,7 @@ static int _get_netdev_proto(netdev_t *netdev, void *value, size_t max_len)
 int _get_max_pdu_size(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = 102U;
     return sizeof(uint16_t);
 }
@@ -70,7 +71,7 @@ int _get_max_pdu_size(netdev_t *dev, void *value, size_t max_len)
 int _get_src_len(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = IEEE802154_LONG_ADDRESS_LEN;
     return sizeof(uint16_t);
 }
@@ -81,7 +82,7 @@ int _get_address_long(netdev_t *dev, void *value, size_t max_len)
                                     _LL4, _LL5, _LL6, _LL7 };
 
     (void)dev;
-    assert(max_len >= sizeof(addr));
+    expect(max_len >= sizeof(addr));
     memcpy(value, addr, sizeof(addr));
     return sizeof(addr);
 }
@@ -89,7 +90,7 @@ int _get_address_long(netdev_t *dev, void *value, size_t max_len)
 int _get_proto(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(gnrc_nettype_t));
+    expect(max_len == sizeof(gnrc_nettype_t));
     *((gnrc_nettype_t *)value) = GNRC_NETTYPE_SIXLOWPAN;
     return sizeof(gnrc_nettype_t);
 }
@@ -116,7 +117,7 @@ void _tests_init(void)
            &_netif, _mock_netif_stack, THREAD_STACKSIZE_DEFAULT,
            GNRC_NETIF_PRIO, "mockup_wpan", &_mock_netdev.netdev.netdev
         );
-    assert(res == 0);
+    expect(res == 0);
     _mock_netif = &_netif;
 }
 

--- a/tests/gnrc_sixlowpan_frag_sfr/mockup_netif.c
+++ b/tests/gnrc_sixlowpan_frag_sfr/mockup_netif.c
@@ -22,6 +22,7 @@
 #include "net/gnrc/netif/internal.h"
 #include "net/netdev_test.h"
 #include "sched.h"
+#include "test_utils/expect.h"
 #include "thread.h"
 
 #define _MSG_QUEUE_SIZE  (2)
@@ -35,7 +36,7 @@ static gnrc_netif_t _netif;
 
 void _common_set_up(void)
 {
-    assert(_mock_netif != NULL);
+    expect(_mock_netif != NULL);
     gnrc_ipv6_nib_init();
     gnrc_netif_acquire(_mock_netif);
     gnrc_ipv6_nib_init_iface(_mock_netif);
@@ -45,14 +46,14 @@ void _common_set_up(void)
 int _get_device_type(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = NETDEV_TYPE_IEEE802154;
     return sizeof(uint16_t);
 }
 
 static int _get_netdev_proto(netdev_t *netdev, void *value, size_t max_len)
 {
-    assert(max_len == sizeof(gnrc_nettype_t));
+    expect(max_len == sizeof(gnrc_nettype_t));
     (void)netdev;
 
     *((gnrc_nettype_t *)value) = GNRC_NETTYPE_SIXLOWPAN;
@@ -62,7 +63,7 @@ static int _get_netdev_proto(netdev_t *netdev, void *value, size_t max_len)
 int _get_max_pdu_size(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = 102U;
     return sizeof(uint16_t);
 }
@@ -70,7 +71,7 @@ int _get_max_pdu_size(netdev_t *dev, void *value, size_t max_len)
 int _get_src_len(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     *((uint16_t *)value) = IEEE802154_LONG_ADDRESS_LEN;
     return sizeof(uint16_t);
 }
@@ -81,7 +82,7 @@ int _get_address_long(netdev_t *dev, void *value, size_t max_len)
                                     _LL4, _LL5, _LL6, _LL7 };
 
     (void)dev;
-    assert(max_len >= sizeof(addr));
+    expect(max_len >= sizeof(addr));
     memcpy(value, addr, sizeof(addr));
     return sizeof(addr);
 }
@@ -89,7 +90,7 @@ int _get_address_long(netdev_t *dev, void *value, size_t max_len)
 int _get_proto(netdev_t *dev, void *value, size_t max_len)
 {
     (void)dev;
-    assert(max_len == sizeof(gnrc_nettype_t));
+    expect(max_len == sizeof(gnrc_nettype_t));
     *((gnrc_nettype_t *)value) = GNRC_NETTYPE_SIXLOWPAN;
     return sizeof(gnrc_nettype_t);
 }
@@ -116,7 +117,7 @@ void _tests_init(void)
             &_netif, _mock_netif_stack, THREAD_STACKSIZE_DEFAULT,
             GNRC_NETIF_PRIO, "mockup_wpan", &_mock_netdev.netdev.netdev
         );
-    assert(res == 0);
+    expect(res == 0);
     _mock_netif = &_netif;
 }
 

--- a/tests/gnrc_sock_ip/main.c
+++ b/tests/gnrc_sock_ip/main.c
@@ -395,18 +395,18 @@ static void test_sock_ip_recv_buf__success(void)
                                          .family = AF_INET6 };
     void *data = NULL, *ctx = NULL;
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                           sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT,
+    expect(sizeof("ABCD") == sock_ip_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT,
                                               NULL));
-    assert(data != NULL);
-    assert(ctx != NULL);
-    assert(0 == sock_ip_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
-    assert(data == NULL);
-    assert(ctx == NULL);
-    assert(_check_net());
+    expect(data != NULL);
+    expect(ctx != NULL);
+    expect(0 == sock_ip_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
+    expect(data == NULL);
+    expect(ctx == NULL);
+    expect(_check_net());
 }
 
 static void test_sock_ip_send__EAFNOSUPPORT_INET(void)

--- a/tests/gnrc_sock_udp/main.c
+++ b/tests/gnrc_sock_udp/main.c
@@ -479,18 +479,18 @@ static void test_sock_udp_recv_buf__success(void)
                                           .port = _TEST_PORT_REMOTE };
     void *data = NULL, *ctx = NULL;
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                           _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                           _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv_buf(&_sock, &data, &ctx,
+    expect(sizeof("ABCD") == sock_udp_recv_buf(&_sock, &data, &ctx,
                                                SOCK_NO_TIMEOUT, NULL));
-    assert(data != NULL);
-    assert(ctx != NULL);
-    assert(0 == sock_udp_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
-    assert(data == NULL);
-    assert(ctx == NULL);
-    assert(_check_net());
+    expect(data != NULL);
+    expect(ctx != NULL);
+    expect(0 == sock_udp_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
+    expect(data == NULL);
+    expect(ctx == NULL);
+    expect(_check_net());
 }
 
 static void test_sock_udp_send__EAFNOSUPPORT(void)

--- a/tests/gnrc_tx_sync/main.c
+++ b/tests/gnrc_tx_sync/main.c
@@ -86,7 +86,7 @@ static int netdev_get_device_type(netdev_t *dev, void *value, size_t max_len)
     (void)dev;
     const uint16_t type_ipv6 = NETDEV_TYPE_ETHERNET;
     const uint16_t type_6lo = NETDEV_TYPE_IEEE802154;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     if (IS_USED(MODULE_NETDEV_IEEE802154)) {
         memcpy(value, &type_6lo, sizeof(type_6lo));
     }
@@ -101,7 +101,7 @@ static int netdev_get_max_pdu_size(netdev_t *dev, void *value, size_t max_len)
     (void)dev;
     const uint16_t pdu_size_ethernet = 1500;
     const uint16_t pdu_size_6lo = 32;
-    assert(max_len == sizeof(uint16_t));
+    expect(max_len == sizeof(uint16_t));
     if (IS_USED(MODULE_NETDEV_IEEE802154)) {
         memcpy(value, &pdu_size_6lo, sizeof(pdu_size_6lo));
     }
@@ -120,7 +120,7 @@ static int netdev_get_proto(netdev_t *dev, void *value, size_t max_len)
 #else
         GNRC_NETTYPE_IPV6;
 #endif
-    assert(max_len == sizeof(proto));
+    expect(max_len == sizeof(proto));
     memcpy(value, &proto, sizeof(proto));
     return sizeof(proto);
 }
@@ -135,7 +135,7 @@ static int netdev_get_address(netdev_t *dev, void *value, size_t max_len)
         0x13, 0x37, 0xac, 0xdc, 0xbe, 0xef
 #endif
     };
-    assert(max_len >= sizeof(addr));
+    expect(max_len >= sizeof(addr));
     memcpy(value, addr, sizeof(addr));
     return sizeof(addr);
 }
@@ -147,7 +147,7 @@ static int netdev_get_address_long(netdev_t *dev, void *value, size_t max_len)
     if (!IS_USED(MODULE_NETDEV_IEEE802154)) {
         return -ENOTSUP;
     }
-    assert(max_len >= sizeof(addr));
+    expect(max_len >= sizeof(addr));
     memcpy(value, addr, sizeof(addr));
     return sizeof(addr);
 }
@@ -159,7 +159,7 @@ static int netdev_get_src_len(netdev_t *dev, void *value, size_t max_len)
     if (!IS_USED(MODULE_NETDEV_IEEE802154)) {
         return -ENOTSUP;
     }
-    assert(max_len == sizeof(src_len));
+    expect(max_len == sizeof(src_len));
     memcpy(value, &src_len, sizeof(src_len));
     return sizeof(src_len);
 }

--- a/tests/ieee802154_hal/main.c
+++ b/tests/ieee802154_hal/main.c
@@ -18,7 +18,6 @@
  * @}
  */
 
-#include <assert.h>
 #include <stdio.h>
 #include <strings.h>
 
@@ -35,6 +34,7 @@
 #include "shell.h"
 #include "shell_commands.h"
 
+#include "test_utils/expect.h"
 #include "xtimer.h"
 
 #define SYMBOL_TIME (16U) /**< 16 us */
@@ -168,7 +168,7 @@ static void _tx_finish_handler(event_t *event)
 
     (void) event;
     /* The TX_DONE event indicates it's safe to call the confirm counterpart */
-    assert(ieee802154_radio_confirm_transmit(&_radio[0], &tx_info) >= 0);
+    expect(ieee802154_radio_confirm_transmit(&_radio[0], &tx_info) >= 0);
 
     if (!ieee802154_radio_has_irq_ack_timeout(&_radio[0]) && !ieee802154_radio_has_frame_retrans(&_radio[0])) {
         /* This is just to show how the MAC layer would handle ACKs... */
@@ -281,7 +281,7 @@ static int _init(void)
     /* Since the device was already initialized, turn on the radio.
      * The transceiver state will be "TRX_OFF" */
     res = ieee802154_radio_request_on(&_radio[0]);
-    assert(res >= 0);
+    expect(res >= 0);
     while(ieee802154_radio_confirm_on(&_radio[0]) == -EAGAIN) {}
 
     ieee802154_radio_set_frame_filter_mode(&_radio[0], IEEE802154_FILTER_ACCEPT);
@@ -291,25 +291,25 @@ static int _init(void)
     /* Set all IEEE addresses */
     res = ieee802154_radio_config_addr_filter(&_radio[0],
                                         IEEE802154_AF_SHORT_ADDR, &short_addr);
-    assert(res >= 0);
+    expect(res >= 0);
     res = ieee802154_radio_config_addr_filter(&_radio[0],
                                         IEEE802154_AF_EXT_ADDR, &ext_addr);
-    assert(res >= 0);
+    expect(res >= 0);
     res = ieee802154_radio_config_addr_filter(&_radio[0],
                                         IEEE802154_AF_PANID, &panid);
-    assert(res >= 0);
+    expect(res >= 0);
 
     /* Set PHY configuration */
     ieee802154_phy_conf_t conf = {.channel=CONFIG_IEEE802154_DEFAULT_CHANNEL, .page=CONFIG_IEEE802154_DEFAULT_SUBGHZ_PAGE, .pow=CONFIG_IEEE802154_DEFAULT_TXPOWER};
 
     res = ieee802154_radio_config_phy(&_radio[0], &conf);
-    assert(res >= 0);
+    expect(res >= 0);
 
     /* ieee802154_radio_set_cca_mode*/
     res = ieee802154_radio_set_cca_mode(&_radio[0], IEEE802154_CCA_MODE_ED_THRESHOLD);
-    assert(res >= 0);
+    expect(res >= 0);
     res = ieee802154_radio_set_cca_threshold(&_radio[0], CONFIG_IEEE802154_CCA_THRESH_DEFAULT);
-    assert(res >= 0);
+    expect(res >= 0);
 
     /* Set the transceiver state to RX_ON in order to receive packets */
     _set_trx_state(IEEE802154_TRX_STATE_RX_ON, false);
@@ -367,7 +367,7 @@ int _cca(int argc, char **argv)
     }
     mutex_lock(&lock);
     int res = ieee802154_radio_confirm_cca(&_radio[0]);
-    assert(res >= 0);
+    expect(res >= 0);
 
     if (res > 0) {
         puts("CLEAR");
@@ -394,7 +394,7 @@ static inline void _set_trx_state(int state, bool verbose)
         a = xtimer_now();
         if(res != 0) {
             printf("%i != 0 \n", res);
-            assert(false);
+            expect(false);
         }
     }
 
@@ -402,7 +402,7 @@ static inline void _set_trx_state(int state, bool verbose)
     if (verbose) {
         if (res != 0) {
             printf("%i != 0 \n", res);
-            assert(false);
+            expect(false);
         }
         uint32_t secs = xtimer_usec_from_ticks(xtimer_diff(xtimer_now(), a));
         printf("\tTransition took %" PRIu32 " usecs\n", secs);

--- a/tests/ieee802154_submac/main.c
+++ b/tests/ieee802154_submac/main.c
@@ -18,7 +18,6 @@
  * @}
  */
 
-#include <assert.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -33,6 +32,7 @@
 #include "net/ieee802154.h"
 #include "net/netdev/ieee802154_submac.h"
 #include "net/l2util.h"
+#include "test_utils/expect.h"
 #include "ztimer.h"
 
 #include "common.h"

--- a/tests/lwip_sock_ip/main.c
+++ b/tests/lwip_sock_ip/main.c
@@ -341,14 +341,14 @@ static void test_sock_ip_recv_buf4__success(void)
                                SOCK_FLAGS_REUSE_EP));
     expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv_buf(&_sock, &data, &ctx,
+    expect(sizeof("ABCD") == sock_ip_recv_buf(&_sock, &data, &ctx,
                                               SOCK_NO_TIMEOUT, NULL));
-    assert(data != NULL);
-    assert(ctx != NULL);
-    assert(0 == sock_ip_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
-    assert(data == NULL);
-    assert(ctx == NULL);
-    assert(_check_net());
+    expect(data != NULL);
+    expect(ctx != NULL);
+    expect(0 == sock_ip_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
+    expect(data == NULL);
+    expect(ctx == NULL);
+    expect(_check_net());
 }
 
 static void test_sock_ip_send4__EAFNOSUPPORT(void)
@@ -908,18 +908,18 @@ static void test_sock_ip_recv_buf6__success(void)
                                          .family = AF_INET6 };
     void *data = NULL, *ctx = NULL;
 
-    assert(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
+    expect(0 == sock_ip_create(&_sock, &local, &remote, _TEST_PROTO,
                                SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
                            sizeof("ABCD"), _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_ip_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT,
+    expect(sizeof("ABCD") == sock_ip_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT,
                                               NULL));
-    assert(data != NULL);
-    assert(ctx != NULL);
-    assert(0 == sock_ip_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
-    assert(data == NULL);
-    assert(ctx == NULL);
-    assert(_check_net());
+    expect(data != NULL);
+    expect(ctx != NULL);
+    expect(0 == sock_ip_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
+    expect(data == NULL);
+    expect(ctx == NULL);
+    expect(_check_net());
 }
 
 static void test_sock_ip_send6__EAFNOSUPPORT(void)

--- a/tests/lwip_sock_udp/main.c
+++ b/tests/lwip_sock_udp/main.c
@@ -436,14 +436,14 @@ static void test_sock_udp_recv_buf4__success(void)
     expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv_buf(&_sock, &data, &ctx,
+    expect(sizeof("ABCD") == sock_udp_recv_buf(&_sock, &data, &ctx,
                                                SOCK_NO_TIMEOUT, NULL));
-    assert(data != NULL);
-    assert(ctx != NULL);
-    assert(0 == sock_udp_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
-    assert(data == NULL);
-    assert(ctx == NULL);
-    assert(_check_net());
+    expect(data != NULL);
+    expect(ctx != NULL);
+    expect(0 == sock_udp_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
+    expect(data == NULL);
+    expect(ctx == NULL);
+    expect(_check_net());
 }
 
 static void test_sock_udp_send4__EAFNOSUPPORT(void)
@@ -1128,18 +1128,18 @@ static void test_sock_udp_recv_buf6__success(void)
                                           .port = _TEST_PORT_REMOTE };
     void *data = NULL, *ctx = NULL;
 
-    assert(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
-    assert(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+    expect(0 == sock_udp_create(&_sock, &local, &remote, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
                            _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
                            _TEST_NETIF));
-    assert(sizeof("ABCD") == sock_udp_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT,
+    expect(sizeof("ABCD") == sock_udp_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT,
                                                NULL));
-    assert(data != NULL);
-    assert(ctx != NULL);
-    assert(0 == sock_udp_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
-    assert(data == NULL);
-    assert(ctx == NULL);
-    assert(_check_net());
+    expect(data != NULL);
+    expect(ctx != NULL);
+    expect(0 == sock_udp_recv_buf(&_sock, &data, &ctx, SOCK_NO_TIMEOUT, NULL));
+    expect(data == NULL);
+    expect(ctx == NULL);
+    expect(_check_net());
 }
 
 static void test_sock_udp_send6__EAFNOSUPPORT(void)

--- a/tests/mtd_raw/main.c
+++ b/tests/mtd_raw/main.c
@@ -18,7 +18,6 @@
  * @}
  */
 
-#include <assert.h>
 #include <inttypes.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -30,6 +29,7 @@
 #include "shell.h"
 #include "board.h"
 #include "macros/units.h"
+#include "test_utils/expect.h"
 
 #ifndef MTD_NUMOF
 #ifdef MTD_0
@@ -401,48 +401,49 @@ static int cmd_test(int argc, char **argv)
 
     /* write dummy data to sectors */
     memset(buffer, 0x23, dev->page_size);
-    assert(mtd_write_page_raw(dev, buffer, page_0, 0, page_size) == 0);
-    assert(mtd_write_page_raw(dev, buffer, page_1, 0, page_size) == 0);
+    expect(mtd_write_page_raw(dev, buffer, page_0, 0, page_size) == 0);
+    expect(mtd_write_page_raw(dev, buffer, page_1, 0, page_size) == 0);
 
     /* erase two sectors and check if they have been erased */
-    assert(mtd_erase_sector(dev, sector, 2) == 0);
-    assert(mtd_read_page(dev, buffer, page_0, 0, page_size) == 0);
-    assert(mem_is_all_set(buffer, 0xFF, page_size) || mem_is_all_set(buffer, 0x00, page_size));
-    assert(mtd_read_page(dev, buffer, page_1, 0, page_size) == 0);
-    assert(mem_is_all_set(buffer, 0xFF, page_size) || mem_is_all_set(buffer, 0x00, page_size));
+    expect(mtd_erase_sector(dev, sector, 2) == 0);
+    expect(mtd_read_page(dev, buffer, page_0, 0, page_size) == 0);
+    expect(mem_is_all_set(buffer, 0xFF, page_size) || mem_is_all_set(buffer, 0x00, page_size));
+    expect(mtd_read_page(dev, buffer, page_1, 0, page_size) == 0);
+    expect(mem_is_all_set(buffer, 0xFF, page_size) || mem_is_all_set(buffer, 0x00, page_size));
 
     /* write test data & read it back */
     const char test_str[] = "0123456789";
     uint32_t offset = 5;
-    assert(mtd_write_page_raw(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
-    assert(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str)) == 0);
-    assert(memcmp(test_str, buffer, sizeof(test_str)) == 0);
+
+    expect(mtd_write_page_raw(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
+    expect(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str)) == 0);
+    expect(memcmp(test_str, buffer, sizeof(test_str)) == 0);
 
     /* write across page boundary */
     offset = page_size - sizeof(test_str) / 2;
-    assert(mtd_write_page_raw(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
-    assert(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str)) == 0);
-    assert(memcmp(test_str, buffer, sizeof(test_str)) == 0);
+    expect(mtd_write_page_raw(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
+    expect(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str)) == 0);
+    expect(memcmp(test_str, buffer, sizeof(test_str)) == 0);
 
     /* write across sector boundary */
     offset = page_size - sizeof(test_str) / 2
            + (dev->pages_per_sector - 1) * page_size;
-    assert(mtd_write_page_raw(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
-    assert(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str)) == 0);
-    assert(memcmp(test_str, buffer, sizeof(test_str)) == 0);
+    expect(mtd_write_page_raw(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
+    expect(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str)) == 0);
+    expect(memcmp(test_str, buffer, sizeof(test_str)) == 0);
 
     /* overwrite first test string, rely on MTD for read-modify-write */
     const char test_str_2[] = "Hello World!";
     offset = 5;
-    assert(mtd_write_page(dev, test_str_2, page_0, offset, sizeof(test_str_2)) == 0);
-    assert(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str_2)) == 0);
-    assert(memcmp(test_str_2, buffer, sizeof(test_str_2)) == 0);
+    expect(mtd_write_page(dev, test_str_2, page_0, offset, sizeof(test_str_2)) == 0);
+    expect(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str_2)) == 0);
+    expect(memcmp(test_str_2, buffer, sizeof(test_str_2)) == 0);
 
     /* test write_page across sectors */
     offset = dev->pages_per_sector * dev->page_size - 2;
-    assert(mtd_write_page(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
-    assert(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str)) == 0);
-    assert(memcmp(test_str, buffer, sizeof(test_str)) == 0);
+    expect(mtd_write_page(dev, test_str, page_0, offset, sizeof(test_str)) == 0);
+    expect(mtd_read_page(dev, buffer, page_0, offset, sizeof(test_str)) == 0);
+    expect(memcmp(test_str, buffer, sizeof(test_str)) == 0);
 
     puts("[SUCCESS]");
 


### PR DESCRIPTION
### Contribution description

This PR fixes compilation problems when `NDEBUG` is defined.

Commit https://github.com/RIOT-OS/RIOT/pull/14364/commits/deb2d466c40422a3942062aafa55cc03a2379f9d is only for defining `NDEBUG` for compilation. It must be dropped before merge.

### Testing procedure

Compilation in CI has to succeed.

### Issues/PRs references
