### PR TITLE
core/init: make boot message configurable

### DIFF
--- a/core/include/kernel_init.h
+++ b/core/include/kernel_init.h
@@ -26,6 +26,27 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup core_init_config Core initialization compile configuration
+ * @ingroup config
+ * @{
+ */
+#ifdef DOXYGEN
+
+/**
+ * @brief Enable this to disable printing a message on bootup.
+ */
+#define CONFIG_SKIP_BOOT_MSG
+
+/**
+ * @brief The message printed by RIOT before calling the main() function, when
+ *        @ref CONFIG_SKIP_BOOT_MSG is not set.
+ */
+#define CONFIG_BOOT_MSG_STRING
+
+#endif /* DOXYGEN */
+/** @} */
+
+/**
  * @brief   Initializes scheduler and creates main and idle task
  */
 void kernel_init(void);

--- a/core/init.c
+++ b/core/init.c
@@ -36,6 +36,10 @@
 #include <auto_init.h>
 #endif
 
+#ifndef CONFIG_BOOT_MSG_STRING
+#define CONFIG_BOOT_MSG_STRING "main(): This is RIOT! (Version: " RIOT_VERSION ")"
+#endif
+
 extern int main(void);
 
 static void *main_trampoline(void *arg)
@@ -46,7 +50,9 @@ static void *main_trampoline(void *arg)
     auto_init();
 #endif
 
-    LOG_INFO("main(): This is RIOT! (Version: " RIOT_VERSION ")\n");
+    if (!IS_ACTIVE(CONFIG_SKIP_BOOT_MSG)) {
+        LOG_INFO(CONFIG_BOOT_MSG_STRING "\n");
+    }
 
     main();
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

It can be desirable to not have the boot message printed each time (e.g. logs are transferred over a wireless link on battery) while still retaining the ability to receive INFO level logs.

This adds the option to disable the boot-up message (and also to customize it if that is desirable).



### Testing procedure

`CFLAGS=-DCONFIG_SKIP_BOOT_MSG make -C examples/hello-world` should suppress the boot-up message. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
