### PR TITLE
boards/kinetis-based: Model features in Kconfig

### DIFF
--- a/boards/common/frdm/Makefile.include
+++ b/boards/common/frdm/Makefile.include
@@ -11,7 +11,13 @@ DEBUG_ADAPTER ?= dap
 # For KW41Z, an OpenOCD version built from source is required. The support for
 # kw41z was introduced in
 # https://github.com/ntfreak/openocd/2c8602ed9f084d6680cec7d0ca1d5dc71c865a5f
-OPENOCD_CONFIG ?= $(RIOTBOARD)/common/frdm/dist/openocd-$(CPU_FAMILY).cfg
+ifeq ($(CPU_CORE), cortex-m0plus)
+  OPENOCD_KINETIS_FAMILY = klx
+else
+  OPENOCD_KINETIS_FAMILY = kx
+endif
+
+OPENOCD_CONFIG ?= $(RIOTBOARD)/common/frdm/dist/openocd-$(OPENOCD_KINETIS_FAMILY).cfg
 
 # Check the flash configuration field before flashing
 PRE_FLASH_CHECK_SCRIPT = $(RIOTCPU)/$(CPU)/dist/check-fcfield.sh

--- a/boards/common/kw41z/Kconfig
+++ b/boards/common/kw41z/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_COMMON_KW41Z
+    bool
+    default y
+    select CPU_MODEL_MKW41Z512VHT4
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_RIOTBOOT

--- a/boards/frdm-k22f/Kconfig
+++ b/boards/frdm-k22f/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "frdm-k22f" if BOARD_FRDM_K22F
+
+config BOARD_FRDM_K22F
+    bool
+    default y
+    select CPU_MODEL_MK22FN512VLH12
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/frdm-k64f/Kconfig
+++ b/boards/frdm-k64f/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "frdm-k64f" if BOARD_FRDM_K64F
+
+config BOARD_FRDM_K64F
+    bool
+    default y
+    select CPU_MODEL_MK64FN1M0VLL12
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_RIOTBOOT

--- a/boards/frdm-kw41z/Kconfig
+++ b/boards/frdm-kw41z/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "frdm-kw41z" if BOARD_FRDM_KW41Z
+
+config BOARD_FRDM_KW41Z
+    bool
+    default y
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select BOARD_COMMON_KW41Z
+
+source "$(RIOTBOARD)/common/kw41z/Kconfig"

--- a/boards/mulle/Kconfig
+++ b/boards/mulle/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "mulle" if BOARD_MULLE
+
+config BOARD_MULLE
+    bool
+    default y
+    select CPU_MODEL_MK60DN512VLL10
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/openlabs-kw41z-mini-256kib/Kconfig
+++ b/boards/openlabs-kw41z-mini-256kib/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "openlabs-kw41z-mini-256kib" if BOARD_OPENLABS_KW41Z_MINI_256KIB
+
+config BOARD_OPENLABS_KW41Z_MINI_256KIB
+    bool
+    default y
+    select CPU_MODEL_MKW41Z256VHT4
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_RIOTBOOT

--- a/boards/openlabs-kw41z-mini/Kconfig
+++ b/boards/openlabs-kw41z-mini/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "openlabs-kw41z-mini" if BOARD_OPENLABS_KW41Z_MINI
+
+config BOARD_OPENLABS_KW41Z_MINI
+    bool
+    default y
+    select CPU_MODEL_MKW41Z512VHT4
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_RIOTBOOT

--- a/boards/pba-d-01-kw2x/Kconfig
+++ b/boards/pba-d-01-kw2x/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "pba-d-01-kw2x" if BOARD_PBA_D_01_KW2X
+
+config BOARD_PBA_D_01_KW2X
+    bool
+    default y
+    select CPU_MODEL_MKW21D256VHA5
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_RIOTBOOT

--- a/boards/phynode-kw41z/Kconfig
+++ b/boards/phynode-kw41z/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "phynode-kw41z" if BOARD_PHYNODE_KW41Z
+
+config BOARD_PHYNODE_KW41Z
+    bool
+    default y
+    select BOARD_COMMON_KW41Z
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+
+source "$(RIOTBOARD)/common/kw41z/Kconfig"

