### PR TITLE
ci/build_system_check: improve check for features only provided in Makefile.features

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -66,14 +66,14 @@ check_providing_features_only_makefile_features() {
     local patterns=()
     local pathspec=()
 
-    patterns+=(-e 'FEATURES_PROVIDED *+= *')
+    patterns+=(-e '^[ ]*FEATURES_PROVIDED *+= *')
 
-    pathspec+=("boards/*Makefile*" "cpu/*Makefile*")
+    pathspec+=("*Makefile\.*")
 
     pathspec+=(":!*Makefile.features")
 
     git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}" \
-        | error_with_message 'Features in cpu and boards should only be provided in Makefile.features files'
+        | error_with_message 'Features should only be provided in Makefile.features files'
 }
 
 # Some variables do not need to be exported and even cause issues when being


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR improves the build system sanity checks to be able to detect the use of `FEATURES_PROVIDED` in files other than Makefile.features: it nows checks for path other than only cpu/boards and it take into account potential spaces at the beginning of lines where it is used.

This allows for catching things like:

https://github.com/RIOT-OS/RIOT/blob/60def8892937844e54417cb78585ff13030c6989/drivers/Makefile.dep#L672


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Static tests should pass. Without #14497 being merged, the check correctly catch the problem mentioned above:

```
$ ./dist/tools/buildsystem_sanity_check/check.sh 
Invalid build system patterns found by ./dist/tools/buildsystem_sanity_check/check.sh:
Features in cpu and boards should only be provided in Makefile.features files
	drivers/Makefile.dep:  FEATURES_PROVIDED += periph_rtc
```

- One can also apply the following patches to verify there's no regression in the check:

<details>

```diff
diff --git a/boards/6lowpan-clicker/Makefile.dep b/boards/6lowpan-clicker/Makefile.dep
index 2fa80dd76e..74b92b3e78 100644
--- a/boards/6lowpan-clicker/Makefile.dep
+++ b/boards/6lowpan-clicker/Makefile.dep
@@ -3,3 +3,5 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
 endif
 
 USEMODULE += newlib_syscalls_mips_uhi
+
+FEATURES_PROVIDED += periph_uart
diff --git a/boards/6lowpan-clicker/Makefile.include b/boards/6lowpan-clicker/Makefile.include
index 9ac719b33b..e9e449090c 100644
--- a/boards/6lowpan-clicker/Makefile.include
+++ b/boards/6lowpan-clicker/Makefile.include
@@ -14,3 +14,5 @@ ifeq ($(PROGRAMMER),pic32prog)
   FLASHFILE ?= $(HEXFILE)
   include $(RIOTMAKE)/tools/pic32prog.inc.mk
 endif
+
+FEATURES_PROVIDED += periph_uart
```

results in:

```
./dist/tools/buildsystem_sanity_check/check.sh 
Invalid build system patterns found by ./dist/tools/buildsystem_sanity_check/check.sh:
Features should only be provided in Makefile.features files
	boards/6lowpan-clicker/Makefile.dep:FEATURES_PROVIDED += periph_uart
	boards/6lowpan-clicker/Makefile.include:FEATURES_PROVIDED += periph_uart
	drivers/Makefile.dep:  FEATURES_PROVIDED += periph_rtc
```


```diff
git diff
diff --git a/cpu/stm32/Makefile.dep b/cpu/stm32/Makefile.dep
index 56bbbc945b..96a3abc50b 100644
--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -17,3 +17,5 @@ ifneq (,$(filter periph_uart_nonblocking,$(USEMODULE)))
 endif
 
 include $(RIOTCPU)/cortexm_common/Makefile.dep
+
+FEATURES_PROVIDED += periph_wdt
diff --git a/cpu/stm32/Makefile.include b/cpu/stm32/Makefile.include
index b0f9a4a681..61057737fd 100644
--- a/cpu/stm32/Makefile.include
+++ b/cpu/stm32/Makefile.include
@@ -46,3 +46,5 @@ endif
 VECTORS_O ?= $(BINDIR)/stm32_vectors/vectors_$(CPU_FAM).o
 
 include $(RIOTMAKE)/arch/cortexm.inc.mk
+
+FEATURES_PROVIDED += periph_wdt
```

results in:

```
./dist/tools/buildsystem_sanity_check/check.sh 
Invalid build system patterns found by ./dist/tools/buildsystem_sanity_check/check.sh:
Features should only be provided in Makefile.features files
	cpu/stm32/Makefile.dep:FEATURES_PROVIDED += periph_wdt
	cpu/stm32/Makefile.include:FEATURES_PROVIDED += periph_wdt
	drivers/Makefile.dep:  FEATURES_PROVIDED += periph_rtc
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Will work when #14497 is merged

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
