### PR TITLE
cpu/stm32/uart: gpio_set before gpio_init to avoid momentary assertion

### DIFF
--- a/cpu/stm32/periph/uart.c
+++ b/cpu/stm32/periph/uart.c
@@ -116,10 +116,10 @@ static inline void uart_init_cts_pin(uart_t uart)
 
 static inline void uart_init_pins(uart_t uart, uart_rx_cb_t rx_cb)
 {
-     /* configure TX pin */
-    gpio_init(uart_config[uart].tx_pin, GPIO_OUT);
     /* set TX pin high to avoid garbage during further initialization */
     gpio_set(uart_config[uart].tx_pin);
+     /* configure TX pin after setting it to avoid a momentary low state */
+    gpio_init(uart_config[uart].tx_pin, GPIO_OUT);
 #ifdef CPU_FAM_STM32F1
     gpio_init_af(uart_config[uart].tx_pin, GPIO_AF_OUT_PP);
 #else


### PR DESCRIPTION
### Contribution description
Similar to #12380, this (ostensibly) resolves an unwanted momentary assertion of the UART TX pin during `uart_init()`. I wanted to help with this one but since I can't review PRs and I can't test the fix I elected to open the PR instead.

This may work or not. It should work if `gpio_init()` leaves the output level untouched on `stm32` as most platforms do, but it won't work if `gpio_init()` clears the output as it does on `efm32`. In that case, some solution like #12612 would be required.

### Testing procedure
I'm not able to test this myself as I don't have an stm32 board. According to #8045, verify that the faulty behavior exists on master for an stm32 board and then verify that this PR resolves it. If you have multiple stm32 boards, ones with slower MCUs may be more likely to exhibit the faulty behavior. They won't all exhibit it due to timing differences. Using a fast baud rate should also help reproduce it.

### Issues/PRs references
Resolves #8045