### PR TITLE
examples/dtls-echo: fix silent fail with ECC

### DIFF
--- a/examples/dtls-echo/dtls-client.c
+++ b/examples/dtls-echo/dtls-client.c
@@ -43,9 +43,9 @@
 
 /* Delay to give time to the remote peer to do the compute (client only). */
 #ifdef CONFIG_DTLS_ECC
-#define DEFAULT_US_DELAY 10000000
+#define DEFAULT_US_DELAY    (20 * US_PER_SEC)
 #else
-#define DEFAULT_US_DELAY 100
+#define DEFAULT_US_DELAY    (1 * US_PER_SEC)
 #endif
 
 static int dtls_connected = 0; /* This is handled by Tinydtls callbacks */
@@ -108,7 +108,7 @@ static int dtls_handle_read(dtls_context_t *ctx)
     }
 
     ssize_t res = sock_udp_recv(sock, packet_rcvd, sizeof(packet_rcvd),
-                                1 * US_PER_SEC + DEFAULT_US_DELAY, &remote);
+                                DEFAULT_US_DELAY, &remote);
 
     if (res <= 0) {
         if ((ENABLE_DEBUG) && (res != -EAGAIN) && (res != -ETIMEDOUT)) {
@@ -454,6 +454,11 @@ static void client_send(char *addr_str, char *data)
         }
         watch--;
     } /* END while */
+
+    /* check if we failed to send */
+    if ((app_data_buf != 0)) {
+        printf("Failed to send the data\n");
+    }
 
     /*
      * BUG: tinyDTLS (<= 0.8.6)


### PR DESCRIPTION
### Contribution description

Sending and receiving packets with DTLS on hardware takes longer (around 90 seconds on `samr21-xpro`). This PR increases the timeout when waiting for the server response and also prints an error message if the message cannot be sent successfully.

### Testing procedure

1. Uncomment `CFLAGS += -DCONFIG_DTLS_ECC` in the Makefile
2. Build and flash on to two boards.
3. Start a server on one board with `dtlss start`. Send a message to the server from the other board with `dtlsc <server ip> hello`.

Without the PR, the client will blocks for a while (~90 seconds) and then returns without receiving any echo back from the server or errors.

With this PR, the client will block for a while and then `Client: got DTLS Data App -- <message> --` will be printed on the shell.

### Issues/PRs references

Fixes #11859 