### PR TITLE
modules/sdcard_spi: improve configurability

### DIFF
--- a/drivers/sdcard_spi/include/sdcard_spi_internal.h
+++ b/drivers/sdcard_spi/include/sdcard_spi_internal.h
@@ -157,22 +157,51 @@ extern "C" {
 #endif
 /** @} */
 
-/* memory capacity in bytes = (C_SIZE+1) * SD_CSD_V2_C_SIZE_BLOCK_MULT * BLOCK_LEN */
+/**
+ * @brief memory capacity in bytes = (C_SIZE+1) * SD_CSD_V2_C_SIZE_BLOCK_MULT * BLOCK_LEN
+ */
 #define SD_CSD_V2_C_SIZE_BLOCK_MULT 1024
 
+/**
+ * @brief SPI mode used for SD card
+ */
+#ifndef SD_CARD_SPI_MODE
 #define SD_CARD_SPI_MODE SPI_MODE_0
+#endif
 
-/* this speed setting is only used while the init procedure is performed */
+/**
+ * @brief this speed setting is only used while the init procedure is performed
+ */
+#ifndef SD_CARD_SPI_SPEED_PREINIT
 #define SD_CARD_SPI_SPEED_PREINIT SPI_CLK_400KHZ
+#endif
 
-/* after init procedure is finished the driver auto sets the card to this speed */
+/**
+ * @brief after init procedure is finished the driver auto sets the card to this speed
+ */
+#ifndef SD_CARD_SPI_SPEED_POSTINIT
 #define SD_CARD_SPI_SPEED_POSTINIT SPI_CLK_10MHZ
+#endif
 
-#define SD_CARD_DUMMY_BYTE 0xFF
+/**
+ * @brief Dummy Byte
+ */
+#define SD_CARD_DUMMY_BYTE  (0xFF)
 
+/**
+ * @brief 1 kiB in Bytes
+ */
 #define SDCARD_SPI_IEC_KIBI (1024L)
+
+/**
+ * @brief 1 kB in Bytes
+ */
 #define SDCARD_SPI_SI_KILO  (1000L)
 
+/**
+ * @brief SD card driver internal states
+ * @{
+ */
 typedef enum {
     SD_INIT_START,
     SD_INIT_SPI_POWER_SEQ,
@@ -190,6 +219,7 @@ typedef enum {
     SD_INIT_SET_MAX_SPI_SPEED,
     SD_INIT_FINISH
 } sd_init_fsm_state_t;
+/** @} */
 
 /**
  * @brief                 Sends a cmd to the sd card.

--- a/drivers/sdcard_spi/include/sdcard_spi_internal.h
+++ b/drivers/sdcard_spi/include/sdcard_spi_internal.h
@@ -125,16 +125,37 @@ extern "C" {
 #define SD_CSD_V2 1
 #define SD_CSD_VUNSUPPORTED -1
 
-/* the retry counters below are used as timeouts for specific actions.
-   The values may need some adjustments to either give the card more time to respond
-   to commands or to achieve a lower delay / avoid infinite blocking. */
-#define R1_POLLING_RETRY_CNT       1000000
-#define SD_DATA_TOKEN_RETRY_CNT    1000000
-#define INIT_CMD_RETRY_CNT         1000000
-#define INIT_CMD0_RETRY_CNT        3
-#define SD_WAIT_FOR_NOT_BUSY_CNT   1000000 /* use -1 for full blocking till the card isn't busy */
-#define SD_BLOCK_READ_CMD_RETRIES  10     /* only affects sending of cmd not whole transaction! */
-#define SD_BLOCK_WRITE_CMD_RETRIES 10    /* only affects sending of cmd not whole transaction! */
+/**
+ * @name    Set retry parameters for specific actions
+ *
+ * Retry timeouts in microseconds for specific actions.
+ * The value interpretation is uint32_t.
+ * A value of 0 disables retries.
+ *
+ * @{
+ */
+#ifndef INIT_CMD_RETRY_US
+#define INIT_CMD_RETRY_US           (250 * US_PER_MS) /**< initialization command retry */
+#endif
+#ifndef INIT_CMD0_RETRY_US
+#define INIT_CMD0_RETRY_US          (100UL)           /**< initialization command 0 retry */
+#endif
+#ifndef R1_POLLING_RETRY_US
+#define R1_POLLING_RETRY_US         (100 * US_PER_MS) /**< initialization first response */
+#endif
+#ifndef SD_DATA_TOKEN_RETRY_US
+#define SD_DATA_TOKEN_RETRY_US      (100 * US_PER_MS) /**< data packet token read retry */
+#endif
+#ifndef SD_WAIT_FOR_NOT_BUSY_US
+#define SD_WAIT_FOR_NOT_BUSY_US     (250 * US_PER_MS) /**< wait for SD card */
+#endif
+#ifndef SD_BLOCK_READ_CMD_RETRY_US
+#define SD_BLOCK_READ_CMD_RETRY_US  (100UL)           /**< only affects sending of cmd not whole transaction! */
+#endif
+#ifndef SD_BLOCK_WRITE_CMD_RETRY_US
+#define SD_BLOCK_WRITE_CMD_RETRY_US (100UL)           /**< only affects sending of cmd not whole transaction! */
+#endif
+/** @} */
 
 /* memory capacity in bytes = (C_SIZE+1) * SD_CSD_V2_C_SIZE_BLOCK_MULT * BLOCK_LEN */
 #define SD_CSD_V2_C_SIZE_BLOCK_MULT 1024
@@ -179,14 +200,14 @@ typedef enum {
  *                        (for CMDX this parameter is simply the integer value X).
  * @param[in] argument    The argument for the given cmd. As described by "7.3.1.1 Command Format".
  *                        This argument is transmitted byte wise with most significant byte first.
- * @param[in] max_retry   Specifies how often the command should be retried if an error occurs.
- *                        Use 0 to try only once, -1 to try forever, or n to retry n times.
+ * @param[in] retry_us    Specifies microsecond timeout for retries in case of command errors.
+ *                        Use 0 to try exactly once.
  *
  * @return                R1 response of the command if no (low-level) communication error occurred
  * @return                SD_INVALID_R1_RESPONSE if either waiting for the card to enter
  *                        not-busy-state timed out or spi communication failed
  */
-uint8_t sdcard_spi_send_cmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t argument, int32_t max_retry);
+uint8_t sdcard_spi_send_cmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t argument, uint32_t retry_us);
 
 /**
  * @brief                 Sends an acmd to the sd card. ACMD<n> consists of sending CMD55 + CMD<n>
@@ -197,14 +218,14 @@ uint8_t sdcard_spi_send_cmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t arg
  *                        (for ACMDX this parameter is simply the integer value X).
  * @param[in] argument    The argument for the given cmd. As described by "7.3.1.1 Command Format".
  *                        This argument is transmitted byte wise with most significant byte first.
- * @param[in] max_retry   Specifies how often the command should be retried if an error occurs.
- *                        Use 0 to try only once, -1 to try forever, or n to retry n times.
+ * @param[in] retry_us    Specifies microsecond timeout for retries in case of command errors.
+ *                        Use 0 to try exactly once.
  *
  * @return                R1 response of the command if no (low-level) communication error occurred
  * @return                SD_INVALID_R1_RESPONSE if either waiting for the card to enter
  *                        not-busy-state timed out or spi communication failed
  */
-uint8_t sdcard_spi_send_acmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t argument, int32_t max_retry);
+uint8_t sdcard_spi_send_acmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t argument, uint32_t retry_us);
 
 /**
  * @brief                 Gets the sector count of the card.

--- a/drivers/sdcard_spi/sdcard_spi.c
+++ b/drivers/sdcard_spi/sdcard_spi.c
@@ -33,10 +33,10 @@
 
 static inline void _select_card_spi(sdcard_spi_t *card);
 static inline void _unselect_card_spi(sdcard_spi_t *card);
-static inline uint8_t _wait_for_r1(sdcard_spi_t *card, int32_t max_retries);
+static inline uint8_t _wait_for_r1(sdcard_spi_t *card, uint32_t retry_us);
 static inline void _send_dummy_byte(sdcard_spi_t *card);
-static inline bool _wait_for_not_busy(sdcard_spi_t *card, int32_t max_retries);
-static inline bool _wait_for_token(sdcard_spi_t *card, uint8_t token, int32_t max_retries);
+static inline bool _wait_for_not_busy(sdcard_spi_t *card, uint32_t retry_us);
+static inline bool _wait_for_token(sdcard_spi_t *card, uint8_t token, uint32_t retry_us);
 static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_state_t state);
 static sd_rw_response_t _read_cid(sdcard_spi_t *card);
 static sd_rw_response_t _read_csd(sdcard_spi_t *card);
@@ -132,7 +132,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
 
             /* select sdcard for cmd0 */
             gpio_clear(card->params.cs);
