### PR TITLE
cpu/cc2538/uart: uart_write wait for all bytes to be sent [backport 2020.07]

### DIFF
--- a/cpu/cc2538/periph/uart.c
+++ b/cpu/cc2538/periph/uart.c
@@ -199,6 +199,9 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
         while (u->cc2538_uart_fr.FRbits.TXFF) {}
         u->DR = data[i];
     }
+
+    /* Wait for the TX FIFO to clear */
+    while (!uart_config[uart].dev->cc2538_uart_fr.FRbits.TXFE) {}
 }
 
 void uart_poweron(uart_t uart)


### PR DESCRIPTION
# Backport of #14577

### Contribution description

`cc2538` has a transmit and receive FIFO. Currently `uart_write` blocks until all bytes have been delivered to the FIFO and not for all bytes to have been sent out, which does not comply with the [api](http://riot-os.org/api/group__drivers__periph__uart.html).

This can have the result that some bytes are lost on prints, evidenced by false negatives on `tests/ssp` and `tests/mpu_noexec_ram` where a couple of prints would be missed.

```
READY
s
START
main(): This is RIOT! (Version: 2020.10-devel-18-gab072-HEAD)
calling stack corruption function
*** RIOT kernel panic:
ssp: stack smashing detectTimeout in expect script at "child.expect('.*stack smashing detected.*')" (tests/ssp/tests/01-run.py:15)
```

### Testing procedure

The following tests now pass:

`BOARD=openmote-b make -C tests/mpu_noexec_ram/ flash test`

```
socat - open:/dev/riot/tty-openmote-b,b115200,echo=0,raw
READY
s
START
main(): This is RIOT! (Version: 2020.10-devel-278-gda171-pr_cc2538_uart_write_synchronous)
Attempting to jump to stack buffer ...

*** RIOT kernel panic:
MEM MANAGE HANDLER

*** halted.
```

` BOARD=openmote-b make -C tests/ssp/ flash test`

```
main(): This is RIOT! (Version: 2020.10-devel-278-gda171-pr_cc2538_uart_write_synchronous)
calling stack corruption function
*** RIOT kernel panic:
ssp: stack smashing detected

*** halted.
```

### Issues/PRs references

Addresses part of https://github.com/RIOT-OS/RIOT/issues/14572
