### PR TITLE
pkg/lvgl: adapt Makefile for nicer build output

### DIFF
--- a/pkg/lvgl/Makefile
+++ b/pkg/lvgl/Makefile
@@ -20,4 +20,4 @@ LVGL_MODULES =  \
 all: $(LVGL_MODULES)
 
 lvgl_%:
-	MODULE=$@ "$(MAKE)" -C $(PKG_SOURCE_DIR)/src/lv_$* -f $(CURDIR)/Makefile.lvgl_module
+	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/lv_$* -f $(CURDIR)/Makefile.lvgl_module MODULE=$@


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a purely cosmetic change of the lvgl build output. For each module of the package, the build line starts with `MODULE=lvgl_core` instead of `"make" `

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just build the `tests/pkg_lvgl` application locally:

<details><summary>this PR</summary>

```
$ BUILD_IN_DOCKER=1 make -C tests/pkg_lvgl --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'        -w '/data/riotbuild/riotbase/tests/pkg_lvgl/' 'riot/riotbuild:latest' make     
Building application "tests_pkg_lvgl" for "stm32f429i-disc1" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/pkg/lvgl
"make" -C /data/riotbuild/riotbase/build/pkg/lvgl/src/lv_core -f /data/riotbuild/riotbase/pkg/lvgl/Makefile.lvgl_module MODULE=lvgl_core
"make" -C /data/riotbuild/riotbase/build/pkg/lvgl/src/lv_draw -f /data/riotbuild/riotbase/pkg/lvgl/Makefile.lvgl_module MODULE=lvgl_draw
"make" -C /data/riotbuild/riotbase/build/pkg/lvgl/src/lv_font -f /data/riotbuild/riotbase/pkg/lvgl/Makefile.lvgl_module MODULE=lvgl_font
"make" -C /data/riotbuild/riotbase/build/pkg/lvgl/src/lv_hal -f /data/riotbuild/riotbase/pkg/lvgl/Makefile.lvgl_module MODULE=lvgl_hal
"make" -C /data/riotbuild/riotbase/build/pkg/lvgl/src/lv_misc -f /data/riotbuild/riotbase/pkg/lvgl/Makefile.lvgl_module MODULE=lvgl_misc
"make" -C /data/riotbuild/riotbase/build/pkg/lvgl/src/lv_objx -f /data/riotbuild/riotbase/pkg/lvgl/Makefile.lvgl_module MODULE=lvgl_objx
"make" -C /data/riotbuild/riotbase/build/pkg/lvgl/src/lv_themes -f /data/riotbuild/riotbase/pkg/lvgl/Makefile.lvgl_module MODULE=lvgl_themes
"make" -C /data/riotbuild/riotbase/pkg/stm32cmsis
"make" -C /data/riotbuild/riotbase/boards/stm32f429i-disc1
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/bootloader
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/disp_dev
"make" -C /data/riotbuild/riotbase/drivers/ili9341
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/pkg/lvgl/contrib
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  83608	    180	  13772	  97560	  17d18	/data/riotbuild/riotbase/tests/pkg_lvgl/bin/stm32f429i-disc1/tests_pkg_lvgl.elf
```

</details>

<details><summary>master</summary>

```
$ BUILD_IN_DOCKER=1 make -C tests/pkg_lvgl --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'        -w '/data/riotbuild/riotbase/tests/pkg_lvgl/' 'riot/riotbuild:latest' make     
Building application "tests_pkg_lvgl" for "stm32f429i-disc1" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/pkg/lvgl
MODULE=lvgl_core "make" -C /data/riotbuild/riotbase/build/pkg/lvgl/src/lv_core -f /data/riotbuild/riotbase/pkg/lvgl/Makefile.lvgl_module
MODULE=lvgl_draw "make" -C /data/riotbuild/riotbase/build/pkg/lvgl/src/lv_draw -f /data/riotbuild/riotbase/pkg/lvgl/Makefile.lvgl_module
MODULE=lvgl_font "make" -C /data/riotbuild/riotbase/build/pkg/lvgl/src/lv_font -f /data/riotbuild/riotbase/pkg/lvgl/Makefile.lvgl_module
MODULE=lvgl_hal "make" -C /data/riotbuild/riotbase/build/pkg/lvgl/src/lv_hal -f /data/riotbuild/riotbase/pkg/lvgl/Makefile.lvgl_module
MODULE=lvgl_misc "make" -C /data/riotbuild/riotbase/build/pkg/lvgl/src/lv_misc -f /data/riotbuild/riotbase/pkg/lvgl/Makefile.lvgl_module
MODULE=lvgl_objx "make" -C /data/riotbuild/riotbase/build/pkg/lvgl/src/lv_objx -f /data/riotbuild/riotbase/pkg/lvgl/Makefile.lvgl_module
MODULE=lvgl_themes "make" -C /data/riotbuild/riotbase/build/pkg/lvgl/src/lv_themes -f /data/riotbuild/riotbase/pkg/lvgl/Makefile.lvgl_module
"make" -C /data/riotbuild/riotbase/pkg/stm32cmsis
"make" -C /data/riotbuild/riotbase/boards/stm32f429i-disc1
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/bootloader
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/disp_dev
"make" -C /data/riotbuild/riotbase/drivers/ili9341
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/pkg/lvgl/contrib
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  83576	    180	  13772	  97528	  17cf8	/data/riotbuild/riotbase/tests/pkg_lvgl/bin/stm32f429i-disc1/tests_pkg_lvgl.elf
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
