### PR TITLE
Fix bad assertion in cpu/stm32/periph/pwm.c

### DIFF
--- a/cpu/stm32/periph/pwm.c
+++ b/cpu/stm32/periph/pwm.c
@@ -45,7 +45,7 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
     uint32_t timer_clk = periph_timer_clk(pwm_config[pwm].bus);
 
     /* verify parameters */
-    assert((pwm < PWM_NUMOF) && ((freq * res) < timer_clk));
+    assert((pwm < PWM_NUMOF) && ((freq * res) <= timer_clk));
 
     /* power on the used timer */
     periph_clk_en(pwm_config[pwm].bus, pwm_config[pwm].rcc_mask);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
`assert((pwm < PWM_NUMOF) && ((freq * res) < timer_clk));`
This prevent to set optimal resolution for a given frequency which is (freq * res) = timer_clk.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Using tests/peiph_pwm on a bluepill (stm32f103c8t6) which have 72MHz clock frequency for the first timer, the best resolution for a 100KHz pwm output is 720 :
```
2020-07-08 12:02:05,649 #  main(): This is RIOT! (Version: 2020.07-devel-1839-g15263e-iss14361)
2020-07-08 12:02:05,651 # PWM peripheral driver test
2020-07-08 12:02:05,651 # 
init 0 0 100000 720
2020-07-08 12:02:10,204 #  init 0 0 100000 720
2020-07-08 12:02:10,208 # The pwm frequency is set to 100000
init 0 0 100000 721
2020-07-08 12:02:13,731 #  init 0 0 100000 721
2020-07-08 12:02:13,731 # 0x80016b3
2020-07-08 12:02:13,734 # *** RIOT kernel panic:
2020-07-08 12:02:13,737 # FAILED ASSERTION.
2020-07-08 12:02:13,738 # 
2020-07-08 12:02:13,738 # *** halted.
2020-07-08 12:02:13,738 # 
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #14361.
