### PR TITLE
boards/lpc1768-based: Model features in Kconfig

### DIFF
--- a/boards/mbed_lpc1768/Kconfig
+++ b/boards/mbed_lpc1768/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "mbed_lpc1768" if BOARD_MBED_LPC1768
+
+config BOARD_MBED_LPC1768
+    bool
+    default y
+    select CPU_MODEL_LPC1768
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/seeeduino_arch-pro/Kconfig
+++ b/boards/seeeduino_arch-pro/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "seeeduino_arch-pro" if BOARD_SEEEDUINO_ARCH_PRO
+
+config BOARD_SEEEDUINO_ARCH_PRO
+    bool
+    default y
+    select CPU_MODEL_LPC1768
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/cpu/lpc1768/Kconfig
+++ b/cpu/lpc1768/Kconfig
@@ -1,0 +1,37 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_FAM_LPC176X
+    bool
+    select CPU_CORE_CORTEX_M3
+    select HAS_CORTEXM_MPU
+    select HAS_PERIPH_CPUID
+    select HAS_PERIPH_PM
+
+## CPU Models
+config CPU_MODEL_LPC1768
+    bool
+    select CPU_FAM_LPC176X
+    select HAS_CPU_LPC1768
+
+## Declaration of specific features
+config HAS_CPU_LPC1768
+    bool
+    help
+        Indicates that an 'lpc1768' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "lpc176x" if CPU_FAM_LPC176X
+
+config CPU_MODEL
+    default "lpc1768" if CPU_MODEL_LPC1768
+
+config CPU
+    default "lpc1768" if CPU_MODEL_LPC1768
+
+source "$(RIOTCPU)/cortexm_common/Kconfig"

--- a/cpu/lpc1768/Makefile.features
+++ b/cpu/lpc1768/Makefile.features
@@ -1,4 +1,5 @@
 CPU_CORE = cortex-m3
+CPU_FAM = lpc176x
 # This CPU only implements one CPU_MODEL with the same name
 CPU_MODEL = lpc1768
 
@@ -6,4 +7,4 @@ FEATURES_PROVIDED += cortexm_mpu
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_pm
 
--include $(RIOTCPU)/cortexm_common/Makefile.features
+include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -59,6 +59,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    lobaro-lorabox \
                    lsn50 \
                    maple-mini \
+                   mbed_lpc1768 \
                    mega-xplained \
                    microbit \
                    microduino-corerf \
@@ -133,6 +134,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    remote-revb \
                    ruuvitag \
                    samr21-xpro \
+                   seeeduino_arch-pro \
                    slstk3401a \
                    slstk3402a \
                    sltb001a \


### PR DESCRIPTION
### Contribution description
This models the features for the boards using the `lpc1768` CPU:
- `mbed_lpc1768`
- `seeeduino_arch-pro`

### Testing procedure
- Green CI
- `tests/kconfig_features` should pass for both boards

### Issues/PRs references
Part of #14148 