### PR TITLE
tests/gnrc_dhcpv6_client: fix expected output

### DIFF
--- a/tests/gnrc_dhcpv6_client/tests/01-run.py
+++ b/tests/gnrc_dhcpv6_client/tests/01-run.py
@@ -18,8 +18,8 @@ def testfunc(child):
     child.expect(r"inet6 addr:\s+(?P<global_addr>[0-9a-f:]+)\s+scope: global")
     global_addr = child.match.group("global_addr")
     child.expect(r"(?P<global_pfx>[0-9a-f:]+)/64\s+dev #\d\s+"
-                 r"expires \d+sec\s+"
-                 r"deprecates \d+sec")
+                 r"expires \d+ sec\s+"
+                 r"deprecates \d+ sec")
     global_pfx = child.match.group("global_pfx")
     if global_pfx.endswith("::"):
         # remove one trailing : in case there are no 0s between prefix and


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The output of the shell command `nib prefix show` was changed in https://github.com/RIOT-OS/RIOT/pull/12776 by adding a space between the number of seconds and the unit. Due to this the test `tests/gnrc_dhcpv6_client` now fails as it expects the output to be without spaces.

As the new `riotctrl_shell` "accidentally" [accounted for that "error"](https://github.com/RIOT-OS/RIOT/blob/1167867d02fff8643262022f7a6328b2cf46d519/dist/pythonlibs/riotctrl_shell/gnrc.py#L197-L198), I decided to rather fix the test than reverting the addition of the whitespace. There is no other test in master that checks this output.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The test requires [`kea`](https://kea.isc.org/) to be installed. It is available in most Linux distributions as a package, but many don't create the status directory of the server:

```sh
sudo mkdir -p /var/kea/
```

Then run on a board of your choice (that supports `ethos`):

```sh
make -C tests/gnrc_dhcpv6_client flash
sudo make -C tests/gnrc_dhcpv6_client test
```


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes a "regression" introduced in https://github.com/RIOT-OS/RIOT/pull/12776
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
