### PR TITLE
cpu/sam0_common: GPIO: use bitarithm_test_and_clear()

### DIFF
--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -25,6 +25,7 @@
  */
 
 #include "cpu.h"
+#include "bitarithm.h"
 #include "periph/gpio.h"
 #include "periph_conf.h"
 
@@ -345,9 +346,9 @@ void isr_eic(void)
     _EIC->INTFLAG.reg = state;
 
     /* execute interrupt callbacks */
+    uint8_t pin = 0;
     while (state) {
-        unsigned pin = 8 * sizeof(state) - __builtin_clz(state) - 1;
-        state &= ~(1 << pin);
+        state = bitarithm_test_and_clear(state, &pin);
         gpio_config[pin].cb(gpio_config[pin].arg);
     }
 


### PR DESCRIPTION
### Contribution description

If no `clz` instruction is available in hardware, the operation will be implemented in software by a series of shifts.
When iterating over all bits in a word, this is sub-optimal as in will create O(n²) shift operations instead of O(n).

Instead of implementing the logic in the platform driver, use a common helper function to simplify the code.

In the case where `clz` is available, the generated code should not differ from the one in `master`.

### Testing procedure

GPIO interrupts should still work

### Issues/PRs references

depends on #14556
