### PR TITLE
gnrc_tcp: Replace xtimer with evtimer

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -422,8 +422,7 @@ ifneq (,$(filter gnrc_tcp,$(USEMODULE)))
   USEMODULE += inet_csum
   USEMODULE += random
   USEMODULE += tcp
-  USEMODULE += xtimer
-  USEMODULE += core_mbox
+  USEMODULE += evtimer_mbox
 endif
 
 ifneq (,$(filter gnrc_pktdump,$(USEMODULE)))

--- a/sys/include/net/gnrc/tcp.h
+++ b/sys/include/net/gnrc/tcp.h
@@ -58,7 +58,7 @@ typedef struct {
  * @param[in]     addr        Address for endpoint.
  * @param[in]     addr_size   Size of @p addr.
  * @param[in]     port        Port number for endpoint.
- * @param[in]     netif       Network inferface to use.
+ * @param[in]     netif       Network interface to use.
  *
  * @return   0 on success.
  * @return   -EAFNOSUPPORT if @p address_family is not supported.
@@ -166,18 +166,18 @@ int gnrc_tcp_open_passive(gnrc_tcp_tcb_t *tcb, const gnrc_tcp_ep_t *local);
  * @param[in,out] tcb                        TCB holding the connection information.
  * @param[in]     data                       Pointer to the data that should be transmitted.
  * @param[in]     len                        Number of bytes that should be transmitted.
- * @param[in]     user_timeout_duration_us   If not zero and there was not data transmitted
- *                                           the function returns after user_timeout_duration_us.
+ * @param[in]     user_timeout_duration_ms   If not zero and there was not data transmitted
+ *                                           the function returns after user_timeout_duration_ms.
  *                                           If zero, no timeout will be triggered.
  *
  * @return   The number of successfully transmitted bytes.
  * @return   -ENOTCONN if connection is not established.
  * @return   -ECONNRESET if connection was reset by the peer.
  * @return   -ECONNABORTED if the connection was aborted.
- * @return   -ETIMEDOUT if @p user_timeout_duration_us expired.
+ * @return   -ETIMEDOUT if @p user_timeout_duration_ms expired.
  */
 ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
-                      const uint32_t user_timeout_duration_us);
+                      const uint32_t user_timeout_duration_ms);
 
 /**
  * @brief Receive Data from the peer.
@@ -193,11 +193,11 @@ ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
  *                                           should be copied into.
  * @param[in]     max_len                    Maximum amount to bytes that should be read
  *                                           into @p data.
- * @param[in]     user_timeout_duration_us   Timeout for receive in microseconds.
+ * @param[in]     user_timeout_duration_ms   Timeout for receive in milliseconds.
  *                                           If zero and no data is available, the function
  *                                           returns immediately. If not zero the function
  *                                           blocks until data is available or
- *                                           @p user_timeout_duration_us microseconds passed.
+ *                                           @p user_timeout_duration_ms milliseconds passed.
  *
  * @return   The number of bytes read into @p data.
  * @return   0, if the connection is closing and no further data can be read.
@@ -205,10 +205,10 @@ ssize_t gnrc_tcp_send(gnrc_tcp_tcb_t *tcb, const void *data, const size_t len,
  * @return   -EAGAIN if  user_timeout_duration_us is zero and no data is available.
  * @return   -ECONNRESET if connection was reset by the peer.
  * @return   -ECONNABORTED if the connection was aborted.
- * @return   -ETIMEDOUT if @p user_timeout_duration_us expired.
+ * @return   -ETIMEDOUT if @p user_timeout_duration_ms expired.
  */
 ssize_t gnrc_tcp_recv(gnrc_tcp_tcb_t *tcb, void *data, const size_t max_len,
-                      const uint32_t user_timeout_duration_us);
+                      const uint32_t user_timeout_duration_ms);
 
 /**
  * @brief Close a TCP connection.

--- a/sys/include/net/gnrc/tcp/config.h
+++ b/sys/include/net/gnrc/tcp/config.h
@@ -48,22 +48,22 @@ extern "C" {
  *     RTO <- SRTT + max (G, K*RTTVAR)
  *
  * where K is a constant, and G is clock granularity in seconds
- * ( @ref CONFIG_GNRC_TCP_RTO_GRANULARITY).
+ * ( @ref CONFIG_GNRC_TCP_RTO_GRANULARITY_MS).
  * For more information refer to https://tools.ietf.org/html/rfc6298
  * @{
  */
 /**
- * @brief Timeout duration for user calls. Default is 2 minutes.
+ * @brief Timeout duration in milliseconds for user calls. Default is 2 minutes.
  */
