### PR TITLE
vagrant: add Vagrantfile to test native in FreeBSD

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -142,6 +142,7 @@ check_not_exporting_variables() {
     # only place that should export common variables
     pathspec+=('*')
     pathspec+=(':!makefiles/vars.inc.mk')
+    pathspec+=(':!**/Vagrantfile')
 
     patterns=()
     for variable in "${EXPORTED_VARIABLES_ONLY_IN_VARS[@]}"; do

--- a/dist/tools/vagrant/freebsd/README.md
+++ b/dist/tools/vagrant/freebsd/README.md
@@ -1,0 +1,70 @@
+# RIOT FreeBSD VM
+
+## About
+This provides a [Vagrantfile] to compile and test the RIOT [`native`][native]
+platform on FreeBSD stable (12.1).
+
+## Requirements
+Make sure your system satisfies the latest version of all following dependencies:
+* [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+* [VirtualBox Extension Pack](https://www.virtualbox.org/wiki/Downloads)
+* [Vagrant](https://www.vagrantup.com/downloads.html)
+
+## General usage
+The following commands must be run from this directory on the host system
+
+```
+vagrant plugin install vagrant-disksize # for big enough disk
+vagrant up
+vagrant provision   # depending on the vagrant version this might alreardy be
+                    # executed with vagrant up
+```
+This will start up and set-up the virtual machine.
+```
+vagrant ssh
+```
+This logs you into the VM as vagrant user.
+
+See the general vagrant [README.md](../README.md) for more commands.
+
+## Inside the VM
+Once logged in to the VM you can run compile and run tests e.g.
+
+```sh
+make -C tests/shell all -j
+make -C tests/shell test
+```
+
+Even applications requiring network interface access should be able to work:
+
+```sh
+sudo dist/tools/tapsetup/tapsetup
+make -C examples/gnrc_networking all -j16
+make -C examples/gnrc_networking term
+```
+
+```
+> ifconfig
+ifconfig
+Iface  6  HWaddr: F1:28:23:23:F1:28
+          L2-PDU:1500  MTU:1500  HL:64  RTR
+          RTR_ADV
+          Source address length: 6
+          Link type: wired
+          inet6 addr: fe80::f328:23ff:fe23:f128  scope: link  TNT[1]
+          inet6 group: ff02::2
+          inet6 group: ff02::1
+          inet6 group: ff02::1:ff23:f128
+
+          Statistics for Layer 2
+            RX packets 5  bytes 738
+            TX packets 2 (Multicast: 2)  bytes 78
+            TX succeeded 2 errors 0
+          Statistics for IPv6
+            RX packets 4  bytes 340
+            TX packets 2 (Multicast: 2)  bytes 128
+            TX succeeded 2 errors 0
+```
+
+[Vagrantfile]: ./Vagrantfile
+[native]: https://doc.riot-os.org/group__boards__native.html

--- a/dist/tools/vagrant/freebsd/Vagrantfile
+++ b/dist/tools/vagrant/freebsd/Vagrantfile
@@ -1,0 +1,38 @@
+$init_riot = <<-INIT_RIOT
+  # vim for xxd
+  pkg install -y bash git gmake gcc cmake afl afl++ \
+      python3 py37-pip py37-scipy py37-pycrypto py37-cython py37-scapy \
+      vim
+  chsh -s /usr/local/bin/bash vagrant
+  if ! [ -d /home/vagrant/RIOT ]; then
+      git clone --recurse-submodules https://github.com/RIOT-OS/RIOT /home/vagrant/RIOT
+  fi
+  chown -R vagrant: /home/vagrant/RIOT
+  curl https://raw.githubusercontent.com/RIOT-OS/riotdocker/master/requirements.txt \
+      > /tmp/requirements.txt
+  su - vagrant -c "pip install --user -r /tmp/requirements.txt"
+  # install most current pexpect to prevent async bug
+  su - vagrant -c "pip install --upgrade --user pexpect"
+  grep -q "export MAKE=gmake" /home/vagrant/.profile || \
+      echo "export MAKE=gmake" >> /home/vagrant/.profile
+  grep -q "export LINK=gcc" /home/vagrant/.profile || \
+      echo "export LINK=gcc" >> /home/vagrant/.profile
+  grep -q "export CC=gcc" /home/vagrant/.profile || \
+      echo "export CC=gcc" >> /home/vagrant/.profile
+  grep -q 'export PATH=/home/vagrant/.local/bin:${PATH}' /home/vagrant/.profile || \
+      echo 'export PATH=/home/vagrant/.local/bin:${PATH}' >> /home/vagrant/.profile
+  # make gmake default make
+  if ! [ -h /home/vagrant/.local/bin/make ]; then
+      # might not be a symlink, so remove
+      rm  -f /home/vagrant/.local/bin/make
+      su - vagrant -c 'ln -s /usr/local/bin/gmake /home/vagrant/.local/bin/make'
+  fi
+INIT_RIOT
+
+Vagrant.configure("2") do |config|
+  config.vm.define "RIOT-FreeBSD"
+  config.vm.box = "freebsd/FreeBSD-12.1-STABLE"
+  config.disksize.size = '50GB'
+  config.vm.provision "shell",
+    inline: $init_riot
+end


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This provides a Vagrantfile for testing RIOT `native` in FreeBSD.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Basically, follow the provided README.md. For the `tapsetup` stuff to work #14457 is required.

I also ran `dist/tools/compile_and_run_for_board` on it overnight, the results can be found [here](https://github.com/miri64/RIOT_2020.07_test_results/blob/master/2020.07-RC1pre-6fc72be72/native%40freebsd/failuresummary.md).

Basically there are some errors (but this does not block this PR), that can be summarized as such:

- Cross-compiling C++ for 32-bit (this seems to be not easily fixable at least not just by installing from `ports`, maybe another argument for #6603)
- Missing names like errno-values or GNU/Linux-specific functions such as [backtrace](https://linux.die.net/man/3/backtrace)
- Missing shell commands like `sha512sum` or `bridge` and other missing tooling
- POSIX definition clashes for `pthread`s
- Timing errors (maybe related to https://github.com/RIOT-OS/RIOT/issues/10073)
- Some minor unexpected scheduling behavior [as it seems](https://github.com/miri64/RIOT_2020.07_test_results/blob/master/2020.07-RC1pre-6fc72be72/native%40freebsd/tests/cond_order/test.failed)
- Missing root privileges for tests that require it (easily fixed for non-automated runs ;-))
- Encoding formats that already in the past yielded different results for different toolchains like [cayenne-lpp](https://github.com/miri64/RIOT_2020.07_test_results/blob/master/2020.07-RC1pre-6fc72be72/native%40freebsd/tests/pkg_cayenne-lpp/test.failed)
- Incompatibilities in OS-specific `scapy` sublayer
- ...

All fixes that can be tackled as follow-ups (I will open a tracking issue if desired).


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
