### PR TITLE
cpu/efm32: prepare for series 2

### DIFF
--- a/boards/common/silabs/drivers/aem/aem.c
+++ b/boards/common/silabs/drivers/aem/aem.c
@@ -35,9 +35,9 @@ void aem_init(void)
     CMU_ClockEnable(cmuClock_GPIO, true);
 
     /* enable debug peripheral via SWO */
-#ifdef _SILICON_LABS_32B_SERIES_0
+#if defined(_SILICON_LABS_32B_SERIES_0)
     DBG_SWOEnable(GPIO_ROUTE_SWLOCATION_LOC0);
-#else
+#elif defined(_SILICON_LABS_32B_SERIES_1)
     DBG_SWOEnable(GPIO_ROUTELOC0_SWVLOC_LOC0);
 #endif
 

--- a/cpu/efm32/cpu.c
+++ b/cpu/efm32/cpu.c
@@ -53,7 +53,7 @@
 
 #ifndef RIOTBOOT
 
-#if defined(_SILICON_LABS_32B_SERIES_1)
+#if defined(DCDC_PRESENT) && DCDC_COUNT > 0
 /**
  * @brief   Initialize integrated DC-DC regulator
  */
@@ -176,7 +176,7 @@ void cpu_init(void)
 
 #ifndef RIOTBOOT
 
-#if defined(_SILICON_LABS_32B_SERIES_1)
+#if defined(DCDC_PRESENT) && DCDC_COUNT > 0
     /* initialize dc-dc */
     dcdc_init();
 #endif

--- a/cpu/efm32/cpu.c
+++ b/cpu/efm32/cpu.c
@@ -53,7 +53,7 @@
 
 #ifndef RIOTBOOT
 
-#ifdef _SILICON_LABS_32B_SERIES_1
+#if defined(_SILICON_LABS_32B_SERIES_1)
 /**
  * @brief   Initialize integrated DC-DC regulator
  */
@@ -99,7 +99,7 @@ static void clk_init(void)
         CMU_OscillatorEnable(cmuOsc_HFRCO, false, false);
     }
 
-#ifdef _SILICON_LABS_32B_SERIES_1
+#if defined(_SILICON_LABS_32B_SERIES_1)
     /* disable LFRCO comparator chopping and dynamic element matching
      * else LFRCO has too much jitter for LEUART > 1800 baud */
     CMU->LFRCOCTRL &= ~(CMU_LFRCOCTRL_ENCHOP | CMU_LFRCOCTRL_ENDEM);
@@ -107,7 +107,7 @@ static void clk_init(void)
 
     /* initialize LFXO with board-specific parameters before switching */
     if (CLOCK_LFA == cmuSelect_LFXO || CLOCK_LFB == cmuSelect_LFXO ||
-#ifdef _SILICON_LABS_32B_SERIES_1
+#if defined(_SILICON_LABS_32B_SERIES_1)
         CLOCK_LFE == cmuSelect_LFXO)
 #else
         false)
@@ -124,14 +124,14 @@ static void clk_init(void)
     /* set (and enable) the LFB clock source */
     CMU_ClockSelectSet(cmuClock_LFB, CLOCK_LFB);
 
-#ifdef _SILICON_LABS_32B_SERIES_1
+#if defined(_SILICON_LABS_32B_SERIES_1)
     /* set (and enable) the LFE clock source */
     CMU_ClockSelectSet(cmuClock_LFE, CLOCK_LFE);
 #endif
 
     /* disable the LFRCO if external crystal is used */
     if (CLOCK_LFA == cmuSelect_LFXO && CLOCK_LFB == cmuSelect_LFXO &&
-#ifdef _SILICON_LABS_32B_SERIES_1
+#if defined(_SILICON_LABS_32B_SERIES_1)
         CLOCK_LFE == cmuSelect_LFXO)
 #else
         true)
@@ -154,7 +154,7 @@ static void pm_init(void)
 
     EMU_EM23Init(&init_em23);
 
