### PR TITLE
tests/trickle: add message queue

### DIFF
--- a/tests/trickle/main.c
+++ b/tests/trickle/main.c
@@ -31,6 +31,9 @@
 #define FIRST_ROUND     (5)
 #define SECOND_ROUND    (12)
 
+#define MAIN_QUEUE_SIZE     (2)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
 static uint32_t old_t = 0;
 static bool error = false;
 
@@ -62,6 +65,8 @@ int main(void)
 {
     msg_t msg;
     unsigned counter = 0;
+
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
 
     trickle_start(sched_active_pid, &trickle, TRICKLE_MSG, TR_IMIN,
                   TR_IDOUBLINGS, TR_REDCONST);


### PR DESCRIPTION
### Contribution description

While testing https://github.com/RIOT-OS/Release-Specs/issues/172 `tests/trickle` was failing on `arduino-uno` and `arduino-mega2560`. It fails because the next message used for intervals is sent before the main thread is expecting it so it gets dropped.

This PR adds a message queue to avoid this.

### Testing procedure

On any of the for mentioned boards:

`BUILD_IN_DOCKER=1 BOARD=arduino-mega2560 make -C tests/trickle/ flash test`

```
main(): This is RIOT! (Version: 2020.10-devel-278-g194d31-pr_tests_trickle_msg_queue)
[START]
now = 1056832, t = 21
now = 1113928, t = 31
now = 1219004, t = 63
now = 1392076, t = 111
now = 1808192, t = 297
[TRICKLE_RESET]
now = 1846724, t = 12
now = 1892820, t = 19
now = 1969892, t = 43
now = 2108964, t = 97
now = 2303036, t = 142
now = 2747148, t = 308
now = 3648260, t = 675
[SUCCESS]
```

- On master this fails after trickle_reset where the next interval is 16 (log with debug enabled)

```
main(): This is RIOT! (Version: 2020.10-devel-277-ge8a8d-HEAD)
trickle: I == 26, diff == 0
[START]
now = 1019892, t = 21
trickle: I == 52, diff == 5
now = 1106084, t = 31
trickle: I == 104, diff == 21
now = 1242340, t = 63
trickle: I == 208, diff == 41
now = 1446592, t = 111
trickle: I == 416, diff == 97
now = 1893892, t = 297
trickle: I == 832, diff == 119
trickle: I == 16, diff == 0
[TRICKLE_RESET]
Timeout in expect script at "child.expect(u"now = \\d+, t = \\d+")" (tests/trickle/tests/01-run.py:22)
```