-            uint8_t cmd0_r1 = sdcard_spi_send_cmd(card, SD_CMD_0, SD_CMD_NO_ARG, INIT_CMD0_RETRY_CNT);
+            uint8_t cmd0_r1 = sdcard_spi_send_cmd(card, SD_CMD_0, SD_CMD_NO_ARG, INIT_CMD0_RETRY_US);
             gpio_set(card->params.cs);
 
             if (R1_VALID(cmd0_r1) && !R1_ERROR(cmd0_r1) && R1_IDLE_BIT_SET(cmd0_r1)) {
@@ -150,7 +150,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
         case SD_INIT_ENABLE_CRC:
             DEBUG("SD_INIT_ENABLE_CRC\n");
             _select_card_spi(card);
-            uint8_t r1 = sdcard_spi_send_cmd(card, SD_CMD_59, SD_CMD_59_ARG_EN, INIT_CMD_RETRY_CNT);
+            uint8_t r1 = sdcard_spi_send_cmd(card, SD_CMD_59, SD_CMD_59_ARG_EN, INIT_CMD_RETRY_US);
             _unselect_card_spi(card);
 
             if (R1_VALID(r1) && !R1_ERROR(r1)) {
@@ -163,7 +163,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
             DEBUG("SD_INIT_SEND_CMD8\n");
             _select_card_spi(card);
             int cmd8_arg = (SD_CMD_8_VHS_2_7_V_TO_3_6_V << 8) | SD_CMD_8_CHECK_PATTERN;
-            uint8_t cmd8_r1 = sdcard_spi_send_cmd(card, SD_CMD_8, cmd8_arg, INIT_CMD_RETRY_CNT);
+            uint8_t cmd8_r1 = sdcard_spi_send_cmd(card, SD_CMD_8, cmd8_arg, INIT_CMD_RETRY_US);
 
             if (R1_VALID(cmd8_r1) && !R1_ERROR(cmd8_r1)) {
                 DEBUG("CMD8: [OK] --> reading remaining bytes for R7\n");
@@ -199,7 +199,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
 
         case SD_INIT_SEND_ACMD41_HCS:
             DEBUG("SD_INIT_SEND_ACMD41_HCS\n");
-            int acmd41_hcs_retries = 0;
+            const uint32_t acmd41_hcs_retry_timeout = xtimer_now_usec() + INIT_CMD_RETRY_US;
             do {
                 uint8_t acmd41hcs_r1 = sdcard_spi_send_acmd(card, SD_CMD_41, SD_ACMD_41_ARG_HC, 0);
                 if (R1_VALID(acmd41hcs_r1) && !R1_ERROR(acmd41hcs_r1) &&
@@ -207,14 +207,13 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
                     DEBUG("ACMD41: [OK]\n");
                     return SD_INIT_SEND_CMD58;
                 }
-                acmd41_hcs_retries++;
-            } while ((INIT_CMD_RETRY_CNT < 0) || (acmd41_hcs_retries <= (int)INIT_CMD_RETRY_CNT));
+            } while (((uint32_t)INIT_CMD_RETRY_US > 0) && (xtimer_now_usec() < acmd41_hcs_retry_timeout));
             _unselect_card_spi(card);
             return SD_INIT_CARD_UNKNOWN;
 
         case SD_INIT_SEND_ACMD41:
             DEBUG("SD_INIT_SEND_ACMD41\n");
-            int acmd41_retries = 0;
+            const uint32_t acmd41_retry_timeout = xtimer_now_usec() + INIT_CMD_RETRY_US;
             do {
                 uint8_t acmd41_r1 = sdcard_spi_send_acmd(card, SD_CMD_41, SD_CMD_NO_ARG, 0);
                 if (R1_VALID(acmd41_r1) && !R1_ERROR(acmd41_r1) && !R1_IDLE_BIT_SET(acmd41_r1)) {
@@ -223,8 +222,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
                     card->card_type = SD_V1;
                     return SD_INIT_SEND_CMD16;
                 }
-                acmd41_retries++;
-            } while ((INIT_CMD_RETRY_CNT < 0) || (acmd41_retries <= (int)INIT_CMD_RETRY_CNT));
+            } while (((uint32_t)INIT_CMD_RETRY_US > 0) && (xtimer_now_usec() < acmd41_retry_timeout));
 
             DEBUG("ACMD41: [ERROR]\n");
             return SD_INIT_SEND_CMD1;
@@ -237,7 +235,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
 
         case SD_INIT_SEND_CMD58:
             DEBUG("SD_INIT_SEND_CMD58\n");
-            uint8_t cmd58_r1 = sdcard_spi_send_cmd(card, SD_CMD_58, SD_CMD_NO_ARG, INIT_CMD_RETRY_CNT);
+            uint8_t cmd58_r1 = sdcard_spi_send_cmd(card, SD_CMD_58, SD_CMD_NO_ARG, INIT_CMD_RETRY_US);
             if (R1_VALID(cmd58_r1) && !R1_ERROR(cmd58_r1)) {
                 DEBUG("CMD58: [OK]\n");
                 card->card_type = SD_V2;
@@ -285,7 +283,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
 
         case SD_INIT_SEND_CMD16:
             DEBUG("SD_INIT_SEND_CMD16\n");
-            uint8_t r1_16 = sdcard_spi_send_cmd(card, SD_CMD_16, SD_HC_BLOCK_SIZE, INIT_CMD_RETRY_CNT);
+            uint8_t r1_16 = sdcard_spi_send_cmd(card, SD_CMD_16, SD_HC_BLOCK_SIZE, INIT_CMD_RETRY_US);
             if (R1_VALID(r1_16) && !R1_ERROR(r1_16)) {
                 DEBUG("CARD TYPE IS SDSC (SD_V1 with byte addressing)\n");
                 _unselect_card_spi(card);
@@ -335,9 +333,9 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
     }
 }
 
-static inline bool _wait_for_token(sdcard_spi_t *card, uint8_t token, int32_t max_retries)
+static inline bool _wait_for_token(sdcard_spi_t *card, uint8_t token, uint32_t retry_us)
 {
-    int tried = 0;
+    const uint32_t retry_timeout = xtimer_now_usec() + retry_us;
 
     do {
         uint8_t read_byte = 0;
@@ -351,8 +349,7 @@ static inline bool _wait_for_token(sdcard_spi_t *card, uint8_t token, int32_t ma
             DEBUG("_wait_for_token: [NO MATCH] (0x%02x)\n", read_byte);
         }
 
-        tried++;
-    } while ((max_retries < 0) || (tried <= max_retries));
+    } while ((retry_us > 0) && (xtimer_now_usec() < retry_timeout));
 
     return false;
 }
