### PR TITLE
doc/header: make hitting return not reload the page

### DIFF
--- a/doc/doxygen/header.html
+++ b/doc/doxygen/header.html
@@ -51,7 +51,7 @@
               <p class="navbar-text navbar-left"><span id="projectbrief">$projectbrief</span></p>
               <ul id="riot-navlist" class="nav navbar-nav"></ul>
               <!--BEGIN SEARCHENGINE-->
-              <form id="riot-searchform" class="navbar-form navbar-left navbar-right hidden-sm hidden-xs">
+              <form id="riot-searchform" class="navbar-form navbar-left navbar-right hidden-sm hidden-xs" onsubmit="return false">
                  <div class="form-group">
                    <div id="MSearchBox" class="MSearchBoxActive">
                      <div class="input-group">


### PR DESCRIPTION
adding onsubmit="return false" stops form submition which leads to reload

### Contribution description

make search not reload

### Testing procedure

I used Firefox inspector to test 

### Issues/PRs references
doc/search: hitting return while searching on api.riot-os.org reloads current page #14409


This is in conflict with  #14412 only one should be applied, I prefer the other one