### PR TITLE
drivers/stmpe811: fix interrupt polarity & interrupt generation

### DIFF
--- a/drivers/stmpe811/stmpe811.c
+++ b/drivers/stmpe811/stmpe811.c
@@ -194,6 +194,13 @@ int stmpe811_read_touch_position(stmpe811_t *dev, stmpe811_touch_position_t *pos
     /* Acquire I2C device */
     i2c_acquire(STMPE811_DEV_I2C);
 
+    /* Ensure there's a least one position measured in the FIFO */
+    uint8_t fifo_size = 0;
+    do {
+        i2c_read_reg(STMPE811_DEV_I2C, STMPE811_DEV_ADDR,
+                     STMPE811_FIFO_SIZE, &fifo_size, 0);
+    } while (!fifo_size);
+
     uint8_t  xyz[4];
     uint32_t xyz_ul;
 
@@ -203,7 +210,6 @@ int stmpe811_read_touch_position(stmpe811_t *dev, stmpe811_touch_position_t *pos
         i2c_release(STMPE811_DEV_I2C);
         return -STMPE811_ERR_I2C;
     }
-    _reset_fifo(dev);
 
     /* Release I2C device */
     i2c_release(STMPE811_DEV_I2C);

--- a/drivers/stmpe811/stmpe811.c
+++ b/drivers/stmpe811/stmpe811.c
@@ -262,8 +262,9 @@ int stmpe811_read_touch_state(const stmpe811_t *dev, stmpe811_touch_state_t *sta
         return -STMPE811_ERR_I2C;
     }
 
+    _clear_interrupt_status(dev);
+
     if ((val & STMPE811_TSC_CTRL_STA)) {
-        _clear_interrupt_status(dev);
         *state = STMPE811_TOUCH_STATE_PRESSED;
     }
     else {

--- a/drivers/stmpe811/stmpe811.c
+++ b/drivers/stmpe811/stmpe811.c
@@ -162,7 +162,7 @@ int stmpe811_init(stmpe811_t *dev, const stmpe811_params_t * params, touch_event
 
     if ((dev->params.int_pin != GPIO_UNDEF) && cb) {
         DEBUG("[stmpe811] init: configuring touchscreen interrupt\n");
-        gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_RISING, cb, arg);
+        gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_FALLING, cb, arg);
 
         /* Enable touchscreen interrupt */
         ret += i2c_write_reg(STMPE811_DEV_I2C, STMPE811_DEV_ADDR,
@@ -170,7 +170,7 @@ int stmpe811_init(stmpe811_t *dev, const stmpe811_params_t * params, touch_event
 
         /* Enable global interrupt */
         ret += i2c_write_reg(STMPE811_DEV_I2C, STMPE811_DEV_ADDR,
-                             STMPE811_INT_CTRL, STMPE811_INT_CTRL_GLOBAL_INT, 0);
+                             STMPE811_INT_CTRL, STMPE811_INT_CTRL_GLOBAL_INT | STMPE811_INT_CTRL_INT_TYPE, 0);
     }
 
     if (ret < 0) {

--- a/tests/driver_stmpe811/Makefile
+++ b/tests/driver_stmpe811/Makefile
@@ -2,7 +2,6 @@ BOARD ?= stm32f429i-disc1
 
 include ../Makefile.tests_common
 
-USEMODULE += xtimer
 USEMODULE += stmpe811
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_stmpe811/README.md
+++ b/tests/driver_stmpe811/README.md
@@ -13,21 +13,17 @@ make -C tests/driver_stmpe811 flash term
 ## Expected output
 
 The application initializes the STMPE811 and displays "Pressed!" when a touch
-event is detected.
-Current touch positions are printed in terminal while holding the screen
-pressed.
+event is detected. The position of the touch event is also displayed.
 "Released" is displayed when the screen is released.
 
 ```
-2020-02-10 10:20:17,647 # Pressed!
-2020-02-10 10:20:17,653 # X: 167, Y:81
-2020-02-10 10:20:17,659 # X: 165, Y:75
-2020-02-10 10:20:17,671 # X: 165, Y:69
-2020-02-10 10:20:17,689 # X: 166, Y:68
-2020-02-10 10:20:17,701 # X: 167, Y:68
-2020-02-10 10:20:17,713 # X: 169, Y:69
-2020-02-10 10:20:17,725 # X: 170, Y:69
-2020-02-10 10:20:17,737 # X: 170, Y:70
-2020-02-10 10:20:17,755 # X: 173, Y:69
-2020-02-10 10:20:17,761 # Released!
+2020-07-21 21:24:49,286 # Pressed!
+2020-07-21 21:24:49,293 # X: 132, Y:138
+2020-07-21 21:24:49,826 # Released!
+2020-07-21 21:24:51,218 # Pressed!
+2020-07-21 21:24:51,219 # X: 42, Y:16
+2020-07-21 21:24:51,614 # Released!
+2020-07-21 21:24:53,385 # Pressed!
+2020-07-21 21:24:53,385 # X: 197, Y:64
+2020-07-21 21:24:53,588 # Released!
 ```


### PR DESCRIPTION
### Contribution description

The Interrupt on the stmpe811 is generated on the falling edge.
By observing the rising edge, we will only get an event if the interrupt gets cleared.

Now that the interrupt of the driver works properly, we don't have to rely on polling.
So also update the test application to make use of this driver feature.

### Testing procedure

Flash `tests/driver_stmpe811` on the `stm32f429i-disco`/`stm32f429i-disc1`.
Touch events should generate an event on the terminal, should also be a bit more responsive than before.


### Issues/PRs references

found while reviewing https://github.com/RIOT-OS/RIOT/pull/14188#discussion_r455306419
