### PR TITLE
sys/usb_board_reset: add usb_board_reset_in_bootloader definition

### DIFF
--- a/boards/adafruit-clue/reset.c
+++ b/boards/adafruit-clue/reset.c
@@ -21,6 +21,7 @@
 
 #define USB_H_USER_IS_RIOT_INTERNAL
 
+#include "cpu.h"
 #include "usb_board_reset.h"
 
 /* Set the value used by the bootloader to select between boot in

--- a/boards/arduino-nano-33-ble/reset.c
+++ b/boards/arduino-nano-33-ble/reset.c
@@ -21,6 +21,7 @@
 
 #define USB_H_USER_IS_RIOT_INTERNAL
 
+#include "cpu.h"
 #include "usb_board_reset.h"
 
 /* Set the value used by the bootloader to select between boot in

--- a/boards/common/samd21-arduino-bootloader/reset.c
+++ b/boards/common/samd21-arduino-bootloader/reset.c
@@ -23,6 +23,7 @@
 
 #define USB_H_USER_IS_RIOT_INTERNAL
 
+#include "cpu.h"
 #include "usb_board_reset.h"
 
 #ifdef HMCRAMC0_ADDR

--- a/sys/include/usb_board_reset.h
+++ b/sys/include/usb_board_reset.h
@@ -48,6 +48,11 @@ int usb_board_reset_coding_cb(usbus_cdcacm_device_t *cdcacm,
  */
 void usb_board_reset_in_application(void);
 
+/**
+ * @brief   Trigger a bootloader reset, start the bootloader after reset
+ */
+void usb_board_reset_in_bootloader(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/usb_board_reset.h
+++ b/sys/include/usb_board_reset.h
@@ -24,25 +24,6 @@
 extern "C" {
 #endif
 
-#include <inttypes.h>
-
-#include "usb/usbus/cdc/acm.h"
-
-/**
- * @brief   USB coding callback used to trigger the board reset
- *
- * @param[in] cdcacm    Pointer to the cdcacm device
- * @param[in] baud      Baudrate used by the client. Only 1200 baud is taken into account
- * @param[in] bits      Number of bit mode used by the client
- * @param[in] parity    Parity mode used by the client
- * @param[in] stop      Stop bit mode used by the client
- *
- * @return  Always return 0
- */
-int usb_board_reset_coding_cb(usbus_cdcacm_device_t *cdcacm,
-                              uint32_t baud, uint8_t bits,
-                              uint8_t parity, uint8_t stop);
-
 /**
  * @brief   Trigger a simple reset, back to the application
  */

--- a/sys/include/usb_board_reset_internal.h
+++ b/sys/include/usb_board_reset_internal.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_usb_board_reset_internal Board reset via USB CDC ACM internals
+ * @ingroup     sys_usb_board_reset
+ * @brief       Callbacks provided by the USB_BOARD_RESET to the ACM subsystem
+ *
+ * @{
+ *
+ * @file
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef USB_BOARD_RESET_INTERNAL_H
+#define USB_BOARD_RESET_INTERNAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <inttypes.h>
+
+#include "usb/usbus/cdc/acm.h"
+
+/**
+ * @brief   USB coding callback used to trigger the board reset
+ *
+ * @param[in] cdcacm    Pointer to the cdcacm device
+ * @param[in] baud      Baudrate used by the client. Only 1200 baud is taken into account
+ * @param[in] bits      Number of bit mode used by the client
+ * @param[in] parity    Parity mode used by the client
+ * @param[in] stop      Stop bit mode used by the client
+ *
+ * @return  Always return 0
+ */
+int usb_board_reset_coding_cb(usbus_cdcacm_device_t *cdcacm,
+                              uint32_t baud, uint8_t bits,
+                              uint8_t parity, uint8_t stop);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* USB_BOARD_RESET_INTERNAL_H */
+/** @} */

--- a/sys/shell/commands/sc_sys.c
+++ b/sys/shell/commands/sc_sys.c
@@ -23,7 +23,6 @@
 #include "periph/pm.h"
 
 #ifdef MODULE_USB_BOARD_RESET
-#define USB_H_USER_IS_RIOT_INTERNAL
 #include "usb_board_reset.h"
 #endif
 

--- a/sys/shell/commands/sc_sys.c
+++ b/sys/shell/commands/sc_sys.c
@@ -22,6 +22,11 @@
 
 #include "periph/pm.h"
 
+#ifdef MODULE_USB_BOARD_RESET
+#define USB_H_USER_IS_RIOT_INTERNAL
+#include "usb_board_reset.h"
+#endif
+
 int _reboot_handler(int argc, char **argv)
 {
     (void) argc;
@@ -33,8 +38,6 @@ int _reboot_handler(int argc, char **argv)
 }
 
 #ifdef MODULE_USB_BOARD_RESET
-void usb_board_reset_in_bootloader(void);
-
 int _bootloader_handler(int argc, char **argv)
 {
     (void) argc;

--- a/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
+++ b/sys/usb/usbus/cdc/acm/cdc_acm_stdio.c
@@ -34,7 +34,7 @@
 #endif
 
 #ifdef MODULE_USB_BOARD_RESET
-#include "usb_board_reset.h"
+#include "usb_board_reset_internal.h"
 #endif
 
 static usbus_cdcacm_device_t cdcacm;

--- a/sys/usb_board_reset/usb_board_reset.c
+++ b/sys/usb_board_reset/usb_board_reset.c
@@ -32,8 +32,6 @@
 #define RESET_IN_APPLICATION_TRIGGER_BAUDRATE   (600U)
 #endif
 
-void usb_board_reset_in_bootloader(void);
-
 int usb_board_reset_coding_cb(usbus_cdcacm_device_t *cdcacm,
                               uint32_t baud, uint8_t bits,
                               uint8_t parity, uint8_t stop)


### PR DESCRIPTION
Move the definition of `usb_board_reset_in_bootloader()` to a common location.
Inclusion of `usb_board_reset.h` needs to be guarded with `#define USB_H_USER_IS_RIOT_INTERNAL`.
We could move that definition into `usb_board_reset.h` instead.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Code should keep compiling.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

suggested in https://github.com/RIOT-OS/RIOT/pull/14378#issuecomment-652008940
