### PR TITLE
make: use $(MAKE) instead of direct `make` call

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -729,7 +729,7 @@ list-ttys:
 	$(Q)$(RIOTTOOLS)/usb-serial/list-ttys.sh
 
 doc:
-	make -BC $(RIOTBASE) doc
+	$(MAKE) -BC $(RIOTBASE) doc
 
 debug: $(DEBUGDEPS)
 	$(call check_cmd,$(DEBUGGER),Debug program)

--- a/boards/common/msba2/Makefile.include
+++ b/boards/common/msba2/Makefile.include
@@ -6,7 +6,7 @@ BOARDS_COMMON_MSBA2_DIR := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 MSBA2_TOOLS = $(BOARDS_COMMON_MSBA2_DIR)/tools
 LPC2K_PGM = $(MSBA2_TOOLS)/bin/lpc2k_pgm
 $(LPC2K_PGM): FORCE
-	env -i PATH=$(PATH) make -C $(MSBA2_TOOLS)
+	env -i PATH=$(PATH) $(MAKE) -C $(MSBA2_TOOLS)
 FLASHDEPS += $(if $(findstring $(LPC2K_PGM),$(FLASHER)),$(LPC2K_PGM))
 
 FLASHER ?= $(LPC2K_PGM)

--- a/boards/teensy31/Makefile.include
+++ b/boards/teensy31/Makefile.include
@@ -15,7 +15,7 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial-*)))
 
 $(TEENSY_LOADER):
 	@echo "[INFO] teensy_loader binary not found - building it from source now"
-	CC= CFLAGS= make -C $(RIOTTOOLS)/teensy-loader-cli
+	CC= CFLAGS= $(MAKE) -C $(RIOTTOOLS)/teensy-loader-cli
 	@echo "[INFO] teensy_loader binary successfully build!"
 
 # setup serial terminal

--- a/dist/tools/Makefile
+++ b/dist/tools/Makefile
@@ -5,4 +5,4 @@ HOST_TOOLS=ethos uhcpd sliptty
 all: $(HOST_TOOLS)
 
 $(HOST_TOOLS):
-	make -C $@
+	$(MAKE) -C $@

--- a/dist/tools/pic32prog/Makefile
+++ b/dist/tools/pic32prog/Makefile
@@ -14,7 +14,7 @@ include $(RIOTBASE)/pkg/pkg.mk
 
 all:
 	@echo "[INFO] compiling pic32prog from source now"
-	@env -i PATH=$(PATH) TERM=$(TERM) make -C $(PKG_BUILD_DIR)
+	@env -i PATH=$(PATH) TERM=$(TERM) $(MAKE) -C $(PKG_BUILD_DIR)
 	@mv $(PKG_BUILD_DIR)/pic32prog pic32prog
 
 distclean::

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -122,7 +122,7 @@ endif
 .PHONY: host-tools
 
 host-tools:
-	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)
+	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS)
 
 # define native specific targets to only run UHCP daemon when required
 ifneq (,$(filter native,$(BOARD)))
@@ -136,7 +136,7 @@ endif
 
 ifeq (slip,$(UPLINK))
 sliptty:
-	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)/sliptty
+	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS)/sliptty
 endif
 
 # Set a custom channel if needed

--- a/examples/suit_update/Makefile
+++ b/examples/suit_update/Makefile
@@ -105,6 +105,6 @@ include $(RIOTBASE)/Makefile.include
 .PHONY: host-tools
 
 host-tools:
-	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)
+	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS)
 
 include $(RIOTMAKE)/default-radio-settings.inc.mk

--- a/makefiles/app_dirs.inc.mk
+++ b/makefiles/app_dirs.inc.mk
@@ -20,7 +20,7 @@ info-applications:
 # All applications / board output of `info-boards-supported`.
 info-applications-supported-boards:
 	@for dir in $(APPLICATION_DIRS); do \
-	  make --no-print-directory -C $${dir} info-boards-supported 2>/dev/null | xargs -n 1 echo $${dir}; \
+	  $(MAKE) --no-print-directory -C $${dir} info-boards-supported 2>/dev/null | xargs -n 1 echo $${dir}; \
 	done
 # BOARDS values from 'boards.inc.mk' to only evaluate it once
 info-applications-supported-boards: export BOARDS ?=

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -291,7 +291,7 @@ docker_run_make = \
 	$(DOCKER_ENVIRONMENT_CMDLINE) \
 	$3 \
 	-w '$(DOCKER_APPDIR)' '$2' \
-	make $(DOCKER_OVERRIDE_CMDLINE) $4 $1
+	$(MAKE) $(DOCKER_OVERRIDE_CMDLINE) $4 $1
 
 # This will execute `make $(DOCKER_MAKECMDGOALS)` inside a Docker container.
 # We do not push the regular $(MAKECMDGOALS) to the container's make command in

--- a/makefiles/scan-build.inc.mk
+++ b/makefiles/scan-build.inc.mk
@@ -95,7 +95,7 @@ endif # BUILD_IN_DOCKER
 	$(Q)mkdir -p '$(SCANBUILD_OUTPUTDIR)'
 	$(Q)env -i $(ENVVARS) \
 	    scan-build -o '$(SCANBUILD_OUTPUTDIR)' $(SCANBUILD_ARGS) \
