### PR TITLE
boards: add support for the ESP32-Ethernet-Kit board

### DIFF
--- a/boards/common/esp32/include/board_common.h
+++ b/boards/common/esp32/include/board_common.h
@@ -30,7 +30,9 @@
 
 #include "cpu.h"
 #include "periph_conf.h"
+#if MODULE_ARDUINO
 #include "arduino_pinmap.h"
+#endif
 
 #include "periph/gpio.h"
 #include "sdk_conf.h"

--- a/boards/esp32-ethernet-kit-v1_0/Kconfig
+++ b/boards/esp32-ethernet-kit-v1_0/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+# Copyright (c) 2020 Google LLC
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32-ethernet-kit-v1_0" if BOARD_ESP32_ETHERNET_KIT_V1_0
+
+config BOARD_ESP32_ETHERNET_KIT_V1_0
+    bool
+    default y
+    select BOARD_COMMON_ESP32
+    select CPU_MODEL_ESP32_WROVER_B
+    select HAS_ESP_SPI_RAM
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_ETH
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+
+source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-ethernet-kit-v1_0/Kconfig
+++ b/boards/esp32-ethernet-kit-v1_0/Kconfig
@@ -14,9 +14,11 @@ config BOARD_ESP32_ETHERNET_KIT_V1_0
     select BOARD_COMMON_ESP32
     select CPU_MODEL_ESP32_WROVER_B
     select HAS_ESP_SPI_RAM
+    select HAS_ESP_JTAG
     select HAS_PERIPH_ADC
     select HAS_PERIPH_ETH
     select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI if !MODULE_ESP_JTAG
 
 source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-ethernet-kit-v1_0/Makefile
+++ b/boards/esp32-ethernet-kit-v1_0/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/esp32
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-ethernet-kit-v1_0/Makefile.dep
+++ b/boards/esp32-ethernet-kit-v1_0/Makefile.dep
@@ -1,0 +1,6 @@
+include $(RIOTBOARD)/common/esp32/Makefile.dep
+
+# enables esp_eth as default network device
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += esp_eth
+endif

--- a/boards/esp32-ethernet-kit-v1_0/Makefile.features
+++ b/boards/esp32-ethernet-kit-v1_0/Makefile.features
@@ -5,6 +5,7 @@ include $(RIOTBOARD)/common/esp32/Makefile.features
 
 # additional features provided by the board
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_eth
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 

--- a/boards/esp32-ethernet-kit-v1_0/Makefile.features
+++ b/boards/esp32-ethernet-kit-v1_0/Makefile.features
@@ -9,4 +9,5 @@ FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 
 # unique features provided by the board
+FEATURES_PROVIDED += esp_jtag
 FEATURES_PROVIDED += esp_spi_ram

--- a/boards/esp32-ethernet-kit-v1_0/Makefile.features
+++ b/boards/esp32-ethernet-kit-v1_0/Makefile.features
@@ -8,6 +8,10 @@ FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 
+ifeq (,$(filter esp_jtag,$(USEMODULE)))
+  FEATURES_PROVIDED += periph_spi
+endif
+
 # unique features provided by the board
 FEATURES_PROVIDED += esp_jtag
 FEATURES_PROVIDED += esp_spi_ram

--- a/boards/esp32-ethernet-kit-v1_0/Makefile.features
+++ b/boards/esp32-ethernet-kit-v1_0/Makefile.features
@@ -1,0 +1,12 @@
+CPU_MODEL = esp32-wrover
+
+# common board and CPU features
+include $(RIOTBOARD)/common/esp32/Makefile.features
+
+# additional features provided by the board
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+
+# unique features provided by the board
+FEATURES_PROVIDED += esp_spi_ram

--- a/boards/esp32-ethernet-kit-v1_0/Makefile.include
+++ b/boards/esp32-ethernet-kit-v1_0/Makefile.include
@@ -1,5 +1,3 @@
-PSEUDOMODULES += esp32_ethernet_kit
-PSEUDOMODULES += esp32_ethernet_kit_v1_0
 
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB1

--- a/boards/esp32-ethernet-kit-v1_0/Makefile.include
+++ b/boards/esp32-ethernet-kit-v1_0/Makefile.include
@@ -1,0 +1,7 @@
+PSEUDOMODULES += esp32_ethernet_kit
+PSEUDOMODULES += esp32_ethernet_kit_v1_0
+
+# configure the serial interface
+PORT_LINUX ?= /dev/ttyUSB1
+
+include $(RIOTBOARD)/common/esp32/Makefile.include

