### PR TITLE
boards/saml1x: provide custom value for XTIMER_BACKOFF to spin for lo…

### DIFF
--- a/boards/common/saml1x/include/board.h
+++ b/boards/common/saml1x/include/board.h
@@ -62,6 +62,12 @@ extern "C" {
 #define BTN0_MODE           GPIO_IN_PU
 /** @} */
 
+/**
+ * @name    Xtimer configuration
+ * @{
+ */
+#define XTIMER_BACKOFF      (40)
+/** @} */
 
 /**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO


### PR DESCRIPTION
### Contribution description
As @pokgak pointed out in [#7347 (comment)](https://github.com/RIOT-OS/RIOT/issues/7347#issuecomment-652478293 ) `tests/xtimer_usleep_short` fails on saml10-xpro.
This PR sets an increased custom value for `XTIMER_BACKOFF` on that board to fix that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Test with `BOARD=saml10-xpro make -C tests/xtimer_usleep_short all flash test`

on master this gives:
```
(...)
going to sleep 43 usecs...
going to sleep 42 usecs...
going to sleep 41 usecs...
going to sleep 40 usecs...
going to sleep 39 usecs...
going to sleep 38 usecs...
xtimer stuck when trying to sleep 38 usecs
[FAILED]
Timeout in expect script at "child.expect(u"[SUCCESS]", timeout=3)" (tests/xtimer_usleep_short/tests/01-run.py:28)

make: *** [/home/michel/devel/riot/tests/xtimer_usleep_short/../../Makefile.include:770: test] Error 1
make: Leaving directory '/home/michel/devel/riot/tests/xtimer_usleep_short'
```

with this PR:
```
(...)
going to sleep 4 usecs...
going to sleep 3 usecs...
going to sleep 2 usecs...
going to sleep 1 usecs...
going to sleep 0 usecs...
[SUCCESS]

make: Leaving directory '/home/michel/devel/riot/tests/xtimer_usleep_short'
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#7347 (not solved by this PR as more boards might be affected).
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
