### PR TITLE
boards/arduino-nano-33-ble: Remove term-delay logic

### DIFF
--- a/boards/arduino-nano-33-ble/Makefile.include
+++ b/boards/arduino-nano-33-ble/Makefile.include
@@ -12,19 +12,8 @@ ifeq ($(PROGRAMMER),bossa)
   BOSSA_ARDUINO_PREFLASH = yes
   PREFLASH_DELAY = 1
 
-  ifneq (,$(filter reset flash flash-only, $(MAKECMDGOALS)))
-    # Add 2 seconds delay before opening terminal: this is required when opening
-    # the terminal right after flashing. In this case, the stdio over USB needs
-    # some time after reset before being ready.
-    TERM_DELAY = 2
-    TERMDEPS += term-delay
-  endif
-
   include $(RIOTMAKE)/tools/bossa.inc.mk
 endif
-
-term-delay:
-	sleep $(TERM_DELAY)
 
 TESTRUNNER_CONNECT_DELAY ?= 2
 $(call target-export-variables,test,TESTRUNNER_CONNECT_DELAY)


### PR DESCRIPTION
### Contribution description
#14212 moved here 2325dba8713921917f365644e77749637127401f the USB reset logic into `usb_board_reset.mk`. The board `arduino-nano-33-ble` still has it on its `Makefile.include`, so we get a warning of `term-delay` target being redefined. This PR removes the extra logic which is already included by the `bossa.inc.mk` makefile.

I don't have the board to test this. Maybe @aabadie could give it a try?

### Testing procedure
- Flashing and using term should still work on the board

- On current master we get a warning when invoking `make` commands:
```sh
$ BOARD=arduino-nano-33-ble make clean -C examples/hello-world

/home/leandro/Work/RIOT/boards/arduino-nano-33-ble/Makefile.include:27: warning: overriding recipe for target 'term-delay'
/home/leandro/Work/RIOT/makefiles/tools/usb_board_reset.mk:35: warning: ignoring old recipe for target 'term-delay'
```
With this PR this should not happen

### Issues/PRs references
#14212