### PR TITLE
tools/flatc: don't clone flatbuffers in the global pkg dir

### DIFF
--- a/dist/tools/flatc/Makefile
+++ b/dist/tools/flatc/Makefile
@@ -6,8 +6,8 @@ PKG_LICENSE=Apache2.0
 # manually set some RIOT env vars, so this Makefile can be called stand-alone
 RIOTBASE ?= $(CURDIR)/../../..
 RIOTTOOLS ?= $(CURDIR)/..
-PKGDIRBASE ?= $(RIOTBASE)/build/pkg
-PKG_BUILD_DIR ?= $(CURDIR)/bin
+PKG_SOURCE_DIR ?= $(CURDIR)/bin
+PKG_BUILD_DIR ?= $(CURDIR)/bin/build
 
 CMAKE_OPTIONS = \
     -DCMAKE_BUILD_TYPE=Release       \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes #14380 by cloning the sources used to build the tool in the `$(RIOTTOOLS)/flatc/bin` directory. This avoids concurrency issues when building with `make -j` (which is used by Murdock): the source for the tool and the package are cloned at the same time, which leads to issues with git trying to clone the same repo in the same location.

The build directory of flatc is now in `$(RIOTTOOLS)/flatc/bin/build` to keep out-of-source build.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- No more issues related to flatc on Murdock
- Build `tests/pkg_flatbuffers` locally with `-j`, no error message should be displayed:

<details><summary>this PR</summary>

```
$ rm -rf build/pkg/flatbuffers && rm -rf tests/pkg_flatbuffers/bin/ && rm -rf tests/pkg_flatbuffers/monster_generated.h && make -C dist/tools/flatc/ distclean && make -j -C tests/pkg_flatbuffers --no-print-directory
make: Entering directory '/work/riot/RIOT/dist/tools/flatc'
rm -rf /work/riot/RIOT/dist/tools/flatc/bin/build
rm -rf /work/riot/RIOT/dist/tools/flatc/bin
make: Leaving directory '/work/riot/RIOT/dist/tools/flatc'
Building application "tests_pkg_flatbuffers" for "native" with MCU "native".
[INFO] flatc binary not found - building it from source now
make -C /work/riot/RIOT/dist/tools/flatc

[INFO] cloning flatbuffers
[INFO] cloning flatbuffers
Cloning into '/work/riot/RIOT/dist/tools/flatc/bin'...
Cloning into '/work/riot/RIOT/build/pkg/flatbuffers'...
remote: Enumerating objects: 6, done.
remote: Counting objects: 100% (6/6), done.
remote: Compressing objects: 100% (6/6), done.
remote: Enumerating objects: 6, done.
remote: Counting objects: 100% (6/6), done.
remote: Compressing objects: 100% (6/6), done.
remote: Total 17894 (delta 1), reused 3 (delta 0), pack-reused 17888
Receiving objects: 100% (17894/17894), 10.67 MiB | 538.00 KiB/s, done.
Resolving deltas: 100% (12418/12418), done. MiB | 556.00 KiB/s
HEAD is now at 9e7e8cbe Bumped version to 1.11.0| 566.00 KiB/s
[INFO] updating flatbuffers /work/riot/RIOT/build/pkg/flatbuffers/.pkg-state.git-downloaded
echo v1.11.0 > /work/riot/RIOT/build/pkg/flatbuffers/.pkg-state.git-downloaded
[INFO] patch flatbuffers
remote: Total 17894 (delta 1), reused 3 (delta 0), pack-reused 17888
Receiving objects: 100% (17894/17894), 10.67 MiB | 481.00 KiB/s, done.
Resolving deltas: 100% (12417/12417), done.
HEAD is now at 9e7e8cbe Bumped version to 1.11.0
[INFO] updating flatbuffers /work/riot/RIOT/dist/tools/flatc/bin/.pkg-state.git-downloaded
echo 9e7e8cbe9f675123dd41b7c62868acad39188cae > /work/riot/RIOT/dist/tools/flatc/bin/.pkg-state.git-downloaded
[INFO] patch flatbuffers
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Looking for strtof_l
-- Looking for strtof_l - found
-- Configuring done
-- Generating done
-- Build files have been written to: /work/riot/RIOT/dist/tools/flatc/bin/build
"make" -C "/work/riot/RIOT/dist/tools/flatc/bin/build"
Scanning dependencies of target flatc
[  4%] Building CXX object CMakeFiles/flatc.dir/src/idl_parser.cpp.o
[ 12%] Building CXX object CMakeFiles/flatc.dir/src/idl_gen_text.cpp.o
[ 12%] Building CXX object CMakeFiles/flatc.dir/src/util.cpp.o
[ 16%] Building CXX object CMakeFiles/flatc.dir/src/idl_gen_cpp.cpp.o
[ 20%] Building CXX object CMakeFiles/flatc.dir/src/idl_gen_general.cpp.o
[ 25%] Building CXX object CMakeFiles/flatc.dir/src/reflection.cpp.o
[ 29%] Building CXX object CMakeFiles/flatc.dir/src/idl_gen_dart.cpp.o
[ 33%] Building CXX object CMakeFiles/flatc.dir/src/code_generators.cpp.o
[ 37%] Building CXX object CMakeFiles/flatc.dir/src/idl_gen_go.cpp.o
[ 41%] Building CXX object CMakeFiles/flatc.dir/src/idl_gen_js_ts.cpp.o
[ 45%] Building CXX object CMakeFiles/flatc.dir/src/idl_gen_php.cpp.o
[ 50%] Building CXX object CMakeFiles/flatc.dir/src/idl_gen_python.cpp.o
[ 54%] Building CXX object CMakeFiles/flatc.dir/src/idl_gen_lobster.cpp.o
[ 58%] Building CXX object CMakeFiles/flatc.dir/src/idl_gen_lua.cpp.o
[ 62%] Building CXX object CMakeFiles/flatc.dir/src/idl_gen_rust.cpp.o
[ 66%] Building CXX object CMakeFiles/flatc.dir/src/idl_gen_fbs.cpp.o
[ 70%] Building CXX object CMakeFiles/flatc.dir/src/idl_gen_grpc.cpp.o
[ 75%] Building CXX object CMakeFiles/flatc.dir/src/idl_gen_json_schema.cpp.o
[ 79%] Building CXX object CMakeFiles/flatc.dir/src/flatc.cpp.o
[ 83%] Building CXX object CMakeFiles/flatc.dir/src/flatc_main.cpp.o
[ 87%] Building CXX object CMakeFiles/flatc.dir/grpc/src/compiler/cpp_generator.cc.o
[ 91%] Building CXX object CMakeFiles/flatc.dir/grpc/src/compiler/go_generator.cc.o
[ 95%] Building CXX object CMakeFiles/flatc.dir/grpc/src/compiler/java_generator.cc.o
[100%] Linking CXX executable flatc
[100%] Built target flatc
[INFO] flatc binary successfully built!
"make" -C /work/riot/RIOT/pkg/flatbuffers
"make" -C /work/riot/RIOT/boards/native
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/native
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/boards/native/drivers
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys/cpp11-compat
"make" -C /work/riot/RIOT/cpu/native/periph
"make" -C /work/riot/RIOT/sys/div
"make" -C /work/riot/RIOT/cpu/native/stdio_native
"make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"make" -C /work/riot/RIOT/sys/timex
"make" -C /work/riot/RIOT/sys/xtimer
"make" -C /work/riot/RIOT/cpu/native/vfs
   text	   data	    bss	    dec	    hex	filename
  76288	    732	  47784	 124804	  1e784	/work/riot/RIOT/tests/pkg_flatbuffers/bin/native/tests_pkg_flatbuffers.elf

$ make -C tests/pkg_flatbuffers --no-print-directory test
r
/work/riot/RIOT/tests/pkg_flatbuffers/bin/native/tests_pkg_flatbuffers.elf  
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2020.07-devel-1610-g86fb-pr/tools/flatc_fix_parallel)
The FlatBuffer was successfully created and verified!

```

