### PR TITLE
boards/ek-lm4f120xl: Model features in Kconfig

### DIFF
--- a/boards/ek-lm4f120xl/Kconfig
+++ b/boards/ek-lm4f120xl/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "ek-lm4f120xl" if BOARD_EK_LM4F120XL
+
+config BOARD_EK_LM4F120XL
+    bool
+    default y
+    select CPU_MODEL_LM4F120H5QR
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/cpu/lm4f120/Kconfig
+++ b/cpu/lm4f120/Kconfig
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_FAM_LM4F120
+    bool
+    select CPU_CORE_CORTEX_M4F
+    select HAS_CORTEXM_MPU
+    select HAS_CPU_LM4F120
+
+config CPU_MODEL_LM4F120H5QR
+    bool
+    select CPU_FAM_LM4F120
+
+## Declaration of specific features
+config HAS_CPU_LM4F120
+    bool
+    help
+        Indicates that a 'lm4f120' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "lm4f120" if CPU_FAM_LM4F120
+
+config CPU
+    default "lm4f120" if CPU_FAM_LM4F120
+
+config CPU_MODEL
+    # uppercase to match the Makefile.features
+    default "LM4F120H5QR" if CPU_MODEL_LM4F120H5QR
+
+source "$(RIOTCPU)/cortexm_common/Kconfig"

--- a/cpu/lm4f120/Makefile.features
+++ b/cpu/lm4f120/Makefile.features
@@ -1,5 +1,6 @@
 CPU_CORE = cortex-m4f
+CPU_FAM = lm4f120
 
 FEATURES_PROVIDED += cortexm_mpu
 
--include $(RIOTCPU)/cortexm_common/Makefile.features
+include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -30,6 +30,7 @@ BOARD_WHITELIST += acd52832 \
                    derfmega128 \
                    derfmega256 \
                    dwm1001 \
+                   ek-lm4f120xl \
                    esp32-heltec-lora32-v2 \
                    esp32-mh-et-live-minikit \
                    esp32-olimex-evb \


### PR DESCRIPTION
### Contribution description
This models the features of the `ek-lm4f120xl` board (the only that uses `lm4f120` CPUs).

### Testing procedure
- Green CI
- `tests/kconfig_features` should pass

### Issues/PRs references
Part of #14148 