### PR TITLE
boards/saml1x-based: Model features in Kconfig

### DIFF
--- a/boards/common/saml1x/Kconfig
+++ b/boards/common/saml1x/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD_COMMON_SAML1X
+    bool
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_RIOTBOOT

--- a/boards/saml10-xpro/Kconfig
+++ b/boards/saml10-xpro/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "saml10-xpro" if BOARD_SAML10_XPRO
+
+config BOARD_SAML10_XPRO
+    bool
+    default y
+    select BOARD_COMMON_SAML1X
+    select CPU_MODEL_SAML10E16A
+
+source "$(RIOTBOARD)/common/saml1x/Kconfig"

--- a/boards/saml10-xpro/Makefile.include
+++ b/boards/saml10-xpro/Makefile.include
@@ -1,4 +1,3 @@
-CPU_FAM = saml10
 CFLAGS += -D__SAML10E16A__
 
 include $(RIOTBOARD)/common/saml1x/Makefile.include

--- a/boards/saml11-xpro/Kconfig
+++ b/boards/saml11-xpro/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "saml11-xpro" if BOARD_SAML11_XPRO
+
+config BOARD_SAML11_XPRO
+    bool
+    default y
+    select BOARD_COMMON_SAML1X
+    select CPU_MODEL_SAML11E16A
+
+source "$(RIOTBOARD)/common/saml1x/Kconfig"

--- a/boards/saml11-xpro/Makefile.include
+++ b/boards/saml11-xpro/Makefile.include
@@ -1,4 +1,3 @@
-CPU_FAM = saml11
 CFLAGS += -D__SAML11E16A__
 
 include $(RIOTBOARD)/common/saml1x/Makefile.include

--- a/cpu/saml1x/Kconfig
+++ b/cpu/saml1x/Kconfig
@@ -5,4 +5,47 @@
 # directory for more details.
 #
 
+config CPU_COMMON_SAML1X
+    bool
+    select CPU_COMMON_SAM0
+    select CPU_CORE_CORTEX_M23
+    select HAS_CORTEXM_MPU
+    select HAS_CPU_SAML1X
+    select HAS_PERIPH_HWRNG
+
+config CPU_FAM_SAML10
+    bool
+    select CPU_COMMON_SAML1X
+
+config CPU_FAM_SAML11
+    bool
+    select CPU_COMMON_SAML1X
+
+## CPU Models
+config CPU_MODEL_SAML10E16A
+    bool
+    select CPU_FAM_SAML10
+
+config CPU_MODEL_SAML11E16A
+    bool
+    select CPU_FAM_SAML11
+
+## Declaration of specific features
+config HAS_CPU_SAML1X
+    bool
+    help
+        Indicates that a 'saml1x' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "saml10" if CPU_FAM_SAML10
+    default "saml11" if CPU_FAM_SAML11
+
+config CPU_MODEL
+    default "saml10e16a" if CPU_MODEL_SAML10E16A
+    default "saml11e16a" if CPU_MODEL_SAML11E16A
+
+config CPU
+    default "saml1x" if CPU_COMMON_SAML1X
+
 source "$(RIOTCPU)/sam0_common/Kconfig"

--- a/cpu/saml1x/Makefile.features
+++ b/cpu/saml1x/Makefile.features
@@ -1,5 +1,12 @@
 CPU_CORE = cortex-m23
-CPU_FAM  = saml1x
+
+ifneq (,$(filter saml10%,$(CPU_MODEL)))
+  CPU_FAM = saml10
+else ifneq (,$(filter saml11%,$(CPU_MODEL)))
+  CPU_FAM = saml11
+else
+  $(error Unknown saml1x CPU Model: $(CPU_MODEL))
+endif
 
 FEATURES_PROVIDED += cortexm_mpu
 FEATURES_PROVIDED += periph_hwrng

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -135,6 +135,8 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    remote-revb \
                    ruuvitag \
                    same54-xpro \
+                   saml10-xpro \
+                   saml11-xpro \
                    samr21-xpro \
                    slstk3401a \
                    slstk3402a \


### PR DESCRIPTION
### Contribution description
This models the features of the `saml1x`-based boards in Kconfig:
- `saml10-xpro`
- `saml11-xpro`

This PR also fixes the issue of `CPU_FAM` being currently set twice (once in the cpu's `Makefile.features` and a second time in the board's `Makefile.include, both with different values).

### Testing procedure
- Check the names and organization of the symbols
- Green CI: `tests/kconfig_features` should pass for both boards

### Issues/PRs references
Part of #14148