### PR TITLE
net/credman : Expose configurations to Kconfig

### DIFF
--- a/sys/include/net/credman.h
+++ b/sys/include/net/credman.h
@@ -37,8 +37,8 @@ extern "C" {
 /**
  * @brief Maximum number of credentials in credential pool
  */
-#ifndef CREDMAN_MAX_CREDENTIALS
-#define CREDMAN_MAX_CREDENTIALS  (2)
+#ifndef CONFIG_CREDMAN_MAX_CREDENTIALS
+#define CONFIG_CREDMAN_MAX_CREDENTIALS  (2)
 #endif
 
 /**
@@ -173,7 +173,7 @@ void credman_delete(credman_tag_t tag, credman_type_t type);
 /**
  * @brief Gets the number of credentials currently in the credential pool
  *
- * Maximum number of allowed credentials is defined by CREDMAN_MAX_CREDENTIALS
+ * Maximum number of allowed credentials is defined by CONFIG_CREDMAN_MAX_CREDENTIALS
  *
  * @return number of credentials currently in the credential pool
  */

--- a/sys/include/net/credman.h
+++ b/sys/include/net/credman.h
@@ -35,11 +35,17 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup net_credman_conf (D)TLS Credential Manager compile configurations
+ * @ingroup config
+ * @{
+ */
+/**
  * @brief Maximum number of credentials in credential pool
  */
 #ifndef CONFIG_CREDMAN_MAX_CREDENTIALS
 #define CONFIG_CREDMAN_MAX_CREDENTIALS  (2)
 #endif
+/** @} */
 
 /**
  * @brief Buffer of the credential

--- a/sys/net/Kconfig
+++ b/sys/net/Kconfig
@@ -7,6 +7,7 @@
 menu "Networking"
 
 rsource "application_layer/Kconfig"
+rsource "credman/Kconfig"
 rsource "gnrc/Kconfig"
 rsource "sock/Kconfig"
 rsource "link_layer/Kconfig"

--- a/sys/net/credman/Kconfig
+++ b/sys/net/credman/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_CREDMAN
+    bool "Configure CREDMAN"
+    depends on MODULE_CREDMAN
+    help
+        Configure CREDMAN, Credentials management module for (D)TLS, using
+        Kconfig.
+
+if KCONFIG_MODULE_CREDMAN
+
+config CREDMAN_MAX_CREDENTIALS
+    int "MAX number of credentials in credential pool"
+    default 2
+    help
+        Configure 'CONFIG_CREDMAN_MAX_CREDENTIALS', the maximum number of
+        allowed credentials in the credential pool.
+
+endif # KCONFIG_MODULE_CREDMAN

--- a/sys/net/credman/credman.c
+++ b/sys/net/credman/credman.c
@@ -26,7 +26,7 @@
 
 static mutex_t _mutex = MUTEX_INIT;
 
-static credman_credential_t credentials[CREDMAN_MAX_CREDENTIALS];
+static credman_credential_t credentials[CONFIG_CREDMAN_MAX_CREDENTIALS];
 static unsigned used = 0;
 
 static int _find_credential_pos(credman_tag_t tag, credman_type_t type,
@@ -129,7 +129,7 @@ int credman_get_used_count(void)
 static int _find_credential_pos(credman_tag_t tag, credman_type_t type,
                                 credman_credential_t **empty)
 {
-    for (unsigned i = 0; i < CREDMAN_MAX_CREDENTIALS; i++) {
+    for (unsigned i = 0; i < CONFIG_CREDMAN_MAX_CREDENTIALS; i++) {
         credman_credential_t *c = &credentials[i];
         if ((c->tag == tag) && (c->type == type)) {
             return i;
@@ -148,7 +148,7 @@ void credman_reset(void)
 {
     mutex_lock(&_mutex);
     memset(credentials, 0,
-           sizeof(credman_credential_t) * CREDMAN_MAX_CREDENTIALS);
+           sizeof(credman_credential_t) * CONFIG_CREDMAN_MAX_CREDENTIALS);
     used = 0;
     mutex_unlock(&_mutex);
 }

--- a/tests/unittests/tests-credman/tests-credman.c
+++ b/tests/unittests/tests-credman/tests-credman.c
@@ -73,7 +73,7 @@ static void test_credman_add(void)
 
     /* fill the pool */
     memcpy(&credential.params.psk, &exp_psk_params, sizeof(psk_params_t));
-    while (credman_get_used_count() < CREDMAN_MAX_CREDENTIALS) {
+    while (credman_get_used_count() < CONFIG_CREDMAN_MAX_CREDENTIALS) {
         /* increase tag number so that it is not recognized as duplicate */
         credential.tag++;
         TEST_ASSERT_EQUAL_INT(CREDMAN_OK, credman_add(&credential));
@@ -176,7 +176,7 @@ static void test_credman_delete_random_order(void)
     };
     TEST_ASSERT_EQUAL_INT(0, credman_get_used_count());
 
-    /* fill the credential pool, assume CREDMAN_MAX_CREDENTIALS is 2 */
+    /* fill the credential pool, assume CONFIG_CREDMAN_MAX_CREDENTIALS is 2 */
     TEST_ASSERT_EQUAL_INT(CREDMAN_OK, credman_add(&in_credential));
     in_credential.tag = tag2;
     TEST_ASSERT_EQUAL_INT(CREDMAN_OK, credman_add(&in_credential));


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in **net/credman** to Kconfig.

### Testing procedure

1. New documentation was built using Doxygen 

   The build works fine.

  2. Test files were added to tests/credman/

      The test file can be found [here](https://github.com/akshaim/RIOT/commit/d4596285ffac6df81ce56c9ce87f2acda79b45dd)

Compiled binaries for native

#### Default State:

##### Firmware Output

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-29-gd4596-Kconfig_credman_tests)
CONFIG_CREDMAN_MAX_CREDENTIALS=(2)

```
#### Usage with CFLAGS :
```
CFLAGS += -DCONFIG_CREDMAN_MAX_CREDENTIALS=3
```

##### Firmware Output

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-29-gd4596-Kconfig_credman_tests)
CONFIG_CREDMAN_MAX_CREDENTIALS=3
```

#### Usage with menuconfig :


`make menuconfig`

#### Default values

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-29-gd4596-Kconfig_credman_tests)
CONFIG_CREDMAN_MAX_CREDENTIALS=2
```
##### Macros Configured output

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-29-gd4596-Kconfig_credman_tests)
CONFIG_CREDMAN_MAX_CREDENTIALS=4
```


**MACROS were successfully configured.**

### Issues/PRs references

#12888 