### PR TITLE
tools: build more tools with tools-buildtest 

### DIFF
--- a/.github/workflows/tools-buildtest.yml
+++ b/.github/workflows/tools-buildtest.yml
@@ -23,6 +23,38 @@ jobs:
       uses: aabadie/riot-action@v1
       with:
         cmd: make -C dist/tools/mosquitto_rsmb
+    - name: Build bossa-1.8 standalone
+      uses: aabadie/riot-action@v1
+      with:
+        cmd: make -C dist/tools/bossa-1.8
+    - name: Build bossa-1.9 standalone
+      uses: aabadie/riot-action@v1
+      with:
+        cmd: make -C dist/tools/bossa-1.9
+    - name: Build bossa-nrf52 standalone
+      uses: aabadie/riot-action@v1
+      with:
+        cmd: make -C dist/tools/bossa-nrf52
+    - name: Build edbg standalone
+      uses: aabadie/riot-action@v1
+      with:
+        cmd: make -C dist/tools/edbg
+    - name: Build pic32prog standalone
+      uses: aabadie/riot-action@v1
+      with:
+        cmd: make -C dist/tools/pic32prog
+    - name: Build setsid standalone
+      uses: aabadie/riot-action@v1
+      with:
+        cmd: make -C dist/tools/setsid
+    - name: Build ethos
+      uses: aabadie/riot-action@v1
+      with:
+        cmd: make -C dist/tools/ethos
+    - name: Build uhcpd
+      uses: aabadie/riot-action@v1
+      with:
+        cmd: make -C dist/tools/uhcpd
     - name: Build stm32 spi_divtable
       uses: aabadie/riot-action@v1
       with:

--- a/dist/tools/bossa-1.8/Makefile
+++ b/dist/tools/bossa-1.8/Makefile
@@ -3,4 +3,9 @@ PKG_URL      = https://github.com/shumatech/BOSSA
 PKG_VERSION  = 26154375695f345491bba158d57177aa231d6765
 PKG_LICENSE  = BSD-3-Clause
 
+# manually set some RIOT env vars, so this Makefile can be called stand-alone
+RIOTBASE ?= $(CURDIR)/../../..
+RIOTTOOLS ?= $(CURDIR)/..
+RIOTMAKE ?= $(RIOTBASE)/makefiles
+
 include $(RIOTMAKE)/tools/bossa-build.inc.mk

--- a/dist/tools/bossa-1.9/Makefile
+++ b/dist/tools/bossa-1.9/Makefile
@@ -3,4 +3,9 @@ PKG_URL      = https://github.com/shumatech/BOSSA
 PKG_VERSION  = 1.9.1
 PKG_LICENSE  = BSD-3-Clause
 
+# manually set some RIOT env vars, so this Makefile can be called stand-alone
+RIOTBASE ?= $(CURDIR)/../../..
+RIOTTOOLS ?= $(CURDIR)/..
+RIOTMAKE ?= $(RIOTBASE)/makefiles
+
 include $(RIOTMAKE)/tools/bossa-build.inc.mk

--- a/dist/tools/bossa-nrf52/Makefile
+++ b/dist/tools/bossa-nrf52/Makefile
@@ -3,4 +3,9 @@ PKG_URL      = https://github.com/arduino/BOSSA
 PKG_VERSION  = 52e0a4a28721296e64083de7780b30580e0fad16
 PKG_LICENSE  = BSD-3-Clause
 
+# manually set some RIOT env vars, so this Makefile can be called stand-alone
+RIOTBASE ?= $(CURDIR)/../../..
+RIOTTOOLS ?= $(CURDIR)/..
+RIOTMAKE ?= $(RIOTBASE)/makefiles
+
 include $(RIOTMAKE)/tools/bossa-build.inc.mk

--- a/dist/tools/edbg/Makefile
+++ b/dist/tools/edbg/Makefile
@@ -3,14 +3,23 @@ PKG_URL=https://github.com/ataradov/edbg
 PKG_VERSION=99d15460fcff723f73b16c29c8ca14bff4b33b20
 PKG_LICENSE=BSD-3-Clause
 
+# manually set some RIOT env vars, so this Makefile can be called stand-alone
+RIOTBASE ?= $(CURDIR)/../../..
+RIOTTOOLS ?= $(CURDIR)/..
+
 PKG_SOURCE_DIR = $(CURDIR)/bin
 PKG_BUILD_OUT_OF_SOURCE = 0
 
 include $(RIOTBASE)/pkg/pkg.mk
 
-all:
+all: $(CURDIR)/edbg
+
+$(CURDIR)/edbg:
 # Start edbg build in a clean environment, so variables set by RIOT's build process
 # for cross compiling a specific target platform are reset and edbg can
 # be built cleanly for the native platform.
 	env -i PATH="$(PATH)" TERM="$(TERM)" "$(MAKE)" -C "$(PKG_BUILD_DIR)"
 	mv $(PKG_BUILD_DIR)/edbg .
+
+clean::
+	rm -f $(CURDIR)/edbg

--- a/dist/tools/pic32prog/Makefile
+++ b/dist/tools/pic32prog/Makefile
@@ -2,7 +2,10 @@ PKG_NAME     = pic32prog
 PKG_URL      = https://github.com/sergev/pic32prog
 PKG_VERSION  = b9f8db3b352804392b02b42475fc42874ac8bf04
 PKG_LICENSE  = GPL-2
-PKG_BUILDDIR = bin
+
+# manually set some RIOT env vars, so this Makefile can be called stand-alone
+RIOTBASE ?= $(CURDIR)/../../..
+RIOTTOOLS ?= $(CURDIR)/..
 
 PKG_SOURCE_DIR = $(CURDIR)/bin
 PKG_BUILD_OUT_OF_SOURCE = 0
@@ -12,10 +15,12 @@ include $(RIOTBASE)/pkg/pkg.mk
 #
 #     sudo apt-get install libusb-dev libusb-1.0-0-dev libudev-dev
 
-all:
+all: $(CURDIR)/pic32prog
+
+$(CURDIR)/pic32prog:
 	@echo "[INFO] compiling pic32prog from source now"
 	@env -i PATH=$(PATH) TERM=$(TERM) $(MAKE) -C $(PKG_BUILD_DIR)
-	@mv $(PKG_BUILD_DIR)/pic32prog pic32prog
+	@mv $(PKG_BUILD_DIR)/pic32prog $(CURDIR)/pic32prog
 
-distclean::
-	@rm -f pic32prog
+clean::
+	rm -f $(CURDIR)/pic32prog

--- a/dist/tools/setsid/Makefile
+++ b/dist/tools/setsid/Makefile
@@ -2,16 +2,21 @@ PKG_NAME     = setsid
 PKG_URL      = https://github.com/tzvetkoff/setsid-macosx
 PKG_VERSION  = e5b851df41591021baf5cf88d4e41572baf8e08b
 PKG_LICENSE  = BSD-2-Clause
-PKG_BUILDDIR = $(CURDIR)/bin
+
+# manually set some RIOT env vars, so this Makefile can be called stand-alone
+RIOTBASE ?= $(CURDIR)/../../..
+RIOTTOOLS ?= $(CURDIR)/..
 
 PKG_SOURCE_DIR = $(CURDIR)/bin
 PKG_BUILD_OUT_OF_SOURCE = 0
 include $(RIOTBASE)/pkg/pkg.mk
 
-all:
+all: $(CURDIR)/setsid
+
+$(CURDIR)/setsid:
 	@echo "[INFO] compiling setsid from source now"
