### PR TITLE
examples/filesystem: add support for littlefs2

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -856,10 +856,18 @@ ifneq (,$(filter spiffs,$(USEMODULE)))
   USEMODULE += spiffs_fs
   USEMODULE += mtd
 endif
+
 ifneq (,$(filter littlefs,$(USEMODULE)))
   USEPKG += littlefs
   USEMODULE += vfs
   USEMODULE += littlefs_fs
+  USEMODULE += mtd
+endif
+
+ifneq (,$(filter littlefs2,$(USEMODULE)))
+  USEPKG += littlefs2
+  USEMODULE += vfs
+  USEMODULE += littlefs2_fs
   USEMODULE += mtd
 endif
 

--- a/examples/filesystem/Makefile
+++ b/examples/filesystem/Makefile
@@ -32,8 +32,8 @@ USEMODULE += mtd
 USEMODULE += vfs
 
 # Use a file system
-USEMODULE += littlefs
-# USEMODULE += littlefs2
+# USEMODULE += littlefs
+USEMODULE += littlefs2
 # USEMODULE += spiffs
 # USEMODULE += fatfs_vfs
 USEMODULE += constfs

--- a/examples/filesystem/Makefile
+++ b/examples/filesystem/Makefile
@@ -33,6 +33,7 @@ USEMODULE += vfs
 
 # Use a file system
 USEMODULE += littlefs
+# USEMODULE += littlefs2
 # USEMODULE += spiffs
 # USEMODULE += fatfs_vfs
 USEMODULE += constfs

