### PR TITLE
cpu/sam0_common: add support to run PWM off TC timers

### DIFF
--- a/boards/common/saml1x/Kconfig
+++ b/boards/common/saml1x/Kconfig
@@ -9,6 +9,7 @@ config BOARD_COMMON_SAML1X
     select HAS_PERIPH_ADC
     select HAS_PERIPH_DAC
     select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC
     select HAS_PERIPH_RTT
     select HAS_PERIPH_SPI

--- a/boards/common/saml1x/Makefile.features
+++ b/boards/common/saml1x/Makefile.features
@@ -4,6 +4,7 @@ CPU = saml1x
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -104,6 +104,52 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
+ * @name PWM configuration
+ * @{
+ */
+#define PWM_0_EN            1
+#define PWM_1_EN            0
+
+#if PWM_0_EN
+/* PWM0 channels */
+static const pwm_conf_chan_t pwm_chan0_config[] = {
+    /* GPIO pin, MUX value, TC channel */
+    { GPIO_PIN(PA, 18), GPIO_MUX_E, 0 },
+    { GPIO_PIN(PA, 19), GPIO_MUX_E, 1 },
+};
+#endif
+#if PWM_1_EN
+/* PWM1 channels */
+static const pwm_conf_chan_t pwm_chan1_config[] = {
+    /* GPIO pin, MUX value, TC channel */
+    { GPIO_PIN(PA, 7), GPIO_MUX_E, 1 }, /* LED */
+};
+#endif
+
+/* PWM device configuration */
+static const pwm_conf_t pwm_config[] = {
+#if PWM_0_EN
+    { .tim  = TC_CONFIG(TC2),
+      .chan = pwm_chan0_config,
+      .chan_numof = ARRAY_SIZE(pwm_chan0_config),
+      .gclk_src = SAM0_GCLK_MAIN,
+    },
+#endif
+#if PWM_1_EN
+    /* conflicts with xtimer config (TC0_TC1) */
+    { .tim  = TC_CONFIG(TC1),
+      .chan = pwm_chan1_config,
+      .chan_numof = ARRAY_SIZE(pwm_chan0_config),
+      .gclk_src = SAM0_GCLK_MAIN,
+    },
+#endif
+};
+
+/* number of devices that are actually defined */
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
+/**
  * @name    SPI configuration
  * @{
  */

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -221,9 +221,14 @@ typedef struct {
  * @brief   Common configuration for timer devices
  */
 typedef struct {
-#ifdef REV_TCC
-    Tcc *dev;                   /**< TCC device to use */
+    union {
+#ifdef REV_TC
+        Tc *tc;                 /**< TC device to use */
 #endif
+#ifdef REV_TCC
+        Tcc *tcc;               /**< TCC device to use */
+#endif
+    } dev;                      /**< The Timer device used for PWM */
 #ifdef MCLK
     volatile uint32_t *mclk;    /**< Pointer to MCLK->APBxMASK.reg */
     uint32_t mclk_mask;         /**< MCLK_APBxMASK bits to enable Timer */
@@ -231,20 +236,20 @@ typedef struct {
     uint32_t pm_mask;           /**< PM_APBCMASK bits to enable Timer */
 #endif
     uint16_t gclk_id;           /**< TCn_GCLK_ID */
-} tcc_cfg_t;
+} tc_tcc_cfg_t;
 
 /**
- * @brief   Static initializer for timer configuration
+ * @brief   Static initializer for TCC timer configuration
  */
 #ifdef MCLK
 #define TCC_CONFIG(tim)                   { \
-        .dev       = tim,                   \
+        .dev.tcc   = tim,                   \
         .mclk      = MCLK_ ## tim,          \
         .mclk_mask = MCLK_ ## tim ## _MASK, \
         .gclk_id   = tim ## _GCLK_ID,     }
 #else
 #define TCC_CONFIG(tim)                   { \
-        .dev       = tim,                   \
+        .dev.tcc   = tim,                   \
         .pm_mask   = PM_APBCMASK_ ## tim,   \
         .gclk_id   = tim ## _GCLK_ID,     }
 #endif
@@ -262,7 +267,7 @@ typedef struct {
  * @brief   PWM device configuration data structure
  */
 typedef struct {
-    tcc_cfg_t tim;                  /**< timer configuration */
+    tc_tcc_cfg_t tim;               /**< timer configuration */
     const pwm_conf_chan_t *chan;    /**< channel configuration */
     uint8_t chan_numof;             /**< number of channels */
     uint8_t gclk_src;               /**< GCLK source which clocks TIMER */

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -217,6 +217,11 @@ typedef struct {
     uint8_t gclk_src;       /**< GCLK source which supplys SERCOM */
 } uart_conf_t;
 
+enum {
+    TIMER_TYPE_TC,          /**< Timer is a TC timer  */
+    TIMER_TYPE_TCC,         /**< Timer is a TCC timer */
+};
+
 /**
  * @brief   Common configuration for timer devices
  */
@@ -236,22 +241,43 @@ typedef struct {
     uint32_t pm_mask;           /**< PM_APBCMASK bits to enable Timer */
 #endif
     uint16_t gclk_id;           /**< TCn_GCLK_ID */
+    uint8_t type;               /**< Timer type (TC/TCC) */
 } tc_tcc_cfg_t;
+
+/**
+ * @brief   Static initializer for TC timer configuration
+ */
+#ifdef MCLK
+#define TC_CONFIG(tim)                    { \
+        .dev       = {.tc = tim},           \
+        .mclk      = MCLK_ ## tim,          \
+        .mclk_mask = MCLK_ ## tim ## _MASK, \
+        .gclk_id   = tim ## _GCLK_ID,       \
+        .type      = TIMER_TYPE_TC,       }
+#else
+#define TC_CONFIG(tim)                    { \
+        .dev       = {.tc = tim},           \
+        .pm_mask   = PM_APBCMASK_ ## tim,   \
+        .gclk_id   = tim ## _GCLK_ID,       \
+        .type      = TIMER_TYPE_TC,       }
+#endif
 
 /**
  * @brief   Static initializer for TCC timer configuration
  */
 #ifdef MCLK
 #define TCC_CONFIG(tim)                   { \
-        .dev.tcc   = tim,                   \
+        .dev       = {.tcc = tim},          \
         .mclk      = MCLK_ ## tim,          \
         .mclk_mask = MCLK_ ## tim ## _MASK, \
-        .gclk_id   = tim ## _GCLK_ID,     }
+        .gclk_id   = tim ## _GCLK_ID,       \
+        .type      = TIMER_TYPE_TCC,      }
 #else
 #define TCC_CONFIG(tim)                   { \
-        .dev.tcc   = tim,                   \
+        .dev       = {.tcc = tim},          \
         .pm_mask   = PM_APBCMASK_ ## tim,   \
-        .gclk_id   = tim ## _GCLK_ID,     }
+        .gclk_id   = tim ## _GCLK_ID,       \
+        .type      = TIMER_TYPE_TCC,      }
 #endif
 
 /**

--- a/cpu/sam0_common/periph/pwm.c
+++ b/cpu/sam0_common/periph/pwm.c
@@ -27,9 +27,39 @@
 #include "periph/gpio.h"
 #include "periph/pwm.h"
 
+/* default to using TCC if nothing else is defined */
+#if !defined(PWM_USE_TC) && !defined(PWM_USE_TCC) && defined(REV_TCC)
+#define PWM_USE_TCC 1
+/* use TC if no TCC is available */
+#elif !defined(PWM_USE_TC) && !defined(PWM_USE_TCC) && defined(REV_TC)
+#define PWM_USE_TC  1
+#endif
+
+/* dummy defines to not litter the code with ifdefs if no TCC is available */
+#ifndef REV_TCC
+typedef TcCount8 Tcc;
+#define TCC_SYNCBUSY_CC0 TC_SYNCBUSY_CC0
+#define TCC_CTRLA_ENABLE TC_CTRLA_ENABLE
+#endif
+
+static inline Tc *_tc(pwm_t dev)
+{
+#ifdef REV_TC
+    return pwm_config[dev].tim.dev.tc;
+#else
+    (void) dev;
+    return NULL;
+#endif
+}
+
 static inline Tcc *_tcc(pwm_t dev)
 {
+#ifdef REV_TCC
     return pwm_config[dev].tim.dev.tcc;
+#else
+    (void) dev;
+    return NULL;
+#endif
 }
 
 static inline uint8_t _chan(pwm_t dev, int chan)