@@ -369,12 +366,12 @@ static inline void _send_dummy_byte(sdcard_spi_t *card)
     }
 }
 
-static inline bool _wait_for_not_busy(sdcard_spi_t *card, int32_t max_retries)
+static inline bool _wait_for_not_busy(sdcard_spi_t *card, uint32_t retry_us)
 {
-    uint8_t read_byte;
-    int tried = 0;
+    const uint32_t retry_timeout = xtimer_now_usec() + retry_us;
 
     do {
+        uint8_t read_byte;
         if (_dyn_spi_rxtx_byte(card, SD_CARD_DUMMY_BYTE, &read_byte) == 1) {
             if (read_byte == 0xFF) {
                 DEBUG("_wait_for_not_busy: [OK]\n");
@@ -389,8 +386,7 @@ static inline bool _wait_for_not_busy(sdcard_spi_t *card, int32_t max_retries)
             return false;
         }
 
-        tried++;
-    } while ((max_retries < 0) || (tried <= max_retries));
+    } while ((retry_us > 0) && (xtimer_now_usec() < retry_timeout));
 
     DEBUG("_wait_for_not_busy: [FAILED]\n");
     return false;
@@ -413,9 +409,10 @@ static uint8_t _crc_7(const uint8_t *data, int n)
     return (crc << 1) | 1;
 }
 