-#ifndef CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION
-#define CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION (120U * US_PER_SEC)
+#ifndef CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION_MS
+#define CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION_MS (120U * MS_PER_SEC)
 #endif
 
 /**
- * @brief Maximum segment lifetime (MSL). Default is 30 seconds.
+ * @brief Maximum segment lifetime (MSL) in milliseconds. Default is 30 seconds.
  */
-#ifndef CONFIG_GNRC_TCP_MSL
-#define CONFIG_GNRC_TCP_MSL (30U * US_PER_SEC)
+#ifndef CONFIG_GNRC_TCP_MSL_MS
+#define CONFIG_GNRC_TCP_MSL_MS (30U * MS_PER_SEC)
 #endif
 
 /**
@@ -109,28 +109,28 @@ extern "C" {
 #endif
 
 /**
- * @brief Lower bound for RTO = 1 sec (see RFC 6298)
+ * @brief Lower bound for RTO in milliseconds. Default is 1 sec (see RFC 6298)
  *
  * @note Retransmission Timeout (RTO) determines how long TCP waits for
  * acknowledgment (ACK) of transmitted segment. If the acknowledgment
  * isn't received within this time it is considered lost.
  */
-#ifndef CONFIG_GNRC_TCP_RTO_LOWER_BOUND
-#define CONFIG_GNRC_TCP_RTO_LOWER_BOUND (1U * US_PER_SEC)
+#ifndef CONFIG_GNRC_TCP_RTO_LOWER_BOUND_MS
+#define CONFIG_GNRC_TCP_RTO_LOWER_BOUND_MS (1U * MS_PER_SEC)
 #endif
 
 /**
- * @brief Upper bound for RTO = 60 sec (see RFC 6298)
+ * @brief Upper bound for RTO in milliseconds. Default is 60 sec (see RFC 6298)
  */
-#ifndef CONFIG_GNRC_TCP_RTO_UPPER_BOUND
-#define CONFIG_GNRC_TCP_RTO_UPPER_BOUND (60U * US_PER_SEC)
+#ifndef CONFIG_GNRC_TCP_RTO_UPPER_BOUND_MS
+#define CONFIG_GNRC_TCP_RTO_UPPER_BOUND_MS (60U * MS_PER_SEC)
 #endif
 
 /**
- * @brief Assumes clock granularity for TCP of 10 ms (see RFC 6298)
+ * @brief Clock granularity for TCP in milliseconds. Dedault is 10 milliseconds (see RFC 6298)
  */
-#ifndef CONFIG_GNRC_TCP_RTO_GRANULARITY
-#define CONFIG_GNRC_TCP_RTO_GRANULARITY (10U * MS_PER_SEC)
+#ifndef CONFIG_GNRC_TCP_RTO_GRANULARITY_MS
+#define CONFIG_GNRC_TCP_RTO_GRANULARITY_MS (10U)
 #endif
 
 /**
@@ -155,17 +155,17 @@ extern "C" {
 #endif
 
 /**
- * @brief Lower bound for the duration between probes
+ * @brief Lower bound for the duration between probes in milliseconds. Default is 1 seconds
  */
