### PR TITLE
tests/gnrc_udp/udp.c: fix netif_hdr typo

### DIFF
--- a/tests/gnrc_udp/udp.c
+++ b/tests/gnrc_udp/udp.c
@@ -142,7 +142,7 @@ static void send(char *addr_str, char *port_str, char *data_len_str, unsigned in
         if (netif != NULL) {
             gnrc_pktsnip_t *netif_hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
 
-            if(netif == NULL) {
+            if (netif_hdr == NULL) {
                 puts("Error: unable to allocate NETIF header");
                 gnrc_pktbuf_release(ip);
                 return;


### PR DESCRIPTION
### Contribution description

Fixes a typo in the comparison of the `netif_hdr` variable which would always return a possible incorrect value.

### Testing procedure

1. `make -C tests/gnrc_udp`
2. `udp send ff02::1 1337 hello`


### Issues/PRs references
