### PR TITLE
tools/bossa: factorize Makefiles

### DIFF
--- a/dist/tools/bossa-1.8/Makefile
+++ b/dist/tools/bossa-1.8/Makefile
@@ -3,15 +3,4 @@ PKG_URL      = https://github.com/shumatech/BOSSA
 PKG_VERSION  = 26154375695f345491bba158d57177aa231d6765
 PKG_LICENSE  = BSD-3-Clause
 
-PKG_SOURCE_DIR = $(CURDIR)/bin
-PKG_BUILD_OUT_OF_SOURCE = 0
-
-include $(RIOTBASE)/pkg/pkg.mk
-
-all:
-	@echo "[INFO] compiling bossac from source now"
-	@env -u CXX COMMON_CXXFLAGS="-std=c++11" $(MAKE) BINDIR=$(PKG_BUILD_DIR) -C $(PKG_BUILD_DIR) strip-bossac
-	@mv $(PKG_BUILD_DIR)/bossac $(CURDIR)/bossac
-
-distclean::
-	@rm -f $(CURDIR)/bossac
+include $(RIOTMAKE)/tools/bossa-build.inc.mk

--- a/dist/tools/bossa-1.9/Makefile
+++ b/dist/tools/bossa-1.9/Makefile
@@ -3,15 +3,4 @@ PKG_URL      = https://github.com/shumatech/BOSSA
 PKG_VERSION  = 1.9.1
 PKG_LICENSE  = BSD-3-Clause
 
-PKG_SOURCE_DIR = $(CURDIR)/bin
-PKG_BUILD_OUT_OF_SOURCE = 0
-
-include $(RIOTBASE)/pkg/pkg.mk
-
-all:
-	@echo "[INFO] compiling bossac from source now"
-	@env -u CXX COMMON_CXXFLAGS="-std=c++11" $(MAKE) BINDIR=$(PKG_BUILD_DIR) -C $(PKG_BUILD_DIR) strip-bossac
-	@mv $(PKG_BUILD_DIR)/bossac $(CURDIR)/bossac
-
-distclean::
-	@rm -f $(CURDIR)/bossac
+include $(RIOTMAKE)/tools/bossa-build.inc.mk

--- a/dist/tools/bossa-nrf52/Makefile
+++ b/dist/tools/bossa-nrf52/Makefile
@@ -3,15 +3,4 @@ PKG_URL      = https://github.com/arduino/BOSSA
 PKG_VERSION  = 52e0a4a28721296e64083de7780b30580e0fad16
 PKG_LICENSE  = BSD-3-Clause
 
-PKG_SOURCE_DIR = $(CURDIR)/bin
-PKG_BUILD_OUT_OF_SOURCE = 0
-
-include $(RIOTBASE)/pkg/pkg.mk
-
-all:
-	@echo "[INFO] compiling bossac from source now"
-	@env -u CXX COMMON_CXXFLAGS="-std=c++11" $(MAKE) BINDIR=$(PKG_BUILD_DIR) -C $(PKG_BUILD_DIR) strip-bossac
-	@mv $(PKG_BUILD_DIR)/bossac $(CURDIR)/bossac
-
-distclean::
-	@rm -f $(CURDIR)/bossac
+include $(RIOTMAKE)/tools/bossa-build.inc.mk

--- a/makefiles/tools/bossa-build.inc.mk
+++ b/makefiles/tools/bossa-build.inc.mk
@@ -1,0 +1,14 @@
+PKG_SOURCE_DIR = $(CURDIR)/bin
+PKG_BUILD_OUT_OF_SOURCE = 0
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+all: $(CURDIR)/bossac
+
+$(CURDIR)/bossac:
+	@echo "[INFO] compiling bossac from source now"
+	@env -u CXX COMMON_CXXFLAGS="-std=c++11" $(MAKE) BINDIR=$(PKG_BUILD_DIR) -C $(PKG_BUILD_DIR) strip-bossac
+	@mv $(PKG_BUILD_DIR)/bossac $(CURDIR)/bossac
+
+clean::
+	rm -f $(CURDIR)/bossac


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR introduces a common Makefile that is used to build the bossa flasher tool. In master, all Makefile rules are duplicated in 3 different Makefiles (one for each bossa version).

