### PR TITLE
pkg/tinydtls: use random_bytes() instead of rand()

### DIFF
--- a/pkg/tinydtls/Makefile.dep
+++ b/pkg/tinydtls/Makefile.dep
@@ -6,5 +6,9 @@ USEMODULE += tinydtls_aes
 USEMODULE += tinydtls_ecc
 USEMODULE += random
 
+# tinydtls needs cryptographically secure randomness
+# TODO: restore configurability, e.g. allow to use HWRNG instead if available
+USEMODULE += prng_sha1prng
+
 # TinyDTLS only has support for 32-bit architectures ATM
 FEATURES_REQUIRED += arch_32bit

--- a/pkg/tinydtls/Makefile.dep
+++ b/pkg/tinydtls/Makefile.dep
@@ -4,6 +4,7 @@ USEMODULE += memarray
 USEMODULE += hashes
 USEMODULE += tinydtls_aes
 USEMODULE += tinydtls_ecc
+USEMODULE += random
 
 # TinyDTLS only has support for 32-bit architectures ATM
 FEATURES_REQUIRED += arch_32bit

--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -10,6 +10,7 @@ INCLUDES += -I$(RIOTBASE)/pkg/tinydtls/include
 INCLUDES += -I$(PKG_BUILDDIR)
 # Mandatory for tinyDTLS
 CFLAGS += -DDTLSv12 -DWITH_SHA256
+CFLAGS += -DHAVE_ASSERT_H
 
 # Dependencies partially under control of the App's requirements
 

--- a/pkg/tinydtls/patches/0001-dtls_prng_riot-use-random_bytes.patch
+++ b/pkg/tinydtls/patches/0001-dtls_prng_riot-use-random_bytes.patch
@@ -1,0 +1,44 @@
+From 8b4f3035a079205884b9e7dcadd6578782ab2205 Mon Sep 17 00:00:00 2001
+From: Benjamin Valentin <benjamin.valentin@ml-pa.com>
+Date: Tue, 7 Jul 2020 14:36:14 +0200
+Subject: [PATCH] dtls_prng_riot: use random_bytes()
+
+Use the system-provided PRNG instead relying on rand() from libc.
+---
+ platform-specific/dtls_prng_riot.c | 13 +++----------
+ 1 file changed, 3 insertions(+), 10 deletions(-)
+
+diff --git a/platform-specific/dtls_prng_riot.c b/platform-specific/dtls_prng_riot.c
+index 1726444..6bfa1ec 100644
+--- a/platform-specific/dtls_prng_riot.c
++++ b/platform-specific/dtls_prng_riot.c
+@@ -20,23 +20,16 @@
+ 
+ #include "tinydtls.h"
+ #include "dtls_prng.h"
++#include "random.h"
+ 
+-#include <stdlib.h>
+-
+-/**
+- * Fills \p buf with \p len random bytes. This is the default
+- * implementation for prng().  You might want to change prng() to use
+- * a better PRNG on your specific platform.
+- */
+ int
+ dtls_prng(unsigned char *buf, size_t len) {
+-  while (len--)
+-    *buf++ = rand() & 0xFF;
++  random_bytes(buf, len);
+   return 1;
+ }
+ 
+ void
+ dtls_prng_init(unsigned seed) {
+-  srand(seed);
++  (void) seed;
+ }
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`dtls_prng()` expects a cryptographically secure source of randomness.
`rand()` does not fulfill this criteria, so make use of `random_bytes()` instead.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/eclipse/tinydtls/pull/42
