### PR TITLE
byteorder: add helpers to for host <-> little endian

### DIFF
--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -204,6 +204,48 @@ static inline uint32_t byteorder_ntohl(network_uint32_t v);
 static inline uint64_t byteorder_ntohll(network_uint64_t v);
 
 /**
+ * @brief          Convert from host byte order to little endian , 16 bit.
+ * @param[in]      v   The integer in host byte order.
+ * @returns        `v` converted to little endian.
+ */
+static inline network_uint16_t byteorder_htols(uint16_t v);
+
+/**
+ * @brief          Convert from host byte order to little endian, 32 bit.
+ * @param[in]      v   The integer in host byte order.
+ * @returns        `v` converted to little endian.
+ */
+static inline network_uint32_t byteorder_htoll(uint32_t v);
+
+/**
+ * @brief          Convert from host byte order to little endian, 64 bit.
+ * @param[in]      v   The integer in host byte order.
+ * @returns        `v` converted to little endian.
+ */
+static inline network_uint64_t byteorder_htolll(uint64_t v);
+
+/**
+ * @brief          Convert from little endian to host byte order, 16 bit.
+ * @param[in]      v   The integer in little endian.
+ * @returns        `v` converted to host byte order.
+ */
+static inline uint16_t byteorder_ltohs(network_uint16_t v);
+
+/**
+ * @brief          Convert from little endian to host byte order, 32 bit.
+ * @param[in]      v   The integer in little endian.
+ * @returns        `v` converted to host byte order.
+ */
+static inline uint32_t byteorder_ltohl(network_uint32_t v);
+
+/**
+ * @brief          Convert from little endian to host byte order, 64 bit.
+ * @param[in]      v   The integer in little endian.
+ * @returns        `v` converted to host byte order.
+ */
+static inline uint64_t byteorder_ltohll(network_uint64_t v);
+
+/**
  * @brief          Swap byte order, 16 bit.
  * @param[in]      v   The integer to swap.
  * @returns        The swapped integer.
@@ -402,8 +444,10 @@ static inline le_uint64_t byteorder_btolll(be_uint64_t v)
  */
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #   define _byteorder_swap(V, T) (byteorder_swap ## T((V)))
+#   define _byteorder_swap_le(V, T) (V)
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 #   define _byteorder_swap(V, T) (V)
+#   define _byteorder_swap_le(V, T) (byteorder_swap ## T((V)))
 #else
 #   error "Byte order is neither little nor big!"
 #endif
@@ -442,6 +486,42 @@ static inline uint32_t byteorder_ntohl(network_uint32_t v)
 static inline uint64_t byteorder_ntohll(network_uint64_t v)
 {
     return _byteorder_swap(v.u64, ll);
+}
+
+static inline network_uint16_t byteorder_htols(uint16_t v)
+{
+    network_uint16_t result = { _byteorder_swap_le(v, s) };
+
+    return result;
+}
+
+static inline network_uint32_t byteorder_htoll(uint32_t v)
+{
+    network_uint32_t result = { _byteorder_swap_le(v, l) };
+
+    return result;
+}
+
+static inline network_uint64_t byteorder_htolll(uint64_t v)
+{
+    network_uint64_t result = { _byteorder_swap_le(v, ll) };
+
+    return result;
+}
+
+static inline uint16_t byteorder_ltohs(network_uint16_t v)
+{
+    return _byteorder_swap_le(v.u16, s);
+}
+
+static inline uint32_t byteorder_ltohl(network_uint32_t v)
+{
+    return _byteorder_swap_le(v.u32, l);
+}
+
+static inline uint64_t byteorder_ltohll(network_uint64_t v)
+{
+    return _byteorder_swap_le(v.u64, ll);
 }
 
 static inline uint16_t htons(uint16_t v)

--- a/tests/unittests/tests-core/tests-core-byteorder.c
+++ b/tests/unittests/tests-core/tests-core-byteorder.c
@@ -80,6 +80,30 @@ static void test_byteorder_host_to_network_64(void)
     TEST_ASSERT_EQUAL_INT(host, byteorder_ntohll(network));
 }
 
+static void test_byteorder_host_to_little_16(void)
+{
+    static const uint16_t host = 0x3412;
+    network_uint16_t network = { .u8 = { 0x12, 0x34 } };
+    TEST_ASSERT_EQUAL_INT(network.u16, byteorder_htols(host).u16);
+    TEST_ASSERT_EQUAL_INT(host, byteorder_ltohs(network));
+}
+
+static void test_byteorder_host_to_little_32(void)
+{
+    static const uint32_t host = 0x78563412ul;
+    network_uint32_t network = { .u8 = { 0x12, 0x34, 0x56, 0x78 } };
+    TEST_ASSERT_EQUAL_INT(network.u32, byteorder_htoll(host).u32);
+    TEST_ASSERT_EQUAL_INT(host, byteorder_ltohl(network));
+}
+
+static void test_byteorder_host_to_little_64(void)
+{
+    static const uint64_t host = 0xf0debc9a78563412ull;
+    network_uint64_t network = { .u8 = { 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0 } };
+    TEST_ASSERT_EQUAL_INT(network.u64, byteorder_htolll(host).u64);
+    TEST_ASSERT_EQUAL_INT(host, byteorder_ltohll(network));
+}
+
 static void test_byteorder_bebuftohs(void)
 {
     static const uint8_t bebuf[2] = { 0xAA, 0xBB };
@@ -132,6 +156,9 @@ Test *tests_core_byteorder_tests(void)
         new_TestFixture(test_byteorder_host_to_network_16),
         new_TestFixture(test_byteorder_host_to_network_32),
         new_TestFixture(test_byteorder_host_to_network_64),
+        new_TestFixture(test_byteorder_host_to_little_16),
+        new_TestFixture(test_byteorder_host_to_little_32),
+        new_TestFixture(test_byteorder_host_to_little_64),
         new_TestFixture(test_byteorder_bebuftohs),
         new_TestFixture(test_byteorder_htobebufs),
         new_TestFixture(test_byteorder_bebuftohl),


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds helpers for converting between host and little endian. These functions are useful for frames using little endian (e.g LoRaWAN).

I also added the corresponding unittests.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`make -C tests/unittests tests-core test`
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Came from #14058 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
