### PR TITLE
 tools: add capability to provide make command via environment 

### DIFF
--- a/dist/pythonlibs/testrunner/spawn.py
+++ b/dist/pythonlibs/testrunner/spawn.py
@@ -43,6 +43,7 @@ TESTRUNNER_RESET_AFTER_TERM = int(os.environ.get('TESTRUNNER_RESET_AFTER_TERM')
 
 MAKE = os.environ.get('MAKE', 'make')
 
+
 def _reset_board(env):
     if MAKE_RESET_DELAY > 0:
         time.sleep(MAKE_RESET_DELAY)

--- a/dist/pythonlibs/testrunner/spawn.py
+++ b/dist/pythonlibs/testrunner/spawn.py
@@ -41,13 +41,14 @@ TEST_INTERACTIVE_DELAY = int(os.environ.get('TEST_INTERACTIVE_DELAY') or 1)
 TESTRUNNER_RESET_AFTER_TERM = int(os.environ.get('TESTRUNNER_RESET_AFTER_TERM')
                                   or '0')
 
+MAKE = os.environ.get('MAKE', 'make')
 
 def _reset_board(env):
     if MAKE_RESET_DELAY > 0:
         time.sleep(MAKE_RESET_DELAY)
 
     try:
-        subprocess.check_output(('make', 'reset'), env=env,
+        subprocess.check_output((MAKE, 'reset'), env=env,
                                 stderr=subprocess.PIPE)
     except subprocess.CalledProcessError:
         # make reset yields error on some boards even if successful
@@ -74,7 +75,7 @@ def setup_child(timeout=10, spawnclass=pexpect.spawnu, env=None, logfile=None):
     # the serial terminal. This gives time for stdio to be ready.
     time.sleep(MAKE_TERM_CONNECT_DELAY)
 
-    child = spawnclass("make cleanterm", env=env, timeout=timeout,
+    child = spawnclass("{} cleanterm".format(MAKE), env=env, timeout=timeout,
                        codec_errors='replace', echo=False)
 
     # on many platforms, the termprog needs a short while to be ready...

--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+MAKE=${MAKE:-make}
+
 get_cmd_version() {
     if [ -z "$1" ]; then
         return
@@ -80,7 +82,7 @@ get_sys_shell() {
 }
 
 _get_make_shell() {
-    make -sf - 2>/dev/null <<MAKEFILE
+    ${MAKE} -sf - 2>/dev/null <<MAKEFILE
 \$(info \$(realpath \$(SHELL)))
 MAKEFILE
 }
@@ -156,7 +158,7 @@ for c in \
          cppcheck \
          doxygen \
          git \
-         make \
+         ${MAKE} \
          openocd \
          python \
          python2 \

--- a/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
+++ b/dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
@@ -95,6 +95,8 @@ LOG_HANDLER.setFormatter(logging.Formatter(logging.BASIC_FORMAT))
 
 LOG_LEVELS = ('debug', 'info', 'warning', 'error', 'fatal', 'critical')
 
+MAKE = os.environ.get('MAKE', 'make')
+
 
 class ErrorInTest(Exception):
     """Custom exception for a failed test.
@@ -156,7 +158,7 @@ def apps_directories(riotdir, apps_dirs=None, apps_dirs_skip=None):
 
 def _riot_applications_dirs(riotdir):
     """Applications directories in the RIOT repository with relative path."""
-    cmd = ['make', 'info-applications']
+    cmd = [MAKE, 'info-applications']
 
     out = subprocess.check_output(cmd, cwd=riotdir)
     out = out.decode('utf-8', errors='replace')
@@ -383,7 +385,7 @@ class RIOTApplication():
         full_env = os.environ.copy()
         full_env.update(env)
 
-        cmd = ['make']
+        cmd = [MAKE]
         cmd.extend(self.MAKEFLAGS)
         cmd.extend(['-C', os.path.join(self.riotdir, self.appdir)])
         cmd.extend(args)

--- a/dist/tools/compile_test/compile_test.py
+++ b/dist/tools/compile_test/compile_test.py
@@ -38,6 +38,9 @@ except ImportError:
 from itertools import tee
 
 
+MAKE = environ.get("MAKE", "make")
+
+
 class Termcolor:
     red = '\033[1;31m'
     green = '\033[1;32m'
@@ -90,7 +93,7 @@ def get_results_and_output_from(fd):
 
 
 def get_app_dirs():
-    return check_output(["make", "-f", "makefiles/app_dirs.inc.mk", "info-applications"]) \
+    return check_output([MAKE, "-f", "makefiles/app_dirs.inc.mk", "info-applications"]) \
             .decode("utf-8", errors="ignore")\
             .split()
 
@@ -130,7 +133,7 @@ def build_all():
             stdout.flush()
             try:
                 app_dir = join(riotbase, folder, application)
-                subprocess = Popen(('make', 'buildtest'),
+                subprocess = Popen((MAKE, 'buildtest'),
                                    bufsize=1, stdin=null, stdout=PIPE, stderr=null,
                                    cwd=app_dir,
                                    env=subprocess_env)

--- a/tests/lwip/tests/01-run.py
+++ b/tests/lwip/tests/01-run.py
@@ -18,6 +18,8 @@ import socket
 
 DEFAULT_TIMEOUT = 5
 
+MAKE = os.environ.get('MAKE', 'make')
+
 
 class Strategy(object):
     def __init__(self, func=None):
@@ -47,7 +49,7 @@ class BoardStrategy(Strategy):
         if env is not None:
             env.update(env)
         env.update(self.board.to_env())
-        cmd = ("make", "-C", application) + make_targets
+        cmd = (MAKE, "-C", application) + make_targets
         print(' '.join(cmd))
         print(subprocess.check_output(cmd, env=env))
 
@@ -165,7 +167,7 @@ def default_test_case(board_group, application, env=None):
         if env is not None:
             env.update(env)
         env.update(board.to_env())
-        with pexpect.spawnu("make", ["-C", application, "term"], env=env,
+        with pexpect.spawnu(MAKE, ["-C", application, "term"], env=env,
                             timeout=DEFAULT_TIMEOUT,
                             logfile=sys.stdout) as spawn:
             spawn.expect("TEST: SUCCESS")
@@ -201,9 +203,9 @@ def test_ipv6_send(board_group, application, env=None):
     if env is not None:
         env_receiver.update(env)
     env_receiver.update(board_group.boards[1].to_env())
-    with pexpect.spawnu("make", ["-C", application, "term"], env=env_sender,
+    with pexpect.spawnu(MAKE, ["-C", application, "term"], env=env_sender,
                         timeout=DEFAULT_TIMEOUT) as sender, \
-        pexpect.spawnu("make", ["-C", application, "term"], env=env_receiver,
+        pexpect.spawnu(MAKE, ["-C", application, "term"], env=env_receiver,
                        timeout=DEFAULT_TIMEOUT) as receiver:
         ipprot = random.randint(0x00, 0xff)
         receiver_ip = get_ipv6_address(receiver)
@@ -225,9 +227,9 @@ def test_udpv6_send(board_group, application, env=None):
     if env is not None:
         env_receiver.update(env)
     env_receiver.update(board_group.boards[1].to_env())
-    with pexpect.spawnu("make", ["-C", application, "term"], env=env_sender,
+    with pexpect.spawnu(MAKE, ["-C", application, "term"], env=env_sender,
                         timeout=DEFAULT_TIMEOUT) as sender, \
-        pexpect.spawnu("make", ["-C", application, "term"], env=env_receiver,
+        pexpect.spawnu(MAKE, ["-C", application, "term"], env=env_receiver,
                        timeout=DEFAULT_TIMEOUT) as receiver:
         port = random.randint(0x0000, 0xffff)
         receiver_ip = get_ipv6_address(receiver)
@@ -250,9 +252,9 @@ def test_tcpv6_send(board_group, application, env=None):
     if env is not None:
         env_server.update(env)
     env_server.update(board_group.boards[1].to_env())
-    with pexpect.spawnu("make", ["-C", application, "term"], env=env_client,
+    with pexpect.spawnu(MAKE, ["-C", application, "term"], env=env_client,
                         timeout=DEFAULT_TIMEOUT) as client, \
-        pexpect.spawnu("make", ["-C", application, "term"], env=env_server,
+        pexpect.spawnu(MAKE, ["-C", application, "term"], env=env_server,
                        timeout=DEFAULT_TIMEOUT) as server:
         port = random.randint(0x0000, 0xffff)
         server_ip = get_ipv6_address(server)
@@ -284,9 +286,9 @@ def test_tcpv6_multiconnect(board_group, application, env=None):
     if env is not None:
         env_server.update(env)
     env_server.update(board_group.boards[1].to_env())
-    with pexpect.spawnu("make", ["-C", application, "term"], env=env_client,
+    with pexpect.spawnu(MAKE, ["-C", application, "term"], env=env_client,
                         timeout=DEFAULT_TIMEOUT) as client, \
-        pexpect.spawnu("make", ["-C", application, "term"], env=env_server,
+        pexpect.spawnu(MAKE, ["-C", application, "term"], env=env_server,
                        timeout=DEFAULT_TIMEOUT) as server:
         port = random.randint(0x0000, 0xffff)
         server_ip = get_ipv6_address(server)
@@ -327,9 +329,9 @@ def test_triple_send(board_group, application, env=None):
     if env is not None:
         env_receiver.update(env)
     env_receiver.update(board_group.boards[1].to_env())
-    with pexpect.spawnu("make", ["-C", application, "term"], env=env_sender,
+    with pexpect.spawnu(MAKE, ["-C", application, "term"], env=env_sender,
                         timeout=DEFAULT_TIMEOUT) as sender, \
-        pexpect.spawnu("make", ["-C", application, "term"], env=env_receiver,
+        pexpect.spawnu(MAKE, ["-C", application, "term"], env=env_receiver,
                        timeout=DEFAULT_TIMEOUT) as receiver:
         udp_port = random.randint(0x0000, 0xffff)
         tcp_port = random.randint(0x0000, 0xffff)

--- a/tests/riotboot/tests/01-run.py
+++ b/tests/riotboot/tests/01-run.py
@@ -10,11 +10,12 @@
 import sys
 import subprocess
 from testrunner import run
+from testrunner.spawn import MAKE
 
 
 def flash_slot(slotnum, version):
     cmd = [
-        "make",
+        MAKE,
         "RIOTBOOT_SKIP_COMPILE=1",
         "riotboot/flash-slot{}".format(slotnum),
         "APP_VER={}".format(version),

--- a/tests/warn_conflict/tests/01-make.py
+++ b/tests/warn_conflict/tests/01-make.py
@@ -7,6 +7,7 @@ from traceback import print_tb
 import pexpect
 
 BOARD = os.getenv('BOARD', 'stm32f4discovery')
+MAKE = os.environ.get('MAKE', 'make')
 
 
 def testfunc():
@@ -20,7 +21,7 @@ def testfunc():
         if exc.errno == os.errno.ENOENT:
             print("ABORTING TEST: {} seems to be missing.\n".format(cross_gcc))
     else:
-        child = pexpect.spawnu(['make'], env=os.environ)
+        child = pexpect.spawnu([MAKE], env=os.environ)
         child.logfile = sys.stdout
 
         try:


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR enables the user to set the name of the `make` command via the `MAKE` environment variable in our test scripts. If it is not provided it defaults to just `make` in all cases.

While not strictly necessary for the use with FreeBSD, as one could bend the `gmake` command accordingly there to not use the incompatible BSD Make

https://github.com/RIOT-OS/RIOT/blob/8204931eb14c2be710b5adeb3b5ef7c7d8cdd992/dist/tools/vagrant/freebsd/Vagrantfile#L24-L28

I find it friendlier if that would be not needed to run our scripts (I can imagine similar problems might be faced on Mac OS X and Windows).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Touched tools and tests should be run 


- [x] `dist/tools/ci/print_toolchain_versions.sh`
- [x] Any test using `testrunner` (one should be enough, but we can also just run `CI: run tests`)
- [x] `dist/tools/compile_and_test_for_board/compile_and_test_for_board.py` for at least one board
- [x] `dist/tools/compile_test/compile_test.py` for at most one application combination (can be canceled after the first application passes)
- [x] `tests/lwip` on `native`
- [x] `tests/riotboot`
- [x] `tests/warn_conflicts`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Discovered while working on #14458, but not required for it.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
