### PR TITLE
cpu/stm32/periph/pwm: some bugfixes...

### DIFF
--- a/cpu/stm32/periph/pwm.c
+++ b/cpu/stm32/periph/pwm.c
@@ -46,7 +46,7 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
 {
     uint32_t timer_clk = periph_timer_clk(pwm_config[pwm].bus);
 
-    /* in PWM_CENTER mode the counter counts up and down at each periode
+    /* in PWM_CENTER mode the counter counts up and down at each period
      * so the resolution had to be divided by 2 */
     res *= (mode == PWM_CENTER) ? 2 : 1;
 
@@ -131,7 +131,7 @@ void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
         value = (uint16_t)dev(pwm)->ARR + 1;
     }
 
-    if (dc_reverse & (1 << pwm)) {
+    if ((dc_reverse & (1 << pwm)) != 0) {
         /* reverse the value */
         value = (uint16_t)dev(pwm)->ARR + 1 - value;
     }

--- a/cpu/stm32/periph/pwm.c
+++ b/cpu/stm32/periph/pwm.c
@@ -33,9 +33,7 @@
                              TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_2)
 #define CCMR_MODE2          (TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_1 | \
                              TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC2M_0 | \
-                             TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_2);
-
-static uint32_t dc_reverse = 0;
+                             TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_2)
 
 static inline TIM_TypeDef *dev(pwm_t pwm)
 {
@@ -75,8 +73,6 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
     dev(pwm)->PSC = (timer_clk / (res * freq)) - 1;
     dev(pwm)->ARR = (mode == PWM_CENTER) ? (res / 2) : res - 1;
 
-    dc_reverse &= ~(1 << pwm);
-
     /* set PWM mode */
     switch (mode) {
         case PWM_LEFT:
@@ -87,7 +83,6 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
             dev(pwm)->CCMR1 = CCMR_MODE2;
             dev(pwm)->CCMR2 = CCMR_MODE2;
             /* duty cycle should be reversed */
-            dc_reverse |= (1 << pwm);
             break;
         case PWM_CENTER:
             dev(pwm)->CCMR1 = CCMR_MODE1;
@@ -131,7 +126,7 @@ void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
         value = (uint16_t)dev(pwm)->ARR + 1;
     }
 
-    if ((dc_reverse & (1 << pwm)) != 0) {
+    if (dev(pwm)->CCMR1 == CCMR_MODE2) {
         /* reverse the value */
         value = (uint16_t)dev(pwm)->ARR + 1 - value;
     }

--- a/cpu/stm32/periph/pwm.c
+++ b/cpu/stm32/periph/pwm.c
@@ -29,20 +29,28 @@
 #include "periph/pwm.h"
 #include "periph/gpio.h"
 
-#define CCMR_LEFT           (TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2 | \
+#define CCMR_MODE1          (TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2 | \
                              TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_2)
-#define CCMR_RIGHT          (TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_1 | \
+#define CCMR_MODE2          (TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_1 | \
                              TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC2M_0 | \
                              TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_2);
+
+static pwm_mode_t mode;
 
 static inline TIM_TypeDef *dev(pwm_t pwm)
 {
     return pwm_config[pwm].dev;
 }
 
-uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
+uint32_t pwm_init(pwm_t pwm, pwm_mode_t m, uint32_t freq, uint16_t res)
 {
     uint32_t timer_clk = periph_timer_clk(pwm_config[pwm].bus);
+
+    mode = m;
+
+    /* in PWM_CENTER mode the counter counts up and down at each periode
+     * so the resolution had to be divided by 2 */
+    res *= (mode == PWM_CENTER) ? 2 : 1;
 
     /* verify parameters */
     assert((pwm < PWM_NUMOF) && ((freq * res) <= timer_clk));
@@ -53,7 +61,7 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
     dev(pwm)->CR1 = 0;
     dev(pwm)->CR2 = 0;
     for (unsigned i = 0; i < TIMER_CHANNEL_NUMOF; ++i) {
-        TIM_CHAN(pwm, i) = 0;
+        TIM_CHAN(pwm, i) = (mode == PWM_RIGHT) ? res : 0;
     }
 
     /* configure the used pins */
@@ -67,21 +75,22 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
     /* configure the PWM frequency and resolution by setting the auto-reload
      * and prescaler registers */
     dev(pwm)->PSC = (timer_clk / (res * freq)) - 1;
-    dev(pwm)->ARR = res - 1;
+    dev(pwm)->ARR = (mode == PWM_CENTER) ? (res / 2) : res - 1;
 
     /* set PWM mode */
     switch (mode) {
         case PWM_LEFT:
-            dev(pwm)->CCMR1 = CCMR_LEFT;
-            dev(pwm)->CCMR2 = CCMR_LEFT;
+            dev(pwm)->CCMR1 = CCMR_MODE1;
+            dev(pwm)->CCMR1 = CCMR_MODE1;
             break;
         case PWM_RIGHT:
-            dev(pwm)->CCMR1 = CCMR_RIGHT;
-            dev(pwm)->CCMR2 = CCMR_RIGHT;
+            dev(pwm)->CCMR1 = CCMR_MODE2;
+            dev(pwm)->CCMR1 = CCMR_MODE2;
             break;
         case PWM_CENTER:
-            dev(pwm)->CCMR1 = 0;
-            dev(pwm)->CCMR2 = 0;
+            dev(pwm)->CCMR1 = CCMR_MODE1;
+            dev(pwm)->CCMR1 = CCMR_MODE1;
+            /* center-aligned mode 3 */
             dev(pwm)->CR1 |= (TIM_CR1_CMS_0 | TIM_CR1_CMS_1);
             break;
     }
@@ -116,9 +125,15 @@ void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
            (pwm_config[pwm].chan[channel].pin != GPIO_UNDEF));
 
     /* norm value to maximum possible value */
