### PR TITLE
boards/same54-xpro: Model features in Kconfig

### DIFF
--- a/boards/same54-xpro/Kconfig
+++ b/boards/same54-xpro/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "same54-xpro" if BOARD_SAME54_XPRO
+
+config BOARD_SAME54_XPRO
+    bool
+    default y
+    select CPU_MODEL_SAME54P20A
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_RIOTBOOT

--- a/cpu/samd5x/Kconfig
+++ b/cpu/samd5x/Kconfig
@@ -5,4 +5,34 @@
 # directory for more details.
 #
 
+config CPU_FAM_SAMD5X
+    bool
+    select CPU_COMMON_SAM0
+    select CPU_CORE_CORTEX_M4F
+    select HAS_BACKUP_RAM
+    select HAS_CORTEXM_MPU
+    select HAS_CPU_SAMD5X
+    select HAS_PERIPH_HWRNG
+
+## CPU Models
+config CPU_MODEL_SAME54P20A
+    bool
+    select CPU_FAM_SAMD5X
+
+## Declaration of specific features
+config HAS_CPU_SAMD5X
+    bool
+    help
+        Indicates that a 'samd5x' cpu is being used.
+
+## CPU common symbols
+config CPU_FAM
+    default "samd5x" if CPU_FAM_SAMD5X
+
+config CPU_MODEL
+    default "same54p20a" if CPU_MODEL_SAME54P20A
+
+config CPU
+    default "samd5x" if CPU_FAM_SAMD5X
+
 source "$(RIOTCPU)/sam0_common/Kconfig"

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -132,6 +132,7 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    remote-reva \
                    remote-revb \
                    ruuvitag \
+                   same54-xpro \
                    samr21-xpro \
                    slstk3401a \
                    slstk3402a \


### PR DESCRIPTION
### Contribution description
This models the features of the `same54-xpro` board, the only one that uses the `samd5x` CPU so far.

### Testing procedure
- Check that symbol organization and naming are correct
- Green CI: `tests/kconfig_features` should pass

### Issues/PRs references
Part of #14148 