### PR TITLE
[WIP] sys/net/sock/udp: Provide access to local IP addr

### DIFF
--- a/pkg/emb6/contrib/sock/udp/emb6_sock_udp.c
+++ b/pkg/emb6/contrib/sock/udp/emb6_sock_udp.c
@@ -143,8 +143,9 @@ int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *ep)
     return -ENOTCONN;
 }
 
-int sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len,
-                  uint32_t timeout, sock_udp_ep_t *remote)
+int sock_udp_recv2(sock_udp_t *sock, void *data, size_t max_len,
+                   uint32_t timeout, sock_udp_ep_t *remote,
+                   sock_udp_ep_t *local)
 {
     xtimer_t timeout_timer;
     int blocking = BLOCKING;
@@ -189,6 +190,13 @@ int sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len,
                 remote->netif = SOCK_ADDR_ANY_NETIF;
                 memcpy(&remote->addr, sock->recv_info.src, sizeof(ipv6_addr_t));
                 remote->port = sock->recv_info.src_port;
+            }
+            if (local != NULL) {
+                local->family = AF_INET6;
+                local->netif = SOCK_ADDR_ANY_NETIF;
+                /* no local IP address in emb6 */
+                memset(&local->addr, 0, sizeof(local->addr));
+                local->port = ntohs(sock->sock.udp_conn->lport);
             }
             res = (int)sock->recv_info.datalen;
             mutex_unlock(&sock->mutex);

