### PR TITLE
drivers/tests: rename private read() and sleep() functions to avoid conflicts with libc

### DIFF
--- a/drivers/bme680/bme680_saul.c
+++ b/drivers/bme680/bme680_saul.c
@@ -54,7 +54,7 @@ static unsigned _dev2index (const bme680_t *dev)
     return BME680_NUMOF;
 }
 
-static int read(int dev)
+static int _read(int dev)
 {
     /* measure and read sensor values */
     int res;
@@ -101,7 +101,7 @@ static int read_temp(const void *dev, phydat_t *data)
     }
 
     /* either local variable is valid or fetching it was successful */
-    if (_temp_valid[dev_index] || read(dev_index) == BME680_OK) {
+    if (_temp_valid[dev_index] || _read(dev_index) == BME680_OK) {
         /* mark local variable as invalid */
         _temp_valid[dev_index] = false;
 
@@ -123,7 +123,7 @@ static int read_press(const void *dev, phydat_t *data)
     }
 
     /* either local variable is valid or fetching it was successful */
-    if (_press_valid[dev_index] || read(dev_index) == BME680_OK) {
+    if (_press_valid[dev_index] || _read(dev_index) == BME680_OK) {
         /* mark local variable as invalid */
         _press_valid[dev_index] = false;
 
@@ -145,7 +145,7 @@ static int read_hum(const void *dev, phydat_t *data)
     }
 
     /* either local variable is valid or fetching it was successful */
-    if (_hum_valid[dev_index] || read(dev_index) == BME680_OK) {
+    if (_hum_valid[dev_index] || _read(dev_index) == BME680_OK) {
         /* mark local variable as invalid */
         _hum_valid[dev_index] = false;
 
@@ -167,7 +167,7 @@ static int read_gas(const void *dev, phydat_t *data)
     }
 
     /* either local variable is valid or fetching it was successful */
-    if (_gas_valid[dev_index] || read(dev_index) == BME680_OK) {
+    if (_gas_valid[dev_index] || _read(dev_index) == BME680_OK) {
         /* mark local variable as invalid */
         _gas_valid[dev_index] = false;
 

--- a/drivers/sht3x/sht3x_saul.c
+++ b/drivers/sht3x/sht3x_saul.c
@@ -51,7 +51,7 @@ static unsigned _dev2index (const sht3x_dev_t *dev)
     return SHT3X_NUM;
 }
 
-static int read(int dev)
+static int _read(int dev)
 {
     /* read both sensor values */
     unsigned res = sht3x_read(&sht3x_devs[dev], &_temp[dev], &_hum[dev]);
@@ -74,7 +74,7 @@ static int read_temp(const void *dev, phydat_t *data)
     }
 
     /* either local variable is valid or fetching it was successful */
-    if (_temp_valid[dev_index] || read(dev_index) == SHT3X_OK) {
+    if (_temp_valid[dev_index] || _read(dev_index) == SHT3X_OK) {
         /* mark local variable as invalid */
         _temp_valid[dev_index] = false;
 
@@ -96,7 +96,7 @@ static int read_hum(const void *dev, phydat_t *data)
     }
 
     /* either local variable is valid or fetching it was successful */
-    if (_hum_valid[dev_index] || read(dev_index) == SHT3X_OK) {
+    if (_hum_valid[dev_index] || _read(dev_index) == SHT3X_OK) {
         /* mark local variable as invalid */
         _hum_valid[dev_index] = false;
 

--- a/drivers/sps30/sps30_saul.c
+++ b/drivers/sps30/sps30_saul.c
@@ -65,7 +65,7 @@ static void _float_fit(float *src, phydat_t *data, size_t dim, uint32_t mul)
     phydat_fit(data, &i32[0], dim);
 }
 
-static int read(const void *dev, phydat_t *data, unsigned int val_idx)
+static int _read(const void *dev, phydat_t *data, unsigned int val_idx)
 {
     /* find the device index */
     unsigned dev_idx = _dev2index((sps30_t*)dev);
@@ -131,27 +131,27 @@ static int read(const void *dev, phydat_t *data, unsigned int val_idx)
 
 static int read_mc_pm_1_2p5_4(const void *dev, phydat_t *data)
 {
-    return read(dev, data, SPS30_SAUL_VAL_IDX_MC_PM_1_2P5_4);
+    return _read(dev, data, SPS30_SAUL_VAL_IDX_MC_PM_1_2P5_4);
 }
 
 static int read_mc_pm_10(const void *dev, phydat_t *data)
 {
-    return read(dev, data, SPS30_SAUL_VAL_IDX_MC_PM_10);
+    return _read(dev, data, SPS30_SAUL_VAL_IDX_MC_PM_10);
 }
 
 static int read_nc_pm_0p5_1_2p5(const void *dev, phydat_t *data)
 {
-    return read(dev, data, SPS30_SAUL_VAL_IDX_NC_PM_0P5_1_2P5);
+    return _read(dev, data, SPS30_SAUL_VAL_IDX_NC_PM_0P5_1_2P5);
 }
 
 static int read_nc_pm_4_10(const void *dev, phydat_t *data)
 {
-    return read(dev, data, SPS30_SAUL_VAL_IDX_NC_PM_4_10);
+    return _read(dev, data, SPS30_SAUL_VAL_IDX_NC_PM_4_10);
 }
 
 static int read_ps(const void *dev, phydat_t *data)
 {
-    return read(dev, data, SPS30_SAUL_VAL_IDX_PS);
+    return _read(dev, data, SPS30_SAUL_VAL_IDX_PS);
 }
 
 const saul_driver_t sps30_saul_driver_mc_pm_1_2p5_4 = {

--- a/tests/driver_pca9633/main.c
+++ b/tests/driver_pca9633/main.c
@@ -52,7 +52,7 @@ int wakeup(int argc, char **argv)
     return 0;
 }
 
-int sleep(int argc, char **argv)
+int enter_sleep(int argc, char **argv)
 {
     (void) argc;
     (void) argv;
@@ -454,7 +454,7 @@ static const shell_command_t shell_commands[] = {
     { "turn_on", "Turn on all LEDs.", turn_on },
     { "turn_off", "Turn off all LEDs.", turn_off },
     { "wakeup", "Switch to normal mode.", wakeup },
-    { "sleep", "Switch to low power mode.", sleep },
+    { "sleep", "Switch to low power mode.", enter_sleep },
     { "pwm", "Set individual PWM signal for a given channel.", pwm },
     { "grp_pwm", "Set global PWM signal.", grp_pwm },
     { "blinking", "Set up values for blinking mode.", blinking },

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -188,7 +188,7 @@ static int enable_int(int argc, char **argv)
 }
 #endif
 
-static int read(int argc, char **argv)
+static int cmd_read(int argc, char **argv)
 {
     int port, pin;
 
@@ -210,7 +210,7 @@ static int read(int argc, char **argv)
     return 0;
 }
 
-static int set(int argc, char **argv)
+static int cmd_set(int argc, char **argv)
 {
     if (argc < 3) {
         printf("usage: %s <port> <pin>\n", argv[0]);
@@ -222,7 +222,7 @@ static int set(int argc, char **argv)
     return 0;
 }
 
-static int clear(int argc, char **argv)
+static int cmd_clear(int argc, char **argv)
 {
     if (argc < 3) {
         printf("usage: %s <port> <pin>\n", argv[0]);
@@ -234,7 +234,7 @@ static int clear(int argc, char **argv)
     return 0;
 }
 
-static int toggle(int argc, char **argv)
+static int cmd_toggle(int argc, char **argv)
 {
     if (argc < 3) {
         printf("usage: %s <port> <pin>\n", argv[0]);
@@ -281,10 +281,10 @@ static const shell_command_t shell_commands[] = {
     { "init_int", "init as external INT w/o pull resistor", init_int },
     { "enable_int", "enable or disable gpio interrupt", enable_int },
 #endif
-    { "read", "read pin status", read },
-    { "set", "set pin to HIGH", set },
-    { "clear", "set pin to LOW", clear },
-    { "toggle", "toggle pin", toggle },
+    { "read", "read pin status", cmd_read },
+    { "set", "set pin to HIGH", cmd_set },
+    { "clear", "set pin to LOW", cmd_clear },
+    { "toggle", "toggle pin", cmd_toggle },
     { "bench", "run a set of predefined benchmarks", bench },
     { NULL, NULL, NULL }
 };


### PR DESCRIPTION
### Contribution description

When introducing new includes to `board.h`, on AVR the avr-libc header got included through some include chain.
This exposed some drivers and tests, that use e.g. `read()` as a name for an internal function.

This will now cause a conflict. To solve this trivially, give the `read` function a better name so it will no longer conflict (and also be less ambiguous). 

### Testing procedure

Check if the new function names make sense.


### Issues/PRs references

split off #13746
