### PR TITLE
 riotctrl_shell.netif: allow for non str values with ifconfig_set()

### DIFF
--- a/dist/pythonlibs/riotctrl_shell/netif.py
+++ b/dist/pythonlibs/riotctrl_shell/netif.py
@@ -286,7 +286,7 @@ class Ifconfig(ShellInteraction):
         if args is not None:
             if netif is None:
                 raise ValueError("netif required when args are provided")
-            cmd += " {args}".format(args=" ".join(args))
+            cmd += " {args}".format(args=" ".join(str(a) for a in args))
         return self.cmd(cmd, timeout=timeout, async_=False)
 
     def ifconfig_help(self, netif, timeout=-1, async_=False):

--- a/dist/pythonlibs/riotctrl_shell/tests/test_netif.py
+++ b/dist/pythonlibs/riotctrl_shell/tests/test_netif.py
@@ -76,12 +76,18 @@ def test_ifconfig_help():
     assert res == "ifconfig foobar help"
 
 
-def test_ifconfig_set():
-    rc = init_ctrl(output="success: address set")
+@pytest.mark.parametrize(
+    "option,value,expected",
+    [("addr", "42:de:ad:c0:ff:ee",
+      "ifconfig foobar set addr 42:de:ad:c0:ff:ee"),
+     ("chan", 17, "ifconfig foobar set chan 17")]
+)
+def test_ifconfig_set(option, value, expected):
+    rc = init_ctrl(output="success: option set")
     si = riotctrl_shell.netif.Ifconfig(rc)
-    res = si.ifconfig_set("foobar", "addr", "42:de:ad:c0:ff:ee")
-    assert res == "success: address set"
-    assert rc.term.last_command == "ifconfig foobar set addr 42:de:ad:c0:ff:ee"
+    res = si.ifconfig_set("foobar", option, value)
+    assert res == "success: option set"
+    assert rc.term.last_command == expected
 
 
 def test_ifconfig_set_error():


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Found another bug. This allows for e.g. `shell.ifconfig_set("chan", 17)`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run `tox`/`tests-tools`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
