### PR TITLE
stm32: model features of cpu families and boards to kconfig

### DIFF
--- a/boards/b-l072z-lrwan1/Kconfig
+++ b/boards/b-l072z-lrwan1/Kconfig
@@ -1,0 +1,30 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "b-l072z-lrwan1" if BOARD_B_L072Z_LRWAN1
+
+config BOARD_B_L072Z_LRWAN1
+    bool
+    default y
+    select CPU_MODEL_STM32L072CZ
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_SPI_GPIO_MODE
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    # For riotboot you need an openocd that supports dualbank flashing.
+    # The 0.10.0 openocd version in Ubuntu Bionic doesn't work. The change was
+    # introduced after Jun 8, 2017 - v0.10.0-1-20170607-2132-dev.
+    select HAS_RIOTBOOT

--- a/boards/b-l475e-iot01a/Kconfig
+++ b/boards/b-l475e-iot01a/Kconfig
@@ -1,0 +1,27 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "b-l475e-iot01a" if BOARD_B_L475E_IOT01A
+
+config BOARD_B_L475E_IOT01A
+    bool
+    default y
+    select CPU_MODEL_STM32L475VG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT

--- a/boards/blackpill-128kib/Kconfig
+++ b/boards/blackpill-128kib/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "blackpill-128kib" if BOARD_BLACKPILL_128KIB
+
+config BOARD_BLACKPILL_128KIB
+    bool
+    default y
+    select BOARD_COMMON_BLXXXPILL
+    select CPU_MODEL_STM32F103CB
+
+source "$(RIOTBOARD)/common/blxxxpill/Kconfig"

--- a/boards/blackpill/Kconfig
+++ b/boards/blackpill/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "blackpill" if BOARD_BLACKPILL
+
+config BOARD_BLACKPILL
+    bool
+    default y
+    select BOARD_COMMON_BLXXXPILL
+    select CPU_MODEL_STM32F103C8
+
+source "$(RIOTBOARD)/common/blxxxpill/Kconfig"

--- a/boards/bluepill-128kib/Kconfig
+++ b/boards/bluepill-128kib/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "bluepill-128kib" if BOARD_BLUEPILL_128KIB
+
+config BOARD_BLUEPILL_128KIB
+    bool
+    default y
+    select BOARD_COMMON_BLXXXPILL
+    select CPU_MODEL_STM32F103CB
+
+source "$(RIOTBOARD)/common/blxxxpill/Kconfig"

--- a/boards/bluepill/Kconfig
+++ b/boards/bluepill/Kconfig
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "bluepill" if BOARD_BLUEPILL
+
+config BOARD_BLUEPILL
+    bool
+    default y
+    select BOARD_COMMON_BLXXXPILL
+    select CPU_MODEL_STM32F103C8
+
+source "$(RIOTBOARD)/common/blxxxpill/Kconfig"

--- a/boards/common/blxxxpill/Kconfig
+++ b/boards/common/blxxxpill/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD_COMMON_BLXXXPILL
+    bool
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_QDEC

--- a/boards/common/iotlab/Kconfig
+++ b/boards/common/iotlab/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD_COMMON_IOTLAB
+    bool
+    select CPU_MODEL_STM32F103RE
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT

--- a/boards/common/nucleo144/Kconfig
+++ b/boards/common/nucleo144/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD_COMMON_NUCLEO144
+    bool
+    select HAS_ARDUINO

--- a/boards/common/nucleo32/Kconfig
+++ b/boards/common/nucleo32/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD_COMMON_NUCLEO32
+    bool
+    select HAS_ARDUINO

--- a/boards/common/nucleo64/Kconfig
+++ b/boards/common/nucleo64/Kconfig
@@ -1,0 +1,10 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD_COMMON_NUCLEO64
+    bool
+    select HAS_ARDUINO

--- a/boards/f4vi1/Kconfig
+++ b/boards/f4vi1/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "f4vi1" if BOARD_F4VI1
+
+config BOARD_F4VI1
+    bool
+    default y
+    select CPU_MODEL_STM32F415RG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/fox/Kconfig
+++ b/boards/fox/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "fox" if BOARD_FOX
+
+config BOARD_FOX
+    bool
+    default y
+    select CPU_MODEL_STM32F103RE
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/i-nucleo-lrwan1/Kconfig
+++ b/boards/i-nucleo-lrwan1/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "i-nucleo-lrwan1" if BOARD_I_NUCLEO_LRWAN1
+
+config BOARD_I_NUCLEO_LRWAN1
+    bool
+    default y
+    select CPU_MODEL_STM32L052T8
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_LPUART
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_SPI_GPIO_MODE
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/im880b/Kconfig
+++ b/boards/im880b/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "im880b" if BOARD_IM880B
+
+config BOARD_IM880B
+    bool
+    default y
+    select CPU_MODEL_STM32L151CB
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/iotlab-a8-m3/Kconfig
+++ b/boards/iotlab-a8-m3/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "iotlab-a8-m3" if BOARD_IOTLAB_A8_M3
+
+config BOARD_IOTLAB_A8_M3
+    bool
+    default y
+    select BOARD_COMMON_IOTLAB
+
+source "$(RIOTBOARD)/common/iotlab/Kconfig"

--- a/boards/iotlab-m3/Kconfig
+++ b/boards/iotlab-m3/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "iotlab-m3" if BOARD_IOTLAB_M3
+
+config BOARD_IOTLAB_M3
+    bool
+    default y
+    select BOARD_COMMON_IOTLAB
+
+    select HAS_PERIPH_DMA
+
+source "$(RIOTBOARD)/common/iotlab/Kconfig"