-    if (value > dev(pwm)->ARR) {
-        value = (uint16_t)dev(pwm)->ARR;
+    if (value > dev(pwm)->ARR + 1) {
+        value = (uint16_t)dev(pwm)->ARR + 1;
     }
+
+    if (mode == PWM_RIGHT) {
+        /* reverse the value */
+        value = (uint16_t)dev(pwm)->ARR + 1 - value;
+    }
+
     /* set new value */
     TIM_CHAN(pwm, pwm_config[pwm].chan[channel].cc_chan) = value;
 }

--- a/cpu/stm32/periph/pwm.c
+++ b/cpu/stm32/periph/pwm.c
@@ -81,17 +81,17 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
     switch (mode) {
         case PWM_LEFT:
             dev(pwm)->CCMR1 = CCMR_MODE1;
-            dev(pwm)->CCMR1 = CCMR_MODE1;
+            dev(pwm)->CCMR2 = CCMR_MODE1;
             break;
         case PWM_RIGHT:
             dev(pwm)->CCMR1 = CCMR_MODE2;
-            dev(pwm)->CCMR1 = CCMR_MODE2;
+            dev(pwm)->CCMR2 = CCMR_MODE2;
             /* duty cycle should be reversed */
             dc_reverse |= (1 << pwm);
             break;
         case PWM_CENTER:
             dev(pwm)->CCMR1 = CCMR_MODE1;
-            dev(pwm)->CCMR1 = CCMR_MODE1;
+            dev(pwm)->CCMR2 = CCMR_MODE1;
             /* center-aligned mode 3 */
             dev(pwm)->CR1 |= (TIM_CR1_CMS_0 | TIM_CR1_CMS_1);
             break;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
PWM_RIGHT and PWM_CENTER wasn't handled correctly for stm32 cpus.

In PWM_RIGHT mode output polarity was reversed which indeed right align
rising edge but also reverses the duty cycle which is not desirable.

In PWM_CENTER mode capture/compare mode registers was set to 0 so there
was no output at all.

Moreover it is not possible to set the duty-cycle to 100% because value
is normed to dev(pwm)->ARR which is equal to (res - 1).

I also renamed CCMR_* constants because I have used CCMR_LEFT for both
PWM_LEFT and PWM_CENTER modes.

Finally in PWM_CENTER mode the resolution have to be divided by two in
pwm_init() call so it must be multiplied by 2 for the parameters
verification, prescaler setting and frequency computation, except for
the auto-reload register.

Regarding the PWM_RIGHT mode, I first tried to reverse the timer
direction in CR1 register but it wasn't possible to get 0% duty cycle
this way because there was allways one clock cycle where the output was
activated (when TIMx_CNT=TIMx_CCR1).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Using tests/periph_pwm and a bluepill or another stm32 board and
checking 2 outputs (A8 and A9 for the bluepill) with a scope.

#### PWM_LEFT
Initialize a left aligned pwm at 1KHz with `init 0 0 1000 4` then set
the first channel to 25% duty-cycle and the second to 50% with
`set 0 0 1` and `set 0 1 2`, we get the following oscillograms as
expected:
```
    _       _ 
1 _| |_____| |_____
    ___     ___
2 _|   |___|   |___
```
But if I try to set a 100% duty-cycle with `set 0 0 4`, I only get 75%
because of value is normed to dev(pwm)->ARR which is equal to (res - 1).

#### PWM_RIGHT
Initialize a right aligned pwm at 1KHz with `init 0 1 1000 4` then set
the first channel to 25% duty-cycle and the second to 50% with
`set 0 0 1` and `set 0 1 2`, we get the following oscillograms.

Expected :

```
      _       _ 
1 ___| |_____| |___
    ___     ___
2 _|   |___|   |___
```
But we get :
```
  _   _____   _____
1  |_|     |_|     
  _     ___     ___
2  |___|   |___|
```
#### PWM_CENTER
Initialize a center aligned pwm at 1KHz with `init 0 2 1000 4` then set
the first channel to 25% duty-cycle and the second to 50% with
`set 0 0 1` and `set 0 1 2` not working at all because of the CCMR
registers are set to 0.

Expected :
```
     _       _
1 __| |_____| |____
    ___     ___
2 _|   |___|   |___
```
But we get a kind of brain dead.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
