### PR TITLE
tests/periph_gpio: enable shell commands

### DIFF
--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -4,6 +4,7 @@ FEATURES_REQUIRED = periph_gpio
 FEATURES_OPTIONAL = periph_gpio_irq
 
 USEMODULE += shell
+USEMODULE += shell_commands
 USEMODULE += benchmark
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

It is useful to have the `pm` command available in this test to see how GPIOs react to different sleep modes.

Enable it be enabling the `shell_commands` module.


### Testing procedure

The `pm` command should now be available together with the GPIO commands.
You can use it to check if an interrupt will wake the CPU from any sleep mode:

```
2020-07-07 13:26:56,382 # GPIO peripheral driver test
2020-07-07 13:26:56,382 # 
2020-07-07 13:26:56,383 # In this test, pins are specified by integer port and pin numbers.
2020-07-07 13:26:56,385 # So if your platform has a pin PA01, it will be port=0 and pin=1,
2020-07-07 13:26:56,385 # PC14 would be port=2 and pin=14 etc.
2020-07-07 13:26:56,385 # 
2020-07-07 13:26:56,386 # NOTE: make sure the values you use exist on your platform! The
2020-07-07 13:26:56,387 #       behavior for not existing ports/pins is not defined!
2020-07-07 13:27:01,048 #  init_int  1 2 1
2020-07-07 13:27:01,063 # GPIO_PIN(1, 2) successfully initialized as ext int
2020-07-07 13:27:04,372 #  init_out 0 3
2020-07-07 13:27:06,322 #  set 0 3

(manually connected PA03 and PB02)

> 2020-07-07 13:27:13,645 #  INT: external interrupt from pin 2
2020-07-07 13:27:13,648 # INT: external interrupt from pin 2
2020-07-07 13:27:13,811 # INT: external interrupt from pin 2
2020-07-07 13:27:13,813 # INT: external interrupt from pin 2
2020-07-07 13:27:13,954 # INT: external interrupt from pin 2
2020-07-07 13:27:18,375 # pm set 0
2020-07-07 13:27:18,378 # CPU is entering power mode 0.
2020-07-07 13:27:18,381 # Now waiting for a wakeup event...
ps
ps

(manually connected PA03 and PB02 again - CPU wakes up, PA3 stayed HIGH during sleep)

2020-07-07 13:27:26,722 # main(): This is RIOT! (Version: 2020.07-devel-1705-g6d158-cpu/sam0_common-rtc_tamper)
2020-07-07 13:27:26,724 # GPIO peripheral driver test
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
