### PR TITLE
core/byteorder: add uint32 from/to buffer funcs

### DIFF
--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -238,6 +238,19 @@ static inline uint64_t byteorder_swapll(uint64_t v);
 static inline uint16_t byteorder_bebuftohs(const uint8_t *buf);
 
 /**
+ * @brief           Read a big endian encoded unsigned integer from a buffer
+ *                  into host byte order encoded variable, 32-bit
+ *
+ * @note            This function is agnostic to the alignment of the target
+ *                  value in the given buffer
+ *
+ * @param[in] buf   position in a buffer holding the target value
+ *
+ * @return          32-bit unsigned integer in host byte order
+ */
+static inline uint32_t byteorder_bebuftohl(const uint8_t *buf);
+
+/**
  * @brief           Write a host byte order encoded unsigned integer as big
  *                  endian encoded value into a buffer, 16-bit
  *
@@ -248,6 +261,18 @@ static inline uint16_t byteorder_bebuftohs(const uint8_t *buf);
  * @param[in]  val  value written to the buffer, in host byte order
  */
 static inline void byteorder_htobebufs(uint8_t *buf, uint16_t val);
+
+/**
+ * @brief           Write a host byte order encoded unsigned integer as big
+ *                  endian encoded value into a buffer, 32-bit
+ *
+ * @note            This function is alignment agnostic and works with any given
+ *                  memory location of the buffer
+ *
+ * @param[out] buf  target buffer, must be able to accept 4 bytes
+ * @param[in]  val  value written to the buffer, in host byte order
+ */
+static inline void byteorder_htobebufl(uint8_t *buf, uint32_t val);
 
 /**
  * @brief          Convert from host byte order to network byte order, 16 bit.
@@ -460,10 +485,26 @@ static inline uint16_t byteorder_bebuftohs(const uint8_t *buf)
     return (uint16_t)((buf[0] << 8) | (buf[1] << 0));
 }
 
+static inline uint32_t byteorder_bebuftohl(const uint8_t *buf)
+{
+    return (((uint32_t) buf[0] << 24)
+          | ((uint32_t) buf[1] << 16)
+          | ((uint32_t) buf[2] << 8)
+          | ((uint32_t) buf[3] << 0));
+}
+
 static inline void byteorder_htobebufs(uint8_t *buf, uint16_t val)
 {
     buf[0] = (uint8_t)(val >> 8);
     buf[1] = (uint8_t)(val >> 0);
+}
+
+static inline void byteorder_htobebufl(uint8_t *buf, uint32_t val)
+{
+    buf[0] = (uint8_t)(val >> 24);
+    buf[1] = (uint8_t)(val >> 16);
+    buf[2] = (uint8_t)(val >> 8);
+    buf[3] = (uint8_t)(val >> 0);
 }
 
 #ifdef __cplusplus

--- a/tests/unittests/tests-core/tests-core-byteorder.c
+++ b/tests/unittests/tests-core/tests-core-byteorder.c
@@ -88,6 +88,14 @@ static void test_byteorder_bebuftohs(void)
     TEST_ASSERT_EQUAL_INT(host, byteorder_bebuftohs(bebuf));
 }
 
+static void test_byteorder_bebuftohl(void)
+{
+    static const uint8_t bebuf[4] = { 0xAA, 0xBB, 0xCC, 0xDD};
+    static const uint32_t host = 0xAABBCCDD;
+
+    TEST_ASSERT_EQUAL_INT(host, byteorder_bebuftohl(bebuf));
+}
+
 static void test_byteorder_htobebufs(void)
 {
     static const uint8_t bebuf[2] = { 0xAA, 0xBB };
@@ -96,6 +104,18 @@ static void test_byteorder_htobebufs(void)
     uint8_t tmp[2] = {0};
 
     byteorder_htobebufs(tmp, host);
+
+    TEST_ASSERT_EQUAL_INT(0, memcmp(bebuf, tmp, sizeof(tmp)));
+}
+
+static void test_byteorder_htobebufl(void)
+{
+    static const uint8_t bebuf[4] = { 0xAA, 0xBB, 0xCC, 0xDD};
+    static const uint32_t host = 0xAABBCCDD;
+
+    uint8_t tmp[4] = {0};
+
+    byteorder_htobebufl(tmp, host);
 
     TEST_ASSERT_EQUAL_INT(0, memcmp(bebuf, tmp, sizeof(tmp)));
 }
@@ -114,6 +134,8 @@ Test *tests_core_byteorder_tests(void)
         new_TestFixture(test_byteorder_host_to_network_64),
         new_TestFixture(test_byteorder_bebuftohs),
         new_TestFixture(test_byteorder_htobebufs),
+        new_TestFixture(test_byteorder_bebuftohl),
+        new_TestFixture(test_byteorder_htobebufl),
     };
 
     EMB_UNIT_TESTCALLER(core_byteorder_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds functions to convert between 32 bit big endian buffer and a host uint32_t value.
Requested in #14058 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run `make -C tests/unittests/tests-core`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#14058 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
