### PR TITLE
.circleci: rename job from build to doc-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@
 version: 2
 
 jobs:
-  build:
+  doc-build:
     docker:
       - image: riot/riotbuild
     steps:
@@ -17,3 +17,9 @@ jobs:
             cp -R doc/doxygen/html /doc
       - store_artifacts:
           path: /doc
+
+workflows:
+  version: 2
+  doc-build:
+    jobs:
+      - doc-build


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR rename the job name configured in circleci from "build" to "doc". It will make it more explicit what the circleci check is about.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just check in this PR, the name of the circleci job.

This PR (just wait a bit):



In master:

![image](https://user-images.githubusercontent.com/1375137/85832511-88695700-b790-11ea-8866-700eb1f7e108.png)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
