### PR TITLE
net/gcoap: remove gcoap_finish

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -412,45 +412,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Reduce payload length by this value for a request
- *
- * Accommodates writing Content-Format option in gcoap_finish(). May set to
- * zero if function not used.
- *
- * @deprecated  Will not be available after the 2020.07 release. Used only by
- * gcoap_finish(), which also is deprecated.
- */
-#ifndef CONFIG_GCOAP_REQ_OPTIONS_BUF
-#define CONFIG_GCOAP_REQ_OPTIONS_BUF   (4)
-#endif
-
-/**
- * @brief   Reduce payload length by this value for a response
- *
- * Accommodates writing Content-Format option in gcoap_finish(). May set to
- * zero if function not used.
- *
- * @deprecated  Will not be available after the 2020.07 release. Used only by
- * gcoap_finish(), which also is deprecated.
- */
-#ifndef CONFIG_GCOAP_RESP_OPTIONS_BUF
-#define CONFIG_GCOAP_RESP_OPTIONS_BUF  (4)
-#endif
-
-/**
- * @brief   Reduce payload length by this value for an observe notification
- *
- * Accommodates writing Content-Format option in gcoap_finish(). May set to
- * zero if function not used.
- *
- * @deprecated  Will not be available after the 2020.07 release. Used only by
- * gcoap_finish(), which also is deprecated.
- */
-#ifndef CONFIG_GCOAP_OBS_OPTIONS_BUF
-#define CONFIG_GCOAP_OBS_OPTIONS_BUF   (4)
-#endif
-
-/**
  * @brief   Maximum number of requests awaiting a response
  */
 #ifndef CONFIG_GCOAP_REQ_WAITING_MAX
@@ -751,31 +712,6 @@ void gcoap_register_listener(gcoap_listener_t *listener);
  */
 int gcoap_req_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                    unsigned code, const char *path);
