### PR TITLE
tests/pkg_libcose: add missing unistd.h include

### DIFF
--- a/tests/pkg_libcose/main.c
+++ b/tests/pkg_libcose/main.c
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "cose.h"
 #include "cose/sign.h"


### PR DESCRIPTION
### Contribution description

Required for `ssize_t` (and successful compilation with PicoLIBC)

### Testing procedure

A successful murdock compilation should be enough

### Issues/PRs references

required for #12305 