### PR TITLE
makefiles/sam0: only fail on missing device with explicit targets

### DIFF
--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -5,15 +5,17 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # DEBUG_ADAPTER_ID="ATML..."
 
 # The SERIAL setting is only available for backwards compatibility with older
-# settings.
-ifneq (,$(SERIAL))
-  EDBG_ARGS += --serial $(SERIAL)
-  SERIAL_TTY = $(firstword $(shell $(RIOTTOOLS)/usb-serial/find-tty.sh $(SERIAL)))
-  ifeq (,$(SERIAL_TTY))
-    $(error Did not find a device with serial $(SERIAL))
+# settings. It's only checked when a target is given to the make command.
+ifneq (,$(filter debug% flash% %term test,$(MAKECMDGOALS)))
+  ifneq (,$(SERIAL))
+    EDBG_ARGS += --serial $(SERIAL)
+    SERIAL_TTY = $(firstword $(shell $(RIOTTOOLS)/usb-serial/find-tty.sh $(SERIAL)))
+    ifeq (,$(SERIAL_TTY))
+      $(error Did not find a device with serial $(SERIAL))
+    endif
+    PORT_LINUX := $(SERIAL_TTY)
+    DEBUG_ADAPTER_ID ?= $(SERIAL)
   endif
-  PORT_LINUX := $(SERIAL_TTY)
-  DEBUG_ADAPTER_ID ?= $(SERIAL)
 endif
 
 # setup serial terminal


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes #10367 by simply using make code to only auto compute `SERIAL_TTY` when an explicit make target is given (term, flash, etc). For a bare make command, this is skipped so there's no more unrelated failure.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- As described in #10367, run `make -C examples/hello-world BOARD=samr21-xpro SERIAL=ATML211234567`:

<details><summary>this PR:</summary>

```
$ make -C examples/hello-world BOARD=samr21-xpro SERIAL=ATML211234567
make: Entering directory '/work/riot/RIOT/examples/hello-world'
Building application "hello-world" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8756	    112	   2560	  11428	   2ca4	/work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf
make: Leaving directory '/work/riot/RIOT/examples/hello-world'
```

</details>

<details><summary>master:</summary>

```
$ make -C examples/hello-world BOARD=samr21-xpro SERIAL=ATML211234567
make: Entering directory '/work/riot/RIOT/examples/hello-world'
/work/riot/RIOT/makefiles/boards/sam0.inc.mk:13: *** Did not find a device with serial ATML211234567.  Stop.
make: Leaving directory '/work/riot/RIOT/examples/hello-world'
```

</details>

- Automatic detection of serial tty still works when only giving the SERIAL variable (output below is given with another board connected on /dev/ttyACM0):

<details>

```
$ make -C examples/hello-world BOARD=samr21-xpro SERIAL=ATML2127031800009840 flash term
make: Entering directory '/work/riot/RIOT/examples/hello-world'
Building application "hello-world" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8756	    112	   2560	  11428	   2ca4	/work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf
/work/riot/RIOT/dist/tools/edbg/edbg --serial ATML2127031800009840 --serial ATML2127031800009840  --target samr21 --verbose --file /work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.bin --verify || /work/riot/RIOT/dist/tools/edbg/edbg --serial ATML2127031800009840 --serial ATML2127031800009840  --target samr21 --verbose --file /work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.bin --verify --program
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009840 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification.......
at address 0x474 expected 0x34, read 0x30
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009840 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming...................................... done.
Verification...................................... done.
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM1" -b "115200" 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-07-03 09:14:30,232 # Connect to serial port /dev/ttyACM1
Welcome to pyterm!
Type '/exit' to exit.
2020-07-03 09:14:33,200 # main(): This is RIOT! (Version: 2020.07-devel-1737-g5d01e-pr/makefile/sam0_serial_no_flash)
2020-07-03 09:14:33,201 # Hello World!
2020-07-03 09:14:33,205 # You are running RIOT on a(n) samr21-xpro board.
2020-07-03 09:14:33,208 # This board features a(n) samd21 MCU.
2020-07-03 09:14:36,400 # Exiting Pyterm
make: Leaving directory '/work/riot/RIOT/examples/hello-world'
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #10367

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
