### PR TITLE
core/panic: launch USB bootloader on crash for easy recovery

### DIFF
--- a/core/panic.c
+++ b/core/panic.c
@@ -36,6 +36,13 @@
 #include "ps.h"
 #endif
 
+/* If a device is flashed over USB bootloader, try to launch
+ * the bootloader again on crash so the user can re-flash it.
+ */
+#if defined(DEVELHELP) && defined(MODULE_USB_BOARD_RESET)
+#include "usb_board_reset.h"
+#endif
+
 const char assert_crash_message[] = "FAILED ASSERTION.";
 
 /* flag preventing "recursive crash printing loop" */
@@ -81,8 +88,13 @@ NORETURN void core_panic(core_panic_t crash_code, const char *message)
     pm_reboot();
 #else
     /* DEVELHELP set => power off system */
+    /*               or start bootloader */
+#ifdef MODULE_USB_BOARD_RESET
+    usb_board_reset_in_bootloader();
+#else
     pm_off();
 #endif
+#endif /* DEVELHELP */
 
     /* tell the compiler that we won't return from this function
        (even if we actually won't even get here...) */


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If a board was flashed via USB bootloader, a crash means the user has to perform a procedure to manually enter the bootloader again for recovery.

To allow for easier recovery, automatically lauch the bootloader on crash if `DEVELHELP` is enabled.


### Testing procedure

I added a simple shell function to provoke a crash:

```C
static int do_crash(int argc, char **argv)
{
    (void) argc;
    (void) argv;

    for (int i = 10; i >= 0; --i) {
        printf("assert fail in %d\n", i);
        assert(i);
    }

    return 0;
}
```

On a board that is flashed over USB and that uses CDC ACM for stdio, this prints

```
2020-06-27 16:12:53,891 # assert fail in 10
2020-06-27 16:12:53,892 # assert fail in 9
2020-06-27 16:12:53,892 # assert fail in 8
2020-06-27 16:12:53,893 # assert fail in 7
2020-06-27 16:12:53,893 # assert fail in 6
2020-06-27 16:12:53,894 # assert fail in 5
2020-06-27 16:12:53,894 # assert fail in 4
2020-06-27 16:12:53,895 # assert fail in 3
2020-06-27 16:12:53,895 # assert fail in 2
2020-06-27 16:12:53,896 # assert fail in 1
2020-06-27 16:12:53,896 # assert fail in 0
2020-06-27 16:12:53,896 # 0x80023ad
2020-06-27 16:12:53,897 # *** RIOT kernel panic:
2020-06-27 16:12:53,897 # FAILED ASSERTION.
2020-06-27 16:12:53,897 # 
2020-06-27 16:12:53,899 # 	pid | name                 | state    Q | pri | stack  ( used) ( free) | base addr  | current     
2020-06-27 16:12:53,900 # 	  - | isr_stack            | -        - |   - |    512 (  160) (  352) | 0x20000000 | 0x200001c8
2020-06-27 16:12:53,902 # 	  1 | main                 | running  Q |   7 |   1536 (  724) (  812) | 0x20000510 | 0x2000083c 
2020-06-27 16:12:53,904 # 	  2 | usbus                | bl anyfl _ |   1 |   1024 (  388) (  636) | 0x20000fbc | 0x200012cc 
2020-06-27 16:12:53,973 # Serial port disconnected, waiting to get reconnected...
```

and leaves the board in bootloader mode where it can be flashed again.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
