### PR TITLE
tests/periph_gpio: allow specifying port under test

### DIFF
--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -7,7 +7,22 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += benchmark
 
+BOARDS_BENCH_PORT_1 = \
+    slstk3402a \
+    #
+
+# port 0 pins are used for serial output on these boards, e.g.: on slstk3402a
+# PA5 (or port 0, pin 5) is used to control the BC enabling serial output,
+# therefore test on port 1.
+ifneq (,$(filter $(BOARD),$(BOARDS_BENCH_PORT_1)))
+  PORT_UNDER_TEST ?= 1
+else
+  PORT_UNDER_TEST ?= 0
+endif
+
 include $(RIOTBASE)/Makefile.include
+
+$(call target-export-variables,test,PORT_UNDER_TEST)
 
 bench:
 	tests/02-bench.py

--- a/tests/periph_gpio/tests/02-bench.py
+++ b/tests/periph_gpio/tests/02-bench.py
@@ -7,16 +7,19 @@
 # directory for more details.
 
 import sys
+import os
 from testrunner import run
 
 
 # On slow platforms, like AVR, this test can take some time to complete.
 TIMEOUT = 30
+# Allow setting a specific port to test
+PORT_UNDER_TEST = int(os.environ.get('PORT_UNDER_TEST') or 0)
 
 
 def testfunc(child):
     for pin in range(0, 8):
-        child.sendline("bench 0 {}".format(pin))
+        child.sendline("bench {} {}".format(PORT_UNDER_TEST, pin))
         child.expect(r" *nop loop: +(\d+)us  --- +(\d+\.\d+)us per call  --- +(\d+) calls per sec")
         child.expect(r" *gpio_set: +(\d+)us  --- +(\d+\.\d+)us per call  --- +(\d+) calls per sec")
         child.expect(r" *gpio_clear: +(\d+)us  --- +(\d+\.\d+)us per call  --- +(\d+) calls per sec")


### PR DESCRIPTION
### Contribution description

By default `tests/periph_gpio` runs the benchmark on port 0. For `slstk3402a` this makes the test fail since `PA5` control serial output so when `bench 0 5` is run the test fails. This PR allows changing the default port to test.

```
/**
 * @name    Board controller configuration
 *
 * Define the GPIO pin to enable the BC, to allow serial communication
 * via the USB port.
 * @{
 */
#define BC_PIN              GPIO_PIN(PA, 5)
/** @} */

```

Failure in master on bench 0 5

```
2020-07-21 12:50:55,724 # bench 0 5
2020-07-21 12:50:55,724 #
2020-07-21 12:50:55,725 # GPIO driver run-time performance benchmark
2020-07-21 12:50:55,725 #
2020-07-21 12:50:55,908 #                  nop loop:    175002us  ---   0.175us per call  ---    5714220 calls per sec
2020-07-21 12:50:56,465 #                  gpio_set:    550002us  ---   0.550us per call  ---    1818175 calls per sec
2020-07-21 12:50:58,875 # �    1818175 calls p  :���}ɕ���   675               gpio_write:    650002us  ---   0.650us per call  ---    1538456 calls per sec
2020-07-21 12:50:58,876 #
2020-07-21 12:50:58,876 #  --- DONE ---
```

### Testing procedure

With this PR the following tests passes:

`BOARD=slstk3402a make -C tests/periph_gpio/ flash test`

```
 --- DONE ---
> bench 1 7
 bench 1 7

GPIO driver run-time performance benchmark

                 nop loop:    175002us  ---   0.175us per call  ---    5714220 calls per sec
                 gpio_set:    550002us  ---   0.550us per call  ---    1818175 calls per sec
               gpio_clear:    550003us  ---   0.550us per call  ---    1818171 calls per sec
              gpio_toggle:    500002us  ---   0.500us per call  ---    1999992 calls per sec
                gpio_read:    675002us  ---   0.675us per call  ---    1481477 calls per sec
               gpio_write:    650002us  ---   0.650us per call  ---    1538456 calls per sec

 --- DONE ---
> Benchmark was successful

```

### Issues/PRs references

Found while testing https://github.com/RIOT-OS/Release-Specs/issues/172
