### PR TITLE
sched: Prevent retriggering the scheduler interrupt during idle sleep

### DIFF
--- a/core/sched.c
+++ b/core/sched.c
@@ -99,7 +99,6 @@ static void _unschedule(thread_t *active_thread)
 
 int __attribute__((used)) sched_run(void)
 {
-    sched_context_switch_request = 0;
     thread_t *active_thread = (thread_t *)sched_active_thread;
 
     if (!IS_USED(MODULE_CORE_IDLE_THREAD)) {
@@ -114,6 +113,8 @@ int __attribute__((used)) sched_run(void)
             }
         }
     }
+
+    sched_context_switch_request = 0;
 
     int nextrq = bitarithm_lsb(runqueue_bitcache);
     thread_t *next_thread = container_of(sched_runqueues[nextrq].next->next,

--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -474,4 +474,5 @@ void sched_arch_idle(void)
 #endif
     irq_restore(state);
     NVIC_SetPriority(PendSV_IRQn, CPU_CORTEXM_PENDSV_IRQ_PRIO);
+    SCB->ICSR = SCB_ICSR_PENDSVCLR_Msk;
 }


### PR DESCRIPTION
### Contribution description

1. The PendSV interrupt is used to request a scheduling operation. An
interrupt during the idle sleep can re-request the PendSV interrupt,
while the PendSV is still busy scheduling the next thread. This clears
the request after sleep to prevent triggering an extra PendSV interrupt
after the current PendSV handler finished

2. An interrupt serviced during the idle sleep can re-request a context
switch while the scheduler is already going to switch contexts after the
idle sleep. Thi sched_context_switch_request should thus be cleared
after the idle sleep and not before where it could be modified during
the idle sleep and get out of sync.

### Testing procedure

I'm not really sure how to test this. These are both edge cases which can re-trigger the scheduler (which should be harmless) directly after a `sched_run()`.

### Issues/PRs references

None