### PR TITLE
boards/ruuvitag: fix lis2dh interrupt pin define

### DIFF
--- a/boards/ruuvitag/include/board.h
+++ b/boards/ruuvitag/include/board.h
@@ -73,9 +73,9 @@ extern "C" {
  * @name    Accelerometer configuration
  * @{
  */
-#define LIS2DH12_PARAM_CS   GPIO_PIN(0, 8)
-#define LIS2DH12_PARAM_INT1 GPIO_PIN(0, 2)
-#define LIS2DH12_PARAM_INT2 GPIO_PIN(0, 6)
+#define LIS2DH12_PARAM_CS       GPIO_PIN(0, 8)
+#define LIS2DH12_PARAM_INT_PIN1 GPIO_PIN(0, 2)
+#define LIS2DH12_PARAM_INT_PIN2 GPIO_PIN(0, 6)
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

The lis2dh12 interrupt pin defines at some point got renamed

    LIS2DH12_PARAM_INT1 ->  LIS2DH12_PARAM_INT_PIN1

but this board was missed out.
This fixes the omission.

There are no more references to `LIS2DH12_PARAM_INT1` in the code.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