--- a/boards/limifrog-v1/Kconfig
+++ b/boards/limifrog-v1/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "limifrog-v1" if BOARD_LIMIFROG_V1
+
+config BOARD_LIMIFROG_V1
+    bool
+    default y
+    select CPU_MODEL_STM32L151RC
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/lobaro-lorabox/Kconfig
+++ b/boards/lobaro-lorabox/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "lobaro-lorabox" if BOARD_LOBARO_LORABOX
+
+config BOARD_LOBARO_LORABOX
+    bool
+    default y
+    select CPU_MODEL_STM32L151CB_A
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_SPI_GPIO_MODE
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/lsn50/Kconfig
+++ b/boards/lsn50/Kconfig
@@ -1,0 +1,30 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "lsn50" if BOARD_LSN50
+
+config BOARD_LSN50
+    bool
+    default y
+    select CPU_MODEL_STM32L072CZ
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_SPI_GPIO_MODE
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    # For riotboot you need an openocd that supports dualbank flashing.
+    # The 0.10.0 openocd version in Ubuntu Bionic doesn't work. The change was
+    # introduced after Jun 8, 2017 - v0.10.0-1-20170607-2132-dev.
+    select HAS_RIOTBOOT

--- a/boards/maple-mini/Kconfig
+++ b/boards/maple-mini/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "maple-mini" if BOARD_MAPLE_MINI
+
+config BOARD_MAPLE_MINI
+    bool
+    default y
+    select CPU_MODEL_STM32F103CB
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/msbiot/Kconfig
+++ b/boards/msbiot/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "msbiot" if BOARD_MSBIOT
+
+config BOARD_MSBIOT
+    bool
+    default y
+    select CPU_MODEL_STM32F415RG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/nucleo-f030r8/Kconfig
+++ b/boards/nucleo-f030r8/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f030r8" if BOARD_NUCLEO_F030R8
+
+config BOARD_NUCLEO_F030R8
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32F030R8
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f031k6/Kconfig
+++ b/boards/nucleo-f031k6/Kconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f031k6" if BOARD_NUCLEO_F031K6
+
+config BOARD_NUCLEO_F031K6
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO32
+    select CPU_MODEL_STM32F031K6
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nucleo32/Kconfig"

--- a/boards/nucleo-f042k6/Kconfig
+++ b/boards/nucleo-f042k6/Kconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f042k6" if BOARD_NUCLEO_F042K6
+
+config BOARD_NUCLEO_F042K6
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO32
+    select CPU_MODEL_STM32F042K6
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nucleo32/Kconfig"

--- a/boards/nucleo-f070rb/Kconfig
+++ b/boards/nucleo-f070rb/Kconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f070rb" if BOARD_NUCLEO_F070RB
+
+config BOARD_NUCLEO_F070RB
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32F070RB
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f072rb/Kconfig
+++ b/boards/nucleo-f072rb/Kconfig
@@ -1,0 +1,26 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f072rb" if BOARD_NUCLEO_F072RB
+
+config BOARD_NUCLEO_F072RB
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32F072RB
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_SPI
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f091rc/Kconfig
+++ b/boards/nucleo-f091rc/Kconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f091rc" if BOARD_NUCLEO_F091RC
+
+config BOARD_NUCLEO_F091RC
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32F091RC
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_SPI
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f103rb/Kconfig
+++ b/boards/nucleo-f103rb/Kconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f103rb" if BOARD_NUCLEO_F103RB
+
+config BOARD_NUCLEO_F103RB
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32F103RB
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_SPI
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f207zg/Kconfig
+++ b/boards/nucleo-f207zg/Kconfig
@@ -1,0 +1,31 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f207zg" if BOARD_NUCLEO_F207ZG
+
+config BOARD_NUCLEO_F207ZG
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32F207ZG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_ETH
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f302r8/Kconfig
+++ b/boards/nucleo-f302r8/Kconfig
@@ -1,0 +1,28 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f302r8" if BOARD_NUCLEO_F302R8
+
+config BOARD_NUCLEO_F302R8
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32F302R8
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f303k8/Kconfig
+++ b/boards/nucleo-f303k8/Kconfig
@@ -1,0 +1,27 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f303k8" if BOARD_NUCLEO_F303K8
+
+config BOARD_NUCLEO_F303K8
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO32
+    select CPU_MODEL_STM32F303K8
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo32/Kconfig"

--- a/boards/nucleo-f303re/Kconfig
+++ b/boards/nucleo-f303re/Kconfig
@@ -1,0 +1,28 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f303re" if BOARD_NUCLEO_F303RE
+
+config BOARD_NUCLEO_F303RE
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32F303RE
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f303ze/Kconfig
+++ b/boards/nucleo-f303ze/Kconfig
@@ -1,0 +1,27 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f303ze" if BOARD_NUCLEO_F303ZE
+
+config BOARD_NUCLEO_F303ZE
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32F303ZE
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f334r8/Kconfig
+++ b/boards/nucleo-f334r8/Kconfig
@@ -1,0 +1,27 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f334r8" if BOARD_NUCLEO_F334R8
+
+config BOARD_NUCLEO_F334R8
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32F334R8
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f401re/Kconfig
+++ b/boards/nucleo-f401re/Kconfig
@@ -1,0 +1,28 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f401re" if BOARD_NUCLEO_F401RE
+
+config BOARD_NUCLEO_F401RE
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32F401RE
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_QDEC
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f410rb/Kconfig
+++ b/boards/nucleo-f410rb/Kconfig
@@ -1,0 +1,26 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f410rb" if BOARD_NUCLEO_F410RB
+
+config BOARD_NUCLEO_F410RB
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32F410RB
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f410rb/Makefile.features
+++ b/boards/nucleo-f410rb/Makefile.features
@@ -9,3 +9,6 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/common/nucleo64/Makefile.features

--- a/boards/nucleo-f411re/Kconfig
+++ b/boards/nucleo-f411re/Kconfig
@@ -1,0 +1,27 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f411re" if BOARD_NUCLEO_F411RE
+
+config BOARD_NUCLEO_F411RE
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32F411RE
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f411re/Makefile.features
+++ b/boards/nucleo-f411re/Makefile.features
@@ -10,3 +10,6 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/common/nucleo64/Makefile.features

