### PR TITLE
cpu/mips: disable BINFILE generation

### DIFF
--- a/cpu/mips_pic32mx/Makefile.include
+++ b/cpu/mips_pic32mx/Makefile.include
@@ -29,3 +29,6 @@ OFLAGS += \
 ifneq (,$(filter cpp,$(FEATURES_USED)))
 OFLAGS += --change-section-lma .gcc_except_table-0x80000000
 endif
+
+# system objcopy is not able to generate a binfile for MIPS
+BINFILE =

--- a/cpu/mips_pic32mz/Makefile.include
+++ b/cpu/mips_pic32mz/Makefile.include
@@ -32,3 +32,6 @@ OFLAGS += \
 ifneq (,$(filter cpp,$(FEATURES_USED)))
 OFLAGS += --change-section-lma .gcc_except_table-0x80000000
 endif
+
+# system objcopy is not able to generate a binfile for MIPS
+BINFILE =


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the build of firmwares for the MIPS platform (currently pic32-wifire and 6lowpan-clicker) by simply disabling the generation of BINFILE, which is required now since #14159.

See #14385 and especially https://github.com/RIOT-OS/RIOT/pull/14385#issuecomment-651995465 for details.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Local build of a firmware for pic32-wifire and 6lowpan-clicker is working:

<details><summary>this PR:</summary>

- 6lowpan-clicker:
```
$ RIOT_VERSION=test make BOARD=6lowpan-clicker -C examples/hello-world/ --no-print-directory 
Building application "hello-world" for "6lowpan-clicker" with MCU "mips_pic32mx".

"make" -C /work/riot/RIOT/boards/6lowpan-clicker
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/mips_pic32mx
"make" -C /work/riot/RIOT/cpu/mips32r2_common
"make" -C /work/riot/RIOT/cpu/mips32r2_common/newlib_syscalls_mips_uhi
"make" -C /work/riot/RIOT/cpu/mips32r2_common/periph
"make" -C /work/riot/RIOT/cpu/mips_pic32_common
"make" -C /work/riot/RIOT/cpu/mips_pic32_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
  71852	   2404	   6232	  80488	  13a68	/work/riot/RIOT/examples/hello-world/bin/6lowpan-clicker/hello-world.elf
```

- pic32-wifire:

```
RIOT_VERSION=test make BOARD=pic32-wifire -C examples/hello-world/ --no-print-directory 
Building application "hello-world" for "pic32-wifire" with MCU "mips_pic32mz".

"make" -C /work/riot/RIOT/boards/pic32-wifire
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/mips_pic32mz
"make" -C /work/riot/RIOT/cpu/mips32r2_common
"make" -C /work/riot/RIOT/cpu/mips32r2_common/newlib_syscalls_mips_uhi
"make" -C /work/riot/RIOT/cpu/mips32r2_common/periph
"make" -C /work/riot/RIOT/cpu/mips_pic32_common
"make" -C /work/riot/RIOT/cpu/mips_pic32_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
 109280	   2780	   7000	 119060	  1d114	/work/riot/RIOT/examples/hello-world/bin/pic32-wifire/hello-world.elf
```

</details>


<details><summary>master:</summary>

- 6lowpan-clicker:

```
RIOT_VERSION=test make BOARD=6lowpan-clicker -C examples/hello-world/ --no-print-directory 
Building application "hello-world" for "6lowpan-clicker" with MCU "mips_pic32mx".

"make" -C /work/riot/RIOT/boards/6lowpan-clicker
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/mips_pic32mx
"make" -C /work/riot/RIOT/cpu/mips32r2_common
"make" -C /work/riot/RIOT/cpu/mips32r2_common/newlib_syscalls_mips_uhi
"make" -C /work/riot/RIOT/cpu/mips32r2_common/periph
"make" -C /work/riot/RIOT/cpu/mips_pic32_common
"make" -C /work/riot/RIOT/cpu/mips_pic32_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/stdio_uart
objcopy: Unable to recognise the format of the input file `/work/riot/RIOT/examples/hello-world/bin/6lowpan-clicker/hello-world.elf'
objcopy: --change-section-lma .startdata+0xffffffff80000000 never used
objcopy: --change-section-lma .bss+0xffffffff80000000 never used
objcopy: --change-section-lma .data+0xffffffff80000000 never used
objcopy: --change-section-lma .rodata+0xffffffff80000000 never used
objcopy: --change-section-lma .dtors+0xffffffff80000000 never used
objcopy: --change-section-lma .ctors+0xffffffff80000000 never used
objcopy: --change-section-lma .jcr+0xffffffff80000000 never used
objcopy: --change-section-lma .eh_frame+0xffffffff80000000 never used
objcopy: --change-section-lma .fini+0xffffffff80000000 never used
objcopy: --change-section-lma .init+0xffffffff80000000 never used
objcopy: --change-section-lma .text+0xffffffff80000000 never used
objcopy: --change-section-lma .exception_vector+0xffffffff80000000 never used
objcopy: --change-section-lma .bootflash+0xffffffff60000000 never used
make: *** [/work/riot/RIOT/examples/hello-world/../../Makefile.include:591: /work/riot/RIOT/examples/hello-world/bin/6lowpan-clicker/hello-world.bin] Error 1

```

- pic32-wifire:

```
RIOT_VERSION=test make BOARD=pic32-wifire -C examples/hello-world/ --no-print-directory 
Building application "hello-world" for "pic32-wifire" with MCU "mips_pic32mz".

"make" -C /work/riot/RIOT/boards/pic32-wifire
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/mips_pic32mz
"make" -C /work/riot/RIOT/cpu/mips32r2_common
"make" -C /work/riot/RIOT/cpu/mips32r2_common/newlib_syscalls_mips_uhi
"make" -C /work/riot/RIOT/cpu/mips32r2_common/periph
"make" -C /work/riot/RIOT/cpu/mips_pic32_common
"make" -C /work/riot/RIOT/cpu/mips_pic32_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/stdio_uart
objcopy: Unable to recognise the format of the input file `/work/riot/RIOT/examples/hello-world/bin/pic32-wifire/hello-world.elf'
objcopy: --change-section-lma .startdata+0xffffffff80000000 never used
objcopy: --change-section-lma .bss+0xffffffff80000000 never used
objcopy: --change-section-lma .data+0xffffffff80000000 never used
objcopy: --change-section-lma .rodata+0xffffffff80000000 never used
objcopy: --change-section-lma .dtors+0xffffffff80000000 never used
objcopy: --change-section-lma .ctors+0xffffffff80000000 never used
objcopy: --change-section-lma .jcr+0xffffffff80000000 never used
objcopy: --change-section-lma .eh_frame+0xffffffff80000000 never used
objcopy: --change-section-lma .fini+0xffffffff80000000 never used
objcopy: --change-section-lma .init+0xffffffff80000000 never used
objcopy: --change-section-lma .text+0xffffffff80000000 never used
objcopy: --change-section-lma .exception_vector+0xffffffff80000000 never used
objcopy: --change-section-lma .bootflash2+0xffffffff60000000 never used
objcopy: --change-section-lma .bootflash1+0xffffffff60000000 never used
objcopy: --change-section-lma .lowerbootflashalias+0xffffffff60000000 never used
make: *** [/work/riot/RIOT/examples/hello-world/../../Makefile.include:591: /work/riot/RIOT/examples/hello-world/bin/pic32-wifire/hello-world.bin] Error 1
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes a regression introduced in #14159 and was discovered while debugging #14385.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
