### PR TITLE
cpu/kinetis: implement Low-Leakage Wakeup Unit and add support to UART

### DIFF
--- a/boards/common/kw41z/include/periph_conf_common.h
+++ b/boards/common/kw41z/include/periph_conf_common.h
@@ -118,8 +118,10 @@ static const uart_conf_t uart_config[] = {
 };
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 #define LPUART_0_ISR        isr_lpuart0
-/* Use MCGIRCLK (internal reference 4 MHz clock) */
-#define LPUART_0_SRC        3
+/* Use MCGIRCLK (4 MHz internal reference - not available <= KINETIS_PM_LLS) */
+#define LPUART_0_SRC                    3
+#define UART_CLOCK_PM_BLOCKER           KINETIS_PM_LLS
+#define UART_MAX_UNCLOCKED_BAUDRATE     19200ul
 /** @} */
 
 /**

--- a/boards/openlabs-kw41z-mini/include/periph_conf.h
+++ b/boards/openlabs-kw41z-mini/include/periph_conf.h
@@ -142,9 +142,6 @@ static const uart_conf_t uart_config[] = {
         .scgc_bit = SIM_SCGC5_LPUART0_SHIFT,
         .mode   = UART_MODE_8N1,
         .type   = KINETIS_LPUART,
-#ifdef MODULE_PERIPH_LLWU /* TODO remove ifdef after #11789 is merged */
-        .llwu_rx = LLWU_WAKEUP_PIN_PTC6,
-#endif
     },
 };
 #define UART_NUMOF          ARRAY_SIZE(uart_config)

--- a/cpu/kinetis/Makefile.dep
+++ b/cpu/kinetis/Makefile.dep
@@ -22,3 +22,6 @@ USEMODULE += periph_wdog
 USEMODULE += pm_layered
 
 include $(RIOTCPU)/cortexm_common/Makefile.dep
+ifneq (,$(filter periph_uart,$(USEMODULE)))
+  FEATURES_OPTIONAL += periph_gpio_irq
+endif

--- a/cpu/kinetis/Makefile.dep
+++ b/cpu/kinetis/Makefile.dep
@@ -17,6 +17,7 @@ else ifneq (,$(filter periph_mcg,$(FEATURES_USED)))
   USEMODULE += periph_mcg
 endif
 
+USEMODULE += periph_llwu
 USEMODULE += periph_wdog
 USEMODULE += pm_layered
 

--- a/cpu/kinetis/Makefile.features
+++ b/cpu/kinetis/Makefile.features
@@ -10,6 +10,7 @@ ifneq (,$(filter-out $(_KINETIS_CPU_MODELS_WITHOUT_HWRNG),$(CPU_MODEL)))
   FEATURES_PROVIDED += periph_hwrng
 endif
 
+FEATURES_PROVIDED += periph_llwu
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_gpio_irq
 

--- a/cpu/kinetis/cpu.c
+++ b/cpu/kinetis/cpu.c
@@ -23,6 +23,11 @@
 #ifdef MODULE_PERIPH_MCG
 #include "mcg.h"
 #endif
