### PR TITLE
drivers/Makefile.dep: remove inappropriate use of FEATURES_PROVIDED for rtt_rtc

### DIFF
--- a/cpu/nrf5x_common/Makefile.dep
+++ b/cpu/nrf5x_common/Makefile.dep
@@ -1,7 +1,3 @@
-ifneq (,$(filter periph_rtc,$(USEMODULE)))
-  USEMODULE += rtt_rtc
-endif
-
 # include nrf5x common periph drivers
 USEMODULE += nrf5x_common_periph
 

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -669,7 +669,6 @@ ifneq (,$(filter rtt_rtc,$(USEMODULE)))
   ifeq (,$(UNIT_TESTS))
     FEATURES_REQUIRED += periph_rtt
   endif
-  FEATURES_PROVIDED += periph_rtc
 endif
 
 ifneq (,$(filter rn2%3,$(USEMODULE)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

As seen when reviewing #14496, there's no reason to use FEATURES_PROVIDED in a Makefile.dep. The dependency resolution can be done later.
Any cpu already providing periph_rtt but not periph_rtc could simply add:

```mk
ifneq (,$(filter periph_rtc,$(USEMODULE)))
  USEMODULE += rtt_rtc
endif
```
in its Makefile.dep and add 

```mk
FEATURES_PROVIDED += periph_rtc
```
in its Makefile.features

and that would work.

Maybe this breaks other platforms, let's see what Murdock has to say.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Test `periph_rtc` on nrf5x platforms with #14496 and it'll still work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while reviewing #14496 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
