### PR TITLE
cpu/esp: add feature arch_esp for all Espressif SoCs

### DIFF
--- a/cpu/esp_common/Makefile.features
+++ b/cpu/esp_common/Makefile.features
@@ -1,6 +1,7 @@
 # MCU defined features that are provided independent on board definitions
 
 FEATURES_PROVIDED += arch_32bit
+FEATURES_PROVIDED += arch_esp
 FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_hwrng


### PR DESCRIPTION
### Contribution description

This PR is a very small change which introduces feature `arch_esp` for Espressif SoCs.

There are features that can be used with both ESP32 and ESP8266, for example the `esp_wifi` module. In order to be able to test for any ESP SoC, the feature 'arch_esp' is introduced.With this feature it is possible to define dependencies like
```
ifneq (,$(filter arch_esp,$(FEATURES_USED)))
  USEMODULE += esp_wifi
endif
```

### Testing procedure

Use commands
```
make BOARD=esp32-wroom-32 -C tests/thread_basic info-debug-variable-FEATURES_USED | grep arch
make BOARD=esp8266-esp-12x -C tests/thread_basic info-debug-variable-FEATURES_USED | grep arch
```
and check for the `arch_esp` feature.

### Issues/PRs references

Required for PR #12647.