### PR TITLE
boards/saml1x: configure second timer

### DIFF
--- a/boards/common/saml1x/include/periph_conf.h
+++ b/boards/common/saml1x/include/periph_conf.h
@@ -50,12 +50,27 @@ static const tc32_conf_t timer_config[] = {
         .gclk_id        = TC0_GCLK_ID,
         .gclk_src       = SAM0_GCLK_MAIN,
         .flags          = TC_CTRLA_MODE_COUNT32,
+    },
+    {
+        .dev            = TC2,
+        .irq            = TC2_IRQn,
+        .mclk           = &MCLK->APBCMASK.reg,
+        .mclk_mask      = MCLK_APBCMASK_TC2,
+        .gclk_id        = TC2_GCLK_ID,
+        .gclk_src       = SAM0_GCLK_MAIN,
+        .flags          = TC_CTRLA_MODE_COUNT16,
     }
 };
 
 /* Timer 0 configuration */
 #define TIMER_0_CHANNELS    2
 #define TIMER_0_ISR         isr_tc0
+
+/* Timer 1 configuration */
+#define TIMER_1_CHANNELS    2
+#define TIMER_1_ISR         isr_tc2
+#define TIMER_1_MAX_VALUE   0xffff
+
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */
 


### PR DESCRIPTION
### Contribution description

saml1x has 3 16 bit timers or 1 32 bit timer and 1 16 bit timer.
Let's configure the remaining timer.

The second patch I'm not so sure if we want it It moves XTIMER to the second timer. This is because I wanted to free up TC1 to driver the on-board LED with PWM.

I'm not sure if we really want a 16 bit XTIMER by default, can drop this patch.
Having the second timer configured is useful regardless. 

Btw: Has there ever been an attempt to just run XTIMER off SysTick?

### Testing procedure

<details><summary>tests/periph_timer</summary>

```
2020-07-16 18:25:27,628 # main(): This is RIOT! (Version: 2020.10-devel-153-g01060-boards/common/saml1x_configure_timer)
2020-07-16 18:25:27,628 # 
2020-07-16 18:25:27,631 # Test for peripheral TIMERs
2020-07-16 18:25:27,631 # 
2020-07-16 18:25:27,632 # Available timers: 2
2020-07-16 18:25:27,633 # 
2020-07-16 18:25:27,634 # Testing TIMER_0:
2020-07-16 18:25:27,637 # TIMER_0: initialization successful
2020-07-16 18:25:27,640 # TIMER_0: stopped
2020-07-16 18:25:27,642 # TIMER_0: set channel 0 to 5000
2020-07-16 18:25:27,645 # TIMER_0: set channel 1 to 10000
2020-07-16 18:25:27,647 # TIMER_0: starting
2020-07-16 18:25:27,663 # TIMER_0: channel 0 fired at SW count     5000 - init:     5000
2020-07-16 18:25:27,669 # TIMER_0: channel 1 fired at SW count     9990 - diff:     4990
2020-07-16 18:25:27,669 # 
2020-07-16 18:25:27,670 # Testing TIMER_1:
2020-07-16 18:25:27,674 # TIMER_1: initialization successful
2020-07-16 18:25:27,675 # TIMER_1: stopped
2020-07-16 18:25:27,678 # TIMER_1: set channel 0 to 5000
2020-07-16 18:25:27,682 # TIMER_1: set channel 1 to 10000
2020-07-16 18:25:27,683 # TIMER_1: starting
2020-07-16 18:25:27,699 # TIMER_1: channel 0 fired at SW count     5000 - init:     5000
2020-07-16 18:25:27,705 # TIMER_1: channel 1 fired at SW count     9990 - diff:     4990
2020-07-16 18:25:27,705 # 
2020-07-16 18:25:27,706 # TEST SUCCEEDED
```
</details>

<details><summary>tests/xtimer_usleep</summary>

