### PR TITLE
drivers/rtt: override RTT_MAX_VALUE and RTT_FREQUENCY for mock

### DIFF
--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -79,21 +79,23 @@ extern "C" {
 #define RTT_MIN_OFFSET (2U)
 #endif
 
-#ifndef RTT_FREQUENCY
 /* Allow mock-RTT for unit tests */
 #ifdef MOCK_RTT_FREQUENCY
+#undef RTT_FREQUENCY
 #define RTT_FREQUENCY MOCK_RTT_FREQUENCY
 #else
+#ifndef RTT_FREQUENCY
 #warning "RTT_FREQUENCY undefined. Set RTT_FREQUENCY to the number of ticks " \
          "per second for the current architecture."
 #endif
 #endif
 
-#ifndef RTT_MAX_VALUE
 /* Allow mock-RTT for unit tests */
 #ifdef MOCK_RTT_MAX_VALUE
+#undef RTT_MAX_VALUE
 #define RTT_MAX_VALUE MOCK_RTT_MAX_VALUE
 #else
+#ifndef RTT_MAX_VALUE
 #warning "RTT_MAX_VALUE is undefined. Set RTT_MAX_VALUE to the maximum value " \
          "for the RTT counter, ensure it is (2^n - 1)."
 #endif


### PR DESCRIPTION
### Contribution description

While testing https://github.com/RIOT-OS/Release-Specs/issues/172 I realized `tests/unittests` was failing on some boards. It was actually a timeout and failure on `tests/unittests/tests-rtt_rtc/tests-rtt_rtc.c`.

mock_rtt relies on setting mock values for RTT_MAX_VALUE and
RTT_FREQUENCY. Platforms with an rtt will already define this
values which leads to mock_rtt working with different values than
rtt_rtc.

This commit changes the ifdef logic so that when using mock_rtt
RTT_MAX_VALUE and RTT_FREQUENCY are redefined.

If debug is enabled for `mock_rtt` one can immediately see that something is off.

```
2020-07-21 15:31:10,059 # START
2020-07-21 15:31:10,062 # rtt_set_alarm(4294956512)
2020-07-21 15:31:10,064 # .rtt_get_counter() = 10
2020-07-21 15:31:10,066 # rtt_set_alarm(4294934538)
2020-07-21 15:31:10,068 # rtt_get_counter() = 10
2020-07-21 15:31:11,883 # rtt_get_counter() = 1966090
```

### Testing procedure

I think this should be reproducible on any platform providing `periph_rtt`, but at least `openmote-b`, `samr21-xpro`, `nucleo-f767zi`.

`BOARD=openmote-b make -C tests/unittests tests-rtt_rtc flash test`

```
READY
s
START
....
OK (4 tests)
```

`BOARD=openmote-b make -C tests/unittests flash est`

```
START
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
OK (1001 tests)
```

### Issues/PRs references

https://github.com/RIOT-OS/Release-Specs/issues/172