-
-/**
- * @brief   Finishes formatting a CoAP PDU after the payload has been written
- *
- * Assumes the PDU has been initialized with a gcoap_xxx_init() function, like
- * gcoap_req_init().
- *
- * @deprecated  Will not be available after the 2020.07 release. Use
- * coap_opt_finish() instead.
- *
- * @warning To use this function, you only may have added an Option with
- * option number less than COAP_OPT_CONTENT_FORMAT. Otherwise, use the
- * struct-based API described with @link net_nanocoap nanocoap. @endlink With
- * this API, you specify the format with coap_opt_add_uint(), prepare for the
- * payload with coap_opt_finish(), and then write the payload.
- *
- * @param[in,out] pdu       Request metadata
- * @param[in] payload_len   Length of the payload, or 0 if none
- * @param[in] format        Format code for the payload; use COAP_FORMAT_NONE if
- *                          not specified
- *
- * @return  size of the PDU
- * @return  < 0 on error
- */
-ssize_t gcoap_finish(coap_pkt_t *pdu, size_t payload_len, unsigned format);
 
 /**
  * @brief   Writes a complete CoAP request PDU when there is not a payload

--- a/sys/net/application_layer/gcoap/Kconfig
+++ b/sys/net/application_layer/gcoap/Kconfig
@@ -13,39 +13,11 @@ menuconfig KCONFIG_MODULE_GCOAP
 
 if KCONFIG_MODULE_GCOAP
 
-menu "Buffer Sizes"
-
 config GCOAP_PDU_BUF_SIZE
     int "Request or response buffer size"
     default 128
     help
         Size of the buffer used to build a CoAP request or response.
-
-config GCOAP_REQ_OPTIONS_BUF
-    int "Request options buffer size"
-    default 4
-    help
-        Reduce payload length by this value for a request.
-        Accommodates writing Content-Format option in gcoap_finish(). May be
-        set to zero if the function is not used.
-
-config GCOAP_RESP_OPTIONS_BUF
-    int "Response options buffer size"
-    default 4
-    help
-        Reduce payload length by this value for a response.
-        Accommodates writing Content-Format option in gcoap_finish(). May be
-        set to zero if the function is not used.
-
-config GCOAP_OBS_OPTIONS_BUF
-    int "Observe notification options buffer size"
-    default 4
-    help
-        Reduce payload length by this value for an observe notification.
-        Accommodates writing Content-Format option in gcoap_finish(). May be
-        set to zero if the function is not used.
-
-endmenu # Buffer Sizes
 
 menu "Observe options"
 

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -680,50 +680,11 @@ int gcoap_req_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
         res = coap_build_hdr(pdu->hdr, COAP_TYPE_CON, NULL, 0, code, msgid);
     }
 
-    coap_pkt_init(pdu, buf, len - CONFIG_GCOAP_REQ_OPTIONS_BUF, res);
+    coap_pkt_init(pdu, buf, len, res);
     if (path != NULL) {
         res = coap_opt_add_uri_path(pdu, path);
     }
     return (res > 0) ? 0 : res;
-}
-
-/*
- * Assumes pdu.payload_len attribute was reduced in gcoap_xxx_init() to
- * ensure enough space in PDU buffer to write Content-Format option and
- * payload marker here.
- */
-ssize_t gcoap_finish(coap_pkt_t *pdu, size_t payload_len, unsigned format)
-{
-    assert( !(pdu->options_len) ||
-            !(payload_len) ||
-            (format == COAP_FORMAT_NONE) ||
-            (pdu->options[pdu->options_len-1].opt_num < COAP_OPT_CONTENT_FORMAT));
-
-    if (payload_len) {
-        /* determine Content-Format option length */
-        unsigned format_optlen = 1;
-        if (format == COAP_FORMAT_NONE) {
-            format_optlen = 0;
-        }
-        else if (format > 255) {
-            format_optlen = 3;
-        }
-        else if (format > 0) {
-            format_optlen = 2;
-        }
-
-        /* move payload to accommodate option and payload marker */
-        memmove(pdu->payload+format_optlen+1, pdu->payload, payload_len);
-
-        if (format_optlen) {
-            coap_opt_add_uint(pdu, COAP_OPT_CONTENT_FORMAT, format);
-        }
-        *pdu->payload++ = 0xFF;
-    }
-    /* must write option before updating PDU with actual length */
-    pdu->payload_len = payload_len;
-
-    return pdu->payload_len + (pdu->payload - (uint8_t *)pdu->hdr);
 }
 
 size_t gcoap_req_send(const uint8_t *buf, size_t len,
@@ -840,7 +801,7 @@ int gcoap_resp_init(coap_pkt_t *pdu, uint8_t *buf, size_t len, unsigned code)
 
     pdu->options_len = 0;
     pdu->payload     = buf + header_len;
-    pdu->payload_len = len - header_len - CONFIG_GCOAP_RESP_OPTIONS_BUF;
+    pdu->payload_len = len - header_len;
 
     if (coap_get_observe(pdu) == COAP_OBS_REGISTER) {
         /* generate initial notification value */
@@ -869,7 +830,7 @@ int gcoap_obs_init(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                                     memo->token_len, COAP_CODE_CONTENT, msgid);
 
     if (hdrlen > 0) {
-        coap_pkt_init(pdu, buf, len - CONFIG_GCOAP_OBS_OPTIONS_BUF, hdrlen);
+        coap_pkt_init(pdu, buf, len, hdrlen);
 
         uint32_t now       = xtimer_now_usec();
         pdu->observe_value = (now >> GCOAP_OBS_TICK_EXPONENT) & 0xFFFFFF;

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -161,7 +161,7 @@ static void test_gcoap__client_put_req(void)
 static void test_gcoap__client_put_req_overfill(void)
 {
     /* header 4, token 2, path 11, format 1, marker 1 = 19 */
-    uint8_t buf[18+CONFIG_GCOAP_REQ_OPTIONS_BUF];
+    uint8_t buf[18];
     coap_pkt_t pdu;
     ssize_t len;
     char path[] = "/riot/value";


### PR DESCRIPTION
### Contribution description
`gcoap_finish` has been deprecated and scheduled for removal in #12838. #14542 removed the remaining usages of it. This PR removes the function and its related macros.

### Testing procedure
- `tests/unittests/tests-gcoap` should be working
- `examples/gcoap` should be used to test the CoAP functionalities

I tested this by running the release spec tests using https://github.com/RIOT-OS/Release-Specs/pull/168 (see output [here](https://gist.github.com/leandrolanzieri/dcb898c362a56a15f0700a13ec2f2d2b)), and checking the messages on WireShark, maybe it would be good to have some further testing.

### Issues/PRs references
Deprecated in #12838