### PR TITLE
.github/workflows: add riot-ryot.yml

### DIFF
--- a/.github/workflows/riot-ryot.yml
+++ b/.github/workflows/riot-ryot.yml
@@ -1,0 +1,94 @@
+# Run 'compile_and_test_for_board.py' on connected boards.
+#
+# This workflow will run on a RYOT machine and lunch all tests on all boards
+# currently connected to that machine. Builds can be parallelized if multiple
+# github self-hosted runners are configured.
+#
+# Running self-hosted runners on public repositories is not advised, but here
+# we do not run them on PRs, only on master and release candidates.
+#
+# Documentation:
+#
+# * Setup a RYOT machine:
+#   https://github.com/fjmolinas/riot-ryot/blob/master/setup.md
+# * Setup Runner:
+#   https://github.com/fjmolinas/riot-ryot/blob/master/setup.md#self-hosted-github-runners
+
+name: riot-ryot
+
+on:
+  # Schedule weekly runs Saturday at 00:00 on master
+  schedule:
+    - cron: '00 0 * * 6'
+  push:
+    # TODO: remove only here to demonstrate build once
+    branches:
+      - master
+    # Run on all new release candidates
+    tags:
+      - '*-RC*'
+
+jobs:
+  # Get all currently connected boards
+  connected_boards:
+    name: Get Connected Boards
+    runs-on: self-hosted
+    env:
+      RIOT_MAKEFILES_GLOBAL_PRE: /builds/conf/makefiles.pre
+    outputs:
+      boards: ${{ steps.list-boards.outputs.boards }}
+    steps:
+      - id: list-boards
+        run: echo "::set-output name=boards::$(make -C /builds/boards/ list-boards-json --no-print-directory)"
+
+  # Runs all tests on connected boards
+  compile_and_test_for_board:
+    name: ${{ matrix.board }}
+    runs-on: self-hosted
+    needs: connected_boards
+    continue-on-error: true
+    # ci-riot-tribe has 7 cores, keep one free
+    strategy:
+      max-parallel: 8
+      matrix:
+        board: ${{fromJson(needs.connected_boards.outputs.boards)}}
+    env:
+      BUILD_IN_DOCKER: 1
+      RIOT_MAKEFILES_GLOBAL_PRE: /builds/conf/makefiles.pre
+      COMPILE_AND_TEST_FOR_BOARD: ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
+      COMPILE_AND_TEST_ARGS: --with-test-only --incremental
+    steps:
+    - name: Checkout RIOT
+      uses: actions/checkout@v2
+    - name: Run compile_and_test_for_board.py
+      run: ${COMPILE_AND_TEST_FOR_BOARD} . ${{ matrix.board }} results ${COMPILE_AND_TEST_ARGS}
+    - name: Archive results
+      if: always()
+      # Store all generated results to same 'results' artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: results
+        path: results
+
+  # Aggregate all boards results
+  results_summary:
+    name: Results Summary
+    needs: compile_and_test_for_board
+    runs-on: self-hosted
+    steps:
+      - name: Download all results
+        uses: actions/download-artifact@v2
+        # Download all artifacts to results
+        with:
+          name: results
+          path: results
+      - name: Aggregate Results
+        shell: bash
+        run: python /builds/scripts/ci_aggregate.py results
+      - name: Archive results summary
+        if: always()
+        # Store all generated results to same 'results' artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: results
+          path: results/failuresummary.md

--- a/.github/workflows/riot-ryot.yml
+++ b/.github/workflows/riot-ryot.yml
@@ -1,18 +1,21 @@
 # Run 'compile_and_test_for_board.py' on connected boards.
 #
 # This workflow will run on a RYOT machine and lunch all tests on all boards
-# currently connected to that machine. Builds can be parallelized if multiple
-# github self-hosted runners are configured.
-#
-# Running self-hosted runners on public repositories is not advised, but here
-# we do not run them on PRs, only on master and release candidates.
+# currently connected to that machine.
 #
 # Documentation:
 #
 # * Setup a RYOT machine:
 #   https://github.com/fjmolinas/riot-ryot/blob/master/setup.md
-# * Setup Runner:
-#   https://github.com/fjmolinas/riot-ryot/blob/master/setup.md#self-hosted-github-runners
+#
+# * Requirements (filled by a RYOT machine):
+#   * ssh access (required secrets set)
+#   * all required flashing tools installed
+#   * udev rules that map all BOARD to /dev/riot/tty-$(BOARD)
+#   * RIOT_MAKEFILES_GLOBAL_PRE that sets PORT and DEBUG_ADAPTER_ID for each
+#     BOARD http://riot-os.org/api/advanced-build-system-tricks.html#multiple-boards-udev
+#   * Static list of connected boards or make target listing them in json format
+#     so that fromJSON can be used.
 
 name: riot-ryot
 
@@ -27,68 +30,79 @@ on:
     # Run on all new release candidates
     tags:
       - '*-RC*'
+env:
+  RIOT_MAKEFILES_GLOBAL_PRE: /home/runner/work/ci-boards.mk.pre
+  RYOT_CI_SERVER: ${{ secrets.RYOT_CI_SERVER }}
+  RYOT_CI: 1
 
 jobs:
   # Get all currently connected boards
   connected_boards:
     name: Get Connected Boards
