### PR TITLE
net/gnrc/mac/types.h : Update configurations

### DIFF
--- a/sys/include/net/gnrc/mac/types.h
+++ b/sys/include/net/gnrc/mac/types.h
@@ -43,9 +43,7 @@ extern "C" {
 /**
  * @brief   MAC message type for getting radio's duty-cycle.
  */
-#ifndef GNRC_MAC_TYPE_GET_DUTYCYCLE
 #define GNRC_MAC_TYPE_GET_DUTYCYCLE      (0x4401)
-#endif
 
 /**
  * @brief definition for device transmission feedback types


### PR DESCRIPTION
### Contribution description

This PR removes #ifndef guards for 'GNRC_MAC_TYPE_GET_DUTYCYCLE', an IPC message type.

### Testing procedure

  1. Test files in  tests/gnrc_lwmac were successfully build

### Issues/PRs references

Based on suggestion[ here](https://github.com/RIOT-OS/RIOT/pull/14138#issuecomment-633663766)
#14138 