--- a/boards/nucleo-f412zg/Kconfig
+++ b/boards/nucleo-f412zg/Kconfig
@@ -1,0 +1,28 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f412zg" if BOARD_NUCLEO_F412ZG
+
+config BOARD_NUCLEO_F412ZG
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO144
+    select CPU_MODEL_STM32F412ZG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+
+source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-f413zh/Kconfig
+++ b/boards/nucleo-f413zh/Kconfig
@@ -1,0 +1,31 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f413zh" if BOARD_NUCLEO_F413ZH
+
+config BOARD_NUCLEO_F413ZH
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO144
+    select CPU_MODEL_STM32F413ZH
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_CAN
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+
+source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-f429zi/Kconfig
+++ b/boards/nucleo-f429zi/Kconfig
@@ -1,0 +1,28 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f429zi" if BOARD_NUCLEO_F429ZI
+
+config BOARD_NUCLEO_F429ZI
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO144
+    select CPU_MODEL_STM32F429ZI
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+
+source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-f446re/Kconfig
+++ b/boards/nucleo-f446re/Kconfig
@@ -1,0 +1,32 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f446re" if BOARD_NUCLEO_F446RE
+
+config BOARD_NUCLEO_F446RE
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32F446RE
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_QDEC
+
+    # Various other features (if any)
+    select HAS_MOTOR_DRIVER
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f446ze/Kconfig
+++ b/boards/nucleo-f446ze/Kconfig
@@ -1,0 +1,27 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f446ze" if BOARD_NUCLEO_F446ZE
+
+config BOARD_NUCLEO_F446ZE
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO144
+    select CPU_MODEL_STM32F446ZE
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+
+source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-f722ze/Kconfig
+++ b/boards/nucleo-f722ze/Kconfig
@@ -1,0 +1,28 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f722ze" if BOARD_NUCLEO_F722ZE
+
+config BOARD_NUCLEO_F722ZE
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO144
+    select CPU_MODEL_STM32F722ZE
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-f746zg/Kconfig
+++ b/boards/nucleo-f746zg/Kconfig
@@ -1,0 +1,28 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f746zg" if BOARD_NUCLEO_F746ZG
+
+config BOARD_NUCLEO_F746ZG
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO144
+    select CPU_MODEL_STM32F746ZG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-f767zi/Kconfig
+++ b/boards/nucleo-f767zi/Kconfig
@@ -1,0 +1,31 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-f767zi" if BOARD_NUCLEO_F767ZI
+
+config BOARD_NUCLEO_F767ZI
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO144
+    select CPU_MODEL_STM32F767ZI
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_PERIPH_ETH
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-g474re/Kconfig
+++ b/boards/nucleo-g474re/Kconfig
@@ -1,0 +1,29 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-g474re" if BOARD_NUCLEO_G474RE
+
+config BOARD_NUCLEO_G474RE
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32G474RE
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_LPUART
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l031k6/Kconfig
+++ b/boards/nucleo-l031k6/Kconfig
@@ -1,0 +1,27 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-l031k6" if BOARD_NUCLEO_L031K6
+
+config BOARD_NUCLEO_L031K6
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO32
+    select CPU_MODEL_STM32L031K6
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nucleo32/Kconfig"

--- a/boards/nucleo-l053r8/Kconfig
+++ b/boards/nucleo-l053r8/Kconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-l053r8" if BOARD_NUCLEO_L053R8
+
+config BOARD_NUCLEO_L053R8
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32L053R8
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l073rz/Kconfig
+++ b/boards/nucleo-l073rz/Kconfig
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-l073rz" if BOARD_NUCLEO_L073RZ
+
+config BOARD_NUCLEO_L073RZ
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32L073RZ
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_LPUART
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_SPI_GPIO_MODE
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    # For riotboot you need an openocd that supports dualbank flashing.
+    # The 0.10.0 openocd version in Ubuntu Bionic doesn't work. The change was
+    # introduced after Jun 8, 2017 - v0.10.0-1-20170607-2132-dev.
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l152re/Kconfig
+++ b/boards/nucleo-l152re/Kconfig
@@ -1,0 +1,32 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-l152re" if BOARD_NUCLE0_L152RE
+
+config BOARD_NUCLE0_L152RE
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32L152RE
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_SPI_GPIO_MODE
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l412kb/Kconfig
+++ b/boards/nucleo-l412kb/Kconfig
@@ -1,0 +1,31 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-l412kb" if BOARD_NUCLEO_L412KB
+
+config BOARD_NUCLEO_L412KB
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO32
+    select CPU_MODEL_STM32L412KB
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    # Note that a recent version of OpenOCD with a slightly patched code is required
+    # for flashing this board. Refer to the following PR for more info:
+    # https://github.com/RIOT-OS/RIOT/pull/12144#issuecomment-527090161
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo32/Kconfig"

--- a/boards/nucleo-l432kc/Kconfig
+++ b/boards/nucleo-l432kc/Kconfig
@@ -1,0 +1,33 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-l432kc" if BOARD_NUCLEO_L432KC
+
+config BOARD_NUCLEO_L432KC
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO32
+    select CPU_MODEL_STM32L432KC
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    # Note that a recent version of OpenOCD is required for flashing an image on
+    # the second slot of the flash memory. This version has to be built from source
+    # and at least contains the following commit
+    # https://github.com/ntfreak/openocd/commit/a4d50544de07f13e3f9644d2b48e41ebdc91a7a3
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo32/Kconfig"

