### PR TITLE
pkg/doc.txt: improve rendering of source location documentation

### DIFF
--- a/pkg/doc.txt
+++ b/pkg/doc.txt
@@ -14,14 +14,23 @@
  * INCLUDE += $(RIOTPKG)/<pkg_name>/...
  * ~~~~~~~~
  *
- * When the package can be build out-of-source, the source code of external
- * packages is fetched in a global location in
- * `$(RIOTBASE)/build/pkg/$(PKG_NAME)`.
+ * When the package can be built out-of-source, the source code of external
+ * packages is fetched in a global location in:
+ *
+ * ~~~~~~~~ {.mk}
+ * $(RIOTBASE)/build/pkg/$(PKG_NAME)
+ * ~~~~~~~~
+ *
  * When out-of-source build is not possible (for example because the package
- * build system doesn't allow it), the source code is fetch in the build
- * directory of the application under `$(BINDIR)/pkg/$(PKG_NAME)`
- * and is the same as the build directory (this is the case for micropython
- * and openthread packages).
+ * build system doesn't allow it), the source code is fetched in the build
+ * directory of the application under:
+ *
+ * ~~~~~~~~ {.mk}
+ * $(BINDIR)/pkg/$(PKG_NAME)
+ * ~~~~~~~~
+ *
+ * In this case, the source and the build directory are the same (currently,
+ * this applies to the micropython and openthread packages).
  *
  * Porting an external library
  * ===========================


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This improves the rendering of the package location documented in http://doc.riot-os.org/group__pkg.html.
The path to the global location just show `/build/pkg` which is confusing:

![image](https://user-images.githubusercontent.com/1375137/86007458-b4e2d480-ba17-11ea-92fe-cb9fdb9f35de.png)

![image](https://user-images.githubusercontent.com/1375137/86007509-c9bf6800-ba17-11ea-9d12-5d7fcd310d96.png)

This PR also improves the documentation itself (fix a typo and reword a bit).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Check that the rendering is now better (let's wait for circleci):

![image](https://user-images.githubusercontent.com/1375137/86007552-dcd23800-ba17-11ea-96c6-ef72052e6520.png)

![image](https://user-images.githubusercontent.com/1375137/86007584-e8256380-ba17-11ea-8573-0731faf7788d.png)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
