### PR TITLE
boards/hifive1b: add support for openocd programmer

### DIFF
--- a/boards/hifive1b/Makefile.include
+++ b/boards/hifive1b/Makefile.include
@@ -5,12 +5,23 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-# setup JLink for flashing
-# export JLINK := JLink
-JLINK_DEVICE = FE310
-JLINK_IF = JTAG
-FLASH_ADDR = 0x20010000
-include $(RIOTMAKE)/tools/jlink.inc.mk
+# Set default programmer as jlink
+PROGRAMMER ?= jlink
+
+ifeq (openocd,$(PROGRAMMER))
+  DEBUG_ADAPTER = jlink
+  OPENOCD_TRANSPORT = jtag
+  OPENOCD_PRE_FLASH_CMDS += "-c flash protect 0 1 last off"
+  include $(RIOTMAKE)/tools/openocd.inc.mk
+else ifeq (jlink,$(PROGRAMMER))
+  # setup JLink for flashing
+  JLINK_DEVICE = FE310
+  JLINK_IF = JTAG
+  FLASH_ADDR = 0x20010000
+  include $(RIOTMAKE)/tools/jlink.inc.mk
+else
+  $(error Programmer '$(PROGRAMMER)' not supported for board '$(BOARD)')
+endif
 
 TESTRUNNER_RESET_DELAY = 1
 $(call target-export-variables,test,TESTRUNNER_RESET_DELAY)

--- a/boards/hifive1b/dist/openocd.cfg
+++ b/boards/hifive1b/dist/openocd.cfg
@@ -1,0 +1,10 @@
+adapter speed 4000
+
+set _CHIPNAME riscv
+jtag newtap $_CHIPNAME cpu -irlen 5 -expected-id 0x20000913
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME.0 riscv -chain-position $_TARGETNAME
+$_TARGETNAME.0 configure -work-area-phys 0x80000000 -work-area-size 0x4000 -work-area-backup 0
+
+flash bank onboard_spi_flash fespi 0x20000000 0 0 0 $_TARGETNAME.0


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

