### PR TITLE
cpu/cc2538: GPIO: use bitarithm_test_and_clear()

### DIFF
--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 #include "cpu.h"
+#include "bitarithm.h"
 #include "periph/gpio.h"
 
 #define ENABLE_DEBUG (0)
@@ -222,10 +223,9 @@ static inline void handle_isr(uint8_t port_num)
 
     /* mask all non-GPIO bits */
     state &= (1 << GPIO_BITS_PER_PORT) - 1;
+    uint8_t pin = 0;
     while (state) {
-        /* we want the position of the first one bit, so N_bits - (N_zeros + 1) */
-        int pin = 32 - __builtin_clz(state) - 1;
-        state &= ~(1 << pin);
+        state = bitarithm_test_and_clear(state, &pin);
         isr_ctx[port_num][pin].cb(isr_ctx[port_num][pin].arg);
     }
 


### PR DESCRIPTION
### Contribution description

If no `clz` instruction is available in hardware, the operation will be implemented in software by a series of shifts.
When iterating over all bits in a word, this is sub-optimal as in will create O(n²) shift operations instead of O(n).

Instead of implementing the logic in the platform driver, use a common helper function to simplify the code.

In the case where `clz` is available, the generated code should not differ from the one in `master`.

### Testing procedure

GPIO interrupts should stil work

### Issues/PRs references

depends on #14556