--- a/boards/teensy31/Kconfig
+++ b/boards/teensy31/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "teensy31" if BOARD_TEENSY31
+
+config BOARD_TEENSY31
+    bool
+    default y
+    select CPU_MODEL_MK20DX256VLH7
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/usb-kw41z/Kconfig
+++ b/boards/usb-kw41z/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "usb-kw41z" if BOARD_USB_KW41Z
+
+config BOARD_USB_KW41Z
+    bool
+    default y
+    select BOARD_COMMON_KW41Z
+    select HAS_PERIPH_SPI
+
+source "$(RIOTBOARD)/common/kw41z/Kconfig"

--- a/cpu/kinetis/Kconfig
+++ b/cpu/kinetis/Kconfig
@@ -1,0 +1,131 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config CPU_COMMON_KINETIS
+    bool
+    select HAS_CPU_KINETIS
+    select HAS_PERIPH_CPUID
+    select HAS_PERIPH_PM
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+
+config CPU_FAM_EA
+    bool
+    select CPU_COMMON_KINETIS
+    select HAS_PERIPH_ICS
+
+config CPU_FAM_K
+    bool
+    select CPU_COMMON_KINETIS
+    select HAS_PERIPH_FLASHPAGE
+    select HAS_PERIPH_FLASHPAGE_RAW
+    select HAS_PERIPH_MCG
+
+config CPU_FAM_W
+    bool
+    select CPU_COMMON_KINETIS
+    select HAS_PERIPH_FLASHPAGE
+    select HAS_PERIPH_FLASHPAGE_RAW
+    select HAS_PERIPH_MCG
+
+## CPU Models
+config CPU_MODEL_MK20DX256VLH7
+    bool
+    select CPU_CORE_CORTEX_M4
+    select CPU_FAM_K
+
+config CPU_MODEL_MK22FN512VLH12
+    bool
+# This is actually M4F; TODO: Add floating point support
+    select CPU_CORE_CORTEX_M4
+    select CPU_FAM_K
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_MK60DN512VLL10
+    bool
+    select CPU_CORE_CORTEX_M4
+    select CPU_FAM_K
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_MK64FN1M0VLL12
+    bool
+# This is actually M4F; TODO: Add floating point support
+    select CPU_CORE_CORTEX_M4
+    select CPU_FAM_K
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_MKW21D256VHA5
+    bool
+    select CPU_CORE_CORTEX_M4
+    select CPU_FAM_W
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_MKW21D512VHA5
+    bool
+    select CPU_CORE_CORTEX_M4
+    select CPU_FAM_W
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_MKW22D512VHA5
+    bool
+    select CPU_CORE_CORTEX_M4
+    select CPU_FAM_W
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_MKW41Z256VHT4
+    bool
+    select CPU_CORE_CORTEX_M0PLUS
+    select CPU_FAM_W
+
+config CPU_MODEL_MKW41Z512VHT4
+    bool
+    select CPU_CORE_CORTEX_M0PLUS
+    select CPU_FAM_W
+
+config CPU_MODEL_S9KEAZ128ACLH
+    bool
+    select CPU_CORE_CORTEX_M4
+    select CPU_FAM_EA
+
+## Definition of specific features
+config HAS_CPU_KINETIS
+    bool
+    help
+        Indicates that a 'kinetis' cpu is being used.
+
+config HAS_PERIPH_MCG
+    bool
+    help
+        Indicates that the cpu uses the Kinetis Multipurpose Clock Generator.
+
+config HAS_PERIPH_ICS
+    bool
+    help
+        Indicates that the cpu uses the Kinetis Internal Clock Source
+        controller.
+
+## Common CPU symbols
+config CPU_FAM
+    default "ea" if CPU_FAM_EA
+    default "k" if CPU_FAM_K
+    default "w" if CPU_FAM_W
+
+config CPU_MODEL
+    default "mk20dx256vlh7"   if CPU_MODEL_MK20DX256VLH7
+    default "mk22fn512vlh12"  if CPU_MODEL_MK22FN512VLH12
+    default "mk60dn512vll10"  if CPU_MODEL_MK60DN512VLL10
+    default "mk64fn1m0vll12"  if CPU_MODEL_MK64FN1M0VLL12
+    default "mkw21d256vha5"   if CPU_MODEL_MKW21D256VHA5
+    default "mkw21d512vha5"   if CPU_MODEL_MKW21D512VHA5
+    default "mkw22d512vha5"   if CPU_MODEL_MKW22D512VHA5
+    default "mkw41z256vht4"   if CPU_MODEL_MKW41Z256VHT4
+    default "mkw41z512vht4"   if CPU_MODEL_MKW41Z512VHT4
+    default "s9keaz128aclh" if CPU_MODEL_S9KEAZ128ACLH
+
+config CPU
+    default "kinetis" if CPU_COMMON_KINETIS
+
+source "$(RIOTCPU)/cortexm_common/Kconfig"