@@ -37,36 +67,79 @@ static inline uint8_t _chan(pwm_t dev, int chan)
     return pwm_config[dev].chan[chan].chan;
 }
 
+static inline bool _use_tc(pwm_t dev)
+{
+    return IS_ACTIVE(PWM_USE_TC) &&
+           pwm_config[dev].tim.type == TIMER_TYPE_TC;
+}
+
+static inline bool _use_tcc(pwm_t dev)
+{
+    return IS_ACTIVE(PWM_USE_TCC) &&
+           pwm_config[dev].tim.type == TIMER_TYPE_TCC;
+}
+
+static inline void _check_defines(void)
+{
+#ifdef TCC_CTRLA_PRESCALER_DIV1024_Val
+    static_assert(TCC_CTRLA_PRESCALER_DIV1024_Val == TC_CTRLA_PRESCALER_DIV1024_Val,
+                  "TCC and TC prescaler not equal");
+#endif
+#ifdef TCC_CTRLA_PRESCALER_DIV256_Val
+    static_assert(TCC_CTRLA_PRESCALER_DIV256_Val == TC_CTRLA_PRESCALER_DIV256_Val,
+                  "TCC and TC prescaler not equal");
+#endif
+#ifdef TCC_CTRLA_PRESCALER_DIV64_Val
+    static_assert(TCC_CTRLA_PRESCALER_DIV64_Val == TC_CTRLA_PRESCALER_DIV64_Val,
+                  "TCC and TC prescaler not equal");
+#endif
+#ifdef TCC_CTRLA_PRESCALER_DIV16_Val
+    static_assert(TCC_CTRLA_PRESCALER_DIV16_Val == TC_CTRLA_PRESCALER_DIV16_Val,
+                  "TCC and TC prescaler not equal");
+#endif
+#ifdef TCC_CTRLA_PRESCALER_DIV8_Val
+    static_assert(TCC_CTRLA_PRESCALER_DIV8_Val == TC_CTRLA_PRESCALER_DIV8_Val,
+                  "TCC and TC prescaler not equal");
+#endif
+#ifdef TCC_CTRLA_PRESCALER_DIV4_Val
+    static_assert(TCC_CTRLA_PRESCALER_DIV4_Val == TC_CTRLA_PRESCALER_DIV4_Val,
+                  "TCC and TC prescaler not equal");
+#endif
+}
+
 static uint8_t _get_prescaler(unsigned int target, int *scale)
 {
+    _check_defines();
+
     if (target == 0) {
         return 0xff;
     }
 
     if (target >= 512) {
         *scale = 1024;
-        return TCC_CTRLA_PRESCALER_DIV1024_Val;
+        return TC_CTRLA_PRESCALER_DIV1024_Val;
     }
     if (target >= 128) {
         *scale = 256;
-        return TCC_CTRLA_PRESCALER_DIV256_Val;
+        return TC_CTRLA_PRESCALER_DIV256_Val;
     }
     if (target >= 32) {
         *scale = 64;
-        return TCC_CTRLA_PRESCALER_DIV64_Val;
+        return TC_CTRLA_PRESCALER_DIV64_Val;
     }
     if (target >= 12) {
         *scale = 16;
-        return TCC_CTRLA_PRESCALER_DIV16_Val;
+        return TC_CTRLA_PRESCALER_DIV16_Val;
     }
     if (target >= 6) {
         *scale = 8;
-        return TCC_CTRLA_PRESCALER_DIV8_Val;
+        return TC_CTRLA_PRESCALER_DIV8_Val;
     }
     if (target >= 3) {
         *scale = 4;
-        return TCC_CTRLA_PRESCALER_DIV4_Val;
+        return TC_CTRLA_PRESCALER_DIV4_Val;
     }
+
     *scale = target;
     return target - 1;
 }
