### PR TITLE
pkg/tinydtls: use latest development version

### DIFF
--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=tinydtls
 PKG_URL=https://github.com/eclipse/tinydtls.git
-PKG_VERSION=7a0420bfe3c041789cc0fe87822832f2fd12d0c3
+PKG_VERSION=eda63f000c2280c7aba29abb60503130e8179e0a
 PKG_LICENSE=EPL-1.0,EDL-1.0
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/tinydtls/Makefile.dep
+++ b/pkg/tinydtls/Makefile.dep
@@ -6,5 +6,9 @@ USEMODULE += random
 USEMODULE += tinydtls_aes
 USEMODULE += tinydtls_ecc
 
+# tinydtls needs cryptographically secure randomness
+# TODO: restore configurability, e.g. allow to use HWRNG instead if available
+USEMODULE += prng_sha1prng
+
 # TinyDTLS only has support for 32-bit architectures ATM
 FEATURES_REQUIRED += arch_32bit

--- a/pkg/tinydtls/Makefile.dep
+++ b/pkg/tinydtls/Makefile.dep
@@ -2,6 +2,7 @@ USEMODULE += tinydtls
 
 USEMODULE += memarray
 USEMODULE += hashes
+USEMODULE += random
 USEMODULE += tinydtls_aes
 USEMODULE += tinydtls_ecc
 


### PR DESCRIPTION
### Contribution description

[tinydtls](https://github.com/eclipse/tinydtls/tree/develop) will now use `random_bytes()` instead of `rand()` to obtain randomness on RIOT.
This updates tinydtls to a version that includes this fix.

As suggested by @PeterKietzmann `prng_sha1prng` is used to provide photographically secure randomness. 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

alternative to #14452