+#if defined(MODULE_PERIPH_LLWU)
+#include "llwu.h"
+#elif defined(MODULE_PM_LAYERED)
+#include "pm_layered.h"
+#endif
 
 /**
  * @brief Initialize the CPU, set IRQ priorities
@@ -45,6 +50,15 @@ void cpu_init(void)
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
     stdio_init();
+
+#if defined(MODULE_PERIPH_LLWU)
+    /* initialize the LLWU module for sleep/wakeup management */
+    llwu_init();
+#elif defined(MODULE_PM_LAYERED)
+    /* Block LLS mode since we are not using the LLWU module, which is required
+     * to be able to wake up from LLS */
+    pm_block(KINETIS_PM_LLS);
+#endif
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/kinetis/include/cpu_conf_kinetis.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis.h
@@ -62,6 +62,145 @@ extern "C"
 /** @} */
 
 /**
+ * @brief Mapping internal module interrupts to LLWU wake up sources
+ *
+ * @note Modules not listed here CAN NOT be used to wake the CPU from LLS or
+ * VLLSx power modes.
+ *
+ * The numbers are hardware specific, but have the same values across all the
+ * supported Kinetis CPUs
+ */
+typedef enum llwu_wakeup_module {
+    LLWU_WAKEUP_MODULE_LPTMR0      = 0,
+    LLWU_WAKEUP_MODULE_CMP0        = 1,
+    LLWU_WAKEUP_MODULE_RADIO       = 2, /* KWx1Z devices */
+    LLWU_WAKEUP_MODULE_CMP1        = 2, /* others */
+    LLWU_WAKEUP_MODULE_DCDC        = 3, /* KWx1Z devices */
+    LLWU_WAKEUP_MODULE_CMP2        = 3, /* others */
+    LLWU_WAKEUP_MODULE_TSI         = 4,
+    LLWU_WAKEUP_MODULE_RTC_ALARM   = 5,
+    LLWU_WAKEUP_MODULE_RESERVED    = 6,
+    LLWU_WAKEUP_MODULE_RTC_SECONDS = 7,
+    LLWU_WAKEUP_MODULE_NUMOF
+} llwu_wakeup_module_t;
+
+/**
+ * @brief   Mapping LLWU wakeup pin sources to PORT interrupt numbers
+ */
+typedef struct {
+    PORT_Type *port; /**< PORT register */
+    uint32_t isfr_mask; /**< ISFR bitmask */
+} llwu_wakeup_pin_to_port_t;
+
+/**
+ * @brief   Mapping physical pins to LLWU wakeup pin source numbers
+ *
+ * @note Pins not listed here CAN NOT be used to wake the CPU from LLS or
+ * VLLSx power modes.
+ *
+ * The numbers are hardware specific, but have the same values across all the
+ * supported Kinetis CPUs.
+ */
+#if defined(KINETIS_SERIES_W) && defined(KINETIS_CORE_Z) && (KINETIS_SUBFAMILY == 1)
+/* KW41Z has different LLWU pins */
+typedef enum llwu_wakeup_pin {
+    LLWU_WAKEUP_PIN_PTC16 =  0,
+    LLWU_WAKEUP_PIN_PTC17 =  1,
+    LLWU_WAKEUP_PIN_PTC18 =  2,
+    LLWU_WAKEUP_PIN_PTC19 =  3,
+    LLWU_WAKEUP_PIN_PTA16 =  4,
+    LLWU_WAKEUP_PIN_PTA17 =  5,
+    LLWU_WAKEUP_PIN_PTA18 =  6,
+    LLWU_WAKEUP_PIN_PTA19 =  7,
+    LLWU_WAKEUP_PIN_PTB0  =  8,
+    LLWU_WAKEUP_PIN_PTC0  =  9,
+    LLWU_WAKEUP_PIN_PTC2  = 10,
+    LLWU_WAKEUP_PIN_PTC3  = 11,
+    LLWU_WAKEUP_PIN_PTC4  = 12,
+    LLWU_WAKEUP_PIN_PTC5  = 13,
+    LLWU_WAKEUP_PIN_PTC6  = 14,
+    LLWU_WAKEUP_PIN_PTC7  = 15,
+    LLWU_WAKEUP_PIN_NUMOF,
+    LLWU_WAKEUP_PIN_UNDEF
+} llwu_wakeup_pin_t;
+
+/**
+ * @brief   Mapping LLWU wakeup pin number to PORT module interrupt flags
+ */
+static const llwu_wakeup_pin_to_port_t llwu_wakeup_pin_to_port[LLWU_WAKEUP_PIN_NUMOF] = {
+    [LLWU_WAKEUP_PIN_PTC16] = { .port = PORTC, .isfr_mask = (1u << 16), },
+    [LLWU_WAKEUP_PIN_PTC17] = { .port = PORTC, .isfr_mask = (1u << 17), },
+    [LLWU_WAKEUP_PIN_PTC18] = { .port = PORTC, .isfr_mask = (1u << 18), },
+    [LLWU_WAKEUP_PIN_PTC19] = { .port = PORTC, .isfr_mask = (1u << 19), },
+    [LLWU_WAKEUP_PIN_PTA16] = { .port = PORTA, .isfr_mask = (1u << 16), },
+    [LLWU_WAKEUP_PIN_PTA17] = { .port = PORTA, .isfr_mask = (1u << 17), },
+    [LLWU_WAKEUP_PIN_PTA18] = { .port = PORTA, .isfr_mask = (1u << 18), },
+    [LLWU_WAKEUP_PIN_PTA19] = { .port = PORTA, .isfr_mask = (1u << 19), },
+    [LLWU_WAKEUP_PIN_PTB0 ] = { .port = PORTB, .isfr_mask = (1u <<  0), },
+    [LLWU_WAKEUP_PIN_PTC0 ] = { .port = PORTC, .isfr_mask = (1u <<  0), },
+    [LLWU_WAKEUP_PIN_PTC2 ] = { .port = PORTC, .isfr_mask = (1u <<  2), },
+    [LLWU_WAKEUP_PIN_PTC3 ] = { .port = PORTC, .isfr_mask = (1u <<  3), },
+    [LLWU_WAKEUP_PIN_PTC4 ] = { .port = PORTC, .isfr_mask = (1u <<  4), },
+    [LLWU_WAKEUP_PIN_PTC5 ] = { .port = PORTC, .isfr_mask = (1u <<  5), },
+    [LLWU_WAKEUP_PIN_PTC6 ] = { .port = PORTC, .isfr_mask = (1u <<  6), },
+    [LLWU_WAKEUP_PIN_PTC7 ] = { .port = PORTC, .isfr_mask = (1u <<  7), },
+};
+#else
+typedef enum llwu_wakeup_pin {
+    LLWU_WAKEUP_PIN_PTE1  =  0,
+    LLWU_WAKEUP_PIN_PTE2  =  1,
+    LLWU_WAKEUP_PIN_PTE4  =  2,
+    LLWU_WAKEUP_PIN_PTA4  =  3,
+    LLWU_WAKEUP_PIN_PTA13 =  4,
+    LLWU_WAKEUP_PIN_PTB0  =  5,
+    LLWU_WAKEUP_PIN_PTC1  =  6,
+    LLWU_WAKEUP_PIN_PTC3  =  7,
+    LLWU_WAKEUP_PIN_PTC4  =  8,
+    LLWU_WAKEUP_PIN_PTC5  =  9,
+    LLWU_WAKEUP_PIN_PTC6  = 10,
+    LLWU_WAKEUP_PIN_PTC11 = 11,
+    LLWU_WAKEUP_PIN_PTD0  = 12,
+    LLWU_WAKEUP_PIN_PTD2  = 13,
+    LLWU_WAKEUP_PIN_PTD4  = 14,
+    LLWU_WAKEUP_PIN_PTD6  = 15,
+    LLWU_WAKEUP_PIN_NUMOF,
+    LLWU_WAKEUP_PIN_UNDEF
+} llwu_wakeup_pin_t;
+
+/**
+ * @brief   Mapping LLWU wakeup pin number to PORT module interrupt flags
+ */
+static const llwu_wakeup_pin_to_port_t llwu_wakeup_pin_to_port[LLWU_WAKEUP_PIN_NUMOF] = {
+    [LLWU_WAKEUP_PIN_PTE1 ] = { .port = PORTE, .isfr_mask = (1u <<  1), },
+    [LLWU_WAKEUP_PIN_PTE2 ] = { .port = PORTE, .isfr_mask = (1u <<  2), },
+    [LLWU_WAKEUP_PIN_PTE4 ] = { .port = PORTE, .isfr_mask = (1u <<  4), },
+    [LLWU_WAKEUP_PIN_PTA4 ] = { .port = PORTA, .isfr_mask = (1u <<  4), },
+    [LLWU_WAKEUP_PIN_PTA13] = { .port = PORTA, .isfr_mask = (1u << 13), },
+    [LLWU_WAKEUP_PIN_PTB0 ] = { .port = PORTB, .isfr_mask = (1u <<  0), },
+    [LLWU_WAKEUP_PIN_PTC1 ] = { .port = PORTC, .isfr_mask = (1u <<  1), },
+    [LLWU_WAKEUP_PIN_PTC3 ] = { .port = PORTC, .isfr_mask = (1u <<  3), },
+    [LLWU_WAKEUP_PIN_PTC4 ] = { .port = PORTC, .isfr_mask = (1u <<  4), },
+    [LLWU_WAKEUP_PIN_PTC5 ] = { .port = PORTC, .isfr_mask = (1u <<  5), },
+    [LLWU_WAKEUP_PIN_PTC6 ] = { .port = PORTC, .isfr_mask = (1u <<  6), },
+    [LLWU_WAKEUP_PIN_PTC11] = { .port = PORTC, .isfr_mask = (1u << 11), },
+    [LLWU_WAKEUP_PIN_PTD0 ] = { .port = PORTD, .isfr_mask = (1u <<  0), },
+    [LLWU_WAKEUP_PIN_PTD2 ] = { .port = PORTD, .isfr_mask = (1u <<  2), },
+    [LLWU_WAKEUP_PIN_PTD4 ] = { .port = PORTD, .isfr_mask = (1u <<  4), },
+    [LLWU_WAKEUP_PIN_PTD6 ] = { .port = PORTD, .isfr_mask = (1u <<  6), },
+};
+#endif
+
+/**
+ * @brief   LLWU wakeup pin edge settings
+ */
+typedef enum llwu_wakeup_edge {
+    LLWU_WAKEUP_EDGE_NONE = 0,
+    LLWU_WAKEUP_EDGE_RISING = 1,
+    LLWU_WAKEUP_EDGE_FALLING = 2,
+    LLWU_WAKEUP_EDGE_BOTH = 3,
+} llwu_wakeup_edge_t;
+
+/**
  * @name Compatibility definitions between vendor headers
  * @{
  */

