### PR TITLE
sys/random: add option to use HWRNG as source of randomness

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -786,6 +786,10 @@ ifneq (,$(filter random,$(USEMODULE)))
     USEMODULE += hashes
   endif
 
+  ifneq (,$(filter prng_hwrng,$(USEMODULE)))
+    FEATURES_REQUIRED += periph_hwrng
+  endif
+
   ifeq (,$(filter puf_sram,$(USEMODULE)))
     FEATURES_OPTIONAL += periph_hwrng
   endif

--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -22,6 +22,9 @@
  *  - Simple Park-Miller PRNG
  *  - Musl C PRNG
  *  - Fortuna (CS)PRNG
+ *  - Hardware Random Number Generator (non-seedable)
+ *    HWRNG differ in how they generate random numbers and may not use a PRNG internally.
+ *    Refer to the manual of your MCU for details.
  */
 
 #ifndef RANDOM_H

--- a/sys/random/hwrng.c
+++ b/sys/random/hwrng.c
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+ /**
+ * @ingroup sys_random
+ * @{
+ * @file
+ *
+ * @brief   Use the HWRNG as source of randomness
+ *
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include "kernel_defines.h"
+#include "periph/hwrng.h"
+#include "random.h"
+
+uint32_t random_uint32(void)
+{
+    uint32_t rnd;
+    hwrng_read(&rnd, sizeof(rnd));
+    return rnd;
+}
+
+void random_init(uint32_t val)
+{
+    (void) val;
+
+    if (!IS_ACTIVE(MODULE_PERIPH_INIT_HWRNG)) {
+        hwrng_init();
+    }
+}

--- a/tests/rng/test.c
+++ b/tests/rng/test.c
@@ -65,6 +65,8 @@ static void test_init(char *name)
         puts("Tiny Mersenne Twister PRNG.\n");
 #elif MODULE_PRNG_XORSHIFT
         puts("XOR Shift PRNG.\n");
+#elif MODULE_PRNG_HWRNG
+        puts("Hardware RNG.\n");
 #else
         puts("unknown PRNG.\n");
 #endif


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Add the `prng_hwrng` module to enable the HWRNG as source of all randomness, not just for seeding a PRNG.

saves ~260 bytes compared to using tinymt32.

### Testing procedure

add `USEMODULE += prng_hwrng` to any application that uses the `random` module.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