[OpenOCD support for the HiFive1b](https://github.com/ntfreak/openocd/commit/7e78c04f1c275176bdee8f9d2553300218164577) is now available upstream so this PR is adding openocd as an optional programmer for this board.

I had to update the `openocd.sh` to make it work though. I tested it on a couple of other boards (stm32f429i-disc1, dwm1001) and it seems to work the same but we should test and review this change in detail.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Flashing the hifive1b with openocd works:

<details><summary>flash</summary>

```
PROGRAMMER=openocd make BOARD=hifive1b -C examples/hello-world flash term
make: Entering directory '/work/riot/RIOT/examples/hello-world'
Building application "hello-world" for "hifive1b" with MCU "fe310".

"make" -C /work/riot/RIOT/boards/hifive1b
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/fe310
"make" -C /work/riot/RIOT/cpu/fe310/nano
"make" -C /work/riot/RIOT/cpu/fe310/periph
"make" -C /work/riot/RIOT/cpu/fe310/vendor
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8874	    104	   2408	  11386	   2c7a	/work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01293-g7c88e76a-dirty (2020-07-01-21:36)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : J-Link OB-K22-SiFive compiled Dec 12 2019 16:26:28
Info : Hardware version: 1.00
Info : VTarget = 3.300 V
Info : clock speed 4000 kHz
Info : JTAG tap: riscv.cpu tap/device found: 0x20000913 (mfg: 0x489 (SiFive, Inc.), part: 0x0000, ver: 0x2)
Info : datacount=1 progbufsize=16
Info : Disabling abstract command reads from CSRs.
Info : Examined RISC-V core; found 1 harts
Info :  hart 0: XLEN=32, misa=0x40101105
Info : starting gdb server for riscv.cpu.0 on 0
Info : Listening on port 33455 for gdb connections
Info : Found flash device 'issi is25lp032' (ID 0x0016609d)
Ready for Remote Connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* riscv.cpu.0        riscv      little riscv.cpu          halted

Info : JTAG tap: riscv.cpu tap/device found: 0x20000913 (mfg: 0x489 (SiFive, Inc.), part: 0x0000, ver: 0x2)
Info : Disabling abstract command writes to CSRs.
auto erase enabled
wrote 65536 bytes from file /work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.elf in 4.180947s (15.308 KiB/s)

verified 8980 bytes in 0.381714s (22.974 KiB/s)

Info : JTAG tap: riscv.cpu tap/device found: 0x20000913 (mfg: 0x489 (SiFive, Inc.), part: 0x0000, ver: 0x2)
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-07-02 16:32:17,233 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Bench Clock Reset Complete
2020-07-02 16:32:18,238 # 
2020-07-02 16:32:18,239 # ATE0-->ATE0
2020-07-02 16:32:18,239 # OK
2020-07-02 16:32:18,240 # AT+BLEINIT=0-->OK
2020-07-02 16:32:18,241 # AT+CWMODE=0-->OK
2020-07-02 16:32:18,241 # 
2020-07-02 16:32:18,242 # main(): This is RIOT! (Version: 2020.07-devel-1708-gcffcb-pr/boards/hifive1b_openocd)
2020-07-02 16:32:18,243 # Hello World!
2020-07-02 16:32:18,243 # You are running RIOT on a(n) hifive1b board.
2020-07-02 16:32:18,243 # This board features a(n) fe310 MCU.
```

</details>

<details><summary>reset</summary>

```
PROGRAMMER=openocd make BOARD=hifive1b -C examples/hello-world reset
make: Entering directory '/work/riot/RIOT/examples/hello-world'
/work/riot/RIOT/dist/tools/openocd/openocd.sh reset
### Resetting Target ###
Open On-Chip Debugger 0.10.0+dev-01293-g7c88e76a-dirty (2020-07-01-21:36)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : J-Link OB-K22-SiFive compiled Dec 12 2019 16:26:28
Info : Hardware version: 1.00
Info : VTarget = 3.300 V
Info : clock speed 4000 kHz
Info : JTAG tap: riscv.cpu tap/device found: 0x20000913 (mfg: 0x489 (SiFive, Inc.), part: 0x0000, ver: 0x2)
Info : datacount=1 progbufsize=16
Info : Disabling abstract command reads from CSRs.
Info : Examined RISC-V core; found 1 harts
Info :  hart 0: XLEN=32, misa=0x40101105
Info : starting gdb server for riscv.cpu.0 on 0
Info : Listening on port 36251 for gdb connections
Info : Found flash device 'issi is25lp032' (ID 0x0016609d)
Ready for Remote Connections
Info : JTAG tap: riscv.cpu tap/device found: 0x20000913 (mfg: 0x489 (SiFive, Inc.), part: 0x0000, ver: 0x2)
shutdown command invoked
make: Leaving directory '/work/riot/RIOT/examples/hello-world'
```

</details>

<details><summary>debug</summary>

```
PROGRAMMER=openocd make BOARD=hifive1b -C examples/hello-world debug
make: Entering directory '/work/riot/RIOT/examples/hello-world'
/work/riot/RIOT/dist/tools/openocd/openocd.sh debug /work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.elf
### Starting Debugging ###
Open On-Chip Debugger 0.10.0+dev-01293-g7c88e76a-dirty (2020-07-01-21:36)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Reading symbols from /work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.elf...
Remote debugging using :3333
0x2001088c in pm_set_lowest () at /work/riot/RIOT/cpu/fe310/periph/pm.c:26
26	    __asm__ volatile ("wfi");
(gdb) l 
21	#include "periph/pm.h"
22	#include "vendor/platform.h"
23	
24	void pm_set_lowest(void)
25	{
26	    __asm__ volatile ("wfi");
27	}
28	
29	void pm_reboot(void)
30	{
(gdb) 

```

</details>

- Flashing the hifive1b with JLink still works and is the default:

<details

```
make BOARD=hifive1b -C examples/hello-world flash
make: Entering directory '/work/riot/RIOT/examples/hello-world'
Building application "hello-world" for "hifive1b" with MCU "fe310".

"make" -C /work/riot/RIOT/boards/hifive1b
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/fe310
"make" -C /work/riot/RIOT/cpu/fe310/nano
"make" -C /work/riot/RIOT/cpu/fe310/periph
"make" -C /work/riot/RIOT/cpu/fe310/vendor
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8874	    104	   2408	  11386	   2c7a	/work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.elf
/work/riot/RIOT/dist/tools/jlink/jlink.sh flash /work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.bin
### Flashing Target ###
### Flashing at base address 0x20010000 with offset 0 ###
SEGGER J-Link Commander V6.56d (Compiled Dec 12 2019 13:05:00)
DLL version V6.56d, compiled Dec 12 2019 13:04:51

J-Link Commander will now exit on Error

J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...O.K.
Firmware: J-Link OB-K22-SiFive compiled Dec 12 2019 16:26:28
Hardware version: V1.00
S/N: 979001370
VTref=3.300V
Target connection not established yet but required for command.
Device "FE310" selected.


Connecting to target via JTAG
ConfigTargetSettings() start
ConfigTargetSettings() end
TotalIRLen = 5, IRPrint = 0x01
JTAG chain detection found 1 devices:
 #0 Id: 0x20000913, IRLen: 05, Unknown device
Debug architecture:
  RISC-V debug: 0.13
  AddrBits: 7
  DataBits: 32
  IdleClks: 5
Memory access:
  Via system bus: No
  Via ProgBuf: Yes (16 ProgBuf entries)
DataBuf: 1 entries
  autoexec[0] implemented: Yes
Detected: RV32 core
CSR access via abs. commands: No
Temp. halted CPU for NumHWBP detection
HW instruction/data BPs: 8
Support set/clr BPs while running: No
HW data BPs trigger before execution of inst
RISC-V identified.
Halting CPU for downloading file.
Downloading file [/work/riot/RIOT/examples/hello-world/bin/hifive1b/hello-world.bin]...
Comparing flash   [100%] Done.
J-Link: Flash download: Bank 0 @ 0x20000000: Skipped. Contents already match
O.K.

Reset delay: 0 ms
Reset type Normal: Resets core & peripherals using <ndmreset> bit in <dmcontrol> debug register.



Script processing completed.

make: Leaving directory '/work/riot/RIOT/examples/hello-world'
```

</details>

- No regression when using OpenOCD with other boards that support it:

<details><summary>stm32f419i-disc1</summary>

- flash

```
make BOARD=stm32f429i-disc1 -C examples/hello-world flash term
make: Entering directory '/work/riot/RIOT/examples/hello-world'
Building application "hello-world" for "stm32f429i-disc1" with MCU "stm32".

"make" -C /work/riot/RIOT/boards/stm32f429i-disc1
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/stm32
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/stm32/bootloader
"make" -C /work/riot/RIOT/cpu/stm32/periph
"make" -C /work/riot/RIOT/cpu/stm32/stmclk
"make" -C /work/riot/RIOT/cpu/stm32/vectors
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8636	    112	   2300	  11048	   2b28	/work/riot/RIOT/examples/hello-world/bin/stm32f429i-disc1/hello-world.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/examples/hello-world/bin/stm32f429i-disc1/hello-world.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01293-g7c88e76a-dirty (2020-07-01-21:36)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : clock speed 2000 kHz
Info : STLINK V2J25M14 (API v2) VID:PID 0483:374B
Info : Target voltage: 2.850960
Info : stm32f4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32f4x.cpu on 0
Info : Listening on port 35845 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f4x.cpu       hla_target little stm32f4x.cpu       running

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x0800054c msp: 0x20000200
Info : device id = 0x20016419
Info : flash size = 2048 kbytes
Info : Dual Bank 2048 kiB STM32F42x/43x/469/479 found
auto erase enabled
wrote 16384 bytes from file /work/riot/RIOT/examples/hello-world/bin/stm32f429i-disc1/hello-world.elf in 0.649240s (24.644 KiB/s)

verified 8748 bytes in 0.128659s (66.400 KiB/s)

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-07-02 16:37:03,055 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2020-07-02 16:37:06,215 # �main(): This is RIOT! (Version: 2020.07-devel-1708-gcffcb-pr/boards/hifive1b_openocd)
2020-07-02 16:37:06,216 # Hello World!
2020-07-02 16:37:06,221 # You are running RIOT on a(n) stm32f429i-disc1 board.
2020-07-02 16:37:06,222 # This board features a(n) stm32 MCU.
2020-07-02 16:37:07,376 # Exiting Pyterm
make: Leaving directory '/work/riot/RIOT/examples/hello-world'
```

- reset:

```
make BOARD=stm32f429i-disc1 -C examples/hello-world reset
make: Entering directory '/work/riot/RIOT/examples/hello-world'
/work/riot/RIOT/dist/tools/openocd/openocd.sh reset
### Resetting Target ###
Open On-Chip Debugger 0.10.0+dev-01293-g7c88e76a-dirty (2020-07-01-21:36)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
Info : clock speed 2000 kHz
Info : STLINK V2J25M14 (API v2) VID:PID 0483:374B
Info : Target voltage: 2.860677
Info : stm32f4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32f4x.cpu on 0
Info : Listening on port 43543 for gdb connections
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
shutdown command invoked
make: Leaving directory '/work/riot/RIOT/examples/hello-world'
```

- debug:

```
make BOARD=stm32f429i-disc1 -C examples/hello-world debug
make: Entering directory '/work/riot/RIOT/examples/hello-world'
/work/riot/RIOT/dist/tools/openocd/openocd.sh debug /work/riot/RIOT/examples/hello-world/bin/stm32f429i-disc1/hello-world.elf
### Starting Debugging ###
Open On-Chip Debugger 0.10.0+dev-01293-g7c88e76a-dirty (2020-07-01-21:36)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Reading symbols from /work/riot/RIOT/examples/hello-world/bin/stm32f429i-disc1/hello-world.elf...
Remote debugging using :3333
__set_PRIMASK (priMask=1) at /work/riot/RIOT/cpu/cortexm_common/include/vendor/cmsis_gcc.h:414
414	  __ASM volatile ("MSR primask, %0" : : "r" (priMask) : "memory");
(gdb) load
Loading section .text, size 0x21bc lma 0x8000000
Loading section .relocate, size 0x70 lma 0x80021bc
Start address 0x800054c, load size 8748
Transfer rate: 10 KB/sec, 4374 bytes/write.
(gdb) l
409	  \details Assigns the given value to the Priority Mask Register.
410	  \param [in]    priMask  Priority Mask
411	 */
412	__STATIC_FORCEINLINE void __set_PRIMASK(uint32_t priMask)
413	{
414	  __ASM volatile ("MSR primask, %0" : : "r" (priMask) : "memory");
415	}
416	
417	
418	#if (defined (__ARM_FEATURE_CMSE ) && (__ARM_FEATURE_CMSE == 3))
(gdb) 
```

</details>

<details><summary>dwm1001</summary>

-  flash:

```
PROGRAMMER=openocd make BOARD=dwm1001 -C examples/hello-world flash term
make: Entering directory '/work/riot/RIOT/examples/hello-world'
Building application "hello-world" for "dwm1001" with MCU "nrf52".

"make" -C /work/riot/RIOT/boards/dwm1001
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/nrf52
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf52/periph
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8032	    108	   2296	  10436	   28c4	/work/riot/RIOT/examples/hello-world/bin/dwm1001/hello-world.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/examples/hello-world/bin/dwm1001/hello-world.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01293-g7c88e76a-dirty (2020-07-01-21:36)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : J-Link OB-STM32F072-128KB-CortexM compiled Dec 11 2019 10:00:25
Info : Hardware version: 1.00
Info : VTarget = 3.300 V
Info : clock speed 1000 kHz
Info : SWD DPIDR 0x2ba01477
Info : nrf52.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for nrf52.cpu on 0
Info : Listening on port 39965 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* nrf52.cpu          cortex_m   little nrf52.cpu          unknown

target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000460 msp: 0x20000200
Info : nRF52832-CIAA(build code: B0) 512kB Flash, 64kB RAM
Warn : Adding extra erase range, 0x00001fcc .. 0x00001fff
auto erase enabled
wrote 8140 bytes from file /work/riot/RIOT/examples/hello-world/bin/dwm1001/hello-world.elf in 0.395670s (20.091 KiB/s)

verified 8140 bytes in 0.132656s (59.924 KiB/s)

shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-07-02 16:37:54,754 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2020-07-02 16:38:02,913 # main(): This is RIOT! (Version: 2020.07-devel-1708-gcffcb-pr/boards/hifive1b_openocd)
2020-07-02 16:38:02,915 # Hello World!
2020-07-02 16:38:02,918 # You are running RIOT on a(n) dwm1001 board.
2020-07-02 16:38:02,922 # This board features a(n) nrf52 MCU.
2020-07-02 16:38:05,184 # Exiting Pyterm
make: Leaving directory '/work/riot/RIOT/examples/hello-world'
```

-  reset:

```
PROGRAMMER=openocd make BOARD=dwm1001 -C examples/hello-world reset
make: Entering directory '/work/riot/RIOT/examples/hello-world'
/work/riot/RIOT/dist/tools/openocd/openocd.sh reset
### Resetting Target ###
Open On-Chip Debugger 0.10.0+dev-01293-g7c88e76a-dirty (2020-07-01-21:36)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : J-Link OB-STM32F072-128KB-CortexM compiled Dec 11 2019 10:00:25
Info : Hardware version: 1.00
Info : VTarget = 3.300 V
Info : clock speed 1000 kHz
Info : SWD DPIDR 0x2ba01477
Info : nrf52.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for nrf52.cpu on 0
Info : Listening on port 40093 for gdb connections
shutdown command invoked
make: Leaving directory '/work/riot/RIOT/examples/hello-world'
```

-  debug:

```
PROGRAMMER=openocd make BOARD=dwm1001 -C examples/hello-world debug
make: Entering directory '/work/riot/RIOT/examples/hello-world'
/work/riot/RIOT/dist/tools/openocd/openocd.sh debug /work/riot/RIOT/examples/hello-world/bin/dwm1001/hello-world.elf
### Starting Debugging ###
Open On-Chip Debugger 0.10.0+dev-01293-g7c88e76a-dirty (2020-07-01-21:36)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Reading symbols from /work/riot/RIOT/examples/hello-world/bin/dwm1001/hello-world.elf...
Remote debugging using :3333
__NVIC_SetPriority (priority=2, IRQn=PendSV_IRQn) at /work/riot/RIOT/cpu/cortexm_common/include/vendor/core_cm4.h:1824
1824	    SCB->SHP[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
(gdb) load
Loading section .text, size 0x1f60 lma 0x0
Loading section .relocate, size 0x6c lma 0x1f60
Start address 0x474, load size 8140
Transfer rate: 12 KB/sec, 4070 bytes/write.
(gdb) l
1819	  {
1820	    NVIC->IP[((uint32_t)IRQn)]               = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
1821	  }
1822	  else
1823	  {
1824	    SCB->SHP[(((uint32_t)IRQn) & 0xFUL)-4UL] = (uint8_t)((priority << (8U - __NVIC_PRIO_BITS)) & (uint32_t)0xFFUL);
1825	  }
1826	}
1827	
1828	
(gdb) quit
```


</details>

<details><summary>samr21-xpro</summary>


- debug:

```
PROGRAMMER=openocd make BOARD=samr21-xpro -C examples/hello-world flash term
make: Entering directory '/work/riot/RIOT/examples/hello-world'
Building application "hello-world" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8752	    112	   2560	  11424	   2ca0	/work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01293-g7c88e76a-dirty (2020-07-01-21:36)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "swd". To override use 'transport select <transport>'.
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 01.1A.00FB
Info : CMSIS-DAP: Serial# = ATML2127031800009840
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 1 SWDIO/TMS = 1 TDI = 1 TDO = 1 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 400 kHz
Info : SWD DPIDR 0x0bc11477
Info : at91samd.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for at91samd.cpu on 0
Info : Listening on port 43527 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* at91samd.cpu       cortex_m   little at91samd.cpu       unknown

target halted due to debug-request, current mode: Thread 
xPSR: 0x21000000 pc: 0x00000458 msp: 0x20000200
Info : SAMD MCU: SAMR21G18A (256KB Flash, 32KB RAM)
auto erase enabled
wrote 8960 bytes from file /work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf in 0.960147s (9.113 KiB/s)

verified 8864 bytes in 0.811806s (10.663 KiB/s)

shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-07-02 16:43:27,305 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2020-07-02 16:43:36,005 # main(): This is RIOT! (Version: 2020.07-devel-1708-gcffcb-pr/boards/hifive1b_openocd)
2020-07-02 16:43:36,007 # Hello World!
2020-07-02 16:43:36,011 # You are running RIOT on a(n) samr21-xpro board.
2020-07-02 16:43:36,014 # This board features a(n) samd21 MCU.
2020-07-02 16:43:37,097 # Exiting Pyterm
make: Leaving directory '/work/riot/RIOT/examples/hello-world'
```

- reset:

```
PROGRAMMER=openocd make BOARD=samr21-xpro -C examples/hello-world reset
make: Entering directory '/work/riot/RIOT/examples/hello-world'
/work/riot/RIOT/dist/tools/openocd/openocd.sh reset
### Resetting Target ###
Open On-Chip Debugger 0.10.0+dev-01293-g7c88e76a-dirty (2020-07-01-21:36)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : auto-selecting first available session transport "swd". To override use 'transport select <transport>'.
Info : CMSIS-DAP: SWD  Supported
Info : CMSIS-DAP: FW Version = 01.1A.00FB
Info : CMSIS-DAP: Serial# = ATML2127031800009840
Info : CMSIS-DAP: Interface Initialised (SWD)
Info : SWCLK/TCK = 1 SWDIO/TMS = 1 TDI = 1 TDO = 1 nTRST = 0 nRESET = 1
Info : CMSIS-DAP: Interface ready
Info : clock speed 400 kHz
Info : SWD DPIDR 0x0bc11477
Info : at91samd.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for at91samd.cpu on 0
Info : Listening on port 41593 for gdb connections
shutdown command invoked
make: Leaving directory '/work/riot/RIOT/examples/hello-world'
```

- debug:

```
PROGRAMMER=openocd make BOARD=samr21-xpro -C examples/hello-world debug
make: Entering directory '/work/riot/RIOT/examples/hello-world'
/work/riot/RIOT/dist/tools/openocd/openocd.sh debug /work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf
### Starting Debugging ###
Open On-Chip Debugger 0.10.0+dev-01293-g7c88e76a-dirty (2020-07-01-21:36)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Reading symbols from /work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf...
Remote debugging using :3333
sam0_cortexm_sleep (deep=<optimized out>) at /work/riot/RIOT/cpu/sam0_common/include/periph_cpu_common.h:419
419	    cpu_pm_cb_leave(deep);
(gdb) load
Loading section .text, size 0x2230 lma 0x0
Loading section .relocate, size 0x70 lma 0x2230
Start address 0x424, load size 8864
Transfer rate: 6 KB/sec, 4432 bytes/write.
(gdb) l
414	
415	    cpu_pm_cb_enter(deep);
416	
417	    cortexm_sleep(deep);
418	
419	    cpu_pm_cb_leave(deep);
420	
421	#ifdef MODULE_PERIPH_GPIO
422	    gpio_pm_cb_leave(deep);
423	#endif
(gdb) quit
```

</details>


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
