### PR TITLE
esptool.py: use Python3

### DIFF
--- a/dist/tools/esptool/esptool.py
+++ b/dist/tools/esptool/esptool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # ESP8266 & ESP32 ROM Bootloader Utility
 # Copyright (C) 2014-2016 Fredrik Ahlberg, Angus Gratton, Espressif Systems (Shanghai) PTE LTD, other contributors as noted.


### PR DESCRIPTION
### Contribution description

All our tools use python3 and `esptool.py` also works fine with it.
To avoid having to install dependencies twice and switch away from EOL Python2, convert `esptool.py` to use Python3.


### Testing procedure

Flashing esp8266 & esp32 should still work.

### Issues/PRs references

alternative to #14033