-uint8_t sdcard_spi_send_cmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t argument, int32_t max_retry)
+uint8_t sdcard_spi_send_cmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t argument, uint32_t retry_us)
 {
-    int try_cnt = 0;
+    const uint32_t retry_timeout = xtimer_now_usec() + retry_us;
+
     uint8_t r1_resu;
     uint8_t cmd_data[6];
 
@@ -429,19 +426,18 @@ uint8_t sdcard_spi_send_cmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t arg
     uint8_t echo[sizeof(cmd_data)];
 
     do {
-        DEBUG("sdcard_spi_send_cmd: CMD%02d (0x%08" PRIx32 ") (retry %d)\n", sd_cmd_idx, argument, try_cnt);
+        DEBUG("sdcard_spi_send_cmd: CMD%02d (0x%08" PRIx32 ") (remaining retry time %"PRIu32" usec)\n", sd_cmd_idx, argument,
+              (retry_timeout > xtimer_now_usec()) ? (retry_timeout - xtimer_now_usec()) : 0);
 
-        if (!_wait_for_not_busy(card, SD_WAIT_FOR_NOT_BUSY_CNT)) {
+        if (!_wait_for_not_busy(card, SD_WAIT_FOR_NOT_BUSY_US)) {
             DEBUG("sdcard_spi_send_cmd: timeout while waiting for bus to be not busy!\n");
             r1_resu = SD_INVALID_R1_RESPONSE;
-            try_cnt++;
             continue;
         }
 
         if (_transfer_bytes(card, cmd_data, echo, sizeof(cmd_data)) != sizeof(cmd_data)) {
             DEBUG("sdcard_spi_send_cmd: _transfer_bytes: send cmd [%d]: [ERROR]\n", sd_cmd_idx);
             r1_resu = SD_INVALID_R1_RESPONSE;
-            try_cnt++;
             continue;
         }
 
@@ -456,7 +452,7 @@ uint8_t sdcard_spi_send_cmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t arg
             _send_dummy_byte(card);
         }
 
-        r1_resu = _wait_for_r1(card, R1_POLLING_RETRY_CNT);
+        r1_resu = _wait_for_r1(card, R1_POLLING_RETRY_US);
 
         if (R1_VALID(r1_resu)) {
             break;
@@ -465,20 +461,21 @@ uint8_t sdcard_spi_send_cmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t arg
             DEBUG("sdcard_spi_send_cmd: R1_TIMEOUT (0x%02x)\n", r1_resu);
             r1_resu = SD_INVALID_R1_RESPONSE;
         }
-        try_cnt++;
 
-    } while ((max_retry < 0) || (try_cnt <= max_retry));
+    } while ((retry_us > 0) && (xtimer_now_usec() < retry_timeout));
 
     return r1_resu;
 }
 