```
2020-07-16 18:22:34,259 # main(): This is RIOT! (Version: 2020.10-devel-154-gd88a6-boards/common/saml1x_configure_timer)
2020-07-16 18:22:34,264 # Running test 5 times with 7 distinct sleep times
2020-07-16 18:22:34,279 # Slept for 10099 us (expected: 10000 us) Offset: 99 us
2020-07-16 18:22:34,334 # Slept for 50100 us (expected: 50000 us) Offset: 100 us
2020-07-16 18:22:34,352 # Slept for 10334 us (expected: 10234 us) Offset: 100 us
2020-07-16 18:22:34,411 # Slept for 56880 us (expected: 56780 us) Offset: 100 us
2020-07-16 18:22:34,428 # Slept for 12222 us (expected: 12122 us) Offset: 100 us
2020-07-16 18:22:34,532 # Slept for 98864 us (expected: 98765 us) Offset: 99 us
2020-07-16 18:22:34,612 # Slept for 75099 us (expected: 75000 us) Offset: 99 us
2020-07-16 18:22:34,627 # Slept for 10100 us (expected: 10000 us) Offset: 100 us
2020-07-16 18:22:34,682 # Slept for 50099 us (expected: 50000 us) Offset: 99 us
2020-07-16 18:22:34,697 # Slept for 10334 us (expected: 10234 us) Offset: 100 us
2020-07-16 18:22:34,759 # Slept for 56879 us (expected: 56780 us) Offset: 99 us
2020-07-16 18:22:34,776 # Slept for 12222 us (expected: 12122 us) Offset: 100 us
2020-07-16 18:22:34,880 # Slept for 98864 us (expected: 98765 us) Offset: 99 us
2020-07-16 18:22:34,960 # Slept for 75099 us (expected: 75000 us) Offset: 99 us
2020-07-16 18:22:34,975 # Slept for 10099 us (expected: 10000 us) Offset: 99 us
2020-07-16 18:22:35,030 # Slept for 50099 us (expected: 50000 us) Offset: 99 us
2020-07-16 18:22:35,045 # Slept for 10334 us (expected: 10234 us) Offset: 100 us
2020-07-16 18:22:35,107 # Slept for 56879 us (expected: 56780 us) Offset: 99 us
2020-07-16 18:22:35,124 # Slept for 12222 us (expected: 12122 us) Offset: 100 us
2020-07-16 18:22:35,228 # Slept for 98864 us (expected: 98765 us) Offset: 99 us
2020-07-16 18:22:35,308 # Slept for 75100 us (expected: 75000 us) Offset: 100 us
2020-07-16 18:22:35,323 # Slept for 10100 us (expected: 10000 us) Offset: 100 us
2020-07-16 18:22:35,378 # Slept for 50100 us (expected: 50000 us) Offset: 100 us
2020-07-16 18:22:35,393 # Slept for 10334 us (expected: 10234 us) Offset: 100 us
2020-07-16 18:22:35,455 # Slept for 56880 us (expected: 56780 us) Offset: 100 us
2020-07-16 18:22:35,472 # Slept for 12222 us (expected: 12122 us) Offset: 100 us
2020-07-16 18:22:35,576 # Slept for 98864 us (expected: 98765 us) Offset: 99 us
2020-07-16 18:22:35,656 # Slept for 75099 us (expected: 75000 us) Offset: 99 us
2020-07-16 18:22:35,671 # Slept for 10099 us (expected: 10000 us) Offset: 99 us
2020-07-16 18:22:35,726 # Slept for 50099 us (expected: 50000 us) Offset: 99 us
2020-07-16 18:22:35,741 # Slept for 10334 us (expected: 10234 us) Offset: 100 us
2020-07-16 18:22:35,803 # Slept for 56879 us (expected: 56780 us) Offset: 99 us
2020-07-16 18:22:35,820 # Slept for 12222 us (expected: 12122 us) Offset: 100 us
2020-07-16 18:22:35,924 # Slept for 98864 us (expected: 98765 us) Offset: 99 us
2020-07-16 18:22:36,004 # Slept for 75098 us (expected: 75000 us) Offset: 98 us
2020-07-16 18:22:36,006 # Test ran for 1746790 us
```
</details>

### Issues/PRs references

needed for #14478