### PR TITLE
cpu/cortexm_common: Fix cpu_switch_context_exit()

### DIFF
--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -265,15 +265,19 @@ void *thread_isr_stack_start(void)
     return (void *)&_sstack;
 }
 
-__attribute__((naked)) void NORETURN cpu_switch_context_exit(void)
+void NORETURN cpu_switch_context_exit(void)
 {
+    /* enable IRQs to make sure the SVC interrupt is reachable */
+    irq_enable();
+    /* trigger the SVC interrupt */
     __asm__ volatile (
-    "bl     irq_enable               \n" /* enable IRQs to make the SVC
-                                           * interrupt is reachable */
-    "svc    #1                            \n" /* trigger the SVC interrupt */
-    "unreachable%=:                       \n" /* this loop is unreachable */
-    "b      unreachable%=                 \n" /* loop indefinitely */
-    :::);
+        "svc    #1                            \n"
+        : /* no outputs */
+        : /* no inputs */
+        : /* no clobbers */
+    );
+
+    UNREACHABLE();
 }
 
 void thread_yield_higher(void)


### PR DESCRIPTION
### Contribution description

- Use `irq_enable()` over `bl irq_enable`, as `irq_enable()` is an inline function and not a C function any more
- Drop `__attribute__((naked))` qualifier
    - It must be used with the declaration of the function, but there it is missing. (And it cannot be added there, as this function would need to be implemented as "naked" by every platform; which is impossible for platforms not supporting `__attribute__((naked))`.)
    - Only functions consisting completely of basic asm may be marked as naked. But both the assembly used to trigger the SVC interrupt as well as the assembly used in `irq_enable()` are extended asm, not basic asm
- Use ` UNREACHABLE();` over a custom asm construct

### Testing procedure

`cpu_switch_context_exit()` is called from `kernel_init()`, so every application on a Cortex M board is affected. This means any application with a Cortex M board can be used for testing.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/14422