### PR TITLE
sys/ztimer: fix missing include for periph_rtt submodule

### DIFF
--- a/sys/ztimer/periph_rtt.c
+++ b/sys/ztimer/periph_rtt.c
@@ -20,6 +20,8 @@
  * @}
  */
 #include "assert.h"
+
+#include "irq.h"
 #include "periph/rtt.h"
 #include "ztimer/periph_rtt.h"
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a missing include of irq.h in the periph_rtt backend of ztimer.
The build issue was raised in #11237 now that ztimer + rtt is used as timer backend. See [here](https://ci.riot-os.org/RIOT-OS/RIOT/11237/0d96f099bb2dc9d691099bc8660d64863c3b2e97/output/compile/tests/driver_sx127x/avr-rss2:gnu.txt) and [here](https://ci.riot-os.org/RIOT-OS/RIOT/11237/0d96f099bb2dc9d691099bc8660d64863c3b2e97/output/compile/tests/driver_sx127x/esp32-wroom-32:gnu.txt)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- With this PR and #11237 the builds for Atmega and ESP32 are fixed:

<details><summary>atmega256rfr2-xpro</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=atmega256rfr2-xpro -C examples/lorawan --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=atmega256rfr2-xpro'  -w '/data/riotbuild/riotbase/examples/lorawan/' 'riot/riotbuild:latest' make 'BOARD=atmega256rfr2-xpro'    
Building application "lorawan" for "atmega256rfr2-xpro" with MCU "atmega256rfr2".

"make" -C /data/riotbuild/riotbase/pkg/semtech-loramac
"make" -C /data/riotbuild/riotbase/build/pkg/semtech-loramac/src/boards/mcu -f /data/riotbuild/riotbase/pkg/semtech-loramac/Makefile.loramac_arch
"make" -C /data/riotbuild/riotbase/build/pkg/semtech-loramac/src/system/crypto -f /data/riotbuild/riotbase/pkg/semtech-loramac/Makefile.loramac_crypto
"make" -C /data/riotbuild/riotbase/build/pkg/semtech-loramac/src/mac -f /data/riotbuild/riotbase/pkg/semtech-loramac/Makefile.loramac_mac
"make" -C /data/riotbuild/riotbase/build/pkg/semtech-loramac/src/mac/region -f /data/riotbuild/riotbase/pkg/semtech-loramac/Makefile.loramac_region
"make" -C /data/riotbuild/riotbase/boards/atmega256rfr2-xpro
"make" -C /data/riotbuild/riotbase/boards/common/atmega
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/atmega256rfr2
"make" -C /data/riotbuild/riotbase/cpu/atmega_common
"make" -C /data/riotbuild/riotbase/cpu/atmega_common/avr_libc_extra
"make" -C /data/riotbuild/riotbase/cpu/atmega_common/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/drivers/sx127x
"make" -C /data/riotbuild/riotbase/pkg/semtech-loramac/contrib
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/iolist
"make" -C /data/riotbuild/riotbase/sys/luid
"make" -C /data/riotbuild/riotbase/sys/net/netif
"make" -C /data/riotbuild/riotbase/sys/random
"make" -C /data/riotbuild/riotbase/sys/random/tinymt32
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  53346	   1880	   4025	  59251	   e773	/data/riotbuild/riotbase/examples/lorawan/bin/atmega256rfr2-xpro/lorawan.elf
```

</details>

<details><summary>esp32-wroom-32</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=esp32-wroom-32 -C examples/lorawan --no-print-directory 
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=esp32-wroom-32'  -w '/data/riotbuild/riotbase/examples/lorawan/' 'riot/riotbuild:latest' make 'BOARD=esp32-wroom-32'    
ESP32_SDK_DIR should be defined as /path/to/esp-idf directory
ESP32_SDK_DIR is set by default to /opt/esp/esp-idf
Building application "lorawan" for "esp32-wroom-32" with MCU "esp32".

"make" -C /data/riotbuild/riotbase/pkg/semtech-loramac
"make" -C /data/riotbuild/riotbase/build/pkg/semtech-loramac/src/boards/mcu -f /data/riotbuild/riotbase/pkg/semtech-loramac/Makefile.loramac_arch
"make" -C /data/riotbuild/riotbase/build/pkg/semtech-loramac/src/system/crypto -f /data/riotbuild/riotbase/pkg/semtech-loramac/Makefile.loramac_crypto
"make" -C /data/riotbuild/riotbase/build/pkg/semtech-loramac/src/mac -f /data/riotbuild/riotbase/pkg/semtech-loramac/Makefile.loramac_mac
"make" -C /data/riotbuild/riotbase/build/pkg/semtech-loramac/src/mac/region -f /data/riotbuild/riotbase/pkg/semtech-loramac/Makefile.loramac_region
"make" -C /data/riotbuild/riotbase/boards/esp32-wroom-32
"make" -C /data/riotbuild/riotbase/boards/common/esp32
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/esp32
"make" -C /data/riotbuild/riotbase/cpu/esp32/freertos
"make" -C /data/riotbuild/riotbase/cpu/esp32/periph
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf/driver
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf/esp32
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf/soc
"make" -C /data/riotbuild/riotbase/cpu/esp32/vendor/esp-idf/spi_flash
"make" -C /data/riotbuild/riotbase/cpu/esp_common
"make" -C /data/riotbuild/riotbase/cpu/esp_common/freertos
"make" -C /data/riotbuild/riotbase/cpu/esp_common/periph
"make" -C /data/riotbuild/riotbase/cpu/esp_common/vendor
"make" -C /data/riotbuild/riotbase/cpu/esp_common/vendor/xtensa
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/drivers/rtt_rtc
"make" -C /data/riotbuild/riotbase/drivers/sx127x
"make" -C /data/riotbuild/riotbase/pkg/semtech-loramac/contrib
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/fmt
"make" -C /data/riotbuild/riotbase/sys/iolist
"make" -C /data/riotbuild/riotbase/sys/log
"make" -C /data/riotbuild/riotbase/sys/luid
"make" -C /data/riotbuild/riotbase/sys/net/netif
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/random
"make" -C /data/riotbuild/riotbase/sys/random/tinymt32
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  90659	   4008	  13000	 107667	  1a493	/data/riotbuild/riotbase/examples/lorawan/bin/esp32-wroom-32/lorawan.elf
```

</details>

On #11237 alone, they fail as reported by Murdock.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Required by #11237 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
