### PR TITLE
riotctrl_shell.netif: add missing check_term decorator

### DIFF
--- a/dist/pythonlibs/riotctrl_shell/netif.py
+++ b/dist/pythonlibs/riotctrl_shell/netif.py
@@ -279,6 +279,7 @@ class Ifconfig(ShellInteraction):
     def ifconfig_list(self, netif=None, timeout=-1, async_=False):
         return self.ifconfig_cmd(netif=netif, timeout=timeout, async_=async_)
 
+    @ShellInteraction.check_term
     def ifconfig_cmd(self, netif=None, args=None, timeout=-1, async_=False):
         cmd = "ifconfig"
         if netif is not None:
@@ -370,6 +371,7 @@ class Ifconfig(ShellInteraction):
 
 
 class TXTSnd(ShellInteraction):
+    @ShellInteraction.check_term
     def netif_txtsnd(self, netif, target, data, timeout=-1, async_=False):
         cmd = "txtsnd {netif} {target} {data}".format(
             netif=netif,

--- a/dist/pythonlibs/riotctrl_shell/tests/common.py
+++ b/dist/pythonlibs/riotctrl_shell/tests/common.py
@@ -4,25 +4,27 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
+import contextlib
+
 
 class MockSpawn():
-    def __init__(self, *args, **kwargs):
+    def __init__(self, ctrl, *args, **kwargs):
+        self.ctrl = ctrl
+        self.last_command = None
         # set some expected attributes
         self.before = None
         self.echo = False
-        self.output = None
-        self.last_command = None
 
     def sendline(self, line, *args, **kwargs):
         self.last_command = line
-        if self.output is None:
+        if self.ctrl.output is None:
             # just echo last input for before (what replwrap is assembling
             # output from)
             self.before = line
         else:
             # use pre-configured output in case command expects a specific
             # output
-            self.before = self.output
+            self.before = self.ctrl.output
 
     def expect_exact(self, *args, **kwargs):
         # always match on prompt with replwrap
@@ -34,11 +36,26 @@ class MockRIOTCtrl():
     Mock RIOT ctrl
     """
     def __init__(self, *args, **kwargs):
-        self.term = MockSpawn()
+        self.term = None
+        self.output = None
         self.last_command = None
+
+    @contextlib.contextmanager
+    def run_term(self, reset=True, **startkwargs):
+        try:
+            self.start_term(**startkwargs)
+            yield self.term
+        finally:
+            self.stop_term()
+
+    def start_term(self, **spawnkwargs):
+        self.term = MockSpawn(self)
+
+    def stop_term(self):
+        pass
 
 
 def init_ctrl(output=None):
     rc = MockRIOTCtrl("foobar", env={"BOARD": "native"})
-    rc.term.output = output
+    rc.output = output
     return rc


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
In #14441 I forgot to add the `check_term()` decorators to the methods that require it, which if not added one might run into a AttributeError since the `term` member of `self.riotctrl` is still None. This fixes that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests-tools` Github Action should still pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #14441.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
