### PR TITLE
tests/pthread_flood: cleanup test

### DIFF
--- a/tests/pthread_flood/tests/01-run.py
+++ b/tests/pthread_flood/tests/01-run.py
@@ -5,10 +5,13 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect_exact(u'[START] Spawning threads')
-    child.expect(r'\.+')
-    child.expect("[SUCCESS]")
-    child.expect("test end")
+    child.expect_exact("Spawning pthreads")
+    child.expect(r"created (\d+) pthreads")
+    pthread_num = int(child.match.group(1))
+    child.expect(r"created (\d+) threads")
+    thread_num = int(child.match.group(1))
+    assert thread_num == pthread_num
+    child.expect_exact("SUCCESS")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

### Contribution description

While testing https://github.com/RIOT-OS/Release-Specs/issues/172 `tests/pthread_flood/` did not pass on `i-nucleo-lrwan1`. It was because when creating the first thread no stacksize or stackadr is specified so the thread is created on the heap, and on this platform its creation failed. This led `pthread_join` getting stuck.

I also cleaned up the code a bit.

- Cleans up pthread initialization, checks for ret code !=0,
  instead of -1. For some platforms the first thread was not
  started and therefore `pthread_join` could not succeed.
- Always specify stackaddr and stacksize to not use malloc
- Formatting and uncrustify


### Testing procedure

`BUILD_IN_DOCKER=1 RYOT_CI=1 BOARD=i-nucleo-lrwan1 make -C tests/pthread_flood/ flash test`

- master:

```
main(): This is RIOT! (Version: 2020.10-devel-274-g0357b-pr-14386)
[START] Spawning threads
......
[SUCCESS]
created 6 pthreads
created 6 threads
Timeout in expect script at "child.expect("test end")" (tests/pthread_flood/tests/01-run.py:11)
````

- pr

```
main(): This is RIOT! (Version: 2020.10-devel-278-g393d4fb-pr_fix_test_pthread_flood)
Spawning pthreads
......
created 6 pthreads
created 6 threads
wait for created pthreads to exit...
SUCCESS
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
