### PR TITLE
examples/cord_epsim: default to first interface when not specified

### DIFF
--- a/examples/cord_epsim/Makefile
+++ b/examples/cord_epsim/Makefile
@@ -28,15 +28,11 @@ DEVELHELP ?= 1
 RD_LT ?= 60
 CFLAGS += -DCORD_LT=$(RD_LT)
 
-# If nothing else is defined, we use CoAP default port
-RD_PORT ?= COAP_PORT
-CFLAGS += -DRD_PORT=$(RD_PORT)
-
 # The RD server's address must be defined by the build environment by setting
 # the RD_ADDR environment variable. Per default, this value is set to the
 # loopback address for enabling the build tests to successfully build this
 # example.
-RD_ADDR ?= \"affe::1\"
+RD_ADDR ?= \"[affe::1]\"
 CFLAGS += -DRD_ADDR=$(RD_ADDR)
 
 include $(RIOTBASE)/Makefile.include

--- a/examples/cord_epsim/README.md
+++ b/examples/cord_epsim/README.md
@@ -8,20 +8,19 @@ draft-ietf-core-resource-directory-15, section 5.3.1.
 When running this example, you **must** define the RD server's IPv6 address
 statically, using the `RD_ADDR` environment variable:
 ```
-RD_ADDR=\\\"abc:0815::123\\\" make all
+RD_ADDR=\\\"[abc:0815::123]\\\" make all
 ```
-Per default, this is set to some random global address (`affe::1`) for compile
+Per default, this is set to some random global address (`[affe::1]`) for compile
 test reasons. So change it!
 
-Additionally, you can change the RD server's port by overriding the `RD_PORT`
-variable:
+Additionally, you can change the RD server's port by specifying it like so:
 ```
-RD_ADDR=\\\"affe::bee\\\" RD_PORT=12345 make all
+RD_ADDR=\\\"[affe::bee]:12345\\\" make all
 ```
 
 The registration lifetime is set for demonstration purposes to a rather short
 time of 60s in this example. You can easily override that value using the
 `RD_LT` variable:
 ```
-RD_ADDR=\\\"abc::def\\\" RD_LT=3600 make all ...
+RD_ADDR=\\\"[abc::def]\\\" RD_LT=3600 make all ...
 ```

--- a/examples/cord_epsim/main.c
+++ b/examples/cord_epsim/main.c
@@ -24,6 +24,8 @@
 #include "net/gcoap.h"
 #include "net/cord/epsim.h"
 #include "net/cord/common.h"
+#include "net/sock/util.h"
+#include "net/ipv6/addr.h"
 
 #define BUFSIZE             (64U)
 #define STARTUP_DELAY       (3U)    /* wait 3s before sending first request*/
@@ -67,6 +69,9 @@ static gcoap_listener_t listener = {
 
 int main(void)
 {
+    char ep_str[CONFIG_SOCK_URLPATH_MAXLEN];
+    uint16_t ep_port;
+
     puts("Simplified CoRE RD registration example\n");
 
     /* fill riot info */
@@ -74,17 +79,32 @@ int main(void)
             cord_common_get_ep(), CORD_LT);
 
     /* parse RD address information */
-    sock_udp_ep_t rd_ep = {
-        .family    = AF_INET6,
-        .netif     = SOCK_ADDR_ANY_NETIF,
-        .port      = RD_PORT,
-    };
+    sock_udp_ep_t rd_ep;
 
-    /* parse RD server address */
-    if (ipv6_addr_from_str((ipv6_addr_t *)&rd_ep.addr.ipv6, RD_ADDR) == NULL) {
+    if (sock_udp_str2ep(&rd_ep, RD_ADDR) < 0) {
         puts("error: unable to parse RD address from RD_ADDR variable");
         return 1;
     }
+
+    /* if netif is not specified in addr and it's link local */
+    if ((rd_ep.netif == SOCK_ADDR_ANY_NETIF) &&
+         ipv6_addr_is_link_local((ipv6_addr_t *) &rd_ep.addr.ipv6)) {
+        /* if there is only one interface we use that */
+        if (gnrc_netif_numof() == 1) {
+            rd_ep.netif = (uint16_t)gnrc_netif_iter(NULL)->pid;
+        }
+        /* if there are many it's an error */
+        else {
+            puts("error: must specify an interface for a link local address");
+            return 1;
+        }
+    }
+
+    if (rd_ep.port == 0) {
+        rd_ep.port = COAP_PORT;
+    }
+
+    sock_udp_ep_fmt(&rd_ep, ep_str, &ep_port);
 
     /* register resource handlers with gcoap */
     gcoap_register_listener(&listener);
@@ -93,7 +113,7 @@ int main(void)
     puts("epsim configuration:");
     printf("         ep: %s\n", cord_common_get_ep());
     printf("         lt: %is\n", (int)CORD_LT);
-    printf(" RD address: [%s]:%u\n\n", RD_ADDR, (unsigned)RD_PORT);
+    printf(" RD address: [%s]:%u\n\n", ep_str, ep_port);
 
     xtimer_sleep(STARTUP_DELAY);
 
@@ -112,8 +132,7 @@ int main(void)
                 break;
         }
 
-        printf("updating registration with RD [%s]:%u\n", RD_ADDR,
-               (unsigned)RD_PORT);
+        printf("updating registration with RD [%s]:%u\n", ep_str, ep_port);
         res = cord_epsim_register(&rd_ep);
         if (res == CORD_EPSIM_BUSY) {
             puts("warning: registration already in progress");


### PR DESCRIPTION
### Contribution description
This modifies the `cord_epsim` example application to use the first interface when there is only one an no interface has been specified in `RD_ADDR`. As now `sock_udp_str2ep` is being used to parse the address, I removed `RD_PORT` and both parameters are configured via `RD_ADDR`.

### Testing procedure
`examples/cord_epsim` should work without having to set `CFLAGS += -DGNRC_NETIF_SINGLE`

### Issues/PRs references
Spotted in #14542 