### PR TITLE
boards/sltb001a: enable CCS811 sensor

### DIFF
--- a/boards/sltb001a/Makefile.dep
+++ b/boards/sltb001a/Makefile.dep
@@ -1,6 +1,7 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
-  USEMODULE += saul_gpio
   USEMODULE += bmp280_i2c
+  USEMODULE += ccs811
+  USEMODULE += saul_gpio
   USEMODULE += si7021
 endif
 

--- a/boards/sltb001a/board.c
+++ b/boards/sltb001a/board.c
@@ -37,7 +37,7 @@ void board_init(void)
     board_common_init();
 
 #ifdef MODULE_SILABS_PIC
-#if CCS811_ENABLED
+#ifdef MODULE_CCS811
     /* enable the CCS811 air quality/gas sensor */
     pic_write(CCS811_PIC_ADDR, (1 << CCS811_PIC_EN_BIT) | (1 << CCS811_PIC_WAKE_BIT));
 #endif

--- a/boards/sltb001a/include/board.h
+++ b/boards/sltb001a/include/board.h
@@ -94,13 +94,13 @@ extern "C" {
  * Connection to the on-board air quality/gas sensor (CCS811).
  * @{
  */
-#ifndef CCS811_ENABLED
-#define CCS811_ENABLED      (0)
-#endif
-#define CCS811_I2C          I2C_DEV(0)
-#define CCS811_PIC_ADDR     (0x03)
-#define CCS811_PIC_EN_BIT   (0x00)
-#define CCS811_PIC_WAKE_BIT (0x01)
+#define CCS811_I2C              I2C_DEV(0)
+
+#define CCS811_PIC_ADDR         (0x03)
+#define CCS811_PIC_EN_BIT       (0x00)
+#define CCS811_PIC_WAKE_BIT     (0x01)
+
+#define CCS811_PARAM_I2C_DEV    CCS811_I2C
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description
This PR enables the CCS811 sensor on the SLTB001A.

Support for that driver was added by #10033.

### Testing procedure
* Driver can be tested using `tests/driver_ccs811`.
* SAUL integration can be tested using `examples/default`.

### Issues/PRs references
None