@@ -135,8 +208,60 @@ static void poweroff(pwm_t dev)
 #endif
 }
 
+static void _tc_init(Tc *tc, pwm_mode_t mode, uint8_t prescaler, uint8_t res)
+{
+    /* reset TC module */
+    tc->COUNT8.CTRLA.bit.SWRST = 1;
+    while (tc->COUNT8.CTRLA.bit.SWRST) {}
+
+    /* set PWM mode */
+    switch (mode) {
+        case PWM_LEFT:
+            tc->COUNT8.CTRLBCLR.reg = TC_CTRLBCLR_DIR;     /* count up */
+            break;
+        case PWM_RIGHT:
+            tc->COUNT8.CTRLBSET.reg = TC_CTRLBSET_DIR;     /* count down */
+            break;
+        case PWM_CENTER:        /* currently not supported */
+        default:
+            assert(0);
+            return;
+    }
+
+    /* configure the TC device */
+    tc->COUNT8.CTRLA.reg = TC_CTRLA_PRESCSYNC_GCLK_Val
+                          | TC_CTRLA_PRESCALER(prescaler)
+                          | TC_CTRLA_MODE_COUNT8
+#ifdef TC_CTRLA_WAVEGEN_NPWM
+                          | TC_CTRLA_WAVEGEN_NPWM;
+#else
+                          ;
+
+    /* select the waveform generation mode -> normal PWM */
+    tc->COUNT8.WAVE.reg = (TC_WAVE_WAVEGEN_NPWM);
+#endif
+
+    /* set the selected period */
+    tc->COUNT8.PER.reg = (res - 1);
+
+#ifdef TC_STATUS_SYNCBUSY
+    while (tc->COUNT8.STATUS.bit.SYNCBUSY) {}
+#else
+    while (tc->COUNT8.SYNCBUSY.reg) {}
+#endif
+
+    /* start PWM operation */
+    tc->COUNT8.CTRLA.reg |= TC_CTRLA_ENABLE;
+}
+
 static void _tcc_init(Tcc *tcc, pwm_mode_t mode, uint8_t prescaler, uint16_t res)
 {
+#ifndef REV_TCC
+    (void) tcc;
+    (void) mode;
+    (void) prescaler;
+    (void) res;
+#else
     /* reset TCC module */
     tcc->CTRLA.reg = TCC_CTRLA_SWRST;
     while (tcc->SYNCBUSY.reg & TCC_SYNCBUSY_SWRST) {}
@@ -151,6 +276,7 @@ static void _tcc_init(Tcc *tcc, pwm_mode_t mode, uint8_t prescaler, uint16_t res
             break;
         case PWM_CENTER:        /* currently not supported */
         default:
+            assert(0);
             return;
     }
     while (tcc->SYNCBUSY.reg & TCC_SYNCBUSY_CTRLB) {}
@@ -169,6 +295,7 @@ static void _tcc_init(Tcc *tcc, pwm_mode_t mode, uint8_t prescaler, uint16_t res
 
     /* start PWM operation */
     tcc->CTRLA.reg |= TCC_CTRLA_ENABLE;
+#endif
 }
 
 uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
@@ -179,6 +306,11 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
 
     if ((unsigned int)dev >= PWM_NUMOF) {
         return 0;
+    }
+
+    /* TC only supports Period in 8-bit mode */
+    if (pwm_config[dev].tim.type == TIMER_TYPE_TC && res > 255) {
+        res = 0xff;
     }
 
     const uint32_t f_src = sam0_gclk_freq(pwm_config[dev].gclk_src);
@@ -201,7 +333,12 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
     /* power on the device */
     poweron(dev);
 
-    _tcc_init(_tcc(dev), mode, prescaler, res);
+    if (_use_tc(dev)) {
+        _tc_init(_tc(dev), mode, prescaler, res);
+    }
+    else if (_use_tcc(dev)) {
+        _tcc_init(_tcc(dev), mode, prescaler, res);
+    }
 
     /* return the actual frequency the PWM is running at */
     return f_real;
@@ -210,6 +347,19 @@ uint32_t pwm_init(pwm_t dev, pwm_mode_t mode, uint32_t freq, uint16_t res)
 uint8_t pwm_channels(pwm_t dev)
 {
     return pwm_config[dev].chan_numof;
+}
+
+static void _tc_set(Tc *tc, uint8_t chan, uint16_t value)
+{
+    /* TC only ever has two channels */
+    chan %= 2;
+    tc->COUNT8.CC[chan].reg = value;
+
+#ifdef TC_STATUS_SYNCBUSY
+    while (tc->COUNT8.STATUS.bit.SYNCBUSY) {}
+#else
+    while (tc->COUNT8.SYNCBUSY.reg & (TC_SYNCBUSY_CC0 << chan)) {}
+#endif
 }
 
 static void _tcc_set(Tcc *tcc, uint8_t chan, uint16_t value)
@@ -227,17 +377,34 @@ void pwm_set(pwm_t dev, uint8_t channel, uint16_t value)
         return;
     }
 
