### PR TITLE
core/assert: ignore condition when NDEBUG defined

### DIFF
--- a/core/include/assert.h
+++ b/core/include/assert.h
@@ -56,7 +56,7 @@ extern "C" {
 extern const char assert_crash_message[];
 
 #ifdef NDEBUG
-#define assert(ignore)((void)0)
+#define assert(ignore)((void)(ignore))
 #elif defined(DEBUG_ASSERT_VERBOSE)
 /**
  * @brief   Function to handle failed assertion


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While looking at `assert.h` for #14418 again, I noticed, that many instances of #14364 can be solved by just ignoring the condition in the assert when `NDEBUG` is defined. 

This way, one does not need to add a `(void)foobar` for every variable used in an assert if it is not used otherwise.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compilation of some application fails on master (if #14364 is not merged before), with this PR they succeed.

```sh
CFLAGS=-DNDEBUG make -C tests/gnrc_ipv6_ext_opt/ -j16
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Partly an alternative to #14364 but they are not contradicting each other necessarily.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