-#ifndef CONFIG_GNRC_TCP_PROBE_LOWER_BOUND
-#define CONFIG_GNRC_TCP_PROBE_LOWER_BOUND (1U * US_PER_SEC)
+#ifndef CONFIG_GNRC_TCP_PROBE_LOWER_BOUND_MS
+#define CONFIG_GNRC_TCP_PROBE_LOWER_BOUND_MS (1U * MS_PER_SEC)
 #endif
 
 /**
- * @brief Upper bound for the duration between probes
+ * @brief Upper bound for the duration between probes in milliseconds. Default is 60 seconds
  */
-#ifndef CONFIG_GNRC_TCP_PROBE_UPPER_BOUND
-#define CONFIG_GNRC_TCP_PROBE_UPPER_BOUND (60U * US_PER_SEC)
+#ifndef CONFIG_GNRC_TCP_PROBE_UPPER_BOUND_MS
+#define CONFIG_GNRC_TCP_PROBE_UPPER_BOUND_MS (60U * MS_PER_SEC)
 #endif
 
 /**

--- a/sys/include/net/gnrc/tcp/tcb.h
+++ b/sys/include/net/gnrc/tcp/tcb.h
@@ -23,8 +23,9 @@
 #include <stdint.h>
 #include "kernel_types.h"
 #include "ringbuffer.h"
-#include "xtimer.h"
 #include "mutex.h"
+#include "evtimer_msg.h"
+#include "evtimer_mbox.h"
 #include "msg.h"
 #include "mbox.h"
 #include "net/gnrc/pkt.h"
@@ -67,11 +68,9 @@ typedef struct _transmission_control_block {
     int32_t srtt;          /**< Smoothed round trip time */
     int32_t rto;           /**< Retransmission timeout duration */
     uint8_t retries;       /**< Number of retransmissions */
-    xtimer_t timer_retransmit; /**< Retransmission timer */
-    xtimer_t timer_misc;       /**< General purpose timer */
-    msg_t msg_retransmit;      /**< Retransmission timer message */
-    msg_t msg_misc;            /**< General purpose timer message */
-    gnrc_pktsnip_t *pkt_retransmit;   /**< Pointer to packet in "retransmit queue" */
+    evtimer_msg_event_t event_retransmit; /**< Retransmission event */
+    evtimer_mbox_event_t event_misc;      /**< General purpose event */
+    gnrc_pktsnip_t *pkt_retransmit;       /**< Pointer to packet in "retransmit queue" */
     mbox_t *mbox;            /**< TCB mbox for synchronization */
     uint8_t *rcv_buf_raw;    /**< Pointer to the receive buffer */
     ringbuffer_t rcv_buf;    /**< Receive buffer data structure */

--- a/sys/net/gnrc/transport_layer/tcp/Kconfig
+++ b/sys/net/gnrc/transport_layer/tcp/Kconfig
@@ -12,18 +12,18 @@ menuconfig KCONFIG_USEMODULE_GNRC_TCP
 
 if KCONFIG_USEMODULE_GNRC_TCP
 
-config GNRC_TCP_CONNECTION_TIMEOUT_DURATION
-    int "Timeout duration for user calls in microseconds"
-    default 120000000
+config GNRC_TCP_CONNECTION_TIMEOUT_DURATION_MS
+    int "Timeout duration for user calls in milliseconds"
+    default 120000
     help
-        Timeout duration for user calls. Default value is 120000000 microseconds
+        Timeout duration for user calls. Default value is 120000 milliseconds
         (2 minutes).
 
-config GNRC_TCP_MSL
-    int "Maximum segment lifetime (MSL) in microseconds"
-    default 30000000
+config GNRC_TCP_MSL_MS
+    int "Maximum segment lifetime (MSL) in milliseconds"
+    default 30000
     help
-        Maximum segment lifetime (MSL) in microseconds. Default value is 30
+        Maximum segment lifetime (MSL) in milliseconds. Default value is 30
         seconds.
 
 config GNRC_TCP_MSS
@@ -59,29 +59,29 @@ config GNRC_TCP_RCV_BUFFERS
     int "Number of preallocated receive buffers"
     default 1
 