--- a/cpu/kinetis/include/llwu.h
+++ b/cpu/kinetis/include/llwu.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2017 SKF AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    cpu_kinetis_llwu Kinetis LLWU
+ * @ingroup     cpu_kinetis
+ * @brief       Kinetis low leakage wakeup unit (LLWU) driver
+
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the Kinetis LLWU driver.
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ */
+
+#ifndef LLWU_H
+#define LLWU_H
+
+#include "cpu.h"
+#include "bit.h"
+#include "periph_conf.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @brief Initialize the Low-Leakage Wake Up (LLWU) hardware module
+ */
+void llwu_init(void);
+
+/**
+ * @brief Enable a wakeup module in the LLWU
+ */
+inline static void llwu_wakeup_module_enable(llwu_wakeup_module_t mod)
+{
+    assert(mod < LLWU_WAKEUP_MODULE_NUMOF);
+    bit_set8(&LLWU->ME, mod);
+}
+
+/**
+ * @brief Disable a wakeup module in the LLWU
+ */
+inline static void llwu_wakeup_module_disable(llwu_wakeup_module_t mod)
+{
+    assert(mod < LLWU_WAKEUP_MODULE_NUMOF);
+    bit_clear8(&LLWU->ME, mod);
+}
+
+/**
+ * @brief Set the mode for a wakeup pin in the LLWU
+ *
+ * If @p cb is NULL when the pin edge is detected, the CPU will wake up for a
+ * few cycles which can allow other hardware modules to detect other interrupts.
+ * This may be particularily useful when using the wakeup pin for communication
+ * functions such as UART RX etc.
+ *
+ * @param[in]  pin  The pin to modify
+ * @param[in]  edge Edge detection setting (rising, falling, both, none)
+ * @param[in]  cb   Callback function to execute when woken with this pin
+ * @param[in]  arg  Argument that will be passed to the callback
+ */
+void llwu_wakeup_pin_set(llwu_wakeup_pin_t pin, llwu_wakeup_edge_t edge, gpio_cb_t cb, void *arg);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* LLWU_H */

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -525,6 +525,11 @@ typedef struct {
     uart_type_t type;             /**< Hardware module type (KINETIS_UART or KINETIS_LPUART)*/
 } uart_conf_t;
 
