### PR TITLE
cpu/kinetis/periph_gpio_irq: fix re-enabling an existing interrupt

### DIFF
--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -787,6 +787,10 @@ typedef struct {
 /**
  * @brief   CPU internal function for initializing PORTs
  *
+ * Sets the pin's PORT.PCR to the specified value, excluding PCR.IRQC
+ * which is not allowed to be set with this function. If pcr has GPIO_AF_ANALOG
+ * then PCR.IRQC will be cleared, as interrupts do not work in analog mode.
+ *
  * @param[in] pin       pin to initialize
  * @param[in] pcr       value for the PORT's PCR register
  */

--- a/cpu/kinetis/periph/gpio.c
+++ b/cpu/kinetis/periph/gpio.c
@@ -86,10 +86,9 @@
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
 /**
- * @brief   Calculate the needed memory (in byte) needed to save 4 bits per MCU
- *          pin
+ * @brief   Calculate the needed memory (in bytes) to store 4 bits per MCU pin
  */
-#define ISR_MAP_SIZE        (GPIO_PORTS_NUMOF * PINS_PER_PORT * 4 / 8)
+#define ISR_MAP_SIZE (GPIO_PORTS_NUMOF * PINS_PER_PORT * 4 / 8 / sizeof(uint32_t))
 
 /**
  * @brief   Define the number of simultaneously configurable interrupt channels


### PR DESCRIPTION

### Contribution description
This PR has 3 related bugfixes that I've split out of #11789. In that PR, the UART implementation is modified to use GPIO interrupts to wake from low power. It fails to work after the first received character without these fixes. IIRC disabling and re-enabling a GPIO interrupt always triggers these bugs.


### Testing procedure
* configure a pin interrupt and test that it works
* disable the interrupt and re-enable it
* test that the pin interrupt still works
* without this PR, the pin interrupt has stopped working until reset

### Issues/PRs references
This PR is needed for #14377 to work properly.
