### PR TITLE
sys/shell: Add optional hooks for shell commands

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -98,6 +98,7 @@ PSEUDOMODULES += saul_nrf_temperature
 PSEUDOMODULES += scanf_float
 PSEUDOMODULES += sched_cb
 PSEUDOMODULES += semtech_loramac_rx
+PSEUDOMODULES += shell_hooks
 PSEUDOMODULES += slipdev_stdio
 PSEUDOMODULES += sock
 PSEUDOMODULES += sock_async

--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -49,6 +49,37 @@ extern "C" {
 #define SHELL_DEFAULT_BUFSIZE   (128)
 
 /**
+ * @brief           Optional hook after readline has triggered.
+ * @details         User implemented function gets called after the shell
+ *                  readline is complete.
+ * @note            Only executed with the `shell_hooks` module.
+ */
+void shell_post_readline_hook(void);
+
+/**
+ * @brief           Optional hook before shell command is called.
+ * @details         User implemented function gets called before a valid shell
+ *                  command will be called.
+ * @note            Only executed with the `shell_hooks` module.
+ *
+ * @param[in]       argc   Number of arguments supplied to the function invocation.
+ * @param[in]       argv   The supplied argument list.
+ */
+void shell_pre_command_hook(int argc, char **argv);
+
+/**
+ * @brief           Optional hook after shell command is called.
+ * @details         User implemented function gets called before a valid shell
+ *                  command will be called.
+ * @note            Only executed with the `shell_hooks` module.
+ *
+ * @param[in]       ret    Return value of the shell command.
+ * @param[in]       argc   Number of arguments supplied to the function invocation.
+ * @param[in]       argv   The supplied argument list.
+ */
+void shell_post_command_hook(int ret, int argc, char **argv);
+
+/**
  * @brief           Protype of a shell callback handler.
  * @details         The functions supplied to shell_run() must use this signature.
  *                  The argument list is terminated with a NULL, i.e ``argv[argc] == NULL`.

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -28,6 +28,28 @@
 #include "xtimer.h"
 #endif
 
+#if MODULE_SHELL_HOOKS
+void shell_post_readline_hook(void)
+{
+    puts("shell_post_readline_hook");
+}
+
+void shell_pre_command_hook(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    puts("shell_pre_command_hook");
+}
+
+void shell_post_command_hook(int ret, int argc, char **argv)
+{
+    (void)ret;
+    (void)argc;
+    (void)argv;
+    puts("shell_post_command_hook");
+}
+#endif
+
 static int print_teststart(int argc, char **argv)
 {
     (void) argc;


### PR DESCRIPTION
### Contribution description

Introduce optional user post_readline_hook, pre_command_hook, post_command_hook.
Enable with USEMODULE=shell_hooks.
Calls user implemented *_hook functions if defined.
If implementation does not exist, nothing happens.

The intent is to make profiling of the shell command timings easier.
Test provided in tests/shell with USEMODULE=shell_hooks.

_Note: By default this does nothing, does not add any size, only compiles empty functions if the shell module is used_
### Testing procedure

`USEMODULE=shell_hooks make all flash term -C tests/shell`

Try any commands an look for the `shell_post_readline_hook`, `shell_pre_command_hook` and `shell_post_command_hook`.

<details><summary>my test results</summary>

`USEMODULE=shell_hooks BOARD=nucleo-f401re make clean all flash term -C tests/shell`

```
main(): This is RIOT! (Version: 2020.07-devel-1796-g478bd-pr/shellhooks)
test_shell.
> help
help
post_readline_hook
Command              Description
---------------------------------------
bufsize              Get the shell's buffer size
start_test           starts a test
end_test             ends a test
echo                 prints the input command
reboot               Reboot the node
version              Prints current RIOT_VERSION
pm                   interact with layered PM subsystem
ps                   Prints information about running threads.
app_metadata         Returns application metadata
> ps
ps
shell_post_readline_hook
shell_pre_command_hook
	pid | state    Q | pri 
	  1 | running  Q |   7
shell_post_command_hook
> 
```
</details>

### Issues/PRs references