+/**
+ * @brief  Override the default uart_isr_ctx_t in uart.c
+ */
+#define HAVE_UART_ISR_CTX_T
+
 #if !defined(KINETIS_HAVE_PLL)
 #if defined(MCG_C6_PLLS_MASK) || DOXYGEN
 /**

--- a/cpu/kinetis/periph/llwu.c
+++ b/cpu/kinetis/periph/llwu.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2017 SKF AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_kinetis
+ * @{
+ *
+ * @file
+ * @brief       Low-leakage wakeup unit (LLWU) driver
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "bit.h"
+#include "llwu.h"
+#include "bitarithm.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+typedef struct {
+    gpio_cb_t cb;
+    void *arg;
+} llwu_pin_config_t;
+
+static llwu_pin_config_t llwu_pin_config[LLWU_WAKEUP_PIN_NUMOF];
+
+void llwu_init(void)
+{
+    /* Setup Low Leakage Wake-up Unit (LLWU) */
+#ifdef SIM_SCGC4_LLWU_SHIFT
+    /* Only the first generation Kinetis K CPUs have a clock gate for the LLWU,
+     * for all others the LLWU clock is always on */
+    bit_set32(&SIM->SCGC4, SIM_SCGC4_LLWU_SHIFT);   /* Enable LLWU clock gate */
+#endif
+
+    /* LLWU needs to have a priority which is equal to or more urgent than the
+     * PORT module to avoid races between the LLWU pin detect interrupt and the
+     * PORT pin detect interrupt */
+    NVIC_SetPriority(LLWU_IRQn, 0);
+}
+
+void llwu_wakeup_pin_set(llwu_wakeup_pin_t pin, llwu_wakeup_edge_t edge, gpio_cb_t cb, void *arg)
+{
+    assert(pin < LLWU_WAKEUP_PIN_NUMOF);
+    llwu_pin_config[pin].cb = cb;
+    llwu_pin_config[pin].arg = arg;
+
+    /* The fields are two bits per pin, and the setting registers are 8 bits
+     * wide, hence 4 pins per register. */
+    unsigned field_offset = (pin & 0x03) << 1;
+    unsigned reg_offset = pin >> 2;
+    (&LLWU->PE1)[reg_offset] = ((&LLWU->PE1)[reg_offset] &
+        (~(0b11 << field_offset))) |
+        (edge << field_offset);
+}
+
+void isr_llwu(void)
+{
+    DEBUG("LLWU IRQ\n");
+
+    for (unsigned reg = 0; reg < ((LLWU_WAKEUP_PIN_NUMOF + 7) / 8); ++reg) {
+        uint8_t status = *(&LLWU->F1 + reg);
+        /* Clear pin interrupt flags */
+        *(&LLWU->F1 + reg) = status;
+        DEBUG("llwu: F%u = %02x\n", reg + 1, (unsigned) status);
+
+        while (status) {
+            unsigned pin = bitarithm_lsb(status);
+            status &= ~(1 << pin);
+            pin += reg * 8;
+            DEBUG("llwu: wakeup pin %u\n", pin);
+            gpio_cb_t cb = llwu_pin_config[pin].cb;
+            if (cb) {
+                cb(llwu_pin_config[pin].arg);
+            }
+            /* Clear PORT interrupt flag to avoid spurious duplicates. */
+            /* In essence, this behavior is similar to a software debounce. Even
+             * very quick contact bounces after the LLWU has begun to wake the
+             * CPU may cause the PORT module to pick up the same trigger event,
+             * which may lead to duplicate software events when using the same
+             * callback for gpio_init_int and llwu_wakeup_pin_set. The bounces
+             * would normally be ignored because of the processing delay in the
+             * interrupt handling before the interrupt flag is cleared, but
+             * since there are two interrupt flags, one in the LLWU module and
+             * one in the PORT module, we can get two events. */
+            DEBUG("PORT ISFR: %08" PRIx32 "\n", llwu_wakeup_pin_to_port[pin].port->ISFR);
+            llwu_wakeup_pin_to_port[pin].port->ISFR = llwu_wakeup_pin_to_port[pin].isfr_mask;
+        }
+    }
+    /* Read only register F3, the flag will need to be cleared in the peripheral
+     * instead of writing a 1 to the MWUFx bit. */
+    DEBUG("llwu: F3 = %02x\n", LLWU->F3);
+    /* Mask the LLWU IRQ until the module interrupt handlers have had a chance
+     * to run and clear the F3 flags */
+    NVIC_DisableIRQ(LLWU_IRQn);
+
+    cortexm_isr_end();
+}

