### PR TITLE
drivers: add driver specific Makefile.dep

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -15,6 +15,9 @@
 include $(RIOTBASE)/sys/Makefile.dep
 include $(RIOTBASE)/drivers/Makefile.dep
 
+# pull Makefile.dep of each driver modules if they exist
+-include $(sort $(USEMODULE:%=$(RIOTBASE)/drivers/%/Makefile.dep))
+
 # pull dependencies from packages
 -include $(USEPKG:%=$(RIOTPKG)/%/Makefile.dep)
 

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -1,894 +1,138 @@
-# driver dependencies (in alphabetical order)
-
-ifneq (,$(filter ad7746,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
+# driver pseudo-modules dependencies (in alphabetical order)
 
 ifneq (,$(filter adc%1c,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_i2c
   USEMODULE += adcxx1c
 endif
 
 ifneq (,$(filter ads101%,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_i2c
   USEMODULE += ads101x
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter adt7310,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_spi
-endif
-
-ifneq (,$(filter adxl345,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter apa102,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-endif
-
-ifneq (,$(filter apds99%full,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio_irq
 endif
 
 ifneq (,$(filter apds99%,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
   USEMODULE += apds99xx
 endif
 
-ifneq (,$(filter at,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_uart
-  USEMODULE += fmt
-  USEMODULE += isrpipe
-  USEMODULE += isrpipe_read_timeout
-
-  _AT_ISR_MODULE := $(filter at_urc_isr_%,$(USEMODULE))
-  ifneq (,$(_AT_ISR_MODULE))
-    # pull in the correspondant event_thread_<priority> module
-    USEMODULE += $(_AT_ISR_MODULE:at_urc_isr_%=event_thread_%)
-    USEMODULE += at_urc
-    USEMODULE += at_urc_isr
-  endif
-endif
-
 ifneq (,$(filter at24c%,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
   USEMODULE += at24cxxx
-endif
-
-ifneq (,$(filter at24mac,$(USEMODULE)))
-  USEMODULE += at24cxxx
-endif
-
-ifneq (,$(filter at25xxx,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_spi
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter at30tse75x,$(USEMODULE)))
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_i2c
 endif
 
 ifneq (,$(filter at86rf215%,$(USEMODULE)))
   USEMODULE += at86rf215
-  DEFAULT_MODULE += auto_init_at86rf215
-  DEFAULT_MODULE += at86rf215_subghz
-
-  DEFAULT_MODULE += netdev_ieee802154_multimode
-
-  DEFAULT_MODULE += netdev_ieee802154_oqpsk
-  DEFAULT_MODULE += netdev_ieee802154_mr_oqpsk
-  DEFAULT_MODULE += netdev_ieee802154_mr_ofdm
-
-  ifeq (,$(filter at86rf215m,$(USEMODULE)))
-    DEFAULT_MODULE += at86rf215_24ghz
-  endif
-
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_spi
-
-  USEMODULE += xtimer
-  USEMODULE += luid
-  USEMODULE += netif
-  USEMODULE += ieee802154
-  USEMODULE += netdev_ieee802154
 endif
 
 ifneq (,$(filter at86rf%, $(filter-out at86rf215%, $(USEMODULE))))
   USEMODULE += at86rf2xx
-  DEFAULT_MODULE += auto_init_at86rf2xx
-  DEFAULT_MODULE += netdev_ieee802154_oqpsk
-
-  USEMODULE += xtimer
-  USEMODULE += luid
-  USEMODULE += netif
-  USEMODULE += ieee802154
-  USEMODULE += netdev_ieee802154
-
-  # only needed for SPI based variants
-  ifeq (,$(filter at86rfa1 at86rfr2,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_gpio
-    FEATURES_REQUIRED += periph_gpio_irq
-    FEATURES_REQUIRED += periph_spi
-  endif
-endif
-
-ifneq (,$(filter ata8520e,$(USEMODULE)))
-  USEMODULE += xtimer
-  USEMODULE += fmt
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_spi
-endif
-
-ifneq (,$(filter atwinc15x0,$(USEMODULE)))
-  USEMODULE += luid
-  USEMODULE += netdev_eth
-  USEMODULE += xtimer
-  USEPKG += driver_atwinc15x0
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_spi
-endif
-
-ifneq (,$(filter bh1750fvi,$(USEMODULE)))
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter bh1900nux,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
 endif
 
 ifneq (,$(filter bme680_%,$(USEMODULE)))
-  USEPKG += driver_bme680
   USEMODULE += bme680
-  ifneq (,$(filter saul%,$(USEMODULE)))
-    USEMODULE += xtimer
-  endif
-endif
-
-ifneq (,$(filter bme680_i2c,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter bme680_spi,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_spi
-endif
-
-ifneq (,$(filter bmp180,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter bm%280_spi,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_spi
-  FEATURES_REQUIRED += periph_gpio
-  USEMODULE += bmx280
 endif
 
 ifneq (,$(filter bm%280_i2c,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
   USEMODULE += bmx280
 endif
 
-ifneq (,$(filter bmx280,$(USEMODULE)))
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter bmx055,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
+ifneq (,$(filter bm%280_spi,$(USEMODULE)))
+  USEMODULE += bmx280
 endif
 
 ifneq (,$(filter cc110%,$(USEMODULE)))
   USEMODULE += cc110x
-  USEMODULE += cc1xxx_common
-  USEMODULE += luid
-  USEMODULE += netif
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_spi
-  ifneq (,$(filter gnrc_ipv6,$(USEMODULE)))
-    USEMODULE += gnrc_sixlowpan
-  endif
 endif
 
-ifneq (,$(filter cc2420,$(USEMODULE)))
-  USEMODULE += xtimer
-  USEMODULE += luid
-  USEMODULE += netif
-  USEMODULE += ieee802154
-  USEMODULE += netdev_ieee802154
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_spi
-endif
-
-ifneq (,$(filter ccs811_full,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio_irq
+ifneq (,$(filter ccs811_%,$(USEMODULE)))
   USEMODULE += ccs811
 endif
 
-ifneq (,$(filter ccs811,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter dcf77,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter dfplayer,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_uart
-  FEATURES_REQUIRED += periph_gpio
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter dht,$(USEMODULE)))
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_gpio
-endif
-
-ifneq (,$(filter ds1307,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter ds18,$(USEMODULE)))
-    USEMODULE += xtimer
-    FEATURES_REQUIRED += periph_gpio
-endif
-
-ifneq (,$(filter ds3234,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_spi
-endif
-
-ifneq (,$(filter ds75lx,$(USEMODULE)))
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter dsp0401,$(USEMODULE)))
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_pwm
-endif
-
-ifneq (,$(filter dynamixel,$(USEMODULE)))
-  USEMODULE += uart_half_duplex
-endif
-
-ifneq (,$(filter edbg_eui,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter enc28j60,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_spi
-  USEMODULE += netdev_eth
-  USEMODULE += xtimer
-  USEMODULE += luid
-endif
-
-ifneq (,$(filter encx24j600,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_spi
-  USEMODULE += netdev_eth
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter ethos,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_uart
-  USEMODULE += iolist
-  USEMODULE += netdev_eth
-  USEMODULE += random
-  USEMODULE += tsrb
-endif
-
-ifneq (,$(filter dose,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_uart
-  USEMODULE += iolist
-  USEMODULE += netdev_eth
-  USEMODULE += random
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_gpio_irq
-endif
-
-ifneq (,$(filter feetech,$(USEMODULE)))
-  USEMODULE += uart_half_duplex
-endif
-
-ifneq (,$(filter fxos8700,$(USEMODULE)))
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter grove_ledbar,$(USEMODULE)))
-  USEMODULE += my9221
-endif
-
-ifneq (,$(filter hd44780,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter hdc1000,$(USEMODULE)))
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter hih6130,$(USEMODULE)))
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter hmc5883l,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter hmc5883l_int,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio_irq
-endif
-
-ifneq (,$(filter hts221,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter ili9341,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_spi
-  FEATURES_REQUIRED += periph_gpio
-  USEMODULE += xtimer
+ifneq (,$(filter hmc5883l_%,$(USEMODULE)))
+  USEMODULE += hmc5883l
 endif
 
 ifneq (,$(filter ina2%,$(USEMODULE)))
   USEMODULE += ina2xx
 endif
 
-ifneq (,$(filter ina2xx,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter ina3221,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter ina3221_alerts,$(USEMODULE)))
+ifneq (,$(filter ina3221_%,$(USEMODULE)))
   USEMODULE += ina3221
-  USEMODULE += periph_gpio_irq
 endif
 
-ifneq (,$(filter io1_xplained,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_adc
-  USEMODULE += at30tse75x
-  USEMODULE += sdcard_spi
-endif
-
-ifneq (,$(filter isl29020,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter isl29125,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter itg320x_int,$(USEMODULE)))
+ifneq (,$(filter itg320x_%,$(USEMODULE)))
   USEMODULE += itg320x
-  FEATURES_REQUIRED += periph_gpio_irq
-endif
-
-ifneq (,$(filter itg320x,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter jc42,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter kw2xrf,$(USEMODULE)))
-  USEMODULE += luid
-  USEMODULE += netif
-  USEMODULE += ieee802154
-  USEMODULE += netdev_ieee802154
-  USEMODULE += core_thread_flags
-  FEATURES_REQUIRED += periph_spi
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-endif
-
-ifneq (,$(filter kw41zrf,$(USEMODULE)))
-  USEMODULE += luid
-  USEMODULE += netif
-  USEMODULE += ieee802154
-  USEMODULE += netdev_ieee802154
-  USEMODULE += core_thread_flags
-  USEMODULE += random
-  USEMODULE += mcux_xcvr_mkw41z
-endif
-
-ifneq (,$(filter l3g4200d,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter lc709203f,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  FEATURES_REQUIRED += periph_gpio_irq
-endif
-
-ifneq (,$(filter lis2dh12_int,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio_irq
 endif
 
 ifneq (,$(filter lis2dh12%,$(USEMODULE)))
   USEMODULE += lis2dh12
-  ifneq (,$(filter lis2dh12_spi,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_gpio
-    FEATURES_REQUIRED += periph_spi
-  else
-    FEATURES_REQUIRED += periph_i2c
-  endif
-endif
-
-ifneq (,$(filter lis3dh,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_spi
-endif
-
-ifneq (,$(filter lis3mdl,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter lpd8808,$(USEMODULE)))
-  USEMODULE += color
-  FEATURES_REQUIRED += periph_gpio
 endif
 
 ifneq (,$(filter lps331ap lps2%hb,$(USEMODULE)))
   USEMODULE += lpsxxx
 endif
 
-ifneq (,$(filter lpsxxx,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter lsm303dlhc,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter lsm6dsl,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter ltc4150_bidirectional,$(USEMODULE)))
+ifneq (,$(filter ltc4150_%,$(USEMODULE)))
   USEMODULE += ltc4150
 endif
 
-ifneq (,$(filter ltc4150,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter mag3110,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter mhz19_pwm,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  USEMODULE += xtimer
+ifneq (,$(filter mhz19_%,$(USEMODULE)))
   USEMODULE += mhz19
-endif
-
-ifneq (,$(filter mhz19_uart,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_uart
-  USEMODULE += xtimer
-  USEMODULE += mhz19
-endif
-
-ifneq (,$(filter mma7660,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter mma8x5x,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter motor_driver,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_pwm
-endif
-
-ifneq (,$(filter mpl3115a2,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
 endif
 
 ifneq (,$(filter mpu9%50,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
   USEMODULE += mpu9x50
-endif
-
-ifneq (,$(filter mq3,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_adc
 endif
 
 ifneq (,$(filter mrf24j40m%,$(USEMODULE)))
   USEMODULE += mrf24j40
-  DEFAULT_MODULE += netdev_ieee802154_oqpsk
-
-  ifndef CONFIG_KCONFIG_MODULE_MRF24J40
-    # all modules but mrf24j40ma have an external PA
-    ifeq (,$(filter mrf24j40ma,$(USEMODULE)))
-      CFLAGS += -DCONFIG_MRF24J40_USE_EXT_PA_LNA
-    endif
-  endif
-endif
-
-ifneq (,$(filter mrf24j40,$(USEMODULE)))
-  USEMODULE += xtimer
-  USEMODULE += luid
-  USEMODULE += netif
-  USEMODULE += ieee802154
-  USEMODULE += netdev_ieee802154
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_spi
 endif
 
 ifneq (,$(filter mtd_%,$(USEMODULE)))
   USEMODULE += mtd
-
-  ifneq (,$(filter mtd_at24cxxx,$(USEMODULE)))
-    USEMODULE += at24cxxx
-  endif
-
-  ifneq (,$(filter mtd_at25xxx,$(USEMODULE)))
-    USEMODULE += at25xxx
-  endif
-
-  ifneq (,$(filter mtd_sdcard,$(USEMODULE)))
-    USEMODULE += sdcard_spi
-  endif
-
-  ifneq (,$(filter mtd_spi_nor,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_spi
-  endif
-
-  ifneq (,$(filter mtd_flashpage,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_flashpage
-    FEATURES_REQUIRED += periph_flashpage_raw
-  endif
 endif
 
-ifneq (,$(filter my9221,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter nvc7356,$(USEMODULE)))
-  USEMODULE += can_trx
-  FEATURES_REQUIRED += periph_gpio
-endif
-
+# nrfmin is a concrete module but comes from cpu/nrf5x_common. Due to limitations
+# in the dependency resolution mechanism it's not possible to move its
+# dependency resolution at cpu level.
 ifneq (,$(filter nrfmin,$(USEMODULE)))
   FEATURES_REQUIRED += radio_nrfmin
   FEATURES_REQUIRED += periph_cpuid
   USEMODULE += netif
 endif
 
-ifneq (,$(filter nrf24l01p,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_spi
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter nvram_spi,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_spi
-  USEMODULE += nvram
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter opt3001,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter pca9633,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter pca9685,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
-
-  # efm32 CPU doesn't support PWM_RIGHT
-  FEATURES_BLACKLIST += arch_efm32
-endif
-
-ifneq (,$(filter pcd8544,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_spi
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter ph_oem,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter pir,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter pn532,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-endif
-
-ifneq (,$(filter pulse_counter,$(USEMODULE)))
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_gpio_irq
-endif
-
-ifneq (,$(filter qmc5883l_int,$(USEMODULE)))
+ifneq (,$(filter qmc5883l_%,$(USEMODULE)))
   USEMODULE += qmc5883l
 endif
 
-ifneq (,$(filter qmc5883l,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  ifneq (,$(filter qmc5883l_int,$(USEMODULE)))
-    FEATURES_REQUIRED += periph_gpio_irq
-  endif
-endif
-
-ifneq (,$(filter rgbled,$(USEMODULE)))
-  USEMODULE += color
-endif
-
-ifneq (,$(filter rtt_rtc,$(USEMODULE)))
-  # Unit tests will use a mock implementation
-  ifeq (,$(UNIT_TESTS))
-    FEATURES_REQUIRED += periph_rtt
-  endif
-endif
-
 ifneq (,$(filter rn2%3,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_uart
-  USEMODULE += xtimer
   USEMODULE += rn2xx3
-  USEMODULE += fmt
-endif
-
-ifneq (,$(filter sdcard_spi,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_spi
-  FEATURES_OPTIONAL += periph_spi_reconfigure
-  USEMODULE += checksum
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter sdp3x,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  FEATURES_REQUIRED += periph_gpio_irq
-  USEMODULE += checksum
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter sds011,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_uart
-endif
-
-ifneq (,$(filter servo,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_pwm
 endif
 
 ifneq (,$(filter sht1%,$(USEMODULE)))
   USEMODULE += sht1x
-  FEATURES_REQUIRED += periph_gpio
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter sht2x,$(USEMODULE)))
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter sht3x,$(USEMODULE)))
-  USEMODULE += xtimer
-  USEMODULE += checksum
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter shtc1,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
-  USEMODULE += checksum
 endif
 
 ifneq (,$(filter si114%,$(USEMODULE)))
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_i2c
   USEMODULE += si114x
 endif
 
 ifneq (,$(filter si70%,$(USEMODULE)))
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_i2c
   USEMODULE += si70xx
 endif
 
-ifneq (,$(filter stmpe811,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter slipdev,$(USEMODULE)))
-  USEMODULE += tsrb
-  FEATURES_REQUIRED += periph_uart
-endif
-
-ifneq (,$(filter slipdev_stdio,$(USEMODULE)))
-  USEMODULE += isrpipe
+ifneq (,$(filter slipdev_%,$(USEMODULE)))
   USEMODULE += slipdev
-  FEATURES_REQUIRED += periph_uart
-endif
-
-ifneq (,$(filter soft_spi,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter soft_uart,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_timer_periodic
-endif
-
-ifneq (,$(filter sps30,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += checksum
-endif
-
-ifneq (,$(filter srf02,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter srf04,$(USEMODULE)))
-  USEMODULE += xtimer
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-endif
-
-ifneq (,$(filter srf08,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter stm32_eth,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_eth
-  FEATURES_REQUIRED += periph_dma
-  USEMODULE += netdev_eth
-  USEMODULE += iolist
-  USEMODULE += luid
 endif
 
 ifneq (,$(filter sx127%,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_spi
-  FEATURES_OPTIONAL += periph_spi_gpio_mode
-  USEMODULE += iolist
-  USEMODULE += xtimer
   USEMODULE += sx127x
-  USEMODULE += netif
-  USEMODULE += lora
-
-  ifneq (,$(filter gnrc,$(USEMODULE)))
-    # Pull in `ifconfig` support for LoRA
-    USEMODULE += gnrc_netif_cmd_lora
-  endif
-endif
-
-ifneq (,$(filter tcs37727,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter tps6274x,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-endif
-
-ifneq (,$(filter tja1042,$(USEMODULE)))
-  USEMODULE += can_trx
-  FEATURES_REQUIRED += periph_gpio
 endif
 
 ifneq (,$(filter tmp00%,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
   USEMODULE += tmp00x
-endif
-
-ifneq (,$(filter tsl2561,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter tsl4531x,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter uart_half_duplex,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_uart
-  USEMODULE += xtimer
 endif
 
 ifneq (,$(filter vcnl40%0,$(USEMODULE)))
   USEMODULE += vcnl40x0
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter veml6070,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter w5100,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio_irq
-  FEATURES_REQUIRED += periph_spi
-  USEMODULE += netdev_eth
-  USEMODULE += luid
 endif
 
 ifneq (,$(filter ws281x_%,$(USEMODULE)))
   USEMODULE += ws281x
-endif
-
-ifneq (,$(filter ws281x,$(USEMODULE)))
-  FEATURES_REQUIRED_ANY += arch_avr8|arch_esp32|arch_native
-
-  ifeq (,$(filter ws281x_%,$(USEMODULE)))
-    ifneq (,$(filter arch_avr8,$(FEATURES_USED)))
-      USEMODULE += ws281x_atmega
-    endif
-    ifneq (,$(filter arch_native,$(FEATURES_USED)))
-      USEMODULE += ws281x_vt100
-    endif
-    ifneq (,$(filter arch_esp32,$(FEATURES_USED)))
-      USEMODULE += ws281x_esp32
-    endif
-  endif
-  ifneq (,$(filter ws281x_atmega,$(USEMODULE)))
-    FEATURES_REQUIRED += arch_avr8
-  endif
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter xbee,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_uart
-  FEATURES_REQUIRED += periph_gpio
-  USEMODULE += ieee802154
-  USEMODULE += xtimer
-  USEMODULE += netif
 endif

--- a/drivers/ad7746/Makefile.dep
+++ b/drivers/ad7746/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/adcxx1c/Makefile.dep
+++ b/drivers/adcxx1c/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/ads101x/Makefile.dep
+++ b/drivers/ads101x/Makefile.dep
@@ -1,0 +1,3 @@
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer

--- a/drivers/adt7310/Makefile.dep
+++ b/drivers/adt7310/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_spi

--- a/drivers/adxl345/Makefile.dep
+++ b/drivers/adxl345/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/apa102/Makefile.dep
+++ b/drivers/apa102/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_gpio

--- a/drivers/apds99xx/Makefile.dep
+++ b/drivers/apds99xx/Makefile.dep
@@ -1,0 +1,5 @@
+FEATURES_REQUIRED += periph_i2c
+
+ifneq (,$(filter apds99%full,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio_irq
+endif

--- a/drivers/at/Makefile.dep
+++ b/drivers/at/Makefile.dep
@@ -1,0 +1,12 @@
+FEATURES_REQUIRED += periph_uart
+USEMODULE += fmt
+USEMODULE += isrpipe
+USEMODULE += isrpipe_read_timeout
+
+_AT_ISR_MODULE := $(filter at_urc_isr_%,$(USEMODULE))
+ifneq (,$(_AT_ISR_MODULE))
+  # pull in the correspondant event_thread_<priority> module
+  USEMODULE += $(_AT_ISR_MODULE:at_urc_isr_%=event_thread_%)
+  USEMODULE += at_urc
+  USEMODULE += at_urc_isr
+endif

--- a/drivers/at24cxxx/Makefile.dep
+++ b/drivers/at24cxxx/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer

--- a/drivers/at24mac/Makefile.dep
+++ b/drivers/at24mac/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += at24cxxx

--- a/drivers/at25xxx/Makefile.dep
+++ b/drivers/at25xxx/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_spi
+USEMODULE += xtimer

--- a/drivers/at30tse75x/Makefile.dep
+++ b/drivers/at30tse75x/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/at86rf215/Makefile.dep
+++ b/drivers/at86rf215/Makefile.dep
@@ -1,0 +1,22 @@
+DEFAULT_MODULE += auto_init_at86rf215
+DEFAULT_MODULE += at86rf215_subghz
+
+DEFAULT_MODULE += netdev_ieee802154_multimode
+
+DEFAULT_MODULE += netdev_ieee802154_oqpsk
+DEFAULT_MODULE += netdev_ieee802154_mr_oqpsk
+DEFAULT_MODULE += netdev_ieee802154_mr_ofdm
+
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_spi
+
+ifeq (,$(filter at86rf215m,$(USEMODULE)))
+  DEFAULT_MODULE += at86rf215_24ghz
+endif
+
+USEMODULE += xtimer
+USEMODULE += luid
+USEMODULE += netif
+USEMODULE += ieee802154
+USEMODULE += netdev_ieee802154

--- a/drivers/at86rf2xx/Makefile.dep
+++ b/drivers/at86rf2xx/Makefile.dep
@@ -1,0 +1,15 @@
+DEFAULT_MODULE += auto_init_at86rf2xx
+DEFAULT_MODULE += netdev_ieee802154_oqpsk
+
+USEMODULE += xtimer
+USEMODULE += luid
+USEMODULE += netif
+USEMODULE += ieee802154
+USEMODULE += netdev_ieee802154
+
+# only needed for SPI based variants
+ifeq (,$(filter at86rfa1 at86rfr2,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_gpio_irq
+  FEATURES_REQUIRED += periph_spi
+endif

--- a/drivers/ata8520e/Makefile.dep
+++ b/drivers/ata8520e/Makefile.dep
@@ -1,0 +1,5 @@
+USEMODULE += xtimer
+USEMODULE += fmt
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_spi

--- a/drivers/atwinc15x0/Makefile.dep
+++ b/drivers/atwinc15x0/Makefile.dep
@@ -1,0 +1,7 @@
+USEMODULE += luid
+USEMODULE += netdev_eth
+USEMODULE += xtimer
+USEPKG += driver_atwinc15x0
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_spi

--- a/drivers/bh1750fvi/Makefile.dep
+++ b/drivers/bh1750fvi/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/bh1900nux/Makefile.dep
+++ b/drivers/bh1900nux/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/bme680/Makefile.dep
+++ b/drivers/bme680/Makefile.dep
@@ -1,0 +1,14 @@
+USEPKG += driver_bme680
+
+ifneq (,$(filter saul%,$(USEMODULE)))
+  USEMODULE += xtimer
+endif
+
+ifneq (,$(filter bme680_i2c,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
+ifneq (,$(filter bme680_spi,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_spi
+endif

--- a/drivers/bmp180/Makefile.dep
+++ b/drivers/bmp180/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer

--- a/drivers/bmx055/Makefile.dep
+++ b/drivers/bmx055/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/bmx280/Makefile.dep
+++ b/drivers/bmx280/Makefile.dep
@@ -1,0 +1,10 @@
+USEMODULE += xtimer
+
+ifneq (,$(filter bm%280_spi,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_spi
+  FEATURES_REQUIRED += periph_gpio
+endif
+
+ifneq (,$(filter bm%280_i2c,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif

--- a/drivers/cc110x/Makefile.dep
+++ b/drivers/cc110x/Makefile.dep
@@ -1,0 +1,11 @@
+USEMODULE += cc1xxx_common
+USEMODULE += luid
+USEMODULE += netif
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_spi
+
+ifneq (,$(filter gnrc_ipv6,$(USEMODULE)))
+  USEMODULE += gnrc_sixlowpan
+endif

--- a/drivers/cc2420/Makefile.dep
+++ b/drivers/cc2420/Makefile.dep
@@ -1,0 +1,8 @@
+USEMODULE += xtimer
+USEMODULE += luid
+USEMODULE += netif
+USEMODULE += ieee802154
+USEMODULE += netdev_ieee802154
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_spi

--- a/drivers/ccs811/Makefile.dep
+++ b/drivers/ccs811/Makefile.dep
@@ -1,0 +1,7 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer
+
+ifneq (,$(filter ccs811_full,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio_irq
+endif

--- a/drivers/dcf77/Makefile.dep
+++ b/drivers/dcf77/Makefile.dep
@@ -1,0 +1,3 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq
+USEMODULE += xtimer

--- a/drivers/dfplayer/Makefile.dep
+++ b/drivers/dfplayer/Makefile.dep
@@ -1,0 +1,3 @@
+FEATURES_REQUIRED += periph_uart
+FEATURES_REQUIRED += periph_gpio
+USEMODULE += xtimer

--- a/drivers/dht/Makefile.dep
+++ b/drivers/dht/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_gpio

--- a/drivers/dose/Makefile.dep
+++ b/drivers/dose/Makefile.dep
@@ -1,0 +1,6 @@
+FEATURES_REQUIRED += periph_uart
+USEMODULE += iolist
+USEMODULE += netdev_eth
+USEMODULE += random
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_gpio_irq

--- a/drivers/ds1307/Makefile.dep
+++ b/drivers/ds1307/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/ds18/Makefile.dep
+++ b/drivers/ds18/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_gpio

--- a/drivers/ds3234/Makefile.dep
+++ b/drivers/ds3234/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_spi

--- a/drivers/ds75lx/Makefile.dep
+++ b/drivers/ds75lx/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/dsp0401/Makefile.dep
+++ b/drivers/dsp0401/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_pwm

--- a/drivers/dynamixel/Makefile.dep
+++ b/drivers/dynamixel/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += uart_half_duplex

--- a/drivers/edbg_eui/Makefile.dep
+++ b/drivers/edbg_eui/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/enc28j60/Makefile.dep
+++ b/drivers/enc28j60/Makefile.dep
@@ -1,0 +1,6 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_spi
+USEMODULE += netdev_eth
+USEMODULE += xtimer
+USEMODULE += luid

--- a/drivers/encx24j600/Makefile.dep
+++ b/drivers/encx24j600/Makefile.dep
@@ -1,0 +1,4 @@
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_spi
+USEMODULE += netdev_eth
+USEMODULE += xtimer

--- a/drivers/ethos/Makefile.dep
+++ b/drivers/ethos/Makefile.dep
@@ -1,0 +1,5 @@
+FEATURES_REQUIRED += periph_uart
+USEMODULE += iolist
+USEMODULE += netdev_eth
+USEMODULE += random
+USEMODULE += tsrb

--- a/drivers/feetech/Makefile.dep
+++ b/drivers/feetech/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += uart_half_duplex

--- a/drivers/fxos8700/Makefile.dep
+++ b/drivers/fxos8700/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/grove_ledbar/Makefile.dep
+++ b/drivers/grove_ledbar/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += my9221

--- a/drivers/hd44780/Makefile.dep
+++ b/drivers/hd44780/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_gpio
+USEMODULE += xtimer

--- a/drivers/hdc1000/Makefile.dep
+++ b/drivers/hdc1000/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/hih6130/Makefile.dep
+++ b/drivers/hih6130/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/hmc5883l/Makefile.dep
+++ b/drivers/hmc5883l/Makefile.dep
@@ -1,0 +1,5 @@
+FEATURES_REQUIRED += periph_i2c
+
+ifneq (,$(filter hmc5883l_int,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio_irq
+endif

--- a/drivers/hts221/Makefile.dep
+++ b/drivers/hts221/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/ili9341/Makefile.dep
+++ b/drivers/ili9341/Makefile.dep
@@ -1,0 +1,3 @@
+FEATURES_REQUIRED += periph_spi
+FEATURES_REQUIRED += periph_gpio
+USEMODULE += xtimer

--- a/drivers/ina2xx/Makefile.dep
+++ b/drivers/ina2xx/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/ina3221/Makefile.dep
+++ b/drivers/ina3221/Makefile.dep
@@ -1,0 +1,6 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_i2c
+
+ifneq (,$(filter ina3221_alerts,$(USEMODULE)))
+  USEMODULE += periph_gpio_irq
+endif

--- a/drivers/io1_xplained/Makefile.dep
+++ b/drivers/io1_xplained/Makefile.dep
@@ -1,0 +1,4 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_adc
+USEMODULE += at30tse75x
+USEMODULE += sdcard_spi

--- a/drivers/isl29020/Makefile.dep
+++ b/drivers/isl29020/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/isl29125/Makefile.dep
+++ b/drivers/isl29125/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/itg320x/Makefile.dep
+++ b/drivers/itg320x/Makefile.dep
@@ -1,0 +1,6 @@
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer
+
+ifneq (,$(filter itg320x_int,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio_irq
+endif

--- a/drivers/jc42/Makefile.dep
+++ b/drivers/jc42/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/kw2xrf/Makefile.dep
+++ b/drivers/kw2xrf/Makefile.dep
@@ -1,0 +1,8 @@
+USEMODULE += luid
+USEMODULE += netif
+USEMODULE += ieee802154
+USEMODULE += netdev_ieee802154
+USEMODULE += core_thread_flags
+FEATURES_REQUIRED += periph_spi
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq

--- a/drivers/kw41zrf/Makefile.dep
+++ b/drivers/kw41zrf/Makefile.dep
@@ -1,0 +1,7 @@
+USEMODULE += luid
+USEMODULE += netif
+USEMODULE += ieee802154
+USEMODULE += netdev_ieee802154
+USEMODULE += core_thread_flags
+USEMODULE += random
+USEMODULE += mcux_xcvr_mkw41z

--- a/drivers/l3g4200d/Makefile.dep
+++ b/drivers/l3g4200d/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/lc709203f/Makefile.dep
+++ b/drivers/lc709203f/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_i2c
+FEATURES_REQUIRED += periph_gpio_irq

--- a/drivers/lis2dh12/Makefile.dep
+++ b/drivers/lis2dh12/Makefile.dep
@@ -1,0 +1,10 @@
+ifneq (,$(filter lis2dh12_spi,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_spi
+else
+  FEATURES_REQUIRED += periph_i2c
+endif
+
+ifneq (,$(filter lis2dh12_int,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio_irq
+endif

--- a/drivers/lis3dh/Makefile.dep
+++ b/drivers/lis3dh/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_spi

--- a/drivers/lis3mdl/Makefile.dep
+++ b/drivers/lis3mdl/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer

--- a/drivers/lpd8808/Makefile.dep
+++ b/drivers/lpd8808/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += color
+FEATURES_REQUIRED += periph_gpio

--- a/drivers/lpsxxx/Makefile.dep
+++ b/drivers/lpsxxx/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/lsm303dlhc/Makefile.dep
+++ b/drivers/lsm303dlhc/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/lsm6dsl/Makefile.dep
+++ b/drivers/lsm6dsl/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer

--- a/drivers/ltc4150/Makefile.dep
+++ b/drivers/ltc4150/Makefile.dep
@@ -1,0 +1,3 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq
+USEMODULE += xtimer

--- a/drivers/mag3110/Makefile.dep
+++ b/drivers/mag3110/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/mhz19/Makefile.dep
+++ b/drivers/mhz19/Makefile.dep
@@ -1,0 +1,9 @@
+USEMODULE += xtimer
+
+ifneq (,$(filter mhz19_pwm,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+endif
+
+ifneq (,$(filter mhz19_uart,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_uart
+endif

--- a/drivers/mma7660/Makefile.dep
+++ b/drivers/mma7660/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/mma8x5x/Makefile.dep
+++ b/drivers/mma8x5x/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/motor_driver/Makefile.dep
+++ b/drivers/motor_driver/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_pwm

--- a/drivers/mpl3115a2/Makefile.dep
+++ b/drivers/mpl3115a2/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/mpu9x50/Makefile.dep
+++ b/drivers/mpu9x50/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer

--- a/drivers/mq3/Makefile.dep
+++ b/drivers/mq3/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_adc

--- a/drivers/mrf24j40/Makefile.dep
+++ b/drivers/mrf24j40/Makefile.dep
@@ -1,0 +1,19 @@
+USEMODULE += xtimer
+USEMODULE += luid
+USEMODULE += netif
+USEMODULE += ieee802154
+USEMODULE += netdev_ieee802154
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_spi
+
+ifneq (,$(filter mrf24j40m%,$(USEMODULE)))
+  DEFAULT_MODULE += netdev_ieee802154_oqpsk
+
+  ifndef CONFIG_KCONFIG_MODULE_MRF24J40
+    # all modules but mrf24j40ma have an external PA
+    ifeq (,$(filter mrf24j40ma,$(USEMODULE)))
+      CFLAGS += -DCONFIG_MRF24J40_USE_EXT_PA_LNA
+    endif
+  endif
+endif

--- a/drivers/mtd/Makefile.dep
+++ b/drivers/mtd/Makefile.dep
@@ -1,0 +1,11 @@
+ifneq (,$(filter mtd_at24cxxx,$(USEMODULE)))
+  USEMODULE += at24cxxx
+endif
+
+ifneq (,$(filter mtd_at25xxx,$(USEMODULE)))
+  USEMODULE += at25xxx
+endif
+
+ifneq (,$(filter mtd_sdcard,$(USEMODULE)))
+  USEMODULE += sdcard_spi
+endif

--- a/drivers/mtd_flashpage/Makefile.dep
+++ b/drivers/mtd_flashpage/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_flashpage
+FEATURES_REQUIRED += periph_flashpage_raw

--- a/drivers/mtd_spi_nor/Makefile.dep
+++ b/drivers/mtd_spi_nor/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_spi

--- a/drivers/my9221/Makefile.dep
+++ b/drivers/my9221/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_gpio
+USEMODULE += xtimer

--- a/drivers/ncv7356/Makefile.dep
+++ b/drivers/ncv7356/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += can_trx
+FEATURES_REQUIRED += periph_gpio

--- a/drivers/nrf24l01p/Makefile.dep
+++ b/drivers/nrf24l01p/Makefile.dep
@@ -1,0 +1,4 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_spi
+USEMODULE += xtimer

--- a/drivers/nvram_spi/Makefile.dep
+++ b/drivers/nvram_spi/Makefile.dep
@@ -1,0 +1,3 @@
+FEATURES_REQUIRED += periph_spi
+USEMODULE += nvram
+USEMODULE += xtimer

--- a/drivers/opt3001/Makefile.dep
+++ b/drivers/opt3001/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer

--- a/drivers/pca9633/Makefile.dep
+++ b/drivers/pca9633/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/pca9685/Makefile.dep
+++ b/drivers/pca9685/Makefile.dep
@@ -1,0 +1,6 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer
+
+# efm32 CPU doesn't support PWM_RIGHT
+FEATURES_BLACKLIST += arch_efm32

--- a/drivers/pcd8544/Makefile.dep
+++ b/drivers/pcd8544/Makefile.dep
@@ -1,0 +1,3 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_spi
+USEMODULE += xtimer

--- a/drivers/ph_oem/Makefile.dep
+++ b/drivers/ph_oem/Makefile.dep
@@ -1,0 +1,3 @@
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer

--- a/drivers/pir/Makefile.dep
+++ b/drivers/pir/Makefile.dep
@@ -1,0 +1,3 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq
+USEMODULE += xtimer

--- a/drivers/pn532/Makefile.dep
+++ b/drivers/pn532/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq

--- a/drivers/pulse_counter/Makefile.dep
+++ b/drivers/pulse_counter/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_gpio_irq

--- a/drivers/qmc5883l/Makefile.dep
+++ b/drivers/qmc5883l/Makefile.dep
@@ -1,0 +1,5 @@
+FEATURES_REQUIRED += periph_i2c
+
+ifneq (,$(filter qmc5883l_int,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio_irq
+endif

--- a/drivers/rgbled/Makefile.dep
+++ b/drivers/rgbled/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += color

--- a/drivers/rn2xx3/Makefile.dep
+++ b/drivers/rn2xx3/Makefile.dep
@@ -1,0 +1,4 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_uart
+USEMODULE += xtimer
+USEMODULE += fmt

--- a/drivers/rtt_rtc/Makefile.dep
+++ b/drivers/rtt_rtc/Makefile.dep
@@ -1,0 +1,4 @@
+# Unit tests will use a mock implementation
+ifeq (,$(UNIT_TESTS))
+  FEATURES_REQUIRED += periph_rtt
+endif

--- a/drivers/sdcard_spi/Makefile.dep
+++ b/drivers/sdcard_spi/Makefile.dep
@@ -1,0 +1,5 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_spi
+FEATURES_OPTIONAL += periph_spi_reconfigure
+USEMODULE += checksum
+USEMODULE += xtimer

--- a/drivers/sdp3x/Makefile.dep
+++ b/drivers/sdp3x/Makefile.dep
@@ -1,0 +1,4 @@
+FEATURES_REQUIRED += periph_i2c
+FEATURES_REQUIRED += periph_gpio_irq
+USEMODULE += checksum
+USEMODULE += xtimer

--- a/drivers/sds011/Makefile.dep
+++ b/drivers/sds011/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_uart

--- a/drivers/servo/Makefile.dep
+++ b/drivers/servo/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_pwm

--- a/drivers/sht1x/Makefile.dep
+++ b/drivers/sht1x/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_gpio
+USEMODULE += xtimer

--- a/drivers/sht2x/Makefile.dep
+++ b/drivers/sht2x/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/sht3x/Makefile.dep
+++ b/drivers/sht3x/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += xtimer
+USEMODULE += checksum
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/shtc1/Makefile.dep
+++ b/drivers/shtc1/Makefile.dep
@@ -1,0 +1,3 @@
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer
+USEMODULE += checksum

--- a/drivers/si114x/Makefile.dep
+++ b/drivers/si114x/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/si70xx/Makefile.dep
+++ b/drivers/si70xx/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/slipdev/Makefile.dep
+++ b/drivers/slipdev/Makefile.dep
@@ -1,0 +1,6 @@
+USEMODULE += tsrb
+FEATURES_REQUIRED += periph_uart
+
+ifneq (,$(filter slipdev_stdio,$(USEMODULE)))
+  USEMODULE += isrpipe
+endif

--- a/drivers/soft_spi/Makefile.dep
+++ b/drivers/soft_spi/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_gpio
+USEMODULE += xtimer

--- a/drivers/soft_uart/Makefile.dep
+++ b/drivers/soft_uart/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_timer_periodic

--- a/drivers/sps30/Makefile.dep
+++ b/drivers/sps30/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += checksum

--- a/drivers/srf02/Makefile.dep
+++ b/drivers/srf02/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer

--- a/drivers/srf04/Makefile.dep
+++ b/drivers/srf04/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += xtimer
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq

--- a/drivers/srf08/Makefile.dep
+++ b/drivers/srf08/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer

--- a/drivers/stm32_eth/Makefile.dep
+++ b/drivers/stm32_eth/Makefile.dep
@@ -1,0 +1,5 @@
+FEATURES_REQUIRED += periph_eth
+FEATURES_REQUIRED += periph_dma
+USEMODULE += netdev_eth
+USEMODULE += iolist
+USEMODULE += luid

--- a/drivers/stmpe811/Makefile.dep
+++ b/drivers/stmpe811/Makefile.dep
@@ -1,0 +1,3 @@
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer

--- a/drivers/sx127x/Makefile.dep
+++ b/drivers/sx127x/Makefile.dep
@@ -1,0 +1,13 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_spi
+FEATURES_OPTIONAL += periph_spi_gpio_mode
+USEMODULE += iolist
+USEMODULE += xtimer
+USEMODULE += netif
+USEMODULE += lora
+
+ifneq (,$(filter gnrc,$(USEMODULE)))
+  # Pull in `ifconfig` support for LoRA
+  USEMODULE += gnrc_netif_cmd_lora
+endif

--- a/drivers/tcs37727/Makefile.dep
+++ b/drivers/tcs37727/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/tja1042/Makefile.dep
+++ b/drivers/tja1042/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += can_trx
+FEATURES_REQUIRED += periph_gpio

--- a/drivers/tmp00x/Makefile.dep
+++ b/drivers/tmp00x/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer

--- a/drivers/tps6274x/Makefile.dep
+++ b/drivers/tps6274x/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_gpio

--- a/drivers/tsl2561/Makefile.dep
+++ b/drivers/tsl2561/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer

--- a/drivers/tsl4531x/Makefile.dep
+++ b/drivers/tsl4531x/Makefile.dep
@@ -1,0 +1,2 @@
+FEATURES_REQUIRED += periph_i2c
+USEMODULE += xtimer

--- a/drivers/uart_half_duplex/Makefile.dep
+++ b/drivers/uart_half_duplex/Makefile.dep
@@ -1,0 +1,3 @@
+FEATURES_REQUIRED += periph_gpio
+FEATURES_REQUIRED += periph_uart
+USEMODULE += xtimer

--- a/drivers/vcnl40x0/Makefile.dep
+++ b/drivers/vcnl40x0/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/veml6070/Makefile.dep
+++ b/drivers/veml6070/Makefile.dep
@@ -1,0 +1,1 @@
+FEATURES_REQUIRED += periph_i2c

--- a/drivers/w5100/Makefile.dep
+++ b/drivers/w5100/Makefile.dep
@@ -1,0 +1,4 @@
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_spi
+USEMODULE += netdev_eth
+USEMODULE += luid

--- a/drivers/ws281x/Makefile.dep
+++ b/drivers/ws281x/Makefile.dep
@@ -1,0 +1,19 @@
+FEATURES_REQUIRED_ANY += arch_avr8|arch_esp32|arch_native
+
+ifeq (,$(filter ws281x_%,$(USEMODULE)))
+  ifneq (,$(filter arch_avr8,$(FEATURES_USED)))
+    USEMODULE += ws281x_atmega
+  endif
+  ifneq (,$(filter arch_native,$(FEATURES_USED)))
+    USEMODULE += ws281x_vt100
+  endif
+  ifneq (,$(filter arch_esp32,$(FEATURES_USED)))
+    USEMODULE += ws281x_esp32
+  endif
+endif
+
+ifneq (,$(filter ws281x_atmega,$(USEMODULE)))
+  FEATURES_REQUIRED += arch_avr8
+endif
+
+USEMODULE += xtimer

--- a/drivers/xbee/Makefile.dep
+++ b/drivers/xbee/Makefile.dep
@@ -1,0 +1,5 @@
+FEATURES_REQUIRED += periph_uart
+FEATURES_REQUIRED += periph_gpio
+USEMODULE += ieee802154
+USEMODULE += xtimer
+USEMODULE += netif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR splits the main `drivers/Makefile.dep` in driver specific `Makefile.dep`s.

The dependency resolution for drivers modules defined as pseudo-modules still have to be done in the main `drivers/Makefile.dep` but just add the "real" module as a dependency.

There was a dependency resolution for `nrfmin` in `drivers/Makefile.dep` but it has nothing to do here, this PR moves it to `cpu/nrf5x_common/Makefile.dep`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Use build system tools to ensure no dependency has changed (help: what are the commands already ?)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Similar to #14369 but for Makefile.dep

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
