### PR TITLE
boards/nrf-based: Model features in Kconfig

### DIFF
--- a/boards/acd52832/Kconfig
+++ b/boards/acd52832/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "acd52832" if BOARD_ACD52832
+
+config BOARD_ACD52832
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52832XXAA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/adafruit-clue/Kconfig
+++ b/boards/adafruit-clue/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "adafruit-clue" if BOARD_ADAFRUIT_CLUE
+
+config BOARD_ADAFRUIT_CLUE
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52840XXAA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_RADIO_NRF802154
+    select HAS_BOOTLOADER_NRFUTIL
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/airfy-beacon/Kconfig
+++ b/boards/airfy-beacon/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "airfy-beacon" if BOARD_AIRFY_BEACON
+
+config BOARD_AIRFY_BEACON
+    bool
+    default y
+    select BOARD_COMMON_NRF51
+    select CPU_MODEL_NRF51X22XXAA
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nrf51/Kconfig"

--- a/boards/arduino-nano-33-ble/Kconfig
+++ b/boards/arduino-nano-33-ble/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "arduino-nano-33-ble" if BOARD_ARDUINO_NANO_33_BLE
+
+config BOARD_ARDUINO_NANO_33_BLE
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52840XXAA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_RADIO_NRF802154
+    select HAS_BOOTLOADER_ARDUINO
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/calliope-mini/Kconfig
+++ b/boards/calliope-mini/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "calliope-mini" if BOARD_CALLIOPE_MINI
+
+config BOARD_CALLIOPE_MINI
+    bool
+    default y
+    select BOARD_COMMON_NRF51
+    select CPU_MODEL_NRF51X22XXAB
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_PWM
+
+source "$(RIOTBOARD)/common/nrf51/Kconfig"

--- a/boards/common/nrf51/Kconfig
+++ b/boards/common/nrf51/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_COMMON_NRF51
+    bool
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_TIMER

--- a/boards/common/nrf52/Kconfig
+++ b/boards/common/nrf52/Kconfig
@@ -1,0 +1,11 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_COMMON_NRF52
+    bool
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_TIMER
+    select HAS_RIOTBOOT if !PKG_NORDIC_SOFTDEVICE_BLE

--- a/boards/common/nrf52xxxdk/Kconfig
+++ b/boards/common/nrf52xxxdk/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_COMMON_NRF52XXXDK
+    bool
+    select BOARD_COMMON_NRF52
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/common/particle-mesh/Kconfig
+++ b/boards/common/particle-mesh/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_COMMON_PARTICLE_MESH
+    bool
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52840XXAA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_RADIO_NRF802154
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/dwm1001/Kconfig
+++ b/boards/dwm1001/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "dwm1001" if BOARD_DWM1001
+
+config BOARD_DWM1001
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52832XXAA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/feather-nrf52840/Kconfig
+++ b/boards/feather-nrf52840/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "feather-nrf52840" if BOARD_FEATHER_NRF52840
+
+config BOARD_FEATHER_NRF52840
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52840XXAA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_RADIO_NRF802154
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/microbit/Kconfig
+++ b/boards/microbit/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "microbit" if BOARD_MICROBIT
+
+config BOARD_MICROBIT
+    bool
+    default y
+    select BOARD_COMMON_NRF51
+    select CPU_MODEL_NRF51X22XXAB
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nrf51/Kconfig"

--- a/boards/nrf51dk/Kconfig
+++ b/boards/nrf51dk/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "nrf51dk" if BOARD_NRF51DK
+
+config BOARD_NRF51DK
+    bool
+    default y
+    select BOARD_COMMON_NRF51
+    select CPU_MODEL_NRF51X22XXAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_UART_HW_FC
+
+source "$(RIOTBOARD)/common/nrf51/Kconfig"

--- a/boards/nrf51dongle/Kconfig
+++ b/boards/nrf51dongle/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "nrf51dongle" if BOARD_NRF51DONGLE
+
+config BOARD_NRF51DONGLE
+    bool
+    default y
+    select BOARD_COMMON_NRF51
+    select CPU_MODEL_NRF51X22XXAB
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_UART_HW_FC
+
+source "$(RIOTBOARD)/common/nrf51/Kconfig"

--- a/boards/nrf52832-mdk/Kconfig
+++ b/boards/nrf52832-mdk/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "nrf52832-mdk" if BOARD_NRF52832_MDK
+
+config BOARD_NRF52832_MDK
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52832XXAA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/nrf52840-mdk/Kconfig
+++ b/boards/nrf52840-mdk/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "nrf52840-mdk" if BOARD_NRF52840_MDK
+
+config BOARD_NRF52840_MDK
+    bool
+    default y
+    select CPU_MODEL_NRF52840XXAA
+    select BOARD_COMMON_NRF52
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_RADIO_NRF802154
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/nrf52840dk/Kconfig
+++ b/boards/nrf52840dk/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "nrf52840dk" if BOARD_NRF52840DK
+
+config BOARD_NRF52840DK
+    bool
+    default y
+    select BOARD_COMMON_NRF52XXXDK
+    select CPU_MODEL_NRF52840XXAA
+    select HAS_RADIO_NRF802154
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_USBDEV
+
+source "$(RIOTBOARD)/common/nrf52xxxdk/Kconfig"

