### PR TITLE
cpu/sam0_common: flashpage: clean up implementation

### DIFF
--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -21,6 +21,7 @@
  * use in RIOT is actually the row size as specified in the datasheet.
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
  *
  * @}
  */
@@ -30,10 +31,10 @@
 #include "cpu.h"
 #include "periph/flashpage.h"
 
-#define NVMCTRL_PAC_BIT     (0x00000002)
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
 
-#define FLASH_MAIN          0
-#define FLASH_RWWEE         1
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
 /**
  * @brief   NVMCTRL selection macros
@@ -59,25 +60,133 @@ static void _unlock(void)
 #ifdef REG_PAC_WRCTRL
     PAC->WRCTRL.reg = (PAC_WRCTRL_KEY_CLR | ID_NVMCTRL);
 #else
-    PAC1->WPCLR.reg = NVMCTRL_PAC_BIT;
+    PAC1->WPCLR.reg = PAC1_WPROT_DEFAULT_VAL;
 #endif
 }
 
 static void _lock(void)
 {
+    wait_nvm_is_ready();
+
     /* put peripheral access lock for the NVMCTRL peripheral */
 #ifdef REG_PAC_WRCTRL
     PAC->WRCTRL.reg = (PAC_WRCTRL_KEY_SET | ID_NVMCTRL);
 #else
-    PAC1->WPSET.reg = NVMCTRL_PAC_BIT;
+    PAC1->WPSET.reg = PAC1_WPROT_DEFAULT_VAL;
 #endif
 }
 
-#ifdef FLASHPAGE_RWWEE_NUMOF
-void flashpage_write_raw_internal(void *target_addr, const void *data, size_t len, int flash_type)
+static void _cmd_clear_page_buffer(void)
+{
+    wait_nvm_is_ready();
+
+#ifdef NVMCTRL_CTRLB_CMDEX_KEY
+    _NVMCTRL->CTRLB.reg = (NVMCTRL_CTRLB_CMDEX_KEY | NVMCTRL_CTRLB_CMD_PBC);
 #else
-void flashpage_write_raw(void *target_addr, const void *data, size_t len)
+    _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_PBC);
 #endif
