### PR TITLE
gnrc_lorawan: add support for RTT (ztimer)

### DIFF
--- a/examples/gnrc_lorawan/main.c
+++ b/examples/gnrc_lorawan/main.c
@@ -22,7 +22,6 @@
 #include <string.h>
 
 #include "thread.h"
-#include "xtimer.h"
 #include "shell.h"
 #include "shell_commands.h"
 

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -189,6 +189,13 @@ void gnrc_lorawan_radio_rx_timeout_cb(gnrc_lorawan_t *mac);
 void gnrc_lorawan_radio_tx_done_cb(gnrc_lorawan_t *mac);
 
 /**
+ * @brief Indicate the MAC layer that the timer was fired
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ */
+void gnrc_lorawan_timeout_cb(gnrc_lorawan_t *mac);
+
+/**
  * @brief Init GNRC LoRaWAN
  *
  * @param[in] mac pointer to the MAC descriptor
@@ -295,6 +302,23 @@ netdev_t *gnrc_lorawan_get_netdev(gnrc_lorawan_t *mac);
  *         enable an undefined channel
  */
 int gnrc_lorawan_phy_set_channel_mask(gnrc_lorawan_t *mac, uint16_t channel_mask);
+
+/**
+ * @brief Set a timer with the given time
+ * @note Supposed to be implemented by the user of GNRC LoRaWAN
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ * @param us timeout microseconds
+ */
+void gnrc_lorawan_set_timer(gnrc_lorawan_t *mac, uint32_t us);
+
+/**
+ * @brief Remove the current timer
+ * @note Supposed to be implemented by the user of GNRC LoRaWAN
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ */
+void gnrc_lorawan_remove_timer(gnrc_lorawan_t *mac);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/lorawan.h
+++ b/sys/include/net/gnrc/lorawan.h
@@ -35,18 +35,6 @@ extern "C" {
  * @{
  */
 /**
- * @brief maximum timer drift in per mille
- *
- * @note this is only a workaround to compensate inaccurate timers.
- *
- * E.g a value of 1 means there's a positive drift of 0.1% (set timeout to
- * 1000 ms => triggers after 1001 ms)
- */
-#ifndef CONFIG_GNRC_LORAWAN_TIMER_DRIFT
-#define CONFIG_GNRC_LORAWAN_TIMER_DRIFT 10
-#endif
-
-/**
  * @brief the minimum symbols to detect a LoRa preamble
  */
 #ifndef CONFIG_GNRC_LORAWAN_MIN_SYMBOLS_TIMEOUT

--- a/sys/include/net/gnrc/netif/lorawan.h
+++ b/sys/include/net/gnrc/netif/lorawan.h
@@ -20,6 +20,8 @@
 
 #include "net/gnrc/lorawan.h"
 
+#include "xtimer.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -39,6 +41,8 @@ typedef struct {
     uint8_t deveui[LORAMAC_DEVEUI_LEN];     /**< Device EUI buffer */
     uint8_t appeui[LORAMAC_APPEUI_LEN];     /**< App EUI buffer */
     gnrc_lorawan_t mac;                     /**< gnrc lorawan mac descriptor */
+    xtimer_t timer;                         /**< General purpose timer */
+    xtimer_t backoff_timer;                 /**< Backoff timer */
     uint8_t flags;                          /**< flags for the LoRaWAN interface */
     uint8_t demod_margin;                   /**< value of last demodulation margin */
     uint8_t num_gateways;                   /**< number of gateways of last link check */

--- a/sys/include/net/gnrc/netif/lorawan.h
+++ b/sys/include/net/gnrc/netif/lorawan.h
@@ -20,7 +20,7 @@
 
 #include "net/gnrc/lorawan.h"
 
-#include "xtimer.h"
+#include "ztimer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,8 +41,8 @@ typedef struct {
     uint8_t deveui[LORAMAC_DEVEUI_LEN];     /**< Device EUI buffer */
     uint8_t appeui[LORAMAC_APPEUI_LEN];     /**< App EUI buffer */
     gnrc_lorawan_t mac;                     /**< gnrc lorawan mac descriptor */
-    xtimer_t timer;                         /**< General purpose timer */
-    xtimer_t backoff_timer;                 /**< Backoff timer */
+    ztimer_t timer;                         /**< General purpose timer */
+    ztimer_t backoff_timer;                 /**< Backoff timer */
     uint8_t flags;                          /**< flags for the LoRaWAN interface */
     uint8_t demod_margin;                   /**< value of last demodulation margin */
     uint8_t num_gateways;                   /**< number of gateways of last link check */

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -25,7 +25,7 @@ ifneq (,$(filter gnrc_gomach,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_lorawan,$(USEMODULE)))
-  USEMODULE += xtimer
+  USEMODULE += ztimer_msec
   USEMODULE += random
   USEMODULE += hashes
   USEMODULE += crypto_aes_128

--- a/sys/net/gnrc/link_layer/lorawan/Kconfig
+++ b/sys/net/gnrc/link_layer/lorawan/Kconfig
@@ -16,16 +16,6 @@ menuconfig KCONFIG_USEMODULE_GNRC_LORAWAN
 
 if KCONFIG_USEMODULE_GNRC_LORAWAN
 
-config GNRC_LORAWAN_TIMER_DRIFT
-    int "Maximum timer drift"
-    default 10
-    range -1000 1000
-    help
-        The value is expressed in per mille. This is only a workaround to
-        compensate inaccurate timers. E.g. a value of 1 means there's a
-        positive drift of 0.1% (set timeout to 1000 ms => triggers after
-        1001 ms)
-
 config GNRC_LORAWAN_MIN_SYMBOLS_TIMEOUT
     int "Minimum symbols to detect a LoRa preamble"
     default 30

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mcps.c
@@ -335,12 +335,8 @@ static void _handle_retransmissions(gnrc_lorawan_t *mac)
 {
     if (mac->mcps.nb_trials-- == 0) {
         _end_of_tx(mac, MCPS_CONFIRMED, -ETIMEDOUT);
-    }
-    else {
-        mac->msg.type = MSG_TYPE_MCPS_ACK_TIMEOUT;
-        xtimer_set_msg(&mac->rx, 1000000 + random_uint32_range(0,
-                                                               2000000), &mac->msg,
-                       thread_getpid());
+    } else {
+        gnrc_lorawan_set_timer(mac, 1000000 + random_uint32_range(0, 2000000));
     }
 }
 

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan_mlme.c
@@ -54,6 +54,13 @@ static void _build_join_req_pkt(uint8_t *appeui, uint8_t *deveui,
                                     &hdr->mic);
 }
 
+void gnrc_lorawan_trigger_join(gnrc_lorawan_t *mac)
+{
+    iolist_t pkt = {.iol_base = mac->mcps.mhdr_mic, .iol_len =
+                    sizeof(lorawan_join_request_t), .iol_next = NULL};
+    gnrc_lorawan_send_pkt(mac, &pkt, mac->last_dr);
+}
+
 static int gnrc_lorawan_send_join_request(gnrc_lorawan_t *mac, uint8_t *deveui,
                                           uint8_t *appeui, uint8_t *appkey,
                                           uint8_t dr)
@@ -68,18 +75,15 @@ static int gnrc_lorawan_send_join_request(gnrc_lorawan_t *mac, uint8_t *deveui,
     mac->mlme.dev_nonce[0] = random_number & 0xFF;
     mac->mlme.dev_nonce[1] = (random_number >> 8) & 0xFF;
 
-    /* build join request */
-    uint8_t psdu[sizeof(lorawan_join_request_t)];
+    mac->last_dr = dr;
+    mac->state = LORAWAN_STATE_JOIN;
 
-    iolist_t pkt =
-    { .iol_base = &psdu, .iol_len = sizeof(psdu), .iol_next = NULL };
-
-    _build_join_req_pkt(appeui, deveui, appkey, mac->mlme.dev_nonce, psdu);
+    /* Use the buffer for MHDR */
+    _build_join_req_pkt(appeui, deveui, appkey, mac->mlme.dev_nonce, (uint8_t*) mac->mcps.mhdr_mic);
 
     /* We need a random delay for join request. Otherwise there might be
      * network congestion if a group of nodes start at the same time */
-    xtimer_usleep(random_uint32() & GNRC_LORAWAN_JOIN_DELAY_U32_MASK);
-    gnrc_lorawan_send_pkt(mac, &pkt, dr);
+    gnrc_lorawan_set_timer(mac, random_uint32() & GNRC_LORAWAN_JOIN_DELAY_U32_MASK);
 
     mac->mlme.backoff_budget -= mac->toa;
 
@@ -156,7 +160,7 @@ out:
     gnrc_lorawan_mlme_confirm(mac, &mlme_confirm);
 }
 
-void gnrc_lorawan_mlme_backoff_expire(gnrc_lorawan_t *mac)
+void gnrc_lorawan_mlme_backoff_expire_cb(gnrc_lorawan_t *mac)
 {
     uint8_t counter = mac->mlme.backoff_state & 0x1F;
     uint8_t state = mac->mlme.backoff_state >> 5;
@@ -183,9 +187,6 @@ void gnrc_lorawan_mlme_backoff_expire(gnrc_lorawan_t *mac)
 
     counter--;
     mac->mlme.backoff_state = state << 5 | (counter & 0x1F);
-    xtimer_set_msg(&mac->mlme.backoff_timer,
-                   GNRC_LORAWAN_BACKOFF_WINDOW_TICK,
-                   &mac->mlme.backoff_msg, thread_getpid());
 }
 
 static void _mlme_set(gnrc_lorawan_t *mac, const mlme_request_t *mlme_request,

--- a/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
+++ b/sys/net/gnrc/link_layer/lorawan/include/gnrc_lorawan_internal.h
@@ -24,8 +24,6 @@
 #include "net/lora.h"
 #include "net/lorawan/hdr.h"
 #include "net/gnrc/pktbuf.h"
-#include "xtimer.h"
-#include "msg.h"
 #include "net/netdev.h"
 #include "net/netdev/layer.h"
 #include "net/loramac.h"
@@ -35,8 +33,6 @@ extern "C" {
 #endif
 
 #define MSG_TYPE_TIMEOUT             (0x3457)           /**< Timeout message type */
-#define MSG_TYPE_MCPS_ACK_TIMEOUT    (0x3458)           /**< ACK timeout message type */
-#define MSG_TYPE_MLME_BACKOFF_EXPIRE (0x3459)           /**< Backoff timer expiration message type */
 
 #define MTYPE_MASK           0xE0                       /**< MHDR mtype mask */
 #define MTYPE_JOIN_REQUEST   0x0                        /**< Join Request type */
@@ -61,6 +57,7 @@ extern "C" {
 #define LORAWAN_STATE_RX_1 (1)                          /**< MAC state machine in RX1 */
 #define LORAWAN_STATE_RX_2 (2)                          /**< MAC state machine in RX2 */
 #define LORAWAN_STATE_TX (3)                            /**< MAC state machine in TX */
+#define LORAWAN_STATE_JOIN (4)                          /**< MAC state machine in Join */
 
 #define GNRC_LORAWAN_DIR_UPLINK (0U)                    /**< uplink frame direction */
 #define GNRC_LORAWAN_DIR_DOWNLINK (1U)                  /**< downlink frame direction */
@@ -163,8 +160,6 @@ typedef struct {
  * @brief MLME service access point descriptor
  */
 typedef struct {
-    xtimer_t backoff_timer; /**< timer used for backoff expiration */
-    msg_t backoff_msg;      /**< msg for backoff expiration */
     uint8_t activation;     /**< Activation mechanism of the MAC layer */
     int pending_mlme_opts;  /**< holds pending mlme opts */
     uint32_t nid;           /**< current Network ID */
@@ -176,8 +171,6 @@ typedef struct {
 /**
  * @brief GNRC LoRaWAN mac descriptor */
 typedef struct {
-    xtimer_t rx;                                    /**< RX timer */
-    msg_t msg;                                      /**< MAC layer message descriptor */
     gnrc_lorawan_mcps_t mcps;                       /**< MCPS descriptor */
     gnrc_lorawan_mlme_t mlme;                       /**< MLME descriptor */
     void *mlme_buf;                                 /**< pointer to MLME buffer */
@@ -420,11 +413,12 @@ uint8_t gnrc_lorawan_region_mac_payload_max(uint8_t datarate);
 /**
  * @brief MLME Backoff expiration tick
  *
- *        Should be called every hour in order to maintain the Time On Air budget.
+ *        Must be called once an hour (right after calling @ref
+ *        gnrc_lorawan_init) in order to maintain the Time On Air budget.
  *
  * @param[in] mac pointer to the MAC descriptor
  */
-void gnrc_lorawan_mlme_backoff_expire(gnrc_lorawan_t *mac);
+void gnrc_lorawan_mlme_backoff_expire_cb(gnrc_lorawan_t *mac);
 
 /**
  * @brief Process and dispatch a full LoRaWAN packet
@@ -486,6 +480,13 @@ static inline void gnrc_lorawan_mac_release(gnrc_lorawan_t *mac)
  * @param[in] rx2_dr datarate of RX2
  */
 void gnrc_lorawan_set_rx2_dr(gnrc_lorawan_t *mac, uint8_t rx2_dr);
+
+/**
+ * @brief Trigger the transmission of the Join Request packet.
+ *
+ * @param[in] mac pointer to the MAC descriptor
+ */
+void gnrc_lorawan_trigger_join(gnrc_lorawan_t *mac);
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
+++ b/sys/net/gnrc/netif/lorawan/gnrc_netif_lorawan.c
@@ -32,11 +32,6 @@
 
 #define MSG_TYPE_MLME_BACKOFF_EXPIRE (0x3458)           /**< Backoff timer expiration message type */
 
-/* This factor is used for converting "real" seconds into microcontroller
- * microseconds. This is done in order to correct timer drift.
- */
-#define ADJUST_DRIFT(us) (int) (us * 100 / (100 + (CONFIG_GNRC_LORAWAN_TIMER_DRIFT / 10.0)))
-
 static uint8_t _nwkskey[LORAMAC_NWKSKEY_LEN];
 static uint8_t _appskey[LORAMAC_APPSKEY_LEN];
 static uint8_t _appkey[LORAMAC_APPKEY_LEN];
@@ -86,13 +81,13 @@ void gnrc_lorawan_mlme_confirm(gnrc_lorawan_t *mac, mlme_confirm_t *confirm)
 void gnrc_lorawan_set_timer(gnrc_lorawan_t *mac, uint32_t us)
 {
     gnrc_netif_lorawan_t *lw_netif = container_of(mac, gnrc_netif_lorawan_t, mac);
-    xtimer_set_msg(&lw_netif->timer, ADJUST_DRIFT(us), &timeout_msg, thread_getpid());
+    ztimer_set_msg(ZTIMER_MSEC, &lw_netif->timer, us/1000, &timeout_msg, thread_getpid());
 }
 
 void gnrc_lorawan_remove_timer(gnrc_lorawan_t *mac)
 {
     gnrc_netif_lorawan_t *lw_netif = container_of(mac, gnrc_netif_lorawan_t, mac);
-    xtimer_remove(&lw_netif->timer);
+    ztimer_remove(ZTIMER_MSEC, &lw_netif->timer);
 }
 
 static inline void _set_be_addr(gnrc_lorawan_t *mac, uint8_t *be_addr)
@@ -252,8 +247,8 @@ static void _init(gnrc_netif_t *netif)
     _set_be_addr(&netif->lorawan.mac, _devaddr);
     gnrc_lorawan_init(&netif->lorawan.mac, netif->lorawan.nwkskey, netif->lorawan.appskey);
 
-    xtimer_set_msg(&netif->lorawan.backoff_timer,
-                   GNRC_LORAWAN_BACKOFF_WINDOW_TICK,
+    ztimer_set_msg(ZTIMER_MSEC, &netif->lorawan.backoff_timer,
+                   GNRC_LORAWAN_BACKOFF_WINDOW_TICK / 1000,
                    &backoff_msg, thread_getpid());
 }
 
@@ -305,8 +300,8 @@ static void _msg_handler(gnrc_netif_t *netif, msg_t *msg)
             break;
         case MSG_TYPE_MLME_BACKOFF_EXPIRE:
             gnrc_lorawan_mlme_backoff_expire_cb(&netif->lorawan.mac);
-            xtimer_set_msg(&netif->lorawan.backoff_timer,
-                           GNRC_LORAWAN_BACKOFF_WINDOW_TICK,
+            ztimer_set_msg(ZTIMER_MSEC, &netif->lorawan.backoff_timer,
+                           GNRC_LORAWAN_BACKOFF_WINDOW_TICK / 1000,
                            &backoff_msg, thread_getpid());
         default:
             break;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds support for using RTT in GNRC LoRaWAN. This is required for the following reasons:
- Standard xtimer cannot go to very low power modes.
- For class B support precise timers are required.

The RTT support is provided vía `ztimer` (`ztimer_periph_rtt` backend).

EDIT: This add an explicit requirement to `periph_rtt`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Test with `examples/gnrc_lorawan`. Try to Join a LoRaWAN network and send/receive data. It should work with all possible DR.
E.g
```
 ifconfig 4 set deveui aaaaaaaaaaaaaaaa
 ifconfig 4 set deveui bbbbbbbbbbbbbbbb
ifconfig 4 set appkey cccccccccccccccccccccccccccccccc

/* Set highest DR */
ifconfig 4 set dr 5

ifconfig 4 up

/* Wait approx 7 seconds and interface should e up*/
ifconfig
2020-07-20 13:36:18,496 # Iface  4  HWaddr: 01:19:86:07  Frequency: 868299987Hz  BW: 125kHz  SF: 7  CR: 4/5  Link: up 
2020-07-20 13:36:18,503 #            TX-Power: 14dBm  State: SLEEP  Demod margin.: 0  Num gateways.: 0 
2020-07-20 13:36:18,507 #           IQ_INVERT 
2020-07-20 13:36:18,509 #           RX_SINGLE OTAA L2-PDU:255 

/* Send a confirmable message (default) and retrieve payload from network sever (remember tha App port is 2!) */

2020-07-20 13:37:14,644 #  send 4 holi
2020-07-20 13:37:14,646 # Done!
> 2020-07-20 13:37:15,798 #  PKTDUMP: data received:
2020-07-20 13:37:15,803 # ~~ SNIP  0 - size:   7 byte, type: NETTYPE_LORAWAN (1)
2020-07-20 13:37:15,806 # 00000000  48  4F  4C  49  49  49  0A
2020-07-20 13:37:15,810 # ~~ PKT    -  1 snips, total size:   7 byte
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->



### Issues/PRs references
Depends on #14065 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