-	$(MAKE) BINDIR=$(PKG_BUILDDIR) -C $(PKG_SOURCE_DIR)
+	$(MAKE) BINDIR=$(PKG_BUILD_DIR) -C $(PKG_SOURCE_DIR)
 	@mv $(PKG_SOURCE_DIR)/setsid $(CURDIR)/setsid
 
-distclean::
-	@rm -f $(CURDIR)/setsid
+clean::
+	rm -f $(CURDIR)/setsid

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -126,17 +126,14 @@ ifeq ($(PKG_SOURCE_DIR),$(PKG_BUILD_DIR))
 # This is the case for packages that are built within their source directory
 # e.g. micropython and openthread
 clean::
-	@-test -d $(PKG_SOURCE_DIR) && $(GIT_IN_PKG) clean $(GIT_QUIET) -xdff
-
-distclean::
-	rm -rf $(PKG_SOURCE_DIR)
+	@-test -d $(PKG_SOURCE_DIR) && $(GIT_IN_PKG) clean -xdff '**' -e $(PKG_STATE:$(PKG_SOURCE_DIR)/%='%*')
 else
 clean::
 	rm -rf $(PKG_BUILD_DIR)
+endif
 
 distclean:: clean
 	rm -rf $(PKG_SOURCE_DIR)
-endif
 
 # Dependencies to 'patches'
 -include $(PKG_PATCHED).d


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR extends the Makefile of remaining built-on-fly tools (bossa, edbg, pic32prog, setsid) so that they can be built as standalone targets and not only via the flash/debug build system targets.
This allows to add them to the tools-buildtest job on GH actions.

There's also a small change with the clean target of packages that are built in source: the target should now exclude the pkg state files and the distclean target is now shared between all types of packages (built/not build out-of-source).

Some tools Makefiles are cleanup a bit: edbg, setsid, pic32prog.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Related tools can be built standalone: bossa*, edbg, pic32prog, setsid. This will be tested automatically by the CI
- Calling make on an already built tools doesn't retrigger a build, calling `clean` and build again doesn't fetch the sources again:

<details><summary>bossa-1.8</summary>

```
$ make -C dist/tools/bossa-1.8 --no-print-directory 
[INFO] cloning bossa
rm -Rf /work/riot/RIOT/dist/tools/bossa-1.8/bin
mkdir -p /work/riot/RIOT/dist/tools/bossa-1.8/bin
/work/riot/RIOT/dist/tools/bossa-1.8/../git/git-cache clone https://github.com/shumatech/BOSSA 26154375695f345491bba158d57177aa231d6765 /work/riot/RIOT/dist/tools/bossa-1.8/bin
Cloning into '/work/riot/RIOT/dist/tools/bossa-1.8/bin'...
remote: Enumerating objects: 11, done.
remote: Counting objects: 100% (11/11), done.
remote: Compressing objects: 100% (10/10), done.
remote: Total 1727 (delta 4), reused 5 (delta 1), pack-reused 1716
Receiving objects: 100% (1727/1727), 1.15 MiB | 593.00 KiB/s, done.
Resolving deltas: 100% (1318/1318), done.
HEAD is now at 2615437 Fixed problem with lock regions on SAM4E.  Some general cleanup.
[INFO] updating bossa /work/riot/RIOT/dist/tools/bossa-1.8/bin/.pkg-state.git-downloaded
git -C /work/riot/RIOT/dist/tools/bossa-1.8/bin --git-dir=.git --work-tree=. fetch  https://github.com/shumatech/BOSSA 26154375695f345491bba158d57177aa231d6765
From https://github.com/shumatech/BOSSA
 * branch            26154375695f345491bba158d57177aa231d6765 -> FETCH_HEAD
echo 26154375695f345491bba158d57177aa231d6765 > /work/riot/RIOT/dist/tools/bossa-1.8/bin/.pkg-state.git-downloaded
[INFO] patch bossa
git -C /work/riot/RIOT/dist/tools/bossa-1.8/bin --git-dir=.git --work-tree=. clean  -xdff '**' -e '.pkg-state.git*'
git -C /work/riot/RIOT/dist/tools/bossa-1.8/bin --git-dir=.git --work-tree=. checkout  -f 26154375695f345491bba158d57177aa231d6765
HEAD is now at 2615437 Fixed problem with lock regions on SAM4E.  Some general cleanup.
git -C /work/riot/RIOT/dist/tools/bossa-1.8/bin --git-dir=.git --work-tree=. -c user.email=buildsystem@riot -c user.name="RIOT buildsystem" am  --no-gpg-sign --ignore-whitespace --whitespace=nowarn /work/riot/RIOT/dist/tools/bossa-1.8/patches/0001-Makefile-fix-build-for-OS-X.patch </dev/null
Applying: Makefile: fix build for OS X
[INFO] compiling bossac from source now
make[1]: wx-config: Command not found
make[1]: wx-config: Command not found
CPP APPLET src/WordCopyArm.cpp
CPP COMMON src/Samba.cpp
src/Samba.cpp: In member function ‘bool Samba::init()’:
src/Samba.cpp:111:12: warning: catching polymorphic type ‘class SambaError’ by value [-Wcatch-value=]
  111 |     catch (SambaError)
      |            ^~~~~~~~~~
src/Samba.cpp: In member function ‘void Samba::writeByte(uint32_t, uint8_t)’:
src/Samba.cpp:252:52: warning: ‘__builtin___snprintf_chk’ output truncated before the last format character [-Wformat-truncation=]
  252 |     snprintf((char*) cmd, sizeof(cmd), "O%08X,%02X#", addr, value);
      |                                                    ^
In file included from /usr/include/stdio.h:867,
                 from /usr/include/c++/9/cstdio:42,
                 from /usr/include/c++/9/ext/string_conversions.h:43,
                 from /usr/include/c++/9/bits/basic_string.h:6493,
                 from /usr/include/c++/9/string:55,
                 from src/Samba.h:33,
                 from src/Samba.cpp:29:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:35: note: ‘__builtin___snprintf_chk’ output 14 bytes into a destination of size 13
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
CPP COMMON src/Flash.cpp
CPP COMMON src/NvmFlash.cpp
CPP COMMON src/EfcFlash.cpp
CPP COMMON src/EefcFlash.cpp
CPP COMMON src/FlashFactory.cpp
CPP COMMON src/Applet.cpp
CPP COMMON src/WordCopyApplet.cpp
CPP COMMON src/Flasher.cpp
CPP COMMON src/PosixSerialPort.cpp
CPP COMMON src/LinuxPortFactory.cpp
CPP BOSSAC src/bossac.cpp
CPP BOSSAC src/CmdOpts.cpp
LD /work/riot/RIOT/dist/tools/bossa-1.8/bin/bossac
STRIP /work/riot/RIOT/dist/tools/bossa-1.8/bin/bossac

$ make -C dist/tools/bossa-1.8
make: Entering directory '/work/riot/RIOT/dist/tools/bossa-1.8'
make: Leaving directory '/work/riot/RIOT/dist/tools/bossa-1.8'

$ make -C dist/tools/bossa-1.8 --no-print-directory  clean
Removing obj/
rm -f /work/riot/RIOT/dist/tools/bossa-1.8/bossac

$ make -C dist/tools/bossa-1.8 --no-print-directory
[INFO] updating bossa /work/riot/RIOT/dist/tools/bossa-1.8/bin/.pkg-state.git-downloaded
git -C /work/riot/RIOT/dist/tools/bossa-1.8/bin --git-dir=.git --work-tree=. fetch  https://github.com/shumatech/BOSSA 26154375695f345491bba158d57177aa231d6765
From https://github.com/shumatech/BOSSA
 * branch            26154375695f345491bba158d57177aa231d6765 -> FETCH_HEAD
echo 26154375695f345491bba158d57177aa231d6765 > /work/riot/RIOT/dist/tools/bossa-1.8/bin/.pkg-state.git-downloaded
[INFO] patch bossa
git -C /work/riot/RIOT/dist/tools/bossa-1.8/bin --git-dir=.git --work-tree=. clean  -xdff '**' -e '.pkg-state.git*'
git -C /work/riot/RIOT/dist/tools/bossa-1.8/bin --git-dir=.git --work-tree=. checkout  -f 26154375695f345491bba158d57177aa231d6765
Warning: you are leaving 1 commit behind, not connected to
any of your branches:

  df84d9e Makefile: fix build for OS X

If you want to keep it by creating a new branch, this may be a good time
to do so with:

 git branch <new-branch-name> df84d9e

HEAD is now at 2615437 Fixed problem with lock regions on SAM4E.  Some general cleanup.
git -C /work/riot/RIOT/dist/tools/bossa-1.8/bin --git-dir=.git --work-tree=. -c user.email=buildsystem@riot -c user.name="RIOT buildsystem" am  --no-gpg-sign --ignore-whitespace --whitespace=nowarn /work/riot/RIOT/dist/tools/bossa-1.8/patches/0001-Makefile-fix-build-for-OS-X.patch </dev/null
Applying: Makefile: fix build for OS X
[INFO] compiling bossac from source now
make[1]: wx-config: Command not found
make[1]: wx-config: Command not found
CPP APPLET src/WordCopyArm.cpp
CPP COMMON src/Samba.cpp
src/Samba.cpp: In member function ‘bool Samba::init()’:
src/Samba.cpp:111:12: warning: catching polymorphic type ‘class SambaError’ by value [-Wcatch-value=]
  111 |     catch (SambaError)
      |            ^~~~~~~~~~
src/Samba.cpp: In member function ‘void Samba::writeByte(uint32_t, uint8_t)’:
src/Samba.cpp:252:52: warning: ‘__builtin___snprintf_chk’ output truncated before the last format character [-Wformat-truncation=]
  252 |     snprintf((char*) cmd, sizeof(cmd), "O%08X,%02X#", addr, value);
      |                                                    ^
In file included from /usr/include/stdio.h:867,
                 from /usr/include/c++/9/cstdio:42,
                 from /usr/include/c++/9/ext/string_conversions.h:43,
                 from /usr/include/c++/9/bits/basic_string.h:6493,
                 from /usr/include/c++/9/string:55,
                 from src/Samba.h:33,
                 from src/Samba.cpp:29:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:35: note: ‘__builtin___snprintf_chk’ output 14 bytes into a destination of size 13
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
CPP COMMON src/Flash.cpp
CPP COMMON src/NvmFlash.cpp
CPP COMMON src/EfcFlash.cpp
CPP COMMON src/EefcFlash.cpp
CPP COMMON src/FlashFactory.cpp
CPP COMMON src/Applet.cpp
CPP COMMON src/WordCopyApplet.cpp
CPP COMMON src/Flasher.cpp
CPP COMMON src/PosixSerialPort.cpp
CPP COMMON src/LinuxPortFactory.cpp
CPP BOSSAC src/bossac.cpp
CPP BOSSAC src/CmdOpts.cpp
LD /work/riot/RIOT/dist/tools/bossa-1.8/bin/bossac
STRIP /work/riot/RIOT/dist/tools/bossa-1.8/bin/bossac
```