--- a/boards/nucleo-l433rc/Kconfig
+++ b/boards/nucleo-l433rc/Kconfig
@@ -1,0 +1,34 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-l433rc" if BOARD_NUCLEO_L433RC
+
+config BOARD_NUCLEO_L433RC
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32L433RC
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_LPUART
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    # Note that a recent version of OpenOCD is required for flashing an image on
+    # the second slot of the flash memory. This version has to be built from source
+    # and at least contains the following commit
+    # https://github.com/ntfreak/openocd/commit/a4d50544de07f13e3f9644d2b48e41ebdc91a7a3
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l452re/Kconfig
+++ b/boards/nucleo-l452re/Kconfig
@@ -1,0 +1,28 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-l452re" if BOARD_NUCLEO_L452RE
+
+config BOARD_NUCLEO_L452RE
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32L452RE
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l476rg/Kconfig
+++ b/boards/nucleo-l476rg/Kconfig
@@ -1,0 +1,32 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-l476rg" if BOARD_NUCLEO_L476RG
+
+config BOARD_NUCLEO_L476RG
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32L476RG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_CAN
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l496zg/Kconfig
+++ b/boards/nucleo-l496zg/Kconfig
@@ -1,0 +1,30 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-l496zg" if BOARD_NUCLEO_L496ZG
+
+config BOARD_NUCLEO_L496ZG
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO144
+    select CPU_MODEL_STM32L496ZG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_LPUART
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-l4r5zi/Kconfig
+++ b/boards/nucleo-l4r5zi/Kconfig
@@ -1,0 +1,29 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-l4r5zi" if BOARD_NUCLEO_L4R5ZI
+
+config BOARD_NUCLEO_L4R5ZI
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO144
+    select CPU_MODEL_STM32L4R5ZI
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_LPUART
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nz32-sc151/Kconfig
+++ b/boards/nz32-sc151/Kconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nz32-sc151" if BOARD_NZ32_SC151
+
+config BOARD_NZ32_SC151
+    bool
+    default y
+    select CPU_MODEL_STM32L151RC
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_SPI_GPIO_MODE
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/olimexino-stm32/Kconfig
+++ b/boards/olimexino-stm32/Kconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "olimexino-stm32" if BOARD_OLIMEXINO_STM32
+
+config BOARD_OLIMEXINO_STM32
+    bool
+    default y
+    select CPU_MODEL_STM32F103RB
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_CAN
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/opencm904/Kconfig
+++ b/boards/opencm904/Kconfig
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "opencm904" if BOARD_OPENCM904
+
+config BOARD_OPENCM904
+    bool
+    default y
+    select CPU_MODEL_STM32F103CB
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/p-l496g-cell02/Kconfig
+++ b/boards/p-l496g-cell02/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "p-l496g-cell02" if BOARD_P_L496G_CELL02
+
+config BOARD_P_L496G_CELL02
+    bool
+    default y
+    select CPU_MODEL_STM32L496AG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_LPUART
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/p-nucleo-wb55/Kconfig
+++ b/boards/p-nucleo-wb55/Kconfig
@@ -1,0 +1,27 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "p-nucleo-wb55" if BOARD_P_NUCLEO_WB55
+
+config BOARD_P_NUCLEO_WB55
+    bool
+    default y
+    select CPU_MODEL_STM32WB55RG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_LPUART
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_ARDUINO
+    select HAS_RIOTBOOT

--- a/boards/pyboard/Kconfig
+++ b/boards/pyboard/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "pyboard" if BOARD_PYBOARD
+
+config BOARD_PYBOARD
+    bool
+    default y
+    select CPU_MODEL_STM32F405RG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV

--- a/boards/spark-core/Kconfig
+++ b/boards/spark-core/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "spark-core" if BOARD_SPARK_CORE
+
+config BOARD_SPARK_CORE
+    bool
+    default y
+    select CPU_MODEL_STM32F103CB
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART

--- a/boards/stm32f030f4-demo/Kconfig
+++ b/boards/stm32f030f4-demo/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "stm32f030f4-demo" if BOARD_STM32F030F4_DEMO
+
+config BOARD_STM32F030F4_DEMO
+    bool
+    default y
+    select CPU_MODEL_STM32F030F4
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_RTC

--- a/boards/stm32f0discovery/Kconfig
+++ b/boards/stm32f0discovery/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "stm32f0discovery" if BOARD_STM32F0DISCOVERY
+
+config BOARD_STM32F0DISCOVERY
+    bool
+    default y
+    select CPU_MODEL_STM32F051R8
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/stm32f3discovery/Kconfig
+++ b/boards/stm32f3discovery/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "stm32f3discovery" if BOARD_STM32F3DISCOVERY
+
+config BOARD_STM32F3DISCOVERY
+    bool
+    default y
+    select CPU_MODEL_STM32F303VC
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/stm32f429i-disc1/Kconfig
+++ b/boards/stm32f429i-disc1/Kconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "stm32f429i-disc1" if BOARD_STM32F429I_DISC1
+
+config BOARD_STM32F429I_DISC1
+    bool
+    default y
+    select CPU_MODEL_STM32F429ZI
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT

--- a/boards/stm32f429i-disco/Kconfig
+++ b/boards/stm32f429i-disco/Kconfig
@@ -1,0 +1,25 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "stm32f429i-disco" if BOARD_STM32F429I_DISCO
+
+config BOARD_STM32F429I_DISCO
+    bool
+    default y
+    select CPU_MODEL_STM32F429ZI
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT

--- a/boards/stm32f4discovery/Kconfig
+++ b/boards/stm32f4discovery/Kconfig
@@ -1,0 +1,29 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "stm32f4discovery" if BOARD_STM32F4DISCOVERY
+
+config BOARD_STM32F4DISCOVERY
+    bool
+    default y
+    select CPU_MODEL_STM32F407VG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+
+    # Various other features (if any)
+    select HAS_ARDUINO

--- a/boards/stm32f723e-disco/Kconfig
+++ b/boards/stm32f723e-disco/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "stm32f723e-disco" if BOARD_STM32F723E_DISCO
+
+config BOARD_STM32F723E_DISCO
+    bool
+    default y
+    select CPU_MODEL_STM32F723IE
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV

--- a/boards/stm32f769i-disco/Kconfig
+++ b/boards/stm32f769i-disco/Kconfig
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "stm32f769i-disco" if BOARD_STM32F769I_DISCO
+
+config BOARD_STM32F769I_DISCO
+    bool
+    default y
+    select CPU_MODEL_STM32F769NI
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV

