### PR TITLE
pkg/fatfs/fatfs_vfs: fix _fstat

### DIFF
--- a/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
+++ b/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
@@ -257,12 +257,9 @@ static off_t _lseek(vfs_file_t *filp, off_t off, int whence)
 
 static int _fstat(vfs_file_t *filp, struct stat *buf)
 {
-    fatfs_file_desc_t *fd = (fatfs_file_desc_t *)filp->private_data.buffer;
     fatfs_desc_t *fs_desc = (fatfs_desc_t *)filp->mp->private_data;
     FILINFO fi;
     FRESULT res;
-
-    _build_abs_path(fs_desc, fd->fname);
 
     memset(buf, 0, sizeof(*buf));
 

--- a/tests/pkg_fatfs_vfs/main.c
+++ b/tests/pkg_fatfs_vfs/main.c
@@ -304,6 +304,27 @@ static void test_create(void)
     print_test_result("test_create__umount", vfs_umount(&_test_vfs_mount) == 0);
 }
 
+static void test_fstat(void)
+{
+    int fd;
+    struct stat stat_buf;
+
+    print_test_result("test_stat__mount", vfs_mount(&_test_vfs_mount) == 0);
+
+    fd = vfs_open(FULL_FNAME1, O_WRONLY | O_TRUNC, 0);
+    print_test_result("test_stat__open", fd >= 0);
+    print_test_result("test_stat__write",
+            vfs_write(fd, test_txt, sizeof(test_txt)) == sizeof(test_txt));
+    print_test_result("test_stat__close", vfs_close(fd) == 0);
+
+    fd = vfs_open(FULL_FNAME1, O_RDONLY, 0);
+    print_test_result("test_stat__open", fd >= 0);
+    print_test_result("test_stat__stat", vfs_fstat(fd, &stat_buf) == 0);
+    print_test_result("test_stat__close", vfs_close(fd) == 0);
+    print_test_result("test_stat__size", stat_buf.st_size == sizeof(test_txt));
+    print_test_result("test_stat__umount", vfs_umount(&_test_vfs_mount) == 0);
+}
+
 #ifdef MODULE_NEWLIB
 static void test_newlib(void)
 {
@@ -399,6 +420,7 @@ int main(void)
     test_unlink();
     test_mkrmdir();
     test_create();
+    test_fstat();
 #ifdef MODULE_NEWLIB
     test_newlib();
 #endif


### PR DESCRIPTION
### Contribution description

`vfs_fstat` failed loading stats from open file.

This happens because `_build_abs_path` is called in `_open` and again in `_fstat`, which leads to a broken absolute path.

This PR adds a test to `tests/pkg_fatfs_vfs` and removes the `_build_abs_path` call in `_fstat` as it is called on an already opened file.


### Testing procedure

Run these [tests](https://github.com/RIOT-OS/RIOT/tree/master/tests/pkg_fatfs_vfs).