The `distclean` target is also now renamed in `clean`: this allows to only removed the bossa binary and generated files because `clean` is already defined in `pkg.mk` (I have another PR to improve this btw).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

All bossa tools are still built automatically when flashing `arduino-due`, `arduino-mkr1000` (or any other samd21 board that use bossa) or `arduino-nano-33-ble`:

<details><summary>arduino-due</summary>

```
$ rm -rf dist/tools/bossa-1.8/bin/ dist/tools/bossa-1.8/bossac
$ make -C examples/hello-world BOARD=arduino-due --no-print-directory flash
Building application "hello-world" for "arduino-due" with MCU "sam3".

"make" -C /work/riot/RIOT/boards/arduino-due
"make" -C /work/riot/RIOT/boards/common/arduino-due
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/sam3
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam3/periph
"make" -C /work/riot/RIOT/cpu/sam_common
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   7740	    108	   2320	  10168	   27b8	/work/riot/RIOT/examples/hello-world/bin/arduino-due/hello-world.elf
stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
sleep 1
[INFO] bossac 1.8 binary not found - building it from source
[INFO] cloning bossa
Cloning into '/work/riot/RIOT/dist/tools/bossa-1.8/bin'...
remote: Enumerating objects: 11, done.
remote: Counting objects: 100% (11/11), done.
remote: Compressing objects: 100% (10/10), done.
remote: Total 1727 (delta 4), reused 5 (delta 1), pack-reused 1716
Receiving objects: 100% (1727/1727), 1.15 MiB | 977.00 KiB/s, done.
Resolving deltas: 100% (1318/1318), done.
HEAD is now at 2615437 Fixed problem with lock regions on SAM4E.  Some general cleanup.
[INFO] updating bossa /work/riot/RIOT/dist/tools/bossa-1.8/bin/.pkg-state.git-downloaded
echo 26154375695f345491bba158d57177aa231d6765 > /work/riot/RIOT/dist/tools/bossa-1.8/bin/.pkg-state.git-downloaded
[INFO] patch bossa
[INFO] compiling bossac from source now
make[2]: wx-config: Command not found
make[2]: wx-config: Command not found
CPP APPLET src/WordCopyArm.cpp
CPP COMMON src/Samba.cpp
src/Samba.cpp: In member function ‘bool Samba::init()’:
src/Samba.cpp:111:12: warning: catching polymorphic type ‘class SambaError’ by value [-Wcatch-value=]
  111 |     catch (SambaError)
      |            ^~~~~~~~~~
src/Samba.cpp: In member function ‘void Samba::writeByte(uint32_t, uint8_t)’:
src/Samba.cpp:252:52: warning: ‘__builtin___snprintf_chk’ output truncated before the last format character [-Wformat-truncation=]
  252 |     snprintf((char*) cmd, sizeof(cmd), "O%08X,%02X#", addr, value);
      |                                                    ^
In file included from /usr/include/stdio.h:867,
                 from /usr/include/c++/9/cstdio:42,
                 from /usr/include/c++/9/ext/string_conversions.h:43,
                 from /usr/include/c++/9/bits/basic_string.h:6493,
                 from /usr/include/c++/9/string:55,
                 from src/Samba.h:33,
                 from src/Samba.cpp:29:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:35: note: ‘__builtin___snprintf_chk’ output 14 bytes into a destination of size 13
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
CPP COMMON src/Flash.cpp
CPP COMMON src/NvmFlash.cpp
CPP COMMON src/EfcFlash.cpp
CPP COMMON src/EefcFlash.cpp
CPP COMMON src/FlashFactory.cpp
CPP COMMON src/Applet.cpp
CPP COMMON src/WordCopyApplet.cpp
CPP COMMON src/Flasher.cpp
CPP COMMON src/PosixSerialPort.cpp
CPP COMMON src/LinuxPortFactory.cpp
CPP BOSSAC src/bossac.cpp
CPP BOSSAC src/CmdOpts.cpp
LD /work/riot/RIOT/dist/tools/bossa-1.8/bin/bossac
STRIP /work/riot/RIOT/dist/tools/bossa-1.8/bin/bossac
[INFO] bossac 1.8 binary successfully built!
/work/riot/RIOT/dist/tools/bossa-1.8/bossac -p /dev/ttyACM0  -e -i -w -v -b -R /work/riot/RIOT/examples/hello-world/bin/arduino-due/hello-world.bin
No device found on /dev/ttyACM0
```

