### PR TITLE
cpu/cortex: add initial support for Cortex-M33

### DIFF
--- a/core/include/panic.h
+++ b/core/include/panic.h
@@ -40,8 +40,9 @@ typedef enum {
 #ifdef MODULE_CORTEXM_COMMON
     PANIC_NMI_HANDLER,          /**< non maskable interrupt */
     PANIC_HARD_FAULT,           /**< hard fault */
-#if defined(CPU_CORE_CORTEX_M3) || defined(CPU_CORE_CORTEX_M4) || \
-    defined(CPU_CORE_CORTEX_M4F) || defined(CPU_CORE_CORTEX_M7)
+#if defined(CPU_CORE_CORTEX_M3) || defined(CPU_CORE_CORTEX_M33) || \
+    defined(CPU_CORE_CORTEX_M4) || defined(CPU_CORE_CORTEX_M4F) || \
+    defined(CPU_CORE_CORTEX_M7)
     PANIC_MEM_MANAGE,           /**< memory controller interrupt */
     PANIC_BUS_FAULT,            /**< bus fault */
     PANIC_USAGE_FAULT,          /**< undefined instruction or unaligned access */

--- a/cpu/cortexm_common/Kconfig
+++ b/cpu/cortexm_common/Kconfig
@@ -52,6 +52,7 @@ config CPU_CORE
     default "cortex-m0plus" if CPU_CORE_CORTEX_M0PLUS
     default "cortex-m23" if CPU_CORE_CORTEX_M23
     default "cortex-m3" if CPU_CORE_CORTEX_M3
+    default "cortex-m33" if CPU_CORE_CORTEX_M33
     default "cortex-m4" if CPU_CORE_CORTEX_M4
     default "cortex-m4f" if CPU_CORE_CORTEX_M4F
     default "cortex-m7" if CPU_CORE_CORTEX_M7
@@ -74,6 +75,11 @@ config CPU_CORE_CORTEX_M23
 config CPU_CORE_CORTEX_M3
     bool
     select CPU_ARCH_ARMV7M
+    select CPU_CORE_CORTEX_M
+
+config CPU_CORE_CORTEX_M33
+    bool
+    select CPU_ARCH_ARMV8M
     select CPU_CORE_CORTEX_M
 
 config CPU_CORE_CORTEX_M4

--- a/cpu/cortexm_common/Makefile.features
+++ b/cpu/cortexm_common/Makefile.features
@@ -19,16 +19,18 @@ ifeq ($(CPU_CORE),cortex-m0)
   CPU_ARCH := armv6m
 else ifeq ($(CPU_CORE),cortex-m0plus)
   CPU_ARCH := armv6m
+else ifeq ($(CPU_CORE),cortex-m23)
+  CPU_ARCH := armv8m
 else ifeq ($(CPU_CORE),cortex-m3)
   CPU_ARCH := armv7m
+else ifeq ($(CPU_CORE),cortex-m33)
+  CPU_ARCH := armv8m
 else ifeq ($(CPU_CORE),cortex-m4)
   CPU_ARCH := armv7m
 else ifeq ($(CPU_CORE),cortex-m4f)
   CPU_ARCH := armv7m
 else ifeq ($(CPU_CORE),cortex-m7)
   CPU_ARCH := armv7m
-else ifeq ($(CPU_CORE),cortex-m23)
-  CPU_ARCH := armv8m
 else
   $(error Unkwnown cortexm core: $(CPU_CORE))
 endif

--- a/cpu/cortexm_common/Makefile.include
+++ b/cpu/cortexm_common/Makefile.include
@@ -31,9 +31,16 @@ LINKFLAGS += $(if $(ROM_OFFSET),$(LINKFLAGPREFIX)--defsym=_rom_offset=$(ROM_OFFS
 # FW_ROM_LEN: rom length to use for firmware linking. Allows linking only in a section of the rom.
 LINKFLAGS += $(if $(FW_ROM_LEN),$(LINKFLAGPREFIX)--defsym=_fw_rom_length=$(FW_ROM_LEN))
 
-# Cortex-M0+/1/3/4/7 riotboot settings
+# Cortex-M riotboot settings
 
-# From ARMv7-M (M4, M3, M7) architecture reference manual, section B1.5.3
+# From ARMv8-M (M23, M33) architecture reference manual, section B3.27
+# https://static.docs.arm.com/ddi0553/a/DDI0553A_e_armv8m_arm.pdf
+# "In a PE with a configurable vector table base, the vector table must be
+# naturally aligned to a power of two, with an alignment value that is:
+# * A minimum of 128 bytes.
+# * Greater than or equal to (Number of Exceptions supported x4)."
+
+# From ARMv7-M (M4, M4F, M3, M7) architecture reference manual, section B1.5.3
 # https://static.docs.arm.com/ddi0403/e/DDI0403E_d_armv7m_arm.pdf
 # "The Vector table must be naturally aligned to a power of two whose alignment
 # value is greater than or equal to number of Exceptions supported x 4"
@@ -47,13 +54,16 @@ LINKFLAGS += $(if $(FW_ROM_LEN),$(LINKFLAGPREFIX)--defsym=_fw_rom_length=$(FW_RO
 
 # For reference on the max number in interrupts per processor look in The
 # technical reference manual "Interrupt Controller Type Register, ICTR" section.
-# * For M4, M3 & M7: Maximum of 256 exceptions (256*4 bytes == 0x400).
+# * For M23 & M33: Maximum of 480 exception (480 * 4 bytes ~= 0x800).
+# * For M4, M4F, M3 & M7: Maximum of 256 exceptions (256*4 bytes == 0x400).
 # * For M0, M0+ & M1: Maximum of 48 exceptions (48*4 bytes = 192 bytes ~= 0x100).
 
 # The values defined here are a theoretical maximum, in practice most cpu's
 # CPU_IRQ_NUMOF value is around 100, in these cases the value can be reduced
 # accordingly in the cpu Makefile.include, e.g: `kinetis/Makefile.include`
-ifneq (,$(filter cortex-m2% cortex-m4% cortex-m3% cortex-m7%,$(CPU_CORE)))
+ifneq (,$(filter cortex-m23% cortex-m33%,$(CPU_CORE)))
+  RIOTBOOT_HDR_LEN ?= 0x800
+else ifneq (,$(filter cortex-m3% cortex-m4% cortex-m7%,$(CPU_CORE)))
   RIOTBOOT_HDR_LEN ?= 0x400
 else
   RIOTBOOT_HDR_LEN ?= 0x100

--- a/cpu/cortexm_common/cortexm_init.c
+++ b/cpu/cortexm_common/cortexm_init.c
@@ -73,8 +73,9 @@ void cortexm_init(void)
     cortexm_init_fpu();
 
     /* configure the vector table location to internal flash */
-#if defined(CPU_CORE_CORTEX_M3) || defined(CPU_CORE_CORTEX_M4) || \
-    defined(CPU_CORE_CORTEX_M4F) || defined(CPU_CORE_CORTEX_M7) || \
+#if defined(CPU_CORE_CORTEX_M3) || defined(CPU_CORE_CORTEX_M33) || \
+    defined(CPU_CORE_CORTEX_M4) || defined(CPU_CORE_CORTEX_M4F) || \
+    defined(CPU_CORE_CORTEX_M7) || \
     (defined(CPU_CORE_CORTEX_M0PLUS) || defined(CPU_CORE_CORTEX_M23) \
     && (__VTOR_PRESENT == 1))
     SCB->VTOR = (uint32_t)&_isr_vectors;
@@ -86,8 +87,9 @@ void cortexm_init(void)
 
 bool cpu_check_address(volatile const char *address)
 {
-#if defined(CPU_CORE_CORTEX_M3) || defined(CPU_CORE_CORTEX_M4) || \
-    defined(CPU_CORE_CORTEX_M4F) || defined(CPU_CORE_CORTEX_M7)
+#if defined(CPU_CORE_CORTEX_M3) || defined(CPU_CORE_CORTEX_M33) || \
+    defined(CPU_CORE_CORTEX_M4) || defined(CPU_CORE_CORTEX_M4F) || \
+    defined(CPU_CORE_CORTEX_M7)
     static const uint32_t BFARVALID_MASK = (0x80 << SCB_CFSR_BUSFAULTSR_Pos);
 
     bool is_valid = true;

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -99,7 +99,7 @@ void cortexm_init(void);
 static inline void cortexm_init_fpu(void)
 {
     /* initialize the FPU on Cortex-M4F CPUs */
-#if defined(CPU_CORE_CORTEX_M4F) || defined(CPU_CORE_CORTEX_M7)
+#if (defined(CPU_CORE_CORTEX_M33) || defined(CPU_CORE_CORTEX_M4F) || defined(CPU_CORE_CORTEX_M7)) && defined(MODULE_CORTEXM_FPU)
     /* give full access to the FPU */
     SCB->CPACR |= (uint32_t)CORTEXM_SCB_CPACR_FPU_ACCESS_FULL;
 #endif
@@ -225,10 +225,11 @@ static inline void cpu_jump_to_image(uint32_t image_address)
 }
 
 /* The following register is only present for
-   Cortex-M0+, -M3, -M4, -M7 and -M23 CPUs */
-#if defined(CPU_CORE_CORTEX_M0PLUS) || defined(CPU_CORE_CORTEX_M3) || \
+   Cortex-M0+, -M23, -M3, -M33, -M4 and M7 CPUs */
+#if defined(CPU_CORE_CORTEX_M0PLUS) || defined(CPU_CORE_CORTEX_M23) || \
+    defined(CPU_CORE_CORTEX_M3) || defined(CPU_CORE_CORTEX_M33) || \
     defined(CPU_CORE_CORTEX_M4) || defined(CPU_CORE_CORTEX_M4F) || \
-    defined(CPU_CORE_CORTEX_M7) || defined(CPU_CORE_CORTEX_M23)
+    defined(CPU_CORE_CORTEX_M7)
 static inline uint32_t cpu_get_image_baseaddr(void)
 {
     return SCB->VTOR;

--- a/cpu/cortexm_common/mpu.c
+++ b/cpu/cortexm_common/mpu.c
@@ -18,8 +18,6 @@
  * @}
  */
 
-#include <assert.h>
-
 #include "cpu.h"
 #include "mpu.h"
 
@@ -59,8 +57,8 @@ bool mpu_enabled(void) {
 }
 
 int mpu_configure(uint_fast8_t region, uintptr_t base, uint_fast32_t attr) {
-/* Todo enable MPU support for Cortex-M23/M33 */
-#if __MPU_PRESENT && !defined(CPU_CORE_CORTEX_M23)
+    /* Todo enable MPU support for Cortex-M23/M33 */
+#if __MPU_PRESENT && !defined(__ARM_ARCH_8M_MAIN__) && !defined(__ARM_ARCH_8M_BASE__)
     MPU->RNR  = region;
     MPU->RBAR = base & MPU_RBAR_ADDR_Msk;
     MPU->RASR = attr | MPU_RASR_ENABLE_Msk;

--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -17,7 +17,7 @@
  * Members of the Cortex-M family know stacks and are able to handle register
  * backups partly, so we make use of that.
  *
- * Cortex-M3 and Cortex-M4 use the
+ * Cortex-M3, Cortex-M33 and Cortex-M4 use the
  * following register layout when saving their context onto the stack:
  *
  * -------- highest address (bottom of stack)
@@ -56,12 +56,12 @@
  * | R4   | <- R4 lowest address (top of stack)
  * --------
  *
- * For the Cortex-M0 and Cortex-M0plus we use a slightly different layout by
- * switching the blocks R11-R8 and R7-R4. This allows more efficient code when
- * saving/restoring the context:
+ * For the Cortex-M0, Cortex-M0+ and Cortex-M23 we use a slightly different
+ * layout by switching the blocks R11-R8 and R7-R4. This allows more efficient
+ * code when saving/restoring the context:
  *
  * ------------- highest address (bottom of stack)
- * | xPSR - R0 | <- same as for Cortex-M3/4
+ * | xPSR - R0 | <- same as for Cortex-M3/33/4
  * -------------
  * | RET  | <- exception return code
  * --------
@@ -109,8 +109,8 @@ extern uint32_t _sstack;
 /**
  * @brief   CPU core supports full Thumb instruction set
  */
-#if defined(CPU_CORE_CORTEX_M0) || defined(CPU_CORE_CORTEX_M0PLUS) \
-    || defined(CPU_CORE_CORTEX_M23)
+#if defined(CPU_CORE_CORTEX_M0) || defined(CPU_CORE_CORTEX_M0PLUS) || \
+    defined(CPU_CORE_CORTEX_M23)
 #define CPU_CORE_CORTEXM_FULL_THUMB 0
 #else
 #define CPU_CORE_CORTEXM_FULL_THUMB 1
@@ -198,10 +198,11 @@ char *thread_stack_init(thread_task_func_t task_func,
 
     /* The following registers are not handled by hardware in return from
      * exception, but manually by select_and_restore_context.
-     * For the Cortex-M0(plus) we write registers R11-R4 in two groups to allow
-     * for more efficient context save/restore code.
-     * For the Cortex-M3 and Cortex-M4 we write them continuously onto the stack
-     * as they can be read/written continuously by stack instructions. */
+     * For the Cortex-M0, Cortex-M0+ and Cortex-M23 we write registers R11-R4
+     * in two groups to allow for more efficient context save/restore code.
+     * For the Cortex-M3, Cortex-M33 and Cortex-M4 we write them continuously
+     * onto the stack as they can be read/written continuously by stack
+     * instructions. */
 
     /* exception return code  - return to task-mode process stack pointer */
     stk--;
@@ -359,7 +360,7 @@ void __attribute__((naked)) __attribute__((used)) isr_pendsv(void) {
                                            * causes end of exception*/
 #else /* CPU_CORE_CORTEXM_FULL_THUMB */
 
-    /* Cortex-M0(+) and Cortex-M23 */
+    /* Cortex-M0, Cortex-M0+ and Cortex-M23 */
     "cmp    r0, r12                   \n" /* if r0 == previous_thread: */
     "bne    cont_schedule             \n" /*   jump over pop if r0 != 0 */
     "pop    {pc}                      \n" /*   Pop exception return to PC */

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -437,8 +437,9 @@ void hard_fault_default(void)
 
 #endif /* DEVELHELP */
 
-#if defined(CPU_CORE_CORTEX_M3) || defined(CPU_CORE_CORTEX_M4) || \
-    defined(CPU_CORE_CORTEX_M4F) || defined(CPU_CORE_CORTEX_M7)
+#if defined(CPU_CORE_CORTEX_M3) || defined(CPU_CORE_CORTEX_M33) || \
+    defined(CPU_CORE_CORTEX_M4) || defined(CPU_CORE_CORTEX_M4F) || \
+    defined(CPU_CORE_CORTEX_M7)
 void mem_manage_default(void)
 {
     core_panic(PANIC_MEM_MANAGE, "MEM MANAGE HANDLER");
@@ -503,9 +504,10 @@ ISR_VECTOR(0) const cortexm_base_t cortex_vector_base = {
         [9] = (isr_t)(CORTEXM_VECTOR_RESERVED_0X28),
         #endif  /* CORTEXM_VECTOR_RESERVED_0X28 */
 
-        /* additional vectors used by M3, M4(F), and M7 */
-#if defined(CPU_CORE_CORTEX_M3) || defined(CPU_CORE_CORTEX_M4) || \
-    defined(CPU_CORE_CORTEX_M4F) || defined(CPU_CORE_CORTEX_M7)
+        /* additional vectors used by M3, M33, M4(F), and M7 */
+#if defined(CPU_CORE_CORTEX_M3) || defined(CPU_CORE_CORTEX_M33) || \
+    defined(CPU_CORE_CORTEX_M4) || defined(CPU_CORE_CORTEX_M4F) || \
+    defined(CPU_CORE_CORTEX_M7)
         /* [-12] memory manage exception */
         [ 3] = mem_manage_default,
         /* [-11] bus fault exception */

--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -85,16 +85,18 @@ ifneq (,$(filter cmsis-dsp,$(USEPKG)))
     CFLAGS += -DARM_MATH_CM0
   else ifeq ($(CPU_CORE),cortex-m0plus)
     CFLAGS += -DARM_MATH_CM0PLUS
+  else ifeq ($(CPU_CORE),cortex-m23)
+    CFLAGS += -DARM_MATH_CM23
   else ifeq ($(CPU_CORE),cortex-m3)
     CFLAGS += -DARM_MATH_CM3
+  else ifeq ($(CPU_CORE),cortex-m33)
+    CFLAGS += -DARM_MATH_CM33
   else ifeq ($(CPU_CORE),cortex-m4)
     CFLAGS += -DARM_MATH_CM4
   else ifeq ($(CPU_CORE),cortex-m4f)
     CFLAGS += -DARM_MATH_CM4
   else ifeq ($(CPU_CORE),cortex-m7)
     CFLAGS += -DARM_MATH_CM7
-  else ifeq ($(CPU_CORE),cortex-m23)
-    CFLAGS += -DARM_MATH_CM23
   endif
 endif
 

--- a/tests/pkg_cmsis-nn/Makefile
+++ b/tests/pkg_cmsis-nn/Makefile
@@ -6,8 +6,9 @@ USEPKG += cmsis-nn
 BLOBS += input
 
 # Boards that were tested and are known to work
-# This package only works with Cortex M3, M4 and M7 CPUs but there's no easy
-# way provided by the build system to filter them at that level
+#
+# This package only works with Cortex M23, M3, M33, M4 and M7 CPUs, but there
+# is no easy way provided by the build system to filter them at that level
 # (cpu_core_cortexm is the only feature available) for the moment.
 BOARD_WHITELIST := \
   b-l475e-iot01a \


### PR DESCRIPTION
### Contribution description
For upcoming support for a new EFM32 board (the [SLTB010A](https://www.silabs.com/products/development-tools/thunderboard/thunderboard-bg22-kit)), I need support for the Cortex-M33.

I think the Cortex-M33 is quite similar to the M4F, but with additional security features. This PR simply adds basic support, but doesn't enable the MPU or any other advanced features.

So far I have been able to compile and flash the SLTB010A, although I haven't got meaningful output (but that is probably related to EFM32 code). I was able to start a debug session and see that it was running 'just fine'.

My goal is to have this PR open already, to get feedback and things to improve, before I open a PR for that new board.

### Testing procedure
Currently none.

### Issues/PRs references
None