### PR TITLE
cord_ep: allow not specify netif if only one interface exist

### DIFF
--- a/sys/shell/commands/sc_cord_ep.c
+++ b/sys/shell/commands/sc_cord_ep.c
@@ -32,8 +32,12 @@ static int make_sock_ep(sock_udp_ep_t *ep, const char *addr)
     if (sock_udp_str2ep(ep, addr) < 0) {
         return -1;
     }
+    /* if netif not specified in addr */
+    if ((ep->netif == SOCK_ADDR_ANY_NETIF) && (gnrc_netif_numof() == 1)) {
+        /* assign the single interface found in gnrc_netif_numof() */
+        ep->netif = (uint16_t)gnrc_netif_iter(NULL)->pid;
+    }
     ep->family  = AF_INET6;
-    ep->netif   = SOCK_ADDR_ANY_NETIF;
     if (ep->port == 0) {
         ep->port = COAP_PORT;
     }


### PR DESCRIPTION
### Contribution description

This PR modifies the `make_sock_ep()` function in `cord_ep` shell function to allow not specifiying the interface when using link-local address.

### Testing procedure

1. Use `aiocoap-rd` version 0.4b3 provided by aiocoap as RD: `pip3 install --upgrade "git+https://github.com/chrysn/aiocoap@0.4b3#egg=aiocoap[all,docs]"`
2. Start the RD: aiocoap-rd
3. From cord_ep example terminal: `cord_ep register/discover [<RD ipv6 ip>]:5683`



Test running `cord_ep register`, `cord_ep discover`:
- using link-local address with and without specifiying the interface
- using global address should also

All of it should not timeout and should register correclty for `cord_ep register` and return the correct registration interface for `cord_ep discover`.

### Issues/PRs references

Fixes #14399 
