### PR TITLE
drivers/kw2xrf: Enable TX end IRQ

### DIFF
--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -82,6 +82,10 @@ static int _init(netdev_t *netdev)
     /* reset device to default values and put it into RX state */
     kw2xrf_reset_phy(dev);
 
+    /* enable TX End IRQ: the driver uses the event and gnrc_netif_ieee802154
+     * only enables this when MODULE_NETSTATS_L2 is active */
+    kw2xrf_clear_dreg_bit(dev, MKW2XDM_PHY_CTRL2, MKW2XDM_PHY_CTRL2_TXMSK);
+
     return 0;
 }
 


### PR DESCRIPTION
### Contribution description
The driver needs this event but `gnrc_netif_ieee802154` only enables the interrupt when `MODULE_NETSTATS_L2` is active. Not enabling this event generates the issue described in #12858.

### Testing procedure
- Flash `examples/gnrc_networking` without including the `netstats_l2` module. Pinging should be reliable.

<details><summary><b>Output when pinging from a samr21-xpro</b></summary>

```
> ping6 fe80::47f7:6d43:828e:3332 -c 30 -i 200
2020-07-06 14:21:04,128 #  ping6 fe80::47f7:6d43:828e:3332 -c 30 -i 200
2020-07-06 14:21:04,154 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=0 ttl=64 rssi=-37 dBm time=17.046 ms
2020-07-06 14:21:04,355 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=1 ttl=64 rssi=-37 dBm time=17.677 ms
2020-07-06 14:21:04,558 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=2 ttl=64 rssi=-37 dBm time=18.947 ms
2020-07-06 14:21:04,758 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=3 ttl=64 rssi=-37 dBm time=18.308 ms
2020-07-06 14:21:04,958 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=4 ttl=64 rssi=-37 dBm time=17.048 ms
2020-07-06 14:21:05,159 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=5 ttl=64 rssi=-37 dBm time=17.353 ms
2020-07-06 14:21:05,563 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=7 ttl=64 rssi=-37 dBm time=18.944 ms
2020-07-06 14:21:05,763 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=8 ttl=64 rssi=-37 dBm time=18.307 ms
2020-07-06 14:21:05,963 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=9 ttl=64 rssi=-37 dBm time=17.045 ms
2020-07-06 14:21:06,166 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=10 ttl=64 rssi=-37 dBm time=18.955 ms
2020-07-06 14:21:06,367 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=11 ttl=64 rssi=-37 dBm time=18.947 ms
2020-07-06 14:21:06,568 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=12 ttl=64 rssi=-37 dBm time=18.950 ms
2020-07-06 14:21:06,768 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=13 ttl=64 rssi=-37 dBm time=18.312 ms
2020-07-06 14:21:06,970 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=14 ttl=64 rssi=-37 dBm time=18.312 ms
2020-07-06 14:21:07,170 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=15 ttl=64 rssi=-37 dBm time=17.676 ms
2020-07-06 14:21:07,372 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=16 ttl=64 rssi=-37 dBm time=18.949 ms
2020-07-06 14:21:07,573 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=17 ttl=64 rssi=-37 dBm time=19.267 ms
2020-07-06 14:21:07,772 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=18 ttl=64 rssi=-37 dBm time=17.361 ms
2020-07-06 14:21:07,975 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=19 ttl=64 rssi=-37 dBm time=18.952 ms
2020-07-06 14:21:08,176 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=20 ttl=64 rssi=-37 dBm time=19.273 ms
2020-07-06 14:21:08,375 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=21 ttl=64 rssi=-37 dBm time=17.356 ms
2020-07-06 14:21:08,578 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=22 ttl=64 rssi=-37 dBm time=19.273 ms
2020-07-06 14:21:08,779 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=23 ttl=64 rssi=-37 dBm time=18.633 ms
2020-07-06 14:21:08,980 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=24 ttl=64 rssi=-37 dBm time=19.274 ms
2020-07-06 14:21:09,181 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=25 ttl=64 rssi=-37 dBm time=19.267 ms
2020-07-06 14:21:09,381 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=26 ttl=64 rssi=-37 dBm time=17.354 ms
2020-07-06 14:21:09,583 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=27 ttl=64 rssi=-35 dBm time=19.266 ms
2020-07-06 14:21:09,784 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=28 ttl=64 rssi=-37 dBm time=19.266 ms
2020-07-06 14:21:09,984 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=29 ttl=64 rssi=-37 dBm time=17.999 ms
2020-07-06 14:21:10,963 # 
2020-07-06 14:21:10,967 # --- fe80::47f7:6d43:828e:3332 PING statistics ---
2020-07-06 14:21:10,972 # 30 packets transmitted, 29 packets received, 3% packet loss
2020-07-06 14:21:10,977 # round-trip min/avg/max = 17.045/18.390/19.274 ms
> ping6 fe80::47f7:6d43:828e:3332 -c 30 -i 200
2020-07-06 14:21:13,387 #  ping6 fe80::47f7:6d43:828e:3332 -c 30 -i 200
2020-07-06 14:21:13,413 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=0 ttl=64 rssi=-37 dBm time=17.672 ms
2020-07-06 14:21:13,614 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=1 ttl=64 rssi=-37 dBm time=18.308 ms
2020-07-06 14:21:13,815 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=2 ttl=64 rssi=-37 dBm time=17.677 ms
2020-07-06 14:21:14,017 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=3 ttl=64 rssi=-37 dBm time=19.271 ms
2020-07-06 14:21:14,217 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=4 ttl=64 rssi=-37 dBm time=17.991 ms
2020-07-06 14:21:14,418 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=5 ttl=64 rssi=-37 dBm time=17.990 ms
2020-07-06 14:21:14,620 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=6 ttl=64 rssi=-37 dBm time=19.267 ms
2020-07-06 14:21:14,820 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=7 ttl=64 rssi=-37 dBm time=17.357 ms
2020-07-06 14:21:15,022 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=8 ttl=64 rssi=-37 dBm time=18.948 ms
2020-07-06 14:21:15,223 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=9 ttl=64 rssi=-37 dBm time=18.313 ms
2020-07-06 14:21:15,422 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=10 ttl=64 rssi=-37 dBm time=17.043 ms
2020-07-06 14:21:15,624 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=11 ttl=64 rssi=-37 dBm time=17.672 ms
2020-07-06 14:21:15,826 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=12 ttl=64 rssi=-37 dBm time=18.629 ms
2020-07-06 14:21:16,027 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=13 ttl=64 rssi=-37 dBm time=18.944 ms
2020-07-06 14:21:16,228 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=14 ttl=64 rssi=-37 dBm time=18.950 ms
2020-07-06 14:21:16,429 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=15 ttl=64 rssi=-37 dBm time=18.634 ms
2020-07-06 14:21:16,629 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=16 ttl=64 rssi=-35 dBm time=17.358 ms
2020-07-06 14:21:16,831 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=17 ttl=64 rssi=-37 dBm time=18.311 ms
2020-07-06 14:21:17,030 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=18 ttl=64 rssi=-37 dBm time=17.048 ms
2020-07-06 14:21:17,433 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=20 ttl=64 rssi=-37 dBm time=17.356 ms
2020-07-06 14:21:17,634 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=21 ttl=64 rssi=-37 dBm time=17.675 ms
2020-07-06 14:21:17,836 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=22 ttl=64 rssi=-37 dBm time=18.950 ms
2020-07-06 14:21:18,035 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=23 ttl=64 rssi=-37 dBm time=17.042 ms
2020-07-06 14:21:18,236 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=24 ttl=64 rssi=-37 dBm time=17.048 ms
2020-07-06 14:21:18,439 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=25 ttl=64 rssi=-37 dBm time=18.952 ms
2020-07-06 14:21:18,640 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=26 ttl=64 rssi=-37 dBm time=18.315 ms
2020-07-06 14:21:18,842 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=27 ttl=64 rssi=-37 dBm time=19.266 ms
2020-07-06 14:21:19,042 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=28 ttl=64 rssi=-37 dBm time=17.989 ms
2020-07-06 14:21:19,243 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=29 ttl=64 rssi=-37 dBm time=17.994 ms
2020-07-06 14:21:20,221 # 
2020-07-06 14:21:20,225 # --- fe80::47f7:6d43:828e:3332 PING statistics ---
2020-07-06 14:21:20,231 # 30 packets transmitted, 29 packets received, 3% packet loss
2020-07-06 14:21:20,235 # round-trip min/avg/max = 17.042/18.136/19.271 ms
> ping6 fe80::47f7:6d43:828e:3332 -c 30 -i 200
2020-07-06 14:21:22,348 #  ping6 fe80::47f7:6d43:828e:3332 -c 30 -i 200
2020-07-06 14:21:22,575 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=1 ttl=64 rssi=-37 dBm time=17.048 ms
2020-07-06 14:21:22,777 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=2 ttl=64 rssi=-38 dBm time=18.313 ms
2020-07-06 14:21:22,979 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=3 ttl=64 rssi=-37 dBm time=19.272 ms
2020-07-06 14:21:23,180 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=4 ttl=64 rssi=-37 dBm time=18.948 ms
2020-07-06 14:21:23,380 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=5 ttl=64 rssi=-37 dBm time=17.995 ms
2020-07-06 14:21:23,582 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=6 ttl=64 rssi=-37 dBm time=18.947 ms
2020-07-06 14:21:23,782 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=7 ttl=64 rssi=-37 dBm time=18.309 ms
2020-07-06 14:21:23,982 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=8 ttl=64 rssi=-37 dBm time=17.355 ms
2020-07-06 14:21:24,184 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=9 ttl=64 rssi=-37 dBm time=18.628 ms
2020-07-06 14:21:24,384 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=10 ttl=64 rssi=-37 dBm time=17.359 ms
2020-07-06 14:21:24,586 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=11 ttl=64 rssi=-37 dBm time=17.993 ms
2020-07-06 14:21:24,787 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=12 ttl=64 rssi=-37 dBm time=18.631 ms
2020-07-06 14:21:24,987 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=13 ttl=64 rssi=-37 dBm time=17.045 ms
2020-07-06 14:21:25,190 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=14 ttl=64 rssi=-37 dBm time=18.945 ms
2020-07-06 14:21:25,389 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=15 ttl=64 rssi=-37 dBm time=17.044 ms
2020-07-06 14:21:25,590 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=16 ttl=64 rssi=-37 dBm time=17.356 ms
2020-07-06 14:21:25,791 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=17 ttl=64 rssi=-37 dBm time=17.350 ms
2020-07-06 14:21:25,993 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=18 ttl=64 rssi=-37 dBm time=17.678 ms
2020-07-06 14:21:26,193 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=19 ttl=64 rssi=-37 dBm time=17.049 ms
2020-07-06 14:21:26,395 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=20 ttl=64 rssi=-38 dBm time=17.674 ms
2020-07-06 14:21:26,595 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=21 ttl=64 rssi=-37 dBm time=17.358 ms
2020-07-06 14:21:26,798 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=22 ttl=64 rssi=-37 dBm time=18.629 ms
2020-07-06 14:21:26,998 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=23 ttl=64 rssi=-37 dBm time=17.991 ms
2020-07-06 14:21:27,199 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=24 ttl=64 rssi=-37 dBm time=17.678 ms
2020-07-06 14:21:27,400 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=25 ttl=64 rssi=-37 dBm time=17.360 ms
2020-07-06 14:21:27,602 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=26 ttl=64 rssi=-37 dBm time=19.271 ms
2020-07-06 14:21:27,803 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=27 ttl=64 rssi=-37 dBm time=18.632 ms
2020-07-06 14:21:28,003 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=28 ttl=64 rssi=-37 dBm time=17.988 ms
2020-07-06 14:21:28,205 # 12 bytes from fe80::47f7:6d43:828e:3332%6: icmp_seq=29 ttl=64 rssi=-37 dBm time=18.632 ms
2020-07-06 14:21:29,183 # 
2020-07-06 14:21:29,187 # --- fe80::47f7:6d43:828e:3332 PING statistics ---
2020-07-06 14:21:29,193 # 30 packets transmitted, 29 packets received, 3% packet loss
2020-07-06 14:21:29,197 # round-trip min/avg/max = 17.044/18.016/19.272 ms
> 
```
</details>

### Issues/PRs references
Fixes #12858