### PR TITLE
Makefile.{base,include}: Fix linking for C++ code in external modules

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -63,6 +63,12 @@ ifeq ($(strip $(ASSMSRC))$(NO_AUTO_SRC),)
   ASSMSRC := $(wildcard *.S)
 endif
 
+ifneq (,$(SRCXX))
+  ifeq (,$(filter cpp,$(FEATURES_USED)))
+    $(error Found C++ source, but feature "cpp" is not used. Add "FEATURES_REQUIRED += cpp")
+  endif
+endif
+
 # include makefile snippets for packages in $(USEPKG) that modify GENSRC:
 -include $(USEPKG:%=$(RIOTPKG)/%/Makefile.gensrc)
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -536,7 +536,9 @@ else
 endif
 
 # variables used to compile and link c++
-CPPMIX ?= $(if $(wildcard *.cpp),1,)
+ifneq (,$(filter cpp,$(FEATURES_USED)))
+  CPPMIX ?= 1
+endif
 
 # We assume $(LINK) to be gcc-like. Use `LINKFLAGPREFIX :=` for ld-like linker options.
 LINKFLAGPREFIX ?= -Wl,

--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -16,6 +16,10 @@ USEMODULE += random
 USEMODULE += stdio_uart
 USEMODULE += xtensa
 
+# Features used by ESP*
+
+FEATURES_REQUIRED += cpp # Vendor code uses C++
+
 ifneq (,$(filter esp_wifi_enterprise,$(USEMODULE)))
   FEATURES_REQUIRED += esp_wifi_enterprise
   USEMODULE += esp_wifi

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -48,6 +48,7 @@ export PYTHONPATH            # Python default search path for module filesi, wit
 export FEATURES_REQUIRED     # List of required features by the application
 export FEATURES_PROVIDED     # List of provided features by the board
 export FEATURES_OPTIONAL     # List of nice to have features
+export FEATURES_USED         # List of features used
 # TOOLCHAINS_SUPPORTED       # List of supported toolchains by an MCU (gnu/llvm/...).
 # TOOLCHAINS_BLACKLISTED     # List of unspported toolchains for a module or an application.
 export TOOLCHAIN             # Base build toolchain, i.e. GNU or LLVM

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -2,6 +2,7 @@ ifneq (,$(filter arduino,$(USEMODULE)))
   FEATURES_OPTIONAL += periph_i2c
   FEATURES_OPTIONAL += periph_spi
   FEATURES_REQUIRED += periph_uart
+  FEATURES_REQUIRED += cpp
   SKETCH_MODULE ?= arduino_sketches
   USEMODULE += $(SKETCH_MODULE)
 endif


### PR DESCRIPTION
### Contribution description

Internal modules are not allowed to use C++ code, as some platforms (might) only support C. This restriction should however not apply to external modules. If an application uses no C++ code but uses an external module using C++ code, linking is still done using `$(CC)` instead of `$(CXX)`. This PR

- Use `$(CXX)` for linking if the feature `cpp` is used, rather than searching the application for C++ sources
- Abort builds when C++ code is detected without feature `cpp` being used, so that a more helpful error message is presented instead of a linking failure

### Testing procedure

The example given in issue https://github.com/RIOT-OS/RIOT/issues/14466 should now error with a helpful error message instead of a linking issue. Add `FEATURES_REQUIRED += cpp` should fix the linking issue, even if no C++ source code is present in the application.

### Issues/PRs references

Fixes: https://github.com/RIOT-OS/RIOT/issues/14466