+}
+
+static void _cmd_erase_row(void)
+{
+    wait_nvm_is_ready();
+
+    /* send Row/Block erase command */
+#ifdef NVMCTRL_CTRLB_CMDEX_KEY
+    _NVMCTRL->CTRLB.reg = (NVMCTRL_CTRLB_CMDEX_KEY | NVMCTRL_CTRLB_CMD_EB);
+#else
+    _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_ER);
+#endif
+}
+
+static void _cmd_write_page(void)
+{
+    wait_nvm_is_ready();
+
+    /* write page */
+#ifdef NVMCTRL_CTRLB_CMDEX_KEY
+    _NVMCTRL->CTRLB.reg = (NVMCTRL_CTRLB_CMDEX_KEY | NVMCTRL_CTRLB_CMD_WP);
+#else
+    _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_WP);
+#endif
+}
+
+static void _write_page(void* dst, const void *data, size_t len, void (*cmd_write)(void))
+{
+    uint32_t *dst32 = dst;
+
+    _unlock();
+    _cmd_clear_page_buffer();
+
+    /* copy whole words */
+    const uint32_t *data32 = data;
+    while (len) {
+        *dst32++ = *data32++;
+        len -= sizeof(uint32_t);
+    }
+
+    cmd_write();
+    _lock();
+}
+
+static void _erase_page(void* page, void (*cmd_erase)(void))
+{
+    uintptr_t page_addr = (uintptr_t)page;
+
+    /* erase given page (the ADDR register uses 16-bit addresses) */
+    _unlock();
+
+    /* ADDR drives the hardware (16-bit) address to the NVM when a command is executed using CMDEX.
+     * 8-bit addresses must be shifted one bit to the right before writing to this register.
+     */
+#if defined(CPU_SAMD21) || defined(CPU_SAML21)
+    page_addr >>= 1;
+#endif
+
+    /* set Row/Block start address */
+    _NVMCTRL->ADDR.reg = page_addr;
+
+    cmd_erase();
+    _lock();
+}
+
+/* dst must be row-aligned */
+static void _write_row(uint8_t *dst, const void *_data, size_t len, size_t chunk_size,
+                       void (*cmd_write)(void))
+{
+    const uint8_t *data = _data;
+
+    /* One RIOT page is FLASHPAGE_PAGES_PER_ROW SAM0 flash pages (a row) as
+     * defined in the file cpu/sam0_common/include/cpu_conf.h, therefore we
+     * have to split the write into FLASHPAGE_PAGES_PER_ROW raw calls
+     * underneath, each writing a physical page in chunks of 4 bytes (see
+     * flashpage_write_raw)
+     * The erasing is done once as a full row is always erased.
+     */
+    while (len) {
+        size_t chunk = MIN(len, chunk_size);
+        _write_page(dst, data, chunk, cmd_write);
+        data += chunk;
+        dst  += chunk;
+        len  -= chunk;
+    }
+}
+
+void flashpage_write(int page, const void *data)
+{
+    assert((unsigned)page < FLASHPAGE_NUMOF);
+
+    _erase_page(flashpage_addr(page), _cmd_erase_row);
+
+    if (data == NULL) {
+        return;
+    }
+
+    _write_row(flashpage_addr(page), data, FLASHPAGE_SIZE, NVMCTRL_PAGE_SIZE,
+               _cmd_write_page);
+}
+
+void flashpage_write_raw(void *target_addr, const void *data, size_t len)
 {
     /* The actual minimal block size for writing is 16B, thus we
      * assert we write on multiples and no less of that length.
@@ -89,155 +198,69 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
             ((unsigned)data % FLASHPAGE_RAW_ALIGNMENT)));
 
     /* ensure the length doesn't exceed the actual flash size */
-#ifdef FLASHPAGE_RWWEE_NUMOF
-    if (flash_type == FLASH_RWWEE) {
-        assert(((unsigned)target_addr + len) <=
-               (CPU_FLASH_RWWEE_BASE + (FLASHPAGE_SIZE * FLASHPAGE_RWWEE_NUMOF)));
-    } else {
-#endif
-        assert(((unsigned)target_addr + len) <=
-               (CPU_FLASH_BASE + (FLASHPAGE_SIZE * FLASHPAGE_NUMOF)));
-#ifdef FLASHPAGE_RWWEE_NUMOF
-    }
-#endif
+    assert(((unsigned)target_addr + len) <=
+           (CPU_FLASH_BASE + (FLASHPAGE_SIZE * FLASHPAGE_NUMOF)));
 
-    uint32_t *dst = (uint32_t *)target_addr;
-    const uint32_t *data_addr = data;
+    _write_page(target_addr, data, len, _cmd_write_page);
 
-    /* write 4 bytes in one go */
-    len /= 4;
-
-    _unlock();
-#ifdef NVMCTRL_CTRLB_CMDEX_KEY
-    _NVMCTRL->CTRLB.reg = (NVMCTRL_CTRLB_CMDEX_KEY | NVMCTRL_CTRLB_CMD_PBC);
-#else
-    _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_PBC);
-#endif
-    wait_nvm_is_ready();
-    for (unsigned i = 0; i < len; i++) {
-        *dst++ = *data_addr++;
-    }
-#ifdef FLASHPAGE_RWWEE_NUMOF
-    if (flash_type == FLASH_RWWEE) {
-#ifdef CPU_SAML1X
-         /* SAML1X use the same Write Page command for both flash memories */
-        _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_WP);
-#else
-        _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_RWWEEWP);
-#endif
-    } else {
-#endif
-#ifdef NVMCTRL_CTRLB_CMDEX_KEY
-        _NVMCTRL->CTRLB.reg = (NVMCTRL_CTRLB_CMDEX_KEY | NVMCTRL_CTRLB_CMD_WP);
-#else
-        _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_WP);
-#endif
-#ifdef FLASHPAGE_RWWEE_NUMOF
-    }
-#endif
-    wait_nvm_is_ready();
-    _lock();
 }
 
 #ifdef FLASHPAGE_RWWEE_NUMOF
