### PR TITLE
tests/kconfig_features: Optimize test

### DIFF
--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -63,15 +63,19 @@ include $(RIOTBASE)/Makefile.include
 # List of variables to compare between Makefile and Kconfig
 _VARS_TO_CHECK = BOARD CPU CPU_MODEL CPU_FAM CPU_CORE CPU_ARCH
 
+# Commands to diff in 'check-values'
+_CMDS = $(foreach v,$(_VARS_TO_CHECK), $(if $($(v)),info-debug-variable-$(v)))
+_CMDS_CONFIG = $(foreach v,$(_VARS_TO_CHECK), $(if $($(v)),info-debug-variable-CONFIG_$(v)))
+
 # Only compare variables that have a value in Makefile
-checks: kconfig-features $(foreach v,$(_VARS_TO_CHECK), $(if $($(v)),check-value-$(v)))
+checks: kconfig-features check-values
 
 kconfig-features: $(KCONFIG_OUT_CONFIG)
 	@bash -c 'diff <($(MAKE) info-features-provided) \
 	    <($(MAKE) dependency-debug-features-provided-kconfig) || \
 	    (echo "ERROR: Kconfig features mismatch" && exit 1)'
 
-check-value-%: $(KCONFIG_OUT_CONFIG)
-	@bash -c '(diff <($(MAKE) info-debug-variable-$*) \
-	    <($(MAKE) info-debug-variable-CONFIG_$*) && echo "SUCCESS: $* values match") || \
-	    (echo "ERROR: The value for $* in Kconfig does not match the one in the Makefile" && exit 1)'
+check-values: $(KCONFIG_OUT_CONFIG)
+	@bash -c '(diff <($(MAKE) $(_CMDS) | sort) \
+	    <($(MAKE) $(_CMDS_CONFIG) | sort) && echo "SUCCESS: $(_CMDS:info-debug-variable-%=%) values match") || \
+	    (echo "ERROR: The value for $(_CMDS:info-debug-variable-%=%) in Kconfig does not match the one in the Makefile" && exit 1)'


### PR DESCRIPTION
### Contribution description
This PR reduces the impact in time of `tests/kconfig_features` test application, by reducing the amount of targets that need to be called.

I measured the time it takes to run the following command (avg of 10 runs):
`for board in $(make info-boards-supported); do echo ${board}; BOARD=${board} make clean checks; done;`

**Master**
```
  Time (mean ± σ):     56.006 s ±  1.899 s    [User: 88.464 s, System: 16.890 s]
  Range (min … max):   51.892 s … 57.978 s    10 runs
```

**With PR**
```
  Time (mean ± σ):     23.681 s ±  1.256 s    [User: 33.958 s, System: 6.362 s]
  Range (min … max):   20.868 s … 25.199 s    10 runs
```

### Testing procedure
- Green CI
- Try modifying some of the checked variables (either on Kconfig or makefiles) the test should still catch this

### Issues/PRs references
None