### PR TITLE
pkg/cryptoauthlib/atca: Fix documentation group

### DIFF
--- a/pkg/cryptoauthlib/include/atca_params.h
+++ b/pkg/cryptoauthlib/include/atca_params.h
@@ -28,6 +28,8 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup drivers_atca_config    ATCA driver compile configuration
+ * @ingroup  config_drivers_misc
  * @brief    Set default configuration parameters for the ATCA device
  *
  *          The CryptoAuth library defines the data structure ATCAIfaceCfg for
@@ -38,7 +40,6 @@ extern "C" {
  *          We also initialize the baud rate with zero, because RIOT doesn't have
  *          an API to change baud.
  *
- * @ingroup  config
  * @{
  */
 


### PR DESCRIPTION
### Contribution description
The compile-time configuration parameters for the ATCA driver are showing up directly on the `config` group in the documentation (see http://doc.riot-os.org/group__config.html). This PR groups them to improve readability.

### Testing procedure
- `make doc` and check the generated documentation

### Issues/PRs references
None
