### PR TITLE
riotctrl_shell.gnrc: remove superfluous quotation marks

### DIFF
--- a/dist/pythonlibs/riotctrl_shell/gnrc.py
+++ b/dist/pythonlibs/riotctrl_shell/gnrc.py
@@ -393,7 +393,7 @@ class GNRCPktbufStatsParser(ShellInteractionParser):
             r"~ unused: 0x(?P<start>[0-9A-Fa-f]+) "
             # flake reports r'\(', r'\)' as invalid escape sequence
             # false positively
-            r"\(next: ""(0x(?P<next>[0-9A-Fa-f]+)|\(nil\)), "   # noqa W605
+            r"\(next: (0x(?P<next>[0-9A-Fa-f]+)|\(nil\)), "
             r"size: +(?P<size>\d+)\) ~"
         )
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
`flake8` and `pytest` were warning about this but the first was suppressed and the latter ignored because the problem was not really obvious for tired eyes :sleepy:. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```sh
cd dist/pythonlibs/riotctrl_shell
tox
```

passes
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
