### PR TITLE
tests/driver_sx127x: remove unused xtimer dependency

### DIFF
--- a/tests/driver_sx127x/Makefile
+++ b/tests/driver_sx127x/Makefile
@@ -6,7 +6,6 @@ USEMODULE += od
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
-USEMODULE += xtimer
 
 DRIVER ?= sx1276
 

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -27,7 +27,6 @@
 #include <inttypes.h>
 
 #include "thread.h"
-#include "xtimer.h"
 #include "shell.h"
 #include "shell_commands.h"
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This removes unused uses of xtimer in `tests/driver_sx127x`:
- an unused include of xtimer.h
- a useless `USEMODULE += xtimer`

xtimer is already a dependency of the driver:

https://github.com/RIOT-OS/RIOT/blob/5801d600fd7ae76f7e60d97d7c31696c2f41c187/drivers/Makefile.dep#L797-L812

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock is clearly enough

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
