### PR TITLE
cpu/cortexm_common: implement SysTick timer, add option to use it for XTIMER

### DIFF
--- a/cpu/cortexm_common/Kconfig
+++ b/cpu/cortexm_common/Kconfig
@@ -46,6 +46,7 @@ config CPU_CORE_CORTEX_M
     select HAS_CPU_CHECK_ADDRESS
     select HAS_SSP
     select HAS_CORTEXM_SVC
+    select HAS_PERIPH_SYSTICK
 
 ## Common CPU symbols
 config CPU_CORE

--- a/cpu/cortexm_common/Kconfig
+++ b/cpu/cortexm_common/Kconfig
@@ -128,4 +128,20 @@ config MODULE_CORTEXM_FPU
     depends on HAS_CORTEXM_FPU
     depends on TEST_KCONFIG
 
+config MODULE_PERIPH_SYSTICK
+    bool "SysTick timer periph driver"
+    help
+        SysTick timer is present on every Cortex-M CPU.
+        It is a 24 bit, down-counting timer that runs at the same
+        frequency as the CPU.
+        This allows to use this timer as an (up-counting) timer in
+        RIOT.
+
+config MODULE_PERIPH_SYSTICK_PRESCALER
+    bool "SysTick timer prescaler"
+    depends on MODULE_PERIPH_SYSTICK
+    help
+        Allows to configure the SysTick backed timer to run at
+        'virtual' frequencies smaller than the CPU frequency.
+
 rsource "periph/Kconfig"

--- a/cpu/cortexm_common/Kconfig
+++ b/cpu/cortexm_common/Kconfig
@@ -128,8 +128,11 @@ config MODULE_CORTEXM_FPU
     depends on HAS_CORTEXM_FPU
     depends on TEST_KCONFIG
 
+if TEST_KCONFIG
+
 config MODULE_PERIPH_SYSTICK
     bool "SysTick timer periph driver"
+    depends on HAS_PERIPH_SYSTICK
     help
         SysTick timer is present on every Cortex-M CPU.
         It is a 24 bit, down-counting timer that runs at the same
@@ -144,4 +147,5 @@ config MODULE_PERIPH_SYSTICK_PRESCALER
         Allows to configure the SysTick backed timer to run at
         'virtual' frequencies smaller than the CPU frequency.
 
+endif
 rsource "periph/Kconfig"

--- a/cpu/cortexm_common/Kconfig
+++ b/cpu/cortexm_common/Kconfig
@@ -128,6 +128,11 @@ config MODULE_CORTEXM_FPU
     depends on HAS_CORTEXM_FPU
     depends on TEST_KCONFIG
 
+config HAS_PERIPH_SYSTICK
+    bool
+    help
+        Indicates that the SysTick timer peripheral is implemented.
+
 if TEST_KCONFIG
 
 config MODULE_PERIPH_SYSTICK
@@ -148,4 +153,5 @@ config MODULE_PERIPH_SYSTICK_PRESCALER
         'virtual' frequencies smaller than the CPU frequency.
 
 endif
+
 rsource "periph/Kconfig"

--- a/cpu/cortexm_common/Makefile.features
+++ b/cpu/cortexm_common/Makefile.features
@@ -1,5 +1,6 @@
 FEATURES_PROVIDED += arch_32bit
 FEATURES_PROVIDED += arch_arm
+FEATURES_PROVIDED += periph_systick
 FEATURES_PROVIDED += cortexm_svc
 FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += cpu_check_address

