### PR TITLE
dist/tools/kconfiglib: Use python3 for RIOT adaption of menuconfig

### DIFF
--- a/dist/tools/kconfiglib/riot_menuconfig.py
+++ b/dist/tools/kconfiglib/riot_menuconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ Menuconfig variant which uses RiotKconfig as base class """
 import menuconfig
 from riot_kconfig import standard_riot_kconfig


### PR DESCRIPTION
### Contribution description
#14401 updated kconfiglib to the newer version which uses python3. This updates our `menuconfig` wrapper to run with python3 as well. @pokgak reported that `menuconfig` fails to execute on Ubuntu 20.04 as python2 is not there.

### Testing procedure
- Green CI
- Run `make menuconfig`, you should be able to configure parameters and configuration files should be generated properly (`bin/<BOARD>/generated`).

### Issues/PRs references
Follow-up of #14401 
