### PR TITLE
boards/lpc2387-based: Model features in Kconfig

### DIFF
--- a/boards/avsextrem/Kconfig
+++ b/boards/avsextrem/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "avsextrem" if BOARD_AVSEXTREM
+
+config BOARD_AVSEXTREM
+    bool
+    default y
+    select CPU_MODEL_LPC2387
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/mcb2388/Kconfig
+++ b/boards/mcb2388/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "mcb2388" if BOARD_MCB2388
+
+config BOARD_MCB2388
+    bool
+    default y
+    select CPU_MODEL_LPC2388
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/msba2/Kconfig
+++ b/boards/msba2/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "msba2" if BOARD_MSBA2
+
+config BOARD_MSBA2
+    bool
+    default y
+    select CPU_MODEL_LPC2387
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/cpu/arm7_common/Kconfig
+++ b/cpu/arm7_common/Kconfig
@@ -1,0 +1,33 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_ARCH_ARMV4T
+    bool
+    select HAS_ARCH_32BIT
+    select HAS_ARCH_ARM
+    select HAS_CPP
+
+config CPU_CORE_ARM7TDMI_S
+    bool
+    select CPU_ARCH_ARMV4T
+    select HAS_ARCH_ARM7
+    select HAS_PERIPH_PM
+    select HAS_PUF_SRAM
+    select HAS_SSP
+
+## Declaration of specific features
+config HAS_ARCH_ARM7
+    bool
+    help
+        Indicates that the core is part of the ARM7 group of cores.
+
+## Common CPU symbols
+config CPU_ARCH
+    default "armv4t" if CPU_ARCH_ARMV4T
+
+config CPU_CORE
+    default "arm7tdmi_s" if CPU_CORE_ARM7TDMI_S

--- a/cpu/arm7_common/Makefile.features
+++ b/cpu/arm7_common/Makefile.features
@@ -1,3 +1,6 @@
+CPU_ARCH = armv4t
+CPU_CORE = arm7tdmi_s
+
 FEATURES_PROVIDED += arch_32bit
 FEATURES_PROVIDED += arch_arm
 FEATURES_PROVIDED += arch_arm7

--- a/cpu/cortexm_common/Kconfig
+++ b/cpu/cortexm_common/Kconfig
@@ -88,11 +88,6 @@ config HAS_CPU_CORE_CORTEXM
     help
         Indicates that the current CPU has an ARM Cortex-M core.
 
-config HAS_ARCH_ARM
-    bool
-    help
-        Indicates that the current architecture is ARM.
-
 config HAS_CORTEXM_FPU
     bool
     help

--- a/cpu/lpc23xx/Kconfig
+++ b/cpu/lpc23xx/Kconfig
@@ -1,0 +1,44 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_FAM_LPC23XX
+    bool
+    select CPU_CORE_ARM7TDMI_S
+    select HAS_BACKUP_RAM
+    select HAS_CPU_LPC23XX
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_TIMER_PERIODIC
+
+## CPU Models
+config CPU_MODEL_LPC2387
+    bool
+    select CPU_FAM_LPC23XX
+
+config CPU_MODEL_LPC2388
+    bool
+    select CPU_FAM_LPC23XX
+
+## Declaration of specific features
+config HAS_CPU_LPC23XX
+    bool
+    help
+        Indicates that an 'lpc23xx' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "lpc23xx" if CPU_FAM_LPC23XX
+
+config CPU_MODEL
+    default "lpc2387" if CPU_MODEL_LPC2387
+    default "lpc2388" if CPU_MODEL_LPC2388
+
+config CPU
+    default "lpc23xx" if CPU_FAM_LPC23XX
+
+source "$(RIOTCPU)/arm7_common/Kconfig"

--- a/cpu/lpc23xx/Makefile.features
+++ b/cpu/lpc23xx/Makefile.features
@@ -4,4 +4,4 @@ FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer_periodic
 
--include $(RIOTCPU)/arm7_common/Makefile.features
+include $(RIOTCPU)/arm7_common/Makefile.features

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -22,6 +22,11 @@ config HAS_ARCH_32BIT
     help
         Indicates that the CPU has a 32-bits architecture.
 
+config HAS_ARCH_ARM
+    bool
+    help
+        Indicates that the current architecture is ARM.
+
 config HAS_ARDUINO
     bool
     help

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -15,6 +15,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    atmega256rfr2-xpro \
                    atmega328p \
                    avr-rss2 \
+                   avsextrem \
                    b-l072z-lrwan1 \
                    b-l475e-iot01a \
                    blackpill \
@@ -61,11 +62,13 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    lsn50 \
                    maple-mini \
                    mbed_lpc1768 \
+                   mcb2388 \
                    mega-xplained \
                    microbit \
                    microduino-corerf \
                    msb-430 \
                    msb-430h \
+                   msba2 \
                    msbiot \
                    mulle \
                    native \


### PR DESCRIPTION
### Contribution description
This PR adds the features for all `lpc2387`-based boards. The symbols for the [arm7tdmi_s](https://developer.arm.com/documentation/ddi0234/b/introduction/about-the-arm7tdmi-s-processor?lang=en) core and the implemented [armv4t](https://developer.arm.com/documentation/dui0471/m/key-features-of-arm-architecture-versions/arm-architecture-v4t) architecture are also added. Missing `CPU_` symbols are added to the Makefiles. The boards are:
- `avsextrem`
- `mcb2388`
- `msba2`

### Testing procedure
- Check the symbol naming and organization
- Green CI
- `test/kconfig_features` should pass for all the boards


### Issues/PRs references
Part of #14148 