-void flashpage_write_internal(int page, const void *data, int flash_type)
-#else
-void flashpage_write(int page, const void *data)
-#endif
+
+static void _cmd_erase_row_rwwee(void)
 {
-    uint32_t *page_addr;
-
-#ifdef FLASHPAGE_RWWEE_NUMOF
-    if (flash_type == FLASH_RWWEE) {
-        page_addr = (uint32_t *)flashpage_rwwee_addr(page);
-    } else {
-#endif
-        page_addr = (uint32_t *)flashpage_addr(page);
-#ifdef FLASHPAGE_RWWEE_NUMOF
-    }
-#endif
-
-    /* erase given page (the ADDR register uses 16-bit addresses) */
-    _unlock();
-#if defined(CPU_SAML1X) || defined(CPU_SAMD5X)
-    /* Ensure address alignment */
-    _NVMCTRL->ADDR.reg = (((uint32_t)page_addr) & 0xfffffffe);
-#else
-    _NVMCTRL->ADDR.reg = (((uint32_t)page_addr) >> 1);
-#endif
-#ifdef FLASHPAGE_RWWEE_NUMOF
-    if (flash_type == FLASH_RWWEE) {
-#ifdef CPU_SAML1X
-         /* SAML1X use the same Erase command for both flash memories */
-        _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_ER);
-#else
-        _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_RWWEEER);
-#endif
-    } else {
-#endif
-#ifdef NVMCTRL_CTRLB_CMDEX_KEY
-        _NVMCTRL->CTRLB.reg = (NVMCTRL_CTRLB_CMDEX_KEY | NVMCTRL_CTRLB_CMD_EB);
-#else
-        _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_ER);
-#endif
-#ifdef FLASHPAGE_RWWEE_NUMOF
-    }
-#endif
     wait_nvm_is_ready();
-    _lock();
 
-    /* write data to page */
-    if (data != NULL) {
-        /* One RIOT page is FLASHPAGE_PAGES_PER_ROW SAM0 flash pages (a row) as
-         * defined in the file cpu/sam0_common/include/cpu_conf.h, therefore we
-         * have to split the write into FLASHPAGE_PAGES_PER_ROW raw calls
-         * underneath, each writing a physical page in chunks of 4 bytes (see
-         * flashpage_write_raw)
-         * The erasing is done once as a full row is always reased.
-         */
-        for (unsigned curpage = 0; curpage < FLASHPAGE_PAGES_PER_ROW; curpage++) {
-#ifdef FLASHPAGE_RWWEE_NUMOF
-            flashpage_write_raw_internal(page_addr + (curpage * NVMCTRL_PAGE_SIZE / 4),
-                                        (void *) ((uint32_t *) data + (curpage * NVMCTRL_PAGE_SIZE / 4)),
-                                        NVMCTRL_PAGE_SIZE, flash_type);
+    /* send erase row command */
+#ifdef NVMCTRL_CTRLA_CMD_RWWEEER
+    _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_RWWEEER);
 #else
-            flashpage_write_raw(page_addr + (curpage * NVMCTRL_PAGE_SIZE / 4),
-                               (void *) ((uint32_t *) data + (curpage * NVMCTRL_PAGE_SIZE / 4)),
-                               NVMCTRL_PAGE_SIZE);
+    /* SAML1X use the same Erase command for both flash memories */
+    _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_ER);
 #endif
-        }
-    }
 }
 
-
-#ifdef FLASHPAGE_RWWEE_NUMOF
-/*
- * If RWWEE flash is present then we create an additional layer for the write functions
- * so we can specify the type (either MAIN or RWWEE) we want to access, keeping the
- * standard API unchanged and code for systems without RWWEE at a minimum at the cost
- * of some more #defines in the code
- */
-void flashpage_write_raw(void *target_addr, const void *data, size_t len)
+static void _cmd_write_page_rwwee(void)
 {
-    flashpage_write_raw_internal(target_addr, data, len, FLASH_MAIN);
-}
+    wait_nvm_is_ready();
 
