### PR TITLE
cortexm_common: fix check for bitbanding feature

### DIFF
--- a/cpu/cc2538/include/cpu_conf.h
+++ b/cpu/cc2538/include/cpu_conf.h
@@ -40,6 +40,7 @@ extern "C" {
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
 #define CPU_IRQ_NUMOF                   PERIPH_COUNT_IRQn
 #define CPU_FLASH_BASE                  FLASH_BASE
+#define CPU_HAS_BITBAND                 (1)
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/cc26x0/include/cpu_conf.h
+++ b/cpu/cc26x0/include/cpu_conf.h
@@ -27,6 +27,11 @@
 #include "cc26x0_fcfg.h"
 #include "cc26x0_prcm.h"
 
+/**
+ * @brief   Bit-Band configuration
+ */
+#define CPU_HAS_BITBAND 1
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/cc26x2_cc13x2/include/cpu_conf.h
+++ b/cpu/cc26x2_cc13x2/include/cpu_conf.h
@@ -29,6 +29,11 @@
 #include "cc26x2_cc13x2_prcm.h"
 #include "cc26x2_cc13x2_setup.h"
 
+/**
+ * @brief   Bit-Band configuration
+ */
+#define CPU_HAS_BITBAND 1
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/cortexm_common/include/bit.h
+++ b/cpu/cortexm_common/include/bit.h
@@ -35,16 +35,8 @@ extern "C" {
 #define CPU_HAS_BITBAND 1 || 0 (1 for Cortex-M3 and up, 0 for Cortex-M0)
 #endif
 
-#ifndef CPU_HAS_BITBAND
-#if (__CORTEX_M >= 3)
-#define CPU_HAS_BITBAND 1
-#else
-#define CPU_HAS_BITBAND 0
-#endif
-#endif
-
 #if CPU_HAS_BITBAND || DOXYGEN
-/* Cortex-M3 and higher provide a bitband address space for atomically accessing
+/* Some MCUs provide a bitband address space for atomically accessing
  * single bits of peripheral registers, and sometimes for RAM as well */
 /**
  * @name Bit manipulation functions

--- a/cpu/efm32/include/cpu_conf.h
+++ b/cpu/efm32/include/cpu_conf.h
@@ -51,6 +51,15 @@ extern "C" {
 #define FLASHPAGE_RAW_ALIGNMENT    (4U)
 /** @} */
 
+/**
+ * @brief   Bit-Band configuration
+ * @{
+ */
+#ifdef BITBAND_RAM_BASE
+#define CPU_HAS_BITBAND 1
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/ezr32wg/include/cpu_conf.h
+++ b/cpu/ezr32wg/include/cpu_conf.h
@@ -42,6 +42,15 @@ extern "C" {
 #define CPU_FLASH_BASE                  FLASH_BASE
 /** @} */
 
+/**
+ * @brief   Bit-Band configuration
+ * @{
+ */
+#ifdef BITBAND_RAM_BASE
+#define CPU_HAS_BITBAND 1
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/kinetis/include/cpu_conf.h
+++ b/cpu/kinetis/include/cpu_conf.h
@@ -44,6 +44,15 @@ extern "C"
 {
 #endif
 
+/**
+ * @brief   Bit-Band configuration
+ * @{
+ */
+#ifdef BITBAND_REG32
+#define CPU_HAS_BITBAND 1
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/lm4f120/include/cpu_conf.h
+++ b/cpu/lm4f120/include/cpu_conf.h
@@ -58,6 +58,7 @@ extern "C" {
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
 #define CPU_IRQ_NUMOF                   (139U)
 #define CPU_FLASH_BASE                  FLASH_BASE
+#define CPU_HAS_BITBAND                 (1)
 /** @} */
 
 /**

--- a/cpu/lpc1768/include/cpu_conf.h
+++ b/cpu/lpc1768/include/cpu_conf.h
@@ -36,6 +36,7 @@ extern "C" {
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
 #define CPU_IRQ_NUMOF                   (35U)
 #define CPU_FLASH_BASE                  LPC_FLASH_BASE
+#define CPU_HAS_BITBAND                 (1)
 /** @} */
 
 /**

--- a/cpu/sam_common/include/cpu_conf.h
+++ b/cpu/sam_common/include/cpu_conf.h
@@ -34,6 +34,7 @@ extern "C" {
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
 #define CPU_IRQ_NUMOF                   PERIPH_COUNT_IRQn
 #define CPU_FLASH_BASE                  IFLASH0_ADDR
+#define CPU_HAS_BITBAND                 (1)
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/stm32/include/cpu_conf.h
+++ b/cpu/stm32/include/cpu_conf.h
@@ -167,6 +167,15 @@ extern "C" {
 #endif
 /** @} */
 
+/**
+ * @brief   Bit-Band configuration
+ * @{
+ */
+#ifdef SRAM_BB_BASE
+#define CPU_HAS_BITBAND 1
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The Bit-Banding function already covers all cases, but the assumption that all Cortex-M3 upwards have this feature is wrong.
Bit-Banding is an optional feature and it's up to the vendor to implement it or not.

### Testing procedure

Read, e.g. [SAM D5x/E5x Family Data Sheet](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM_D5xE5x_Family_Data_Sheet_DS60001507F.pdf)

![image](https://user-images.githubusercontent.com/1301112/89662401-53ded400-d8d4-11ea-8d81-10ad4dbd52be.png)

#### nrf52
![image](https://user-images.githubusercontent.com/1301112/89664620-bab1bc80-d8d7-11ea-942d-147b087dfa5a.png)


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