-    _tcc_set(_tcc(dev), _chan(dev, channel), value);
+    if (_use_tc(dev)) {
+        _tc_set(_tc(dev), _chan(dev, channel), value);
+    }
+    else if (_use_tcc(dev)) {
+        _tcc_set(_tcc(dev), _chan(dev, channel), value);
+    }
 }
 
 void pwm_poweron(pwm_t dev)
 {
     poweron(dev);
-    _tcc(dev)->CTRLA.reg |= (TCC_CTRLA_ENABLE);
+
+    if (_use_tc(dev)) {
+        _tc(dev)->COUNT8.CTRLA.reg |= (TC_CTRLA_ENABLE);
+    }
+    else if (_use_tcc(dev)) {
+        _tcc(dev)->CTRLA.reg |= (TCC_CTRLA_ENABLE);
+    }
 }
 
 void pwm_poweroff(pwm_t dev)
 {
-    _tcc(dev)->CTRLA.reg &= ~(TCC_CTRLA_ENABLE);
+    if (_use_tc(dev)) {
+        _tc(dev)->COUNT8.CTRLA.reg &= ~(TC_CTRLA_ENABLE);
+    }
+    else if (_use_tcc(dev)) {
+        _tcc(dev)->CTRLA.reg &= ~(TCC_CTRLA_ENABLE);
+    }
+
     poweroff(dev);
 }

