### PR TITLE
cortexm_common: Make no_thread_idle compatible with cortex-m0

### DIFF
--- a/cpu/cortexm_common/Kconfig
+++ b/cpu/cortexm_common/Kconfig
@@ -16,6 +16,7 @@ config CPU_ARCH_ARMV6M
     bool
     select HAS_ARCH_ARM
     select HAS_ARCH_32BIT
+    select HAS_NO_IDLE_THREAD
 
 config CPU_ARCH_ARMV7M
     bool

--- a/cpu/cortexm_common/Makefile.features
+++ b/cpu/cortexm_common/Makefile.features
@@ -33,9 +33,6 @@ else
   $(error Unkwnown cortexm core: $(CPU_CORE))
 endif
 
-# cortex-m3 and higher don't need the idle thread
-ifneq (,$(filter armv7m armv8m,$(CPU_ARCH)))
-  FEATURES_PROVIDED += no_idle_thread
-endif
+FEATURES_PROVIDED += no_idle_thread
 
 KCONFIG_ADD_CONFIG += $(RIOTCPU)/cortexm_common/cortexm_common.config

--- a/cpu/cortexm_common/include/cpu_conf_common.h
+++ b/cpu/cortexm_common/include/cpu_conf_common.h
@@ -142,7 +142,7 @@ extern "C" {
  * If you want to set this, define it in your `cpu_conf.h`.
  */
 #ifndef CPU_CORTEXM_PENDSV_IRQ_PRIO
-#define CPU_CORTEXM_PENDSV_IRQ_PRIO (CPU_DEFAULT_IRQ_PRIO)
+#define CPU_CORTEXM_PENDSV_IRQ_PRIO (UINT8_MAX)
 #endif
 /** @} */
 


### PR DESCRIPTION
### Contribution description

This PR modifies the cortexm thread specific bits to allow running the PendSV IRQ permanently at a lower priority than the other IRQs. With this, the `no_thread_idle` feature is extended to cover the cortex-m0(+).

Interrupts are disabled during `sched_run` to prevent the scheduler bits from being modified during the scheduling algorithm. They are briefly enabled after the sleep in sched_arch_idle so that pending interrupts can be serviced after the CPU returns from sleeping.

### Testing procedure

Same as #14224, but now with the samr21-xpro (or other cortex-m0) included in the tests. Everything should still work as usual.

### Benchmarks

Early benchmarks shows that this decreases raw thread switch performance by about 5%:

<details><summary>samr21-xpro on Master</summary>

```
2020-07-20 11:29:46,590 # START
2020-07-20 11:29:46,595 # main(): This is RIOT! (Version: 2020.10-devel-264-ge5d69-HEAD)
2020-07-20 11:29:46,597 # main starting
2020-07-20 11:29:47,598 # { "result" : 65217 }
2020-07-20 11:31:46,644 # Exiting Pyterm
```

</details>

<details><summary>samr21-xpro on this PR</summary>

```
2020-07-20 11:29:25,821 # START
2020-07-20 11:29:25,829 # main(): This is RIOT! (Version: 2020.10-devel-266-gcf82c3-pr/cortexm_common/pendsv_priority)
2020-07-20 11:29:25,830 # main starting
2020-07-20 11:29:26,832 # { "result" : 62176 }
2020-07-20 11:29:29,660 # Exiting Pyterm
```

</details>

### Issues/PRs references

None