--- a/boards/nrf52840dongle/Kconfig
+++ b/boards/nrf52840dongle/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "nrf52840dongle" if BOARD_NRF52840DONGLE
+
+config BOARD_NRF52840DONGLE
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52840XXAA
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_RADIO_NRF802154
+    select HAS_BOOTLOADER_NRFUTIL
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/nrf52dk/Kconfig
+++ b/boards/nrf52dk/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "nrf52dk" if BOARD_NRF52DK
+
+config BOARD_NRF52DK
+    bool
+    default y
+    select BOARD_COMMON_NRF52XXXDK
+    select CPU_MODEL_NRF52832XXAA
+
+source "$(RIOTBOARD)/common/nrf52xxxdk/Kconfig"

--- a/boards/nrf6310/Kconfig
+++ b/boards/nrf6310/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "nrf6310" if BOARD_NRF6310
+
+config BOARD_NRF6310
+    bool
+    default y
+    select BOARD_COMMON_NRF51
+    select CPU_MODEL_NRF51X22XXAA
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nrf51/Kconfig"

--- a/boards/particle-argon/Kconfig
+++ b/boards/particle-argon/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "particle-argon" if BOARD_PARTICLE_ARGON
+
+config BOARD_PARTICLE_ARGON
+    bool
+    default y
+    select BOARD_COMMON_PARTICLE_MESH
+
+source "$(RIOTBOARD)/common/particle-mesh/Kconfig"

--- a/boards/particle-boron/Kconfig
+++ b/boards/particle-boron/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "particle-boron" if BOARD_PARTICLE_BORON
+
+config BOARD_PARTICLE_BORON
+    bool
+    default y
+    select BOARD_COMMON_PARTICLE_MESH
+
+source "$(RIOTBOARD)/common/particle-mesh/Kconfig"

--- a/boards/particle-xenon/Kconfig
+++ b/boards/particle-xenon/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "particle-xenon" if BOARD_PARTICLE_XENON
+
+config BOARD_PARTICLE_XENON
+    bool
+    default y
+    select BOARD_COMMON_PARTICLE_MESH
+
+source "$(RIOTBOARD)/common/particle-mesh/Kconfig"

--- a/boards/pinetime/Kconfig
+++ b/boards/pinetime/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "pinetime" if BOARD_PINETIME
+
+config BOARD_PINETIME
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52832XXAA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/reel/Kconfig
+++ b/boards/reel/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "reel" if BOARD_REEL
+
+config BOARD_REEL
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52840XXAA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_RADIO_NRF802154
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/ruuvitag/Kconfig
+++ b/boards/ruuvitag/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "ruuvitag" if BOARD_RUUVITAG
+
+config BOARD_RUUVITAG
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52832XXAA
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/thingy52/Kconfig
+++ b/boards/thingy52/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "thingy52" if BOARD_THINGY52
+
+config BOARD_THINGY52
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52832XXAA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/yunjia-nrf51822/Kconfig
+++ b/boards/yunjia-nrf51822/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "yunjia-nrf51822" if BOARD_YUNJIA_NRF51822
+
+config BOARD_YUNJIA_NRF51822
+    bool
+    default y
+    select BOARD_COMMON_NRF51
+    select CPU_MODEL_NRF51X22XXAA
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nrf51/Kconfig"

--- a/cpu/nrf51/Kconfig
+++ b/cpu/nrf51/Kconfig
@@ -1,9 +1,51 @@
 # Copyright (c) 2020 Freie Universitaet Berlin
+#               2020 HAW Hamburg
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 #
+
+config CPU_FAM_NRF51
+    bool
+    select CPU_CORE_CORTEX_M0
+    select CPU_COMMON_NRF5X
+    select HAS_CPU_NRF51
+
+## CPU Models
+config CPU_MODEL_NRF51X22XXAA
+    bool
+    select CPU_FAM_NRF51
+
+config CPU_MODEL_NRF51X22XXAB
+    bool
+    select CPU_FAM_NRF51
+
+config CPU_MODEL_NRF51X22XXAC
+    bool
+    select CPU_FAM_NRF51
+
+## CPU common symbols
+config CPU_FAM
+    default "nrf51" if CPU_FAM_NRF51
+
+config CPU_MODEL
+    default "nrf51x22xxaa" if CPU_MODEL_NRF51X22XXAA
+    default "nrf51x22xxab" if CPU_MODEL_NRF51X22XXAB
+    default "nrf51x22xxac" if CPU_MODEL_NRF51X22XXAC
+
+config CPU
+    default "nrf51" if CPU_FAM_NRF51
+
+## Definition of specific features
+config HAS_CPU_NRF51
+    bool
+    help
+        Indicates that the current cpu is 'nrf51'.
+
+## Platform-specific defaults
 config GNRC_PKTBUF_SIZE
     default 2048
     depends on KCONFIG_MODULE_GNRC_PKTBUF_STATIC