-config GNRC_TCP_RTO_LOWER_BOUND
-    int "Lower bound for RTO in microseconds"
-    default 1000000
+config GNRC_TCP_RTO_LOWER_BOUND_MS
+    int "Lower bound for RTO in milliseconds"
+    default 1000
     help
-        Lower bound value for retransmission timeout (RTO) in microseconds.
-        Default value is 1000000 microseconds (1 second). Retransmission
+        Lower bound value for retransmission timeout (RTO) in milliseconds.
+        Default value is 1000 milliseconds (1 second). Retransmission
         timeout determines how long TCP waits for acknowledgment (ACK) of
         transmitted segment. Refer to RFC 6298 for more information.
 
-config GNRC_TCP_RTO_UPPER_BOUND
-    int "Upper bound for RTO in microseconds"
-    default 60000000
+config GNRC_TCP_RTO_UPPER_BOUND_MS
+    int "Upper bound for RTO in milliseconds"
+    default 60000
     help
-        Upper bound value for retransmission timeout (RTO) in microseconds.
-        Default value is 60000000 microseconds (60 seconds). Refer to RFC 6298
+        Upper bound value for retransmission timeout (RTO) in milliseconds.
+        Default value is 60000 milliseconds (60 seconds). Refer to RFC 6298
         for more information.
 
-config GNRC_TCP_RTO_GRANULARITY
-    int "Clock granularity for RTO in microseconds"
-    default 10000
+config GNRC_TCP_RTO_GRANULARITY_MS
+    int "Clock granularity for RTO in milliseconds"
+    default 10
     help
         Clock granularity for retransmission timeout (RTO) for TCP in
-        microseconds. Default value is 10000 microseconds (10 milliseconds).
+        milliseconds. Default value is 10 milliseconds.
         Refer to RFC 6298 for more information.
 
 config GNRC_TCP_RTO_A_DIV
@@ -104,13 +104,21 @@ config GNRC_TCP_RTO_K
     int "K value for RTO calculation"
     default 4
 
-config GNRC_TCP_PROBE_LOWER_BOUND
-    int "Lower bound for the duration between probes in microseconds"
-    default 1000000
+config GNRC_TCP_PROBE_LOWER_BOUND_MS
+    int "Lower bound for the duration between probes in milliseconds"
+    default 1000
+    help
+        Lower bound value for window probes in milliseconds.
+        Default value is 1000 milliseconds (1 second).
+        Refer to RFC 6298 for more information.
 
-config GNRC_TCP_PROBE_UPPER_BOUND
-    int "Lower bound for the duration between probes in microseconds"
-    default 60000000
+config GNRC_TCP_PROBE_UPPER_BOUND_MS
+    int "Lower bound for the duration between probes in milliseconds"
+    default 60000
+    help
+        Upper bound value for window probes in milliseconds.
+        Default value is 60000 milliseconds (60 seconds). Refer to RFC 6298
+        for more information.
 
 config GNRC_TCP_MSG_QUEUE_SIZE_SIZE_EXP
     int "Message queue size for TCP API internal messaging (as exponent of 2^n)"

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
@@ -39,6 +39,39 @@
 static msg_t _eventloop_msg_queue[TCP_EVENTLOOP_MSG_QUEUE_SIZE];
 
 /**
+ * @brief Allocate memory for GNRC TCP thread stack.
+ */
+#if ENABLE_DEBUG
+static char _stack[TCP_EVENTLOOP_STACK_SIZE + THREAD_EXTRA_STACKSIZE_PRINTF];
+#else
+static char _stack[TCP_EVENTLOOP_STACK_SIZE];
+#endif
+
+/**
+ * @brief Central evtimer for gnrc_tcp event loop
+ */
+static evtimer_t _tcp_msg_timer;
+
+/**
+ * @brief TCPs eventloop pid
+ */
+static kernel_pid_t _tcp_eventloop_pid = KERNEL_PID_UNDEF;
+
+void _gnrc_tcp_event_loop_sched(evtimer_msg_event_t *event, uint32_t offset,
+                                uint16_t type, void *context)
+{
+    event->event.offset = offset;
+    event->msg.type = type;
+    event->msg.content.ptr = context;
+    evtimer_add_msg(&_tcp_msg_timer, event, _tcp_eventloop_pid);
+}
+
+void _gnrc_tcp_event_loop_unsched(evtimer_msg_event_t *event)
+{
+    evtimer_del(&_tcp_msg_timer, (evtimer_event_t *)event);
+}
+
+/**
  * @brief Send function, pass packet down the network stack.
  *
  * @param[in] pkt   Packet to send.
@@ -220,6 +253,9 @@ static int _receive(gnrc_pktsnip_t *pkt)
     mutex_unlock(&_list_tcb_lock);
 
     /* Call FSM with event RCVD_PKT if a fitting TCB was found */
