### PR TITLE
tests/bench_sys_base64: reduce test iterations (10000 -> 1000)

### DIFF
--- a/tests/bench_sys_base64/main.c
+++ b/tests/bench_sys_base64/main.c
@@ -75,24 +75,24 @@ int main(void) {
     }
 
     start = xtimer_now_usec();
-    for (unsigned i = 0; i < 10000; i++) {
+    for (unsigned i = 0; i < 1000; i++) {
         size = sizeof(buf);
         base64_encode(input, sizeof(input), buf, &size);
     }
     stop = xtimer_now_usec();
 
-    print_str("Encoding 10.000 x 96 bytes (128 bytes in base64): ");
+    print_str("Encoding 1.000 x 96 bytes (128 bytes in base64): ");
     print_u32_dec(stop - start);
     print_str(" µs\n");
 
     start = xtimer_now_usec();
-    for (unsigned i = 0; i < 10000; i++) {
+    for (unsigned i = 0; i < 1000; i++) {
         size = sizeof(buf);
         base64_decode(base64, sizeof(base64), buf, &size);
     }
     stop = xtimer_now_usec();
 
-    print_str("Decoding 10.000 x 96 bytes (128 bytes in base64): ");
+    print_str("Decoding 1.000 x 96 bytes (128 bytes in base64): ");
     print_u32_dec(stop - start);
     print_str(" µs\n");
     return 0;

--- a/tests/bench_sys_base64/tests/01-run.py
+++ b/tests/bench_sys_base64/tests/01-run.py
@@ -13,8 +13,8 @@ from testrunner import run
 def testfunc(child):
     child.expect_exact("Verifying that base64 encoding works for benchmark input: OK\r\n")
     child.expect_exact("Verifying that base64 decoding works for benchmark input: OK\r\n")
-    child.expect(r"Encoding 10\.000 x 96 bytes \(128 bytes in base64\): [0-9]+ µs\r\n")
-    child.expect(r"Decoding 10\.000 x 96 bytes \(128 bytes in base64\): [0-9]+ µs\r\n")
+    child.expect(r"Encoding 1\.000 x 96 bytes \(128 bytes in base64\): [0-9]+ µs\r\n")
+    child.expect(r"Decoding 1\.000 x 96 bytes \(128 bytes in base64\): [0-9]+ µs\r\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Test otherwise times out on msp430 (#12457). Instead of increasing the timeout, reduce iterations. On our predictable MCUs, it should take exatcly one tenth of the previous time.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I think testing on native (as done by regular CI run) should be sufficient.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Needed for #12457.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
