### PR TITLE
core/sched: tiny logic optimization in idle case

### DIFF
--- a/core/sched.c
+++ b/core/sched.c
@@ -109,9 +109,9 @@ int __attribute__((used)) sched_run(void)
                 active_thread = NULL;
             }
 
-            while (!runqueue_bitcache) {
+            do {
                 sched_arch_idle();
-            }
+            } while (!runqueue_bitcache);
         }
     }
 


### PR DESCRIPTION
### Contribution description

In the case that the no_thread_idle feature is active, the
runqueue_bitcache is checked twice in the case no thread is available to
schedule. This changes the inner while loop to a do-while loop to save
one check from the initial loop iteration, saving a cycle or so in the
idle case.

### Testing procedure

- Check the logic in the code
- The benchmark utility in `tests/periph_spi_bench should show a tiny decrease in the `user time` column

### Issues/PRs references

None