-	      make -C $(CURDIR) all $(strip $(CMDVARS)) FORCE_ASSERTS=1
+	      $(MAKE) -C $(CURDIR) all $(strip $(CMDVARS)) FORCE_ASSERTS=1
 
 ..scan-build-view: scan-build-analyze
 	@echo "Showing most recent report in your web browser..."

--- a/makefiles/tools/kconfiglib.inc.mk
+++ b/makefiles/tools/kconfiglib.inc.mk
@@ -6,7 +6,7 @@ MERGECONFIG ?= $(RIOTTOOLS)/kconfiglib/merge_config.py
 
 $(BASE_MENUCONFIG):
 	@echo "[INFO] Kconfiglib not found - getting it"
-	@make -C $(RIOTTOOLS)/kconfiglib
+	@$(MAKE) -C $(RIOTTOOLS)/kconfiglib
 	@echo "[INFO] Kconfiglib downloaded"
 
 $(GENCONFIG): $(BASE_MENUCONFIG)

--- a/makefiles/tools/targets.inc.mk
+++ b/makefiles/tools/targets.inc.mk
@@ -9,38 +9,38 @@
 # target for building the bossac binary
 $(RIOTTOOLS)/bossa-$(BOSSA_VERSION)/bossac:
 	@echo "[INFO] bossac $(BOSSA_VERSION) binary not found - building it from source"
-	@make -C $(RIOTTOOLS)/bossa-$(BOSSA_VERSION)
+	@$(MAKE) -C $(RIOTTOOLS)/bossa-$(BOSSA_VERSION)
 	@echo "[INFO] bossac $(BOSSA_VERSION) binary successfully built!"
 
 $(RIOTTOOLS)/pic32prog/pic32prog: $(RIOTTOOLS)/pic32prog/Makefile
 	@echo "[INFO] $(@F) binary not found - building it from source now"
-	make -C $(@D)
+	$(MAKE) -C $(@D)
 	@echo "[INFO] $(@F) binary successfully built!"
 
 $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py:
 	@echo "[INFO] cc2538-bsl.py not found - fetching it from GitHub now"
-	CC= CFLAGS= make -C $(RIOTTOOLS)/cc2538-bsl
+	CC= CFLAGS= $(MAKE) -C $(RIOTTOOLS)/cc2538-bsl
 	@echo "[INFO] cc2538-bsl.py successfully fetched!"
 
 $(RIOTTOOLS)/edbg/edbg: $(RIOTTOOLS)/edbg/Makefile
 	@echo "[INFO] edbg binary not found - building it from source now"
-	CC= CFLAGS= make -C $(RIOTTOOLS)/edbg
+	CC= CFLAGS= $(MAKE) -C $(RIOTTOOLS)/edbg
 	@echo "[INFO] edbg binary successfully built!"
 
 $(RIOTTOOLS)/mosquitto_rsmb/mosquitto_rsmb:
 	@echo "[INFO] rsmb binary not found - building it from source now"
-	@make -C $(RIOTTOOLS)/mosquitto_rsmb
+	@$(MAKE) -C $(RIOTTOOLS)/mosquitto_rsmb
 	@echo "[INFO] rsmb binary successfully built!"
 
 mosquitto_rsmb: $(RIOTTOOLS)/mosquitto_rsmb/mosquitto_rsmb
-	@make -C $(RIOTTOOLS)/mosquitto_rsmb run
+	@$(MAKE) -C $(RIOTTOOLS)/mosquitto_rsmb run
 
 $(RIOTTOOLS)/setsid/setsid: $(RIOTTOOLS)/setsid/Makefile
 	@echo "[INFO] setsid binary not found - building it from source now"
-	@make -C $(RIOTTOOLS)/setsid
+	@$(MAKE) -C $(RIOTTOOLS)/setsid
 	@echo "[INFO] setsid binary successfully built!"
 
 $(RIOTTOOLS)/flatc/flatc: $(RIOTTOOLS)/flatc/Makefile
 	@echo "[INFO] flatc binary not found - building it from source now"
-	make -C $(RIOTTOOLS)/flatc
+	$(MAKE) -C $(RIOTTOOLS)/flatc
 	@echo "[INFO] flatc binary successfully built!"

--- a/pkg/nanopb/Makefile.gensrc
+++ b/pkg/nanopb/Makefile.gensrc
@@ -22,7 +22,7 @@ $(GENSRC): $(PROTOBUF_FILES)
 	$(Q)D=$(BINDIR)/$(MODULE) && \
 	  mkdir -p "$$D" && \
 		cd $(CURDIR) && \
