### PR TITLE
examples/micropython: fix checked PID [backport 2020.07]

### DIFF
--- a/examples/micropython/tests/01-run.py
+++ b/examples/micropython/tests/01-run.py
@@ -22,7 +22,7 @@ def testfunc(child):
     # test riot.thread_getpid()
     child.sendline('import riot')
     child.sendline('print(riot.thread_getpid())')
-    child.expect_exact('2')
+    child.expect(r'\d+')
     child.expect_exact('>>>')
 
     #


### PR DESCRIPTION
# Backport of #14518


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
With https://github.com/RIOT-OS/RIOT/pull/14224 the idle thread became optional, so the main thread can have either 1 or 2 as PID, depending if the idle thread is included or not. As this might also change in the future, it is probably the best to just expect any number.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```
make -C examples/micropython flash test
```
Should now succeed again on e.g. Cortex-M platforms.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #14224
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
