### PR TITLE
cpu/mips_pic32_common: GPIO: use bitarithm_test_and_clear()

### DIFF
--- a/cpu/mips32r2_common/include/cpu.h
+++ b/cpu/mips32r2_common/include/cpu.h
@@ -33,6 +33,14 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Select fastest bitarithm_lsb implementation
+ * @{
+ */
+#define BITARITHM_LSB_BUILTIN
+#define BITARITHM_HAS_CLZ
+/** @} */
+
+/**
  * @brief   Print the last instruction's address
  *
  * @todo:   Not supported


### PR DESCRIPTION
### Contribution description

If no `clz` instruction is available in hardware, the operation will be implemented in software by a series of shifts.
When iterating over all bits in a word, this is sub-optimal as in will create O(n²) shift operations instead of O(n).

Instead of implementing the logic in the platform driver, use a common helper function to simplify the code.

In the case where `clz` is available, the generated code should not differ from the one in `master`.

### Testing procedure

GPIO interrupts should still work

To verify, connect two GPIOs and run the `auto_test` command (from `tests/periph_gpio`) on them.

### Issues/PRs references

depends on #14556