+
+source "$(RIOTCPU)/nrf5x_common/Kconfig"

--- a/cpu/nrf51/Makefile.features
+++ b/cpu/nrf51/Makefile.features
@@ -1,4 +1,4 @@
 CPU_CORE = cortex-m0
 CPU_FAM  = nrf51
 
--include $(RIOTCPU)/nrf5x_common/Makefile.features
+include $(RIOTCPU)/nrf5x_common/Makefile.features

--- a/cpu/nrf52/Kconfig
+++ b/cpu/nrf52/Kconfig
@@ -1,0 +1,46 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config CPU_FAM_NRF52
+    bool
+    select CPU_CORE_CORTEX_M4F
+    select CPU_COMMON_NRF5X
+# The ADC does not depend on any board configuration, so always available
+    select HAS_PERIPH_ADC
+# So far, NimBLE netif does not support nrf51 platforms, so we use a dedicated
+# feature to mark this
+    select HAS_BLE_NIMBLE_NETIF
+    select HAS_CORTEXM_MPU
+    select HAS_CPU_NRF52
+
+## CPU Models
+config CPU_MODEL_NRF52832XXAA
+    bool
+    select CPU_FAM_NRF52
+    select HAS_BLE_NORDIC_SOFTDEVICE
+
+config CPU_MODEL_NRF52840XXAA
+    bool
+    select CPU_FAM_NRF52
+
+## CPU common symbols
+config CPU_FAM
+    default "nrf52" if CPU_FAM_NRF52
+
+config CPU_MODEL
+    default "nrf52832xxaa" if CPU_MODEL_NRF52832XXAA
+    default "nrf52840xxaa" if CPU_MODEL_NRF52840XXAA
+
+config CPU
+    default "nrf52" if CPU_FAM_NRF52
+
+## Definition of specific features
+config HAS_CPU_NRF52
+    bool
+    help
+        Indicates that the current cpu is 'nrf52'.
+
+source "$(RIOTCPU)/nrf5x_common/Kconfig"

--- a/cpu/nrf52/Makefile.features
+++ b/cpu/nrf52/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += ble_nimble_netif
 # all nrf52 have an MPU
 FEATURES_PROVIDED += cortexm_mpu
 
--include $(RIOTCPU)/nrf5x_common/Makefile.features
+include $(RIOTCPU)/nrf5x_common/Makefile.features

--- a/cpu/nrf52/radio/nrf802154/Kconfig
+++ b/cpu/nrf52/radio/nrf802154/Kconfig
@@ -20,3 +20,9 @@ config NRF802154_CCA_THRESH_DEFAULT
         Default CCA threshold value for the CCACTRL register.
 
 endif # KCONFIG_MODULE_NRF802154
+
+## Related features
+config HAS_RADIO_NRF802154
+    bool
+    help
+        Indicates that a IEEE 802.15.4 NRF52 radio is present.

--- a/cpu/nrf5x_common/Kconfig
+++ b/cpu/nrf5x_common/Kconfig
@@ -1,0 +1,57 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config CPU_COMMON_NRF5X
+    bool
+    select HAS_PERIPH_CPUID
+    select HAS_PERIPH_FLASHPAGE
+    select HAS_PERIPH_FLASHPAGE_RAW
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_HWRNG
+    select HAS_PERIPH_TEMPERATURE
+    select HAS_PERIPH_UART_MODECFG
+    select HAS_PERIPH_WDT
+    select HAS_PERIPH_WDT_CB
+    select HAS_BLE_NIMBLE
+    select HAS_RADIO_NRFBLE
+    select HAS_RADIO_NRFMIN
+    select HAS_PUF_SRAM
+
+## Definition of specific features
+config HAS_BOOTLOADER_NRFUTIL
+    bool
+    help
+        Indicates that the nRF Util bootloader is being used.
+
+config HAS_BLE_NIMBLE
+    bool
+    help
+        Indicates that the NimBLE stack is supported on the current platform.
+
+config HAS_BLE_NIMBLE_NETIF
+    bool
+    help
+        Indicates that NimBLE netif is supported on the current platform.
+
+config HAS_RADIO_NRFBLE
+    bool
+    help
+        Indicates that a BLE-compatible nRF radio is present.
+
+config HAS_RADIO_NRFMIN
+    bool
+    help
+        Indicates that a radio compatible with the nRF minimal radio driver is
+        present.
+
+config HAS_BLE_NORDIC_SOFTDEVICE
+    bool
+    help
+        Indicates that Nordic SoftDevice support in RIOT has been verified on the
+        current platform.
+
+source "$(RIOTCPU)/cortexm_common/Kconfig"

