### PR TITLE
drivers/pca9633: fix wrong enum name

### DIFF
--- a/drivers/include/pca9633.h
+++ b/drivers/include/pca9633.h
@@ -68,10 +68,10 @@ typedef struct {
 /**
  * @brief   PCA9633 driver error codes
  */
-typedef enum {
+enum {
     PCA9633_OK              = 0,    /**< Success */
     PCA9633_ERROR_I2C       = 1,    /**< I2C communication error */
-} pca9685_error_t;
+};
 
 /**
  * @brief   PCA9633 PWM channel definitions


### PR DESCRIPTION
This PR fixes the name given to the enum for error codes.