--- a/examples/filesystem/main.c
+++ b/examples/filesystem/main.c
@@ -72,6 +72,22 @@ static littlefs_desc_t fs_desc = {
 /* littlefs file system driver will be used */
 #define FS_DRIVER littlefs_file_system
 
+#elif defined(MODULE_LITTLEFS2)
+/* include file system header for driver */
+#include "fs/littlefs2_fs.h"
+
+/* file system specific descriptor
+ * for littlefs2, some fields can be tweaked to define the size
+ * of the partition, see header documentation.
+ * In this example, default behavior will be used, i.e. the entire
+ * memory will be used (parameters come from mtd) */
+static littlefs2_desc_t fs_desc = {
+    .lock = MUTEX_INIT,
+};
+
+/* littlefs file system driver will be used */
+#define FS_DRIVER littlefs2_file_system
+
 #elif defined(MODULE_SPIFFS)
 /* include file system header */
 #include "fs/spiffs_fs.h"
@@ -153,7 +169,7 @@ static int _mount(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS) || defined(MODULE_FATFS_VFS))
+#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS) || defined(MODULE_LITTLEFS2) || defined(MODULE_FATFS_VFS))
     int res = vfs_mount(&flash_mount);
     if (res < 0) {
         printf("Error while mounting %s...try format\n", FLASH_MOUNT_POINT);
@@ -172,7 +188,7 @@ static int _format(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS) || defined(MODULE_FATFS_VFS))
+#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS) || defined(MODULE_LITTLEFS2) || defined(MODULE_FATFS_VFS))
     int res = vfs_format(&flash_mount);
     if (res < 0) {
         printf("Error while formatting %s\n", FLASH_MOUNT_POINT);
@@ -191,7 +207,7 @@ static int _umount(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS) || defined(MODULE_FATFS_VFS))
+#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS) || defined(MODULE_LITTLEFS2) || defined(MODULE_FATFS_VFS))
     int res = vfs_umount(&flash_mount);
     if (res < 0) {
         printf("Error while unmounting %s\n", FLASH_MOUNT_POINT);
@@ -283,7 +299,7 @@ static const shell_command_t shell_commands[] = {
 
 int main(void)
 {
-#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS))
+#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS) || defined(MODULE_LITTLEFS2))
     /* spiffs and littlefs need a mtd pointer
      * by default the whole memory is used */
     fs_desc.dev = MTD_0;

--- a/pkg/littlefs2/fs/littlefs2_fs.c
+++ b/pkg/littlefs2/fs/littlefs2_fs.c
@@ -66,7 +66,7 @@ static int littlefs_err_to_errno(ssize_t err)
 static int _dev_read(const struct lfs_config *c, lfs_block_t block,
                  lfs_off_t off, void *buffer, lfs_size_t size)
 {
-    littlefs_desc_t *fs = c->context;
+    littlefs2_desc_t *fs = c->context;
     mtd_dev_t *mtd = fs->dev;
 
     DEBUG("lfs_read: c=%p, block=%" PRIu32 ", off=%" PRIu32 ", buf=%p, size=%" PRIu32 "\n",
@@ -78,7 +78,7 @@ static int _dev_read(const struct lfs_config *c, lfs_block_t block,
 static int _dev_write(const struct lfs_config *c, lfs_block_t block,
                   lfs_off_t off, const void *buffer, lfs_size_t size)
 {
-    littlefs_desc_t *fs = c->context;
+    littlefs2_desc_t *fs = c->context;
     mtd_dev_t *mtd = fs->dev;
 
     DEBUG("lfs_write: c=%p, block=%" PRIu32 ", off=%" PRIu32 ", buf=%p, size=%" PRIu32 "\n",
@@ -99,7 +99,7 @@ static int _dev_write(const struct lfs_config *c, lfs_block_t block,
 
 static int _dev_erase(const struct lfs_config *c, lfs_block_t block)
 {
-    littlefs_desc_t *fs = c->context;
+    littlefs2_desc_t *fs = c->context;
     mtd_dev_t *mtd = fs->dev;
 
     DEBUG("lfs_erase: c=%p, block=%" PRIu32 "\n", (void *)c, block);
@@ -119,7 +119,7 @@ static int _dev_sync(const struct lfs_config *c)
     return 0;
 }
 
-static int prepare(littlefs_desc_t *fs)
+static int prepare(littlefs2_desc_t *fs)
 {
     mutex_init(&fs->lock);
     mutex_lock(&fs->lock);
@@ -172,7 +172,7 @@ static int prepare(littlefs_desc_t *fs)
 
 static int _format(vfs_mount_t *mountp)
 {
-    littlefs_desc_t *fs = mountp->private_data;
+    littlefs2_desc_t *fs = mountp->private_data;
 
     DEBUG("littlefs: format: mountp=%p\n", (void *)mountp);
     int ret = prepare(fs);
@@ -193,7 +193,7 @@ static int _mount(vfs_mount_t *mountp)
     BUILD_BUG_ON(VFS_DIR_BUFFER_SIZE < sizeof(lfs_dir_t));
     BUILD_BUG_ON(VFS_FILE_BUFFER_SIZE < sizeof(lfs_file_t));
 
-    littlefs_desc_t *fs = mountp->private_data;
+    littlefs2_desc_t *fs = mountp->private_data;
 
     DEBUG("littlefs: mount: mountp=%p\n", (void *)mountp);
     int ret = prepare(fs);
@@ -209,7 +209,7 @@ static int _mount(vfs_mount_t *mountp)
 
 static int _umount(vfs_mount_t *mountp)
 {
-    littlefs_desc_t *fs = mountp->private_data;
+    littlefs2_desc_t *fs = mountp->private_data;
 
     mutex_lock(&fs->lock);
 
@@ -223,7 +223,7 @@ static int _umount(vfs_mount_t *mountp)
 
 static int _unlink(vfs_mount_t *mountp, const char *name)
 {
-    littlefs_desc_t *fs = mountp->private_data;
+    littlefs2_desc_t *fs = mountp->private_data;
 
     mutex_lock(&fs->lock);
 
@@ -238,7 +238,7 @@ static int _unlink(vfs_mount_t *mountp, const char *name)
 
 static int _rename(vfs_mount_t *mountp, const char *from_path, const char *to_path)
 {
-    littlefs_desc_t *fs = mountp->private_data;
+    littlefs2_desc_t *fs = mountp->private_data;
 
     mutex_lock(&fs->lock);
 
@@ -254,7 +254,7 @@ static int _rename(vfs_mount_t *mountp, const char *from_path, const char *to_pa
 static int _mkdir(vfs_mount_t *mountp, const char *name, mode_t mode)
 {
     (void)mode;
-    littlefs_desc_t *fs = mountp->private_data;
+    littlefs2_desc_t *fs = mountp->private_data;
 
     mutex_lock(&fs->lock);
 
@@ -269,7 +269,7 @@ static int _mkdir(vfs_mount_t *mountp, const char *name, mode_t mode)
 
 static int _rmdir(vfs_mount_t *mountp, const char *name)
 {
-    littlefs_desc_t *fs = mountp->private_data;
+    littlefs2_desc_t *fs = mountp->private_data;
 
     mutex_lock(&fs->lock);
 
@@ -284,7 +284,7 @@ static int _rmdir(vfs_mount_t *mountp, const char *name)
 
 static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode, const char *abs_path)
 {
-    littlefs_desc_t *fs = filp->mp->private_data;
+    littlefs2_desc_t *fs = filp->mp->private_data;
     lfs_file_t *fp = (lfs_file_t *)&filp->private_data.buffer;
     (void) abs_path;
     (void) mode;
@@ -326,7 +326,7 @@ static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode, con
 
 static int _close(vfs_file_t *filp)
 {
-    littlefs_desc_t *fs = filp->mp->private_data;
+    littlefs2_desc_t *fs = filp->mp->private_data;
     lfs_file_t *fp = (lfs_file_t *)&filp->private_data.buffer;
 
     mutex_lock(&fs->lock);
@@ -341,7 +341,7 @@ static int _close(vfs_file_t *filp)
 
 static ssize_t _write(vfs_file_t *filp, const void *src, size_t nbytes)
 {
-    littlefs_desc_t *fs = filp->mp->private_data;
+    littlefs2_desc_t *fs = filp->mp->private_data;
     lfs_file_t *fp = (lfs_file_t *)&filp->private_data.buffer;
 
     mutex_lock(&fs->lock);
@@ -357,7 +357,7 @@ static ssize_t _write(vfs_file_t *filp, const void *src, size_t nbytes)
 
 static ssize_t _read(vfs_file_t *filp, void *dest, size_t nbytes)
 {
-    littlefs_desc_t *fs = filp->mp->private_data;
+    littlefs2_desc_t *fs = filp->mp->private_data;
     lfs_file_t *fp = (lfs_file_t *)&filp->private_data.buffer;
 
     mutex_lock(&fs->lock);
@@ -373,7 +373,7 @@ static ssize_t _read(vfs_file_t *filp, void *dest, size_t nbytes)
 
 static off_t _lseek(vfs_file_t *filp, off_t off, int whence)
 {
-    littlefs_desc_t *fs = filp->mp->private_data;
+    littlefs2_desc_t *fs = filp->mp->private_data;
     lfs_file_t *fp = (lfs_file_t *)&filp->private_data.buffer;
 
     mutex_lock(&fs->lock);
@@ -389,7 +389,7 @@ static off_t _lseek(vfs_file_t *filp, off_t off, int whence)
 
 static int _stat(vfs_mount_t *mountp, const char *restrict path, struct stat *restrict buf)
 {
-    littlefs_desc_t *fs = mountp->private_data;
+    littlefs2_desc_t *fs = mountp->private_data;
 
     mutex_lock(&fs->lock);
 
@@ -425,7 +425,7 @@ static int _traverse_cb(void *param, lfs_block_t block)
 static int _statvfs(vfs_mount_t *mountp, const char *restrict path, struct statvfs *restrict buf)
 {
     (void)path;
-    littlefs_desc_t *fs = mountp->private_data;
+    littlefs2_desc_t *fs = mountp->private_data;
 
     mutex_lock(&fs->lock);
 
@@ -450,7 +450,7 @@ static int _statvfs(vfs_mount_t *mountp, const char *restrict path, struct statv
 static int _opendir(vfs_DIR *dirp, const char *dirname, const char *abs_path)
 {
     (void)abs_path;
-    littlefs_desc_t *fs = dirp->mp->private_data;
+    littlefs2_desc_t *fs = dirp->mp->private_data;
     lfs_dir_t *dir = (lfs_dir_t *)&dirp->private_data.buffer;
 
     mutex_lock(&fs->lock);
@@ -466,7 +466,7 @@ static int _opendir(vfs_DIR *dirp, const char *dirname, const char *abs_path)
 
 static int _readdir(vfs_DIR *dirp, vfs_dirent_t *entry)
 {
-    littlefs_desc_t *fs = dirp->mp->private_data;
+    littlefs2_desc_t *fs = dirp->mp->private_data;
     lfs_dir_t *dir = (lfs_dir_t *)&dirp->private_data.buffer;
 
     mutex_lock(&fs->lock);
@@ -489,7 +489,7 @@ static int _readdir(vfs_DIR *dirp, vfs_dirent_t *entry)
 
 static int _closedir(vfs_DIR *dirp)
 {
-    littlefs_desc_t *fs = dirp->mp->private_data;
+    littlefs2_desc_t *fs = dirp->mp->private_data;
     lfs_dir_t *dir = (lfs_dir_t *)&dirp->private_data.buffer;
 
     mutex_lock(&fs->lock);

--- a/sys/include/fs/littlefs2_fs.h
+++ b/sys/include/fs/littlefs2_fs.h
@@ -105,7 +105,7 @@ typedef struct {
 #endif
     /** lookahead buffer to use internally */
     uint8_t lookahead_buf[CONFIG_LITTLEFS2_LOOKAHEAD_SIZE];
-} littlefs_desc_t;
+} littlefs2_desc_t;
 
 /** The littlefs vfs driver */
 extern const vfs_file_system_t littlefs2_file_system;

--- a/tests/pkg_littlefs2/main.c
+++ b/tests/pkg_littlefs2/main.c
@@ -117,7 +117,7 @@ static mtd_dev_t dev = {
 static mtd_dev_t *_dev = (mtd_dev_t*) &dev;
 #endif /* MTD_0 */
 
-static littlefs_desc_t littlefs_desc;
+static littlefs2_desc_t littlefs_desc;
 
 static vfs_mount_t _test_littlefs_mount = {
     .fs = &littlefs2_file_system,


### PR DESCRIPTION
### Contribution description

This adds support for littlefs2 to `examples/filesystem`.

There were also some bits missed when creating the littlefs2 package from littlefs, this fixes that as it is a requirement for VFS support.

### Testing procedure

run `examples/filesystem`

### Issues/PRs references

depends on #13866
