### PR TITLE
cpu/{mips32r2_common,arm7_common,native}/Kconfig: Select HAS_LIBSTDCPP

### DIFF
--- a/cpu/arm7_common/Kconfig
+++ b/cpu/arm7_common/Kconfig
@@ -10,6 +10,7 @@ config CPU_ARCH_ARMV4T
     select HAS_ARCH_32BIT
     select HAS_ARCH_ARM
     select HAS_CPP
+    select HAS_LIBSTDCPP
 
 config CPU_CORE_ARM7TDMI_S
     bool

--- a/cpu/mips32r2_common/Kconfig
+++ b/cpu/mips32r2_common/Kconfig
@@ -10,6 +10,7 @@ config CPU_ARCH_MIPS32R2
     select HAS_ARCH_32BIT
     select HAS_ARCH_MIPS32R2
     select HAS_CPP
+    select HAS_LIBSTDCPP
     select HAS_PERIPH_PM
 
 config CPU_CORE_M4K

--- a/cpu/native/Kconfig
+++ b/cpu/native/Kconfig
@@ -7,10 +7,11 @@
 
 config CPU_ARCH_NATIVE
     bool
-    select HAS_ARCH_NATIVE
     select HAS_ARCH_32BIT
+    select HAS_ARCH_NATIVE
     select HAS_CPP
     select HAS_CPU_NATIVE
+    select HAS_LIBSTDCPP
     select HAS_PERIPH_CPUID
     select HAS_PERIPH_EEPROM
     select HAS_PERIPH_HWRNG


### PR DESCRIPTION
### Contribution description

Apparently, I failed to bring features provided by `Kconfig` and `Makefile.features` in sync and Murdock is not happy about this.

### Testing procedure

Murdock should be happy again.

### Issues/PRs references

I messed up in https://github.com/RIOT-OS/RIOT/pull/14503