=> No error message (related to the same repository being cloned twice in parallel)
```
fatal: destination path '/work/riot/RIOT/build/pkg/flatbuffers' already exists and is not an empty directory.
make[1]: *** [/work/riot/RIOT/pkg/pkg.mk:123: /work/riot/RIOT/build/pkg/flatbuffers/.git] Error 128
make: *** [/work/riot/RIOT/makefiles/tools/targets.inc.mk:45: /work/riot/RIOT/dist/tools/flatc/flatc] Error 2
```
=> The application works

</details>

<details><summary>master</summary>

```
rm -rf build/pkg/flatbuffers && rm -rf tests/pkg_flatbuffers/bin/ && rm -rf tests/pkg_flatbuffers/monster_generated.h && make -C dist/tools/flatc/ distclean && make -j -C tests/pkg_flatbuffers --no-print-directory
make: Entering directory '/work/riot/RIOT/dist/tools/flatc'
rm -rf /work/riot/RIOT/dist/tools/flatc/bin
rm -rf /work/riot/RIOT/dist/tools/flatc/../../../build/pkg/flatbuffers
make: Leaving directory '/work/riot/RIOT/dist/tools/flatc'
Building application "tests_pkg_flatbuffers" for "native" with MCU "native".
[INFO] flatc binary not found - building it from source now
make -C /work/riot/RIOT/dist/tools/flatc

[INFO] cloning flatbuffers
[INFO] cloning flatbuffers
Cloning into '/work/riot/RIOT/build/pkg/flatbuffers'...
fatal: destination path '/work/riot/RIOT/build/pkg/flatbuffers' already exists and is not an empty directory.
make[1]: *** [/work/riot/RIOT/pkg/pkg.mk:123: /work/riot/RIOT/build/pkg/flatbuffers/.git] Error 128
make: *** [/work/riot/RIOT/makefiles/tools/targets.inc.mk:45: /work/riot/RIOT/dist/tools/flatc/flatc] Error 2
make: *** Waiting for unfinished jobs....
remote: Enumerating objects: 6, done.
remote: Counting objects: 100% (6/6), done.
remote: Compressing objects: 100% (6/6), done.
remote: Total 17894 (delta 1), reused 3 (delta 0), pack-reused 17888
Receiving objects: 100% (17894/17894), 10.67 MiB | 576.00 KiB/s, done.
Resolving deltas: 100% (12418/12418), done.
HEAD is now at 9e7e8cbe Bumped version to 1.11.0
[INFO] updating flatbuffers /work/riot/RIOT/build/pkg/flatbuffers/.pkg-state.git-downloaded
echo v1.11.0 > /work/riot/RIOT/build/pkg/flatbuffers/.pkg-state.git-downloaded
[INFO] patch flatbuffers

echo $?
2
```

=> The build fails (I got one that is failing but this doesn't happen all the time)

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #14380 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
