### PR TITLE
openocd-adapters: select transport based on adapter

### DIFF
--- a/boards/common/frdm/dist/openocd-klx.cfg
+++ b/boards/common/frdm/dist/openocd-klx.cfg
@@ -10,9 +10,6 @@
 # CMSIS-DAP (DAPLink) compatible OpenSDA firmware binary images can be found at:
 # http://www.nxp.com/opensda
 
-# Kinetis L only supports SWD
-transport select swd
-
 # Kinetis L series CPUs
 source [find target/klx.cfg]
 

--- a/boards/common/nrf52/dist/openocd.cfg
+++ b/boards/common/nrf52/dist/openocd.cfg
@@ -1,3 +1,1 @@
-transport select swd
-
 source [find target/nrf52.cfg]

--- a/boards/common/nrf52/doc.txt
+++ b/boards/common/nrf52/doc.txt
@@ -25,4 +25,10 @@ To flash the board with OpenOCD, use the `PROGRAMMER` variable:
     PROGRAMMER=openocd make BOARD=<nrf52 board> -C examples/hello-world flash
 ```
 
+It is also possible to use the SWD interface of a ST-LINK/V2 in-circuit
+debugger/programmer with OpenOCD to flash a nrf52 board:
+```
+    PROGRAMMER=openocd DEBUG_ADAPTER=stlink make BOARD=<nrf52 board> -C examples/hello-world flash
+```
+
 */

--- a/boards/mcb2388/Makefile.include
+++ b/boards/mcb2388/Makefile.include
@@ -3,6 +3,7 @@ DEBUG_ADAPTER ?= dap
 PROGRAMMER ?= openocd
 
 JLINK_DEVICE := LPC2388
+OPENOCD_TRANSPORT := jtag
 
 include $(RIOTBOARD)/common/msba2/Makefile.include
 include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/mcb2388/dist/openocd.cfg
+++ b/boards/mcb2388/dist/openocd.cfg
@@ -1,5 +1,3 @@
-transport select jtag
-
 source [find target/lpc2xxx.cfg]
 # parameters:
 # - core_freq_khz - frequency of core in kHz during flashing, usually equal to connected crystal or internal oscillator, e.g. 12000

--- a/makefiles/tools/openocd-adapters/dap.inc.mk
+++ b/makefiles/tools/openocd-adapters/dap.inc.mk
@@ -1,5 +1,9 @@
 # CMSIS DAP debug adapter
 OPENOCD_ADAPTER_INIT ?= -c 'source [find interface/cmsis-dap.cfg]'
+
+# default to SWD
+OPENOCD_TRANSPORT ?= swd
+
 # Add serial matching command, only if DEBUG_ADAPTER_ID was specified
 ifneq (,$(DEBUG_ADAPTER_ID))
   OPENOCD_ADAPTER_INIT += -c 'cmsis_dap_serial $(DEBUG_ADAPTER_ID)'

--- a/makefiles/tools/openocd-adapters/iotlab.inc.mk
+++ b/makefiles/tools/openocd-adapters/iotlab.inc.mk
@@ -1,6 +1,9 @@
 # iotlab-usb debug adapter
 OPENOCD_ADAPTER_INIT ?= -c 'source [find interface/ftdi/iotlab-usb.cfg]'
 
+# default to SWD
+OPENOCD_TRANSPORT ?= swd
+
 # Add serial matching command, only if DEBUG_ADAPTER_ID was specified
 ifneq (,$(DEBUG_ADAPTER_ID))
   OPENOCD_ADAPTER_INIT += -c 'ftdi_serial $(DEBUG_ADAPTER_ID)'

--- a/makefiles/tools/openocd-adapters/jlink.inc.mk
+++ b/makefiles/tools/openocd-adapters/jlink.inc.mk
@@ -1,5 +1,9 @@
 # Segger J-Link debug adapter
 OPENOCD_ADAPTER_INIT ?= -c 'source [find interface/jlink.cfg]'
+
+# default to SWD
+OPENOCD_TRANSPORT ?= swd
+
 # Add serial matching command, only if DEBUG_ADAPTER_ID was specified
 ifneq (,$(DEBUG_ADAPTER_ID))
   OPENOCD_ADAPTER_INIT += -c 'jlink serial $(DEBUG_ADAPTER_ID)'

--- a/makefiles/tools/openocd-adapters/mulle.inc.mk
+++ b/makefiles/tools/openocd-adapters/mulle.inc.mk
@@ -26,6 +26,9 @@ PROGRAMMER_VERSION ?= 0.70
 
 OPENOCD_ADAPTER_INIT ?= -f '$(RIOTBASE)/boards/mulle/dist/openocd/mulle-programmer-$(PROGRAMMER_VERSION).cfg'
 
+# Default to SWD
+OPENOCD_TRANSPORT ?= swd
+
 # Add serial matching command, only if DEBUG_ADAPTER_ID was specified
 ifneq (,$(DEBUG_ADAPTER_ID))
   OPENOCD_ADAPTER_INIT += -c 'ftdi_serial $(DEBUG_ADAPTER_ID)'

--- a/makefiles/tools/openocd-adapters/raspi.inc.mk
+++ b/makefiles/tools/openocd-adapters/raspi.inc.mk
@@ -29,8 +29,10 @@ OPENOCD_ADAPTER_INIT ?= \
   -c 'bcm2835gpio_peripheral_base $(PERIPH_BASE)' \
   -c 'bcm2835gpio_speed_coeffs $(SPEED_COEFF) $(SPEED_OFFSET)' \
   -c 'bcm2835gpio_swd_nums $(SWCLK_PIN ) $(SWDIO_PIN)' \
-  -c 'bcm2835gpio_srst_num $(SRST_PIN)' \
-  -c 'transport select swd'
+  -c 'bcm2835gpio_srst_num $(SRST_PIN)'
+
+# Default to SWD
+OPENOCD_TRANSPORT ?= swd
 
 # bcm2835gpio needs access to /dev/mem
 export OPENOCD ?= sudo -E openocd

--- a/makefiles/tools/openocd-adapters/stlink.inc.mk
+++ b/makefiles/tools/openocd-adapters/stlink.inc.mk
@@ -3,14 +3,20 @@
 STLINK_VERSION ?= 2-1
 
 # Use STLINK_VERSION to select which stlink version is used
-OPENOCD_ADAPTER_INIT ?= \
-  -c 'source [find interface/stlink-v$(STLINK_VERSION).cfg]' \
-  -c 'transport select hla_swd'
+OPENOCD_ADAPTER_INIT ?= -c 'source [find interface/stlink-v$(STLINK_VERSION).cfg]'
+
+# If swd / jtag is selected by the board, prefix it with hla_
+ifneq (,$(filter swd jtag,$(OPENOCD_TRANSPORT)))
+  OPENOCD_TRANSPORT := hla_$(OPENOCD_TRANSPORT)
+endif
+
+# All ST-Link adapters support hla_swd, so use that for simplicity
+OPENOCD_TRANSPORT ?= hla_swd
+
 # Add serial matching command, only if DEBUG_ADAPTER_ID was specified
 ifneq (,$(DEBUG_ADAPTER_ID))
   OPENOCD_ADAPTER_INIT += -c 'hla_serial $(DEBUG_ADAPTER_ID)'
 endif
-
 
 # Some stlink clones cannot signal reset properly,
 # In this case, use SRST=none

--- a/makefiles/tools/openocd-adapters/sysfs_gpio.inc.mk
+++ b/makefiles/tools/openocd-adapters/sysfs_gpio.inc.mk
@@ -6,8 +6,10 @@ SRST_PIN ?= 16
 
 OPENOCD_ADAPTER_INIT ?= \
   -c 'interface sysfsgpio' \
-  -c 'transport select swd' \
   -c 'sysfsgpio_swd_nums $(SWCLK_PIN) $(SWDIO_PIN)' \
   -c 'sysfsgpio_srst_num $(SRST_PIN)' \
   -c 'adapter_nsrst_delay 100' \
   -c 'adapter_nsrst_assert_width 100'
+
+# default to SWD
+OPENOCD_TRANSPORT ?= swd

--- a/makefiles/tools/openocd.inc.mk
+++ b/makefiles/tools/openocd.inc.mk
@@ -11,6 +11,7 @@ RESET_FLAGS ?= reset
 
 ifneq (,$(DEBUG_ADAPTER))
   include $(RIOTMAKE)/tools/openocd-adapters/$(DEBUG_ADAPTER).inc.mk
+  OPENOCD_ADAPTER_INIT += -c 'transport select $(OPENOCD_TRANSPORT)'
 endif
 
 OPENOCD_CONFIG ?= $(BOARDDIR)/dist/openocd.cfg


### PR DESCRIPTION
### Contribution description

Things were a bit muddled since some boards come with a debug adapter while other boards have to use an external one.

This allows for more flexibility in external debug adapter use. The Adapter will select it's default transport, but boards can overwrite them if they need something special (this can only be JTAG instead of SWD since `hla_swd` is an implementation detail of the adpater and should not be selected by the board.

There are some boards that don't use the `DEBUG_ADAPTER` property at all and define everything in their private `openocd.cfg`.

Those can of course still select their own transport, but ideally they should be transferred to `openocd-adapters/` so the adapters can be shared with other boards.

### Testing procedure

Flashing should still work.
I tried

 - [x] flashing a Kinetis board with OpenOCD
 - [x] flashing a nRF52 board with OpenOCD
 - [x] flashing a board that uses `iotlab.inc.mk`
 - [x] flashing a board that uses JLink with OpenOCD (all the nrf52xxxdk boards come with an on-board JLink)
 - [ ] flashing a mulle board with OpenOCD


### Issues/PRs references

alternative to #13858
