### PR TITLE
examples/filesystem: Cleanup filesystem/mtd check

### DIFF
--- a/examples/filesystem/main.c
+++ b/examples/filesystem/main.c
@@ -130,6 +130,18 @@ static vfs_mount_t flash_mount = {
 };
 #endif /* MTD_0 */
 
+/* Add simple macro to check if an MTD device together with a filesystem is
+ * compiled in */
+#if  defined(MTD_0) && \
+     (defined(MODULE_SPIFFS) || \
+      defined(MODULE_LITTLEFS) || \
+      defined(MODULE_LITTLEFS2) || \
+      defined(MODULE_FATFS_VFS))
+#define FLASH_AND_FILESYSTEM_PRESENT    1
+#else
+#define FLASH_AND_FILESYSTEM_PRESENT    0
+#endif
+
 /* constfs example */
 #include "fs/constfs.h"
 
@@ -169,7 +181,7 @@ static int _mount(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS) || defined(MODULE_LITTLEFS2) || defined(MODULE_FATFS_VFS))
+#if FLASH_AND_FILESYSTEM_PRESENT
     int res = vfs_mount(&flash_mount);
     if (res < 0) {
         printf("Error while mounting %s...try format\n", FLASH_MOUNT_POINT);
@@ -188,7 +200,7 @@ static int _format(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS) || defined(MODULE_LITTLEFS2) || defined(MODULE_FATFS_VFS))
+#if FLASH_AND_FILESYSTEM_PRESENT
     int res = vfs_format(&flash_mount);
     if (res < 0) {
         printf("Error while formatting %s\n", FLASH_MOUNT_POINT);
@@ -207,7 +219,7 @@ static int _umount(int argc, char **argv)
 {
     (void)argc;
     (void)argv;
-#if defined(MTD_0) && (defined(MODULE_SPIFFS) || defined(MODULE_LITTLEFS) || defined(MODULE_LITTLEFS2) || defined(MODULE_FATFS_VFS))
+#if FLASH_AND_FILESYSTEM_PRESENT
     int res = vfs_umount(&flash_mount);
     if (res < 0) {
         printf("Error while unmounting %s\n", FLASH_MOUNT_POINT);


### PR DESCRIPTION
### Contribution description

This cleans up the growing ifdefs in the filesystem example with a single macro to check for.

### Testing procedure

Binaries between current master and this PR must not be different for the different filesystems available

### Issues/PRs references

None