--- a/boards/stm32l0538-disco/Kconfig
+++ b/boards/stm32l0538-disco/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "stm32l0538-disco" if BOARD_STM32L0538_DISCO
+
+config BOARD_STM32L0538_DISCO
+    bool
+    default y
+    select CPU_MODEL_STM32L053C8
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/stm32l476g-disco/Kconfig
+++ b/boards/stm32l476g-disco/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "stm32l476g-disco" if BOARD_STM32L476G_DISCO
+
+config BOARD_STM32L476G_DISCO
+    bool
+    default y
+    select CPU_MODEL_STM32L476VG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT

--- a/boards/ublox-c030-u201/Kconfig
+++ b/boards/ublox-c030-u201/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "ublox-c030-u201" if BOARD_UBLOX_C030_U201
+
+config BOARD_UBLOX_C030_U201
+    bool
+    default y
+    select CPU_MODEL_STM32F437VG
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DMA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/weact-f411ce/Kconfig
+++ b/boards/weact-f411ce/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "weact-f411ce" if BOARD_WEACT_F411CE
+
+config BOARD_WEACT_F411CE
+    bool
+    default y
+    select CPU_MODEL_STM32F411CEU6
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV

--- a/cpu/stm32/Kconfig
+++ b/cpu/stm32/Kconfig
@@ -1,0 +1,546 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_STM32
+    bool
+    select HAS_CPU_STM32
+    select HAS_BOOTLOADER_STM32
+    select HAS_PERIPH_CPUID
+    select HAS_PERIPH_GPIO
+    select HAS_PERIPH_GPIO_IRQ
+    select HAS_PUF_SRAM
+    select HAS_PERIPH_UART_MODECFG
+    select HAS_PERIPH_UART_NONBLOCKING
+    select HAS_PERIPH_WDT
+
+config CPU_FAM_F0
+    bool
+    select CPU_STM32
+    select CPU_CORE_CORTEX_M0
+    select HAS_CPU_STM32F0
+    select HAS_PERIPH_FLASHPAGE
+    select HAS_PERIPH_FLASHPAGE_RAW
+
+config CPU_FAM_F1
+    bool
+    select CPU_STM32
+    select CPU_CORE_CORTEX_M3
+    select HAS_CPU_STM32F1
+    select HAS_PERIPH_FLASHPAGE
+    select HAS_PERIPH_FLASHPAGE_RAW
+
+config CPU_FAM_F2
+    bool
+    select CPU_STM32
+    select CPU_CORE_CORTEX_M3
+    select HAS_CPU_STM32F2
+    select HAS_CORTEXM_MPU
+    select HAS_PERIPH_HWRNG
+
+config CPU_FAM_F3
+    bool
+    select CPU_STM32
+    select CPU_CORE_CORTEX_M4F
+    select HAS_CPU_STM32F3
+    select HAS_PERIPH_FLASHPAGE
+    select HAS_PERIPH_FLASHPAGE_RAW
+
+config CPU_FAM_F4
+    bool
+    select CPU_STM32
+    select CPU_CORE_CORTEX_M4F
+    select HAS_CPU_STM32F4
+    select HAS_CORTEXM_MPU
+
+config CPU_FAM_F7
+    bool
+    select CPU_STM32
+    select CPU_CORE_CORTEX_M7
+    select HAS_CPU_STM32F7
+    select HAS_CORTEXM_MPU
+    select HAS_PERIPH_HWRNG
+
+config CPU_FAM_G4
+    bool
+    select CPU_STM32
+    select CPU_CORE_CORTEX_M4
+    select HAS_CPU_STM32G4
+    select HAS_CORTEXM_MPU
+    select HAS_PERIPH_FLASHPAGE
+    select HAS_PERIPH_FLASHPAGE_RAW
+    select HAS_PERIPH_HWRNG
+
+config CPU_FAM_L0
+    bool
+    select CPU_STM32
+    select CPU_CORE_CORTEX_M0PLUS
+    select HAS_CPU_STM32L0
+    select HAS_PERIPH_FLASHPAGE
+    select HAS_PERIPH_FLASHPAGE_RAW
+    select HAS_PERIPH_EEPROM
+
+config CPU_FAM_L1
+    bool
+    select CPU_STM32
+    select CPU_CORE_CORTEX_M3
+    select HAS_CPU_STM32L1
+    select HAS_CORTEXM_MPU
+    select HAS_PERIPH_FLASHPAGE
+    select HAS_PERIPH_FLASHPAGE_RAW
+    select HAS_PERIPH_EEPROM
+
+config CPU_FAM_L4
+    bool
+    select CPU_STM32
+    select CPU_CORE_CORTEX_M4F
+    select HAS_CPU_STM32L4
+    select HAS_CORTEXM_MPU
+    select HAS_PERIPH_FLASHPAGE
+    select HAS_PERIPH_FLASHPAGE_RAW
+    select HAS_PERIPH_HWRNG
+
+config CPU_FAM_WB
+    bool
+    select CPU_STM32
+    select CPU_CORE_CORTEX_M4
+    select HAS_CPU_STM32WB
+    select HAS_PERIPH_FLASHPAGE
+    select HAS_PERIPH_FLASHPAGE_RAW
+    select HAS_PERIPH_HWRNG
+
+# CPU Models
+
+# STM32F0
+config CPU_MODEL_STM32F030F4
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F030R8
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F031K6
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F042K6
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F051R8
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F070RB
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F072RB
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F091RC
+    bool
+    select CPU_FAM_F0
+
+# STM32F1
+config CPU_MODEL_STM32F103C8
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103CB
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103RB
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103RE
+    bool
+    select CPU_FAM_F1
+
+# STM32F2
+config CPU_MODEL_STM32F207ZG
+    bool
+    select CPU_FAM_F2
+
+# STM32F3
+config CPU_MODEL_STM32F302R8
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F303K8
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F303RE
+    bool
+    select CPU_FAM_F3
+    select HAS_CORTEXM_MPU
+
+config CPU_MODEL_STM32F303VC
+    bool
+    select CPU_FAM_F3
+    select HAS_CORTEXM_MPU
+
+config CPU_MODEL_STM32F303ZE
+    bool
+    select CPU_FAM_F3
+    select HAS_CORTEXM_MPU
+
+config CPU_MODEL_STM32F334R8
+    bool
+    select CPU_FAM_F3
+
+# STM32F4
+config CPU_MODEL_STM32F401RE
+    bool
+    select CPU_FAM_F4
+
+config CPU_MODEL_STM32F405RG
+    bool
+    select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_STM32F407VG
+    bool
+    select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_STM32F410RB
+    bool
+    select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_STM32F411RE
+    bool
+    select CPU_FAM_F4
+
+config CPU_MODEL_STM32F411CEU6
+    bool
+    select CPU_FAM_F4
+
+config CPU_MODEL_STM32F412ZG
+    bool
+    select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_STM32F413ZH
+    bool
+    select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_STM32F415RG
+    bool
+    select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_STM32F429ZI
+    bool
+    select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_STM32F437VG
+    bool
+    select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_STM32F446RE
+    bool
+    select CPU_FAM_F4
+
+config CPU_MODEL_STM32F446ZE
+    bool
+    select CPU_FAM_F4
+
+# STM32F7
+config CPU_MODEL_STM32F722ZE
+    bool
+    select CPU_FAM_F7
+
+config CPU_MODEL_STM32F723IE
+    bool
+    select CPU_FAM_F7
+
+config CPU_MODEL_STM32F746ZG
+    bool
+    select CPU_FAM_F7
+
+config CPU_MODEL_STM32F767ZI
+    bool
+    select CPU_FAM_F7
+
+config CPU_MODEL_STM32F769NI
+    bool
+    select CPU_FAM_F7
+
+# STM32G4
+config CPU_MODEL_STM32G474RE
+    bool
+    select CPU_FAM_G4
+
+# STM32L0
+config CPU_MODEL_STM32L031K6
+    bool
+    select CPU_FAM_L0
+
+config CPU_MODEL_STM32L052T8
+    bool
+    select CPU_FAM_L0
+    select HAS_CORTEXM_MPU
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_STM32L053R8
+    bool
+    select CPU_FAM_L0
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_STM32L053C8
+    bool
+    select CPU_FAM_L0
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_STM32L072CZ
+    bool
+    select CPU_FAM_L0
+    select HAS_PERIPH_HWRNG
+
+config CPU_MODEL_STM32L073RZ
+    bool
+    select CPU_FAM_L0
+    select HAS_PERIPH_HWRNG
+
+# STM32L1
+config CPU_MODEL_STM32L151CB
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L151CB_A
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L151RC
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L152RE
+    bool
+    select CPU_FAM_L1
+
+# STM32L4
+config CPU_MODEL_STM32L412KB
+    bool
+    select CPU_FAM_L4
+
+config CPU_MODEL_STM32L432KC
+    bool
+    select CPU_FAM_L4
+
+config CPU_MODEL_STM32L433RC
+    bool
+    select CPU_FAM_L4
+
+config CPU_MODEL_STM32L452RE
+    bool
+    select CPU_FAM_L4
+
+config CPU_MODEL_STM32L475VG
+    bool
+    select CPU_FAM_L4
+
+config CPU_MODEL_STM32L476RG
+    bool
+    select CPU_FAM_L4
+
+config CPU_MODEL_STM32L476VG
+    bool
+    select CPU_FAM_L4
+
+config CPU_MODEL_STM32L496AG
+    bool
+    select CPU_FAM_L4
+
+config CPU_MODEL_STM32L496ZG
+    bool
+    select CPU_FAM_L4
+
+config CPU_MODEL_STM32L4R5ZI
+    bool
+    select CPU_FAM_L4
+
+# STM32WB
+config CPU_MODEL_STM32WB55RG
+    bool
+    select CPU_FAM_WB
+
+# Definition of specific features
+config HAS_CPU_STM32
+    bool
+    help
+        Indicates that a 'stm32' cpu is being used.
+
+config HAS_CPU_STM32F0
+    bool
+    help
+        Indicates that the cpu being used belongs to the 'stm32f0' family.
+
+config HAS_CPU_STM32F1
+    bool
+    help
+        Indicates that the cpu being used belongs to the 'stm32f1' family.
+
+config HAS_CPU_STM32F2
+    bool
+    help
+        Indicates that the cpu being used belongs to the 'stm32f2' family.
+
+config HAS_CPU_STM32F3
+    bool
+    help
+        Indicates that the cpu being used belongs to the 'stm32f3' family.
+
+config HAS_CPU_STM32F4
+    bool
+    help
+        Indicates that the cpu being used belongs to the 'stm32f4' family.
+
+config HAS_CPU_STM32F7
+    bool
+    help
+        Indicates that the cpu being used belongs to the 'stm32f7' family.
+
+config HAS_CPU_STM32G4
+    bool
+    help
+        Indicates that the cpu being used belongs to the 'stm32g4' family.
+
+config HAS_CPU_STM32L0
+    bool
+    help
+        Indicates that the cpu being used belongs to the 'stm32l0' family.
+
+config HAS_CPU_STM32L1
+    bool
+    help
+        Indicates that the cpu being used belongs to the 'stm32l1' family.
+
+config HAS_CPU_STM32L4
+    bool
+    help
+        Indicates that the cpu being used belongs to the 'stm32l4' family.
+
+config HAS_CPU_STM32WB
+    bool
+    help
+        Indicates that the cpu being used belongs to the 'stm32wb' family.
+
+config HAS_BOOTLOADER_STM32
+    bool
+    help
+        Indicates that the stm32 bootloader is being used.
+
+# Common CPU symbols
+config CPU_FAM
+    default "f0" if CPU_FAM_F0
+    default "f1" if CPU_FAM_F1
+    default "f2" if CPU_FAM_F2
+    default "f3" if CPU_FAM_F3
+    default "f4" if CPU_FAM_F4
+    default "f7" if CPU_FAM_F7
+    default "g4" if CPU_FAM_G4
+    default "l0" if CPU_FAM_L0
+    default "l1" if CPU_FAM_L1
+    default "l4" if CPU_FAM_L4
+    default "wb" if CPU_FAM_WB
+
+config CPU_MODEL
+    # STM32F0
+    default "stm32f030f4" if CPU_MODEL_STM32F030F4
+    default "stm32f030r8" if CPU_MODEL_STM32F030R8
+    default "stm32f031k6" if CPU_MODEL_STM32F031K6
+    default "stm32f042k6" if CPU_MODEL_STM32F042K6
+    default "stm32f051r8" if CPU_MODEL_STM32F051R8
+    default "stm32f070rb" if CPU_MODEL_STM32F070RB
+    default "stm32f072rb" if CPU_MODEL_STM32F072RB
+    default "stm32f091rc" if CPU_MODEL_STM32F091RC
+
+    # STM32F1
+    default "stm32f103c8" if CPU_MODEL_STM32F103C8
+    default "stm32f103cb" if CPU_MODEL_STM32F103CB
+    default "stm32f103rb" if CPU_MODEL_STM32F103RB
+    default "stm32f103re" if CPU_MODEL_STM32F103RE
+
+    # STM32F2
+    default "stm32f207zg" if CPU_MODEL_STM32F207ZG
+
+    # STM32F3
+    default "stm32f302r8" if CPU_MODEL_STM32F302R8
+    default "stm32f303k8" if CPU_MODEL_STM32F303K8
+    default "stm32f303re" if CPU_MODEL_STM32F303RE
+    default "stm32f303vc" if CPU_MODEL_STM32F303VC
+    default "stm32f303ze" if CPU_MODEL_STM32F303ZE
+    default "stm32f334r8" if CPU_MODEL_STM32F334R8
+
+    # STM32F4
+    default "stm32f401re" if CPU_MODEL_STM32F401RE
+    default "stm32f405rg" if CPU_MODEL_STM32F405RG
+    default "stm32f407vg" if CPU_MODEL_STM32F407VG
+    default "stm32f410rb" if CPU_MODEL_STM32F410RB
+    default "stm32f411re" if CPU_MODEL_STM32F411RE
+    default "stm32f411ceu6" if CPU_MODEL_STM32F411CEU6
+    default "stm32f412zg" if CPU_MODEL_STM32F412ZG
+    default "stm32f413zh" if CPU_MODEL_STM32F413ZH
+    default "stm32f415rg" if CPU_MODEL_STM32F415RG
+    default "stm32f429zi" if CPU_MODEL_STM32F429ZI
+    default "stm32f437vg" if CPU_MODEL_STM32F437VG
+    default "stm32f446re" if CPU_MODEL_STM32F446RE
+    default "stm32f446ze" if CPU_MODEL_STM32F446ZE
+
+    # STM32F7
+    default "stm32f722ze" if CPU_MODEL_STM32F722ZE
+    default "stm32f723ie" if CPU_MODEL_STM32F723IE
+    default "stm32f746zg" if CPU_MODEL_STM32F746ZG
+    default "stm32f767zi" if CPU_MODEL_STM32F767ZI
+    default "stm32f769ni" if CPU_MODEL_STM32F769NI
+
+    # STM32G4
+    default "stm32g474re" if CPU_MODEL_STM32G474RE
+
+    # STM32L0
+    default "stm32l031k6" if CPU_MODEL_STM32L031K6
+    default "stm32l052t8" if CPU_MODEL_STM32L052T8
+    default "stm32l053r8" if CPU_MODEL_STM32L053R8
+    default "stm32l053c8" if CPU_MODEL_STM32L053C8
+    default "stm32l072cz" if CPU_MODEL_STM32L072CZ
+    default "stm32l073rz" if CPU_MODEL_STM32L073RZ
+
+    # STM32L1
+    default "stm32l151cb" if CPU_MODEL_STM32L151CB
+    default "stm32l151cb_a" if CPU_MODEL_STM32L151CB_A
+    default "stm32l151rc" if CPU_MODEL_STM32L151RC
+    default "stm32l152re" if CPU_MODEL_STM32L152RE
+
+    # STM32L4
+    default "stm32l412kb" if CPU_MODEL_STM32L412KB
+    default "stm32l432kc" if CPU_MODEL_STM32L432KC
+    default "stm32l433rc" if CPU_MODEL_STM32L433RC
+    default "stm32l452re" if CPU_MODEL_STM32L452RE
+    default "stm32l475vg" if CPU_MODEL_STM32L475VG
+    default "stm32l476rg" if CPU_MODEL_STM32L476RG
+    default "stm32l476vg" if CPU_MODEL_STM32L476VG
+    default "stm32l496ag" if CPU_MODEL_STM32L496AG
+    default "stm32l496zg" if CPU_MODEL_STM32L496ZG
+    default "stm32l4r5zi" if CPU_MODEL_STM32L4R5ZI
+
+    # STM32WB
+    default "stm32wb55rg" if CPU_MODEL_STM32WB55RG
+
+config CPU
+    default "stm32" if CPU_STM32
+
+source "$(RIOTCPU)/cortexm_common/Kconfig"

