### PR TITLE
gcoap: Add file server

### DIFF
--- a/examples/filesystem/Makefile
+++ b/examples/filesystem/Makefile
@@ -24,6 +24,14 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
+ifeq (${NETWORK},1)
+USEMODULE += gcoap
+USEMODULE += coapfileserver
+USEMODULE += gnrc_ipv6_default
+USEMODULE += gnrc_netdev_default
+USEMODULE += auto_init_gnrc_netif
+endif
+
 # Use MTD (flash layer)
 USEMODULE += mtd
 # USEMODULE += mtd_sdcard

--- a/examples/filesystem/README.md
+++ b/examples/filesystem/README.md
@@ -76,3 +76,21 @@ Hello World!
 cat /const/hello-riot
 Hello RIOT!
 ```
+
+## Network file server
+
+If ``NETWORK=1`` is passed to make, the board's default network setup is
+enabled, and a CoAP server is started that exports the file system at the path
+``/vfs``.
+
+You can access the file system from another board that runs the gcoap example:
+
+```
+> coap get fe80::3c63:beff:fe85:ca96%6 5683 /vfs/const/
+<hello-world>,<hello-riot>
+> coap get fe80::3c63:beff:fe85:ca96%6 5683 /vfs/const/hello-riot
+--- blockwise start ---
+gcoap: response Success, code 2.05, 13 bytes
+00000000  48  65  6C  6C  6F  20  52  49  4F  54  21  0A  00
+--- blockwise complete ---
+```

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -179,6 +179,9 @@ endif
 ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
   FILTER += xtimer
 endif
+ifneq (,$(filter coapfileserver,$(USEMODULE)))
+    DIRS += net/application_layer/coapfileserver
+endif
 
 DIRS += $(dir $(wildcard $(addsuffix /Makefile, $(filter-out $(FILTER), $(USEMODULE)))))
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -760,6 +760,10 @@ ifneq (,$(filter devfs,$(USEMODULE)))
   USEMODULE += vfs
 endif
 
+ifneq (,$(filter coapfileserver,$(USEMODULE)))
+  USEMODULE += vfs
+endif
+
 ifneq (,$(filter vfs,$(USEMODULE)))
   USEMODULE += posix_headers
   ifeq (native, $(BOARD))

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -36,6 +36,7 @@ extern "C" {
  * @{
  */
 #define COAP_OPT_URI_HOST       (3)
+#define COAP_OPT_ETAG           (4)
 #define COAP_OPT_OBSERVE        (6)
 #define COAP_OPT_LOCATION_PATH  (8)
 #define COAP_OPT_URI_PATH       (11)

--- a/sys/include/net/coapfileserver.h
+++ b/sys/include/net/coapfileserver.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2020 chrysn
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_coapfileserver
+ * @{
+ *
+ * @file
+ * @brief       Resource handler for the CoAP file system server
+ *
+ * @author      chrysn <chrysn@fsfe.org>
+ *
+ * @}
+ */
+
+#ifndef COAPFILESERVER_H
+#define COAPFILESERVER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <net/nanocoap.h>
+
+/** File server starting point
+ *
+ * This struct needs to be present at the ctx of a coapfileserver_handler entry
+ * in a resource list.
+ *
+ */
+struct coapfileserver_entry {
+    /** Path in the VFS that should be served.
+     *
+     * This does not need a trailing slash. */
+    char *nameprefix;
+    /** Number of leading path components to ignore as they are the common prefix.
+     *
+     * If the file server is bound to the "/" resource, make this 0; if there
+     * is an entry
+     *
+     * ``{ "/files/sd", COAP_GET | COAP_MATCH_SUBTREE, coapfileserver_handler, files_sd }``
+     *
+     * then ``files_sd.strip_path`` needs to be 2.
+     *
+     * */
+    uint8_t strip_path;
+};
+
+/**
+ * File server handler
+ *
+ * Serve a directory from the VFS as a CoAP resource tree.
+ *
+ * @p ctx pointer to a @ref coapfileserver_entry
+ *
+ * @see net_coapfileserver
+ */
+ssize_t coapfileserver_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+/** @} */

--- a/sys/include/net/coapfileserver.h
+++ b/sys/include/net/coapfileserver.h
@@ -18,8 +18,8 @@
  * @}
  */
 
-#ifndef COAPFILESERVER_H
-#define COAPFILESERVER_H
+#ifndef NET_COAPFILESERVER_H
+#define NET_COAPFILESERVER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,6 +66,6 @@ ssize_t coapfileserver_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *
 }
 #endif
 
-#endif
+#endif /* NET_COAPFILESERVER_H */
 
 /** @} */

--- a/sys/net/application_layer/coapfileserver/Makefile
+++ b/sys/net/application_layer/coapfileserver/Makefile
@@ -1,0 +1,5 @@
+MODULE = coapfileserver
+
+SRC = coapfileserver.c
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/application_layer/coapfileserver/coapfileserver.c
+++ b/sys/net/application_layer/coapfileserver/coapfileserver.c
@@ -282,6 +282,10 @@ static ssize_t coapfileserver_directory_handler(coap_pkt_t *pdu, uint8_t *buf, s
             entry_name += 1;
         }
         size_t entry_len = strlen(entry_name);
+        if (entry_len <= 2 && memcmp(entry_name, "..", entry_len) == 0) {
+            /* Up pointers don't work the same way in URI semantics */
+            continue;
+        }
         /* maybe ",", "<>", and the length */
         ssize_t need_bytes = (payload_cursor == 0 ? 0 : 1) + 2 + entry_len;
         if (payload_cursor + need_bytes > pdu->payload_len) {

--- a/sys/net/application_layer/coapfileserver/coapfileserver.c
+++ b/sys/net/application_layer/coapfileserver/coapfileserver.c
@@ -18,7 +18,7 @@
 #include <fcntl.h>
 #include <error.h>
 
-#define ENABLE_DEBUG 0
+#define ENABLE_DEBUG 1
 #include "debug.h"
 
 /** Maximum length of an expressible path, including the trailing 0 character. */
@@ -257,10 +257,6 @@ static ssize_t coapfileserver_directory_handler(coap_pkt_t *pdu, uint8_t *buf, s
 {
     /**
      * ToDo:
-     *
-     * * Produce actual link format (considering the 'origin' part, ie. always
-     *   giving full paths including path-so-far from the request PDU), or
-     *   serve CoRAL right away
      *
      * * Blockwise
      *

--- a/sys/net/application_layer/coapfileserver/coapfileserver.c
+++ b/sys/net/application_layer/coapfileserver/coapfileserver.c
@@ -24,16 +24,47 @@
 /** Maximum length of an expressible path, including the trailing 0 character. */
 #define COAPFILESERVER_PATH_MAX (64)
 
-static ssize_t coapfileserver_file_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx);
-static ssize_t coapfileserver_directory_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx);
+/** Constant ETag length */
+#define ETAG_LENGTH 8
+
+/** Data extracted from a request on a file */
+struct requestdata {
+    /** 0-terminated expanded file name in the VFS */
+    char namebuf[COAPFILESERVER_PATH_MAX];
+    bool etag_sent;
+    uint8_t etag[ETAG_LENGTH];
+};
+
+/* See stat_etag */
+union stattag {
+    struct stat stat;
+    struct {
+        uint8_t etag[ETAG_LENGTH];
+        /* This will be as many repetitions of ETAG_LENGTH that together
+         * with the original etag field id's larger than the stat */
+        uint8_t etag_padding[(sizeof(struct stat) - 1) / ETAG_LENGTH * ETAG_LENGTH];
+    };
+};
+
+/** Build an ETag based on the given file's VFS stat. If the stat fails,
+ * returns the error and leaves stattag in any state; otherwise there's an etag
+ * in the stattag's field */
+static int stat_etag(char *filename, union stattag *stattag);
+
+/* These are almost but but not quite coap_handler_t -- they require the
+ * request to be already fully read and digested into the last argument. */
+
+static ssize_t coapfileserver_file_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, struct requestdata *request);
+static ssize_t coapfileserver_directory_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, struct requestdata *request);
 /** Create a CoAP response for a given errno (eg. EACCESS -> 4.03 Forbidden
  * etc., defaulting to 5.03 Internal Server Error) */
 static size_t coapfileserver_errno_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, int err);
 
 ssize_t coapfileserver_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx) {
     struct coapfileserver_entry *entry = (struct coapfileserver_entry *)ctx;
-    char namebuf[COAPFILESERVER_PATH_MAX];
-    /** Index in namebuf. Must not point at the last entry as that will be
+    struct requestdata request;
+    request.etag_sent = false;
+    /** Index in request.namebuf. Must not point at the last entry as that will be
      * zeroed to get a 0-terminated string. */
     size_t namelength = 0;
     bool trailing_slash = false;
@@ -43,7 +74,7 @@ ssize_t coapfileserver_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *
     uint8_t errorcode = COAP_CODE_INTERNAL_SERVER_ERROR;
 
     uint8_t strip_remaining = entry->strip_path;
-    namelength += namebuf - strncpy(namebuf, entry->nameprefix, sizeof(namebuf) - 1);
+    namelength += request.namebuf - strncpy(request.namebuf, entry->nameprefix, sizeof(request.namebuf) - 1);
 
     coap_optpos_t opt;
     bool is_first = true;
@@ -80,14 +111,28 @@ ssize_t coapfileserver_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *
                     goto error;
                 }
                 size_t newlength = namelength + 1 + optlen;
-                if (newlength > sizeof(namebuf) - 1) {
+                if (newlength > sizeof(request.namebuf) - 1) {
                     /* Path too long, therefore can't exist in this mapping */
                     errorcode = COAP_CODE_PATH_NOT_FOUND;
                     goto error;
                 }
-                namebuf[namelength] = '/';
-                memcpy(&namebuf[namelength] + 1, value, optlen);
+                request.namebuf[namelength] = '/';
+                memcpy(&request.namebuf[namelength] + 1, value, optlen);
                 namelength = newlength;
+                break;
+            case COAP_OPT_ETAG:
+                if (optlen != sizeof(request.etag)) {
+                    /* Can't be a matching tag, no use in carrying that */
+                    continue;
+                }
+                if (request.etag_sent) {
+                    /* We can reasonably only check for a limited sized set,
+                     * and it size is 1 here (sending multiple ETags is
+                     * possible but rare) */
+                    continue;
+                }
+                request.etag_sent = true;
+                memcpy(request.etag, value, sizeof(request.etag));
                 break;
             default:
                 if (opt.opt_num & 1) {
@@ -99,39 +144,50 @@ ssize_t coapfileserver_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *
         }
     }
 
-    namebuf[namelength] = '\0';
+    request.namebuf[namelength] = '\0';
     bool is_directory = trailing_slash | !any_component;
 
     /* Note to self: As we parse more options than just Uri-Path, we'll likely
      * pass a struct pointer later. So far, those could even be hooked into the
      * resource list, but that'll go away once we parse more options */
     if (is_directory) {
-        return coapfileserver_directory_handler(pdu, buf, len, namebuf);
+        return coapfileserver_directory_handler(pdu, buf, len, &request);
     } else {
-        return coapfileserver_file_handler(pdu, buf, len, namebuf);
+        return coapfileserver_file_handler(pdu, buf, len, &request);
     }
 
 error:
     return gcoap_response(pdu, buf, len, errorcode);
 }
 
-static ssize_t coapfileserver_file_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx) {
+static ssize_t coapfileserver_file_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, struct requestdata *request)
+{
     /**
      * ToDo:
      *
      * * Blockwise
      *
-     * * ETag
-     *
      * * Error handling on late read errors
      */
-    const char *name = (char *)ctx;
+    int err;
 
-    int fd = vfs_open(name, O_RDONLY, 0);
+    union stattag stattag;
+    err = stat_etag(request->namebuf, &stattag);
+    if (err < 0)
+        return coapfileserver_errno_handler(pdu, buf, len, err);
+
+    if (request->etag_sent && memcmp(stattag.etag, request->etag, ETAG_LENGTH) == 0) {
+        gcoap_resp_init(pdu, buf, len, COAP_CODE_VALID);
+        coap_opt_add_opaque(pdu, COAP_OPT_ETAG, stattag.etag, ETAG_LENGTH);
+        return coap_opt_finish(pdu, COAP_OPT_FINISH_NONE);
+    }
+
+    int fd = vfs_open(request->namebuf, O_RDONLY, 0);
     if (fd < 0)
         return coapfileserver_errno_handler(pdu, buf, len, fd);
 
     gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
+    coap_opt_add_opaque(pdu, COAP_OPT_ETAG, stattag.etag, ETAG_LENGTH);
     size_t resp_len = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
 
     int read = vfs_read(fd, pdu->payload, pdu->payload_len);
@@ -147,7 +203,8 @@ static ssize_t coapfileserver_file_handler(coap_pkt_t *pdu, uint8_t *buf, size_t
     return resp_len + read;
 }
 
-static ssize_t coapfileserver_directory_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx) {
+static ssize_t coapfileserver_directory_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, struct requestdata *request)
+{
     /**
      * ToDo:
      *
@@ -159,10 +216,9 @@ static ssize_t coapfileserver_directory_handler(coap_pkt_t *pdu, uint8_t *buf, s
      *
      * * Directories don't have their trailing slashes yet
      */
-    const char *name = (char *)ctx;
     vfs_DIR dir;
 
-    int err = vfs_opendir(&dir, name);
+    int err = vfs_opendir(&dir, request->namebuf);
     if (err != 0) {
         return coapfileserver_errno_handler(pdu, buf, len, err);
     }
@@ -214,4 +270,27 @@ static size_t coapfileserver_errno_handler(coap_pkt_t *pdu, uint8_t *buf, size_t
     };
     DEBUG("coapfileserver: Rejecting error %d (%s) as %d.%02d\n", err, strerror(err), code >> 5, code & 0x1f);
     return gcoap_response(pdu, buf, len, code);
+}
+
+static int stat_etag(char *filename, union stattag *stattag)
+{
+    int err;
+
+    memset(stattag, 0, sizeof(union stattag));
+    err = vfs_stat(filename, &stattag->stat);
+    if (err < 0)
+        return err;
+
+    /* Normalizing fields whose value can change without affecting the ETag */
+    stattag->stat.st_nlink = 0;
+    memset(&stattag->stat.st_atim, 0, sizeof(stattag->stat.st_atim));
+
+    /* Build a compact ETag by XORing the stat onto itself */
+    for (unsigned int i = 0; i < sizeof(stattag->etag_padding) / sizeof(stattag->etag); ++i) {
+        for (int j = 0; j < ETAG_LENGTH; ++j) {
+            stattag->etag[j] ^= stattag->etag_padding[i * ETAG_LENGTH + j];
+        }
+    }
+
+    return 0;
 }

--- a/sys/net/application_layer/coapfileserver/coapfileserver.c
+++ b/sys/net/application_layer/coapfileserver/coapfileserver.c
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2020 chrysn
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <assert.h>
+#include <assert.h>
+
+#include <net/coapfileserver.h>
+#include <net/gcoap.h>
+#include <vfs.h>
+#include <fcntl.h>
+#include <error.h>
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+/** Maximum length of an expressible path, including the trailing 0 character. */
+#define COAPFILESERVER_PATH_MAX (64)
+
+static ssize_t coapfileserver_file_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx);
+static ssize_t coapfileserver_directory_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx);
+/** Create a CoAP response for a given errno (eg. EACCESS -> 4.03 Forbidden
+ * etc., defaulting to 5.03 Internal Server Error) */
+static size_t coapfileserver_errno_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, int err);
+
+ssize_t coapfileserver_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx) {
+    struct coapfileserver_entry *entry = (struct coapfileserver_entry *)ctx;
+    char namebuf[COAPFILESERVER_PATH_MAX];
+    /** Index in namebuf. Must not point at the last entry as that will be
+     * zeroed to get a 0-terminated string. */
+    size_t namelength = 0;
+    bool trailing_slash = false;
+    /** If no path component comes along at all, it'll count as a trailing
+     * slash no matter the trailing_slash value */
+    bool any_component = false;
+    uint8_t errorcode = COAP_CODE_INTERNAL_SERVER_ERROR;
+
+    uint8_t strip_remaining = entry->strip_path;
+    namelength += namebuf - strncpy(namebuf, entry->nameprefix, sizeof(namebuf) - 1);
+
+    coap_optpos_t opt;
+    bool is_first = true;
+    uint8_t *value;
+    ssize_t optlen;
+    while ((optlen = coap_opt_get_next(pdu, &opt, &value, is_first)) !=
+            -ENOENT)
+    {
+        if (optlen < 0) {
+            errorcode = COAP_CODE_BAD_REQUEST;
+            goto error;
+        }
+
+        is_first = false;
+        switch (opt.opt_num) {
+            case COAP_OPT_URI_PATH:
+                if (strip_remaining != 0) {
+                    strip_remaining -= 1;
+                    continue;
+                }
+                if (trailing_slash) {
+                    errorcode = COAP_CODE_BAD_REQUEST;
+                    goto error;
+                }
+                any_component = true;
+                if (optlen == 0) {
+                    trailing_slash = true;
+                    continue;
+                }
+                if (memchr(value, '0', optlen) != NULL ||
+                        memchr(value, '/', optlen) != NULL) {
+                    /* Path can not be expressed in the file system */
+                    errorcode = COAP_CODE_PATH_NOT_FOUND;
+                    goto error;
+                }
+                size_t newlength = namelength + 1 + optlen;
+                if (newlength > sizeof(namebuf) - 1) {
+                    /* Path too long, therefore can't exist in this mapping */
+                    errorcode = COAP_CODE_PATH_NOT_FOUND;
+                    goto error;
+                }
+                namebuf[namelength] = '/';
+                memcpy(&namebuf[namelength] + 1, value, optlen);
+                namelength = newlength;
+                break;
+            default:
+                if (opt.opt_num & 1) {
+                    errorcode = COAP_CODE_BAD_REQUEST;
+                    goto error;
+                } else {
+                    /* Ignoring elective option */
+                }
+        }
+    }
+
+    namebuf[namelength] = '\0';
+    bool is_directory = trailing_slash | !any_component;
+
+    /* Note to self: As we parse more options than just Uri-Path, we'll likely
+     * pass a struct pointer later. So far, those could even be hooked into the
+     * resource list, but that'll go away once we parse more options */
+    if (is_directory) {
+        return coapfileserver_directory_handler(pdu, buf, len, namebuf);
+    } else {
+        return coapfileserver_file_handler(pdu, buf, len, namebuf);
+    }
+
+error:
+    return gcoap_response(pdu, buf, len, errorcode);
+}
+
+static ssize_t coapfileserver_file_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx) {
+    /**
+     * ToDo:
+     *
+     * * Blockwise
+     *
+     * * ETag
+     *
+     * * Error handling on late read errors
+     */
+    const char *name = (char *)ctx;
+
+    int fd = vfs_open(name, O_RDONLY, 0);
+    if (fd < 0)
+        return coapfileserver_errno_handler(pdu, buf, len, fd);
+
+    gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
+    size_t resp_len = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
+
+    int read = vfs_read(fd, pdu->payload, pdu->payload_len);
+    assert(read >= 0); /* Can't rewind PDU yet */
+
+    vfs_close(fd);
+
+    if (read == 0) {
+        /* Rewind to clear payload marker */
+        read -= 1;
+    }
+
+    return resp_len + read;
+}
+
+static ssize_t coapfileserver_directory_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, void *ctx) {
+    /**
+     * ToDo:
+     *
+     * * Produce actual link format (considering the 'origin' part, ie. always
+     *   giving full paths including path-so-far from the request PDU), or
+     *   serve CoRAL right away
+     *
+     * * Blockwise
+     *
+     * * Directories don't have their trailing slashes yet
+     */
+    const char *name = (char *)ctx;
+    vfs_DIR dir;
+
+    int err = vfs_opendir(&dir, name);
+    if (err != 0) {
+        return coapfileserver_errno_handler(pdu, buf, len, err);
+    }
+    DEBUG("coapfileserver: Serving directory listing\n");
+
+    gcoap_resp_init(pdu, buf, len, COAP_CODE_CONTENT);
+    coap_opt_add_format(pdu, COAP_FORMAT_LINK);
+    size_t resp_len = coap_opt_finish(pdu, COAP_OPT_FINISH_PAYLOAD);
+
+    vfs_dirent_t entry;
+    ssize_t payload_cursor = 0;
+    while (vfs_readdir(&dir, &entry) > 0) {
+        size_t entry_len = strlen((char*)&entry.d_name);
+        /* maybe ",", "<>", and the length without leading slash */
+        ssize_t need_bytes = (payload_cursor == 0 ? 0 : 1) + 2 + entry_len - 1;
+        if (payload_cursor + need_bytes > pdu->payload_len) {
+            /* Without blockwise, this is the best approximation we can do */
+            DEBUG("coapfileserver: Directory listing truncated\n");
+            break;
+        }
+        if (payload_cursor != 0) {
+            pdu->payload[payload_cursor++] = ',';
+        }
+        pdu->payload[payload_cursor++] = '<';
+        memcpy(&pdu->payload[payload_cursor], &entry.d_name[1], entry_len - 1);
+        payload_cursor += entry_len - 1;
+        pdu->payload[payload_cursor++] = '>';
+    }
+    vfs_closedir(&dir);
+
+    if (payload_cursor == 0) {
+        /* Rewind to clear payload marker */
+        payload_cursor -= 1;
+    }
+
+    return resp_len + payload_cursor;
+}
+
+static size_t coapfileserver_errno_handler(coap_pkt_t *pdu, uint8_t *buf, size_t len, int err)
+{
+    uint8_t code;
+    switch (err) {
+        case -EACCES:
+            code = COAP_CODE_FORBIDDEN; break;
+        case -ENOENT:
+            code = COAP_CODE_PATH_NOT_FOUND; break;
+        default:
+            code = COAP_CODE_INTERNAL_SERVER_ERROR;
+    };
+    DEBUG("coapfileserver: Rejecting error %d (%s) as %d.%02d\n", err, strerror(err), code >> 5, code & 0x1f);
+    return gcoap_response(pdu, buf, len, code);
+}

--- a/sys/net/application_layer/coapfileserver/doc.txt
+++ b/sys/net/application_layer/coapfileserver/doc.txt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 chrysn
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_coapfileserver CoAP file server
+ * @ingroup     net
+ * @brief       Library for serving files from the VFS to CoAP clients
+ *
+ * # About
+ * 
+ * This maps files in the local file system onto a resources in CoAP. In that,
+ * is is what is called a static web server in the unconstrained web.
+ *
+ * As usual, GET operations are used to read files<!-- WRITESUPPORT, and PUT writes to files.
+ * In the current implementation, PUTs are expressed as random-access, meaning
+ * that files are not updated atomically -->.
+ *
+ * Directories are expressed to URIs with trailing slashes<!-- WRITESUPPORT, and are always
+ * created implicitly when files are PUT under them; they can be DELETEd when
+ * empty -->.
+ *
+ *
+ * # Usage
+ *
+ * * ``USEMODULE += coapfileserver``
+ *
+ * * Have a @ref coapfileserver_entry populated with the path you want to serve,
+ *   and the number of path components to strip from incoming requests:
+ *
+ *   ```
+ *   static const struct coapfileserver_entry files_sd = {
+ *       "/sd",
+ *       2
+ *   };
+ *   ```
+ *
+ * * Enter a @ref coapfileserver_handler handler into your CoAP server's
+ *   resource list like this:
+ *
+ *   ```
+ *   static const coap_resource_t _resources[] = {
+ *       ...,
+ *       { "/files/sd", COAP_GET | COAP_MATCH_SUBTREE, coapfileserver_handler, files_sd },
+ *       ...
+ *   }
+ *   ```
+ *
+ *   The allowed methods dictate whether it's read-only (``COAP_GET``) or (in the
+ *   future<!-- WRITESUPPORT -->) read-write (``1COAP_GET | COAP_PUT | COAP_DELETE``).
+ *
+ */

--- a/sys/net/application_layer/coapfileserver/doc.txt
+++ b/sys/net/application_layer/coapfileserver/doc.txt
@@ -12,7 +12,7 @@
  * @brief       Library for serving files from the VFS to CoAP clients
  *
  * # About
- * 
+ *
  * This maps files in the local file system onto a resources in CoAP. In that,
  * is is what is called a static web server in the unconstrained web.
  *

--- a/sys/net/application_layer/coapfileserver/doc.txt
+++ b/sys/net/application_layer/coapfileserver/doc.txt
@@ -24,6 +24,13 @@
  * created implicitly when files are PUT under them; they can be DELETEd when
  * empty -->.
  *
+ * @note The file server uses ETag for cache validation. The ETags are built
+ * from the file system stat values. As clients rely on the ETag to differ when
+ * the file changes, it is important that file modification times are set. The
+ * precise time values do not matter, but if a file is changed in place and
+ * neither its length nor its modification time is varied, then clients will
+ * not become aware of the change or may even mix up the versions half way
+ * through if they have a part of the old version cached.
  *
  * # Usage
  *


### PR DESCRIPTION
### Contribution description

This ties in the Gcoap module with the VFS module in the style of a static web server.

This is quite minimal (no write support, no blockwise, no ETag), but already fully documented. The example commit is marked WIP as it's not sure yet where to best put the example.

### Testing procedure

Currently: Run the gcoap example, and ``GET /vfs/const/`` or ``GET /vfs/const/hello-world``, which should show a directory listing or the file content, respectively.