### PR TITLE
cpu/stm32: GPIO ports definition fix

### DIFF
--- a/boards/common/nucleo32/include/arduino_pinmap.h
+++ b/boards/common/nucleo32/include/arduino_pinmap.h
@@ -39,7 +39,8 @@ extern "C" {
 #define ARDUINO_PIN_4           GPIO_PIN(PORT_B, 7)
 #define ARDUINO_PIN_5           GPIO_PIN(PORT_B, 6)
 #define ARDUINO_PIN_6           GPIO_PIN(PORT_B, 1)
-#if defined(CPU_MODEL_STM32L031K6) || defined(CPU_MODEL_STM32L432KC)
+#if defined(CPU_MODEL_STM32L031K6) || defined(CPU_MODEL_STM32L432KC) || \
+    defined(CPU_MODEL_STM32L412KB)
 #define ARDUINO_PIN_7           GPIO_PIN(PORT_C, 14)
 #define ARDUINO_PIN_8           GPIO_PIN(PORT_C, 15)
 #else

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -217,32 +217,37 @@ typedef uint32_t gpio_t;
  * @brief   Available GPIO ports
  */
 enum {
+#ifdef GPIOA
     PORT_A = 0,             /**< port A */
+#endif
+#ifdef GPIOB
     PORT_B = 1,             /**< port B */
+#endif
+#ifdef GPIOC
     PORT_C = 2,             /**< port C */
+#endif
+#ifdef GPIOD
     PORT_D = 3,             /**< port D */
+#endif
+#ifdef GPIOE
     PORT_E = 4,             /**< port E */
+#endif
+#ifdef GPIOF
     PORT_F = 5,             /**< port F */
-#if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || \
-    defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32F4) || \
-    defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L1) || \
-    defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32G4)
+#endif
+#ifdef GPIOG
     PORT_G = 6,             /**< port G */
 #endif
-#if defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F3) || \
-    defined(CPU_FAM_STM32F4) || defined(CPU_FAM_STM32F7) || \
-    defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1) || \
-    defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
-    defined(CPU_FAM_STM32G4)
+#ifdef GPIOH
     PORT_H = 7,             /**< port H */
 #endif
-#if defined(CPU_FAM_STM32F2) || defined(CPU_FAM_STM32F4) || \
-    defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L4) || \
-    defined(CPU_FAM_STM32G4)
+#ifdef GPIOI
     PORT_I = 8,             /**< port I */
 #endif
-#if defined(CPU_FAM_STM32F7)
+#ifdef GPIOJ
     PORT_J = 9,             /**< port J */
+#endif
+#ifdef GPIOK
     PORT_K = 10,            /**< port K */
 #endif
 };


### PR DESCRIPTION
### Contribution description

This PR changes the definition of available GPIO ports for STM32 MCUs.

The available GPIO ports may differ within a family. For example, the STM32F410xx has only the ports A...C and H while the STM32F437xx has the ports A...K.Therefore, the vendor definitions `GPIOx` are used instead of `CPU_FAM_STM32xx` definitions to determine which ports are available for a given MCU.

### Testing procedure

Compilation in Murdock should succeed.

### Issues/PRs references

Changes the GPIO port definition introducd with PR #14021.