### PR TITLE
boards/mips32r2-based: Model features in Kconfig

### DIFF
--- a/boards/6lowpan-clicker/Kconfig
+++ b/boards/6lowpan-clicker/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "6lowpan-clicker" if BOARD_6LOWPAN_CLICKER
+
+config BOARD_6LOWPAN_CLICKER
+    bool
+    default y
+    select CPU_MODEL_P32MX470F512H
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/pic32-wifire/Kconfig
+++ b/boards/pic32-wifire/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "pic32-wifire" if BOARD_PIC32_WIFIRE
+
+config BOARD_PIC32_WIFIRE
+    bool
+    default y
+    select CPU_MODEL_P32MZ2048EFG100
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/cpu/mips32r2_common/Kconfig
+++ b/cpu/mips32r2_common/Kconfig
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_ARCH_MIPS32R2
+    bool
+    select HAS_ARCH_32BIT
+    select HAS_ARCH_MIPS32R2
+    select HAS_CPP
+    select HAS_PERIPH_PM
+
+config CPU_CORE_M4K
+    bool
+    select CPU_ARCH_MIPS32R2
+
+config CPU_CORE_M5101
+    bool
+    select CPU_ARCH_MIPS32R2
+
+## Declaration of specific features
+config HAS_ARCH_MIPS32R2
+    bool
+    help
+        Indicates that the current architecture is 'mips32r2'.
+
+## Common CPU symbols
+config CPU_ARCH
+    default "mips32r2" if CPU_ARCH_MIPS32R2
+
+config CPU_CORE
+    default "m4k" if CPU_CORE_M4K
+    default "m5101" if CPU_CORE_M5101

--- a/cpu/mips32r2_common/Makefile.features
+++ b/cpu/mips32r2_common/Makefile.features
@@ -1,3 +1,5 @@
+CPU_ARCH = mips32r2
+
 FEATURES_PROVIDED += arch_32bit
 FEATURES_PROVIDED += arch_mips32r2
 FEATURES_PROVIDED += cpp

--- a/cpu/mips_pic32_common/Kconfig
+++ b/cpu/mips_pic32_common/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_COMMON_MIPS_PIC32
+    bool
+    select HAS_PERIPH_CPUID
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+
+source "$(RIOTCPU)/mips32r2_common/Kconfig"

--- a/cpu/mips_pic32_common/Makefile.features
+++ b/cpu/mips_pic32_common/Makefile.features
@@ -1,4 +1,4 @@
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 
--include $(RIOTCPU)/mips32r2_common/Makefile.features
+include $(RIOTCPU)/mips32r2_common/Makefile.features

--- a/cpu/mips_pic32mx/Kconfig
+++ b/cpu/mips_pic32mx/Kconfig
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_FAM_PIC32MX
+    bool
+    select CPU_COMMON_MIPS_PIC32
+    select CPU_CORE_M4K
+    select HAS_CPU_MIPS_PIC32MX
+
+## CPU Models
+config CPU_MODEL_P32MX470F512H
+    bool
+    select CPU_FAM_PIC32MX
+
+## Declaration of specific features
+config HAS_CPU_MIPS_PIC32MX
+    bool
+    help
+        Indicates that a 'mips_pic32mx' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "pic32mx" if CPU_FAM_PIC32MX
+
+config CPU_MODEL
+    default "p32mx470f512h" if CPU_MODEL_P32MX470F512H
+
+config CPU
+    default "mips_pic32mx" if CPU_FAM_PIC32MX
+
+source "$(RIOTCPU)/mips_pic32_common/Kconfig"

--- a/cpu/mips_pic32mx/Makefile.features
+++ b/cpu/mips_pic32mx/Makefile.features
@@ -1,5 +1,4 @@
-CPU_ARCH = mips32
 CPU_CORE = m4k
 CPU_FAM = pic32mx
 
--include $(RIOTCPU)/mips_pic32_common/Makefile.features
+include $(RIOTCPU)/mips_pic32_common/Makefile.features

--- a/cpu/mips_pic32mz/Kconfig
+++ b/cpu/mips_pic32mz/Kconfig
@@ -1,0 +1,36 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_FAM_PIC32MZ
+    bool
+    select CPU_COMMON_MIPS_PIC32
+    select CPU_CORE_M5101
+    select HAS_CPU_MIPS_PIC32MZ
+    select HAS_PERIPH_HWRNG
+
+## CPU Models
+config CPU_MODEL_P32MZ2048EFG100
+    bool
+    select CPU_FAM_PIC32MZ
+
+## Declaration of specific features
+config HAS_CPU_MIPS_PIC32MZ
+    bool
+    help
+        Indicates that a 'mips_pic32mz' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "pic32mz" if CPU_FAM_PIC32MZ
+
+config CPU_MODEL
+    default "p32mz2048efg100" if CPU_MODEL_P32MZ2048EFG100
+
+config CPU
+    default "mips_pic32mz" if CPU_FAM_PIC32MZ
+
+source "$(RIOTCPU)/mips_pic32_common/Kconfig"

--- a/cpu/mips_pic32mz/Makefile.features
+++ b/cpu/mips_pic32mz/Makefile.features
@@ -1,7 +1,6 @@
-CPU_ARCH = mips32
 CPU_CORE = m5101
 CPU_FAM = pic32mz
 
 FEATURES_PROVIDED += periph_hwrng
 
--include $(RIOTCPU)/mips_pic32_common/Makefile.features
+include $(RIOTCPU)/mips_pic32_common/Makefile.features

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_WHITELIST += acd52832 \
+BOARD_WHITELIST += 6lowpan-clicker \
+                   acd52832 \
                    adafruit-clue \
                    airfy-beacon \
                    arduino-duemilanove \
@@ -122,6 +123,7 @@ BOARD_WHITELIST += acd52832 \
                    particle-xenon \
                    pba-d-01-kw2x \
                    phynode-kw41z \
+                   pic32-wifire \
                    pinetime \
                    pyboard \
                    reel \


### PR DESCRIPTION
### Contribution description
This models the features provided by the boards based on CPUs implementing the `mips32r2` architecture:
- `6lowpan-clicker`
- `pic32-wifire`

### Testing procedure
- Check symbol organization and naming
- Green CI: `tests/kconfig_features` should pass for both boards

### Issues/PRs references
Part of #14148