### PR TITLE
uncrustify-riot.cfg: Don't indent switch cases

### DIFF
--- a/core/thread_flags.c
+++ b/core/thread_flags.c
@@ -32,15 +32,15 @@ static inline int __attribute__((always_inline)) _thread_flags_wake(thread_t *th
     thread_flags_t mask = (uint16_t)(unsigned)thread->wait_data;
 
     switch (thread->status) {
-        case STATUS_FLAG_BLOCKED_ANY:
-            wakeup = (thread->flags & mask);
-            break;
-        case STATUS_FLAG_BLOCKED_ALL:
-            wakeup = ((thread->flags & mask) == mask);
-            break;
-        default:
-            wakeup = 0;
-            break;
+    case STATUS_FLAG_BLOCKED_ANY:
+        wakeup = (thread->flags & mask);
+        break;
+    case STATUS_FLAG_BLOCKED_ALL:
+        wakeup = ((thread->flags & mask) == mask);
+        break;
+    default:
+        wakeup = 0;
+        break;
     }
 
     if (wakeup) {

--- a/uncrustify-riot.cfg
+++ b/uncrustify-riot.cfg
@@ -7,7 +7,7 @@ input_tab_size          = 4                 # original tab size
 output_tab_size         = 4                 # new tab size
 indent_columns          = output_tab_size   #
 indent_label            = 1                 # pos: absolute col, neg: relative column
-indent_switch_case      = 4                 # number
+indent_switch_case      = 0                 # number
 indent_ternary_operator = 2                 # When the `:` is a continuation, indent it under `?`
 
 #


### PR DESCRIPTION
### Contribution description

`uncrustify` currently enforces that cases in a switch statement are indented, but the should be on the same level as the switch statement according to the coding convention. This PR fixes this.

### Testing procedure

Paste the following into a shell (after applying the usual common sense when pasting random stuff from browsers into terminals):

<details><summary>Test input</summary>

```sh
cat << EOF | uncrustify -c uncrustify-riot.cfg
#include <stddef.h>

size_t foo(char suffix)
{
    size_t mem = 1;
    switch (suffix) {
    case 'G':
    case 'g':
        mem <<= 30;
        break;
    case 'M':
    case 'm':
        mem <<= 20;
        break;
    case 'K':
    case 'k':
        mem <<= 10;
        fallthrough;
    default:
        break;
    }

    return mem;
}
EOF
```

</details>

<details><summary>Output on master</summary>

```C
#include <stddef.h>

size_t foo(char suffix)
{
    size_t mem = 1;

    switch (suffix) {
        case 'G':
        case 'g':
            mem <<= 30;
            break;
        case 'M':
        case 'm':
            mem <<= 20;
            break;
        case 'K':
        case 'k':
            mem <<= 10;
            fallthrough;
        default:
            break;
    }

    return mem;
}
```

</details>

<details><summary>Correct output (should be shown with this PR)</summary>

```C
#include <stddef.h>

size_t foo(char suffix)
{
    size_t mem = 1;

    switch (suffix) {
    case 'G':
    case 'g':
        mem <<= 30;
        break;
    case 'M':
    case 'm':
        mem <<= 20;
        break;
    case 'K':
    case 'k':
        mem <<= 10;
        fallthrough;
    default:
        break;
    }

    return mem;
}
```

</details>

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/14514