+    /* cppcheck-suppress knownConditionTrueFalse
+     * (reason: tcb can be NULL at runtime)
+     */
     if (tcb != NULL) {
         _fsm(tcb, FSM_EVENT_RCVD_PKT, pkt, NULL, 0);
     }
@@ -228,7 +264,7 @@ static int _receive(gnrc_pktsnip_t *pkt)
         DEBUG("gnrc_tcp_eventloop.c : _receive() : Can't find fitting tcb\n");
         if ((ctl & MSK_RST) != MSK_RST) {
             _pkt_build_reset_from_pkt(&reset, pkt);
-            if (gnrc_netapi_send(gnrc_tcp_pid, reset) < 1) {
+            if (gnrc_netapi_send(_tcp_eventloop_pid, reset) < 1) {
                 DEBUG("gnrc_tcp_eventloop.c : _receive() : unable to send reset packet\n");
                 gnrc_pktbuf_release(reset);
             }
@@ -240,13 +276,13 @@ static int _receive(gnrc_pktsnip_t *pkt)
     return 0;
 }
 
-void *_event_loop(__attribute__((unused)) void *arg)
+static void *_event_loop(__attribute__((unused)) void *arg)
 {
     msg_t msg;
     msg_t reply;
 
     /* Store pid */
-    gnrc_tcp_pid = thread_getpid();
+    _tcp_eventloop_pid = thread_getpid();
 
     /* Setup reply message */
     reply.type = GNRC_NETAPI_MSG_TYPE_ACK;
@@ -257,7 +293,7 @@ void *_event_loop(__attribute__((unused)) void *arg)
 
     /* Register GNRC TCPs handling thread in netreg */
     gnrc_netreg_entry_t entry;
-    gnrc_netreg_entry_init_pid(&entry, GNRC_NETREG_DEMUX_CTX_ALL, gnrc_tcp_pid);
+    gnrc_netreg_entry_init_pid(&entry, GNRC_NETREG_DEMUX_CTX_ALL, _tcp_eventloop_pid);
     gnrc_netreg_register(GNRC_NETTYPE_TCP, &entry);
 
     /* dispatch NETAPI messages */
@@ -302,4 +338,19 @@ void *_event_loop(__attribute__((unused)) void *arg)
     }
     /* Never reached */
     return NULL;
+}
+
+int _gnrc_tcp_event_loop_init(void)
+{
+    /* Guard: Check if thread is already running */
+    if (_tcp_eventloop_pid != KERNEL_PID_UNDEF) {
+        return -EEXIST;
+    }
+
+    /* Initialize timers */
+    evtimer_init_msg(&_tcp_msg_timer);
+
+    return thread_create(_stack, sizeof(_stack), TCP_EVENTLOOP_PRIO,
+                         THREAD_CREATE_STACKTEST, _event_loop, NULL,
+                         "gnrc_tcp");
 }

--- a/sys/net/gnrc/transport_layer/tcp/internal/common.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/common.h
@@ -25,6 +25,7 @@
 #include "kernel_types.h"
 #include "thread.h"
 #include "mutex.h"