--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -10,10 +10,8 @@ FEATURES_PROVIDED += periph_uart_nonblocking
 FEATURES_PROVIDED += periph_wdt
 
 ifneq (,$(filter $(CPU_FAM),f0 f1 f3 g4 l0 l1 l4 wb))
-  ifeq (,$(filter nucleo-f031k6,$(BOARD)))
-    FEATURES_PROVIDED += periph_flashpage
-    FEATURES_PROVIDED += periph_flashpage_raw
-  endif
+  FEATURES_PROVIDED += periph_flashpage
+  FEATURES_PROVIDED += periph_flashpage_raw
 endif
 
 ifneq (,$(filter $(CPU_FAM),l0 l1))

--- a/cpu/stm32/include/cpu_conf.h
+++ b/cpu/stm32/include/cpu_conf.h
@@ -136,7 +136,8 @@ extern "C" {
 #define FLASHPAGE_SIZE                  (2048U)
 #elif defined(CPU_LINE_STM32F051x8) || defined(CPU_LINE_STM32F042x6) \
    || defined(CPU_LINE_STM32F070xB) || defined(CPU_LINE_STM32F030x8) \
-   || defined(CPU_LINE_STM32F030x4) || defined(CPU_LINE_STM32F103xB)
+   || defined(CPU_LINE_STM32F030x4) || defined(CPU_LINE_STM32F103xB) \
+   || defined(CPU_LINE_STM32F031x6)
 #define FLASHPAGE_SIZE                  (1024U)
 #elif defined(CPU_FAM_STM32L1)
 #define FLASHPAGE_SIZE                  (256U)

--- a/tests/kconfig_features/Makefile
+++ b/tests/kconfig_features/Makefile
@@ -13,6 +13,12 @@ BOARD_WHITELIST += acd52832 \
                    atmega256rfr2-xpro \
                    atmega328p \
                    avr-rss2 \
+                   b-l072z-lrwan1 \
+                   b-l475e-iot01a \
+                   blackpill \
+                   blackpill-128kib \
+                   bluepill \
+                   bluepill-128kib \
                    calliope-mini \
                    cc1312-launchpad \
                    cc1352-launchpad \
@@ -34,18 +40,29 @@ BOARD_WHITELIST += acd52832 \
                    esp8266-esp-12x \
                    esp8266-olimex-mod \
                    esp8266-sparkfun-thing \
+                   f4vi1 \
                    feather-nrf52840 \
                    firefly \
+                   fox \
                    frdm-k22f \
                    frdm-k64f \
                    hifive1 \
                    hifive1b \
                    ikea-tradfri \
+                   im880b \
+                   i-nucleo-lrwan1 \
+                   iotlab-a8-m3 \
+                   iotlab-m3 \
+                   limifrog-v1 \
+                   lobaro-lorabox \
+                   lsn50 \
+                   maple-mini \
                    mega-xplained \
                    microbit \
                    microduino-corerf \
                    msb-430 \
                    msb-430h \
+                   msbiot \
                    mulle \
                    nrf51dk \
                    nrf51dongle \
@@ -55,16 +72,58 @@ BOARD_WHITELIST += acd52832 \
                    nrf52840dongle \
                    nrf52dk \
                    nrf6310 \
+                   nucleo-f030r8 \
+                   nucleo-f031k6 \
+                   nucleo-f042k6 \
+                   nucleo-f070rb \
+                   nucleo-f072rb \
+                   nucleo-f091rc \
+                   nucleo-f103rb \
+                   nucleo-f207zg \
+                   nucleo-f302r8 \
+                   nucleo-f303k8 \
+                   nucleo-f303re \
+                   nucleo-f303ze \
+                   nucleo-f334r8 \
+                   nucleo-f401re \
+                   nucleo-f410rb \
+                   nucleo-f411re \
+                   nucleo-f412zg \
+                   nucleo-f413zh \
+                   nucleo-f429zi \
+                   nucleo-f446re \
+                   nucleo-f446ze \
+                   nucleo-f722ze \
+                   nucleo-f746zg \
+                   nucleo-f767zi \
+                   nucleo-g474re \
+                   nucleo-l031k6 \
+                   nucleo-l053r8 \
+                   nucleo-l073rz \
+                   nucleo-l152re \
+                   nucleo-l412kb \
+                   nucleo-l432kc \
+                   nucleo-l433rc \
+                   nucleo-l452re \
+                   nucleo-l476rg \
+                   nucleo-l496zg \
+                   nucleo-l4r5zi \
+                   nz32-sc151 \
+                   olimexino-stm32 \
+                   opencm904 \
                    openlabs-kw41z-mini \
                    openlabs-kw41z-mini-256kib \
                    openmote-b \
                    openmote-cc2538 \
+                   p-l496g-cell02 \
+                   p-nucleo-wb55 \
                    particle-argon \
                    particle-boron \
                    particle-xenon \
                    pba-d-01-kw2x \
                    phynode-kw41z \
                    pinetime \
+                   pyboard \
                    reel \
                    remote-pa \
                    remote-reva \
@@ -77,15 +136,26 @@ BOARD_WHITELIST += acd52832 \
                    slwstk6000b-slwrb4150a \
                    slwstk6000b-slwrb4162a \
                    slwstk6220a \
+                   spark-core \
                    stk3600 \
                    stk3700 \
+                   stm32f030f4-demo \
+                   stm32f0discovery \
+                   stm32f3discovery \
+                   stm32f4discovery \
+                   stm32f429i-disc1 \
+                   stm32f429i-disco \
+                   stm32f723e-disco \
+                   stm32f769i-disco \
+                   stm32l0538-disco \
+                   stm32l476g-disco \
                    teensy31 \
                    telosb \
                    thingy52 \
+                   ublox-c030-u201 \
                    usb-kw41z \
                    waspmote-pro \
-                   wsn430-v1_3b \
-                   wsn430-v1_4 \
+                   weact-f411ce \
                    yunjia-nrf51822 \
                    z1
                    #

--- a/tests/suit_manifest/Makefile.ci
+++ b/tests/suit_manifest/Makefile.ci
@@ -4,6 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     msb-430 \
     msb-430h \
     nucleo-f030r8 \
+    nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l031k6 \
     nucleo-l053r8 \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR models all STM32 families to Kconfig and also all boards based on a STM32 CPU.

Features that are conflicting for a family or a board are not handled by this PR.

This PR also enables periph_flashpage for nucleo-f031k6 since there's no reason (according to the manual) to skip this feature on it.

There's also a small cleanup for nucleo-f410rb/nucleo-f411re that were not including the common nucleo64 features.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock should be OK since all boards are added to `tests/kconfig_features`

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Part of #14148

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
