### PR TITLE
boards/sltb001a+slstk3402a: minor updates to headers

### DIFF
--- a/boards/slstk3402a/include/board.h
+++ b/boards/slstk3402a/include/board.h
@@ -93,9 +93,6 @@ extern "C" {
  * Connection to the on-board temperature/humidity sensor (Si7021).
  * @{
  */
-#ifndef SI7021_ENABLED
-#define SI7021_ENABLED          (1)
-#endif
 #define SI7021_I2C              I2C_DEV(0)
 #define SI7021_EN_PIN           GPIO_PIN(PB, 10)
 

--- a/boards/sltb001a/board.c
+++ b/boards/sltb001a/board.c
@@ -47,7 +47,7 @@ void board_init(void)
     pic_write(ICM20648_PIC_ADDR, 1 << ICM20648_PIC_EN_BIT);
 #endif
 
-#if defined(MODULE_BMP280) || defined(MODULE_SI7021) || SI1133_ENABLED || SI7210A_ENABLED
+#if defined(MODULE_BMP280) || defined(MODULE_SI7021) || SI1133_ENABLED || SI7210_ENABLED
     /* enable the environmental sensors */
     pic_write(ENV_SENSE_PIC_ADDR, 1 << ENV_SENSE_PIC_BIT);
 #endif

--- a/boards/sltb001a/include/board.h
+++ b/boards/sltb001a/include/board.h
@@ -70,7 +70,7 @@ extern "C" {
 /**
  * @name    Environmental sensors configuration
  *
- * Pin for enabling environmental sensors (BMP280, Si1133, Si7021, Si7210A).
+ * Pin for enabling environmental sensors (BMP280, Si1133, Si7021, Si7210).
  * @{
  */
 #define ENV_SENSE_PIC_ADDR  (0x01)
@@ -180,14 +180,14 @@ extern "C" {
 /**
  * @name    Hall-effect sensor configuration
  *
- * Connection to the on-board hall-effect sensor (Si7210A). Available on Rev. A02
- * boards only.
+ * Connection to the on-board hall-effect sensor (Si7210). Available on
+ * Rev. A02 boards only.
  * @{
  */
-#ifndef SI7210A_ENABLED
-#define SI7210A_ENABLED     (0)
+#ifndef SI7210_ENABLED
+#define SI7210_ENABLED      (0)
 #endif
-#define SI7210A_I2C         I2C_DEV(0)
+#define SI7210_I2C          I2C_DEV(0)
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description
This PR provides minor changes to the SLTB001A and SLSTK3402A.

* SLTB001A: Si7210A should be named Si7210 (but there is no driver, yet).
* SLSTK3402A: remove `SI7021_ENABLED` in favor of `MODULE_SI7021`.

### Testing procedure
Murdock is green.

### Issues/PRs references
None
