### PR TITLE
mips: adapt for toolchain update (2020.06-01)

### DIFF
--- a/cpu/mips_pic32_common/Makefile.include
+++ b/cpu/mips_pic32_common/Makefile.include
@@ -1,5 +1,10 @@
 include $(RIOTCPU)/mips32r2_common/Makefile.include
 
+# The 2020.06-01 toolchain provides POSIX defines for pthread which conflicts
+# with the one in RIOT. The following CFLAGS skip the inclusion of the types
+# shipped by the toolchain.
+CFLAGS += -D_SYS__PTHREADTYPES_H_
+
 CFLAGS += -DCPU_FAM_$(call uppercase_and_underscore,$(CPU_FAM))
 
 INCLUDES += -I$(RIOTCPU)/mips_pic32_common/include

--- a/cpu/mips_pic32_common/periph/gpio.c
+++ b/cpu/mips_pic32_common/periph/gpio.c
@@ -201,9 +201,9 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
             pu = 1;
             break;
         case GPIO_OD_PU:
-            pu = 1;
+            pu = 1; /* fall-through */
         case GPIO_OD:
-            od = 1;
+            od = 1; /* fall-through */
         case GPIO_OUT:
             output = 1;
             break;

--- a/cpu/mips_pic32mx/Makefile.include
+++ b/cpu/mips_pic32mx/Makefile.include
@@ -18,7 +18,6 @@ OFLAGS += \
     --change-section-lma .init-0x80000000 \
     --change-section-lma .fini-0x80000000 \
     --change-section-lma .eh_frame-0x80000000 \
-    --change-section-lma .jcr-0x80000000 \
     --change-section-lma .ctors-0x80000000 \
     --change-section-lma .dtors-0x80000000 \
     --change-section-lma .rodata-0x80000000 \

--- a/cpu/mips_pic32mz/Makefile.include
+++ b/cpu/mips_pic32mz/Makefile.include
@@ -21,7 +21,6 @@ OFLAGS += \
     --change-section-lma .init-0x80000000 \
     --change-section-lma .fini-0x80000000 \
     --change-section-lma .eh_frame-0x80000000 \
-    --change-section-lma .jcr-0x80000000 \
     --change-section-lma .ctors-0x80000000 \
     --change-section-lma .dtors-0x80000000 \
     --change-section-lma .rodata-0x80000000 \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes some build issues that are triggered when bumps the MIPS toolchain to use the latest release 2020.06-01.
Note that this PR should have no effect compared to master when using the old toolchain (same firmware size).

I'm not on the order of doing things in this case. But maybe we should merge this PR before https://github.com/RIOT-OS/riotdocker/pull/107 is merged ?

Note that this PR doesn't address #14410 but maybe the new tool toolchain could help.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Test locally:
  - Upgrade to 2020.06-01 toolchain: build the `riotbuild` Docker image from https://github.com/RIOT-OS/riotdocker/pull/107.
  - Use `compile_and_test_for_board.py` to build all applications for one of the MIPS board:
    ```
    BUILD_IN_DOCKER=1 ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . pic32-wifire --jobs=8 --no-test
    ```
     The command should report no build failures.
    - Manually test some application on a pic32 board. @francois-berder that would help if you could try since you have that hardware !

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Will be required for https://github.com/RIOT-OS/riotdocker/pull/107

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
