### PR TITLE
boards/sam3-based: Model features in Kconfig

### DIFF
--- a/boards/arduino-due/Kconfig
+++ b/boards/arduino-due/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "arduino-due" if BOARD_ARDUINO_DUE
+
+config BOARD_ARDUINO_DUE
+    bool
+    default y
+    select BOARD_COMMON_ARDUINO_DUE
+
+source "$(RIOTBOARD)/common/arduino-due/Kconfig"

--- a/boards/common/arduino-due/Kconfig
+++ b/boards/common/arduino-due/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_COMMON_ARDUINO_DUE
+    bool
+    select CPU_MODEL_SAM3X8E
+    select HAS_ARDUINO
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/udoo/Kconfig
+++ b/boards/udoo/Kconfig
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "udoo" if BOARD_UDOO
+
+config BOARD_UDOO
+    bool
+    default y
+    select BOARD_COMMON_ARDUINO_DUE
+
+source "$(RIOTBOARD)/common/arduino-due/Kconfig"

--- a/cpu/sam3/Kconfig
+++ b/cpu/sam3/Kconfig
@@ -1,0 +1,37 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_FAM_SAM3
+    bool
+    select CPU_CORE_CORTEX_M3
+    select HAS_CORTEXM_MPU
+    select HAS_CPU_SAM3
+    select HAS_PERIPH_CPUID
+    select HAS_PERIPH_HWRNG
+
+## CPU Models
+config CPU_MODEL_SAM3X8E
+    bool
+    select CPU_FAM_SAM3
+
+## Declaration of specific features
+config HAS_CPU_SAM3
+    bool
+    help
+        Indicates that a 'sam3' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "sam3" if CPU_FAM_SAM3
+
+config CPU_MODEL
+    default "sam3x8e" if CPU_MODEL_SAM3X8E
+
+config CPU
+    default "sam3" if CPU_FAM_SAM3
+
+source "$(RIOTCPU)/cortexm_common/Kconfig"

--- a/cpu/sam3/Makefile.features
+++ b/cpu/sam3/Makefile.features
@@ -5,4 +5,4 @@ FEATURES_PROVIDED += cortexm_mpu
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_hwrng
 
--include $(RIOTCPU)/cortexm_common/Makefile.features
+include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -4,6 +4,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    acd52832 \
                    adafruit-clue \
                    airfy-beacon \
+                   arduino-due \
                    arduino-duemilanove \
                    arduino-leonardo \
                    arduino-mega2560 \
@@ -156,6 +157,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    telosb \
                    thingy52 \
                    ublox-c030-u201 \
+                   udoo \
                    usb-kw41z \
                    waspmote-pro \
                    weact-f411ce \


### PR DESCRIPTION
### Contribution description
This models the features provided by the boards based on the `sam3` family of CPUs:
- `arduino-due`
- `udoo`

### Testing procedure
- Check symbol organization and naming
- Green CI: `tests/kconfig_features` should pass for both boards

### Issues/PRs references
Part of #14148 