### PR TITLE
tests/warn_conflict: fix python test script

### DIFF
--- a/tests/warn_conflict/tests/01-make.py
+++ b/tests/warn_conflict/tests/01-make.py
@@ -26,7 +26,7 @@ def testfunc():
         try:
             if BOARD == 'stm32f4discovery':
                 child.expect_exact('\x1b[1;33mThe following features may conflict:'
-                                   '\x1b[0m \x1b[1;32mperiph_dac periph_spi\x1b[0m')
+                                   '\x1b[0m periph_dac periph_spi')
                 child.expect_exact('\x1b[1;33mRationale: '
                                    '\x1b[0mOn stm32f4discovery boards there are '
                                    'the same pins for the DAC and/or SPI_0.')


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the Python test script of the `tests/warn_conflict` test: in master the Python test script expects that the conflicting features are displayed with a specific color, which is not the case.

There are 2 ways to fix this:
- restore the color used to print the conflicting features in the build system
- adapt the Python test script

This PR goes for the latter because there's already a lot of colors in the output and it's already enough readable.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `make -C tests/warn_conflict test` (can only be tested for stm32f4discovery but the board is not required):

<details><summary>this PR</summary>

```
make -C tests/warn_conflict clean test --no-print-directory 
The following features may conflict: periph_dac periph_spi
Rationale: On stm32f4discovery boards there are the same pins for the DAC and/or SPI_0.

EXPECT undesired behaviour!
```

</details>


<details><summary>master</summary>

```
make -C tests/warn_conflict clean test --no-print-directory 
The following features may conflict: periph_dac periph_spi
Rationale: On stm32f4discovery boards there are the same pins for the DAC and/or SPI_0.

EXPECT undesired behaviour!
Building application "tests_warn_conflict" for "stm32f4discovery" with MCU "stm32".

"/usr/bin/make" -C /work/riot/RIOT/boards/stm32f4discovery
"/usr/bin/make" -C /work/riot/RIOT/core
"/usr/bin/make" -C /work/riot/RIOT/cpu/stm32
"/usr/bin/make" -C /work/riot/RIOT/cpu/cortexm_common
"/usr/bin/make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"/usr/bin/make" -C /work/riot/RIOT/cpu/stm32/bootloader
"/usr/bin/make" -C /work/riot/RIOT/cpu/stm32/periph
"/usr/bin/make" -C /work/riot/RIOT/cpu/stm32/stmclk
"/usr/bin/make" -C /work/riot/RIOT/cpu/stm32/vectors
"/usr/bin/make" -C /work/riot/RIOT/drivers
"/usr/bin/make" -C /work/riot/RIOT/drivers/periph_common
"/usr/bin/make" -C /work/riot/RIOT/sys
"/usr/bin/make" -C /work/riot/RIOT/sys/auto_init
"/usr/bin/make" -C /work/riot/RIOT/sys/isrpipe
"/usr/bin/make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"/usr/bin/make" -C /work/riot/RIOT/sys/pm_layered
"/usr/bin/make" -C /work/riot/RIOT/sys/stdio_uart
"/usr/bin/make" -C /work/riot/RIOT/sys/test_utils/interactive_sync
"/usr/bin/make" -C /work/riot/RIOT/sys/tsrb
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/stm32_vectors/vectors_f4.o: in function `dummy_handler':
/work/riot/RIOT/cpu/stm32/vectors/vectors_f4.c:28: multiple definition of `dummy_handler'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/stm32_vectors/vectors_f4.o:/work/riot/RIOT/cpu/stm32/vectors/vectors_f4.c:28: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/stm32_vectors/vectors_f4.o:/work/riot/RIOT/cpu/stm32/vectors/vectors_f4.c:142: multiple definition of `vector_cpu'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/stm32_vectors/vectors_f4.o:/work/riot/RIOT/cpu/stm32/vectors/vectors_f4.c:142: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_init':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:141: multiple definition of `_init'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:141: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_fini':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:150: multiple definition of `_fini'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:150: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_exit':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:161: multiple definition of `_exit'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:161: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_sbrk_r':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:177: multiple definition of `_sbrk_r'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:177: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_getpid':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:232: multiple definition of `_getpid'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:232: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_getpid_r':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:243: multiple definition of `_getpid_r'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:243: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_read_r':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:500: multiple definition of `_read_r'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:500: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_write_r':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:513: multiple definition of `_write_r'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:513: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_open_r':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:522: multiple definition of `_open_r'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:522: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_close_r':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:529: multiple definition of `_close_r'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:529: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_lseek_r':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:538: multiple definition of `_lseek_r'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:538: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_fstat_r':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:546: multiple definition of `_fstat_r'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:546: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_stat_r':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:554: multiple definition of `_stat_r'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:554: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_unlink_r':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:561: multiple definition of `_unlink_r'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:561: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_link_r':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:578: multiple definition of `_link_r'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:578: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_isatty_r':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:600: multiple definition of `_isatty_r'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:600: first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_gettimeofday_r':
syscalls.c:(.text._gettimeofday_r+0x0): multiple definition of `_gettimeofday_r'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:syscalls.c:(.text._gettimeofday_r+0x0): first defined here
/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o: in function `_times_r':
/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:649: multiple definition of `_times_r'; /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/newlib_syscalls_default/syscalls.o:/work/riot/RIOT/sys/newlib_syscalls_default/syscalls.c:649: first defined here
collect2: error: ld returned 1 exit status
make[1]: *** [/work/riot/RIOT/Makefile.include:572: /work/riot/RIOT/tests/warn_conflict/bin/stm32f4discovery/tests_warn_conflict.elf] Error 1
Unexpected end of file in expect script
  File "/work/riot/RIOT/tests/warn_conflict/tests/01-make.py", line 28, in testfunc
    child.expect_exact('\x1b[1;33mThe following features may conflict:'
  File "/usr/lib/python3/dist-packages/pexpect/spawnbase.py", line 418, in expect_exact
    return exp.expect_loop(timeout)
  File "/usr/lib/python3/dist-packages/pexpect/expect.py", line 117, in expect_loop
    return self.eof(e)
  File "/usr/lib/python3/dist-packages/pexpect/expect.py", line 63, in eof
    raise EOF(msg)
make: *** [/work/riot/RIOT/tests/warn_conflict/../../Makefile.include:770: test] Error 1
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while reviewing #14459

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
