### PR TITLE
sx127x: add support for implicit header mode

### DIFF
--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -455,6 +455,11 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
             sx127x_set_fixed_header_len_mode(dev, *((const netopt_enable_t*) val) ? true : false);
             return sizeof(netopt_enable_t);
 
+        case NETOPT_PDU_SIZE:
+            assert(len <= sizeof(uint16_t));
+            sx127x_set_payload_length(dev, *((const uint16_t*) val));
+            return sizeof(uint16_t);
+
         case NETOPT_PREAMBLE_LENGTH:
             assert(len <= sizeof(uint16_t));
             sx127x_set_preamble_length(dev, *((const uint16_t*) val));

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -196,6 +196,22 @@ typedef enum {
      */
     NETOPT_MAX_PDU_SIZE,
     /**
+     * @brief   (uint16_t) protocol data unit size
+     *
+     * When set, fixes the number of bytes to be received. This is required for
+     * MAC layers with implicit header mode (no packet length information in
+     * PDDU) and predictable packet length (e.g LoRaWAN beacons). The device
+     * driver implementation should attempt to read exactly the expected number
+     * of bytes (possibly filling it up with garbage data if the payload is
+     * smaller).
+     *
+     * When get, returns the number of expected bytes for the next reception.
+     *
+     * In some MAC layers it will only be effective if used in conjunction with
+     * @ref NETOPT_FIXED_HEADER
+     */
+    NETOPT_PDU_SIZE,
+    /**
      * @brief   (@ref netopt_enable_t) frame preloading
      *
      * Preload frame data using gnrc_netdev_driver_t::send_data() or gnrc_netapi_send(),

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -41,6 +41,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_IPV6_FORWARDING]       = "NETOPT_IPV6_FORWARDING",
     [NETOPT_IPV6_SND_RTR_ADV]      = "NETOPT_IPV6_SND_RTR_ADV",
     [NETOPT_TX_POWER]              = "NETOPT_TX_POWER",
+    [NETOPT_PDU_SIZE]              = "NETOPT_PDU_SIZE",
     [NETOPT_MAX_PDU_SIZE]          = "NETOPT_MAX_PDU_SIZE",
     [NETOPT_PRELOADING]            = "NETOPT_PRELOADING",
     [NETOPT_PROMISCUOUSMODE]       = "NETOPT_PROMISCUOUSMODE",

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -379,8 +379,65 @@ int reset_cmd(int argc, char **argv)
     return 0;
 }
 
+static void _set_opt(netdev_t *netdev, netopt_t opt, bool val, char* str_help)
+{
+    netopt_enable_t en = val ? NETOPT_ENABLE : NETOPT_DISABLE;
+    netdev->driver->set(netdev, opt, &en, sizeof(en));
+    printf("Successfully ");
+    if (val) {
+        printf("enabled ");
+    }
+    else {
+        printf("disabled ");
+    }
+    printf("%s\n", str_help);
+}
+
+int crc_cmd(int argc, char **argv)
+{
+    netdev_t *netdev = (netdev_t *)&sx127x;
+    if (argc < 3 || strcmp(argv[1], "set") != 0) {
+        printf("usage: %s set <1|0>\n", argv[0]);
+        return 1;
+    }
+
+    int tmp = atoi(argv[2]);
+    _set_opt(netdev, NETOPT_INTEGRITY_CHECK, tmp, "CRC check");
+    return 0;
+}
+
+int implicit_cmd(int argc, char **argv)
+{
+    netdev_t *netdev = (netdev_t *)&sx127x;
+    if (argc < 3 || strcmp(argv[1], "set") != 0) {
+        printf("usage: %s set <1|0>\n", argv[0]);
+        return 1;
+    }
+
+    int tmp = atoi(argv[2]);
+    _set_opt(netdev, NETOPT_FIXED_HEADER, tmp, "implicit header");
+    return 0;
+}
+
+int payload_cmd(int argc, char **argv)
+{
+    netdev_t *netdev = (netdev_t *)&sx127x;
+    if (argc < 3 || strcmp(argv[1], "set") != 0) {
+        printf("usage: %s set <payload length>\n", argv[0]);
+        return 1;
+    }
+
+    uint16_t tmp = atoi(argv[2]);
+    netdev->driver->set(netdev, NETOPT_PDU_SIZE, &tmp, sizeof(tmp));
+    printf("Successfully set payload to %i\n", tmp);
+    return 0;
+}
+
 static const shell_command_t shell_commands[] = {
     { "setup",    "Initialize LoRa modulation settings",     lora_setup_cmd },
+    { "implicit", "Enable implicit header",                  implicit_cmd },
+    { "crc",      "Enable CRC",                              crc_cmd },
+    { "payload",  "Set payload length (implicit header)",    payload_cmd },
     { "random",   "Get random number from sx127x",           random_cmd },
     { "syncword", "Get/Set the syncword",                    syncword_cmd },
     { "rx_timeout", "Set the RX timeout",                    rx_timeout_cmd },


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds the missing component to support Implicit Header mode in SX127x radios.
This mode is required in order to detect class B beacons.

I simply defined a `NETOPT_PDU_SIZE` to fix the expected packet length and adapted the test to support activation of CRC, Implicit Header mode and setting payload length,
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Refer to the [datasheet](https://cdn-shop.adafruit.com/product-files/3179/sx1276_77_78_79.pdf) for registers information
- Check that the `crc` command interacts with the correct register. This command should modify the `0x1E` register (mask `0x04`).
```
2020-07-14 13:29:53,904 #  crc set 0
2020-07-14 13:29:53,907 # Successfully disabled CRC check
register get 0x1e
2020-07-14 13:29:55,068 #  register get 0x1e
2020-07-14 13:29:55,070 # [regs] 0x1E = 0xC0
crc 1
2020-07-14 13:29:57,338 #  crc set 1
2020-07-14 13:29:57,341 # Successfully enabled CRC check
register get 0x1e
2020-07-14 13:29:58,383 #  register get 0x1e
2020-07-14 13:29:58,385 # [regs] 0x1E = 0xC4
```

- Check that the `implicit` command interacts with the correct register. This command should modify the `0x1D` register (mask `0x01`)
```
2020-07-14 13:33:09,820 #  implicit set 1
2020-07-14 13:33:09,829 # Successfully enabled implicit header
register get 0x1d
2020-07-14 13:33:11,026 #  register get 0x1d
2020-07-14 13:33:11,027 # [regs] 0x1D = 0x79
implicit 0
2020-07-14 13:33:12,847 #  implicit set 0
2020-07-14 13:33:12,851 # Successfully disabled implicit header
register get 0x1d
2020-07-14 13:33:13,647 #  register get 0x1d
2020-07-14 13:33:13,649 # [regs] 0x1D = 0x78
> 
```

- Check that the `payload` command correctly sets the payload length (register `0x22`):
```
2020-07-14 13:38:53,498 #  register get 0x22
2020-07-14 13:38:53,500 # [regs] 0x22 = 0x00
payload set 17
2020-07-14 13:39:00,158 #  payload set 17
2020-07-14 13:39:00,161 # Succesfully set payload to 17
register get 0x22
2020-07-14 13:39:00,829 #  register get 0x22
2020-07-14 13:39:00,832 # [regs] 0x22 = 0x11
```

- Run and flash `make -C tests/driver_sx127x`. Set the implicit header mode and payload length in 2 SX127x radios:
```
implicit 1
payload 4
```
Send with using one of the radios (assuming both share PHY settings):
```
send RIOT
```

Check the other radio receives the packet and reports the expect length (4 bytes).

- Optional: if you are close to a LoRaWAN class B gateway (in EU868 region), try detecting beacons with the following settings:
```
crc 0
setup 125 9 5
payload 17
channel set 869525000
implicit 1
listen
```
You should see the beacons every 128 seconds:
```
> 2020-07-14 12:35:49,067 #  Data reception started
2020-07-14 12:35:49,168 # {Payload: "����[��<q��" (17 bytes), RSSI: 182, SNR: 4, TOA: 165}
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far, but it's required for LoRaWAN class B support
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
