### PR TITLE
riotctrl_shell.netif: fix for multiple interfaces with netstats

### DIFF
--- a/dist/pythonlibs/riotctrl_shell/netif.py
+++ b/dist/pythonlibs/riotctrl_shell/netif.py
@@ -106,7 +106,9 @@ class IfconfigListParser(ShellInteractionParser):
                     if stats is not None:
                         current["stats"] = stats
                         # assume stats to be always last
-                        break
+                        current = None
+                        parse_blacklist = False
+                        parse_ipv6 = False
             offset += len(line)
         return netifs
 

--- a/dist/pythonlibs/riotctrl_shell/tests/test_netif_list_parse.py
+++ b/dist/pythonlibs/riotctrl_shell/tests/test_netif_list_parse.py
@@ -364,3 +364,49 @@ Iface  7  HWaddr: 3A:A4  Channel: 26  NID: 0x23  PHY: MR-FSK
     assert "mcs" not in res["7"]
     assert len(res["7"]["ipv6_addrs"]) == 1
     assert len(res["7"]["ipv6_groups"]) == 3
+
+
+def test_ifconfig_list_parser7():
+    cmd_output = """
+Iface  8  HWaddr: 45:5B  Channel: 26  NID: 0x23
+          Long HWaddr: 00:5A:45:50:0A:00:45:5B
+          L2-PDU:102  MTU:1280  HL:64  RTR
+          6LO  IPHC
+          Source address length: 8
+          Link type: wireless
+          inet6 addr: fe80::25a:4550:a00:455b  scope: link  VAL
+          inet6 group: ff02::2
+          inet6 group: ff02::1
+          inet6 group: ff02::1:ff00:455b
+
+          Statistics for Layer 2
+            RX packets 0  bytes 0
+            TX packets 2 (Multicast: 2)  bytes 43
+            TX succeeded 3 errors 0
+          Statistics for IPv6
+            RX packets 0  bytes 0
+            TX packets 2 (Multicast: 2)  bytes 128
+            TX succeeded 2 errors 0
+
+Iface  7  HWaddr: B6:4F:A1:0E:8F:CC
+          L2-PDU:1500  MTU:1500  HL:64  RTR
+          Source address length: 6
+          Link type: wired
+          inet6 addr: fe80::b44f:a1ff:fe0e:8fcc  scope: link  VAL
+          inet6 group: ff02::2
+          inet6 group: ff02::1
+          inet6 group: ff02::1:ff0e:8fcc
+
+          Statistics for Layer 2
+            RX packets 4  bytes 480
+            TX packets 3 (Multicast: 3)  bytes 210
+            TX succeeded 3 errors 0
+          Statistics for IPv6
+            RX packets 4  bytes 424
+            TX packets 3 (Multicast: 3)  bytes 168
+            TX succeeded 3 errors 0"""
+    parser = riotctrl_shell.netif.IfconfigListParser()
+    res = parser.parse(cmd_output)
+    assert len(res) == 2
+    assert "7" in res
+    assert "8" in res


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This provides a fix to `riotctrl_shell.netif` for when there is more than one interface and network statistics are provided. I also added a regression test for that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`cd dist/pythontools/riotctrl_shell; tox`, or just let `tools-test` do its thing :-)
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Required for the test integration of release spec [10-icmpv6-error](https://github.com/RIOT-OS/Release-Specs/blob/master/10-icmpv6-error/10-icmpv6-error.md) (see https://github.com/RIOT-OS/Release-Specs/pull/167).
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
