### PR TITLE
  net/gnrc/ipv6/nib: fix ref to net_gnrc_ipv6_nib_nc_info 

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib.h
+++ b/sys/include/net/gnrc/ipv6/nib.h
@@ -274,8 +274,9 @@ enum {
      * on routes via this neighbor.
      *
      * The `ctx_addr` is the address of the neighbor, `ctx` is a value equal
-     * to the new NUD state as defined in [the NC info flags](@ref
-     * net_gnrc_ipv6_nib_nc_info). If the entry is deleted, `ctx` will be set
+     * to the new NUD state as defined in
+     * [the NC info flags](@ref net_gnrc_ipv6_nib_nc_info). If the entry is
+     * deleted, `ctx` will be set
      * to @ref GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNREACHABLE (except if it was
      * already in the `UNREACHABLE` state). This does not include cache-outs,
      * since they give no information about the neighbor's reachability (you


### PR DESCRIPTION
### Contribution description

Spotted this while reading the `route_info_cb` `type` parameter values. Seems that doxygen doesn't like newlines between links.

**Before**
![Screenshot from 2020-07-01 14-19-36](https://user-images.githubusercontent.com/5952531/86283063-f30dfe80-bba5-11ea-8b7c-fccfd02bc262.png)


**After**

![Screenshot from 2020-07-01 14-19-45](https://user-images.githubusercontent.com/5952531/86283068-f6a18580-bba5-11ea-98f5-c6a63e6d79e3.png)

### Testing procedure

- `make doc` :wink: 