-    runs-on: self-hosted
-    env:
-      RIOT_MAKEFILES_GLOBAL_PRE: /builds/conf/makefiles.pre
+    runs-on: ubuntu-latest
     outputs:
       boards: ${{ steps.list-boards.outputs.boards }}
     steps:
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.RYOT_PRIVATE_KEY}}
+          known_hosts: ${{ secrets.RYOT_KNOWN_HOSTS }}
+          config: ${{ secrets.RYOT_SSH_CONFIG }}
+      - name: Checkout RIOT
+        uses: actions/checkout@v2
+      - name: Fetch makefile pre
+        run: |
+          wget -q https://raw.githubusercontent.com/fjmolinas/riot-ryot/master/local/ci-boards.mk.pre \
+          -P /home/runner/work/
       - id: list-boards
-        run: echo "::set-output name=boards::$(make -C /builds/boards/ list-boards-json --no-print-directory)"
+        run: echo "::set-output name=boards::$(make -C ./examples/hello-world list-ci-boards-json --no-print-directory)"
 
   # Runs all tests on connected boards
   compile_and_test_for_board:
     name: ${{ matrix.board }}
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: connected_boards
-    continue-on-error: true
-    # ci-riot-tribe has 7 cores, keep one free
+    # ci-riot-tribe has 8 cores
     strategy:
       max-parallel: 8
+      fail-fast: false
       matrix:
-        board: ${{fromJson(needs.connected_boards.outputs.boards)}}
+        board: ${{ fromJson(needs.connected_boards.outputs.boards) }}
     env:
       BUILD_IN_DOCKER: 1
-      RIOT_MAKEFILES_GLOBAL_PRE: /builds/conf/makefiles.pre
       COMPILE_AND_TEST_FOR_BOARD: ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py
-      COMPILE_AND_TEST_ARGS: --with-test-only --incremental
+      COMPILE_AND_TEST_ARGS: --with-test-only
     steps:
+    - name: Install SSH key
+      uses: shimataro/ssh-key-action@v2
+      with:
+        key: ${{ secrets.RYOT_PRIVATE_KEY}}
+        known_hosts: ${{ secrets.RYOT_KNOWN_HOSTS }}
+        config: ${{ secrets.RYOT_SSH_CONFIG }}
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install iotlabcli pexpect
+    - name: Pull riotbuild docker image
+      run: docker pull riot/riotbuild:latest
+    - name: Fetch makefile pre
+      run: |
+        wget -q https://raw.githubusercontent.com/fjmolinas/riot-ryot/master/local/ci-boards.mk.pre \
+        -P /home/runner/work/
     - name: Checkout RIOT
       uses: actions/checkout@v2
     - name: Run compile_and_test_for_board.py
-      run: ${COMPILE_AND_TEST_FOR_BOARD} . ${{ matrix.board }} results ${COMPILE_AND_TEST_ARGS}
+      run: |
+        ${COMPILE_AND_TEST_FOR_BOARD} . ${{ matrix.board }} \
+          results-${{ matrix.board }} ${COMPILE_AND_TEST_ARGS}
     - name: Archive results
       if: always()
-      # Store all generated results to same 'results' artifact
       uses: actions/upload-artifact@v2
       with:
-        name: results
-        path: results
-
-  # Aggregate all boards results
-  results_summary:
-    name: Results Summary
-    needs: compile_and_test_for_board
-    runs-on: self-hosted
-    steps:
-      - name: Download all results
-        uses: actions/download-artifact@v2
-        # Download all artifacts to results
-        with:
-          name: results
-          path: results
-      - name: Aggregate Results
-        shell: bash
-        run: python /builds/scripts/ci_aggregate.py results
-      - name: Archive results summary
-        if: always()
-        # Store all generated results to same 'results' artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: results
-          path: results/failuresummary.md
+        name: ${{ matrix.board }}
+        path: results-${{ matrix.board }}


### PR DESCRIPTION
### Contribution description

This PR adds a github action workflow that launch `compile_and_test_for_board` on all boards currently connected to a [RYOT](https://github.com/fjmolinas/riot-ryot) machine.

For each board compile_and_test script starts. At the end result are archived.

For each board, jobs are run in parallel, I limited it at 8 for this particular configuration (since I have 8 cores), it takes quite some time to run all tests since about 30 boards are connected, the time to execute each test varies depending on the supported applications.

Since it takes a lot of time to complete, it's not ~possible~ acceptable to perform this check on PR basis, so the action is configured to be run on a weekly basis on master and for each RC tag pushed.

This could be extended to many more machine individually hosting many boards, different maintainers could contribute a different set of boards. Since tests are not ran on a fix set of boards, they can be plugged/unplugged when needed by that maintainer. Checkout the [RYOT repo](https://github.com/fjmolinas/riot-ryot) for more information.

### Testing procedure

See [here](https://github.com/fjmolinas/RIOT/actions/runs/183987041) to see what it looks like, I'm running it on my ryot machine which has around 30 boards connected to.

### Issues/PRs references

Complementary to https://github.com/RIOT-OS/RIOT/pull/14587