### PR TITLE
boards: provide RTC feature for boards with the RTT feature

### DIFF
--- a/boards/common/nrf51/Makefile.features
+++ b/boards/common/nrf51/Makefile.features
@@ -1,5 +1,6 @@
 CPU = nrf51
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer

--- a/boards/common/nrf52/Makefile.features
+++ b/boards/common/nrf52/Makefile.features
@@ -1,6 +1,7 @@
 CPU = nrf52
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 ifeq (,$(filter nordic_softdevice_ble,$(USEPKG)))

--- a/boards/common/remote/Makefile.features
+++ b/boards/common/remote/Makefile.features
@@ -4,6 +4,7 @@ CPU_MODEL = cc2538sf53
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/openmote-b/Makefile.features
+++ b/boards/openmote-b/Makefile.features
@@ -4,6 +4,7 @@ CPU_MODEL = cc2538sf53
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer


### PR DESCRIPTION
### Contribution description

If those boards all provide the RTT feature, they will also provide the RTC feature.

### Testing procedure

Run `tests/periph_rtc` on a nrf51/nrf52 board.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