(I don't have that board for testing but the output above show that the tool is correctly built)

</details>

<details><summary>arduino-mkr1000</summary>

```
$ rm -rf dist/tools/bossa-1.9/bin/ dist/tools/bossa-1.9/bossac
$ make -C examples/hello-world BOARD=arduino-mkr1000 --no-print-directory flash
Building application "hello-world" for "arduino-mkr1000" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/arduino-mkr1000
"make" -C /work/riot/RIOT/boards/common/arduino-mkr
"make" -C /work/riot/RIOT/boards/common/samd21-arduino-bootloader
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/auto_init/usb
"make" -C /work/riot/RIOT/sys/event
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/usb/usbus
"make" -C /work/riot/RIOT/sys/usb/usbus/cdc/acm
"make" -C /work/riot/RIOT/sys/usb_board_reset
   text	   data	    bss	    dec	    hex	filename
  15248	    132	   5868	  21248	   5300	/work/riot/RIOT/examples/hello-world/bin/arduino-mkr1000/hello-world.elf
stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
sleep 1
[INFO] bossac 1.9 binary not found - building it from source
[INFO] cloning bossa
Cloning into '/work/riot/RIOT/dist/tools/bossa-1.9/bin'...
remote: Enumerating objects: 11, done.
remote: Counting objects: 100% (11/11), done.
remote: Compressing objects: 100% (10/10), done.
remote: Total 1727 (delta 4), reused 5 (delta 1), pack-reused 1716
Receiving objects: 100% (1727/1727), 1.15 MiB | 993.00 KiB/s, done.
Resolving deltas: 100% (1318/1318), done.
HEAD is now at 4bd2e65 Use git describe for the bossa version
[INFO] updating bossa /work/riot/RIOT/dist/tools/bossa-1.9/bin/.pkg-state.git-downloaded
echo 1.9.1 > /work/riot/RIOT/dist/tools/bossa-1.9/bin/.pkg-state.git-downloaded
[INFO] patch bossa
[INFO] compiling bossac from source now
make[2]: wx-config: Command not found
make[2]: wx-config: Command not found
CPP APPLET src/WordCopyArm.cpp
CPP COMMON src/Samba.cpp
CPP COMMON src/Flash.cpp
CPP COMMON src/D5xNvmFlash.cpp
CPP COMMON src/D2xNvmFlash.cpp
CPP COMMON src/EfcFlash.cpp
CPP COMMON src/EefcFlash.cpp
CPP COMMON src/Applet.cpp
CPP COMMON src/WordCopyApplet.cpp
CPP COMMON src/Flasher.cpp
CPP COMMON src/Device.cpp
CPP COMMON src/PosixSerialPort.cpp
CPP COMMON src/LinuxPortFactory.cpp
CPP BOSSAC src/bossac.cpp
CPP BOSSAC src/CmdOpts.cpp
LD /work/riot/RIOT/dist/tools/bossa-1.9/bin/bossac
STRIP /work/riot/RIOT/dist/tools/bossa-1.9/bin/bossac
[INFO] bossac 1.9 binary successfully built!
/work/riot/RIOT/dist/tools/bossa-1.9/bossac -p /dev/ttyACM0  -o 0x2000 -e -i -w -v -b -R /work/riot/RIOT/examples/hello-world/bin/arduino-mkr1000/hello-world.bin
Device       : ATSAMD21x18
Version      : v2.0 [Arduino:XYZ] Apr 11 2019 13:09:51
Address      : 0x0
Pages        : 4096
Page Size    : 64 bytes
Total Size   : 256KB
Planes       : 1
Lock Regions : 16
Locked       : none
Security     : false
BOD          : true
BOR          : true
Erase flash

Done in 0.788 seconds
Write 15380 bytes to flash (241 pages)
[==============================] 100% (241/241 pages)
Done in 0.089 seconds
Verify 15380 bytes of flash
[==============================] 100% (241/241 pages)
Verify successful
Done in 0.195 seconds
Set boot flash true
```

</details>

<details><summary>arduino-nano-33-ble</summary>

```
$ rm -rf dist/tools/bossa-nrf52/bin/ dist/tools/bossa-nrf52/bossac
$ make -C examples/hello-world BOARD=arduino-nano-33-ble --no-print-directory flash term
Building application "hello-world" for "arduino-nano-33-ble" with MCU "nrf52".

"make" -C /work/riot/RIOT/boards/arduino-nano-33-ble
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/nrf52
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf52/periph
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/auto_init/usb
"make" -C /work/riot/RIOT/sys/event
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/usb/usbus
"make" -C /work/riot/RIOT/sys/usb/usbus/cdc/acm
"make" -C /work/riot/RIOT/sys/usb_board_reset
   text	   data	    bss	    dec	    hex	filename
  14928	    128	   5356	  20412	   4fbc	/work/riot/RIOT/examples/hello-world/bin/arduino-nano-33-ble/hello-world.elf
stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
sleep 1
[INFO] bossac nrf52 binary not found - building it from source
[INFO] updating bossa /work/riot/RIOT/dist/tools/bossa-nrf52/bin/.pkg-state.git-downloaded
echo 52e0a4a28721296e64083de7780b30580e0fad16 > /work/riot/RIOT/dist/tools/bossa-nrf52/bin/.pkg-state.git-downloaded
[INFO] patch bossa
[INFO] compiling bossac from source now
make[2]: wx-config: Command not found
make[2]: wx-config: Command not found
CPP APPLET src/WordCopyArm.cpp
CPP COMMON src/Samba.cpp
CPP COMMON src/Flash.cpp
CPP COMMON src/D5xNvmFlash.cpp
CPP COMMON src/D2xNvmFlash.cpp
CPP COMMON src/NullFlash.cpp
CPP COMMON src/EfcFlash.cpp
CPP COMMON src/EefcFlash.cpp
CPP COMMON src/Applet.cpp
CPP COMMON src/WordCopyApplet.cpp
CPP COMMON src/Flasher.cpp
CPP COMMON src/Device.cpp
CPP COMMON src/PosixSerialPort.cpp
CPP COMMON src/LinuxPortFactory.cpp
CPP BOSSAC src/bossac.cpp
CPP BOSSAC src/CmdOpts.cpp
LD /work/riot/RIOT/dist/tools/bossa-nrf52/bin/bossac
STRIP /work/riot/RIOT/dist/tools/bossa-nrf52/bin/bossac
[INFO] bossac nrf52 binary successfully built!
/work/riot/RIOT/dist/tools/bossa-nrf52/bossac -p /dev/ttyACM0  -e -i -w -v -b -R /work/riot/RIOT/examples/hello-world/bin/arduino-nano-33-ble/hello-world.bin
Device       : nRF52840-QIAA
Version      : Arduino Bootloader (SAM-BA extended) 2.0 [Arduino:IKXYZ]
Address      : 0x0
Pages        : 256
Page Size    : 4096 bytes
Total Size   : 1024KB
Planes       : 1
Lock Regions : 0
Locked       : none
Security     : false
Erase flash

Done in 0.001 seconds
Write 15056 bytes to flash (4 pages)
[==============================] 100% (4/4 pages)
Done in 0.615 seconds
Verify 15056 bytes of flash
[==============================] 100% (4/4 pages)
Verify successful
Done in 0.024 seconds
Set boot flash true
sleep 2
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-07-10 11:10:40,824 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2020-07-10 11:10:41,828 # tools/bossa_factorize)
2020-07-10 11:10:41,829 # Hello World!
2020-07-10 11:10:41,831 # You are running RIOT on a(n) arduino-nano-33-ble board.
2020-07-10 11:10:41,832 # This board features a(n) nrf52 MCU.
2020-07-10 11:10:43,218 # Exiting Pyterm
```

</details>
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