--- a/cpu/kinetis/periph/uart.c
+++ b/cpu/kinetis/periph/uart.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Eistec AB
+ * Copyright (C) 2017-2018 Eistec AB
  * Copyright (C) 2014 PHYTEC Messtechnik GmbH
  * Copyright (C) 2014 Freie Universität Berlin
  *
@@ -77,6 +77,25 @@
 #define LPUART_1_SRC            0
 #endif
 
+#ifndef LPUART_IDLECFG
+/* See IDLECFG in the reference manual. Longer idle configurations give more
+ * robust LPUART RX from low power modes, but will also keep the CPU awake for
+ * longer periods. */
+#define LPUART_IDLECFG      (0b001)
+#endif
+
+/* This power mode is blocked while the LP/UART clock needs to stay running */
+#ifndef UART_CLOCK_PM_BLOCKER
+#define UART_CLOCK_PM_BLOCKER           KINETIS_PM_STOP
+#endif
+
+typedef struct {
+    uart_rx_cb_t rx_cb;     /**< data received interrupt callback */
+    void *arg;              /**< argument to both callback routines */
+    unsigned active;        /**< set to 1 while the receiver is active, to avoid mismatched PM_BLOCK/PM_UNBLOCK */
+    unsigned enabled;       /**< set to 1 while the receiver is enabled, to avoid mismatched PM_BLOCK/PM_UNBLOCK */
+} uart_isr_ctx_t;
+
 /**
  * @brief Runtime configuration space, holds pointers to callback functions for RX
  */
@@ -86,9 +105,13 @@ static inline void uart_init_pins(uart_t uart);
 
 #if KINETIS_HAVE_UART
 static inline void uart_init_uart(uart_t uart, uint32_t baudrate);
+static inline void uart_poweron_uart(uart_t uart);
+static inline void uart_poweroff_uart(uart_t uart);
 #endif
 #if KINETIS_HAVE_LPUART
 static inline void uart_init_lpuart(uart_t uart, uint32_t baudrate);
+static inline void uart_poweron_lpuart(uart_t uart);
+static inline void uart_poweroff_lpuart(uart_t uart);
 #endif
 
 /* Only use the dispatch function for uart_write if both UART and LPUART are
@@ -110,14 +133,23 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 {
     assert(uart < UART_NUMOF);
 
-    /* remember callback addresses */
-    config[uart].rx_cb = rx_cb;
-    config[uart].arg = arg;
-
-    uart_init_pins(uart);
+    /* disable interrupts from UART module */
+    NVIC_DisableIRQ(uart_config[uart].irqn);
 
     /* Turn on module clock gate */
     bit_set32(uart_config[uart].scgc_addr, uart_config[uart].scgc_bit);
+
+    /* Power off before messing with settings, this will ensure a consistent
+     * state if we are re-initializing an already initialized module */
+    uart_poweroff(uart);
+
+    /* remember callback addresses */
+    config[uart].rx_cb = rx_cb;
+    config[uart].arg = arg;
+    config[uart].active = 0;
+    config[uart].enabled = 0;
+
+    uart_init_pins(uart);
 
     switch (uart_config[uart].type) {
 #if KINETIS_HAVE_UART
@@ -133,19 +165,78 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
         default:
             return UART_NODEV;
     }