+#include "evtimer.h"
 #include "net/gnrc/netapi.h"
 #include "net/gnrc/tcp/tcb.h"
 
@@ -112,11 +113,6 @@ extern "C" {
  * @brief Extract offset value from "offctl" field in TCP header.
  */
 #define GET_OFFSET( x ) (((x) & MSK_OFFSET) >> 12)
-
-/**
- * @brief PID of GNRC TCP event handling thread
- */
-extern kernel_pid_t gnrc_tcp_pid;
 
 /**
  * @brief Head of linked TCB list.

--- a/sys/net/gnrc/transport_layer/tcp/internal/eventloop.h
+++ b/sys/net/gnrc/transport_layer/tcp/internal/eventloop.h
@@ -20,18 +20,43 @@
 #ifndef EVENTLOOP_H
 #define EVENTLOOP_H
 
+#include <stdint.h>
+
+#include "evtimer_msg.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @brief GNRC TCPs main processing thread.
+ * @brief Starts GNRC TCP's main processing thread.
  *
- * @param[in] arg   Thread arguments (unused).
- *
- * @returns   Never, its an endless loop
+ * @retval  PID of processing thread on success
+ * @retval  -EEXIST if processing thread was already started
+ * @retval  see @ref thread_create() for more error cases.
  */
-void *_event_loop(__attribute__((unused)) void *arg);
+int _gnrc_tcp_event_loop_init(void);
+
+/**
+ * @brief   Schedule event to event loop
+ *
+ * @param[in] event     The event to schedule
+ * @param[in] offset    Offset in milliseconds when the event should be handled
+ *                      in the event loop
+ * @param[in] type      Type of the message for the event
+ * @param[in] context   Context of the event.
+ */
+void _gnrc_tcp_event_loop_sched(evtimer_msg_event_t *event, uint32_t offset,
+                                uint16_t type, void *context);
+
+/**
+ * @brief   Unschedule event to event loop
+ *
+ * Does nothing if @p event was not scheduled.
+ *
+ * @param[in] event The event to unschedule
+ */
+void _gnrc_tcp_event_loop_unsched(evtimer_msg_event_t *event);
 
 #ifdef __cplusplus
 }

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -5,8 +5,8 @@ BOARD ?= native
 TAP ?= tap0
 
 # Shorten default TCP timeouts to speedup testing
-MSL_US ?= 1000000
-TIMEOUT_US ?= 3000000
+MSL_MS ?= 1000
+TIMEOUT_MS ?= 3000
 
 # This test depends on tap device setup (only allowed by root)
 # Suppress test execution to avoid CI errors
@@ -45,12 +45,12 @@ ethos:
 include $(RIOTBASE)/Makefile.include
 
 # Set CONFIG_GNRC_TCP_MSL via CFLAGS if not being set via Kconfig
-ifndef CONFIG_GNRC_TCP_MSL
-  CFLAGS += -DCONFIG_GNRC_TCP_MSL=$(MSL_US)
+ifndef CONFIG_GNRC_TCP_MSL_MS
+  CFLAGS += -DCONFIG_GNRC_TCP_MSL_MS=$(MSL_MS)
 endif
 
 # Set CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION via CFLAGS if not being set
 # via Kconfig
-ifndef CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION
-  CFLAGS += -DCONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION=$(TIMEOUT_US)
+ifndef CONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION_MS
+  CFLAGS += -DCONFIG_GNRC_TCP_CONNECTION_TIMEOUT_DURATION_MS=$(TIMEOUT_MS)
 endif


### PR DESCRIPTION
Hi,

As suggested in #14294, this PR replaces all xtimers used in gnrc_tcp with a single evtimer, reducing the memory footprint gnrc_tcp significantly. Note that this PR builds onto of #14498.

Aside from replacing the xtimers, all timeout specifying constants were adjusted to fit the lower resolution of evtimer.
The functionality of this PR can be tested by running the gnrc_tcp test suite.