--- a/cpu/cortexm_common/include/systick.h
+++ b/cpu/cortexm_common/include/systick.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_periph_systick SysTick Timer
+ * @ingroup     cpu_cortexm_common
+ * @ingroup     drivers_periph
+ * @brief       Low-level timer based on SysTick
+ *
+ * SysTick is a 24 bit down-counting timer that is implemented on every Cortex-M
+ * processor. It runs at the same frequency as the CPU and will generate an
+ * interrupt when it reaches zero.
+ *
+ * To comply with the RIOT timer interface that expects an up-counting, monotonic
+ * timer, SysTick is augmented by software to fulfill these requirements.
+ * This also adds a software prescaler to simulate arbitrary frequencies and introduces
+ * a virtual, 32 bit counter.
+ * That allows for longer intervals than would be possible with the SysTick hardware
+ * peripheral alone.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Low-level SysTick timer peripheral driver interface definitions
+ *              The API makes no guarantees about thread-safety.
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef SYSTICK_H
+#define SYSTICK_H
+
+#include <stdint.h>
+#include <limits.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   SysTick is extended to 32 bit by software
+ */
+#define SYSTICK_TIMER_MAX_VALUE UINT32_MAX
+
+/**
+ * @brief Initialize the SysTick timer
+ *
+ * The timer is configured in up-counting mode and will count until
+ * SYSTICK_TIMER_MAX_VALUE until overflowing.
+ *
+ * The timer will be started automatically after initialization with interrupts
+ * enabled.
+ *
+ * The user must implement a `void systick_callback(void)` function that will
+ * be called when the timer expires.
+ *
+ * @param[in] freq          requested number of ticks per second
+ *
+ *                          If you want to set this to anything other than `CLOCK_CORECLOCK`
+ *                          the `systick_prescaler` pseudo-module is required.
+ */
+void systick_timer_init(unsigned long freq);
+
+/**
+ * @brief Set the SysTick timer
+ *
+ * The callback given during initialization is called when timeout ticks have
+ * passed after calling this function
+ *
+ * @param[in] timeout       timeout in ticks after that the registered callback
+ *                          is executed
+ *
+ * @return                  0 on success
+ * @return                  -1 on error
+ */
+int systick_timer_set(unsigned int timeout);
+
+/**
+ * @brief Set an absolute timeout value for the SysTick timer
+ *
+ * @param[in] timeout       the absolute compare value when the callback will be
+ *                          triggered
+ *
+ * @return                  0 on success
+ * @return                  -1 on error
+ */
+int systick_timer_set_absolute(unsigned int timeout);
+
+/**
+ * @brief Disable the alarm from the SysTick timer
+ */
+void systick_timer_clear(void);
+
+/**
+ * @brief Read the current (virtual) value of the SysTick timer
+ *
+ * @return                  the timers current value
+ */
+unsigned int systick_timer_read(void);
+
+/**
+ * @brief Start the SysTick timer
+ *
+ * This function is only needed if the timer was stopped manually before.
+ */
+void systick_timer_start(void);
+
+/**
+ * @brief Stop the SysTick timer
+ *
+ * When the timer is stopped, no alarms will be executed and the counter
+ * does not advance.
+ */
+void systick_timer_stop(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSTICK_H */
+/** @} */

--- a/cpu/cortexm_common/periph/systick.c
+++ b/cpu/cortexm_common/periph/systick.c
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_periph_systick
+ * @{
+ *
+ * @file        systick.c
+ * @brief       Low-level timer driver implementation based on SysTick
+ *
+ *              SysTick is a 24-bit Down-Counting Timer
+ *              It runs at the same frequency as the CPU
+ *              The count (VAL) register can only be set to 0 on write
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include <assert.h>
+#include "board.h"
+#include "periph_conf.h"
+#include "systick.h"
+
+/* SysTick CTRL configuration */
+#define ENABLE_MASK     (SysTick_CTRL_CLKSOURCE_Msk |\
+                         SysTick_CTRL_ENABLE_Msk    |\
+                         SysTick_CTRL_TICKINT_Msk)
+
+#define ALARM_EXT_MAX   ((1UL << (8 * sizeof(alarm_ext))) - 1)
+
+/* interrupt is always enabled to update time */
+static bool alarm_enabled;
+
+/* divider for CLOCK_CORECLOCK */
+static uint16_t prescaler = 1;
+
+/* full periods before alarm */
+static uint16_t alarm_ext;
+
+/* remaining time to alarm (last period length) */
+static uint32_t alarm_val;
+
+/* current time if the timer ran at freq Hz */
+static uint32_t now;
+
+/* offset in CLOCK_CORECLOCK ticks */
+static uint32_t now_offset;
+
+/* dummy SysTick callback */
+__attribute__((weak))
+void systick_callback(void)
+{
+    /* no-op */
+}
+
+void systick_timer_init(unsigned long freq)
+{
+    if (IS_USED(MODULE_SYSTICK_PRESCALER)) {
+        assert(freq <= CLOCK_CORECLOCK);
+
+        prescaler = CLOCK_CORECLOCK / freq;
+        assert(CLOCK_CORECLOCK % freq == 0);
+    } else {
+        assert(freq == CLOCK_CORECLOCK);
+    }
+
+    SysTick->VAL  = 0;
+    SysTick->LOAD = SysTick_LOAD_RELOAD_Msk;
+    SysTick->CTRL = ENABLE_MASK;
+
+    NVIC_SetPriority(SysTick_IRQn, CPU_DEFAULT_IRQ_PRIO);
+    NVIC_EnableIRQ(SysTick_IRQn);
+}
+
+int systick_timer_set(unsigned int value)
+{
+    uint64_t val64 = value * prescaler;
+
+    /* check if value fits with prescaler */
+    if ((val64 >> 24) > ALARM_EXT_MAX) {
+        return -1;
+    }
+
+    /* stop timer to prevent race condition */
+    SysTick->CTRL = 0;
+
+    alarm_ext = val64 >> 24;
+    alarm_val = val64 & SysTick_LOAD_RELOAD_Msk;
+
+    if (IS_USED(MODULE_SYSTICK_PRESCALER)) {
+        now_offset += SysTick->LOAD - SysTick->VAL;
+    } else {
+        now += SysTick->LOAD - SysTick->VAL;
+    }
+
+    if (alarm_ext) {
+        SysTick->LOAD = SysTick_LOAD_RELOAD_Msk;
+    } else {
+        SysTick->LOAD = alarm_val;
+    }
+
+    /* force reload */
+    SysTick->VAL = 0;
+
+    /* start the timer again */
+    SysTick->CTRL = ENABLE_MASK;
+
+    /* check if the last period is after the next reload */
+    if (alarm_ext == 1) {
+        SysTick->LOAD = alarm_val;
+    }
+
+    alarm_enabled = 1;
+
+    return 0;
+}
+
+int systick_timer_set_absolute(unsigned int value)
+{
+    return systick_timer_set(value - systick_timer_read());
+}
+
+void systick_timer_clear(void)
+{
+    SysTick->LOAD = SysTick_LOAD_RELOAD_Msk;
+    alarm_enabled = 0;
+}
+
+unsigned int systick_timer_read(void)
+{
+    uint32_t val, load;
+
+    /* re-read registers if VAL wraps around */
+    do {
+        val  = SysTick->VAL;
+        load = SysTick->LOAD;
+    } while (SysTick->VAL > val);
+
+    if (IS_USED(MODULE_SYSTICK_PRESCALER)) {
+        uint32_t current_offset = load - val;
+        return now + (current_offset + now_offset) / prescaler;
+    } else {
+        return now + load - val;
+    }
+}
+
+void systick_timer_start(void)
+{
+    SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
+}
+
+void systick_timer_stop(void)
+{
+    SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;
+}
+
+void isr_systick(void)
+{
+    /* update clock */
+    if (IS_USED(MODULE_SYSTICK_PRESCALER)) {
+        now_offset += SysTick->LOAD;
+
+        now += now_offset / prescaler;
+        now_offset = now_offset % prescaler;
+    } else {
+        now += SysTick->LOAD;
+    }
+
+    if (!alarm_enabled) {
+        return;
+    }
+
+    /* alarm handling */
+
+    if (alarm_ext) {
+        /* alarm happens after next period
+         * set reload value to remaining alarm time
+         */
+        if (--alarm_ext == 1) {
+            SysTick->LOAD = alarm_val;
+        }
+
+        return;
+    }
+
+    alarm_enabled = 0;
+
+    systick_callback();
+
+    /* We only need to trigger the scheduler after the callback was executed. */
+    /* No need to trigger scheduling when just updating the counter.          */
+    cortexm_isr_end();
+}

--- a/cpu/cortexm_common/periph/systick.c
+++ b/cpu/cortexm_common/periph/systick.c
@@ -60,7 +60,7 @@ void systick_callback(void)
 
 void systick_timer_init(unsigned long freq)
 {
-    if (IS_USED(MODULE_SYSTICK_PRESCALER)) {
+    if (IS_USED(MODULE_PERIPH_SYSTICK_PRESCALER)) {
         assert(freq <= CLOCK_CORECLOCK);
 
         prescaler = CLOCK_CORECLOCK / freq;
@@ -92,7 +92,7 @@ int systick_timer_set(unsigned int value)
     alarm_ext = val64 >> 24;
     alarm_val = val64 & SysTick_LOAD_RELOAD_Msk;
 
-    if (IS_USED(MODULE_SYSTICK_PRESCALER)) {
+    if (IS_USED(MODULE_PERIPH_SYSTICK_PRESCALER)) {
         now_offset += SysTick->LOAD - SysTick->VAL;
     } else {
         now += SysTick->LOAD - SysTick->VAL;
@@ -141,7 +141,7 @@ unsigned int systick_timer_read(void)
         load = SysTick->LOAD;
     } while (SysTick->VAL > val);
 
-    if (IS_USED(MODULE_SYSTICK_PRESCALER)) {
+    if (IS_USED(MODULE_PERIPH_SYSTICK_PRESCALER)) {
         uint32_t current_offset = load - val;
         return now + (current_offset + now_offset) / prescaler;
     } else {
@@ -162,7 +162,7 @@ void systick_timer_stop(void)
 void isr_systick(void)
 {
     /* update clock */
-    if (IS_USED(MODULE_SYSTICK_PRESCALER)) {
+    if (IS_USED(MODULE_PERIPH_SYSTICK_PRESCALER)) {
         now_offset += SysTick->LOAD;
 
         now += now_offset / prescaler;

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -487,7 +487,7 @@ ISR_VECTOR(0) const cortexm_base_t cortex_vector_base = {
         [10] = isr_svc,
         /* [-2] pendSV interrupt, in RIOT use to do the actual context switch */
         [13] = isr_pendsv,
-        /* [-1] SysTick interrupt, not used in RIOT */
+        /* [-1] SysTick interrupt, only used by periph_systick module */
         [14] = isr_systick,
 
         /* -9 to -6 reserved entries can be defined by the cpu module */

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -255,6 +255,11 @@ config HAS_PERIPH_SPI_GPIO_MODE
     help
         Indicates that the SPI peripheral supports configuring the GPIOs modes.
 
+config HAS_PERIPH_SYSTICK
+    bool
+    help
+        Indicates that the SysTick timer peripheral is implemented.
+
 config HAS_PERIPH_TEMPERATURE
     bool
     help

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -255,11 +255,6 @@ config HAS_PERIPH_SPI_GPIO_MODE
     help
         Indicates that the SPI peripheral supports configuring the GPIOs modes.
 
-config HAS_PERIPH_SYSTICK
-    bool
-    help
-        Indicates that the SysTick timer peripheral is implemented.
-
 config HAS_PERIPH_TEMPERATURE
     bool
     help

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -138,6 +138,7 @@ PSEUDOMODULES += sys_bus_%
 PSEUDOMODULES += systick_prescaler
 PSEUDOMODULES += wakaama_objects_%
 PSEUDOMODULES += wifi_enterprise
+PSEUDOMODULES += xtimer_on_systick
 PSEUDOMODULES += xtimer_on_ztimer
 PSEUDOMODULES += zptr
 PSEUDOMODULES += ztimer%

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -135,6 +135,7 @@ PSEUDOMODULES += stm32mp1_eng_mode
 PSEUDOMODULES += suit_transport_%
 PSEUDOMODULES += suit_storage_%
 PSEUDOMODULES += sys_bus_%
+PSEUDOMODULES += systick_prescaler
 PSEUDOMODULES += wakaama_objects_%
 PSEUDOMODULES += wifi_enterprise
 PSEUDOMODULES += xtimer_on_ztimer

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -135,7 +135,6 @@ PSEUDOMODULES += stm32mp1_eng_mode
 PSEUDOMODULES += suit_transport_%
 PSEUDOMODULES += suit_storage_%
 PSEUDOMODULES += sys_bus_%
-PSEUDOMODULES += systick_prescaler
 PSEUDOMODULES += wakaama_objects_%
 PSEUDOMODULES += wifi_enterprise
 PSEUDOMODULES += xtimer_on_systick

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -1005,9 +1005,14 @@ ifneq (,$(filter xtimer,$(USEMODULE)))
     # xtimer is used, ztimer xtimer wrapper is not
     DEFAULT_MODULE += auto_init_xtimer
     USEMODULE += div
-    ifeq (,$(filter xtimer_on_ztimer,$(USEMODULE)))
+    ifeq (,$(filter xtimer_on_systick xtimer_on_ztimer,$(USEMODULE)))
       # ztimer is not used, so use *periph_timer as low-level timer*.
       FEATURES_REQUIRED += periph_timer
+    else ifneq (,$(filter xtimer_on_systick,$(USEMODULE)))
+      # will use *SysTick as low-level timer*
+      FEATURES_REQUIRED += periph_systick
+      # xtimer requires prescaling
+      USEMODULE += systick_prescaler
     else
       # will use *ztimer_usec as low-level timer*
     endif

--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -27,8 +27,10 @@
 #error "Do not include this file directly! Use xtimer.h instead"
 #endif
 
-#ifdef MODULE_XTIMER_ON_ZTIMER
+#if defined(MODULE_XTIMER_ON_ZTIMER)
 #include "ztimer.h"
+#elif defined(MODULE_XTIMER_ON_SYSTICK)
+#include "systick.h"
 #else
 #include "periph/timer.h"
 #endif
@@ -52,10 +54,12 @@ extern volatile uint64_t _xtimer_current_time;
  */
 static inline uint32_t _xtimer_lltimer_now(void)
 {
-#ifndef MODULE_XTIMER_ON_ZTIMER
-    return timer_read(XTIMER_DEV);
-#else
+#if defined(MODULE_XTIMER_ON_ZTIMER)
     return ztimer_now(ZTIMER_USEC);
+#elif defined(MODULE_XTIMER_ON_SYSTICK)
+    return systick_timer_read();
+#else
+    return timer_read(XTIMER_DEV);
 #endif
 
 }

--- a/tests/periph_systick/Makefile
+++ b/tests/periph_systick/Makefile
@@ -1,0 +1,7 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_systick
+
+USEMODULE += systick_prescaler
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_systick/Makefile
+++ b/tests/periph_systick/Makefile
@@ -1,7 +1,6 @@
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_systick
-
-USEMODULE += systick_prescaler
+USEMODULE += periph_systick_prescaler
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_systick/app.config.test
+++ b/tests/periph_systick/app.config.test
@@ -1,0 +1,5 @@
+# this file enables modules defined in Kconfig. Do not use this file for
+# application configuration. This is only needed during migration.
+CONFIG_MODULE_TEST_UTILS_INTERACTIVE_SYNC=y
+CONFIG_MODULE_PERIPH_SYSTICK=y
+CONFIG_MODULE_PERIPH_SYSTICK_PRESCALER=y

--- a/tests/periph_systick/app.config.test
+++ b/tests/periph_systick/app.config.test
@@ -1,5 +1,4 @@
 # this file enables modules defined in Kconfig. Do not use this file for
 # application configuration. This is only needed during migration.
-CONFIG_MODULE_TEST_UTILS_INTERACTIVE_SYNC=y
 CONFIG_MODULE_PERIPH_SYSTICK=y
 CONFIG_MODULE_PERIPH_SYSTICK_PRESCALER=y

--- a/tests/periph_systick/main.c
+++ b/tests/periph_systick/main.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       SysTick timer test application
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "board.h"
+
+#include "mutex.h"
+#include "systick.h"
+#include "macros/units.h"
+
+#include "timex.h"
+
+#define INTERVAL_US         ( 2 * US_PER_SEC)
+#define INTERVAL_LONG_US    (30 * US_PER_SEC)
+
+static mutex_t lock = MUTEX_INIT_LOCKED;
+
+void systick_callback(void)
+{
+    mutex_unlock(&lock);
+}
+
+static void test_timer_set(unsigned period, unsigned iterations)
+{
+
+    systick_timer_init(MHZ(1));
+
+    while (iterations--) {
+        if (systick_timer_set(period)) {
+            puts("too large offset");
+            return;
+        }
+        mutex_lock(&lock);
+        printf("now: %u\n", systick_timer_read());
+    }
+}
+
+int main(void)
+{
+    printf("Test setting %lu ms intervals\n", INTERVAL_US / US_PER_MS);
+    test_timer_set(INTERVAL_US, 5);
+
+    printf("Test setting %lu s intervals\n", INTERVAL_LONG_US / US_PER_SEC);
+    test_timer_set(INTERVAL_LONG_US, 5);
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

SysTick is a 24 bit down-counting timer that is implemented on every Cortex-M processor.
It runs at the same frequency as the CPU and can generate an interrupt when it reaches 0.

It allows to free up hardware timers for other uses and accelerates bring-up of new Cortex-M platforms since SysTick is implemented the same everywhere.

To comply with the RIOT timer interface (xtimer & ztimer) that expect an up-counting, monotonic timer,
SysTick is augmented by software to fulfill these requirements. 

This also adds a software prescaler to simulate arbitrary frequencies and introduces a virtual, 32 bit counter.
That allows for longer intervals than would be possible with the SysTick hardware peripheral alone and makes it possible to use it as a backed for xtimer.

I initially hoped to see some power savings by not running a timer peripheral, but on `examples/timer_periodic_wakeup` power draw went up from 2.35 mA with the periph timer to 2.37 mA with the SysTick timer as source for the xtimer clock.


### Testing procedure

A basic test is included with `tests/periph_systick`.
But it is possible to run any test or application that uses xtimer off SysTick by adding 

```
USEMODULE += xtimer_on_systick
```

to the application Makefile.

This should work on any Cortex-M processor.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