--- a/pkg/lwip/include/lwipopts.h
+++ b/pkg/lwip/include/lwipopts.h
@@ -33,119 +33,119 @@ extern "C" {
  * @{
  */
 #ifdef MODULE_LWIP_ARP
-#define LWIP_ARP                (1)
+#define LWIP_ARP                1
 #else  /* MODULE_LWIP_ARP */
-#define LWIP_ARP                (0)
+#define LWIP_ARP                0
 #endif /* MODULE_LWIP_ARP */
 
 #ifdef MODULE_LWIP_AUTOIP
-#define LWIP_AUTOIP             (1)
+#define LWIP_AUTOIP             1
 #else  /* MODULE_LWIP_AUTOIP */
-#define LWIP_AUTOIP             (0)
+#define LWIP_AUTOIP             0
 #endif /* MODULE_LWIP_AUTOIP */
 
 #ifdef MODULE_LWIP_DHCP
-#define LWIP_DHCP               (1)
+#define LWIP_DHCP               1
 #else  /* MODULE_LWIP_DHCP */
-#define LWIP_DHCP               (0)
+#define LWIP_DHCP               0
 #endif /* MODULE_LWIP_DHCP */
 
 #ifdef MODULE_LWIP_ETHERNET
-#define LWIP_ETHERNET           (1)
+#define LWIP_ETHERNET           1
 #else  /* MODULE_LWIP_ETHERNET */
-#define LWIP_ETHERNET           (0)
+#define LWIP_ETHERNET           0
 #endif /* MODULE_LWIP_ETHERNET */
 
 #ifdef MODULE_LWIP_IGMP
-#define LWIP_IGMP               (1)
+#define LWIP_IGMP               1
 #else  /* MODULE_LWIP_IGMP */
-#define LWIP_IGMP               (0)
+#define LWIP_IGMP               0
 #endif /* MODULE_LWIP_IGMP */
 
 #ifdef MODULE_LWIP_IPV4
-#define LWIP_IPV4               (1)
+#define LWIP_IPV4               1
 #else  /* MODULE_LWIP_IPV4 */
-#define LWIP_IPV4               (0)
+#define LWIP_IPV4               0
 #endif /* MODULE_LWIP_IPV4 */
 
 #ifdef MODULE_LWIP_IPV6_AUTOCONFIG
-#define LWIP_IPV6_AUTOCONFIG    (1)
+#define LWIP_IPV6_AUTOCONFIG    1
 #else  /* MODULE_LWIP_IPV6_AUTOCONFIG */
-#define LWIP_IPV6_AUTOCONFIG    (0)
+#define LWIP_IPV6_AUTOCONFIG    0
 #endif /* MODULE_LWIP_IPV6_AUTOCONFIG */
 
 #ifdef MODULE_LWIP_IPV6_MLD
-#define LWIP_IPV6_MLD           (1)
+#define LWIP_IPV6_MLD           1
 #else  /* MODULE_LWIP_IPV6 */
-#define LWIP_IPV6_MLD           (0)
+#define LWIP_IPV6_MLD           0
 #endif /* MODULE_LWIP_IPV6 */
 
 #ifdef MODULE_LWIP_IPV6
-#define LWIP_IPV6               (1)
+#define LWIP_IPV6               1
 #else  /* MODULE_LWIP_IPV6 */
-#define LWIP_IPV6               (0)
+#define LWIP_IPV6               0
 #endif /* MODULE_LWIP_IPV6 */
 
 #ifdef MODULE_LWIP_NETIF_PPP
-#define PPP_SUPPORT             (1)
+#define PPP_SUPPORT             1
 #else  /* MODULE_LWIP_NETIF_PPP */
-#define PPP_SUPPORT             (0)
+#define PPP_SUPPORT             0
 #endif /* MODULE_LWIP_NETIF_PPP */
 
 #ifdef MODULE_LWIP_RAW
-#define LWIP_RAW                (1)
+#define LWIP_RAW                1
 #else  /* MODULE_LWIP_RAW */
-#define LWIP_RAW                (0)
+#define LWIP_RAW                0
 #endif /* MODULE_LWIP_RAW */
 
 #ifdef MODULE_LWIP_SIXLOWPAN
-#define LWIP_6LOWPAN            (1)
+#define LWIP_6LOWPAN            1
 #else  /* MODULE_LWIP_STATS */
-#define LWIP_6LOWPAN            (0)
+#define LWIP_6LOWPAN            0
 #endif /* MODULE_LWIP_STATS */
 
 #ifdef MODULE_LWIP_STATS
-#define LWIP_STATS              (1)
+#define LWIP_STATS              1
 #else  /* MODULE_LWIP_STATS */
-#define LWIP_STATS              (0)
+#define LWIP_STATS              0
 #endif /* MODULE_LWIP_STATS */
 
 #ifdef MODULE_LWIP_TCP
-#define LWIP_TCP                (1)
+#define LWIP_TCP                1
 #else  /* MODULE_LWIP_TCP */
-#define LWIP_TCP                (0)
+#define LWIP_TCP                0
 #endif /* MODULE_LWIP_TCP */
 
 #ifdef MODULE_LWIP_UDP
-#define LWIP_UDP                (1)
+#define LWIP_UDP                1
 #else  /* MODULE_LWIP_UDP */
-#define LWIP_UDP                (0)
+#define LWIP_UDP                0
 #endif /* MODULE_LWIP_UDP */
 
 #ifdef MODULE_LWIP_UDPLITE
-#define LWIP_UDPLITE            (1)
+#define LWIP_UDPLITE            1
 #else  /* MODULE_LWIP_UDPLITE */
-#define LWIP_UDPLITE            (0)
+#define LWIP_UDPLITE            0
 #endif /* MODULE_LWIP_UDPLITE */
 
 #if defined(MODULE_LWIP_SOCK)
-#define LWIP_NETCONN            (1)
+#define LWIP_NETCONN            1
 #else
-#define LWIP_NETCONN            (0)
+#define LWIP_NETCONN            0
 #endif
 
 #ifndef TCP_LISTEN_BACKLOG
 # if defined(MODULE_LWIP_SOCK_TCP)
-# define TCP_LISTEN_BACKLOG     (1)
+# define TCP_LISTEN_BACKLOG     1
 # else
-# define TCP_LISTEN_BACKLOG     (0)
+# define TCP_LISTEN_BACKLOG     0
 # endif
 #endif /* TCP_LISTEN_BACKLOG */
 
-#define LWIP_SOCKET             (0)
+#define LWIP_SOCKET             0
 
 #define LWIP_DONT_PROVIDE_BYTEORDER_FUNCTIONS
-#define MEMP_MEM_MALLOC         (1)
+#define MEMP_MEM_MALLOC         1
 #define NETIF_MAX_HWADDR_LEN    (GNRC_NETIF_HDR_L2ADDR_MAX_LEN)
 
 #ifndef TCPIP_THREAD_STACKSIZE


### PR DESCRIPTION
### Contribution description

#### Motivation / Background

In some use cases where a socket is bound to multiple IP addresses, it is useful to know on which address a datagram was received. The current sock API makes it hard to retrieve this information: [`sock_udp_get_local()`](http://api.riot-os.org/group__net__sock__udp.html#ga1a0e4c3a85b42cfcdc2f016dd2c96c83) will return whatever IP the interface was bound to; which in the use case of multiple IP addresses often is `SOCK_IPV6_EP_ANY`.

E.g. lets say we have a RIOT border router connected to the Internet via Ethernet and to an IEEE 802.15.4 network. A CoAP server running additionally on this border router might provide access to its resources without access control, DTLS, OSCORE, ... over IEEE 802.15.4, as Layer 2 security might be considered as sufficient in that scenario. However, for requests received from the Internet, additional security measures seem to be a good idea.

There are likely many other use cases for virtual hosting there.

#### Proposed solution

Add an `sock_udp_recv2()` function, which in addition to `sock_udp_ep_t *remote` also takes an `sock_udp_ep_t *local` as optional argument (optional = "pass `NULL` if you don't care). The existing `sock_udp_recv()` is implemented as `static inline` wrapper on top of `sock_udp_recv2()`, passing `NULL` for `local`. Thus, sock implementations don't need to provide both functions and existing code can keep using `sock_udp_recv()`.

A proof of concept implementation was added for GNRC, lwIP, and emb6.

### Testing procedure

TBD

### Issues/PRs references

None