### PR TITLE
riotctrl_shell.gnrc: add doctests as parsing examples and bugfixes

### DIFF
--- a/dist/pythonlibs/riotctrl_shell/gnrc.py
+++ b/dist/pythonlibs/riotctrl_shell/gnrc.py
@@ -93,7 +93,7 @@ class GNRCICMPv6EchoParser(ShellInteractionParser):
         8.839
         """
         res = {}
-        c_reply = re.compile(r"\d+ bytes from (?P<source>[0-9a-f:]+): "
+        c_reply = re.compile(r"\d+ bytes from (?P<source>[0-9a-f:]+(%\S+)?): "
                              r"icmp_seq=(?P<seq>\d+) ttl=(?P<ttl>\d+) "
                              r"(rssi=(?P<rssi>-?\d+) dBm )?"
                              r"time=(?P<rtt>\d+.\d+) ms")

--- a/dist/pythonlibs/riotctrl_shell/tests/test_gnrc.py
+++ b/dist/pythonlibs/riotctrl_shell/tests/test_gnrc.py
@@ -19,7 +19,7 @@ def test_ping6():
     assert " -i 100 " in res
 
 
-def test_ping6_parser_success():
+def test_ping6_parser_success1():
     parser = riotctrl_shell.gnrc.GNRCICMPv6EchoParser()
     ping_res = parser.parse("""
 12 bytes from ::1: icmp_seq=0 ttl=64 time=0.435 ms
@@ -29,27 +29,46 @@ def test_ping6_parser_success():
 --- ::1 PING statistics ---
 3 packets transmitted, 3 packets received, 0% packet loss
 round-trip min/avg/max = 0.432/0.433/0.435 ms""")
-    assert ping_res is not None
+    assert ping_res
     assert "rtts" in ping_res
     assert "avg" in ping_res["rtts"]
+
+
+def test_ping6_parser_success2():
+    parser = riotctrl_shell.gnrc.GNRCICMPv6EchoParser()
+    ping_res = parser.parse("""
+12 bytes from ::1: icmp_seq=0 ttl=64
+12 bytes from ::1: icmp_seq=1 ttl=64
+12 bytes from ::1: icmp_seq=1 ttl=64 (DUP)
+
+--- ::1 PING statistics ---
+2 packets transmitted, 3 packets received, 1 duplicates, 0% packet loss
+round-trip min/avg/max = 0.432/0.433/0.435 ms""")
+    assert ping_res
+    assert "rtts" in ping_res
+    assert "avg" in ping_res["rtts"]
+    assert len(ping_res["replies"]) == 3
+    assert ping_res["replies"][2]["dup"]
 
 
 def test_ping6_parser_empty():
     parser = riotctrl_shell.gnrc.GNRCICMPv6EchoParser()
     ping_res = parser.parse("")
-    assert ping_res is None
+    assert not ping_res
 
 
 def test_ping6_parser_missing_rtts():
     parser = riotctrl_shell.gnrc.GNRCICMPv6EchoParser()
     ping_res = parser.parse("""
-12 bytes from ::1: icmp_seq=0 ttl=64 time=0.553 ms
-12 bytes from ::1: icmp_seq=1 ttl=64 time=0.496 ms
-12 bytes from ::1: icmp_seq=2 ttl=64 time=0.496 ms
+12 bytes from ::1: icmp_seq=0 ttl=64
+12 bytes from ::1: icmp_seq=1 ttl=64
+12 bytes from ::1: icmp_seq=2 ttl=64
 
 --- ::1 PING statistics ---
 3 packets transmitted, 3 packets received, 0% packet loss""")
-    assert ping_res is None
+    assert ping_res
+    assert "rtts" not in ping_res
+    assert len(ping_res["replies"]) == 3
 
 
 def test_pktbuf():


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Examples are always good to understand a concept, that's why I added further `doctests` to the documentation of the GNRC shell interaction parsers (for those that did not have any yet).

In this instance I found a bug as well in the ping6 parser due to using a real-world example from the testbed in the doc-test, for which I piggy-backed the fix.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tox` executes the doctests, so `tools-test` should pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