--- a/cpu/sam0_common/periph/pwm.c
+++ b/cpu/sam0_common/periph/pwm.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     cpu_samd21
+ * @ingroup     cpu_sam0_common
  * @ingroup     drivers_periph_pwm
  * @{
  *


### PR DESCRIPTION
### Contribution description

TC timers can be used for PWM generation just like TCC timers, they just have a few less features.
Some MCUs (e.g. saml1x) only have TC timers, so this is needed to enable PWM on this platform.

### Testing procedure

The xtimer configuration on `saml1x-xpro` conflicts with the use of PWM for the on-board LED so by default PWM is configured on two external pins.

To test PWM functionality without any additional tools, apply

<details><summary>this patch</summary>

```patch
diff --git a/boards/common/saml1x/include/board.h b/boards/common/saml1x/include/board.h
index 2d023ea3aa..583bb55e17 100644
--- a/boards/common/saml1x/include/board.h
+++ b/boards/common/saml1x/include/board.h
@@ -67,6 +67,7 @@ extern "C" {
  * @{
  */
 #define XTIMER_BACKOFF      (40)
+#define XTIMER_WIDTH        (16)
 /** @} */
 
 /**
diff --git a/boards/common/saml1x/include/periph_conf.h b/boards/common/saml1x/include/periph_conf.h
index a2da83fe14..ad98c5b50b 100644
--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -43,11 +43,11 @@ extern "C" {
  */
 static const tc32_conf_t timer_config[] = {
     {   /* Timer 0 - System Clock */
-        .dev            = TC0,
-        .irq            = TC0_IRQn,
+        .dev            = TC2,
+        .irq            = TC2_IRQn,
         .mclk           = &MCLK->APBCMASK.reg,
-        .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
-        .gclk_id        = TC0_GCLK_ID,
+        .mclk_mask      = MCLK_APBCMASK_TC2,
+        .gclk_id        = TC2_GCLK_ID,
         .gclk_src       = SAM0_GCLK_MAIN,
         .flags          = TC_CTRLA_MODE_COUNT32,
     }
@@ -55,7 +55,7 @@ static const tc32_conf_t timer_config[] = {
 
 /* Timer 0 configuration */
 #define TIMER_0_CHANNELS    2
-#define TIMER_0_ISR         isr_tc0
+#define TIMER_0_ISR         isr_tc2
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 
@@ -107,8 +107,8 @@ static const uart_conf_t uart_config[] = {
  * @name PWM configuration
  * @{
  */
-#define PWM_0_EN            1
-#define PWM_1_EN            0
+#define PWM_0_EN            0
+#define PWM_1_EN            1
 
 #if PWM_0_EN
 /* PWM0 channels */
```
</details>

Flash `tests/periph_pwm` and run the `osci` command.
You should see the on-board LED flash.

### Issues/PRs references

follow-up on #14007