+
+    /* Turn on module */
+    uart_poweron(uart);
+
+    /* enable interrupts from UART module */
+    NVIC_EnableIRQ(uart_config[uart].irqn);
+
     return UART_OK;
 }
 
 void uart_poweron(uart_t uart)
 {
-    (void)uart;
-    /* not implemented (yet) */
+    assert(uart < UART_NUMOF);
+    unsigned state = irq_disable();
+
+    if (config[uart].rx_cb && !config[uart].enabled) {
+        config[uart].enabled = 1;
+        DEBUG("uart: Blocking power mode %u\n", UART_CLOCK_PM_BLOCKER);
+        PM_BLOCK(UART_CLOCK_PM_BLOCKER);
+    }
+
+    switch (uart_config[uart].type) {
+#if KINETIS_HAVE_UART
+        case KINETIS_UART:
+            uart_poweron_uart(uart);
+            break;
+#endif
+#if KINETIS_HAVE_LPUART
+        case KINETIS_LPUART:
+            uart_poweron_lpuart(uart);
+            break;
+#endif
+        default:
+            break;
+    }
+
+    irq_restore(state);
 }
 
 void uart_poweroff(uart_t uart)
 {
-    (void)uart;
-    /* not implemented (yet) */
+    assert(uart < UART_NUMOF);
+    unsigned state = irq_disable();
+    if (config[uart].rx_cb && config[uart].enabled) {
+        config[uart].enabled = 0;
+        DEBUG("uart: Unblocking power mode %u\n", UART_CLOCK_PM_BLOCKER);
+        PM_UNBLOCK(UART_CLOCK_PM_BLOCKER);
+
+        if (config[uart].active) {
+            /* We were in the middle of a RX sequence, need to release that
+                * clock blocker as well */
+            PM_UNBLOCK(UART_CLOCK_PM_BLOCKER);
+            config[uart].active = 0;
+        }
+    }
+
+    switch (uart_config[uart].type) {
+#if KINETIS_HAVE_UART
+        case KINETIS_UART:
+            uart_poweroff_uart(uart);
+            break;
+#endif
+#if KINETIS_HAVE_LPUART
+        case KINETIS_LPUART:
+            uart_poweroff_lpuart(uart);
+            break;
+#endif
+        default:
+            break;
+    }
+
+    irq_restore(state);
 }
 
 #if KINETIS_HAVE_UART && KINETIS_HAVE_LPUART
@@ -189,7 +280,7 @@ static inline void uart_init_uart(uart_t uart, uint32_t baudrate)
     clk = uart_config[uart].freq;
 
     /* disable transmitter and receiver */
-    dev->C2 &= ~(UART_C2_TE_MASK | UART_C2_RE_MASK);
+    dev->C2 = 0;
 
     /* Select mode */
     dev->C1 = uart_config[uart].mode;
@@ -213,8 +304,8 @@ static inline void uart_init_uart(uart_t uart, uint32_t baudrate)
      * TXFIFOSIZE == 0 means size = 1 (i.e. only one byte, no hardware FIFO) */
     if ((dev->PFIFO & UART_PFIFO_TXFIFOSIZE_MASK) != 0) {
         uint8_t txfifo_size =
-        (2 << ((dev->PFIFO & UART_PFIFO_TXFIFOSIZE_MASK) >>
-        UART_PFIFO_TXFIFOSIZE_SHIFT));
+            (2 << ((dev->PFIFO & UART_PFIFO_TXFIFOSIZE_MASK) >>
+            UART_PFIFO_TXFIFOSIZE_SHIFT));
         dev->TWFIFO = UART_TWFIFO_TXWATER(txfifo_size - 1);
     }
     else {
@@ -228,15 +319,19 @@ static inline void uart_init_uart(uart_t uart, uint32_t baudrate)
     dev->CFIFO = UART_CFIFO_RXFLUSH_MASK | UART_CFIFO_TXFLUSH_MASK;
 #endif /* KINETIS_UART_ADVANCED */
 
-    /* enable transmitter and receiver + RX interrupt */
-    dev->C2 |= UART_C2_TE_MASK | UART_C2_RE_MASK | UART_C2_RIE_MASK;
-
-    /* enable receive interrupt */
-    NVIC_EnableIRQ(uart_config[uart].irqn);
+    if (config[uart].rx_cb) {
+        /* enable RX active edge interrupt */
+        bit_set8(&dev->BDH, UART_BDH_RXEDGIE_SHIFT);
+        /* enable receiver + RX interrupt + IDLE interrupt */
+        dev->C2 = UART_C2_RIE_MASK | UART_C2_ILIE_MASK;
+        /* enable interrupts on failure flags */
+        dev->C3 |= UART_C3_ORIE_MASK | UART_C3_PEIE_MASK | UART_C3_FEIE_MASK | UART_C3_NEIE_MASK;
+    }
+    /* clear interrupt flags */
+    uint8_t s = dev->S2;
+    dev->S2 = s;
 }
-#endif /* KINETIS_HAVE_UART */
 
-#if KINETIS_HAVE_UART
 KINETIS_UART_WRITE_INLINE void uart_write_uart(uart_t uart, const uint8_t *data, size_t len)
 {
     UART_Type *dev = uart_config[uart].dev;
@@ -245,6 +340,30 @@ KINETIS_UART_WRITE_INLINE void uart_write_uart(uart_t uart, const uint8_t *data,
         while (!(dev->S1 & UART_S1_TDRE_MASK)) {}
         dev->D = data[i];
     }
+    /* Wait for transmission complete */
+    while ((dev->S1 & UART_S1_TC_MASK) == 0) {}
+}
+
+static inline void uart_poweron_uart(uart_t uart)
+{
+    UART_Type *dev = uart_config[uart].dev;
+
+    /* Enable transmitter */
+    bit_set8(&dev->C2, UART_C2_TE_SHIFT);
+    if (config[uart].rx_cb) {
+        /* Enable receiver */
+        bit_set8(&dev->C2, UART_C2_RE_SHIFT);
+    }
+}
+
+static inline void uart_poweroff_uart(uart_t uart)
+{
+    UART_Type *dev = uart_config[uart].dev;
+
+    /* Disable receiver */
+    bit_clear8(&dev->C2, UART_C2_RE_SHIFT);
+    /* Disable transmitter */
+    bit_clear8(&dev->C2, UART_C2_TE_SHIFT);
 }
 
 #if defined(UART_0_ISR) || defined(UART_1_ISR) || defined(UART_2_ISR) || \
