### PR TITLE
kconfiglib: bump to v14.1.0

### DIFF
--- a/dist/tools/kconfiglib/Makefile
+++ b/dist/tools/kconfiglib/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=kconfiglib
 PKG_URL=https://github.com/ulfalizer/Kconfiglib
-PKG_VERSION=82f59179b1b35fcd8b6d188453b283599ea70518
+PKG_VERSION=061e71f7d78cb057762d88de088055361863deff
 PKG_LICENSE=ISC
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

I noticed the build would fail on a fresh Ubuntu 20.04 install.
That is because Python2 is no longer installed by default.
The latest upstream version uses Python3 instead of Python2, so upgrade kconfiglib to fix that.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
