### PR TITLE
tapsetup: fix for FreeBSD

### DIFF
--- a/dist/tools/tapsetup/tapsetup
+++ b/dist/tools/tapsetup/tapsetup
@@ -48,7 +48,7 @@ create_bridge() {
 
     case "${PLATFORM}" in
         FreeBSD)
-            kldload if_bridge
+            kldload if_bridge       # module might be already loaded => error
             ifconfig ${BRNAME} create || exit 1 ;;
         Linux)
             ip link add name ${BRNAME} type bridge || exit 1
@@ -88,8 +88,9 @@ delete_bridge() {
     case "${PLATFORM}" in
         FreeBSD)
             sysctl net.link.tap.user_open=0
-            kldunload if_tap || exit 1
-            kldunload if_bridge || exit 1 ;;
+            ifconfig ${BRNAME} destroy || exit 1
+            kldunload if_tap        # unloading might fail due to dependencies
+            kldunload if_bridge ;;
         Linux)
             for IF in $(ls /sys/class/net/${BRNAME}/brif); do
                 if [ "${IF}" != "${UPLINK}" ]; then
@@ -113,7 +114,7 @@ delete_bridge() {
 begin_tap() {
     case "${PLATFORM}" in
         FreeBSD)
-            kldload if_tap || exit 1
+            kldload if_tap          # module might be already loaded => error
             sysctl net.link.tap.user_open=1 ;;
         *)
             ;;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While testing on FreeBSD (see #14458) I noticed some errors in our `tapsetup` script for FreeBSD.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Read the script or use the VM I provided in #14458.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Required for easier testing of #14458
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