-uint8_t sdcard_spi_send_acmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t argument, int32_t max_retry)
+uint8_t sdcard_spi_send_acmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t argument, uint32_t retry_us)
 {
-    int err_cnt = 0;
+    const uint32_t retry_timeout = xtimer_now_usec() + retry_us;
+
     uint8_t r1_resu;
 
     do {
-        DEBUG("sdcard_spi_send_acmd: CMD%02d (0x%08" PRIx32 ")(retry %d)\n", sd_cmd_idx, argument, err_cnt);
+        DEBUG("sdcard_spi_send_acmd: CMD%02d (0x%08" PRIx32 ") (remaining retry time %"PRIu32" usec)\n", sd_cmd_idx, argument,
+              (retry_timeout > xtimer_now_usec()) ? (retry_timeout - xtimer_now_usec()) : 0);
         r1_resu = sdcard_spi_send_cmd(card, SD_CMD_55, SD_CMD_NO_ARG, 0);
         if (R1_VALID(r1_resu) && !R1_ERROR(r1_resu)) {
             r1_resu = sdcard_spi_send_cmd(card, sd_cmd_idx, argument, 0);
@@ -488,29 +485,27 @@ uint8_t sdcard_spi_send_acmd(sdcard_spi_t *card, uint8_t sd_cmd_idx, uint32_t ar
             }
             else {
                 DEBUG("ACMD%02d: [ERROR / NO RESPONSE]\n", sd_cmd_idx);
-                err_cnt++;
             }
         }
         else {
             DEBUG("CMD55: [ERROR / NO RESPONSE]\n");
-            err_cnt++;
         }
 
-    } while ((max_retry < 0) || (err_cnt <= max_retry));
+    } while ((retry_us > 0) && (xtimer_now_usec() < retry_timeout));
 
     DEBUG("sdcard_spi_send_acmd: [TIMEOUT]\n");
     return r1_resu;
 }
 
-static inline uint8_t _wait_for_r1(sdcard_spi_t *card, int32_t max_retries)
+static inline uint8_t _wait_for_r1(sdcard_spi_t *card, uint32_t retry_us)
 {
-    int tried = 0;
+    const uint32_t retry_timeout = xtimer_now_usec() + retry_us;
+
     uint8_t r1;
 
     do {
         if (_dyn_spi_rxtx_byte(card, SD_CARD_DUMMY_BYTE, &r1) != 1) {
             DEBUG("_wait_for_r1: _dyn_spi_rxtx_byte:[ERROR]\n");
-            tried++;
             continue;
         }
         else {
@@ -521,8 +516,8 @@ static inline uint8_t _wait_for_r1(sdcard_spi_t *card, int32_t max_retries)
             DEBUG("_wait_for_r1: R1_VALID\n");
             return r1;
         }
-        tried++;
-    } while ((max_retries < 0) || (tried <= max_retries));
+
+    } while ((retry_us > 0) && (xtimer_now_usec() < retry_timeout));
 
     DEBUG("_wait_for_r1: [TIMEOUT]\n");
     return r1;