--- a/cpu/nrf5x_common/Makefile.features
+++ b/cpu/nrf5x_common/Makefile.features
@@ -14,4 +14,4 @@ FEATURES_PROVIDED += radio_nrfble
 FEATURES_PROVIDED += radio_nrfmin
 FEATURES_PROVIDED += puf_sram
 
--include $(RIOTCPU)/cortexm_common/Makefile.features
+include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -42,11 +42,6 @@ config HAS_BOOTLOADER_ARDUINO
     help
         Indicates that the Arduino bootloader is used.
 
-config HAS_BOOTLOADER_NRFUTIL
-    bool
-    help
-        Indicates that the NRF Util bootloader is used.
-
 config HAS_CPP
     bool
     help

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -1,14 +1,19 @@
 include ../Makefile.tests_common
 
-BOARD_WHITELIST += arduino-duemilanove \
+BOARD_WHITELIST += acd52832 \
+                   adafruit-clue \
+                   airfy-beacon \
+                   arduino-duemilanove \
                    arduino-leonardo \
                    arduino-mega2560 \
                    arduino-nano \
+                   arduino-nano-33-ble \
                    arduino-uno \
                    atmega1284p \
                    atmega256rfr2-xpro \
                    atmega328p \
                    avr-rss2 \
+                   calliope-mini \
                    cc1312-launchpad \
                    cc1352-launchpad \
                    cc1352p-launchpad \
@@ -18,6 +23,7 @@ BOARD_WHITELIST += arduino-duemilanove \
                    chronos \
                    derfmega128 \
                    derfmega256 \
+                   dwm1001 \
                    esp32-heltec-lora32-v2 \
                    esp32-mh-et-live-minikit \
                    esp32-olimex-evb \
@@ -28,6 +34,7 @@ BOARD_WHITELIST += arduino-duemilanove \
                    esp8266-esp-12x \
                    esp8266-olimex-mod \
                    esp8266-sparkfun-thing \
+                   feather-nrf52840 \
                    firefly \
                    frdm-k22f \
                    frdm-k64f \
@@ -35,19 +42,34 @@ BOARD_WHITELIST += arduino-duemilanove \
                    hifive1b \
                    ikea-tradfri \
                    mega-xplained \
+                   microbit \
                    microduino-corerf \
                    msb-430 \
                    msb-430h \
                    mulle \
+                   nrf51dk \
+                   nrf51dongle \
+                   nrf52832-mdk \
+                   nrf52840-mdk \
+                   nrf52840dk \
+                   nrf52840dongle \
+                   nrf52dk \
+                   nrf6310 \
                    openlabs-kw41z-mini \
                    openlabs-kw41z-mini-256kib \
                    openmote-b \
                    openmote-cc2538 \
+                   particle-argon \
+                   particle-boron \
+                   particle-xenon \
                    pba-d-01-kw2x \
                    phynode-kw41z \
+                   pinetime \
+                   reel \
                    remote-pa \
                    remote-reva \
                    remote-revb \
+                   ruuvitag \
                    samr21-xpro \
                    slstk3401a \
                    slstk3402a \
@@ -59,8 +81,12 @@ BOARD_WHITELIST += arduino-duemilanove \
                    stk3700 \
                    teensy31 \
                    telosb \
+                   thingy52 \
                    usb-kw41z \
                    waspmote-pro \
+                   wsn430-v1_3b \
+                   wsn430-v1_4 \
+                   yunjia-nrf51822 \
                    z1
                    #
 


### PR DESCRIPTION
### Contribution description
This models the provided features for all nrf5x-based boards:
- acd52832
- adafruit-clue
- airfy-beacon
- arduino-nano-33-ble
- calliope-mini
- dwm1001
- feather-nrf52840
- microbit
- nrf51dk
- nrf51dongle
- nrf52832-mdk
- nrf52840-mdk
- nrf52840dk
- nrf52840dongle
- nrf52dk
- nrf6310
- particle-argon
- particle-boron
- particle-xenon
- pinetime
- reel
- ruuvitag
- thingy52
- yunjia-nrf51822

### Testing procedure
- Check the symbol organization and naming
- `tests/kconfig_features` should pass for all boards

### Issues/PRs references
Part of #14148 