### PR TITLE
cpu/fe310: use common names for heap markers

### DIFF
--- a/cpu/fe310/ldscripts/fe310_base.ld
+++ b/cpu/fe310/ldscripts/fe310_base.ld
@@ -166,11 +166,11 @@ SECTIONS
   . = ALIGN(8);
   PROVIDE( _end = . );
   PROVIDE( end = . );
-  PROVIDE( _heap_start = . );
+  PROVIDE( _sheap = . );
 
   .stack ORIGIN(ram) + LENGTH(ram) - __stack_size :
   {
-    PROVIDE( _heap_end = . );
+    PROVIDE( _eheap = . );
     . = __stack_size;
     PROVIDE( _sp = . );
   } >ram AT>ram :ram

--- a/cpu/fe310/nano/nanostubs.c
+++ b/cpu/fe310/nano/nanostubs.c
@@ -29,9 +29,9 @@
 #include "cpu.h"
 #include "stdio_uart.h"
 
-extern char _heap_start;            /* Heap markers from fe310.ld file */
-extern char _heap_end;
-char *heap_top = &_heap_start + 4;
+extern char _sheap;            /* Heap markers from fe310.ld file */
+extern char _eheap;
+char *heap_top = &_sheap + 4;
 
 /**
  * @brief Initialize the Newlib-nano functions (also forces inclusion of stubs for linking)
@@ -59,7 +59,7 @@ void *_sbrk(ptrdiff_t incr)
     void *res = heap_top;
 
     /* Allocate memory from heap */
-    if ((heap_top + incr > &_heap_end) || (heap_top + incr < &_heap_start)) {
+    if ((heap_top + incr > &_eheap) || (heap_top + incr < &_sheap)) {
         errno = ENOMEM;
         res = (void *) -1;
     }

--- a/cpu/fe310/thread_arch.c
+++ b/cpu/fe310/thread_arch.c
@@ -187,10 +187,10 @@ void thread_yield_higher(void)
  */
 void heap_stats(void)
 {
-    extern char _heap_start; /* defined in linker script */
-    extern char _heap_end;   /* defined in linker script */
+    extern char _sheap;     /* defined in linker script */
+    extern char _eheap;     /* defined in linker script */
 
-    long int heap_size = &_heap_end - &_heap_start;
+    long int heap_size = &_eheap - &_sheap;
     struct mallinfo minfo = mallinfo();
     printf("heap: %ld (used %u, free %ld) [bytes]\n",
            heap_size, minfo.uordblks, heap_size - minfo.uordblks);


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Other archs use `_sheap` and `_eheap` to mark the start and end of the heap.
fe310 uses `_heap_start` and `_heap_end`, so platform independent code that wants to make use of this will needlessly fail.

For compatibility with common code, name them the same on fe310.


### Testing procedure

Only variable names changed, the same binary should still be generated.




### Issues/PRs references

previous PR #12328
came up again in https://github.com/RIOT-OS/RIOT/pull/12305#discussion_r450920876