### PR TITLE
cpu/cortexm_common: Fixes for thread_arch.c and dropped workaround

### DIFF
--- a/cpu/cortexm_common/Makefile
+++ b/cpu/cortexm_common/Makefile
@@ -1,6 +1,3 @@
-# see https://github.com/RIOT-OS/RIOT/issues/5775.
-SRC_NOLTO += vectors_cortexm.c
-
 DIRS = periph
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/cortexm_common/Makefile
+++ b/cpu/cortexm_common/Makefile
@@ -1,7 +1,3 @@
-# thread_arch.c's inline assembler breaks when compiling with link time
-# optimization. see https://github.com/RIOT-OS/RIOT/issues/5774.
-SRC_NOLTO += thread_arch.c
-
 # see https://github.com/RIOT-OS/RIOT/issues/5775.
 SRC_NOLTO += vectors_cortexm.c
 

--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -372,6 +372,8 @@ void __attribute__((naked)) __attribute__((used)) isr_pendsv(void) {
                                            * causes end of exception*/
 #endif
     /* {r0-r3,r12,LR,PC,xPSR,s0-s15,FPSCR} are restored automatically on exception return */
+     ".ltorg                           \n" /* literal pool needed to access
+                                            * sched_active_thread */
     );
 }
 


### PR DESCRIPTION
### Contribution description

- Add a literate pool at the end of `isr_pendsv()`
    - This allows the assembler to emit machine code for `ldr    r1, =sched_active_thread`, as otherwise the immediate offset would be out of range; at least with `LTO=1`.
- Drop #7776's LTO workaround
- Drop https://github.com/RIOT-OS/RIOT/issues/5775 LTO workaround

### Testing procedure

Compile, flash, and run a couple of tests with `LTO=1`.

### Issues/PRs references

Fixes: https://github.com/RIOT-OS/RIOT/issues/5774
Fixes: https://github.com/RIOT-OS/RIOT/issues/5775
Depends on and includes: https://github.com/RIOT-OS/RIOT/pull/14434