### PR TITLE
cpu/lpc23xx: GPIO: use bitarithm_test_and_clear()

### DIFF
--- a/cpu/lpc23xx/periph/gpio.c
+++ b/cpu/lpc23xx/periph/gpio.c
@@ -26,6 +26,7 @@
 
 #include "irq.h"
 #include "periph/gpio.h"
+#include "bitarithm.h"
 #include "bitfield.h"
 
 #define ENABLE_DEBUG (0)
@@ -273,9 +274,10 @@ static void test_irq(int port, unsigned long active_pins)
     /* Test each bit of rising and falling masks, if set trigger interrupt
      * on corresponding device */
 
+    uint8_t pin = 0;
     while (active_pins) {
-        /* we want the position of the first one bit, so N_bits - (N_leading_zeros + 1) */
-        unsigned pin = 32 - __builtin_clz(active_pins) - 1;
+        /* get the index of the next set pin */
+        active_pins = bitarithm_test_and_clear(active_pins, &pin);
 
         /* get the index of the configured interrupt */
         int _state_index = _gpio_isr_map[_isr_map_entry2(port, pin)];
@@ -284,9 +286,6 @@ static void test_irq(int port, unsigned long active_pins)
         if (_state_index != 0xff) {
             _gpio_states[_state_index].cb(_gpio_states[_state_index].arg);
         }
-
-        /* clear bit */
-        active_pins &= ~(1 << pin);
     }
 }
 


### PR DESCRIPTION
### Contribution description

If no `clz` instruction is available in hardware, the operation will be implemented in software by a series of shifts.
When iterating over all bits in a word, this is sub-optimal as in will create O(n²) shift operations instead of O(n).

Instead of implementing the logic in the platform driver, use a common helper function to simplify the code.

In the case where `clz` is available, the generated code should not differ from the one in `master`.

### Testing procedure

GPIO interrupts should stil work

### Issues/PRs references

depends on #14556
