### PR TITLE
core/msg_bus: fix shift on 8-bit platforms [backport 2020.07]

### DIFF
--- a/core/include/msg_bus.h
+++ b/core/include/msg_bus.h
@@ -146,7 +146,7 @@ msg_bus_entry_t *msg_bus_get_entry(msg_bus_t *bus);
 static inline void msg_bus_subscribe(msg_bus_entry_t *entry, uint8_t type)
 {
     assert(type < 32);
-    entry->event_mask |= (1 << type);
+    entry->event_mask |= (1UL << type);
 }
 
 /**
@@ -160,7 +160,7 @@ static inline void msg_bus_subscribe(msg_bus_entry_t *entry, uint8_t type)
 static inline void msg_bus_unsubscribe(msg_bus_entry_t *entry, uint8_t type)
 {
     assert(type < 32);
-    entry->event_mask &= ~(1 << type);
+    entry->event_mask &= ~(1UL << type);
 }
 
 /**

--- a/core/msg.c
+++ b/core/msg.c
@@ -239,7 +239,7 @@ int msg_send_int(msg_t *m, kernel_pid_t target_pid)
 int msg_send_bus(msg_t *m, msg_bus_t *bus)
 {
     const bool in_irq = irq_is_in();
-    const uint32_t event_mask = (1 << (m->type & 0x1F));
+    const uint32_t event_mask = (1UL << (m->type & 0x1F));
     int count = 0;
 
     m->sender_pid = in_irq ? KERNEL_PID_ISR : sched_active_pid;

--- a/tests/thread_msg_bus/main.c
+++ b/tests/thread_msg_bus/main.c
@@ -123,7 +123,14 @@ int main(void)
         printf("Posted event %d to %d threads\n", id, woken);
     }
 
-    puts("SUCCESS");
+    /* make sure all threads have terminated */
+    if (thread_getstatus(p1) != STATUS_NOT_FOUND ||
+        thread_getstatus(p2) != STATUS_NOT_FOUND ||
+        thread_getstatus(p3) != STATUS_NOT_FOUND ) {
+        puts("FAILED");
+        return 1;
+    }
 
+    puts("SUCCESS");
     return 0;
 }


### PR DESCRIPTION
# Backport of #14582



<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The previous shift would wrap if the compiler defaults to 16 bit words.
Use explicit `unsigned long` integer constants to mitigate that.



### Testing procedure

Run `tests/thread_msg_bus`

#### before:

```
2020-07-22 15:25:17,063 # THREAD 1 start
2020-07-22 15:25:17,063 # THREAD 2 start
2020-07-22 15:25:17,065 # THREAD 3 start
2020-07-22 15:25:17,066 # THREADS CREATED
2020-07-22 15:25:17,068 # Posted event 22 to 0 threads
2020-07-22 15:25:17,071 # Posted event 23 to 0 threads
2020-07-22 15:25:17,076 # Posted event 24 to 0 threads
2020-07-22 15:25:17,076 # SUCCESS
2020-07-22 15:26:00,188 # Exiting Pyterm
```

#### after:

```
2020-07-22 15:26:10,374 # THREAD 1 start
2020-07-22 15:26:10,374 # THREAD 2 start
2020-07-22 15:26:10,377 # THREAD 3 start
2020-07-22 15:26:10,377 # THREADS CREATED
2020-07-22 15:26:10,380 # Posted event 22 to 0 threads
2020-07-22 15:26:10,383 # T1 recv: Hello Threads! (type=23)
2020-07-22 15:26:10,386 # T3 recv: Hello Threads! (type=23)
2020-07-22 15:26:10,388 # Posted event 23 to 2 threads
2020-07-22 15:26:10,391 # T2 recv: Hello Threads! (type=24)
2020-07-22 15:26:10,394 # Posted event 24 to 1 threads
2020-07-22 15:26:10,396 # SUCCESS
```

### Issues/PRs references

found in https://github.com/RIOT-OS/RIOT/issues/12651#issuecomment-662439073