@@ -591,7 +586,7 @@ static inline int _transfer_bytes(sdcard_spi_t *card, const uint8_t *out, uint8_
 static sd_rw_response_t _read_data_packet(sdcard_spi_t *card, uint8_t token, uint8_t *data, int size)
 {
     DEBUG("_read_data_packet: size: %d\n", size);
-    if (_wait_for_token(card, token, SD_DATA_TOKEN_RETRY_CNT) == true) {
+    if (_wait_for_token(card, token, SD_DATA_TOKEN_RETRY_US) == true) {
         DEBUG("_read_data_packet: [GOT TOKEN]\n");
     }
     else {
@@ -636,7 +631,7 @@ static inline int _read_blocks(sdcard_spi_t *card, int cmd_idx, int bladdr, uint
     int reads = 0;
 
     uint32_t addr = card->use_block_addr ? bladdr : (bladdr * SD_HC_BLOCK_SIZE);
-    uint8_t cmd_r1_resu = sdcard_spi_send_cmd(card, cmd_idx, addr, SD_BLOCK_READ_CMD_RETRIES);
+    uint8_t cmd_r1_resu = sdcard_spi_send_cmd(card, cmd_idx, addr, SD_BLOCK_READ_CMD_RETRY_US);
 
     if (R1_VALID(cmd_r1_resu) && !R1_ERROR(cmd_r1_resu)) {
         DEBUG("_read_blocks: send CMD%d: [OK]\n", cmd_idx);
@@ -752,7 +747,7 @@ static inline int _write_blocks(sdcard_spi_t *card, uint8_t cmd_idx, int bladdr,
     int written = 0;
 
     uint32_t addr = card->use_block_addr ? bladdr : (bladdr * SD_HC_BLOCK_SIZE);
-    uint8_t cmd_r1_resu = sdcard_spi_send_cmd(card, cmd_idx, addr, SD_BLOCK_WRITE_CMD_RETRIES);
+    uint8_t cmd_r1_resu = sdcard_spi_send_cmd(card, cmd_idx, addr, SD_BLOCK_WRITE_CMD_RETRY_US);
 
     if (R1_VALID(cmd_r1_resu) && !R1_ERROR(cmd_r1_resu)) {
         DEBUG("_write_blocks: send CMD%d: [OK]\n", cmd_idx);
@@ -773,7 +768,7 @@ static inline int _write_blocks(sdcard_spi_t *card, uint8_t cmd_idx, int bladdr,
                 *state = write_resu;
                 return written;
             }
-            if (!_wait_for_not_busy(card, SD_WAIT_FOR_NOT_BUSY_CNT)) {
+            if (!_wait_for_not_busy(card, SD_WAIT_FOR_NOT_BUSY_US)) {
                 DEBUG("_write_blocks: _wait_for_not_busy: [FAILED]\n");
                 _unselect_card_spi(card);
                 *state = SD_RW_TIMEOUT;
@@ -792,7 +787,7 @@ static inline int _write_blocks(sdcard_spi_t *card, uint8_t cmd_idx, int bladdr,
             /* sd card needs dummy byte before we can wait for not-busy
                state */
             _send_dummy_byte(card);
-            if (!_wait_for_not_busy(card, SD_WAIT_FOR_NOT_BUSY_CNT)) {
+            if (!_wait_for_not_busy(card, SD_WAIT_FOR_NOT_BUSY_US)) {
                 _unselect_card_spi(card);
                 *state = SD_RW_TIMEOUT;
             }

--- a/tests/driver_sdcard_spi/main.c
+++ b/tests/driver_sdcard_spi/main.c
@@ -369,7 +369,7 @@ static const shell_command_t shell_commands[] = {
     { "read", "'read n m' reads m blocks beginning at block address n and prints the result. "
               "Append -c option to print data readable chars", _read },
     { "write", "'write n data' writes data to block n. Append -r option to "
-               "repeatedly write data to coplete block", _write },
+               "repeatedly write data to complete block", _write },
     { "copy", "'copy src dst' copies block src to block dst", _copy },
     { NULL, NULL, NULL }
 };

--- a/tests/pkg_fatfs_vfs/Makefile.ci
+++ b/tests/pkg_fatfs_vfs/Makefile.ci
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     msb-430 \
     msb-430h \
     nucleo-f031k6 \
+    nucleo-f042k6 \
     stm32f030f4-demo \
     telosb \
     wsn430-v1_3b \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR concerns the timeout or retry parameterization of drivers/sdcard_spi.
The following changes are proposed to improve the module's usability:

- make retry parameters available to user by guarding them
- convert retry parameters from counts to microsecond timeouts to make them more understandable

Some default values put in the timeout section are related to the millisecond timeout values found in [this elderly SanDisk manual](https://www.convict.lu/pdf/ProdManualSDCardv1.9.pdf), p. 88. Other timings provided, e.g. clock cycle based timings, were not considered. Still the choice of timeouts is quite arbitrary and there is no clear rationale behind this.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The test in tests/drivers_sdcard_spi should work as expected.

Auto-init and all commands work for me on a SAMD21-XPRO with attached SD card adapter:

```console
2020-07-02 10:09:28,654 #  main(): This is RIOT! (Version: 2020.07-devel-1669-g07d56-fix/20200630__sdcard_spi)
2020-07-02 10:09:28,657 # SD-card spi driver test application
2020-07-02 10:09:28,663 # insert SD-card and use 'init' command to set card to spi mode
2020-07-02 10:09:28,670 # WARNING: using 'write' or 'copy' commands WILL overwrite data on your sd-card and
2020-07-02 10:09:28,677 # almost for sure corrupt existing filesystems, partitions and contained data!
> ?
2020-07-02 10:09:44,334 #  help
2020-07-02 10:09:44,336 # Command              Description
2020-07-02 10:09:44,340 # ---------------------------------------
2020-07-02 10:09:44,346 # init                 initializes default card
2020-07-02 10:09:44,351 # cid                  print content of CID (Card IDentification) register
2020-07-02 10:09:44,357 # csd                  print content of CSD (Card-Specific Data) register
2020-07-02 10:09:44,360 # sds                  print SD status
2020-07-02 10:09:44,363 # size                 print card size
2020-07-02 10:09:44,368 # sectors              print sector count of card
2020-07-02 10:09:44,381 # read                 'read n m' reads m blocks beginning at block address n and prints the result. Append -c option to print data readable chars
2020-07-02 10:09:44,391 # write                'write n data' writes data to block n. Append -r option to repeatedly write data to complete block
2020-07-02 10:09:44,397 # copy                 'copy src dst' copies block src to block dst
> init
2020-07-02 10:09:46,631 #  init
2020-07-02 10:09:46,645 # Initializing SD-card at SPI_0...[OK]
> cid
2020-07-02 10:09:50,522 #  cid
2020-07-02 10:09:50,525 # ----------------------------------------
2020-07-02 10:09:50,526 # MID: 116
2020-07-02 10:09:50,527 # OID: J`
2020-07-02 10:09:50,528 # PNM: `USD 
2020-07-02 10:09:50,529 # PRV: 16
2020-07-02 10:09:50,530 # PSN: 3356716353
2020-07-02 10:09:50,531 # MDT: 28
2020-07-02 10:09:50,534 # CRC: 189
2020-07-02 10:09:50,536 # ----------------------------------------
> csd
2020-07-02 10:09:54,004 #  csd
2020-07-02 10:09:54,005 # CSD V2:
2020-07-02 10:09:54,008 # ----------------------------------------
2020-07-02 10:09:54,011 # CSD_STRUCTURE: 0x1
2020-07-02 10:09:54,012 # TAAC: 0xe
2020-07-02 10:09:54,012 # NSAC: 0x0
2020-07-02 10:09:54,014 # TRAN_SPEED: 0x32
2020-07-02 10:09:54,014 # CCC: 0x5b5
2020-07-02 10:09:54,016 # READ_BL_LEN: 0x9
2020-07-02 10:09:54,017 # READ_BL_PARTIAL: 0x0
2020-07-02 10:09:54,020 # WRITE_BLK_MISALIGN: 0x0
2020-07-02 10:09:54,022 # READ_BLK_MISALIGN: 0x0
2020-07-02 10:09:54,030 # DSR_IMP: 0x0
2020-07-02 10:09:54,032 # C_SIZE: 0x3add
2020-07-02 10:09:54,033 # ERASE_BLK_EN: 0x1
2020-07-02 10:09:54,034 # SECTOR_SIZE: 0x7f
2020-07-02 10:09:54,035 # WP_GRP_SIZE: 0x0
2020-07-02 10:09:54,035 # WP_GRP_ENABLE: 0x0
2020-07-02 10:09:54,036 # R2W_FACTOR: 0x2
2020-07-02 10:09:54,036 # WRITE_BL_LEN: 0x9
2020-07-02 10:09:54,037 # WRITE_BL_PARTIAL: 0x0
2020-07-02 10:09:54,038 # FILE_FORMAT_GRP: 0x0
2020-07-02 10:09:54,038 # COPY: 0x0
2020-07-02 10:09:54,047 # PERM_WRITE_PROTECT: 0x0
2020-07-02 10:09:54,048 # TMP_WRITE_PROTECT: 0x0
2020-07-02 10:09:54,048 # FILE_FORMAT: 0x0
2020-07-02 10:09:54,049 # CRC: 0xa9
2020-07-02 10:09:54,050 # ----------------------------------------
> sds
2020-07-02 10:10:04,207 #  sds
2020-07-02 10:10:04,208 # SD status:
2020-07-02 10:10:04,212 # ----------------------------------------
2020-07-02 10:10:04,215 # SIZE_OF_PROTECTED_AREA: 0x3000000
2020-07-02 10:10:04,216 # SUS_ADDR: 0x0
2020-07-02 10:10:04,230 # VSC_AU_SIZE: 0x0
2020-07-02 10:10:04,242 # SD_CARD_TYPE: 0x0
2020-07-02 10:10:04,242 # ERASE_SIZE: 0x8
2020-07-02 10:10:04,243 # SPEED_CLASS: 0x2
2020-07-02 10:10:04,243 # PERFORMANCE_MOVE: 0x2
2020-07-02 10:10:04,244 # VIDEO_SPEED_CLASS: 0x0
2020-07-02 10:10:04,245 # ERASE_TIMEOUT: 0x4
2020-07-02 10:10:04,245 # ERASE_OFFSET: 0x1
2020-07-02 10:10:04,246 # UHS_SPEED_GRADE: 0x0
2020-07-02 10:10:04,247 # UHS_AU_SIZE: 0x0
2020-07-02 10:10:04,247 # AU_SIZE: 0x9
2020-07-02 10:10:04,248 # DAT_BUS_WIDTH: 0x0
2020-07-02 10:10:04,248 # SECURED_MODE: 0x0
2020-07-02 10:10:04,249 # ----------------------------------------
> size
2020-07-02 10:10:24,974 #  size
2020-07-02 10:10:24,977 # 
2020-07-02 10:10:24,978 # Card size: 
2020-07-02 10:10:24,979 # 7901020160 bytes (7,358 GiB | 7,901 GB)
> sectors
2020-07-02 10:10:28,727 #  sectors
2020-07-02 10:10:28,731 # available sectors on card: 15431680
> read 100 1
2020-07-02 10:10:45,722 #  read 100 1
2020-07-02 10:10:45,727 # BLOCK 100:
2020-07-02 10:10:45,733 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,741 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,748 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,755 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,764 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,774 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,778 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,783 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,789 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,798 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,807 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,812 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,819 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,827 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,836 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,841 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,850 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,856 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,864 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,871 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,879 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,880 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,881 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,882 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,883 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,884 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,885 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,886 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,887 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,888 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,889 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,890 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:45,890 # 
> read 101 1
2020-07-02 10:10:52,521 #  read 101 1
2020-07-02 10:10:52,526 # BLOCK 101:
2020-07-02 10:10:52,532 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,537 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,545 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,552 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,559 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,566 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,572 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,576 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,582 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,588 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,593 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,601 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,607 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,612 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,616 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,621 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,627 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,633 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,640 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,644 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,649 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,659 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,668 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,674 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,679 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,680 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,681 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,682 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,683 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,684 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,685 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,686 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:10:52,686 # 
write 100 "a b c d"
2020-07-02 10:11:13,558 #  write 100 "a b c d"
2020-07-02 10:11:13,566 # will write 'a b c d' (7 chars) at start of block 100
2020-07-02 10:11:13,567 # the rest of the block will be filled with zeros
2020-07-02 10:11:13,637 # write block 100 [OK]
> copy 100 101
2020-07-02 10:11:21,847 #  copy 100 101
2020-07-02 10:11:21,859 # copy block 100 to 101 [OK]
> read 100
2020-07-02 10:11:24,733 #  read 100
2020-07-02 10:11:24,736 # usage: read blockaddr cnt [-c]
> read 100 1
2020-07-02 10:11:27,986 #  read 100 1
2020-07-02 10:11:27,991 # BLOCK 100:
2020-07-02 10:11:27,997 # 61 20 62 20 63 20 64 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,003 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,006 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,010 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,019 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,021 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,024 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,029 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,035 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,038 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,043 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,048 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,054 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,058 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,064 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,069 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,072 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,077 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,082 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,086 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,091 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,096 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,106 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,107 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,110 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,115 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,119 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,124 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,129 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,134 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,138 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,143 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:28,144 # 
> read 101 1
2020-07-02 10:11:35,311 #  read 101 1
2020-07-02 10:11:35,315 # BLOCK 101:
2020-07-02 10:11:35,320 # 61 20 62 20 63 20 64 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,325 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,329 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,334 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,339 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,344 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,348 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,353 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,358 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,362 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,367 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,372 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,377 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,381 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,386 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,391 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,396 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,401 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,405 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,410 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,415 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,419 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,424 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,429 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,434 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,438 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,443 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,448 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,452 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,458 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,462 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,467 # 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 
2020-07-02 10:11:35,467 # 
> write 100 ""
2020-07-02 10:11:45,051 #  write 100 ""
2020-07-02 10:11:45,056 # will write '' (0 chars) at start of block 100
2020-07-02 10:11:45,060 # the rest of the block will be filled with zeros
2020-07-02 10:11:45,068 # write block 100 [OK]
> write 101 ""
2020-07-02 10:11:48,596 #  write 101 ""
2020-07-02 10:11:48,597 # will write '' (0 chars) at start of block 101
2020-07-02 10:11:48,601 # the rest of the block will be filled with zeros
2020-07-02 10:11:48,608 # write block 101 [OK]
> 
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #11388.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
