### PR TITLE
boards: purge gnrc_netdev_default

### DIFF
--- a/boards/feather-m0/Makefile.dep
+++ b/boards/feather-m0/Makefile.dep
@@ -3,7 +3,7 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
 endif
 
 ifneq (,$(filter feather-m0-wifi,$(USEMODULE)))
-  ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+  ifneq (,$(filter netdev_default,$(USEMODULE)))
     USEMODULE += atwinc15x0
   endif
 endif

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -69,7 +69,7 @@ endif
 LINKFLAGS += -ffunction-sections
 
 # set the tap interface for term/valgrind
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   PORT ?= tap0
 endif
 


### PR DESCRIPTION
### Contribution description

`gnrc_netdev_default` will pull in `netdev_default`, so no need to check for both here.


### Testing procedure

The default network device should still be selected with `gnrc_netdev_default`, that is the binary should not change.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