(we would have the same results with bossa-1.9 and bossa-nrf52 since they share the same Makefile)

</details>

<details><summary>edbg</summary>

```
$ make -C dist/tools/edbg/ --no-print-directory 
[INFO] cloning edbg
rm -Rf /work/riot/RIOT/dist/tools/edbg/bin
mkdir -p /work/riot/RIOT/dist/tools/edbg/bin
/work/riot/RIOT/dist/tools/edbg/../git/git-cache clone https://github.com/ataradov/edbg 99d15460fcff723f73b16c29c8ca14bff4b33b20 /work/riot/RIOT/dist/tools/edbg/bin
Cloning into '/work/riot/RIOT/dist/tools/edbg/bin'...
remote: Enumerating objects: 62, done.
remote: Counting objects: 100% (62/62), done.
remote: Compressing objects: 100% (44/44), done.
remote: Total 591 (delta 33), reused 37 (delta 18), pack-reused 529
Receiving objects: 100% (591/591), 244.92 KiB | 781.00 KiB/s, done.
Resolving deltas: 100% (375/375), done.
HEAD is now at 99d1546 Merge pull request #90 from ooxi/feature/hidapi-brew
[INFO] updating edbg /work/riot/RIOT/dist/tools/edbg/bin/.pkg-state.git-downloaded
git -C /work/riot/RIOT/dist/tools/edbg/bin --git-dir=.git --work-tree=. fetch  https://github.com/ataradov/edbg 99d15460fcff723f73b16c29c8ca14bff4b33b20
From https://github.com/ataradov/edbg
 * branch            99d15460fcff723f73b16c29c8ca14bff4b33b20 -> FETCH_HEAD
echo 99d15460fcff723f73b16c29c8ca14bff4b33b20 > /work/riot/RIOT/dist/tools/edbg/bin/.pkg-state.git-downloaded
[INFO] patch edbg
git -C /work/riot/RIOT/dist/tools/edbg/bin --git-dir=.git --work-tree=. clean  -xdff '**' -e '.pkg-state.git*'
git -C /work/riot/RIOT/dist/tools/edbg/bin --git-dir=.git --work-tree=. checkout  -f 99d15460fcff723f73b16c29c8ca14bff4b33b20
HEAD is now at 99d1546 Merge pull request #90 from ooxi/feature/hidapi-brew
git -C /work/riot/RIOT/dist/tools/edbg/bin --git-dir=.git --work-tree=. -c user.email=buildsystem@riot -c user.name="RIOT buildsystem" am  --no-gpg-sign --ignore-whitespace --whitespace=nowarn  </dev/null
env -i PATH="/home/aabadie/.local/bin:/work/tools/mips-mti-elf/2020.06-01/bin:/work/tools/avr8-gnu-toolchain-linux_x86_64/bin:/work/tools/riscv-none-gcc/8.2.0-2.2-20190521-0004/bin:/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/:/home/aabadie/.cargo/bin:/home/aabadie/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/work/tools/packer" TERM="xterm-256color" "make" -C "/work/riot/RIOT/dist/tools/edbg/bin"
make: Entering directory '/work/riot/RIOT/dist/tools/edbg/bin'
gcc -W -Wall -Wextra -O2 -std=gnu11 dap.c edbg.c target.c target_atmel_cm0p.c target_atmel_cm3.c target_atmel_cm4.c target_atmel_cm7.c target_atmel_cm4v2.c target_mchp_cm23.c target_st_stm32g0.c target_gd_gd32f4xx.c  dbg_lin.c -ludev -o edbg
make: Leaving directory '/work/riot/RIOT/dist/tools/edbg/bin'
mv /work/riot/RIOT/dist/tools/edbg/bin/edbg .

$ make -C dist/tools/edbg
make: Entering directory '/work/riot/RIOT/dist/tools/edbg'
make: Leaving directory '/work/riot/RIOT/dist/tools/edbg'

$ make -C dist/tools/edbg/ --no-print-directory clean
rm -f /work/riot/RIOT/dist/tools/edbg/edbg

$ make -C dist/tools/edbg/ --no-print-directory 
env -i PATH="/home/aabadie/.local/bin:/work/tools/mips-mti-elf/2020.06-01/bin:/work/tools/avr8-gnu-toolchain-linux_x86_64/bin:/work/tools/riscv-none-gcc/8.2.0-2.2-20190521-0004/bin:/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/:/home/aabadie/.cargo/bin:/home/aabadie/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/work/tools/packer" TERM="xterm-256color" "make" -C "/work/riot/RIOT/dist/tools/edbg/bin"
make: Entering directory '/work/riot/RIOT/dist/tools/edbg/bin'
gcc -W -Wall -Wextra -O2 -std=gnu11 dap.c edbg.c target.c target_atmel_cm0p.c target_atmel_cm3.c target_atmel_cm4.c target_atmel_cm7.c target_atmel_cm4v2.c target_mchp_cm23.c target_st_stm32g0.c target_gd_gd32f4xx.c  dbg_lin.c -ludev -o edbg
make: Leaving directory '/work/riot/RIOT/dist/tools/edbg/bin'
mv /work/riot/RIOT/dist/tools/edbg/bin/edbg .

$ make -C dist/tools/edbg/ --no-print-directory distclean 
rm -f /work/riot/RIOT/dist/tools/edbg/edbg
rm -rf /work/riot/RIOT/dist/tools/edbg/bin
```