--- a/boards/esp32-ethernet-kit-v1_0/doc.txt
+++ b/boards/esp32-ethernet-kit-v1_0/doc.txt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ * Copyright (C) 2020 Google LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_esp32_esp-ethernet-kit-v1_0 ESP32-Ethernet-Kit v1.0
+ * @ingroup     boards_esp32
+ * @brief       Support for for Espressif ESP32-Ethernet-Kit v1.0
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Erik Ekman <eekman@google.com>
+
+## <a name="toc"> Table of Contents </a>
+
+1. [Overview](#overview)
+2. [Hardware](#hardware)
+    1. [MCU](#mcu)
+    2. [Board Configuration](#board_configuration)
+    3. [Board Pinout](#pinout)
+3. [Flashing the Device](#flashing)
+4. [On-Chip Debugging with the device](#debugging)
+5. [Other Documentation Resources](#other-resources)
+
+## <a name="overview"> Overview </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+The Espressif [ESP32-Ethernet-Kit](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit-v1.0.html) is a development board that uses the ESP32-WROVER-B module. Most important features of the board are
+
+- 100 Mbps Ethernet via IP101G PHY
+- USB bridge with JTAG interface
+
+Furthermore, some GPIOs are broken out for extension. The USB bridge based on FDI FT2232HL provides a JTAG interface for OCD debugging through the USB interface.
+
+## <a name="hardware"> Hardware </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+This section describes
+
+- the [MCU](#mcu),
+- the default [board configuration](#board_configuration),
+- the [board pinout](#pinout).
+
+### <a name="mcu"> MCU </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+Most features of the board are provided by the ESP32 SoC. For detailed
+information about the ESP32, see section \ref esp32_mcu "MCU ESP32".
+
+### <a name="board_configuration"> Board Configuration </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+ESP32-Ethernet-Kit v1.0 has the following on-board components
+
+- 100 Mbps Ethernet via IP101G PHY
+- USB bridge with JTAG interface
+
+For detailed information about the configuration of ESP32 boards, see
+section Peripherals in \ref esp32_riot.
+
+@note
+Only a few GPIOs are broken out and available for external hardware on ESP32-Ethernet-Kit boards. Which GPIOs are available as peripherals depends on used modules.
+
+<center>
+\anchor esp32_ethernet_kit_table_board_configuration
+Function        | GPIOs  | Remarks |Configuration
+:---------------|:-------|:--------|:----------------------------------
+BTN0            | GPIO0  | not available if `esp_eth` is used | |
+ADC             | GPIO34, GPIO35, GPIO36, GPIO39 | | \ref esp32_adc_channels "ADC Channels"
+DAC             | - | | \ref esp32_dac_channels "DAC Channels"
+PWM_DEV(0)      | GPIO4 | | \ref esp32_pwm_channels "PWM Channels"
+I2C_DEV(0):SDA  | GPIO32 | | \ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0):SCL  | GPIO33 | | \ref esp32_i2c_interfaces "I2C Interfaces"
+SPI_DEV(0):CLK  | GPIO14 | HSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MISO | GPIO12 | HSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MOSI | GPIO13 | HSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):CS0  | GPIO15  | HSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+UART_DEV(0):TxD | GPIO1  | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0):RxD | GPIO3  | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+</center>
+
+@note
+- GPIO4 only works properly on the board if the function switch for GPIO4 (DIP SW 5) is OFF.
+- SPI_DEV(0) is not available if module `esp_jtag` is used. For the SPI_DEV(0) pins to work properly, the function switches (DIP switches) for the JTAG signals must be set to OFF.
+
+### <a name="pinout"> Board Pinout </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+The board schematic can be found [here](https://dl.espressif.com/dl/schematics/SCH_ESP32-ETHERNET-KIT_A_V1.0_20190517.pdf).
+
+By default, only 3 bidirectional GPIO pins are unused: GPIO4, GPIO32, GPIO33. The suggested configuration is for PWM
+and I2C, but they can also be used for SPI or another serial port. By disabling the JTAG interface on the board,
+another 4 GPIOs can be made available (GPIO12, GPIO13, GPIO14, GPIO15).
+
+## <a name="flashing"> Flashing the Device </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+Flashing RIOT is quite straight forward. The board has a Micro-USB connector with reset/boot/flash logic. Just connect the board using the programming port to your host computer and type:
+```
+make flash BOARD=esp32-ethernet-kit-v1_0 ...
+```
+
+The USB bridge is based on FDI FT2232HL and offers two USB interfaces:
+
+- the first interface is the JTAG interface for [On-Chip debugging](#debugging)
+- the second interface is the console interface, which is also used for flashing
+
+Therefore, you have to declare the USB interface in the make command. For example, if the ESP32-Ethernet-Kit is connected to the host computer through the USB interfaces `/dev/ttyUSB0` and `/dev/ttyUSB1`, the make command would be used as following:
+```
+make flash BOARD=esp32-ethernet-kit-v1_0 PORT=/dev/ttyUSB1 ...
+```
+
+For detailed information about ESP32 as well as configuring and compiling RIOT for ESP32 boards, see \ref esp32_riot.
+
+## <a name="debugging"> On-Chip Debugging with the Device </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+Since the USB bridge based on FDI FT2232HL provides a JTAG interface for debugging through an USB interface, using ESP32-Ethernet-Kit is the easiest and most convenient way for On-Chip debugging. Please refer the [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/jtag-debugging/index.html) for details on how to setup and how to use ESP32-Ethernet-Kit and OpenOCD.
+
+To use the JTAG interface, the `esp_jtag' module must be used to disable the `SPI_DEV(0)` which normally uses the GPIOs for the JTAG signals.
+USEMODULE=esp_jtag make flash BOARD=esp32-ethernet-kit-v1_0 ...
+Furthermore the function switches (DIP switches) for the JTAG signals must be set to ON.
+
+## <a name="other-resources"> Other Documentation Resources </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+There is a comprehensive [Getting Started Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit-v1.0.html) for the ESP32-Ethernet-Kit with a lot information about hardware configuration.
+ */

--- a/boards/esp32-ethernet-kit-v1_0/doc_common.txt
+++ b/boards/esp32-ethernet-kit-v1_0/doc_common.txt
@@ -35,6 +35,7 @@ Furthermore, some GPIOs are broken out for extension. The USB bridge based on FD
 There are different revisions of the board:
 - \ref boards_esp32_esp-ethernet-kit-v1_0
 - \ref boards_esp32_esp-ethernet-kit-v1_1
+- \ref boards_esp32_esp-ethernet-kit-v1_2
 
 ## <a name="hardware"> Hardware </a> &nbsp;&nbsp; [[TOC](#toc)]
 

--- a/boards/esp32-ethernet-kit-v1_0/doc_common.txt
+++ b/boards/esp32-ethernet-kit-v1_0/doc_common.txt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ * Copyright (C) 2020 Google LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_esp32_esp-ethernet-kit ESP32-Ethernet-Kit
+ * @ingroup     boards_esp32
+ * @brief       Support for for Espressif ESP32-Ethernet-Kit
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Erik Ekman <eekman@google.com>
+
+## <a name="toc"> Table of Contents </a>
+
+1. [Overview](#overview)
+2. [Hardware](#hardware)
+    1. [MCU](#mcu)
+    2. [Board Configuration](#common_board_configuration)
+3. [Flashing the Device](#flashing)
+4. [On-Chip Debugging with the device](#debugging)
+
+## <a name="overview"> Overview </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+The Espressif [ESP32-Ethernet-Kit](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit.html) is a development board that uses a ESP32-WROVER module (-B or -E depending on version). Most important features of the board are
+
+- 100 Mbps Ethernet via IP101G PHY
+- USB bridge with JTAG interface
+
+Furthermore, some GPIOs are broken out for extension. The USB bridge based on FDI FT2232HL provides a JTAG interface for OCD debugging through the USB interface.
+
+There are different revisions of the board:
+- \ref boards_esp32_esp-ethernet-kit-v1_0
+- \ref boards_esp32_esp-ethernet-kit-v1_1
+
+## <a name="hardware"> Hardware </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+This section describes
+
+- the [MCU](#mcu),
+- the default [board configuration](#common_board_configuration).
+
+### <a name="mcu"> MCU </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+Most features of the board are provided by the ESP32 SoC. For detailed
+information about the ESP32, see section \ref esp32_mcu "MCU ESP32".
+
+### <a name="common_board_configuration"> Board Configuration </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+ESP32-Ethernet-Kit has the following on-board components
+
+- 100 Mbps Ethernet via IP101G PHY
+- USB bridge with JTAG interface
+
+For detailed information about the configuration of ESP32 boards, see
+section Peripherals in \ref esp32_riot.
+
+The board is available in different versions. See the per-version file for details.
+
+## <a name="flashing"> Flashing the Device </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+Flashing RIOT is quite straight forward. The board has a Micro-USB connector with reset/boot/flash logic. Just connect the board using the programming port to your host computer and type:
+```
+make flash BOARD=esp32-ethernet-kit-v1_X ...
+```
+where `X` is the minor revision number of the board.
+
+The USB bridge is based on FDI FT2232HL and offers two USB interfaces:
+
+- the first interface is the JTAG interface for [On-Chip debugging](#debugging)
+- the second interface is the console interface, which is also used for flashing
+
+Therefore, it might be necessary have to declare the USB interface in the make command. For example, if the ESP32-Ethernet-Kit is connected to the host computer through the USB interfaces `/dev/ttyUSB0` and `/dev/ttyUSB1`, the make command would be used as following:
+```
+make flash BOARD=esp32-ethernet-kit-v1_X PORT=/dev/ttyUSB1 ...
+```
+Please note that `/dev/ttyUSB1` is used as the console port by default. Therefore the variable `PORT` only needs to be defined if the console port is another port.
+
+For detailed information about ESP32 as well as configuring and compiling RIOT for ESP32 boards, see \ref esp32_riot.
+
+## <a name="debugging"> On-Chip Debugging with the Device </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+Since the USB bridge based on FDI FT2232HL provides a JTAG interface for debugging through an USB interface, using ESP32-Ethernet-Kit is the easiest and most convenient way for On-Chip debugging. Please refer the [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/jtag-debugging/index.html) for details on how to setup and how to use ESP32-Ethernet-Kit and OpenOCD.
+
+To use the JTAG interface, the `esp_jtag` module must be used to disable the `SPI_DEV(0)` which normally uses the GPIOs for the JTAG signals.
+USEMODULE=esp_jtag make flash BOARD=esp32-ethernet-kit-v1_X ...
+Furthermore the function switches (DIP switches) for the JTAG signals must be set to ON.
+
+ */

--- a/boards/esp32-ethernet-kit-v1_0/include/board.h
+++ b/boards/esp32-ethernet-kit-v1_0/include/board.h
@@ -33,6 +33,40 @@ static inline void board_init(void) {
     board_init_common();
 }
 
+#if !MODULE_ESP_ETH || DOXYGEN
+/**
+ * @name    Button pin definitions
+ * @{
+ */
+/**
+ * @brief   Default button GPIO pin definition
+ *
+ * The button is only available when Ethernet is not used, as is shares its pin
+ * with the Phy clock.
+ */
+#define BTN0_PIN        GPIO0
+
+/**
+ * @brief   Default button GPIO mode definition
+ *
+ * Since the GPIO of the button is pulled up with an external resistor, the
+ * mode for the GPIO pin has to be GPIO_IN.  */
+#define BTN0_MODE       GPIO_IN
+
+/**
+ * @brief   Default interrupt flank definition for the button GPIO
+ */
+#ifndef BTN0_INT_FLANK
+#define BTN0_INT_FLANK  GPIO_FALLING
+#endif
+
+/**
+ * @brief   Definition for compatibility with previous versions
+ */
+#define BUTTON0_PIN     BTN0_PIN
+/** @} */
+#endif /* !MODULE_ESP_ETH || DOXYGEN */
+
 /**
  * @name    ESP32 Ethernet (EMAC) configuration
  * @{

--- a/boards/esp32-ethernet-kit-v1_0/include/board.h
+++ b/boards/esp32-ethernet-kit-v1_0/include/board.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ * Copyright (C) 2020 Google LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32_esp-ethernet-kit-v1_0
+ * @file
+ * @{
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include <stdint.h>
+
+/* include common board definitions as last step */
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize the board specific hardware
+ */
+static inline void board_init(void) {
+    /* there is nothing special to initialize on this board */
+    board_init_common();
+}
+
+/**
+ * @name    ESP32 Ethernet (EMAC) configuration
+ * @{
+ */
+#define EMAC_PHY_IP101G         1                   /**< IP101G used as PHY interface */
+#define EMAC_PHY_ADDRESS        1                   /**< PHY1 used as base address */
+#define EMAC_PHY_SMI_MDC_PIN    23                  /**< SMI MDC pin */
+#define EMAC_PHY_SMI_MDIO_PIN   18                  /**< SMI MDC pin */
+#define EMAC_PHY_CLOCK_MODE     ETH_CLOCK_GPIO0_IN  /**< external 50 MHz clock */
+#define EMAC_PHY_POWER_PIN      GPIO5               /**< PHY RESET_N connected to pin 5 */
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/esp32-ethernet-kit-v1_0/include/board.h
+++ b/boards/esp32-ethernet-kit-v1_0/include/board.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     boards_esp32_esp-ethernet-kit-v1_0
+ * @ingroup     boards_esp32_esp-ethernet-kit
  * @file
  * @{
  */

--- a/boards/esp32-ethernet-kit-v1_0/include/gpio_params.h
+++ b/boards/esp32-ethernet-kit-v1_0/include/gpio_params.h
@@ -11,7 +11,7 @@
 #define GPIO_PARAMS_H
 
 /**
- * @ingroup     boards_esp32_esp-ethernet-kit-v1_0
+ * @ingroup     boards_esp32_esp-ethernet-kit
  * @brief       Board specific configuration of direct mapped GPIOs
  * @file
  * @author      Gunar Schorcht <gunar@schorcht.net>

--- a/boards/esp32-ethernet-kit-v1_0/include/gpio_params.h
+++ b/boards/esp32-ethernet-kit-v1_0/include/gpio_params.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ * Copyright (C) 2020 Google LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+/**
+ * @ingroup     boards_esp32_esp-ethernet-kit-v1_0
+ * @brief       Board specific configuration of direct mapped GPIOs
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Erik Ekman <eekman@google.com>
+ * @{
+ */
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   LED and button configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/esp32-ethernet-kit-v1_0/include/gpio_params.h
+++ b/boards/esp32-ethernet-kit-v1_0/include/gpio_params.h
@@ -31,6 +31,14 @@ extern "C" {
  */
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
+#ifndef MODULE_ESP_ETH
+    {
+        .name = "BOOT",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED
+    },
+#endif
 };
 
 #ifdef __cplusplus

--- a/boards/esp32-ethernet-kit-v1_0/include/periph_conf.h
+++ b/boards/esp32-ethernet-kit-v1_0/include/periph_conf.h
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     boards_esp32_esp-ethernet-kit-v1_0
+ * @ingroup     boards_esp32_esp-ethernet-kit
  * @brief       Peripheral MCU configuration for Espressif ESP32-Ethernet-Kit
  * @file
  * @author      Gunar Schorcht <gunar@schorcht.net>
@@ -80,7 +80,7 @@
  * @{
  */
 #ifndef PWM0_GPIOS
-#ifdef MODULE_ESP32_ETHERNET_KIT_V1_0
+#ifdef BOARD_ESP32_ETHERNET_KIT_V1_0
 #define PWM0_GPIOS  { GPIO4 }
 #else
 #define PWM0_GPIOS  { GPIO2, GPIO4 }

--- a/boards/esp32-ethernet-kit-v1_0/include/periph_conf.h
+++ b/boards/esp32-ethernet-kit-v1_0/include/periph_conf.h
@@ -93,6 +93,23 @@
 #endif
 /** @} */
 
+/**
+ * @name    SPI configuration
+ *
+ * SPI configuration depends on configured/connected components.
+ *
+ * HSPI is only available when all JTAG pins are disabled.
+ *
+ * @{
+ */
+#ifndef MODULE_ESP_JTAG
+#define SPI0_CTRL   HSPI    /**< HSPI is used as SPI_DEV(0) */
+#define SPI0_SCK    GPIO14  /**< HSPI SCK */
+#define SPI0_MISO   GPIO12  /**< HSPI MISO */
+#define SPI0_MOSI   GPIO13  /**< HSPI MOSI */
+#define SPI0_CS0    GPIO15  /**< HSPI CS0 */
+#endif /* MODULE_ESP_JTAG not defined */
+/** @} */
 
 /**
  * @name   UART configuration

--- a/boards/esp32-ethernet-kit-v1_0/include/periph_conf.h
+++ b/boards/esp32-ethernet-kit-v1_0/include/periph_conf.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ * Copyright (C) 2020 Google LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_esp32_esp-ethernet-kit-v1_0
+ * @brief       Peripheral MCU configuration for Espressif ESP32-Ethernet-Kit
+ * @file
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Erik Ekman <eekman@google.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @name    ADC and DAC channel configuration
+ * @{
+ */
+
+/**
+ * @brief   Declaration of GPIOs that can be used as ADC channels
+ *
+ * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
+ * channels with the `adc_init` function, they can be used for other
+ * purposes.
+ */
+#ifndef ADC_GPIOS
+#define ADC_GPIOS   { GPIO34, GPIO35, GPIO36, GPIO39 }
+#endif
+
+/**
+ * @brief   Declaration of GPIOs that can be used as DAC channels
+ *
+ * ESP32-Ethernet-Kit has no GPIOs left that might be used as DAC channels.
+ */
+#ifndef DAC_GPIOS
+#define DAC_GPIOS   { }
+#endif
+/** @} */
+
+/**
+ * @name   I2C configuration
+ *
+ * @note The GPIOs listed in the configuration are only initialized as I2C
+ * signals when module `periph_i2c` is used. Otherwise they are not
+ * allocated and can be used for other purposes.
+ *
+ * @{
+ */
+#ifndef I2C0_SPEED
+#define I2C0_SPEED  I2C_SPEED_FAST  /**< I2C bus speed of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SCL
+#define I2C0_SCL    GPIO33          /**< SCL signal of I2C_DEV(0) */
+#endif
+#ifndef I2C0_SDA
+#define I2C0_SDA    GPIO32          /**< SDA signal of I2C_DEV(0) */
+#endif
+/** @} */
+
+/**
+ * @name   PWM channel configuration
+ *
+ * @note As long as the according PWM device is not initialized with
+ * the `pwm_init`, the GPIOs declared for this device can be used
+ * for other purposes.
+ *
+ * @{
+ */
+#ifndef PWM0_GPIOS
+#ifdef MODULE_ESP32_ETHERNET_KIT_V1_0
+#define PWM0_GPIOS  { GPIO4 }
+#else
+#define PWM0_GPIOS  { GPIO2, GPIO4 }
+#endif
+#endif /* PWM0_GPIOS */
+
+/** PWM_DEV(1) is not used */
+#ifndef PWM1_GPIOS
+#define PWM1_GPIOS  { }
+#endif
+/** @} */
+
+
+/**
+ * @name   UART configuration
+ *
+ * ESP32 provides 3 UART interfaces at maximum:
+ *
+ * UART_DEV(0) uses fixed standard configuration.<br>
+ * UART_DEV(1) is not available.<br>
+ * UART_DEV(2) is not available.<br>
+ * @{
+ */
+#define UART0_TXD   GPIO1  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO3  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+/** @} */
+
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+/* include common board definitions as last step */
+#include "periph_conf_common.h"
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/boards/esp32-ethernet-kit-v1_1/Kconfig
+++ b/boards/esp32-ethernet-kit-v1_1/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+# Copyright (c) 2020 Google LLC
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32-ethernet-kit-v1_1" if BOARD_ESP32_ETHERNET_KIT_V1_1
+
+config BOARD_ESP32_ETHERNET_KIT_V1_1
+    bool
+    default y
+    select BOARD_COMMON_ESP32
+    select CPU_MODEL_ESP32_WROVER_B
+    select HAS_ESP_SPI_RAM
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_ETH
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+
+source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-ethernet-kit-v1_1/Kconfig
+++ b/boards/esp32-ethernet-kit-v1_1/Kconfig
@@ -14,9 +14,11 @@ config BOARD_ESP32_ETHERNET_KIT_V1_1
     select BOARD_COMMON_ESP32
     select CPU_MODEL_ESP32_WROVER_B
     select HAS_ESP_SPI_RAM
+    select HAS_ESP_JTAG
     select HAS_PERIPH_ADC
     select HAS_PERIPH_ETH
     select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI if !MODULE_ESP_JTAG
 
 source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-ethernet-kit-v1_1/Makefile
+++ b/boards/esp32-ethernet-kit-v1_1/Makefile
@@ -1,0 +1,2 @@
+DIRS = $(RIOTBOARD)/esp32-ethernet-kit-v1_0
+include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-ethernet-kit-v1_1/Makefile.dep
+++ b/boards/esp32-ethernet-kit-v1_1/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/esp32-ethernet-kit-v1_0/Makefile.dep

--- a/boards/esp32-ethernet-kit-v1_1/Makefile.features
+++ b/boards/esp32-ethernet-kit-v1_1/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/esp32-ethernet-kit-v1_0/Makefile.features

--- a/boards/esp32-ethernet-kit-v1_1/Makefile.include
+++ b/boards/esp32-ethernet-kit-v1_1/Makefile.include
@@ -1,0 +1,3 @@
+
+INCLUDES += -I$(RIOTBOARD)/esp32-ethernet-kit-v1_0/include
+include $(RIOTBOARD)/esp32-ethernet-kit-v1_0/Makefile.include

--- a/boards/esp32-ethernet-kit-v1_1/doc.txt
+++ b/boards/esp32-ethernet-kit-v1_1/doc.txt
@@ -8,9 +8,9 @@
  */
 
 /**
- * @defgroup    boards_esp32_esp-ethernet-kit-v1_0 v1.0 Board
+ * @defgroup    boards_esp32_esp-ethernet-kit-v1_1 v1.1 Board
  * @ingroup     boards_esp32_esp-ethernet-kit
- * @brief       Support for for Espressif ESP32-Ethernet-Kit v1.0
+ * @brief       Support for for Espressif ESP32-Ethernet-Kit v1.1
  * @author      Gunar Schorcht <gunar@schorcht.net>
  * @author      Erik Ekman <eekman@google.com>
 
@@ -24,7 +24,7 @@
 
 ## <a name="overview"> Overview </a> &nbsp;&nbsp; [[TOC](#toc)]
 
-The Espressif [ESP32-Ethernet-Kit](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit-v1.0.html) is a development board that uses the ESP32-WROVER-B module. Most important features of the board are
+The Espressif [ESP32-Ethernet-Kit](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit-v1.1.html) is a development board that uses the ESP32-WROVER-B module. Most important features of the board are
 
 - 100 Mbps Ethernet via IP101G PHY
 - USB bridge with JTAG interface
@@ -41,7 +41,7 @@ This section describes
 
 ### <a name="board_configuration"> Board Configuration </a> &nbsp;&nbsp; [[TOC](#toc)]
 
-ESP32-Ethernet-Kit v1.0 has the following on-board components
+ESP32-Ethernet-Kit v1.1 has the following on-board components
 
 - 100 Mbps Ethernet via IP101G PHY
 - USB bridge with JTAG interface
@@ -53,13 +53,13 @@ section Peripherals in \ref esp32_riot.
 Only a few GPIOs are broken out and available for external hardware on ESP32-Ethernet-Kit boards. Which GPIOs are available as peripherals depends on used modules.
 
 <center>
-\anchor esp32_ethernet_kit_v1_0_table_board_configuration
+\anchor esp32_ethernet_kit_v1_1_table_board_configuration
 Function        | GPIOs  | Remarks |Configuration
 :---------------|:-------|:--------|:----------------------------------
 BTN0            | GPIO0  | not available if `esp_eth` is used | |
 ADC             | GPIO34, GPIO35, GPIO36, GPIO39 | | \ref esp32_adc_channels "ADC Channels"
 DAC             | - | | \ref esp32_dac_channels "DAC Channels"
-PWM_DEV(0)      | GPIO4 | | \ref esp32_pwm_channels "PWM Channels"
+PWM_DEV(0)      | GPIO2, GPIO4 | | \ref esp32_pwm_channels "PWM Channels"
 I2C_DEV(0):SDA  | GPIO32 | | \ref esp32_i2c_interfaces "I2C Interfaces"
 I2C_DEV(0):SCL  | GPIO33 | | \ref esp32_i2c_interfaces "I2C Interfaces"
 SPI_DEV(0):CLK  | GPIO14 | HSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
@@ -71,18 +71,17 @@ UART_DEV(0):RxD | GPIO3  | Console (configuration is fixed) | \ref esp32_uart_in
 </center>
 
 @note
-- GPIO4 only works properly on the board if the function switch for GPIO4 (DIP SW 5) is OFF.
 - SPI_DEV(0) is not available if module `esp_jtag` is used. For the SPI_DEV(0) pins to work properly, the function switches (DIP switches) for the JTAG signals must be set to OFF.
 
 ### <a name="pinout"> Board Pinout </a> &nbsp;&nbsp; [[TOC](#toc)]
 
-The board schematic can be found [here](https://dl.espressif.com/dl/schematics/SCH_ESP32-ETHERNET-KIT_A_V1.0_20190517.pdf).
+The board schematic can be found [here](https://dl.espressif.com/dl/schematics/SCH_ESP32-ETHERNET-KIT_A_V1.1_20190711.pdf).
 
-By default, only 3 bidirectional GPIO pins are unused: GPIO4, GPIO32, GPIO33. The suggested configuration is for PWM
+By default, only 4 bidirectional GPIO pins are unused: GPIO2, GPIO4, GPIO32, GPIO33. The suggested configuration is for PWM
 and I2C, but they can also be used for SPI or another serial port. By disabling the JTAG interface on the board,
 another 4 GPIOs can be made available (GPIO12, GPIO13, GPIO14, GPIO15).
 
 ## <a name="other-resources"> Other Documentation Resources </a> &nbsp;&nbsp; [[TOC](#toc)]
 
-There is a comprehensive [Getting Started Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit-v1.0.html) for the ESP32-Ethernet-Kit with a lot information about hardware configuration.
+There is a comprehensive [Getting Started Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit-v1.1.html) for the ESP32-Ethernet-Kit with a lot information about hardware configuration.
  */

--- a/boards/esp32-ethernet-kit-v1_2/Kconfig
+++ b/boards/esp32-ethernet-kit-v1_2/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+# Copyright (c) 2020 Google LLC
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "esp32-ethernet-kit-v1_2" if BOARD_ESP32_ETHERNET_KIT_V1_2
+
+config BOARD_ESP32_ETHERNET_KIT_V1_2
+    bool
+    default y
+    select BOARD_COMMON_ESP32
+    select CPU_MODEL_ESP32_WROVER_E
+    select HAS_ESP_SPI_RAM
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_ETH
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+
+source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-ethernet-kit-v1_2/Kconfig
+++ b/boards/esp32-ethernet-kit-v1_2/Kconfig
@@ -14,9 +14,11 @@ config BOARD_ESP32_ETHERNET_KIT_V1_2
     select BOARD_COMMON_ESP32
     select CPU_MODEL_ESP32_WROVER_E
     select HAS_ESP_SPI_RAM
+    select HAS_ESP_JTAG
     select HAS_PERIPH_ADC
     select HAS_PERIPH_ETH
     select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI if !MODULE_ESP_JTAG
 
 source "$(RIOTBOARD)/common/esp32/Kconfig"

--- a/boards/esp32-ethernet-kit-v1_2/Makefile
+++ b/boards/esp32-ethernet-kit-v1_2/Makefile
@@ -1,0 +1,2 @@
+DIRS = $(RIOTBOARD)/esp32-ethernet-kit-v1_0
+include $(RIOTBASE)/Makefile.base

--- a/boards/esp32-ethernet-kit-v1_2/Makefile.dep
+++ b/boards/esp32-ethernet-kit-v1_2/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/esp32-ethernet-kit-v1_0/Makefile.dep

--- a/boards/esp32-ethernet-kit-v1_2/Makefile.features
+++ b/boards/esp32-ethernet-kit-v1_2/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/esp32-ethernet-kit-v1_0/Makefile.features

--- a/boards/esp32-ethernet-kit-v1_2/Makefile.include
+++ b/boards/esp32-ethernet-kit-v1_2/Makefile.include
@@ -1,0 +1,3 @@
+
+INCLUDES += -I$(RIOTBOARD)/esp32-ethernet-kit-v1_0/include
+include $(RIOTBOARD)/esp32-ethernet-kit-v1_0/Makefile.include

--- a/boards/esp32-ethernet-kit-v1_2/doc.txt
+++ b/boards/esp32-ethernet-kit-v1_2/doc.txt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ * Copyright (C) 2020 Google LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_esp32_esp-ethernet-kit-v1_2 v1.2 Board
+ * @ingroup     boards_esp32_esp-ethernet-kit
+ * @brief       Support for for Espressif ESP32-Ethernet-Kit v1.2
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Erik Ekman <eekman@google.com>
+
+## <a name="toc"> Table of Contents </a>
+
+1. [Overview](#overview)
+2. [Hardware](#hardware)
+    1. [Board Configuration](#board_configuration)
+    2. [Board Pinout](#pinout)
+3. [Other Documentation Resources](#other-resources)
+
+## <a name="overview"> Overview </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+The Espressif [ESP32-Ethernet-Kit](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit.html) is a development board that uses the ESP32-WROVER-E module. Most important features of the board are
+
+- 100 Mbps Ethernet via IP101G PHY
+- USB bridge with JTAG interface
+
+Furthermore, some GPIOs are broken out for extension. The USB bridge based on FDI FT2232HL provides a JTAG interface for OCD debugging through the USB interface.
+For flashing and debugging the board, see \ref boards_esp32_esp-ethernet-kit common board documentation.
+
+## <a name="hardware"> Hardware </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+This section describes
+
+- the default [board configuration](#board_configuration),
+- the [board pinout](#pinout).
+
+### <a name="board_configuration"> Board Configuration </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+ESP32-Ethernet-Kit v1.2 has the following on-board components
+
+- 100 Mbps Ethernet via IP101G PHY
+- USB bridge with JTAG interface
+
+For detailed information about the configuration of ESP32 boards, see
+section Peripherals in \ref esp32_riot.
+
+@note
+Only a few GPIOs are broken out and available for external hardware on ESP32-Ethernet-Kit boards. Which GPIOs are available as peripherals depends on used modules.
+
+<center>
+\anchor esp32_ethernet_kit_v1_2_table_board_configuration
+Function        | GPIOs  | Remarks |Configuration
+:---------------|:-------|:--------|:----------------------------------
+BTN0            | GPIO0  | not available if `esp_eth` is used | |
+ADC             | GPIO34, GPIO35, GPIO36, GPIO39 | | \ref esp32_adc_channels "ADC Channels"
+DAC             | - | | \ref esp32_dac_channels "DAC Channels"
+PWM_DEV(0)      | GPIO2, GPIO4 | | \ref esp32_pwm_channels "PWM Channels"
+I2C_DEV(0):SDA  | GPIO32 | | \ref esp32_i2c_interfaces "I2C Interfaces"
+I2C_DEV(0):SCL  | GPIO33 | | \ref esp32_i2c_interfaces "I2C Interfaces"
+SPI_DEV(0):CLK  | GPIO14 | HSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MISO | GPIO12 | HSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):MOSI | GPIO13 | HSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+SPI_DEV(0):CS0  | GPIO15  | HSPI is used | \ref esp32_spi_interfaces "SPI Interfaces"
+UART_DEV(0):TxD | GPIO1  | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+UART_DEV(0):RxD | GPIO3  | Console (configuration is fixed) | \ref esp32_uart_interfaces "UART interfaces"
+</center>
+
+@note
+- SPI_DEV(0) is not available if module `esp_jtag` is used. For the SPI_DEV(0) pins to work properly, the function switches (DIP switches) for the JTAG signals must be set to OFF.
+
+### <a name="pinout"> Board Pinout </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+The board schematic can be found [here](https://dl.espressif.com/dl/schematics/SCH_ESP32-Ethernet-Kit_A_V1.2_20200528.pdf).
+
+By default, only 4 bidirectional GPIO pins are unused: GPIO2, GPIO4, GPIO32, GPIO33. The suggested configuration is for PWM
+and I2C, but they can also be used for SPI or another serial port. By disabling the JTAG interface on the board,
+another 4 GPIOs can be made available (GPIO12, GPIO13, GPIO14, GPIO15).
+
+## <a name="other-resources"> Other Documentation Resources </a> &nbsp;&nbsp; [[TOC](#toc)]
+
+There is a comprehensive [Getting Started Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit.html) for the ESP32-Ethernet-Kit with a lot information about hardware configuration.
+ */

--- a/boards/esp32-heltec-lora32-v2/include/periph_conf.h
+++ b/boards/esp32-heltec-lora32-v2/include/periph_conf.h
@@ -75,7 +75,7 @@
  * Only I2C interface I2C_DEV(0) is used.
  *
  * @note The GPIOs listed in the configuration are only initialized as I2C
- * signals when module `perpih_i2c` is used. Otherwise they are not
+ * signals when module `periph_i2c` is used. Otherwise they are not
  * allocated and can be used for other purposes.
  *
  * @{
@@ -96,7 +96,7 @@
  * @name   PWM channel configuration
  *
  * @note As long as the according PWM device is not initialized with
- * the ```pwm_init```, the GPIOs declared for this device can be used
+ * the `pwm_init`, the GPIOs declared for this device can be used
  * for other purposes.
  *
  * @{
@@ -117,7 +117,7 @@
  *
  * @note The GPIOs listed in the configuration are first initialized as SPI
  * signals when the corresponding SPI interface is used for the first time
- * by either calling the ```spi_init_cs``` function or the ```spi_acquire```
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
  * function. That is, they are not allocated as SPI signals before and can
  * be used for other purposes as long as the SPI interface is not used.
  *

--- a/boards/esp32-mh-et-live-minikit/include/board_modules.h
+++ b/boards/esp32-mh-et-live-minikit/include/board_modules.h
@@ -34,7 +34,7 @@ extern "C" {
 /**
  * @name    MRF24J40 shield configuration
  *
- * Configuration for the MRF24J40 shield when module ```mrf24j40``` is used.
+ * Configuration for the MRF24J40 shield when module `mrf24j40` is used.
  *
  * MRF24J40 module uses SPI_DEV(0) and according pins on this board to be
  * compatible with the Wemos D1 mini MRF24J40 shield.
@@ -64,7 +64,7 @@ extern "C" {
 /**
  * @name    SD-Card shield configuration
  *
- * Configuration of the SD-Card interface when module ```sdcard_spi``` is used.
+ * Configuration of the SD-Card interface when module `sdcard_spi` is used.
  *
  * SD card interface uses SPI_DEV(0) on this board to be compatible with the
  * Wemos D1 mini micro SD card shield. The D8 pin (GPIO5) is used as default

--- a/boards/esp32-mh-et-live-minikit/include/periph_conf.h
+++ b/boards/esp32-mh-et-live-minikit/include/periph_conf.h
@@ -46,7 +46,7 @@
  * @brief   Declaration of GPIOs that can be used as ADC channels
  *
  * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
- * channels with the ```adc_init``` function, they can be used for other
+ * channels with the `adc_init` function, they can be used for other
  * purposes.
  */
 #ifndef ADC_GPIOS
@@ -57,7 +57,7 @@
  * @brief   Declaration of GPIOs that can be used as DAC channels
  *
  * @note As long as the GPIOs listed in DAC_GPIOS are not initialized as DAC
- * channels with the ```dac_init``` function, they can be used for other
+ * channels with the `dac_init` function, they can be used for other
  * purposes.
  */
 #ifndef DAC_GPIOS
@@ -72,7 +72,7 @@
  * Only I2C interface I2C_DEV(0) is used.
  *
  * @note The GPIOs listed in the configuration are only initialized as I2C
- * signals when module ```perpih_i2c``` is used. Otherwise they are not
+ * signals when module `periph_i2c` is used. Otherwise they are not
  * allocated and can be used for other purposes.
  *
  * @{
@@ -93,7 +93,7 @@
  * @name   PWM channel configuration
  *
  * @note As long as the according PWM device is not initialized with
- * the ```pwm_init```, the GPIOs declared for this device can be used
+ * the `pwm_init`, the GPIOs declared for this device can be used
  * for other purposes.
  *
  * @{
@@ -114,7 +114,7 @@
  *
  * @note The GPIOs listed in the configuration are first initialized as SPI
  * signals when the corresponding SPI interface is used for the first time
- * by either calling the ```spi_init_cs``` function or the ```spi_acquire```
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
  * function. That is, they are not allocated as SPI signals before and can
  * be used for other purposes as long as the SPI interface is not used.
  *

--- a/boards/esp32-olimex-evb/include/periph_conf.h
+++ b/boards/esp32-olimex-evb/include/periph_conf.h
@@ -44,7 +44,7 @@ extern "C" {
  * @name    ADC and DAC channel configuration
  *
  * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
- * channels with the ```adc_init``` function, they can be used for other
+ * channels with the `adc_init` function, they can be used for other
  *
  * purposes.
  * @{
@@ -53,7 +53,7 @@ extern "C" {
  * @brief   Declaration of GPIOs that can be used as ADC channels
  *
  * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
- * channels with the ```adc_init``` function, they can be used for other
+ * channels with the `adc_init` function, they can be used for other
  * purposes.
  */
 #ifndef ADC_GPIOS
@@ -83,12 +83,12 @@ extern "C" {
 /**
  * @name    I2C configuration
  *
- * Olimex ESP32-EVB/GATEWAY have one I2C interface ```I2C_DEV(0)```. However,
+ * Olimex ESP32-EVB/GATEWAY have one I2C interface `I2C_DEV(0)`. However,
  * they use different GPIOs. Olimex ESP32-EVB, the interface is also available
  * at the [UEXT] connector.
  *
  * @note The GPIOs listed in the configuration are only initialized as I2C
- * signals when module ```perpih_i2c``` is used. Otherwise they are not
+ * signals when module `periph_i2c` is used. Otherwise they are not
  * allocated and can be used for other purposes.
  *
  * @{
@@ -119,14 +119,14 @@ extern "C" {
  * @name    PWM channel configuration
  *
  * @note As long as the according PWM device is not initialized with
- * the ```pwm_init```, the GPIOs declared for this device can be used
+ * the `pwm_init`, the GPIOs declared for this device can be used
  * for other purposes.
  *
  * @{
  */
 /**
  * In DOUT and DIO flash mode, GPIO9 and GIO10 are available and can be used
- * as PWM channels with ```PWM_DEV(0)```.
+ * as PWM channels with `PWM_DEV(0)`.
  */
 #ifndef PWM0_GPIOS
 #if FLASH_MODE_DOUT || FLASH_MODE_DIO || DOXYGEN
@@ -154,14 +154,14 @@ extern "C" {
  * It is available at the [UEXT] connector on Olimex ESP32-EVB.
  *
  * Although the SD card interface of the Olimex ESP32-EVB is also available at
- * the ```SPI_DEV(0)``` interface, it does not have a CS signal. Therefore,
- * it cannot be used in SPI mode with the ```sdcard_spi``` module. Olimex
+ * the `SPI_DEV(0)` interface, it does not have a CS signal. Therefore,
+ * it cannot be used in SPI mode with the `sdcard_spi` module. Olimex
  * ESP32-GATEWAY uses the integrated SD card interface with another GPIO for
  * the CS signal.
  *
  * @note The GPIOs listed in the configuration are first initialized as SPI
  * signals when the corresponding SPI interface is used for the first time
- * by either calling the ```spi_init_cs``` function or the ```spi_acquire```
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
  * function. That is, they are not allocated as SPI signals before and can
  * be used for other purposes as long as the SPI interface is not used.
  */

--- a/boards/esp32-ttgo-t-beam/include/periph_conf.h
+++ b/boards/esp32-ttgo-t-beam/include/periph_conf.h
@@ -80,7 +80,7 @@
  * Only I2C interface I2C_DEV(0) is used.
  *
  * @note The GPIOs listed in the configuration are only initialized as I2C
- * signals when module `perpih_i2c` is used. Otherwise they are not
+ * signals when module `periph_i2c` is used. Otherwise they are not
  * allocated and can be used for other purposes.
  *
  * @{
@@ -101,7 +101,7 @@
  * @name   PWM channel configuration
  *
  * @note As long as the according PWM device is not initialized with
- * the ```pwm_init```, the GPIOs declared for this device can be used
+ * the `pwm_init`, the GPIOs declared for this device can be used
  * for other purposes.
  *
  * @{
@@ -117,7 +117,7 @@
  *
  * @note The GPIOs listed in the configuration are first initialized as SPI
  * signals when the corresponding SPI interface is used for the first time
- * by either calling the ```spi_init_cs``` function or the ```spi_acquire```
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
  * function. That is, they are not allocated as SPI signals before and can
  * be used for other purposes as long as the SPI interface is not used.
  *

--- a/boards/esp32-wemos-lolin-d32-pro/include/periph_conf.h
+++ b/boards/esp32-wemos-lolin-d32-pro/include/periph_conf.h
@@ -60,7 +60,7 @@
  * GPIO35 is used to measure V_BAT and is therefore not broken out.
  *
  * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
- * channels with the ```adc_init``` function, they can be used for other
+ * channels with the `adc_init` function, they can be used for other
  * purposes.
  */
 #ifndef ADC_GPIOS
@@ -75,7 +75,7 @@
  * @brief   Declaration of GPIOs that can be used as DAC channels
  *
  * @note As long as the GPIOs listed in DAC_GPIOS are not initialized as DAC
- * channels with the ```dac_init``` function, they can be used for other
+ * channels with the `dac_init` function, they can be used for other
  * purposes.
  */
 #ifndef DAC_GPIOS
@@ -90,7 +90,7 @@
  * Only I2C interface I2C_DEV(0) is used.
  *
  * @note The GPIOs listed in the configuration are only initialized as I2C
- * signals when module ```perpih_i2c``` is used. Otherwise they are not
+ * signals when module `periph_i2c` is used. Otherwise they are not
  * allocated and can be used for other purposes.
  *
  * @{
@@ -111,7 +111,7 @@
  * @name   PWM channel configuration
  *
  * @note As long as the according PWM device is not initialized with
- * the ```pwm_init```, the GPIOs declared for this device can be used
+ * the `pwm_init`, the GPIOs declared for this device can be used
  * for other purposes.
  *
  * @{
@@ -134,7 +134,7 @@
  *
  * @note The GPIOs listed in the configuration are first initialized as SPI
  * signals when the corresponding SPI interface is used for the first time
- * by either calling the ```spi_init_cs``` function or the ```spi_acquire```
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
  * function. That is, they are not allocated as SPI signals before and can
  * be used for other purposes as long as the SPI interface is not used.
  *

--- a/boards/esp32-wroom-32/include/periph_conf.h
+++ b/boards/esp32-wroom-32/include/periph_conf.h
@@ -48,7 +48,7 @@ extern "C" {
  * channels.
  *
  * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
- * channels with the ```adc_init``` function, they can be used for other
+ * channels with the `adc_init` function, they can be used for other
  * purposes.
  */
 #ifndef ADC_GPIOS
@@ -64,7 +64,7 @@ extern "C" {
  * DAC channels.
  *
  * @note As long as the GPIOs listed in DAC_GPIOS are not initialized as DAC
- * channels with the ```dac_init``` function, they can be used for other
+ * channels with the `dac_init` function, they can be used for other
  * purposes.
  */
 #ifndef DAC_GPIOS
@@ -78,7 +78,7 @@ extern "C" {
  * For generic boards, only one I2C interface I2C_DEV(0) is defined.
  *
  * The GPIOs listed in the configuration are only initialized as I2C signals
- * when module ```perpih_i2c``` is used. Otherwise they are not allocated and
+ * when module `periph_i2c` is used. Otherwise they are not allocated and
  * can be used for other purposes.
  *
  * @{
@@ -102,7 +102,7 @@ extern "C" {
  * Generally, all outputs pins could be used as PWM channels.
  *
  * @note As long as the according PWM device is not initialized with
- * the ```pwm_init```, the GPIOs declared for this device can be used
+ * the `pwm_init`, the GPIOs declared for this device can be used
  * for other purposes.
  *
  * @{
@@ -130,7 +130,7 @@ extern "C" {
  *
  * @note The GPIOs listed in the configuration are first initialized as SPI
  * signals when the corresponding SPI interface is used for the first time
- * by either calling the ```spi_init_cs``` function or the ```spi_acquire```
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
  * function. That is, they are not allocated as SPI signals before and can
  * be used for other purposes as long as the SPI interface is not used.
  * @{

--- a/boards/esp32-wrover-kit/Kconfig
+++ b/boards/esp32-wrover-kit/Kconfig
@@ -15,6 +15,7 @@ config BOARD_ESP32_WROVER_KIT
     select HAS_ARDUINO
     select HAS_ESP_RTC_TIMER_32K
     select HAS_ESP_SPI_RAM
+    select HAS_ESP_JTAG
     select HAS_PERIPH_ADC
     select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM

--- a/boards/esp32-wrover-kit/Makefile.features
+++ b/boards/esp32-wrover-kit/Makefile.features
@@ -11,6 +11,7 @@ FEATURES_PROVIDED += periph_spi
 
 # unique features provided by the board
 FEATURES_PROVIDED += sdcard_spi
+FEATURES_PROVIDED += esp_jtag
 FEATURES_PROVIDED += esp_spi_ram
 FEATURES_PROVIDED += esp_rtc_timer_32k
 

--- a/boards/esp32-wrover-kit/include/periph_conf.h
+++ b/boards/esp32-wrover-kit/include/periph_conf.h
@@ -63,7 +63,7 @@
  * as ADC channels.
  *
  * @note As long as the GPIOs listed in ADC_GPIOS are not initialized as ADC
- * channels with the ```adc_init``` function, they can be used for other
+ * channels with the `adc_init` function, they can be used for other
  * purposes.
  */
 #ifndef ADC_GPIOS
@@ -89,7 +89,7 @@
  * @name   I2C configuration
  *
  * @note The GPIOs listed in the configuration are only initialized as I2C
- * signals when module ```perpih_i2c``` is used. Otherwise they are not
+ * signals when module `periph_i2c` is used. Otherwise they are not
  * allocated and can be used for other purposes.
  *
  * @{
@@ -115,7 +115,7 @@
  * purposes.
  *
  * @note As long as the according PWM device is not initialized with
- * the ```pwm_init```, the GPIOs declared for this device can be used
+ * the `pwm_init`, the GPIOs declared for this device can be used
  * for other purposes.
  *
  * @{
@@ -140,7 +140,7 @@
  *
  * SPI configuration depends on configured/connected components.
  *
- * HSPI is is always available and therefore used as SPI_DEV(0)
+ * HSPI is always available and therefore used as SPI_DEV(0)
  * VSPI is only available when the camera is not plugged.
  *
  * @{
@@ -169,7 +169,7 @@
  *
  * @note The GPIOs listed in the configuration are first initialized as SPI
  * signals when the corresponding SPI interface is used for the first time
- * by either calling the ```spi_init_cs``` function or the ```spi_acquire```
+ * by either calling the `spi_init_cs` function or the `spi_acquire`
  * function. That is, they are not allocated as SPI signals before and can
  * be used for other purposes as long as the SPI interface is not used.
  *

--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -85,6 +85,7 @@ config CPU_MODEL
     default "esp32-wroom_32" if CPU_MODEL_ESP32_WROOM_32
     default "esp32-wrover" if CPU_MODEL_ESP32_WROVER
     default "esp32-wrover" if CPU_MODEL_ESP32_WROVER_B
+    default "esp32-wrover" if CPU_MODEL_ESP32_WROVER_E
     default "esp32-d0wd" if CPU_MODEL_ESP32_D0WD
 
 config CPU

--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -32,6 +32,10 @@ config CPU_MODEL_ESP32_WROVER_B
     bool
     select CPU_FAM_ESP32
 
+config CPU_MODEL_ESP32_WROVER_E
+    bool
+    select CPU_FAM_ESP32
+
 config CPU_MODEL_ESP32_D0WD
     bool
     select CPU_FAM_ESP32

--- a/cpu/esp32/Kconfig
+++ b/cpu/esp32/Kconfig
@@ -28,6 +28,10 @@ config CPU_MODEL_ESP32_WROVER
     bool
     select CPU_FAM_ESP32
 
+config CPU_MODEL_ESP32_WROVER_B
+    bool
+    select CPU_FAM_ESP32
+
 config CPU_MODEL_ESP32_D0WD
     bool
     select CPU_FAM_ESP32
@@ -76,6 +80,7 @@ config CPU_FAM
 config CPU_MODEL
     default "esp32-wroom_32" if CPU_MODEL_ESP32_WROOM_32
     default "esp32-wrover" if CPU_MODEL_ESP32_WROVER
+    default "esp32-wrover" if CPU_MODEL_ESP32_WROVER_B
     default "esp32-d0wd" if CPU_MODEL_ESP32_D0WD
 
 config CPU

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -26,6 +26,7 @@ PSEUDOMODULES += esp_gdbstub
 PSEUDOMODULES += esp_hw_counter
 PSEUDOMODULES += esp_i2c_hw
 PSEUDOMODULES += esp_idf_newlib
+PSEUDOMODULES += esp_jtag
 PSEUDOMODULES += esp_rtc_timer_32k
 PSEUDOMODULES += esp_spi_ram
 PSEUDOMODULES += esp_wifi_enterprise
@@ -47,6 +48,10 @@ INCLUDES += -I$(RIOTCPU)/$(CPU)
 ifneq (,$(filter esp_eth,$(USEMODULE)))
   INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/ethernet
   INCLUDES += -I$(ESP32_SDK_DIR)/components/ethernet/include
+endif
+
+ifneq (,$(filter esp_jtag,$(USEMODULE)))
+  FEATURES_REQUIRED += esp_jtag
 endif
 
 CFLAGS += -DSDK_NOT_USED -DCONFIG_FREERTOS_UNICORE=1 -DESP_PLATFORM

--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -1142,7 +1142,7 @@ ESP32 provides different built-in possibilities to realize network devices:
 \anchor esp32_ethernet_network_interface
 ## <a name="esp32_ethernet_network_interface"> Ethernet MAC Network Interface </a> &nbsp;[[TOC](#esp32_toc)]
 
-ESP32 provides an <b>Ethernet MAC layer module (EMAC)</b> according to the IEEE 802.3 standard which can be used together with an external physical layer chip (PHY) to realize a 100/10 Mbps Ethernet interface. Supported PHY chips are the Microchip LAN8710/LAN8720 and the Texas Instruments TLK110.
+ESP32 provides an <b>Ethernet MAC layer module (EMAC)</b> according to the IEEE 802.3 standard which can be used together with an external physical layer chip (PHY) to realize a 100/10 Mbps Ethernet interface. Supported PHY chips are the Microchip LAN8710/LAN8720, the IC Plus 101G, and the Texas Instruments TLK110.
 
 The RIOT port for ESP32 realizes with module ```esp_eth``` a ```netdev``` driver for the EMAC which uses RIOT's standard Ethernet interface.
 

--- a/cpu/esp32/esp-eth/doc.txt
+++ b/cpu/esp32/esp-eth/doc.txt
@@ -16,7 +16,7 @@
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
 
-ESP32 provides an <b>Ethernet MAC layer module (EMAC)</b> according to the IEEE 802.3 standard which can be used together with an external physical layer chip (PHY) to realize a 100/10 Mbps Ethernet interface. Supported PHY chips are the Microchip LAN8710/LAN8720 and the Texas Instruments TLK110.
+ESP32 provides an <b>Ethernet MAC layer module (EMAC)</b> according to the IEEE 802.3 standard which can be used together with an external physical layer chip (PHY) to realize a 100/10 Mbps Ethernet interface. Supported PHY chips are the Microchip LAN8710/LAN8720, the IC Plus 101G, and the Texas Instruments TLK110.
 
 The RIOT port for ESP32 realizes with module ```esp_eth``` a ```netdev``` driver for the EMAC which uses RIOT's standard Ethernet interface.
 

--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -56,6 +56,10 @@
 #include "eth_phy/phy_lan8720.h"
 #define EMAC_ETHERNET_PHY_CONFIG phy_lan8720_default_ethernet_config
 #endif
+#ifdef EMAC_PHY_IP101G
+#include "eth_phy/phy_ip101g.h"
+#define EMAC_ETHERNET_PHY_CONFIG phy_ip101g_default_ethernet_config
+#endif
 #ifdef EMAC_PHY_TLK110
 #include "eth_phy/phy_tlk110.h"
 #define EMAC_ETHERNET_PHY_CONFIG phy_tlk110_default_ethernet_config

--- a/cpu/esp32/vendor/esp-idf/ethernet/eth_phy/phy_ip101g.c
+++ b/cpu/esp32/vendor/esp-idf/ethernet/eth_phy/phy_ip101g.c
@@ -1,0 +1,154 @@
+// Copyright 2015-2017 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#include "esp_attr.h"
+#include "esp_log.h"
+#include "esp_eth.h"
+
+#include "eth_phy/phy_ip101g.h"
+#include "eth_phy/phy_reg.h"
+
+/* Value of MII_PHY_IDENTIFIER_REGs for IC Plus IP101G
+ * (Except for bottom 4 bits of ID2, used for model revision)
+ */
+#define IP101G_PHY_ID1 0x0243
+#define IP101G_PHY_ID2 0x0C50
+#define IP101G_PHY_ID2_MASK 0xFFF0
+
+/* IP101G-specific registers */
+#define PAGE_CONTROL_REG (0x14)
+
+#define POWER_DOWN                         BIT(11)
+
+#define PHY_SPECIAL_CONTROL_STATUS_REG    (0x12)
+#define AUTO_NEGOTIATION_DONE              BIT(11)
+
+#define PHY_CTRL_AND_SPECIFIC_STATUS_REG  (0x1e)
+#define SPEED_DUPLEX_INDICATION_MASK      (0x7)
+#define SPEED_DUPLEX_INDICATION_10T_HALF   0x01
+#define SPEED_DUPLEX_INDICATION_10T_FULL   0x05
+#define SPEED_DUPLEX_INDICATION_100T_HALF  0x02
+#define SPEED_DUPLEX_INDICATION_100T_FULL  0x06
+
+static const char *TAG = "ip101";
+
+static void phy_ip101g_page_select(uint8_t page)
+{
+    ESP_LOGD(TAG, "phy_ip101g_page_select(%u)", page);
+    esp_eth_smi_write(PAGE_CONTROL_REG, page);
+}
+
+void phy_ip101g_check_phy_init(void)
+{
+    phy_ip101g_dump_registers();
+
+    esp_eth_smi_wait_set(MII_BASIC_MODE_STATUS_REG, MII_AUTO_NEGOTIATION_COMPLETE, 0);
+    phy_ip101g_page_select(16);
+    esp_eth_smi_wait_set(PHY_SPECIAL_CONTROL_STATUS_REG, AUTO_NEGOTIATION_DONE, 0);
+}
+
+eth_speed_mode_t phy_ip101g_get_speed_mode(void)
+{
+    phy_ip101g_page_select(16);
+    uint16_t speed = esp_eth_smi_read(PHY_CTRL_AND_SPECIFIC_STATUS_REG) & SPEED_DUPLEX_INDICATION_MASK;
+    if (speed == SPEED_DUPLEX_INDICATION_100T_HALF || speed == SPEED_DUPLEX_INDICATION_100T_FULL) {
+        ESP_LOGD(TAG, "phy_ip101g_get_speed_mode(100)");
+        return ETH_SPEED_MODE_100M;
+    }
+    ESP_LOGD(TAG, "phy_ip101g_get_speed_mode(10)");
+    return ETH_SPEED_MODE_10M;
+}
+
+eth_duplex_mode_t phy_ip101g_get_duplex_mode(void)
+{
+    phy_ip101g_page_select(16);
+    uint16_t speed = esp_eth_smi_read(PHY_CTRL_AND_SPECIFIC_STATUS_REG) & SPEED_DUPLEX_INDICATION_MASK;
+    if (speed == SPEED_DUPLEX_INDICATION_10T_FULL || speed == SPEED_DUPLEX_INDICATION_100T_FULL) {
+        ESP_LOGD(TAG, "phy_ip101g_get_duplex_mode(FULL)");
+        return ETH_MODE_FULLDUPLEX;
+    }
+    ESP_LOGD(TAG, "phy_ip101g_get_duplex_mode(HALF)");
+    return ETH_MODE_HALFDUPLEX;
+}
+
+void phy_ip101g_power_enable(bool enable)
+{
+    ESP_LOGD(TAG, "phy_ip101g_power_enable(%d)", enable);
+    uint16_t cfg = esp_eth_smi_read(MII_BASIC_MODE_CONTROL_REG);
+    if (enable) {
+        cfg &= (UINT16_MAX ^ POWER_DOWN);
+    } else {
+        cfg |= POWER_DOWN;
+    }
+    esp_eth_smi_write(MII_BASIC_MODE_CONTROL_REG, cfg);
+    // TODO: only enable if config.flow_ctrl_enable == true
+    phy_mii_enable_flow_ctrl();
+}
+
+void phy_ip101g_init(void)
+{
+    ESP_LOGD(TAG, "phy_ip101g_init()");
+    phy_ip101g_dump_registers();
+
+    esp_eth_smi_write(MII_BASIC_MODE_CONTROL_REG, MII_SOFTWARE_RESET);
+
+    esp_err_t res1, res2;
+    do {
+        // Call esp_eth_smi_wait_value() with a timeout so it prints an error periodically
+        res1 = esp_eth_smi_wait_value(MII_PHY_IDENTIFIER_1_REG, IP101G_PHY_ID1, UINT16_MAX, 1000);
+        res2 = esp_eth_smi_wait_value(MII_PHY_IDENTIFIER_2_REG, IP101G_PHY_ID2, IP101G_PHY_ID2_MASK, 1000);
+    } while(res1 != ESP_OK || res2 != ESP_OK);
+
+    ets_delay_us(300);
+
+    // TODO: only enable if config.flow_ctrl_enable == true
+    phy_mii_enable_flow_ctrl();
+}
+
+const eth_config_t phy_ip101g_default_ethernet_config = {
+    // By default, the PHY address is 0 or 1 based on PHYAD0
+    // pin. Can also be overriden in software. See datasheet
+    // for defaults.
+    .phy_addr = 1,
+    .mac_mode = ETH_MODE_RMII,
+    .clock_mode = ETH_CLOCK_GPIO0_IN,
+    //Only FULLDUPLEX mode support flow ctrl now!
+    .flow_ctrl_enable = true,
+    .phy_init = phy_ip101g_init,
+    .phy_check_init = phy_ip101g_check_phy_init,
+    .phy_power_enable = phy_ip101g_power_enable,
+    .phy_check_link = phy_mii_check_link_status,
+    .phy_get_speed_mode = phy_ip101g_get_speed_mode,
+    .phy_get_duplex_mode = phy_ip101g_get_duplex_mode,
+    .phy_get_partner_pause_enable = phy_mii_get_partner_pause_enable,
+};
+
+void phy_ip101g_dump_registers(void)
+{
+    ESP_LOGD(TAG, "IP101G Registers:");
+    ESP_LOGD(TAG, "BCR    0x%04x", esp_eth_smi_read(0x0));
+    ESP_LOGD(TAG, "BSR    0x%04x", esp_eth_smi_read(0x1));
+    ESP_LOGD(TAG, "PHY1   0x%04x", esp_eth_smi_read(0x2));
+    ESP_LOGD(TAG, "PHY2   0x%04x", esp_eth_smi_read(0x3));
+    ESP_LOGD(TAG, "ANAR   0x%04x", esp_eth_smi_read(0x4));
+    ESP_LOGD(TAG, "ANLPAR 0x%04x", esp_eth_smi_read(0x5));
+    ESP_LOGD(TAG, "ANER   0x%04x", esp_eth_smi_read(0x6));
+    phy_ip101g_page_select(16);
+    ESP_LOGD(TAG, "PSCR   0x%04x", esp_eth_smi_read(0x10));
+    ESP_LOGD(TAG, "PSMR   0x%04x", esp_eth_smi_read(0x18));
+    ESP_LOGD(TAG, "PMCSSR 0x%04x", esp_eth_smi_read(0x1e));
+}

--- a/cpu/esp32/vendor/esp-idf/include/ethernet/eth_phy/phy_ip101g.h
+++ b/cpu/esp32/vendor/esp-idf/include/ethernet/eth_phy/phy_ip101g.h
@@ -1,0 +1,73 @@
+// Copyright 2015-2017 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ETHERNET_ETH_PHY_PHY_IP101G_H
+#define ETHERNET_ETH_PHY_PHY_IP101G_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef RIOT_VERSION
+#include "eth_phy/phy.h"
+#else
+#include "phy.h"
+#endif
+
+/** @brief Dump all IP101G PHY SMI configuration registers
+ *
+ * @note These registers are dumped at 'debug' level, so output
+ * may not be visible depending on default log levels.
+ */
+void phy_ip101g_dump_registers(void);
+
+/** @brief Default IP101G phy_check_init function.
+ */
+void phy_ip101g_check_phy_init(void);
+
+/** @brief Default IP101G phy_get_speed_mode function.
+ */
+eth_speed_mode_t phy_ip101g_get_speed_mode(void);
+
+/** @brief Default IP101G phy_get_duplex_mode function.
+ */
+eth_duplex_mode_t phy_ip101g_get_duplex_mode(void);
+
+/** @brief Default IP101G phy_power_enable function.
+ *
+ * @note This function may need to be replaced with a custom function
+ * if the PHY has a GPIO to enable power or start a clock.
+ *
+ * Consult the ethernet example to see how this is done.
+ */
+void phy_ip101g_power_enable(bool);
+
+/** @brief Default IP101G phy_init function.
+ */
+void phy_ip101g_init(void);
+
+/** @brief Default IP101G PHY configuration
+ *
+ * This configuration is not suitable for use as-is, it will need
+ * to be modified for your particular PHY hardware setup.
+ *
+ * Consult the Ethernet example to see how this is done.
+ */
+extern const eth_config_t phy_ip101g_default_ethernet_config;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ETHERNET_ETH_PHY_PHY_IP101G_H */

--- a/cpu/esp_common/Kconfig
+++ b/cpu/esp_common/Kconfig
@@ -45,6 +45,11 @@ config HAS_ESP_NOW
     help
         Indicates that an ESP NOW-compatible radio is present.
 
+config HAS_ESP_JTAG
+    bool
+    help
+        Indicates that a JTAG interface is present.
+
 config HAS_ARCH_ESP
     bool
     help


### PR DESCRIPTION
### Contribution description

I recently got this board and am looking for ways to use it with less connection to the official SDK.
It seemed pretty easy to get started here, I only had to port the PHY driver and do some setup.
I do not know what I am doing in a few places, so comments are welcome.

### Testing procedure

Install app like `examples/gnrc_networking` with `BOARD=esp32-ethernet-kit`
```
rst:0x1 (POWERON_RESET),boot:0x12 (SPI_FAST_FLASH_BOOT)
configsip: 0, SPIWP:0xee
clk_drv:0x00,q_drv:0x00,d_drv:0x00,cs0_drv:0x00,hd_drv:0x00,wp_drv:0x00
mode:DOUT, clock div:2
load:0x3fff0018,len:4
load:0x3fff001c,len:4004
load:0x40078000,len:7304
load:0x40080000,len:7224
entry 0x40080350

initializing ESP32 Ethernet MAC (EMAC) device
main(): This is RIOT! (Version: 2020.07-devel-1919-g694f0-esp32_eth_kit)
RIOT network stack example application
All up, running the shell now
> emac start !!!

emac reset done
emac start success !!!
eth link_up!!!
> 
> ifconfig
Iface  11  HWaddr: 24:0A:C4:E6:0E:9D  Channel: 6 
          L2-PDU:249  MTU:1280  HL:64  RTR  
          6LO  Source address length: 6
          Link type: wireless
          inet6 addr: fe80::260a:c4ff:fee6:e9d  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffe6:e9d
          
          Statistics for Layer 2
            RX packets 0  bytes 0
            TX packets 0 (Multicast: 0)  bytes 0
            TX succeeded 0 errors 0
          Statistics for IPv6
            RX packets 0  bytes 0
            TX packets 8 (Multicast: 8)  bytes 448
            TX succeeded 8 errors 0

Iface  8  HWaddr: 24:0A:C4:E6:0E:9F  Link: up 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          Source address length: 6
          Link type: wired
          inet6 group: ff02::2
          inet6 group: ff02::1
          
          Statistics for Layer 2
            RX packets 26  bytes 4286
            TX packets 3 (Multicast: 3)  bytes 0
            TX succeeded 0 errors 0
          Statistics for IPv6
            RX packets 9  bytes 1062
            TX packets 3 (Multicast: 3)  bytes 144
            TX succeeded 3 errors 0



> ping6 fe80::1832:ca40:978e:c22%8
12 bytes from fe80::1832:ca40:978e:c22%8: icmp_seq=0 ttl=64 time=1.989 ms
12 bytes from fe80::1832:ca40:978e:c22%8: icmp_seq=1 ttl=64 time=1.517 ms
12 bytes from fe80::1832:ca40:978e:c22%8: icmp_seq=2 ttl=64 time=1.509 ms

--- fe80::1832:ca40:978e:c22 PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 1.509/1.671/1.989 ms
> 
```
The board has 6 GPIO left over when all other things are active, and I have not tested them.
The button is not set up correctly yet.


### Issues/PRs references

None.