--- a/cpu/kinetis/Makefile.features
+++ b/cpu/kinetis/Makefile.features
@@ -13,22 +13,19 @@ endif
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_gpio_irq
 
-# This applies to all Kinetis EA series, for now this is only s9keaz128aclh48
-ifeq (s9keaz128aclh48,$(CPU_MODEL))
-  FEATURES_PROVIDED += periph_ics
-else
-  FEATURES_PROVIDED += periph_mcg
-endif
+# Parse parameters from CPU_MODEL using the kinetis-info.mk script in the same
+# directory as this Makefile.
+include $(LAST_MAKEFILEDIR)/kinetis-info.mk
 
-# Since KINETIS_SERIES isn't available in Makefile.features filter according to
-# CPU_MODEL
-ifneq (,$(filter mkw% mk%,$(CPU_MODEL)))
+ifneq (,$(filter k w,$(CPU_FAM)))
   FEATURES_PROVIDED += periph_flashpage
   FEATURES_PROVIDED += periph_flashpage_raw
 endif
 
-# Parse parameters from CPU_MODEL using the kinetis-info.mk script in the same
-# directory as this Makefile.
-include $(LAST_MAKEFILEDIR)/kinetis-info.mk
+ifeq (ea,$(CPU_FAM))
+  FEATURES_PROVIDED += periph_ics
+else
+  FEATURES_PROVIDED += periph_mcg
+endif
 
 include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/kinetis/kinetis-info.mk
+++ b/cpu/kinetis/kinetis-info.mk
@@ -32,17 +32,17 @@ export KINETIS_SPEED := $(word 11, $(KINETIS_INFO))
 ifeq ($(KINETIS_CORE), Z)
   # Cortex-M0+
   CPU_CORE = cortex-m0plus
-  CPU_FAMILY = klx
 else ifeq ($(KINETIS_CORE), D)
   # Cortex-M4
   CPU_CORE = cortex-m4
-  CPU_FAMILY = kx
 else ifeq ($(KINETIS_CORE), F)
   # Cortex-M4F or Cortex-M7
   # TODO: Add floating point support
   CPU_CORE = cortex-m4
-  CPU_FAMILY = kx
 endif
+
+# For the rest of the build system we expose the series as family
+CPU_FAM = $(call lowercase,$(KINETIS_SERIES))
 
 # RAM sizes are a bit arbitrary, but are usually dependent on ROM size and core speed.
 # KINETIS_RAMSIZE is used inside a $(( )) shell arithmetic block, so it is OK to

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -19,6 +19,8 @@ BOARD_WHITELIST += arduino-duemilanove \
                    derfmega128 \
                    derfmega256 \
                    firefly \
+                   frdm-k22f \
+                   frdm-k64f \
                    hifive1 \
                    hifive1b \
                    ikea-tradfri \
@@ -26,8 +28,13 @@ BOARD_WHITELIST += arduino-duemilanove \
                    microduino-corerf \
                    msb-430 \
                    msb-430h \
+                   mulle \
+                   openlabs-kw41z-mini \
+                   openlabs-kw41z-mini-256kib \
                    openmote-b \
                    openmote-cc2538 \
+                   pba-d-01-kw2x \
+                   phynode-kw41z \
                    remote-pa \
                    remote-reva \
                    remote-revb \
@@ -40,7 +47,9 @@ BOARD_WHITELIST += arduino-duemilanove \
                    slwstk6220a \
                    stk3600 \
                    stk3700 \
+                   teensy31 \
                    telosb \
+                   usb-kw41z \
                    waspmote-pro \
                    wsn430-v1_3b \
                    wsn430-v1_4 \


### PR DESCRIPTION
### Contribution description
This models the features provided by the kinetis CPUs and all the boards based on them:
- `frdm-k22f`
- `frdm-k64f`
- `frdm-kw41z`
- `mulle`
- `openlabs-kw41z-mini`
- `openlabs-kw41z-mini-256kib`
- `pba-d-01-kw2x`
- `phynode-kw41z`
- `teensy31`
- `usb-kw41z`

Also cleans up the `Makefile.features` of kinetis a bit.

### Testing procedure
- Check the symbol organization in kinetis. As some features depend on the series I used intermediate symbols `CPU_SERIES_` to group this.
- Features provided should not change for kinetis-based boards.
- `tests/kconfig_features` should pass for all boards.

### Issues/PRs references
Part of #14148 