### PR TITLE
tests/xtimer_now_irq: don't fail for 32bit timers

### DIFF
--- a/tests/xtimer_now_irq/main.c
+++ b/tests/xtimer_now_irq/main.c
@@ -26,22 +26,27 @@
 
 int main(void)
 {
-    puts("xtimer_now_irq test application.\n");
-
-    uint8_t count = TEST_COUNT;
-    while (count) {
-        unsigned int state = irq_disable();
-        uint32_t t1 = xtimer_now_usec();
-        xtimer_spin(xtimer_ticks((uint32_t)(~XTIMER_MASK) / 2));
-        uint32_t t2 = xtimer_now_usec();
-        irq_restore(state);
-        if (t2 < t1) {
-            puts("ERROR: wrong time with interrupts disabled");
-            return -1;
-        }
-        puts("OK");
-        count --;
+    if (XTIMER_WIDTH == 32) {
+        puts("Nothing to do for 32 bit timers.\n");
     }
+    else {
+        puts("xtimer_now_irq test application.\n");
+        uint8_t count = TEST_COUNT;
+        while (count) {
+            unsigned int state = irq_disable();
+            uint32_t t1 = xtimer_now_usec();
+            xtimer_spin(xtimer_ticks((uint32_t)(~XTIMER_MASK) / 2));
+            uint32_t t2 = xtimer_now_usec();
+            irq_restore(state);
+            if (t2 < t1) {
+                puts("ERROR: wrong time with interrupts disabled");
+                return -1;
+            }
+            puts("OK");
+            count --;
+        }
+    }
+
     puts("SUCCESS");
     return 0;
 }

--- a/tests/xtimer_now_irq/tests/01-run.py
+++ b/tests/xtimer_now_irq/tests/01-run.py
@@ -15,8 +15,11 @@ TIMEOUT = 20
 
 
 def testfunc(child):
-    for _ in range(4):
-        child.expect_exact("OK", timeout=TIMEOUT)
+    res = child.expect(['Nothing to do for 32 bit timers.\r\n',
+                        'xtimer_now_irq test application.\r\n'])
+    if res == 1:
+        for _ in range(4):
+            child.expect_exact("OK", timeout=TIMEOUT)
     child.expect_exact("SUCCESS")
 
 


### PR DESCRIPTION
### Contribution description

This test is not supposed to work on 32bit timers but there is nothing blacklisting it, we don't have a feature do identify platforms using a 32bit timers at compile time so instead let the application return silently.

I'm running the release tests on multiple platforms and I don't like to see tests failing, so this wants to fix this.

### Testing procedure

` BOARD=pba-d-01-kw2x make -C tests/xtimer_now_irq/ flash test`

```
START
main(): This is RIOT! (Version: 2020.07-devel-1691-g6bb76-pr_xtimer_now_irq_32b)
Nothing to do for 32 bit timers.

SUCCESS
```
