### PR TITLE
cortexm_common: disable IRQ during thread_sched_idle

### DIFF
--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -462,6 +462,7 @@ void sched_arch_idle(void)
      * According to [this](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dai0321a/BIHJICIE.html),
      * dynamically changing the priority is not supported on CortexM0(+).
      */
+    unsigned state = irq_disable();
     NVIC_SetPriority(PendSV_IRQn, CPU_CORTEXM_PENDSV_IRQ_PRIO + 1);
     __DSB();
     __ISB();
@@ -471,5 +472,6 @@ void sched_arch_idle(void)
 #else
     __WFI();
 #endif
+    irq_restore(state);
     NVIC_SetPriority(PendSV_IRQn, CPU_CORTEXM_PENDSV_IRQ_PRIO);
 }


### PR DESCRIPTION
### Contribution description

A race condition is present where an IRQ is serviced between the
priority increase of the PENDSV and the sleep. When the IRQ
is serviced before the WFI sleep, the core will sleep until the next
IRQ and the thread activated by the IRQ will not be scheduled until
a new IRQ triggers.

This commit wraps an IRQ disable and restore around the priority
modification and sleep to prevent interrupts from being serviced until
the WFI call returns.

### Testing procedure

- `tests/test_tools` should work on the iotlab_m3 (see #14521)
- `tests/xtimer_periodic_wakeup` should work on the nucleo-l152 (see https://github.com/RIOT-OS/RIOT/pull/14224#issuecomment-658828134)

### Issues/PRs references
Fixes #14521 
See https://github.com/RIOT-OS/RIOT/pull/14224#issuecomment-658828134