### PR TITLE
tools/backport_pr: fix checks run by tox 

### DIFF
--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -70,6 +70,18 @@ def _branch_name_strip(branch_name, prefix=RELEASE_PREFIX,
 
 
 def _get_latest_release(branches):
+    """Get latest release from a list of branches.
+
+    >>> _get_latest_release([{'name': '2018.10-branch'}, \
+        {'name': '2020.10-branch'}])
+    ('2020.10', '2020.10-branch')
+    >>> _get_latest_release([{'name': '2020.01-branch'}, \
+        {'name': '2020.04-branch'}])
+    ('2020.04', '2020.04-branch')
+    >>> _get_latest_release([{'name': 'non-release-branch'}, \
+        {'name': '2020.04-branch'}])
+    ('2020.04', '2020.04-branch')
+    """
     version_latest = 0
     release_fullname = ''
     release_short = ''

--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -9,6 +9,8 @@
 #
 # @author   Koen Zandberg <koen@bergzand.net>
 
+"""Script used to backport PRs."""
+
 import os
 import os.path
 import sys
@@ -32,18 +34,19 @@ LABELS_ADD = ['Process: release backport']
 BACKPORT_BRANCH = 'backport/{release}/{origbranch}'
 
 
-def _get_labels(pr):
+def _get_labels(pull_request):
     """
     >>> _get_labels({'labels': [{'name': 'test'}, {'name': 'abcd'}]})
     ['Process: release backport', 'abcd', 'test']
-    >>> _get_labels({'labels': [{'name': 'Reviewed: what'}, {'name': 'Reviewed: 3-testing'}]})
+    >>> _get_labels({'labels': [{'name': 'Reviewed: what'}, \
+        {'name': 'Reviewed: 3-testing'}]})
     ['Process: release backport']
     >>> _get_labels({'labels': [{'name': 'Process: release backport'}]})
     ['Process: release backport']
     >>> _get_labels({'labels': [{'name': 'Process: needs backport'}]})
     ['Process: release backport']
     """
-    labels = set(label['name'] for label in pr['labels']
+    labels = set(label['name'] for label in pull_request['labels']
                  if all(not label['name'].startswith(remove)
                         for remove in LABELS_REMOVE))
     labels.update(LABELS_ADD)
@@ -103,6 +106,8 @@ def _delete_worktree(repo, workdir):
 
 
 def main():
+    # pylint:disable=too-many-locals,too-many-branches,too-many-statements
+    """Main function of this script."""
     keyfile = os.path.join(os.environ['HOME'], GITHUBTOKEN_FILE)
     parser = argparse.ArgumentParser()
     parser.add_argument("-k", "--keyfile", type=argparse.FileType('r'),
@@ -129,15 +134,15 @@ def main():
     args = parser.parse_args()
 
     gittoken = args.keyfile.read().strip()
-    g = GitHub(token=gittoken)
+    github_api = GitHub(token=gittoken)
     # TODO: exception handling
-    status, user = g.user.get()
+    status, user = github_api.user.get()
     if status != 200:
         print("Could not retrieve user: {}".format(user['message']))
-        exit(1)
+        sys.exit(1)
     # Token-scope-check: Is the token is powerful enough to complete
     # the Backport?
-    response_headers = dict(g.getheaders())
+    response_headers = dict(github_api.getheaders())
     # agithub documentation says it's lower case header field-names but
     # at this moment it's not
     if 'X-OAuth-Scopes' in response_headers:
@@ -148,18 +153,18 @@ def main():
     if not ('public_repo' in scopes_list or 'repo' in scopes_list):
         print("missing public_repo scope from token settings."
               " Please add it on the GitHub webinterface")
-        exit(1)
+        sys.exit(1)
     username = user['login']
-    status, pulldata = g.repos[ORG][REPO].pulls[args.PR].get()
+    status, pulldata = github_api.repos[ORG][REPO].pulls[args.PR].get()
     if status != 200:
         print("Commit #{} not found: {}".format(args.PR, pulldata['message']))
         sys.exit(2)
     if not pulldata['merged']:
         print("Original PR not yet merged")
-        exit(0)
+        sys.exit(0)
     print("Fetching for commit: #{}: {}".format(args.PR, pulldata['title']))
     orig_branch = pulldata['head']['ref']
-    status, commits = g.repos[ORG][REPO].pulls[args.PR].commits.get()
+    status, commits = github_api.repos[ORG][REPO].pulls[args.PR].commits.get()
     if status != 200:
         print("No commits found for #{}: {}".format(args.PR,
                                                     commits['message']))
@@ -173,7 +178,7 @@ def main():
         release_fullname = args.release_branch
         release_shortname = _branch_name_strip(args.release_branch)
     else:
-        status, branches = g.repos[ORG][REPO].branches.get()
+        status, branches = github_api.repos[ORG][REPO].branches.get()
         if status != 200:
             print("Could not retrieve branches for {}/{}: {}"
                   .format(ORG,
@@ -191,7 +196,7 @@ def main():
     upstream_remote = _get_upstream(repo)
     if not upstream_remote:
         print("No upstream remote found, can't fetch")
-        exit(6)
+        sys.exit(6)
     print("Fetching {} remote".format(upstream_remote))
 
     upstream_remote.fetch()
@@ -236,7 +241,7 @@ def main():
     merger = pulldata['merged_by']['login']
     if not args.noop:
         # Open new PR on github
-        pr = {
+        pull_request = {
             'title': "{} [backport {}]".format(pulldata['title'],
                                                release_shortname),
             'head': '{}:{}'.format(username, new_branch),
@@ -245,22 +250,23 @@ def main():
                                                      pulldata['body']),
             'maintainer_can_modify': True,
         }
-        status, new_pr = g.repos[ORG][REPO].pulls.post(body=pr)
+        status, new_pr = github_api.repos[ORG][REPO].pulls.post(
+            body=pull_request)
         if status != 201:
             print("Error creating the new pr: \"{}\". Is \"Public Repo\""
                   " access enabled for the token"
                   .format(new_pr['message']))
         pr_number = new_pr['number']
         print("Create PR number #{} for backport".format(pr_number))
-        g.repos[ORG][REPO].issues[pr_number].labels.post(body=labels)
+        github_api.repos[ORG][REPO].issues[pr_number].labels.post(body=labels)
         review_request = {"reviewers": [merger]}
-        g.repos[ORG][REPO].pulls[pr_number].\
+        github_api.repos[ORG][REPO].pulls[pr_number].\
             requested_reviewers.post(body=review_request)
 
     # Put commit under old PR
     if args.comment and not args.noop:
         comment = {"body": "Backport provided in #{}".format(pr_number)}
-        status, res = g.repos[ORG][REPO].\
+        status, res = github_api.repos[ORG][REPO].\
             issues[args.PR].comments.post(body=comment)
         if status != 201:
             print("Something went wrong adding the comment: {}"

--- a/dist/tools/backport_pr/tox.ini
+++ b/dist/tools/backport_pr/tox.ini
@@ -24,9 +24,11 @@ deps =
     pylint
     {[testenv]deps}
 commands =
-    pylint {env:script}
+    # Suppress warning about TODO in code
+    pylint --disable=fixme {env:script}
 
 [testenv:flake8]
 deps = flake8
 commands =
-    flake8 --max-complexity=10 {env:script}
+    # main() is quite complex, provide enough margin
+    flake8 --max-complexity=25 {env:script}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the checks performed by tox on the backport_pr script. The changes applied here are minimal (rename variables, add missing docstrings, use `sys.exit` instead of `exit`.
Since most of the complexity of the script is in the `main`, I chose to silent the complexity related errors when invoking flake8 and pylint. We could keep the previous parameters but that would mean a complete rewrite of the script.

This PR also adds a docstring test to the `_get_latest_release` function.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `tox` from the `dist/tools/backport_pr` directory:

<details><summary>this PR:</summary>

```
$ cd dist/tools/backport_pr
$ tox --recreate
test recreate: /work/riot/RIOT/dist/tools/backport_pr/.tox/test
test installdeps: pytest, -r/work/riot/RIOT/dist/tools/backport_pr/requirements.txt
test installed: agithub==2.1,attrs==19.3.0,gitdb2==2.0.3,GitPython==2.1.9,more-itertools==8.4.0,packaging==20.4,pluggy==0.13.1,py==1.9.0,pyparsing==2.4.7,pytest==5.4.3,six==1.15.0,smmap2==2.0.3,wcwidth==0.2.5
test run-test-pre: PYTHONHASHSEED='167647392'
test run-test: commands[0] | pytest -v --doctest-modules backport_pr.py
============================================================ test session starts ============================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /work/riot/RIOT/dist/tools/backport_pr/.tox/test/bin/python
cachedir: .tox/test/.pytest_cache
rootdir: /work/riot/RIOT/dist/tools/backport_pr
collected 3 items                                                                                                                           

backport_pr.py::backport_pr._branch_name_strip PASSED                                                                                 [ 33%]
backport_pr.py::backport_pr._get_labels PASSED                                                                                        [ 66%]
backport_pr.py::backport_pr._get_latest_release PASSED                                                                                [100%]

============================================================= 3 passed in 0.06s =============================================================
lint recreate: /work/riot/RIOT/dist/tools/backport_pr/.tox/lint
lint installdeps: pylint, -r/work/riot/RIOT/dist/tools/backport_pr/requirements.txt
lint installed: agithub==2.1,astroid==2.4.2,gitdb2==2.0.3,GitPython==2.1.9,isort==4.3.21,lazy-object-proxy==1.4.3,mccabe==0.6.1,pylint==2.5.3,six==1.15.0,smmap2==2.0.3,toml==0.10.1,wrapt==1.12.1
lint run-test-pre: PYTHONHASHSEED='167647392'
lint run-test: commands[0] | pylint --disable=fixme backport_pr.py

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

flake8 recreate: /work/riot/RIOT/dist/tools/backport_pr/.tox/flake8
flake8 installdeps: flake8
flake8 installed: flake8==3.8.3,mccabe==0.6.1,pycodestyle==2.6.0,pyflakes==2.2.0
flake8 run-test-pre: PYTHONHASHSEED='167647392'
flake8 run-test: commands[0] | flake8 --max-complexity=25 backport_pr.py
__________________________________________________________________ summary __________________________________________________________________
  test: commands succeeded
  lint: commands succeeded
  flake8: commands succeeded
  congratulations :)
```

</details>

<details><summary>master:</summary>

```
$ cd dist/tools/backport_pr
$ tox --recreate
test recreate: /work/riot/RIOT/dist/tools/backport_pr/.tox/test
test installdeps: pytest, -r/work/riot/RIOT/dist/tools/backport_pr/requirements.txt
test installed: agithub==2.1,attrs==19.3.0,gitdb2==2.0.3,GitPython==2.1.9,more-itertools==8.4.0,packaging==20.4,pluggy==0.13.1,py==1.9.0,pyparsing==2.4.7,pytest==5.4.3,six==1.15.0,smmap2==2.0.3,wcwidth==0.2.5
test run-test-pre: PYTHONHASHSEED='1175415831'
test run-test: commands[0] | pytest -v --doctest-modules backport_pr.py
============================================================ test session starts ============================================================
platform linux -- Python 3.8.2, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /work/riot/RIOT/dist/tools/backport_pr/.tox/test/bin/python
cachedir: .tox/test/.pytest_cache
rootdir: /work/riot/RIOT/dist/tools/backport_pr
collected 2 items                                                                                                                           

backport_pr.py::backport_pr._branch_name_strip PASSED                                                                                 [ 50%]
backport_pr.py::backport_pr._get_labels PASSED                                                                                        [100%]

============================================================= 2 passed in 0.06s =============================================================
lint recreate: /work/riot/RIOT/dist/tools/backport_pr/.tox/lint
lint installdeps: pylint, -r/work/riot/RIOT/dist/tools/backport_pr/requirements.txt
lint installed: agithub==2.1,astroid==2.4.2,gitdb2==2.0.3,GitPython==2.1.9,isort==4.3.21,lazy-object-proxy==1.4.3,mccabe==0.6.1,pylint==2.5.3,six==1.15.0,smmap2==2.0.3,toml==0.10.1,wrapt==1.12.1
lint run-test-pre: PYTHONHASHSEED='1175415831'
lint run-test: commands[0] | pylint backport_pr.py
************* Module backport_pr
backport_pr.py:133:2: W0511: TODO: exception handling (fixme)
backport_pr.py:1:0: C0114: Missing module docstring (missing-module-docstring)
backport_pr.py:35:0: C0103: Argument name "pr" doesn't conform to snake_case naming style (invalid-name)
backport_pr.py:105:0: C0116: Missing function or method docstring (missing-function-docstring)
backport_pr.py:105:0: R0914: Too many local variables (34/15) (too-many-locals)
backport_pr.py:132:4: C0103: Variable name "g" doesn't conform to snake_case naming style (invalid-name)
backport_pr.py:137:8: R1722: Consider using sys.exit() (consider-using-sys-exit)
backport_pr.py:151:8: R1722: Consider using sys.exit() (consider-using-sys-exit)
backport_pr.py:159:8: R1722: Consider using sys.exit() (consider-using-sys-exit)
backport_pr.py:194:8: R1722: Consider using sys.exit() (consider-using-sys-exit)
backport_pr.py:239:8: C0103: Variable name "pr" doesn't conform to snake_case naming style (invalid-name)
backport_pr.py:105:0: R0912: Too many branches (22/12) (too-many-branches)
backport_pr.py:105:0: R0915: Too many statements (102/50) (too-many-statements)

-------------------------------------------------------------------
Your code has been rated at 9.17/10 (previous run: 10.00/10, -0.83)

ERROR: InvocationError for command /work/riot/RIOT/dist/tools/backport_pr/.tox/lint/bin/pylint backport_pr.py (exited with code 28)
flake8 recreate: /work/riot/RIOT/dist/tools/backport_pr/.tox/flake8
flake8 installdeps: flake8
flake8 installed: flake8==3.8.3,mccabe==0.6.1,pycodestyle==2.6.0,pyflakes==2.2.0
flake8 run-test-pre: PYTHONHASHSEED='1175415831'
flake8 run-test: commands[0] | flake8 --max-complexity=10 backport_pr.py
backport_pr.py:39:80: E501 line too long (94 > 79 characters)
backport_pr.py:105:1: C901 'main' is too complex (21)
ERROR: InvocationError for command /work/riot/RIOT/dist/tools/backport_pr/.tox/flake8/bin/flake8 --max-complexity=10 backport_pr.py (exited with code 1)
__________________________________________________________________ summary __________________________________________________________________
  test: commands succeeded
ERROR:   lint: commands failed
ERROR:   flake8: commands failed
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