@@ -253,31 +372,64 @@ static inline void irq_handler_uart(uart_t uart)
 {
     UART_Type *dev = uart_config[uart].dev;
 
-    /*
-     * On Cortex-M0, it happens that S1 is read with LDR
-     * instruction instead of LDRB. This will read the data register
-     * at the same time and arrived byte will be lost. Maybe it's a GCC bug.
-     *
-     * Observed with: arm-none-eabi-gcc (4.8.3-8+..)
-     * It does not happen with: arm-none-eabi-gcc (4.8.3-9+11)
-     */
-
-    if (dev->S1 & UART_S1_RDRF_MASK) {
-        /* RDRF flag will be cleared when dev-D was read */
-        uint8_t data = dev->D;
-
-        if (config[uart].rx_cb != NULL) {
+    uint8_t s1 = dev->S1;
+    uint8_t s2 = dev->S2;
+    /* Clear IRQ flags */
+    dev->S2 = s2;
+    /* The IRQ flags in S1 are cleared by reading the D register */
+    uint8_t data = dev->D;
+    (void) data;
+    if (dev->SFIFO & UART_SFIFO_RXUF_MASK) {
+        /* RX FIFO underrun occurred, flush the RX FIFO to get the internal
+         * pointer back in sync */
+        dev->CFIFO |= UART_CFIFO_RXFLUSH_MASK;
+        /* Clear SFIFO flags */
+        dev->SFIFO = dev->SFIFO;
+        DEBUG("UART RXUF\n");
+    }
+    DEBUG("U: %c\n", data);
+    if (s2 & UART_S2_RXEDGIF_MASK) {
+        if (!config[uart].active) {
+            config[uart].active = 1;
+            /* Keep UART clock on until we are finished with RX */
+            DEBUG("UART ACTIVE\n");
+            PM_BLOCK(UART_CLOCK_PM_BLOCKER);
+        }
+    }
+    if (s1 & UART_S1_OR_MASK) {
+        /* UART overrun, some data has been lost */
+        DEBUG("UART OR\n");
+    }
+    if (s1 & UART_S1_RDRF_MASK) {
+        if (s1 & (UART_S1_FE_MASK | UART_S1_PF_MASK | UART_S1_NF_MASK)) {
+            if (s1 & UART_S1_FE_MASK) {
+                DEBUG("UART framing error %02x\n", (unsigned) s1);
+            }
+            if (s1 & UART_S1_PF_MASK) {
+                DEBUG("UART parity error %02x\n", (unsigned) s1);
+            }
+            if (s1 & UART_S1_NF_MASK) {
+                DEBUG("UART noise %02x\n", (unsigned) s1);
+            }
+            /* FE is set when a logic 0 is accepted as the stop bit. */
+            /* PF is set when PE is set, S2[LBKDE] is disabled, and the parity
+             * of the received data does not match its parity bit. */
+            /* NF is set when the UART detects noise on the receiver input. */
+        }
+        /* Only run callback if no error occurred */
+        else if (config[uart].rx_cb != NULL) {
             config[uart].rx_cb(config[uart].arg, data);
         }
     }
-
-#if (KINETIS_UART_ADVANCED == 0)
-    /* clear overrun flag */
-    if (dev->S1 & UART_S1_OR_MASK) {
-        dev->S1 = UART_S1_OR_MASK;
+    if (s1 & UART_S1_IDLE_MASK) {
+        if (config[uart].active) {
+            config[uart].active = 0;
+            /* UART clock can stop now that RX is complete */
+            PM_UNBLOCK(UART_CLOCK_PM_BLOCKER);
+            DEBUG("UART IDLE\n");
+        }
     }
-#endif
-
+    DEBUG("UART: s1 %x C1 %x C2 %x S1 %x S2 %x D %x SF %x\n", s1, dev->C1, dev->C2, dev->S1, dev->S2, data, dev->SFIFO);
     cortexm_isr_end();
 }
 #endif
@@ -358,14 +510,21 @@ static inline void uart_init_lpuart(uart_t uart, uint32_t baudrate)
     }
 
     uint32_t sbr = clk / (best_osr * baudrate);
-    /* set baud rate */
+    /* set baud rate, enable RX active edge interrupt */
     dev->BAUD = LPUART_BAUD_OSR(best_osr - 1) | LPUART_BAUD_SBR(sbr);
 
-    /* enable transmitter and receiver + RX interrupt */
-    dev->CTRL |= LPUART_CTRL_TE_MASK | LPUART_CTRL_RE_MASK | LPUART_CTRL_RIE_MASK;
-
-    /* enable receive interrupt */
-    NVIC_EnableIRQ(uart_config[uart].irqn);
+    if (config[uart].rx_cb) {
+        /* enable RX active edge interrupt */
+        bit_set32(&dev->BAUD, LPUART_BAUD_RXEDGIE_SHIFT);
+        /* enable RX interrupt + error interrupts */
+        dev->CTRL |= LPUART_CTRL_RIE_MASK |
+            LPUART_CTRL_ILIE_MASK | LPUART_CTRL_IDLECFG(LPUART_IDLECFG) |
+            LPUART_CTRL_ORIE_MASK | LPUART_CTRL_PEIE_MASK |
+            LPUART_CTRL_FEIE_MASK | LPUART_CTRL_NEIE_MASK;
+    }
+    /* clear interrupt flags */
+    uint32_t s = dev->STAT;
+    dev->STAT = s;
 }
 
 KINETIS_UART_WRITE_INLINE void uart_write_lpuart(uart_t uart, const uint8_t *data, size_t len)
@@ -376,6 +535,30 @@ KINETIS_UART_WRITE_INLINE void uart_write_lpuart(uart_t uart, const uint8_t *dat
         while ((dev->STAT & LPUART_STAT_TDRE_MASK) == 0) {}
         dev->DATA = data[i];
     }
+    /* Wait for transmission complete */
+    while ((dev->STAT & LPUART_STAT_TC_MASK) == 0) {}
+}
+
+static inline void uart_poweron_lpuart(uart_t uart)
+{
+    LPUART_Type *dev = uart_config[uart].dev;
+
+    /* Enable transmitter */
+    bit_set32(&dev->CTRL, LPUART_CTRL_TE_SHIFT);
+    if (config[uart].rx_cb) {
+        /* Enable receiver */
+        bit_set32(&dev->CTRL, LPUART_CTRL_RE_SHIFT);
+    }
+}
+
+static inline void uart_poweroff_lpuart(uart_t uart)
+{
+    LPUART_Type *dev = uart_config[uart].dev;
+
+    /* Disable receiver */
+    bit_clear32(&dev->CTRL, LPUART_CTRL_RE_SHIFT);
+    /* Disable transmitter */
+    bit_clear32(&dev->CTRL, LPUART_CTRL_TE_SHIFT);
 }
 
 #if defined(LPUART_0_ISR) || defined(LPUART_1_ISR) || defined(LPUART_2_ISR) || \
