### PR TITLE
boards/saml21-based: Model features in Kconfig

### DIFF
--- a/boards/saml21-xpro/Kconfig
+++ b/boards/saml21-xpro/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "saml21-xpro" if BOARD_SAML21_XPRO
+
+config BOARD_SAML21_XPRO
+    bool
+    default y
+    select CPU_MODEL_SAML21J18A
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_RIOTBOOT

--- a/boards/samr30-xpro/Kconfig
+++ b/boards/samr30-xpro/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "samr30-xpro" if BOARD_SAMR30_XPRO
+
+config BOARD_SAMR30_XPRO
+    bool
+    default y
+    select CPU_MODEL_SAMR30G18A
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_RIOTBOOT

--- a/boards/samr34-xpro/Kconfig
+++ b/boards/samr34-xpro/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "samr34-xpro" if BOARD_SAMR34_XPRO
+
+config BOARD_SAMR34_XPRO
+    bool
+    default y
+    select CPU_MODEL_SAMR34J18B
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_RIOTBOOT

--- a/cpu/saml21/Kconfig
+++ b/cpu/saml21/Kconfig
@@ -5,4 +5,44 @@
 # directory for more details.
 #
 
+config CPU_FAM_SAML21
+    bool
+    select CPU_COMMON_SAM0
+    select CPU_CORE_CORTEX_M0PLUS
+    select HAS_BACKUP_RAM
+    select HAS_CPU_SAML21
+
+## CPU Models
+config CPU_MODEL_SAML21J18A
+    bool
+    select CPU_FAM_SAML21
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_SAMR30G18A
+    bool
+    select CPU_FAM_SAML21
+
+config CPU_MODEL_SAMR34J18B
+    bool
+    select CPU_FAM_SAML21
+    select HAS_PERIPH_HWRNG
+
+## Declaration of specific features
+config HAS_CPU_SAML21
+    bool
+    help
+        Indicates that a 'saml21' cpu is being used.
+
+## Common CPU symbols
+config CPU_FAM
+    default "saml21" if CPU_FAM_SAML21
+
+config CPU_MODEL
+    default "saml21j18a" if CPU_MODEL_SAML21J18A
+    default "samr30g18a" if CPU_MODEL_SAMR30G18A
+    default "samr34j18b" if CPU_MODEL_SAMR34J18B
+
+config CPU
+    default "saml21" if CPU_FAM_SAML21
+
 source "$(RIOTCPU)/sam0_common/Kconfig"

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -141,7 +141,10 @@ BOARD_WHITELIST += 6lowpan-clicker \
                    same54-xpro \
                    saml10-xpro \
                    saml11-xpro \
+                   saml21-xpro \
                    samr21-xpro \
+                   samr30-xpro \
+                   samr34-xpro \
                    seeeduino_arch-pro \
                    slstk3401a \
                    slstk3402a \


### PR DESCRIPTION
### Contribution description
This models the features of the `saml21`-based boards:
- `saml21-xpro`
- `samr30-xpro`
- `samr34-xpro`

### Testing procedure
- Check the symbol organization and naming
- Green CI: `tests/kconfig_features` should pass for all the boards

### Issues/PRs references
Part of #14148