-#ifdef _SILICON_LABS_32B_SERIES_1
+#if defined(_SILICON_LABS_32B_SERIES_1)
     /* initialize EM4 */
     EMU_EM4Init_TypeDef init_em4 = EMU_EM4INIT;
 
@@ -176,7 +176,7 @@ void cpu_init(void)
 
 #ifndef RIOTBOOT
 
-#ifdef _SILICON_LABS_32B_SERIES_1
+#if defined(_SILICON_LABS_32B_SERIES_1)
     /* initialize dc-dc */
     dcdc_init();
 #endif

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -30,7 +30,7 @@
 #include "em_gpio.h"
 #include "em_timer.h"
 #include "em_usart.h"
-#ifdef _SILICON_LABS_32B_SERIES_0
+#if defined(_SILICON_LABS_32B_SERIES_0)
 #include "em_dac.h"
 #endif
 
@@ -79,9 +79,9 @@ typedef struct {
  */
 typedef struct {
     uint8_t dev;                      /**< device index */
-#ifdef _SILICON_LABS_32B_SERIES_0
+#if defined(_SILICON_LABS_32B_SERIES_0)
     ADC_SingleInput_TypeDef input;    /**< input channel */
-#else
+#elif defined(_SILICON_LABS_32B_SERIES_1)
     ADC_PosSel_TypeDef input;         /**< input channel */
 #endif
     ADC_Ref_TypeDef reference;        /**< channel voltage reference */
@@ -211,7 +211,7 @@ typedef enum {
 #ifdef AES_CTRL_AES256
 #define HAVE_HWCRYPTO_AES256
 #endif
-#ifdef _SILICON_LABS_32B_SERIES_1
+#if defined(_SILICON_LABS_32B_SERIES_1)
 #define HAVE_HWCRYPTO_SHA1
 #define HAVE_HWCRYPTO_SHA256
 #endif

--- a/cpu/efm32/periph/adc.c
+++ b/cpu/efm32/periph/adc.c
@@ -77,9 +77,9 @@ int32_t adc_sample(adc_t line, adc_res_t res)
     init.acqTime = adc_channel_config[line].acq_time;
     init.reference = adc_channel_config[line].reference;
     init.resolution = (ADC_Res_TypeDef) (res & 0x0F);
-#ifdef _SILICON_LABS_32B_SERIES_0
+#if defined(_SILICON_LABS_32B_SERIES_0)
     init.input = adc_channel_config[line].input;
-#else
+#elif defined(_SILICON_LABS_32B_SERIES_1)
     init.posSel = adc_channel_config[line].input;
 #endif
 

--- a/cpu/efm32/periph/gpio.c
+++ b/cpu/efm32/periph/gpio.c
@@ -62,7 +62,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 
     /* configure pin */
     GPIO_PinModeSet(_port_num(pin), _pin_num(pin), mode >> 1, mode & 0x1);
-#ifdef _SILICON_LABS_32B_SERIES_0
+#if defined(_SILICON_LABS_32B_SERIES_0)
     GPIO_DriveModeSet(_port_num(pin), gpioDriveModeStandard);
 #endif
 

--- a/cpu/efm32/periph/i2c.c
+++ b/cpu/efm32/periph/i2c.c
@@ -126,10 +126,10 @@ void i2c_init(i2c_t dev)
     I2C_Init(i2c_config[dev].dev, &init);
 
     /* configure pin functions */
-#ifdef _SILICON_LABS_32B_SERIES_0
+#if defined(_SILICON_LABS_32B_SERIES_0)
     i2c_config[dev].dev->ROUTE = (i2c_config[dev].loc |
                                   I2C_ROUTE_SDAPEN | I2C_ROUTE_SCLPEN);
-#else
+#elif defined(_SILICON_LABS_32B_SERIES_1)
     i2c_config[dev].dev->ROUTEPEN = I2C_ROUTEPEN_SDAPEN | I2C_ROUTEPEN_SCLPEN;
     i2c_config[dev].dev->ROUTELOC0 = i2c_config[dev].loc;
 #endif

--- a/cpu/efm32/periph/pwm.c
+++ b/cpu/efm32/periph/pwm.c
@@ -70,10 +70,10 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
         gpio_init(channel.pin, GPIO_OUT);
 
         /* configure pin function */
-#ifdef _SILICON_LABS_32B_SERIES_0
+#if defined(_SILICON_LABS_32B_SERIES_0)
         pwm_config[dev].dev->ROUTE |= (channel.loc |
                                        TIMER_Channel2Route(channel.index));
-#else
+#elif defined(_SILICON_LABS_32B_SERIES_1)
         pwm_config[dev].dev->ROUTELOC0 |= channel.loc;
         pwm_config[dev].dev->ROUTEPEN |= TIMER_Channel2Route(channel.index);
 #endif

--- a/cpu/efm32/periph/spi.c
+++ b/cpu/efm32/periph/spi.c
@@ -73,12 +73,12 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     USART_InitSync(spi_config[bus].dev, &init);
 
     /* configure pin functions */
-#ifdef _SILICON_LABS_32B_SERIES_0
+#if defined(_SILICON_LABS_32B_SERIES_0)
     spi_config[bus].dev->ROUTE = (spi_config[bus].loc |
                                   USART_ROUTE_RXPEN |
                                   USART_ROUTE_TXPEN |
                                   USART_ROUTE_CLKPEN);
-#else
+#elif defined(_SILICON_LABS_32B_SERIES_1)
     spi_config[bus].dev->ROUTELOC0 = spi_config[bus].loc;
     spi_config[bus].dev->ROUTEPEN = (USART_ROUTEPEN_RXPEN |
                                      USART_ROUTEPEN_TXPEN |

--- a/cpu/efm32/periph/uart.c
+++ b/cpu/efm32/periph/uart.c
@@ -89,11 +89,11 @@ int uart_init(uart_t dev, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
         USART_InitAsync(uart, &init);
 
         /* configure pin functions */
-#ifdef _SILICON_LABS_32B_SERIES_0
+#if defined(_SILICON_LABS_32B_SERIES_0)
         uart->ROUTE = (uart_config[dev].loc |
                        USART_ROUTE_RXPEN |
                        USART_ROUTE_TXPEN);
-#else
+#elif defined(_SILICON_LABS_32B_SERIES_1)
         uart->ROUTELOC0 = uart_config[dev].loc;
         uart->ROUTEPEN = USART_ROUTEPEN_RXPEN | USART_ROUTEPEN_TXPEN;
 #endif
@@ -118,11 +118,11 @@ int uart_init(uart_t dev, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
         LEUART_Init(leuart, &init);
 
         /* configure pin functions */
-#ifdef _SILICON_LABS_32B_SERIES_0
+#if defined(_SILICON_LABS_32B_SERIES_0)
         leuart->ROUTE = (uart_config[dev].loc |
                          LEUART_ROUTE_RXPEN |
                          LEUART_ROUTE_TXPEN);
-#else
+#elif defined(_SILICON_LABS_32B_SERIES_1)
         leuart->ROUTELOC0 = uart_config[dev].loc;
         leuart->ROUTEPEN = LEUART_ROUTEPEN_RXPEN | LEUART_ROUTEPEN_TXPEN;
 #endif


### PR DESCRIPTION
### Contribution description
In preparation for the Series 2 MCUs by Silicon Labs, I have refactored the EFM32 a tiny bit to be more explicit about the defines. Current implementation only supports Series 0 and Series 1 MCUs, but some code would have been compiled for Series 2, because of the `#else` cases.

I opted for `#if defined(..)` instead of `#ifdef`, because with Series 2 I might need to extend certain definitions.

In addition, I also modified the DC-DC initialization because that is also a feature available on Series 2 as well.

Tested this with the SLTB001a, SLSTK3401a, SLSTK3402 and STK3600 and `examples/default`.

### Testing procedure
* Murdock is green
* Any EFM32 board currently supported stays working.

### Issues/PRs references
None