### PR TITLE
boards/slwstk6220a: Model features provided in Kconfig

### DIFF
--- a/boards/slwstk6220a/Kconfig
+++ b/boards/slwstk6220a/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "slwstk6220a" if BOARD_SLWSTK6220A
+
+config BOARD_SLWSTK6220A
+    bool
+    default y
+    select CPU_MODEL_EZR32WG330F256R60
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/cpu/ezr32wg/Kconfig
+++ b/cpu/ezr32wg/Kconfig
@@ -1,0 +1,37 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config CPU_FAM_EZR32WG
+    bool
+    select CPU_CORE_CORTEX_M4F
+    select HAS_CORTEXM_MPU
+    select HAS_CPU_EZR32WG
+    select HAS_PERIPH_CPUID
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+
+## CPU Models
+config CPU_MODEL_EZR32WG330F256R60
+    bool
+    select CPU_FAM_EZR32WG
+
+## Definition of specific features
+config HAS_CPU_EZR32WG
+    bool
+    help
+        Indicates that an 'ezr32wg' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "ezr32wg" if CPU_FAM_EZR32WG
+
+config CPU_MODEL
+    default "ezr32wg330f256r60" if CPU_MODEL_EZR32WG330F256R60
+
+config CPU
+    default "ezr32wg" if CPU_FAM_EZR32WG
+
+source "$(RIOTCPU)/cortexm_common/Kconfig"

--- a/cpu/ezr32wg/Makefile.features
+++ b/cpu/ezr32wg/Makefile.features
@@ -1,4 +1,5 @@
 CPU_CORE = cortex-m4f
+CPU_FAM = ezr32wg
 
 FEATURES_PROVIDED += cortexm_mpu
 FEATURES_PROVIDED += periph_cpuid

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -37,6 +37,7 @@ BOARD_WHITELIST += arduino-duemilanove \
                    sltb001a \
                    slwstk6000b-slwrb4150a \
                    slwstk6000b-slwrb4162a \
+                   slwstk6220a \
                    stk3600 \
                    stk3700 \
                    telosb \


### PR DESCRIPTION
### Contribution description
This models in Kconfig the features provided by the `ezr32wg` CPU and the only board that uses it so far (`slwstk6220a`).

### Testing procedure
- Check the symbol organization
- The board should pass `tests/kconfig_features`

### Issues/PRs references
Part of #14148