-		make -C $(PKGDIRBASE)/nanopb/generator/proto && \
+		$(MAKE) -C $(PKGDIRBASE)/nanopb/generator/proto && \
 		for protofile in $(PROTOBUF_FILES); do \
 			protoc --plugin=protoc-gen-nanopb=$(PROTOC_GEN_NANOPB) \
 				--nanopb_out="$$D" $(PROTO_INCLUDES) \

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -48,7 +48,7 @@ $(BINDIR)/openthread-cli.a: $(BINDIR)/openthread-$(TD).a
 	@cp $(OT_LIB_DIR)/libopenthread-cli-$(TD).a $@
 
 $(OT_LIB_DIR)/libopenthread-$(TD).a: $(PKG_BUILD_DIR)/Makefile
-	$(MAKE) -C $(PKG_BUILD_DIR) -j4 --no-print-directory install DESTDIR=$(PKG_BUILD_DIR)/output PREFIX=/
+	$(MAKE) -C $(PKG_BUILD_DIR) --no-print-directory install DESTDIR=$(PKG_BUILD_DIR)/output PREFIX=/
 	$(Q)printf "OpenThread built for %s device\n" $(TD)
 
 $(PKG_BUILD_DIR)/Makefile: $(PKG_BUILD_DIR)/configure

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -48,7 +48,7 @@ $(BINDIR)/openthread-cli.a: $(BINDIR)/openthread-$(TD).a
 	@cp $(OT_LIB_DIR)/libopenthread-cli-$(TD).a $@
 
 $(OT_LIB_DIR)/libopenthread-$(TD).a: $(PKG_BUILD_DIR)/Makefile
-	make -C $(PKG_BUILD_DIR) -j4 --no-print-directory install DESTDIR=$(PKG_BUILD_DIR)/output PREFIX=/
+	$(MAKE) -C $(PKG_BUILD_DIR) -j4 --no-print-directory install DESTDIR=$(PKG_BUILD_DIR)/output PREFIX=/
 	$(Q)printf "OpenThread built for %s device\n" $(TD)
 
 $(PKG_BUILD_DIR)/Makefile: $(PKG_BUILD_DIR)/configure

--- a/tests/emcute/Makefile
+++ b/tests/emcute/Makefile
@@ -35,6 +35,6 @@ TEST_ON_CI_BLACKLIST += all
 .PHONY: ethos
 
 ethos:
-	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)/ethos
+	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS)/ethos
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_dhcpv6_client/Makefile
+++ b/tests/gnrc_dhcpv6_client/Makefile
@@ -46,5 +46,5 @@ ifeq (,$(filter native,$(BOARD)))
 .PHONY: ethos
 
 ethos:
-	$(Q)env -u CC -u CFLAGS make -C $(RIOTBASE)/dist/tools/ethos
+	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTBASE)/dist/tools/ethos
 endif

--- a/tests/gnrc_dhcpv6_client_6lbr/Makefile
+++ b/tests/gnrc_dhcpv6_client_6lbr/Makefile
@@ -47,5 +47,5 @@ ifeq (,$(filter native,$(BOARD)))
 .PHONY: ethos
 
 ethos:
-	$(Q)env -u CC -u CFLAGS make -C $(RIOTBASE)/dist/tools/ethos
+	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTBASE)/dist/tools/ethos
 endif

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -35,6 +35,6 @@ TEST_ON_CI_BLACKLIST += all
 .PHONY: ethos
 
 ethos:
-	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)/ethos
+	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS)/ethos
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_ipv6_ext_frag/Makefile
+++ b/tests/gnrc_ipv6_ext_frag/Makefile
@@ -47,7 +47,7 @@ SHOULD_RUN_KCONFIG ?=
 .PHONY: ethos
 
 ethos:
-	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)/ethos
+	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS)/ethos
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/gnrc_ipv6_ext_opt/Makefile
+++ b/tests/gnrc_ipv6_ext_opt/Makefile
@@ -34,6 +34,6 @@ TEST_ON_CI_BLACKLIST += all
 .PHONY: ethos
 
 ethos:
-	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)/ethos
+	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS)/ethos
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_ipv6_nib_dns/Makefile
+++ b/tests/gnrc_ipv6_nib_dns/Makefile
@@ -44,6 +44,6 @@ TEST_ON_CI_BLACKLIST += all
 .PHONY: ethos
 
 ethos:
-	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)/ethos
+	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS)/ethos
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_rpl_srh/Makefile
+++ b/tests/gnrc_rpl_srh/Makefile
@@ -39,6 +39,6 @@ TEST_ON_CI_BLACKLIST += all
 .PHONY: ethos
 
 ethos:
-	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)/ethos
+	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS)/ethos
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -47,6 +47,6 @@ TEST_ON_CI_BLACKLIST += all
 .PHONY: ethos
 
 ethos:
-	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)/ethos
+	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS)/ethos
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -40,7 +40,7 @@ export TAPDEV = $(TAP)
 .PHONY: ethos
 
 ethos:
-	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)/ethos
+	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(RIOTTOOLS)/ethos
 
 include $(RIOTBASE)/Makefile.include
 


### PR DESCRIPTION
### Contribution description
Many places still use a direct call to `make` instead of `$(MAKE)`. Parameters, like `-j4 (MAKEFLAGS)`, are not passed down to these sub make calls.

The second commit removes the hardcoded `-j4` in the openthread package.

### Testing procedure
murdock should agree.


### Issues/PRs references
--