</details>

<details><summary>pic32prog</summary>

```
$ make -C dist/tools/pic32prog/ --no-print-directory
[INFO] cloning pic32prog
rm -Rf /work/riot/RIOT/dist/tools/pic32prog/bin
mkdir -p /work/riot/RIOT/dist/tools/pic32prog/bin
/work/riot/RIOT/dist/tools/pic32prog/../git/git-cache clone https://github.com/sergev/pic32prog b9f8db3b352804392b02b42475fc42874ac8bf04 /work/riot/RIOT/dist/tools/pic32prog/bin
Cloning into '/work/riot/RIOT/dist/tools/pic32prog/bin'...
remote: Enumerating objects: 135, done.
remote: Counting objects: 100% (135/135), done.
remote: Compressing objects: 100% (88/88), done.
remote: Total 1290 (delta 83), reused 90 (delta 47), pack-reused 1155
Receiving objects: 100% (1290/1290), 5.01 MiB | 996.00 KiB/s, done.
Resolving deltas: 100% (900/900), done.
HEAD is now at b9f8db3 Fix build warnings.
[INFO] updating pic32prog /work/riot/RIOT/dist/tools/pic32prog/bin/.pkg-state.git-downloaded
git -C /work/riot/RIOT/dist/tools/pic32prog/bin --git-dir=.git --work-tree=. fetch  https://github.com/sergev/pic32prog b9f8db3b352804392b02b42475fc42874ac8bf04
From https://github.com/sergev/pic32prog
 * branch            b9f8db3b352804392b02b42475fc42874ac8bf04 -> FETCH_HEAD
echo b9f8db3b352804392b02b42475fc42874ac8bf04 > /work/riot/RIOT/dist/tools/pic32prog/bin/.pkg-state.git-downloaded
[INFO] patch pic32prog
git -C /work/riot/RIOT/dist/tools/pic32prog/bin --git-dir=.git --work-tree=. clean  -xdff '**' -e '.pkg-state.git*'
git -C /work/riot/RIOT/dist/tools/pic32prog/bin --git-dir=.git --work-tree=. checkout  -f b9f8db3b352804392b02b42475fc42874ac8bf04
HEAD is now at b9f8db3 Fix build warnings.
git -C /work/riot/RIOT/dist/tools/pic32prog/bin --git-dir=.git --work-tree=. -c user.email=buildsystem@riot -c user.name="RIOT buildsystem" am  --no-gpg-sign --ignore-whitespace --whitespace=nowarn  </dev/null
[INFO] compiling pic32prog from source now
make: Entering directory '/work/riot/RIOT/dist/tools/pic32prog/bin'
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o pic32prog.o pic32prog.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o target.o target.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o executive.o executive.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o serial.o serial.c
git submodule update --init
Submodule 'hidapi' (https://github.com/signal11/hidapi.git) registered for path 'hidapi'
Cloning into '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi'...
Submodule path 'hidapi': checked out 'b5b2e1779b6cd2edda3066bbbf0921a2d6b1c3c0'
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-pickit2.o adapter-pickit2.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-hidboot.o adapter-hidboot.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-an1388.o adapter-an1388.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-bitbang.o adapter-bitbang.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-stk500v2.o adapter-stk500v2.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-uhb.o adapter-uhb.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-an1388-uart.o adapter-an1388-uart.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o configure.o configure.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o family-mx1.o family-mx1.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o family-mx3.o family-mx3.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o family-mz.o family-mz.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o family-mm.o family-mm.c
if [ ! -f hidapi/configure ]; then cd hidapi && ./bootstrap; fi
+ autoreconf --install --verbose --force
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in '.'.
libtoolize: copying file './ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
autoreconf: running: /usr/bin/autoconf --force
autoreconf: running: /usr/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:25: installing './ar-lib'
configure.ac:25: installing './compile'
configure.ac:26: installing './config.guess'
configure.ac:26: installing './config.sub'
configure.ac:22: installing './install-sh'
configure.ac:22: installing './missing'
hidtest/Makefile.am: installing './depcomp'
autoreconf: Leaving directory `.'
cd hidapi && ./configure --enable-shared=no CFLAGS=''
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether make supports the include directive... yes (GNU style)
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking dependency style of gcc... gcc3
checking for ar... ar
checking the archiver (ar) interface... ar
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking how to print strings... printf
checking for a sed that does not truncate output... /usr/bin/sed
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for fgrep... /usr/bin/grep -F
checking for ld used by gcc... /usr/bin/ld
checking if the linker (/usr/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/bin/ld option to reload object files... -r
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for archiver @FILE support... @
checking for strip... strip
checking for ranlib... ranlib
checking command to parse /usr/bin/nm -B output from gcc object... ok
checking for sysroot... no
checking for a working dd... /usr/bin/dd
checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
checking for mt... mt
checking if mt is a manifest tool... no
checking how to run the C preprocessor... gcc -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... yes
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... no
checking whether to build static libraries... yes
checking for gcc... (cached) gcc
checking whether we are using the GNU C compiler... (cached) yes
checking whether gcc accepts -g... (cached) yes
checking for gcc option to accept ISO C89... (cached) none needed
checking whether gcc understands -c and -o together... (cached) yes
checking dependency style of gcc... (cached) gcc3
checking for g++... g++
checking whether we are using the GNU C++ compiler... yes
checking whether g++ accepts -g... yes
checking dependency style of g++... gcc3
checking how to run the C++ preprocessor... g++ -E
checking for ld used by g++... /usr/bin/ld -m elf_x86_64
checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
checking whether the g++ linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking for g++ option to produce PIC... -fPIC -DPIC
checking if g++ PIC flag -fPIC -DPIC works... yes
checking if g++ static flag -static works... yes
checking if g++ supports -c -o file.o... yes
checking if g++ supports -c -o file.o... (cached) yes
checking whether the g++ linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... (cached) GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking for gcc... gcc
checking whether we are using the GNU Objective C compiler... no
checking whether gcc accepts -g... no
checking dependency style of gcc... gcc3
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking whether make supports nested variables... (cached) yes
checking operating system... x86_64-pc-linux-gnu
 (Linux back-end)
checking for libudev... yes
checking for clock_gettime in -lrt... yes
checking for libusb... yes
checking for the pthreads library -lpthreads... no
checking whether pthreads work without any flags... no
checking whether pthreads work with -Kthread... no
checking whether pthreads work with -kthread... no
checking for the pthreads library -llthread... no
checking whether pthreads work with -pthread... yes
checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
checking if more special flags are required for pthreads... no
checking for PTHREAD_PRIO_INHERIT... yes
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating pc/hidapi-hidraw.pc
config.status: creating pc/hidapi-libusb.pc
config.status: creating Makefile
config.status: creating hidtest/Makefile
config.status: creating libusb/Makefile
config.status: creating linux/Makefile
config.status: creating mac/Makefile
config.status: creating testgui/Makefile
config.status: creating windows/Makefile
config.status: creating config.h
config.status: executing depfiles commands
config.status: executing libtool commands
make -C hidapi
make[1]: Entering directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi'
make  all-recursive
make[2]: Entering directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi'
Making all in linux
make[3]: Entering directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi/linux'
  CC       hid.lo
  CCLD     libhidapi-hidraw.la
make[3]: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi/linux'
Making all in libusb
make[3]: Entering directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi/libusb'
  CC       hid.lo
  CCLD     libhidapi-libusb.la
make[3]: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi/libusb'
Making all in hidtest
make[3]: Entering directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi/hidtest'
  CXX      hidtest.o
  CXXLD    hidtest-libusb
  CXXLD    hidtest-hidraw
make[3]: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi/hidtest'
make[3]: Entering directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi'
make[3]: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi'
make[2]: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi'
make[1]: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi'
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-mpsse.o adapter-mpsse.c
gcc -g -o pic32prog pic32prog.o target.o executive.o serial.o adapter-pickit2.o adapter-hidboot.o adapter-an1388.o adapter-bitbang.o adapter-stk500v2.o adapter-uhb.o adapter-an1388-uart.o configure.o family-mx1.o family-mx3.o family-mz.o family-mm.o hidapi/libusb/.libs/libhidapi-libusb.a adapter-mpsse.o -Wl,-Bstatic -lusb-1.0 -Wl,-Bdynamic -lpthread -ludev
make: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog/bin'

$ make -C dist/tools/pic32prog/
make: Entering directory '/work/riot/RIOT/dist/tools/pic32prog'
make: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog'

$ make -C dist/tools/pic32prog/ --no-print-directory clean 
Removing adapter-an1388-uart.o
Removing adapter-an1388.o
Removing adapter-bitbang.o
Removing adapter-hidboot.o
Removing adapter-mpsse.o
Removing adapter-pickit2.o
Removing adapter-stk500v2.o
Removing adapter-uhb.o
Removing configure.o
Removing executive.o
Removing family-mm.o
Removing family-mx1.o
Removing family-mx3.o
Removing family-mz.o
Removing pic32prog.o
Removing serial.o
Removing target.o
rm -f /work/riot/RIOT/dist/tools/pic32prog/pic32prog

$ make -C dist/tools/pic32prog/ --no-print-directory
[INFO] compiling pic32prog from source now
make: Entering directory '/work/riot/RIOT/dist/tools/pic32prog/bin'
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o pic32prog.o pic32prog.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o target.o target.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o executive.o executive.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o serial.o serial.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-pickit2.o adapter-pickit2.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-hidboot.o adapter-hidboot.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-an1388.o adapter-an1388.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-bitbang.o adapter-bitbang.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-stk500v2.o adapter-stk500v2.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-uhb.o adapter-uhb.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-an1388-uart.o adapter-an1388-uart.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o configure.o configure.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o family-mx1.o family-mx1.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o family-mx3.o family-mx3.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o family-mz.o family-mz.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o family-mm.o family-mm.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-mpsse.o adapter-mpsse.c
gcc -g -o pic32prog pic32prog.o target.o executive.o serial.o adapter-pickit2.o adapter-hidboot.o adapter-an1388.o adapter-bitbang.o adapter-stk500v2.o adapter-uhb.o adapter-an1388-uart.o configure.o family-mx1.o family-mx3.o family-mz.o family-mm.o hidapi/libusb/.libs/libhidapi-libusb.a adapter-mpsse.o -Wl,-Bstatic -lusb-1.0 -Wl,-Bdynamic -lpthread -ludev
make: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog/bin'

$ make -C dist/tools/pic32prog/ --no-print-directory distclean 
Removing adapter-an1388-uart.o
Removing adapter-an1388.o
Removing adapter-bitbang.o
Removing adapter-hidboot.o
Removing adapter-mpsse.o
Removing adapter-pickit2.o
Removing adapter-stk500v2.o
Removing adapter-uhb.o
Removing configure.o
Removing executive.o
Removing family-mm.o
Removing family-mx1.o
Removing family-mx3.o
Removing family-mz.o
Removing pic32prog.o
Removing serial.o
Removing target.o
rm -f /work/riot/RIOT/dist/tools/pic32prog/pic32prog
rm -rf /work/riot/RIOT/dist/tools/pic32prog/bin
```

</details>

<details><summary>setsid</summary>

```
$ make -C dist/tools/setsid/ --no-print-directory 
[INFO] cloning setsid
rm -Rf /work/riot/RIOT/dist/tools/setsid/bin
mkdir -p /work/riot/RIOT/dist/tools/setsid/bin
/work/riot/RIOT/dist/tools/setsid/../git/git-cache clone https://github.com/tzvetkoff/setsid-macosx e5b851df41591021baf5cf88d4e41572baf8e08b /work/riot/RIOT/dist/tools/setsid/bin
Cloning into '/work/riot/RIOT/dist/tools/setsid/bin'...
remote: Enumerating objects: 13, done.
remote: Total 13 (delta 0), reused 0 (delta 0), pack-reused 13
Unpacking objects: 100% (13/13), 4.04 KiB | 590.00 KiB/s, done.
HEAD is now at e5b851d add license
[INFO] updating setsid /work/riot/RIOT/dist/tools/setsid/bin/.pkg-state.git-downloaded
git -C /work/riot/RIOT/dist/tools/setsid/bin --git-dir=.git --work-tree=. fetch  https://github.com/tzvetkoff/setsid-macosx e5b851df41591021baf5cf88d4e41572baf8e08b
From https://github.com/tzvetkoff/setsid-macosx
 * branch            e5b851df41591021baf5cf88d4e41572baf8e08b -> FETCH_HEAD
echo e5b851df41591021baf5cf88d4e41572baf8e08b > /work/riot/RIOT/dist/tools/setsid/bin/.pkg-state.git-downloaded
[INFO] patch setsid
git -C /work/riot/RIOT/dist/tools/setsid/bin --git-dir=.git --work-tree=. clean  -xdff '**' -e '.pkg-state.git*'
git -C /work/riot/RIOT/dist/tools/setsid/bin --git-dir=.git --work-tree=. checkout  -f e5b851df41591021baf5cf88d4e41572baf8e08b
HEAD is now at e5b851d add license
git -C /work/riot/RIOT/dist/tools/setsid/bin --git-dir=.git --work-tree=. -c user.email=buildsystem@riot -c user.name="RIOT buildsystem" am  --no-gpg-sign --ignore-whitespace --whitespace=nowarn  </dev/null
[INFO] compiling setsid from source now
make BINDIR=/work/riot/RIOT/dist/tools/setsid/bin -C /work/riot/RIOT/dist/tools/setsid/bin
gcc -o setsid setsid.c
setsid.c: In function ‘main’:
setsid.c:104:21: warning: implicit declaration of function ‘wait’ [-Wimplicit-function-declaration]
  104 |                 if (wait(&status) != pid) {
      |                     ^~~~


$ make -C dist/tools/setsid/
make: Entering directory '/work/riot/RIOT/dist/tools/setsid'
make: Leaving directory '/work/riot/RIOT/dist/tools/setsid'

$ make -C dist/tools/setsid/ --no-print-directory clean
rm -f /work/riot/RIOT/dist/tools/setsid/setsid

$ make -C dist/tools/setsid/ --no-print-directory
[INFO] compiling setsid from source now
make BINDIR=/work/riot/RIOT/dist/tools/setsid/bin -C /work/riot/RIOT/dist/tools/setsid/bin
gcc -o setsid setsid.c
setsid.c: In function ‘main’:
setsid.c:104:21: warning: implicit declaration of function ‘wait’ [-Wimplicit-function-declaration]
  104 |                 if (wait(&status) != pid) {
      |                     ^~~~

$ make -C dist/tools/setsid/ --no-print-directory distclean 
rm -f /work/riot/RIOT/dist/tools/setsid/setsid
rm -rf /work/riot/RIOT/dist/tools/setsid/bin
```

</details>

- Calling the tools in the regular workflow is still functional:

<details><summary>bossa-nrf52</summary>

```
$ make -C dist/tools/bossa-nrf52/ distclean
$ make -C examples/hello-world BOARD=arduino-nano-33-ble --no-print-directory flash term
Building application "hello-world" for "arduino-nano-33-ble" with MCU "nrf52".

"make" -C /work/riot/RIOT/boards/arduino-nano-33-ble
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/nrf52
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/nrf52/periph
"make" -C /work/riot/RIOT/cpu/nrf5x_common
"make" -C /work/riot/RIOT/cpu/nrf5x_common/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/auto_init/usb
"make" -C /work/riot/RIOT/sys/event
"make" -C /work/riot/RIOT/sys/isrpipe
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/tsrb
"make" -C /work/riot/RIOT/sys/usb/usbus
"make" -C /work/riot/RIOT/sys/usb/usbus/cdc/acm
"make" -C /work/riot/RIOT/sys/usb_board_reset
   text	   data	    bss	    dec	    hex	filename
  14940	    128	   5356	  20424	   4fc8	/work/riot/RIOT/examples/hello-world/bin/arduino-nano-33-ble/hello-world.elf
stty -F /dev/ttyACM0 raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
sleep 1
[INFO] bossac nrf52 binary not found - building it from source
[INFO] cloning bossa
Cloning into '/work/riot/RIOT/dist/tools/bossa-nrf52/bin'...
remote: Enumerating objects: 1760, done.
remote: Total 1760 (delta 0), reused 0 (delta 0), pack-reused 1760
Receiving objects: 100% (1760/1760), 1.15 MiB | 943.00 KiB/s, done.
Resolving deltas: 100% (1348/1348), done.
HEAD is now at 52e0a4a Fix Windows build
[INFO] updating bossa /work/riot/RIOT/dist/tools/bossa-nrf52/bin/.pkg-state.git-downloaded
echo 52e0a4a28721296e64083de7780b30580e0fad16 > /work/riot/RIOT/dist/tools/bossa-nrf52/bin/.pkg-state.git-downloaded
[INFO] patch bossa
[INFO] compiling bossac from source now
make[2]: wx-config: Command not found
make[2]: wx-config: Command not found
CPP APPLET src/WordCopyArm.cpp
CPP COMMON src/Samba.cpp
CPP COMMON src/Flash.cpp
CPP COMMON src/D5xNvmFlash.cpp
CPP COMMON src/D2xNvmFlash.cpp
CPP COMMON src/NullFlash.cpp
CPP COMMON src/EfcFlash.cpp
CPP COMMON src/EefcFlash.cpp
CPP COMMON src/Applet.cpp
CPP COMMON src/WordCopyApplet.cpp
CPP COMMON src/Flasher.cpp
CPP COMMON src/Device.cpp
CPP COMMON src/PosixSerialPort.cpp
CPP COMMON src/LinuxPortFactory.cpp
CPP BOSSAC src/bossac.cpp
CPP BOSSAC src/CmdOpts.cpp
LD /work/riot/RIOT/dist/tools/bossa-nrf52/bin/bossac
STRIP /work/riot/RIOT/dist/tools/bossa-nrf52/bin/bossac
[INFO] bossac nrf52 binary successfully built!
/work/riot/RIOT/dist/tools/bossa-nrf52/bossac -p /dev/ttyACM0  -e -i -w -v -b -R /work/riot/RIOT/examples/hello-world/bin/arduino-nano-33-ble/hello-world.bin
Device       : nRF52840-QIAA
Version      : Arduino Bootloader (SAM-BA extended) 2.0 [Arduino:IKXYZ]
Address      : 0x0
Pages        : 256
Page Size    : 4096 bytes
Total Size   : 1024KB
Planes       : 1
Lock Regions : 0
Locked       : none
Security     : false
Erase flash

Done in 0.001 seconds
Write 15068 bytes to flash (4 pages)
[==============================] 100% (4/4 pages)
Done in 0.614 seconds
Verify 15068 bytes of flash
[==============================] 100% (4/4 pages)
Verify successful
Done in 0.024 seconds
Set boot flash true
sleep 2
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-07-10 12:11:00,842 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2020-07-10 12:11:01,846 # lean_build_standalone)
2020-07-10 12:11:01,847 # Hello World!
2020-07-10 12:11:01,849 # You are running RIOT on a(n) arduino-nano-33-ble board.
2020-07-10 12:11:01,850 # This board features a(n) nrf52 MCU.
2020-07-10 12:11:44,425 # Exiting Pyterm
```

</details>

<details><summary>edbg</summary>

```
$ make -C dist/tools/edbg/ distclean
$ make -C examples/hello-world BOARD=samr21-xpro --no-print-directory flash term
Building application "hello-world" for "samr21-xpro" with MCU "samd21".

"make" -C /work/riot/RIOT/boards/samr21-xpro
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/samd21
"make" -C /work/riot/RIOT/cpu/cortexm_common
"make" -C /work/riot/RIOT/cpu/cortexm_common/periph
"make" -C /work/riot/RIOT/cpu/sam0_common
"make" -C /work/riot/RIOT/cpu/sam0_common/periph
"make" -C /work/riot/RIOT/cpu/samd21/periph
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/newlib_syscalls_default
"make" -C /work/riot/RIOT/sys/pm_layered
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8752	    112	   2560	  11424	   2ca0	/work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.elf
[INFO] edbg binary not found - building it from source now
CC= CFLAGS= make -C /work/riot/RIOT/dist/tools/edbg
[INFO] cloning edbg
Cloning into '/work/riot/RIOT/dist/tools/edbg/bin'...
remote: Enumerating objects: 62, done.
remote: Counting objects: 100% (62/62), done.
remote: Compressing objects: 100% (44/44), done.
remote: Total 591 (delta 33), reused 37 (delta 18), pack-reused 529
Receiving objects: 100% (591/591), 244.92 KiB | 220.00 KiB/s, done.
Resolving deltas: 100% (375/375), done.
HEAD is now at 99d1546 Merge pull request #90 from ooxi/feature/hidapi-brew
[INFO] updating edbg /work/riot/RIOT/dist/tools/edbg/bin/.pkg-state.git-downloaded
echo 99d15460fcff723f73b16c29c8ca14bff4b33b20 > /work/riot/RIOT/dist/tools/edbg/bin/.pkg-state.git-downloaded
[INFO] patch edbg
env -i PATH="/home/aabadie/.local/bin:/work/tools/mips-mti-elf/2020.06-01/bin:/work/tools/avr8-gnu-toolchain-linux_x86_64/bin:/work/tools/riscv-none-gcc/8.2.0-2.2-20190521-0004/bin:/work/tools/gcc-arm-none-eabi-9-2019-q4-major/bin/:/home/aabadie/.cargo/bin:/home/aabadie/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/work/tools/packer" TERM="xterm-256color" "make" -C "/work/riot/RIOT/dist/tools/edbg/bin"
make: Entering directory '/work/riot/RIOT/dist/tools/edbg/bin'
gcc -W -Wall -Wextra -O2 -std=gnu11 dap.c edbg.c target.c target_atmel_cm0p.c target_atmel_cm3.c target_atmel_cm4.c target_atmel_cm7.c target_atmel_cm4v2.c target_mchp_cm23.c target_st_stm32g0.c target_gd_gd32f4xx.c  dbg_lin.c -ludev -o edbg
make: Leaving directory '/work/riot/RIOT/dist/tools/edbg/bin'
mv /work/riot/RIOT/dist/tools/edbg/bin/edbg .
[INFO] edbg binary successfully built!
/work/riot/RIOT/dist/tools/edbg/edbg  --target samr21 --verbose --file /work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.bin --verify || /work/riot/RIOT/dist/tools/edbg/edbg  --target samr21 --verbose --file /work/riot/RIOT/examples/hello-world/bin/samr21-xpro/hello-world.bin --verify --program
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009840 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification...
at address 0x4 expected 0x1d, read 0xbd
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009840 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming...................................... done.
Verification...................................... done.
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-07-10 12:13:05,707 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2020-07-10 12:13:09,261 # main(): This is RIOT! (Version: 2020.07-devel-1918-g2d861-pr/tools/pkg_clean_build_standalone)
2020-07-10 12:13:09,262 # Hello World!
2020-07-10 12:13:09,266 # You are running RIOT on a(n) samr21-xpro board.
2020-07-10 12:13:09,269 # This board features a(n) samd21 MCU.
2020-07-10 12:13:10,194 # Exiting Pyterm
```

</details>

<details><summary>pic32prog</summary>

```
$ make -C dist/tools/pic32prog/ distclean
$ make BOARD=pic32-wifire -C examples/hello-world/ flash
make: Entering directory '/work/riot/RIOT/examples/hello-world'
Building application "hello-world" for "pic32-wifire" with MCU "mips_pic32mz".

"make" -C /work/riot/RIOT/boards/pic32-wifire
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/mips_pic32mz
"make" -C /work/riot/RIOT/cpu/mips32r2_common
"make" -C /work/riot/RIOT/cpu/mips32r2_common/newlib_syscalls_mips_uhi
"make" -C /work/riot/RIOT/cpu/mips32r2_common/periph
"make" -C /work/riot/RIOT/cpu/mips_pic32_common
"make" -C /work/riot/RIOT/cpu/mips_pic32_common/periph
"make" -C /work/riot/RIOT/cpu/mips_pic32mz/p32mz2048efg100
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
"make" -C /work/riot/RIOT/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
 109268	   2780	   7000	 119048	  1d108	/work/riot/RIOT/examples/hello-world/bin/pic32-wifire/hello-world.elf
[INFO] pic32prog binary not found - building it from source now
make -C /work/riot/RIOT/dist/tools/pic32prog
[INFO] cloning pic32prog
Cloning into '/work/riot/RIOT/dist/tools/pic32prog/bin'...
remote: Enumerating objects: 135, done.
remote: Counting objects: 100% (135/135), done.
remote: Compressing objects: 100% (88/88), done.
remote: Total 1290 (delta 83), reused 90 (delta 47), pack-reused 1155
Receiving objects: 100% (1290/1290), 5.01 MiB | 1.02 MiB/s, done.
Resolving deltas: 100% (900/900), done.
HEAD is now at b9f8db3 Fix build warnings.
[INFO] updating pic32prog /work/riot/RIOT/dist/tools/pic32prog/bin/.pkg-state.git-downloaded
echo b9f8db3b352804392b02b42475fc42874ac8bf04 > /work/riot/RIOT/dist/tools/pic32prog/bin/.pkg-state.git-downloaded
[INFO] patch pic32prog
[INFO] compiling pic32prog from source now
make: Entering directory '/work/riot/RIOT/dist/tools/pic32prog/bin'
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o pic32prog.o pic32prog.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o target.o target.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o executive.o executive.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o serial.o serial.c
git submodule update --init
Submodule 'hidapi' (https://github.com/signal11/hidapi.git) registered for path 'hidapi'
Cloning into '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi'...
Submodule path 'hidapi': checked out 'b5b2e1779b6cd2edda3066bbbf0921a2d6b1c3c0'
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-pickit2.o adapter-pickit2.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-hidboot.o adapter-hidboot.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-an1388.o adapter-an1388.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-bitbang.o adapter-bitbang.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-stk500v2.o adapter-stk500v2.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-uhb.o adapter-uhb.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-an1388-uart.o adapter-an1388-uart.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o configure.o configure.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o family-mx1.o family-mx1.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o family-mx3.o family-mx3.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o family-mz.o family-mz.c
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o family-mm.o family-mm.c
if [ ! -f hidapi/configure ]; then cd hidapi && ./bootstrap; fi
+ autoreconf --install --verbose --force
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in '.'.
libtoolize: copying file './ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
autoreconf: running: /usr/bin/autoconf --force
autoreconf: running: /usr/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:25: installing './ar-lib'
configure.ac:25: installing './compile'
configure.ac:26: installing './config.guess'
configure.ac:26: installing './config.sub'
configure.ac:22: installing './install-sh'
configure.ac:22: installing './missing'
hidtest/Makefile.am: installing './depcomp'
autoreconf: Leaving directory `.'
cd hidapi && ./configure --enable-shared=no CFLAGS=''
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
checking for gawk... gawk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking whether make supports the include directive... yes (GNU style)
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking whether gcc understands -c and -o together... yes
checking dependency style of gcc... gcc3
checking for ar... ar
checking the archiver (ar) interface... ar
checking build system type... x86_64-pc-linux-gnu
checking host system type... x86_64-pc-linux-gnu
checking how to print strings... printf
checking for a sed that does not truncate output... /usr/bin/sed
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for fgrep... /usr/bin/grep -F
checking for ld used by gcc... /usr/bin/ld
checking if the linker (/usr/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 1572864
checking how to convert x86_64-pc-linux-gnu file names to x86_64-pc-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-pc-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/bin/ld option to reload object files... -r
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for archiver @FILE support... @
checking for strip... strip
checking for ranlib... ranlib
checking command to parse /usr/bin/nm -B output from gcc object... ok
checking for sysroot... no
checking for a working dd... /usr/bin/dd
checking how to truncate binary pipes... /usr/bin/dd bs=4096 count=1
checking for mt... mt
checking if mt is a manifest tool... no
checking how to run the C preprocessor... gcc -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... yes
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... no
checking whether to build static libraries... yes
checking for gcc... (cached) gcc
checking whether we are using the GNU C compiler... (cached) yes
checking whether gcc accepts -g... (cached) yes
checking for gcc option to accept ISO C89... (cached) none needed
checking whether gcc understands -c and -o together... (cached) yes
checking dependency style of gcc... (cached) gcc3
checking for g++... g++
checking whether we are using the GNU C++ compiler... yes
checking whether g++ accepts -g... yes
checking dependency style of g++... gcc3
checking how to run the C++ preprocessor... g++ -E
checking for ld used by g++... /usr/bin/ld -m elf_x86_64
checking if the linker (/usr/bin/ld -m elf_x86_64) is GNU ld... yes
checking whether the g++ linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking for g++ option to produce PIC... -fPIC -DPIC
checking if g++ PIC flag -fPIC -DPIC works... yes
checking if g++ static flag -static works... yes
checking if g++ supports -c -o file.o... yes
checking if g++ supports -c -o file.o... (cached) yes
checking whether the g++ linker (/usr/bin/ld -m elf_x86_64) supports shared libraries... yes
checking dynamic linker characteristics... (cached) GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking for gcc... gcc
checking whether we are using the GNU Objective C compiler... no
checking whether gcc accepts -g... no
checking dependency style of gcc... gcc3
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking whether make supports nested variables... (cached) yes
checking operating system... x86_64-pc-linux-gnu
 (Linux back-end)
checking for libudev... yes
checking for clock_gettime in -lrt... yes
checking for libusb... yes
checking for the pthreads library -lpthreads... no
checking whether pthreads work without any flags... no
checking whether pthreads work with -Kthread... no
checking whether pthreads work with -kthread... no
checking for the pthreads library -llthread... no
checking whether pthreads work with -pthread... yes
checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
checking if more special flags are required for pthreads... no
checking for PTHREAD_PRIO_INHERIT... yes
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating pc/hidapi-hidraw.pc
config.status: creating pc/hidapi-libusb.pc
config.status: creating Makefile
config.status: creating hidtest/Makefile
config.status: creating libusb/Makefile
config.status: creating linux/Makefile
config.status: creating mac/Makefile
config.status: creating testgui/Makefile
config.status: creating windows/Makefile
config.status: creating config.h
config.status: executing depfiles commands
config.status: executing libtool commands
make -C hidapi
make[1]: Entering directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi'
make  all-recursive
make[2]: Entering directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi'
Making all in linux
make[3]: Entering directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi/linux'
  CC       hid.lo
  CCLD     libhidapi-hidraw.la
make[3]: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi/linux'
Making all in libusb
make[3]: Entering directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi/libusb'
  CC       hid.lo
  CCLD     libhidapi-libusb.la
make[3]: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi/libusb'
Making all in hidtest
make[3]: Entering directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi/hidtest'
  CXX      hidtest.o
  CXXLD    hidtest-libusb
  CXXLD    hidtest-hidraw
make[3]: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi/hidtest'
make[3]: Entering directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi'
make[3]: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi'
make[2]: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi'
make[1]: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog/bin/hidapi'
gcc -Wall -g -O -Ihidapi/hidapi -DGITCOUNT='"235"' -DUSE_MPSSE   -c -o adapter-mpsse.o adapter-mpsse.c
gcc -g -o pic32prog pic32prog.o target.o executive.o serial.o adapter-pickit2.o adapter-hidboot.o adapter-an1388.o adapter-bitbang.o adapter-stk500v2.o adapter-uhb.o adapter-an1388-uart.o configure.o family-mx1.o family-mx3.o family-mz.o family-mm.o hidapi/libusb/.libs/libhidapi-libusb.a adapter-mpsse.o -Wl,-Bstatic -lusb-1.0 -Wl,-Bdynamic -lpthread -ludev
make: Leaving directory '/work/riot/RIOT/dist/tools/pic32prog/bin'
[INFO] pic32prog binary successfully built!
/work/riot/RIOT/dist/tools/pic32prog/pic32prog /work/riot/RIOT/examples/hello-world/bin/pic32-wifire/hello-world.hex
Programmer for Microchip PIC32 microcontrollers, Version 2.0.235
    Copyright: (C) 2011-2015 Serge Vakulenko

No target found.
```

=> I don't have the pic32-wifire.

</details>

<details><summary>setsid</summary>

- First apply this patch to force the setsid build:

```diff
diff --git a/Makefile.include b/Makefile.include
index f02da86641..d1b93e4e27 100644
--- a/Makefile.include
+++ b/Makefile.include
@@ -648,7 +648,7 @@ endef
 # Check if setsid command is available on the system for debug target
 # This is not the case on MacOSX, so it must be built on the fly
 ifneq (,$(filter debug, $(MAKECMDGOALS)))
-  ifneq (0,$(shell which setsid 2>&1 > /dev/null ; echo $$?))
+  ifneq (0,$(shell which invalid 2>&1 > /dev/null ; echo $$?))
     SETSID = $(RIOTTOOLS)/setsid/setsid
     $(call target-export-variables,debug,$(SETSID))
     DEBUGDEPS += $(SETSID)
```

- Then run the following:

```
$ make -C dist/tools/setsid distclean
$ make -C examples/hello-world/ all debug --no-print-directory
Building application "hello-world" for "native" with MCU "native".

"make" -C /work/riot/RIOT/boards/native
"make" -C /work/riot/RIOT/boards/native/drivers
"make" -C /work/riot/RIOT/core
"make" -C /work/riot/RIOT/cpu/native
"make" -C /work/riot/RIOT/cpu/native/periph
"make" -C /work/riot/RIOT/cpu/native/stdio_native
"make" -C /work/riot/RIOT/cpu/native/vfs
"make" -C /work/riot/RIOT/drivers
"make" -C /work/riot/RIOT/drivers/periph_common
"make" -C /work/riot/RIOT/sys
"make" -C /work/riot/RIOT/sys/auto_init
   text	   data	    bss	    dec	    hex	filename
  24952	    568	  47728	  73248	  11e20	/work/riot/RIOT/examples/hello-world/bin/native/hello-world.elf
[INFO] setsid binary not found - building it from source now
[INFO] cloning setsid
Cloning into '/work/riot/RIOT/dist/tools/setsid/bin'...
remote: Enumerating objects: 13, done.
remote: Total 13 (delta 0), reused 0 (delta 0), pack-reused 13
Unpacking objects: 100% (13/13), 4.04 KiB | 1.35 MiB/s, done.
HEAD is now at e5b851d add license
[INFO] updating setsid /work/riot/RIOT/dist/tools/setsid/bin/.pkg-state.git-downloaded
echo e5b851df41591021baf5cf88d4e41572baf8e08b > /work/riot/RIOT/dist/tools/setsid/bin/.pkg-state.git-downloaded
[INFO] patch setsid
[INFO] compiling setsid from source now
make BINDIR=/work/riot/RIOT/dist/tools/setsid/bin -C /work/riot/RIOT/dist/tools/setsid/bin
gcc -o setsid setsid.c
setsid.c: In function ‘main’:
setsid.c:104:21: warning: implicit declaration of function ‘wait’ [-Wimplicit-function-declaration]
  104 |                 if (wait(&status) != pid) {
      |                     ^~~~
[INFO] setsid binary successfully built!
gdb -q --args /work/riot/RIOT/examples/hello-world/bin/native/hello-world.elf 
Reading symbols from /work/riot/RIOT/examples/hello-world/bin/native/hello-world.elf...
(gdb) quit
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This PR is based on #14484 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