-void flashpage_write(int page, const void *data)
-{
-    assert((uint32_t)page < FLASHPAGE_NUMOF);
-
-    flashpage_write_internal(page, data, FLASH_MAIN);
+    /* write page */
+#ifdef NVMCTRL_CTRLA_CMD_RWWEEWP
+    _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_RWWEEWP);
+#else
+    /* SAML1X use the same Write Page command for both flash memories */
+    _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_WP);
+#endif
 }
 
 void flashpage_rwwee_write_raw(void *target_addr, const void *data, size_t len)
 {
-    flashpage_write_raw_internal(target_addr, data, len, FLASH_RWWEE);
+    /* The actual minimal block size for writing is 16B, thus we
+     * assert we write on multiples and no less of that length.
+     */
+    assert(!(len % FLASHPAGE_RAW_BLOCKSIZE));
+
+    /* ensure 4 byte aligned writes */
+    assert(!(((unsigned)target_addr % FLASHPAGE_RAW_ALIGNMENT) ||
+            ((unsigned)data % FLASHPAGE_RAW_ALIGNMENT)));
+
+    assert(((unsigned)target_addr + len) <=
+           (CPU_FLASH_RWWEE_BASE + (FLASHPAGE_SIZE * FLASHPAGE_RWWEE_NUMOF)));
+
+    _write_page(target_addr, data, len, _cmd_write_page_rwwee);
 }
 
 void flashpage_rwwee_write(int page, const void *data)
 {
-    assert((uint32_t)page < FLASHPAGE_RWWEE_NUMOF);
+    assert((unsigned)page < FLASHPAGE_RWWEE_NUMOF);
 
-    flashpage_write_internal(page, data, FLASH_RWWEE);
+    _erase_page(flashpage_rwwee_addr(page), _cmd_erase_row_rwwee);
+
+    if (data == NULL) {
+        return;
+    }
+
+    _write_row(flashpage_rwwee_addr(page), data, FLASHPAGE_SIZE, NVMCTRL_PAGE_SIZE,
+               _cmd_write_page_rwwee);
 }
-#endif
+#endif /* FLASHPAGE_RWWEE_NUMOF */

--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -44,10 +44,9 @@
 #define _NVMCTRL NVMCTRL
 #endif
 
-static inline void wait_nvm_is_ready(void) __attribute__((always_inline));
 static inline void wait_nvm_is_ready(void)
 {
-#if defined(CPU_SAML1X) || defined(CPU_SAMD5X)
+#ifdef NVMCTRL_STATUS_READY
     while (!_NVMCTRL->STATUS.bit.READY) {}
 #else
     while (!_NVMCTRL->INTFLAG.bit.READY) {}
@@ -60,9 +59,7 @@ static void _unlock(void)
 #ifdef REG_PAC_WRCTRL
     PAC->WRCTRL.reg = (PAC_WRCTRL_KEY_CLR | ID_NVMCTRL);
 #else
-    if (PAC1->WPSET.reg & NVMCTRL_PAC_BIT) {
-        PAC1->WPCLR.reg = NVMCTRL_PAC_BIT;
-    }
+    PAC1->WPCLR.reg = NVMCTRL_PAC_BIT;
 #endif
 }
 
@@ -72,9 +69,7 @@ static void _lock(void)
 #ifdef REG_PAC_WRCTRL
     PAC->WRCTRL.reg = (PAC_WRCTRL_KEY_SET | ID_NVMCTRL);
 #else
-    if (PAC1->WPCLR.reg & NVMCTRL_PAC_BIT) {
-        PAC1->WPSET.reg = NVMCTRL_PAC_BIT;
-    }
+    PAC1->WPSET.reg = NVMCTRL_PAC_BIT;
 #endif
 }
 


### PR DESCRIPTION
### Contribution description

`periph/flashpage.c` is a thicket of `#ifdefs` that makes it hard to extend functionality.
To clean this up, move all commands that differ between RWWEE and normal flash page writing into helper functions and rely on common code for both without the ifdefs, by using function pointers.

No functional changes so far, but will be the basis for writing to the config section of sam0 MCUs.

### Testing procedure

Run `tests/periph_flashpage` and `tests/mtd_flashpage` on

 - [x] saml1x
 - [x] saml2x
 - [x] samd2x
 - [x] samd5x

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
