### PR TITLE
tests/trace: reduce trace buffer size

### DIFF
--- a/tests/trace/Makefile
+++ b/tests/trace/Makefile
@@ -2,4 +2,7 @@ include ../Makefile.tests_common
 
 USEMODULE += trace
 
+# reduce tracebuffer (default is 512), so this test compiles for more boards
+CFLAGS += -DCONFIG_TRACE_BUFSIZE=64
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The tests previously compiled with the trace module's default 512 trace buffer entries. That uses too much memory, requiring blacklisting for some targets.

This PR makes the test compile with a reduced size of 64 entries.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

The tests only uses two entries, so this *shouldn't* change anything. Running the test on native (as done by compilation tests on CI) should be enough.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
