### PR TITLE
boards/sensebox_samd21: fix RTT configuration

### DIFF
--- a/boards/sensebox_samd21/Makefile.features
+++ b/boards/sensebox_samd21/Makefile.features
@@ -5,6 +5,7 @@ CPU_MODEL = samd21g18a
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/sensebox_samd21/include/periph_conf.h
+++ b/boards/sensebox_samd21/include/periph_conf.h
@@ -210,11 +210,12 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF          ARRAY_SIZE(i2c_config)
 
 /**
- * @name    RTC configuration
+ * @name RTT configuration
  * @{
  */
-#define RTC_DEV             RTC->MODE2
-
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtc_rtt.c` */
+#endif
 /** @} */
 
 /**


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The board did not have an updated RTT configuration yet.
Also remove the obsolete RTC configuration.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

split off #14416
