### PR TITLE
tests/shell: add blacklist for check_line_exceeded(), add z1

### DIFF
--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -136,14 +136,21 @@ def check_and_get_bufsize(child):
     return bufsize
 
 
+# there's an issue with some boards' serial that causes lost characters.
+LINE_EXCEEDED_BLACKLIST = {
+    # There is an issue with nrf52dk when the Virtual COM port is connected
+    # and sending more than 64 bytes over UART. If no terminal is connected
+    # to the Virtual COM and interfacing directly to the nrf52832 UART pins
+    # the issue is not present. See issue #10639 on GitHub.
+    'nrf52dk',
+    'z1',
+}
+
+
 def check_line_exceeded(child, longline):
 
-    if BOARD == 'nrf52dk':
-        # There is an issue with nrf52dk when the Virtual COM port is connected
-        # and sending more than 64 bytes over UART. If no terminal is connected
-        # to the Virtual COM and interfacing directly to the nrf52832 UART pins
-        # the issue is not present. See issue #10639 on GitHub.
-        print_error('test case "check_line_exceeded" broken for nrf52dk. SKIP')
+    if BOARD in LINE_EXCEEDED_BLACKLIST:
+        print_error('test case "check_line_exceeded" blacklisted, SKIP')
         return
 
     child.sendline(longline)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Turns out the nrf52dk is not the only board that has a shitty onboard uart-to-usb connection, the test also fails on z1.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Running CI tests should execute the test on native and samr21-xpro, not for nrf52dk.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Found while investigating the tests failure in #12457 (also fauls on master), on z1.