@@ -387,6 +570,14 @@ static inline void irq_handler_lpuart(uart_t uart)
     /* Clear all IRQ flags */
     dev->STAT = stat;
 
+    if (stat & LPUART_STAT_RXEDGIF_MASK) {
+        if (!config[uart].active) {
+            config[uart].active = 1;
+            /* Keep UART clock on until we are finished with RX */
+            DEBUG("LPUART ACTIVE\n");
+            PM_BLOCK(UART_CLOCK_PM_BLOCKER);
+        }
+    }
     if (stat & LPUART_STAT_RDRF_MASK) {
         /* RDRF flag will be cleared when LPUART_DATA is read */
         uint8_t data = dev->DATA;
@@ -412,6 +603,14 @@ static inline void irq_handler_lpuart(uart_t uart)
         /* Input buffer overflow, means that the software was too slow to
          * receive the data */
         DEBUG("LPUART overrun %08" PRIx32 "\n", stat);
+    }
+    if (stat & LPUART_STAT_IDLE_MASK) {
+        if (config[uart].active) {
+            config[uart].active = 0;
+            /* UART clock can stop now that RX is complete */
+            PM_UNBLOCK(UART_CLOCK_PM_BLOCKER);
+            DEBUG("LPUART IDLE\n");
+        }
     }
 
     cortexm_isr_end();


### PR DESCRIPTION
### Contribution description
Split out of #11789 and originally partly from #7897, this PR adds support for the Kinetis LLWU peripheral (which is used by other peripherals to wake from the lowest power mode) and adds UART support to make use of it.

This allows sleeping all the way down to the lowest power mode (~5uA) while retaining a working LEUART or even UART by waking on a pin interrupt instead of waking via the UART hardware.


### Testing procedure
Compile with `CFLAGS=-DPM_BLOCKER_INITIAL=0x0 make` to unblock all modes by default and confirm that the shell remains working.

It should remain working either (depending on the baud rate and board clock configuration) because the correct power mode has been blocked to keep the UART clocked or because it is able to wake via LLWU or GPIO interrupt, but in any case it should "automatically" remain working for any baud and board configuration.

_Currently there are bugs preventing GPIO interrupts from working properly on Kinetis. This is fixed in #14376._

_There also may be an issue with some boards working at baud rates below 115200 which appears to be reproducible on master._


### Issues/PRs references
This PR needs #14376 for GPIO interrupt bugfixes.