### PR TITLE
net/l2filter : Expose configurations to Kconfig

### DIFF
--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -281,11 +281,11 @@ typedef void (*netdev_event_cb_t)(netdev_t *dev, netdev_event_t event);
  * be used by upper layers to store reference information.
  */
 struct netdev {
-    const struct netdev_driver *driver;     /**< ptr to that driver's interface. */
-    netdev_event_cb_t event_callback;       /**< callback for device events */
-    void *context;                          /**< ptr to network stack context */
+    const struct netdev_driver *driver;            /**< ptr to that driver's interface. */
+    netdev_event_cb_t event_callback;              /**< callback for device events */
+    void *context;                                 /**< ptr to network stack context */
 #ifdef MODULE_NETDEV_LAYER
-    netdev_t *lower;                        /**< ptr to the lower netdev layer */
+    netdev_t *lower;                               /**< ptr to the lower netdev layer */
 #endif
 #ifdef MODULE_L2FILTER
     l2filter_t filter[CONFIG_L2FILTER_LISTSIZE];   /**< link layer address filters */

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -288,7 +288,7 @@ struct netdev {
     netdev_t *lower;                        /**< ptr to the lower netdev layer */
 #endif
 #ifdef MODULE_L2FILTER
-    l2filter_t filter[L2FILTER_LISTSIZE];   /**< link layer address filters */
+    l2filter_t filter[CONFIG_L2FILTER_LISTSIZE];   /**< link layer address filters */
 #endif
 };
 

--- a/sys/include/net/l2filter.h
+++ b/sys/include/net/l2filter.h
@@ -50,8 +50,8 @@ extern "C" {
 /**
  * @brief   Number of slots in each filter list (filter entries per device)
  */
-#ifndef L2FILTER_LISTSIZE
-#define L2FILTER_LISTSIZE               (8U)
+#ifndef CONFIG_L2FILTER_LISTSIZE
+#define CONFIG_L2FILTER_LISTSIZE               (8U)
 #endif
 
 /**

--- a/sys/include/net/l2filter.h
+++ b/sys/include/net/l2filter.h
@@ -43,8 +43,8 @@ extern "C" {
 /**
  * @brief   Maximal length of addresses that can be stored in the filter list
  */
-#ifndef L2FILTER_ADDR_MAXLEN
-#define L2FILTER_ADDR_MAXLEN            (8U)
+#ifndef CONFIG_L2FILTER_ADDR_MAXLEN
+#define CONFIG_L2FILTER_ADDR_MAXLEN            (8U)
 #endif
 
 /**
@@ -62,7 +62,7 @@ extern "C" {
  * addresses at the same time.
  */
 typedef struct {
-    uint8_t addr[L2FILTER_ADDR_MAXLEN];     /**< link layer address */
+    uint8_t addr[CONFIG_L2FILTER_ADDR_MAXLEN];     /**< link layer address */
     size_t addr_len;                        /**< address length in byte */
 } l2filter_t;
 
@@ -75,7 +75,7 @@ typedef struct {
  *
  * @pre     @p list != NULL
  * @pre     @p addr != NULL
- * @pre     @p addr_maxlen <= @ref L2FILTER_ADDR_MAXLEN
+ * @pre     @p addr_maxlen <= @ref CONFIG_L2FILTER_ADDR_MAXLEN
  *
  * @return  0 on success
  * @return  -ENOMEM if no empty slot left in list
@@ -91,7 +91,7 @@ int l2filter_add(l2filter_t *list, const void *addr, size_t addr_len);
  *
  * @pre     @p list != NULL
  * @pre     @p addr != NULL
- * @pre     @p addr_maxlen <= @ref L2FILTER_ADDR_MAXLEN
+ * @pre     @p addr_maxlen <= @ref CONFIG_L2FILTER_ADDR_MAXLEN
  *
  * @return  0 on success
  * @return  -ENOENT if @p addr was not found in @p list
@@ -112,7 +112,7 @@ int l2filter_rm(l2filter_t *list, const void *addr, size_t addr_len);
  *
  * @pre     @p list != NULL
  * @pre     @p addr != NULL
- * @pre     @p addr_maxlen <= @ref L2FILTER_ADDR_MAXLEN
+ * @pre     @p addr_maxlen <= @ref CONFIG_L2FILTER_ADDR_MAXLEN
  *
  * @return  in whitelist mode: true if @p addr is in @p list
  * @return  in whitelist mode: false if @p addr is not in @p list

--- a/sys/include/net/l2filter.h
+++ b/sys/include/net/l2filter.h
@@ -41,6 +41,11 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup net_l2filter_conf Link layer address filter compile configurations
+ * @ingroup config
+ * @{
+ */
+/**
  * @brief   Maximal length of addresses that can be stored in the filter list
  */
 #ifndef CONFIG_L2FILTER_ADDR_MAXLEN
@@ -53,6 +58,7 @@ extern "C" {
 #ifndef CONFIG_L2FILTER_LISTSIZE
 #define CONFIG_L2FILTER_LISTSIZE               (8U)
 #endif
+/** @} */
 
 /**
  * @brief   Filter list entries
@@ -63,7 +69,7 @@ extern "C" {
  */
 typedef struct {
     uint8_t addr[CONFIG_L2FILTER_ADDR_MAXLEN];     /**< link layer address */
-    size_t addr_len;                        /**< address length in byte */
+    size_t addr_len;                               /**< address length in byte */
 } l2filter_t;
 
 /**

--- a/sys/net/link_layer/Kconfig
+++ b/sys/net/link_layer/Kconfig
@@ -6,3 +6,4 @@
 
 rsource "csma_sender/Kconfig"
 rsource "ieee802154/Kconfig"
+rsource "l2filter/Kconfig"

--- a/sys/net/link_layer/l2filter/Kconfig
+++ b/sys/net/link_layer/l2filter/Kconfig
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_L2FILTER
+    bool "Configure L2filter"
+    depends on MODULE_L2FILTER
+    help
+        Configure L2filter using Kconfig. This module is used for filtering
+        (allowlisting or denylisting) link layer addresses.
+
+if KCONFIG_MODULE_L2FILTER
+
+config L2FILTER_ADDR_MAXLEN
+    int "Maximum length of addresses that can be stored in the filter list"
+    default 8
+
+config L2FILTER_LISTSIZE
+    int "Number of slots in each filter list (filter entries per device)"
+    default 8
+
+endif # KCONFIG_MODULE_L2FILTER

--- a/sys/net/link_layer/l2filter/l2filter.c
+++ b/sys/net/link_layer/l2filter/l2filter.c
@@ -37,7 +37,7 @@ void l2filter_init(l2filter_t *list)
 {
     assert(list);
 
-    for (unsigned i = 0; i < L2FILTER_LISTSIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_L2FILTER_LISTSIZE; i++) {
         list[i].addr_len = 0;
     }
 }
@@ -48,7 +48,7 @@ int l2filter_add(l2filter_t *list, const void *addr, size_t addr_len)
 
     int res = -ENOMEM;
 
-    for (unsigned i = 0; i < L2FILTER_LISTSIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_L2FILTER_LISTSIZE; i++) {
         if (list[i].addr_len == 0) {
             list[i].addr_len = addr_len;
             memcpy(list[i].addr, addr, addr_len);
@@ -66,7 +66,7 @@ int l2filter_rm(l2filter_t *list, const void *addr, size_t addr_len)
 
     int res = -ENOENT;
 
-    for (unsigned i = 0; i < L2FILTER_LISTSIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_L2FILTER_LISTSIZE; i++) {
         if (match(&list[i], addr, addr_len)) {
             list[i].addr_len = 0;
             res = 0;
@@ -83,7 +83,7 @@ bool l2filter_pass(const l2filter_t *list, const void *addr, size_t addr_len)
 
 #ifdef MODULE_L2FILTER_WHITELIST
     bool res = false;
-    for (unsigned i = 0; i < L2FILTER_LISTSIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_L2FILTER_LISTSIZE; i++) {
         if (match(&list[i], addr, addr_len)) {
             DEBUG("[l2filter] whitelist: address match -> packet passes\n");
             res = true;
@@ -93,7 +93,7 @@ bool l2filter_pass(const l2filter_t *list, const void *addr, size_t addr_len)
     DEBUG("[l2filter] whitelist: no match -> packet dropped\n");
 #else
     bool res = true;
-    for (unsigned i = 0; i < L2FILTER_LISTSIZE; i++) {
+    for (unsigned i = 0; i < CONFIG_L2FILTER_LISTSIZE; i++) {
         if (match(&list[i], addr, addr_len)) {
             DEBUG("[l2filter] blacklist: address match -> packet dropped\n");
             res = false;

--- a/sys/net/link_layer/l2filter/l2filter.c
+++ b/sys/net/link_layer/l2filter/l2filter.c
@@ -44,7 +44,7 @@ void l2filter_init(l2filter_t *list)
 
 int l2filter_add(l2filter_t *list, const void *addr, size_t addr_len)
 {
-    assert(list && addr && (addr_len <= L2FILTER_ADDR_MAXLEN));
+    assert(list && addr && (addr_len <= CONFIG_L2FILTER_ADDR_MAXLEN));
 
     int res = -ENOMEM;
 
@@ -62,7 +62,7 @@ int l2filter_add(l2filter_t *list, const void *addr, size_t addr_len)
 
 int l2filter_rm(l2filter_t *list, const void *addr, size_t addr_len)
 {
-    assert(list && addr && (addr_len <= L2FILTER_ADDR_MAXLEN));
+    assert(list && addr && (addr_len <= CONFIG_L2FILTER_ADDR_MAXLEN));
 
     int res = -ENOENT;
 
@@ -79,7 +79,7 @@ int l2filter_rm(l2filter_t *list, const void *addr, size_t addr_len)
 
 bool l2filter_pass(const l2filter_t *list, const void *addr, size_t addr_len)
 {
-    assert(list && addr && (addr_len <= L2FILTER_ADDR_MAXLEN));
+    assert(list && addr && (addr_len <= CONFIG_L2FILTER_ADDR_MAXLEN));
 
 #ifdef MODULE_L2FILTER_WHITELIST
     bool res = false;

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -1242,7 +1242,7 @@ static int _netif_addrm_l2filter(netif_t *iface, char *val, bool add)
     uint8_t addr[GNRC_NETIF_L2ADDR_MAXLEN];
     size_t addr_len = gnrc_netif_addr_from_str(val, addr);
 
-    if ((addr_len == 0) || (addr_len > L2FILTER_ADDR_MAXLEN)) {
+    if ((addr_len == 0) || (addr_len > CONFIG_L2FILTER_ADDR_MAXLEN)) {
         puts("error: given address is invalid");
         return 1;
     }

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -784,7 +784,7 @@ static void _netif_list(netif_t *iface)
         puts("\n           Black-listed link layer addresses:");
 #endif
         int count = 0;
-        for (unsigned i = 0; i < L2FILTER_LISTSIZE; i++) {
+        for (unsigned i = 0; i < CONFIG_L2FILTER_LISTSIZE; i++) {
             if (filter[i].addr_len > 0) {
                 char hwaddr_str[filter[i].addr_len * 3];
                 gnrc_netif_addr_to_str(filter[i].addr, filter[i].addr_len,


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in **net/l2filter** to Kconfig.

### Testing procedure

1. New documentation was built using Doxygen 

   The build works fine.

  2. Test files were added to tests/net_l2filter/

      The test file can be found [here](https://github.com/akshaim/RIOT/commit/96fa2044262d5f593140e22223a44255146701c7)

      Compiled binaries for native

#### Default State:

##### Firmware Output

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-293-g96fa2-Kconfig_l2filter_tests)
CONFIG_L2FILTER_ADDR_MAXLEN=(8U)
CONFIG_L2FILTER_LISTSIZE=(8U)
```
#### Usage with CFLAGS :
```
CFLAGS += -DCONFIG_L2FILTER_ADDR_MAXLEN=6
CFLAGS += -DCONFIG_L2FILTER_LISTSIZE=6
```

##### Firmware Output

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-293-g96fa2-Kconfig_l2filter_tests)
CONFIG_L2FILTER_ADDR_MAXLEN=6
CONFIG_L2FILTER_LISTSIZE=6
```

#### Usage with menuconfig :


`make menuconfig`

#### Default values

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-293-g96fa2-Kconfig_l2filter_tests)
CONFIG_L2FILTER_ADDR_MAXLEN=8
CONFIG_L2FILTER_LISTSIZE=8
```
##### Macros Configured output

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-293-g96fa2-Kconfig_l2filter_tests)
CONFIG_L2FILTER_ADDR_MAXLEN=10
CONFIG_L2FILTER_LISTSIZE=10
```

**MACROS were successfully configured.**

### Issues/PRs references

#12888 