### PR TITLE
drivers/at86rf2xx: support frame retry reporting on AT86RFR2

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -145,6 +145,13 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     /* enable interrupts */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__IRQ_MASK,
                         AT86RF2XX_IRQ_STATUS_MASK__TRX_END);
+
+    /* enable TX start interrupt for retry counter */
+#ifdef AT86RF2XX_REG__IRQ_MASK1
+    at86rf2xx_reg_write(dev, AT86RF2XX_REG__IRQ_MASK1,
+                             AT86RF2XX_IRQ_STATUS_MASK1__TX_START);
+#endif
+
     /* clear interrupt flags */
     at86rf2xx_reg_read(dev, AT86RF2XX_REG__IRQ_STATUS);
 
@@ -189,9 +196,13 @@ size_t at86rf2xx_tx_load(at86rf2xx_t *dev, const uint8_t *data,
     return offset + len;
 }
 
-void at86rf2xx_tx_exec(const at86rf2xx_t *dev)
+void at86rf2xx_tx_exec(at86rf2xx_t *dev)
 {
     netdev_t *netdev = (netdev_t *)dev;
+
+#if AT86RF2XX_HAVE_RETRIES
+    dev->tx_retries = -1;
+#endif
 
     /* write frame length field in FIFO */
     at86rf2xx_sram_write(dev, 0, &(dev->tx_frame_len), 1);

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -690,7 +690,7 @@ static void _isr_send_complete(at86rf2xx_t *dev, uint8_t trac_status)
         return;
     }
 /* Only radios with the XAH_CTRL_2 register support frame retry reporting */
-#if AT86RF2XX_HAVE_RETRIES
+#if AT86RF2XX_HAVE_RETRIES && defined(AT86RF2XX_REG__XAH_CTRL_2)
     dev->tx_retries = (at86rf2xx_reg_read(dev, AT86RF2XX_REG__XAH_CTRL_2)
                        & AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_MASK) >>
                       AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_OFFSET;
@@ -820,6 +820,26 @@ static void _isr(netdev_t *netdev)
 }
 
 #if defined(MODULE_AT86RFA1) || defined(MODULE_AT86RFR2)
+
+/**
+ * @brief ISR for transceiver's TX_START interrupt
+ *
+ * In procedure TX_ARET the TRX24_TX_START interrupt is issued separately for every
+ * frame transmission and frame retransmission.
+ * Indicates the frame start of a transmitted acknowledge frame in procedure RX_AACK.
+ *
+ * Flow Diagram Manual p. 52 / 63
+ */
+#if AT86RF2XX_HAVE_RETRIES
+ISR(TRX24_TX_START_vect){
+    /* __enter_isr(); is not neccessary as there is nothing which causes a
+     * thread_yield and the interrupt can not be interrupted by an other ISR */
+
+    at86rf2xx_t *dev = (at86rf2xx_t *) at86rfmega_dev;
+
+    dev->tx_retries++;
+}
+#endif
 
 /**
  * @brief ISR for transceiver's receive end interrupt

--- a/drivers/at86rf2xx/include/at86rf2xx_registers.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_registers.h
@@ -87,6 +87,9 @@ extern "C" {
 #define AT86RF2XX_REG__TRX_RPC                                  (&TRX_RPC)
 #define AT86RF2XX_REG__ANT_DIV                                  (&ANT_DIV)
 #define AT86RF2XX_REG__IRQ_MASK                                 (&IRQ_MASK)
+#ifdef IRQ_MASK1
+#define AT86RF2XX_REG__IRQ_MASK1                                (&IRQ_MASK1)
+#endif
 #define AT86RF2XX_REG__IRQ_STATUS                               (&IRQ_STATUS)
 #define AT86RF2XX_REG__IRQ_STATUS1                              (&IRQ_STATUS1)
 #define AT86RF2XX_REG__VREG_CTRL                                (&VREG_CTRL)

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -120,7 +120,7 @@ extern "C" {
 #   define MIN_RX_SENSITIVITY              (-101)
 #endif
 
-#if defined(DOXYGEN) || defined(MODULE_AT86RF232) || defined(MODULE_AT86RF233)
+#if defined(DOXYGEN) || defined(MODULE_AT86RF232) || defined(MODULE_AT86RF233) || defined(MODULE_AT86RFR2)
 /**
  * @brief   Frame retry counter reporting
  *
@@ -284,7 +284,7 @@ typedef struct {
                                              return to @ref at86rf2xx_t::idle_state */
 #if AT86RF2XX_HAVE_RETRIES
     /* Only radios with the XAH_CTRL_2 register support frame retry reporting */
-    uint8_t tx_retries;                 /**< Number of NOACK retransmissions */
+    int8_t tx_retries;                  /**< Number of NOACK retransmissions */
 #endif
     /** @} */
 } at86rf2xx_t;
@@ -619,7 +619,7 @@ size_t at86rf2xx_tx_load(at86rf2xx_t *dev, const uint8_t *data,
  *
  * @param[in] dev           device to trigger
  */
-void at86rf2xx_tx_exec(const at86rf2xx_t *dev);
+void at86rf2xx_tx_exec(at86rf2xx_t *dev);
 
 /**
  * @brief   Perform one manual channel clear assessment (CCA)


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

AT86RFR2 doesn't report retries directly, but it can generate a TX start interrupt for each (re)try, so we can count manually.


### Testing procedure

Currently retry count is not used anywhere in RIOT.
So you will either need #14448 or you manually add

```patch
--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -696,6 +696,8 @@ static void _isr_send_complete(at86rf2xx_t *dev, uint8_t trac_status)
                       AT86RF2XX_XAH_CTRL_2__ARET_FRAME_RETRIES_OFFSET;
 #endif
 
+    printf("retries: %d\n", dev->tx_retries);
+
     DEBUG("[at86rf2xx] EVT - TX_END\n");
 
     if (netdev->event_callback && (dev->flags & AT86RF2XX_OPT_TELL_TX_END)) {
```

to check that retries are reported correctly.

### Issues/PRs references

Missing feature from #9172
