### PR TITLE
pkg/lwip: fixes the netif handling for the atwinc15x0 driver

### DIFF
--- a/boards/arduino-mkr1000/Makefile.dep
+++ b/boards/arduino-mkr1000/Makefile.dep
@@ -1,6 +1,6 @@
 USEMODULE += boards_common_arduino-mkr
 
-ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += atwinc15x0
 endif
 

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -210,19 +210,11 @@ void lwip_bootstrap(void)
 #elif defined(MODULE_ATWINC15X0)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         atwinc15x0_setup(&atwinc15x0_devs[i], &atwinc15x0_params[i]);
-#ifdef MODULE_LWIP_IPV4
-        if (netif_add(&netif[0], IP4_ADDR_ANY, IP4_ADDR_ANY, IP4_ADDR_ANY,
-            &atwinc15x0_devs[i], lwip_netdev_init, tcpip_input) == NULL) {
+        if (_netif_add(&netif[0], &atwinc15x0_devs[i], lwip_netdev_init,
+                       tcpip_input) == NULL) {
             DEBUG("Could not add atwinc15x0 device\n");
             return;
         }
-#else /* MODULE_LWIP_IPV4 */
-        if (netif_add(&netif[0], &atwinc15x0_devs[i], lwip_netdev_init,
-            tcpip_input) == NULL) {
-            DEBUG("Could not add atwinc15x0 device\n");
-            return;
-        }
-#endif /* MODULE_LWIP_IPV4 */
     }
 #elif defined(MODULE_ENC28J60)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {


### PR DESCRIPTION
### Contribution description

With PR #14349 the double stack mode for lwIP was enabled. The ATWINC15x0 driver was provided before the changes in PR #14349 but merged after that. Therefore, the changes for the driver were not taken into account and have to be applied accordingly.

### Testing procedure

Compilation of `tests/lwip` in dual stack mode should succeed.
```
LWIP_IPV4=1 LWIP_IPV6=1 USEMODULE=feather-m0-wifi CFLAGS='-DWIFI_SSID=\"ssid\" -DWIFI_PASS=\"pass\"' \
make BOARD=feather-m0 -C tests/lwip flash
```
If you have the hardware at hand, you can test it with command `ifconfig`.

### Issues/PRs references

Changes for PR #14349 