### PR TITLE
periph/gpio: new expandable GPIO API

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1069,6 +1069,11 @@ ifneq (,$(filter periph_gpio_irq,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
 endif
 
+# Enable optionally periph_gpio_ext when the MCU supports it as feature
+ifneq (,$(filter periph_gpio,$(USEMODULE)))
+  FEATURES_OPTIONAL += periph_gpio_exp
+endif
+
 ifneq (,$(filter periph_timer_periodic,$(USEMODULE)))
   FEATURES_REQUIRED += periph_timer
 endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -44,6 +44,10 @@ ifneq (,$(filter ccs811_%,$(USEMODULE)))
   USEMODULE += ccs811
 endif
 
+ifneq (,$(filter gpio_exp,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio_exp
+endif
+
 ifneq (,$(filter hmc5883l_%,$(USEMODULE)))
   USEMODULE += hmc5883l
 endif

--- a/drivers/adcxx1c/adcxx1c.c
+++ b/drivers/adcxx1c/adcxx1c.c
@@ -103,7 +103,7 @@ int adcxx1c_enable_alert(adcxx1c_t *dev, adcxx1c_cb_t cb, void *arg)
 
     i2c_acquire(DEV);
     i2c_read_reg(DEV, ADDR, ADCXX1C_CONF_ADDR, &reg, 0);
-    reg |= (dev->params.alert_pin != GPIO_UNDEF ? ADCXX1C_CONF_ALERT_PIN_EN : 0)
+    reg |= (!gpio_is_undef(dev->params.alert_pin) ? ADCXX1C_CONF_ALERT_PIN_EN : 0)
             | ADCXX1C_CONF_ALERT_FLAG_EN;
     status = i2c_write_reg(DEV, ADDR, ADCXX1C_CONF_ADDR, reg, 0);
     i2c_release(DEV);
@@ -113,7 +113,7 @@ int adcxx1c_enable_alert(adcxx1c_t *dev, adcxx1c_cb_t cb, void *arg)
         return ADCXX1C_NOI2C;
     }
 
-    if (dev->params.alert_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.alert_pin)) {
         dev->cb = cb;
         dev->arg = arg;
         /* alert active low */

--- a/drivers/ads101x/ads101x.c
+++ b/drivers/ads101x/ads101x.c
@@ -159,7 +159,7 @@ int ads101x_enable_alert(ads101x_alert_t *dev,
 {
     uint8_t regs[2];
 
-    if (dev->params.alert_pin == GPIO_UNDEF) {
+    if (gpio_is_undef(dev->params.alert_pin)) {
         return ADS101X_OK;
     }
 

--- a/drivers/ccs811/ccs811.c
+++ b/drivers/ccs811/ccs811.c
@@ -75,7 +75,7 @@ int ccs811_init(ccs811_t *dev, const ccs811_params_t *params)
 
     int res = CCS811_OK;
 
-    if (dev->params.reset_pin != GPIO_UNDEF &&
+    if (!gpio_is_undef(dev->params.reset_pin) &&
         gpio_init(dev->params.reset_pin, GPIO_OUT) == 0) {
         DEBUG_DEV("nRESET pin configured", dev);
         /* enable low active reset signal */
@@ -88,7 +88,7 @@ int ccs811_init(ccs811_t *dev, const ccs811_params_t *params)
         xtimer_usleep(1000);
     }
 
-    if (dev->params.wake_pin != GPIO_UNDEF &&
+    if (!gpio_is_undef(dev->params.wake_pin) &&
         gpio_init(dev->params.wake_pin, GPIO_OUT) == 0) {
         gpio_clear(dev->params.wake_pin);
         DEBUG_DEV("nWAKE pin configured", dev);
@@ -208,7 +208,7 @@ int ccs811_set_int_mode(ccs811_t *dev, ccs811_int_mode_t mode)
 {
     ASSERT_PARAM(dev != NULL);
 
-    if (dev->params.int_pin == GPIO_UNDEF) {
+    if (gpio_is_undef(dev->params.int_pin)) {
         DEBUG_DEV("nINT pin not configured", dev);
         return CCS811_ERROR_NO_INT_PIN;
     }
@@ -365,7 +365,7 @@ int ccs811_power_down (ccs811_t *dev)
     int res = ccs811_set_mode(dev, CCS811_MODE_IDLE);
     dev->params.mode = tmp_mode;
 
-    if (dev->params.wake_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.wake_pin)) {
         DEBUG_DEV("Setting nWAKE pin high", dev);
         gpio_set(dev->params.wake_pin);
     }
@@ -377,7 +377,7 @@ int ccs811_power_up (ccs811_t *dev)
 {
     ASSERT_PARAM(dev != NULL);
 
-    if (dev->params.wake_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.wake_pin)) {
         DEBUG_DEV("Setting nWAKE pin low", dev);
         gpio_clear(dev->params.wake_pin);
     }
@@ -490,7 +490,7 @@ static int _reg_read(const ccs811_t *dev, uint8_t reg, uint8_t *data, uint32_t l
     }
 
 #if MODULE_CCS811_FULL
-    if (dev->params.wake_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.wake_pin)) {
         /* wake the sensor with low active WAKE signal */
         gpio_clear(dev->params.wake_pin);
         /* t_WAKE is 50 us */
@@ -502,7 +502,7 @@ static int _reg_read(const ccs811_t *dev, uint8_t reg, uint8_t *data, uint32_t l
     i2c_release(dev->params.i2c_dev);
 
 #if MODULE_CCS811_FULL
-    if (dev->params.wake_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.wake_pin)) {
         /* let the sensor enter to sleep mode */
         gpio_set(dev->params.wake_pin);
         /* minimum t_DWAKE is 20 us */
@@ -551,7 +551,7 @@ static int _reg_write(const ccs811_t *dev, uint8_t reg, uint8_t *data, uint32_t 
     }
 
 #if MODULE_CCS811_FULL
-    if (dev->params.wake_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.wake_pin)) {
         /* wake the sensor with low active WAKE signal */
         gpio_clear(dev->params.wake_pin);
         /* t_WAKE is 50 us */
@@ -568,7 +568,7 @@ static int _reg_write(const ccs811_t *dev, uint8_t reg, uint8_t *data, uint32_t 
     i2c_release(dev->params.i2c_dev);
 
 #if MODULE_CCS811_FULL
-    if (dev->params.wake_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.wake_pin)) {
         /* let the sensor enter to sleep mode */
         gpio_set(dev->params.wake_pin);
         /* minimum t_DWAKE is 20 us */

--- a/drivers/hd44780/hd44780.c
+++ b/drivers/hd44780/hd44780.c
@@ -72,7 +72,7 @@ static void _send(const hd44780_t *dev, uint8_t value, hd44780_state_t state)
 {
     (state == HD44780_ON) ? gpio_set(dev->p.rs) : gpio_clear(dev->p.rs);
     /* if RW pin is available, set it to LOW */
-    if (dev->p.rw != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->p.rw)) {
         gpio_clear(dev->p.rw);
     }
     /* write data in 8Bit or 4Bit mode */
@@ -110,7 +110,7 @@ int hd44780_init(hd44780_t *dev, const hd44780_params_t *params)
     }
     dev->flag = 0;
     /* set mode depending on configured pins */
-    if (dev->p.data[4] != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->p.data[4])) {
         dev->flag |= HD44780_8BITMODE;
     }
     else {
@@ -133,7 +133,7 @@ int hd44780_init(hd44780_t *dev, const hd44780_params_t *params)
 
     gpio_init(dev->p.rs, GPIO_OUT);
     /* RW (read/write) of LCD not required, set it to GPIO_UNDEF */
-    if (dev->p.rw != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->p.rw)) {
         gpio_init(dev->p.rw, GPIO_OUT);
     }
     gpio_init(dev->p.enable, GPIO_OUT);
@@ -145,7 +145,7 @@ int hd44780_init(hd44780_t *dev, const hd44780_params_t *params)
     xtimer_usleep(HD44780_INIT_WAIT_XXL);
     gpio_clear(dev->p.rs);
     gpio_clear(dev->p.enable);
-    if (dev->p.rw != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->p.rw)) {
         gpio_clear(dev->p.rw);
     }
     /* put the LCD into 4 bit or 8 bit mode */

--- a/drivers/ili9341/ili9341.c
+++ b/drivers/ili9341/ili9341.c
@@ -96,7 +96,7 @@ int ili9341_init(ili9341_t *dev, const ili9341_params_t *params)
         return -1;
     }
 
-    if (dev->params->rst_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params->rst_pin)) {
         gpio_init(dev->params->rst_pin, GPIO_OUT);
         gpio_clear(dev->params->rst_pin);
         xtimer_usleep(120 * US_PER_MS);

--- a/drivers/ina3221/alerts.c
+++ b/drivers/ina3221/alerts.c
@@ -29,7 +29,7 @@ int _ina3221_enable_alert(ina3221_t *dev, ina3221_alert_t alert,
     if (alert >= INA3221_NUM_ALERTS) {
         return -ERANGE;
     }
-    if (dev->params.upins.apins.alert_pins[alert] == GPIO_UNDEF) {
+    if (gpio_is_undef(dev->params.upins.apins.alert_pins[alert])) {
         return -ENOTSUP;
     }
     dev->alert_callbacks[alert] = cb;
@@ -49,7 +49,7 @@ int _ina3221_disable_alert(ina3221_t *dev, ina3221_alert_t alert)
     if (alert >= INA3221_NUM_ALERTS) {
         return -ERANGE;
     }
-    if (dev->params.upins.apins.alert_pins[alert] == GPIO_UNDEF) {
+    if (gpio_is_undef(dev->params.upins.apins.alert_pins[alert])) {
         return -ENOTSUP;
     }
     gpio_irq_disable(dev->params.upins.apins.alert_pins[alert]);

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -43,6 +43,11 @@
  * definitions in `RIOT/boards/ * /include/periph_conf.h` will define the selected
  * GPIO pin.
  *
+ * @warning The scalar GPIO pin type `gpio_t` is deprecated and will be
+ * replaced by a structured GPIO pin type in a future GPIO API. Therefore,
+ * don't use the direct comparison of GPIO pins anymore. Instead, use the
+ * inline comparison functions @ref gpio_is_equal and @ref gpio_is_undef.
+ *
  * # (Low-) Power Implications
  *
  * On almost all platforms, we can only control the peripheral power state of
@@ -249,6 +254,27 @@ void gpio_toggle(gpio_t pin);
  * @param[in] value     value to set the pin to, 0 for LOW, HIGH otherwise
  */
 void gpio_write(gpio_t pin, int value);
+
+/**
+ * @brief   Test if a GPIO pin is equal to another GPIO pin
+ *
+ * @param[in] gpio1 First GPIO pin to check
+ * @param[in] gpio2 Second GPIO pin to check
+ */
+static inline int gpio_is_equal(gpio_t gpio1, gpio_t gpio2)
+{
+    return (gpio1 == gpio2);
+}
+
+/**
+ * @brief   Test if a GPIO pin is undefined
+ *
+ * @param[in] gpio GPIO pin to check
+ */
+static inline int gpio_is_undef(gpio_t gpio)
+{
+    return (gpio == GPIO_UNDEF);
+}
 
 #ifdef __cplusplus
 }

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -1,15 +1,34 @@
 /*
  * Copyright (C) 2015 Freie Universität Berlin
+ *               2020 Gunar Schorcht
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
 
+#ifndef PERIPH_GPIO_H
+#define PERIPH_GPIO_H
+
+#ifdef MODULE_PERIPH_GPIO_EXP
+
+#include "periph/gpio_exp.h"
+
+#else /* MODULE_PERIPH_GPIO_EXP */
+
 /**
+ * @anchor      drivers_periph_gpio
  * @defgroup    drivers_periph_gpio GPIO
  * @ingroup     drivers_periph
- * @brief       Low-level GPIO peripheral driver
+ * @brief       GPIO peripheral driver
+ *
+ * @note This is the legacy GPIO API. It will be removed once all platforms
+ * implement the new GPIO API which allows to implement the API for any kind
+ * of GPIO hardware. The new GPIO API is compatible with this legacy API.
+ * @warning The scalar GPIO pin type `gpio_t` is deprecated and will be
+ * replaced by a structured GPIO pin type in the new GPIO API. Therefore,
+ * don't use the direct comparison of GPIO pins anymore. Instead, use the
+ * inline comparison functions @ref gpio_is_equal and @ref gpio_is_undef.
  *
  * This is a basic GPIO (General-purpose input/output) interface to allow
  * platform independent access to a MCU's input/output pins. This interface is
@@ -43,11 +62,6 @@
  * definitions in `RIOT/boards/ * /include/periph_conf.h` will define the selected
  * GPIO pin.
  *
- * @warning The scalar GPIO pin type `gpio_t` is deprecated and will be
- * replaced by a structured GPIO pin type in a future GPIO API. Therefore,
- * don't use the direct comparison of GPIO pins anymore. Instead, use the
- * inline comparison functions @ref gpio_is_equal and @ref gpio_is_undef.
- *
  * # (Low-) Power Implications
  *
  * On almost all platforms, we can only control the peripheral power state of
@@ -71,9 +85,6 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
-
-#ifndef PERIPH_GPIO_H
-#define PERIPH_GPIO_H
 
 #include <limits.h>
 
@@ -280,5 +291,7 @@ static inline int gpio_is_undef(gpio_t gpio)
 }
 #endif
 
-#endif /* PERIPH_GPIO_H */
 /** @} */
+
+#endif /* MODULE_PERIPH_GPIO_EXP */
+#endif /* PERIPH_GPIO_H */

--- a/drivers/include/periph/gpio_exp.h
+++ b/drivers/include/periph/gpio_exp.h
@@ -1,0 +1,982 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *               2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_periph_gpio_exp GPIO Expandable
+ * @ingroup     drivers_periph
+ * @brief       New expandable GPIO peripheral driver
+ *
+ * This API is the **new expandable GPIO API** that provides a consistent
+ * access to GPIO pins of the MCU and GPIO expanders. This allows to expand
+ * MCU GPIO pins by GPIO expanders. The API consists of
+ *
+ * - a **pin-oriented high-level API** which is compatible with the
+ *   @ref drivers_periph_gpio "Legacy GPIO API" and
+ * - a **port-oriented low-level API** that has to be implemented by drivers for
+ *   each GPIO hardware component (MCU GPIO ports and GPIO expanders).
+ *
+ * @note Since the high-level API uses the functions of the
+ * low-level API, the new expandable GPIO API can only be used if the
+ * low-level API is also implemented by the MCU. This is automatically
+ * detected when the file `periph/gpio.h` is included.
+ *
+ * The GPIO API provides capabilities to initialize a pin as output-,
+ * input- and interrupt pin. With the API you can basically set/clear/toggle
+ * the digital signal at the hardware pin when in output mode. Configured as
+ * input you can read a digital value that is being applied to the pin
+ * externally. When initializing an external interrupt pin, you can register
+ * a callback function that is executed in interrupt context once the interrupt
+ * condition applies to the pin. Usually you can react to rising or falling
+ * signal flanks (or both).
+ *
+ * In addition the API provides to set standard input/output circuit modes
+ * such as e.g. internal push-pull configurations.
+ *
+ * All modern micro controllers organize their GPIOs in some form of ports,
+ * often named `PA`, `PB`, `PC`..., or `P0`, `P1`, `P2`..., or similar. Each
+ * of these ports is then assigned a number of pins, often 8, 16, or 32. A
+ * hardware pin can thus be described by its port/pin tuple. To access a pin,
+ * the #GPIO_PIN(port, pin) macro should be used. For example: If your
+ * platform has a pin PB22, it will be port=1 and pin=22.
+ *
+ * ## Implementation
+ *
+ * The GPIO API is divided into a low-level API and a high-level API.
+ *
+ * ### High Level API
+ *
+ * The high-level API is used by the application and provides a pin-oriented
+ * access to the GPIO pins. For this purpose it uses the functions of the
+ * low-level API, whereby a distinction is made between two cases:
+ *
+ * 1. Default case without GPIO expanders (module `gpio_exp` is not enabled)<br>
+ *    Only MCU GPIO ports are used. The functions of the high-level API can
+ *    therefore directly calls the the low-level API functions `gpio_cpu_*`
+ *    of the MCU implementation.
+ * 2. GPIO expanders are used (module `gpio_exp` is enabled)<br>
+ *    The functions of the high-level API always call the low-level API
+ *    functions indirectly via a driver interface of type #gpio_driver_t.
+ *    For GPIO expanders this driver is stored in an associated device
+ *    structure of type #gpio_dev_t.
+ *    For MCU GPIO Ports the driver interface #gpio_cpu_driver is used.
+ *
+ * ### Low-Level API
+ *
+ * The low-level API allows port-oriented access to the GPIOs. It has to be
+ * implemented by every hardware driver that provides GPIOs, including the
+ * MCU. The functions of the low-level API are called by the high-level API.
+ *
+ * @note The MCU functions of the low-level API must follow a special naming
+ * scheme where all function names have the prefix `gpio_cpu_*`. These
+ * functions are used to automatically create the driver interface
+ * #gpio_cpu_driver for MCU GPIO ports.
+ *
+ * See @ref drivers_periph_gpio_exp_low_level_api_impl
+ * "Low-Level API Implementation" for further information.
+ *
+ * ### GPIO Pins
+ *
+ * GPIO pins are of type #gpio_t and are defined as a tuple of a GPIO port
+ * and the number of the pin on that GPIO port.
+ *
+ * GPIOs of type #gpio_t are defined with the #GPIO_PIN(port,pin) macro.
+ * The #GPIO_UNDEF macro declares a GPIO pin as undefined.
+ *
+ * ### GPIO Ports
+ *
+ * A GPIO port is a hardware component that provides a certain number of
+ * GPIO pins. Such hardware can be either a MCU GPIO port or a GPIO expander
+ * port. The number of pins per GPIO port is defined by the width of
+ * type #gpio_mask_t which in turn can be either
+ *
+ * - `uint32_t` if module `gpio_mask_32bit` is enabled,
+ * - `uint16_t` if module `gpio_mask_16bit` is enabled or
+ * - `uint8_t` if module `gpio_mask_8bit` is enabled.
+ *
+ * Each driver for GPIO ports including the MCU implementation has to enable
+ * the according module. The width of type #gpio_mask_t is then the maximum
+ * width of all different GPIO ports used in the system.
+ *
+ * The definition of a GPIO port is of type #gpio_port_t and can be either
+ *
+ * - the register address in case of a MCU GPIO port and if all MCU GPIO ports
+ *   follow a consistent address scheme,
+ * - the address of a device descriptor in case of a GPIO expander port or
+ * - the port number.
+ *
+ * The respective implementation of the low-level API determines which
+ * representation of a port is used.
+ *
+ * The port number is a sequential number that goes from 0 to `GPIO_EXP_PORT-1`
+ * for MCU GPIO ports. For GPIO expanders, the port number is derived from
+ * `GPIO_EXP_PORT` and their index in the GPIO device table #gpio_devs as
+ * offset. Thus the port numbers for MCU ports and GPIO expander ports are
+ * numbered consecutively and can be used with the GPIO_PIN macro in the
+ * same way. The number of a port of type #gpio_port_t can be determined
+ * using the #gpio_port_num function.
+ *
+ * In the case of GPIO expander ports, the port is defined as a reference to
+ * a device descriptor of type #gpio_dev_t. This device descriptor
+ * contains:
+ *
+ * 1. A reference to a device-specific descriptor which is used by the
+ *    associated device driver to store the state and parameters
+ *    of the device. The structure of the device-specific descriptor is
+ *    defined by the device driver.
+ * 2. A reference to a driver interface of type #gpio_driver_t. The driver
+ *    interface contains the references to the low-level GPIO API functions
+ *    of the associated device driver.
+ *
+ * Device descriptors of type #gpio_dev_t are stored for all existing
+ * GPIO expander ports in a device table for GPIO Ports #gpio_devs, where each
+ * entry contains a device descriptor for exactly one GPIO expander port.
+ * If a GPIO expander provides multiple ports, each port has to be defined as
+ * separate device of type #gpio_dev_t. Using the same GPIO expander for
+ * different ports must then be implemented by the device driver using a
+ * device-specific driver interface in combination with a device-specific
+ * descriptor.
+ *
+ * The device table for GPIO Ports #gpio_devs is automatically generated from
+ * the `GPIO_EXP_PORTS` macro definition which has to be defined either by
+ * the board definition or by the application.
+ *
+ * ### Using GPIO Expander
+ *
+ * The use of GPIO expanders is enabled by the `gpio_exp` module. If
+ * the `gpio_exp` module is enabled, either the board definition or the
+ * application must provide the configuration of the GPIO expanders in file
+ * `gpio_exp_conf.h`. This file has to contain the definition of
+ * macro `GPIO_EXP_PORTS`.
+ *
+ * For example, if a GPIO expander device driver implements the low-level
+ * GPIO API functions `foo_gpio_*(foo_gpio_exp_t* dev, ...)`, it can be
+ * integrated by defining configuration as follows.
+ * ```c
+ * extern foo_gpio_exp_t    foo_gpio_exp;
+ * extern foo_gpio_driver_t foo_gpio_exp_driver;
+ *
+ * #define GPIO_EXP_PORTS \
+ *     { .port.dev = &foo_gpio_exp, .driver = &foo_gpio_exp_driver },
+ * ```
+ * ```c
+ * foo_gpio_exp_t foo_gpio_exp = { ... };
+ *
+ * const gpio_driver_t foo_gpio_exp_driver = {
+ *     .init = foo_gpio_exp_init,
+ * #ifdef MODULE_PERIPH_GPIO_IRQ
+ *     .init_int = foo_gpio_exp_init_int,
+ *     .irq_enable = foo_gpio_exp_irq_enable,
+ *     .irq_disable = foo_gpio_exp_irq_disable,
+ * #endif
+ *     .read = foo_gpio_exp_read,
+ *     .set = foo_gpio_exp_set,
+ *     .clear = foo_gpio_exp_clear,
+ *     .toggle = foo_gpio_exp_toggle,
+ *     .write = foo_gpio_exp_write,
+ * };
+ * ```
+ *
+ * If a GPIO expander provides multiple ports, each port has to be defined by a
+ * separate device descriptor. Ports are then handled by the device driver
+ * using a device-specific driver interface and a device-specific descriptor.
+ *
+ * For example, a driver for a multiple port GPIO expander would implement
+ * functions `bar_*(bar_exp_t* dev, uint8_t port, ...)` using a device-specific
+ * descriptor of type `bar_exp_t`. Low-level GPIO API functions
+ * `bar_gpio_*(bar_gpio_exp_t* dev, ...)` would then have to be realized
+ * as wrapper functions using descriptors of type `bar_gpio_exp_t` for each
+ * port. See `tests/periph_gpio_exp/bar_gpio_exp.h` for an example.
+ * ```c
+ * extern bar_exp_t         bar_exp;
+ * extern bar_gpio_exp_t    bar_gpio_exp1;
+ * extern bar_gpio_exp_t    bar_gpio_exp2;
+ * extern bar_gpio_driver_t bar_gpio_exp_driver;
+ *
+ * #define GPIO_EXP_PORTS \
+ *     { .port.dev = &bar_gpio_exp1, .driver = &bar_gpio_exp_driver }, \
+ *     { .port.dev = &bar_gpio_exp2, .driver = &bar_gpio_exp_driver },
+ * ```
+ * ```c
+ * bar_exp_t bar_exp = { ... };
+ * bar_gpio_exp_t bar_gpio_exp_1 = { .dev = &bar_exp, .port = 0 };
+ * bar_gpio_exp_t bar_gpio_exp_2 = { .dev = &bar_exp, .port = 1 };
+ * const bar_gpio_driver_t bar_gpio_exp_driver = { ... };
+ * ```
+ *
+ * See `tests/periph_gpio_exp` as an example for defining GPIO expander
+ * configurations. The example shows how to define and use GPIO expanders
+ * with a single port and with multiple ports.
+ *
+ * @anchor  drivers_periph_gpio_exp_low_level_api_impl
+ * ### Low-Level API Implementations
+ *
+ * Each GPIO hardware driver, i.e. each MCU and each GPIO expander driver,
+ * has to implement the low-level API functions, see section
+ * @ref drivers_periph_gpio_exp_low_level_api_functions
+ * "Low-level API functions".
+ *
+ * @note The MCU functions of the low-level API must follow a special naming
+ * scheme where all function names have the prefix `gpio_cpu_*`, see @ref
+ * drivers_periph_gpio_cpu_low_level_api_impl
+ * "Low-level API functions for MCU GPIO ports".
+ *
+ * If an MCU implementation uses register addresses for port definitions of
+ * type #gpio_port_t, it has to define the #GPIO_CPU_PORT and
+ * #GPIO_CPU_PORT_NUM macros. Otherwise, the port number is used by default
+ * to define a #gpio_port_t port.
+ * While #GPIO_CPU_PORT converts the port number to the corresponding register
+ * address, #GPIO_CPU_PORT_NUM provides the port number for a specific register
+ * address. Both macros are required by the GPIO API.
+ *
+ * If an MCU imeplementation uses register addresses and defines the
+ * #GPIO_CPU_PORT and #GPIO_CPU_PORT_NUM macros, it has also to define the
+ * GPIO port base register address #GPIO_CPU_PORT_BASE and a
+ * #GPIO_CPU_PORT_MASK mask to uniquely distinguish a pointer to a memory
+ * address in RAM or ROM from a register address. This is needed by macro
+ * #GPIO_CPU_PORT_IS to clearly identify whether a port definition of type
+ * #gpio_port_t is a register address or a pointer to the device structure
+ * of type #gpio_dev_t, i.e. whether it is a MCU port or a GPIO expander port.
+ * Alternatively, the macro #GPIO_CPU_PORT_IS can be overridden by the MCU
+ * implementation with a more efficient implementation if possible.
+ *
+ * Thus the MCU implementation of the low-level API must define the following
+ *
+ * - the width of its GPIO ports using the according `gpio_mask_*bit` module
+ * - if register address are used as port definitions the macros
+ *   - #GPIO_CPU_PORT and #GPIO_CPU_PORT_NUM
+ *   - #GPIO_CPU_PORT_BASE and #GPIO_CPU_PORT_MASK or alternatively
+ *     #GPIO_CPU_PORT_IS
+ * - the low-level API functions with prefix `gpio_cpu_*`, see section
+ *   @ref drivers_periph_gpio_exp_low_level_api_functions
+ *   "Low-level API functions".
+ *
+ * ## (Low-) Power Implications
+ *
+ * On almost all platforms, we can only control the peripheral power state of
+ * full ports (i.e. groups of pins), but not for single GPIO pins. Together with
+ * CPU specific alternate function handling for pins used by other peripheral
+ * drivers, this can make it quite complex to keep track of pins that are
+ * currently used at a certain moment. To simplify the implementations (and ease
+ * the memory consumption), we expect ports to be powered on (e.g. through
+ * peripheral clock gating) when first used and never be powered off again.
+ *
+ * GPIO driver implementations **should** power on the corresponding port during
+ * gpio_init() and gpio_init_int().
+ *
+ * For external interrupts to work, some platforms may need to block certain
+ * power modes (although this is not very likely). This should be done during
+ * gpio_init_int().
+ *
+ * @{
+ * @file
+ * @brief       Low-level GPIO peripheral driver interface definitions
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef PERIPH_GPIO_EXP_H
+#define PERIPH_GPIO_EXP_H
+
+#include <limits.h>
+
+#include "gpio_arch.h"  /* include architecture specific GPIO definitions */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef HAVE_GPIO_PIN_T
+/**
+ * @brief   GPIO pin number type
+ */
+typedef uint_fast8_t gpio_pin_t;
+#endif
+
+/**
+ * @brief   Register address type for GPIO ports of the MCU
+ *
+ * The size of this type must match the size of a pointer to distinguish
+ * between MCU GPIO register addresses and pointers on GPIO devices.
+ */
+#ifndef HAVE_GPIO_REG_T
+typedef uint32_t gpio_reg_t;
+#endif
+
+/**
+ * @brief   GPIO mask type that corresponds to the supported GPIO port width
+ *
+ * This type is used to mask the pins of a GPIO port in various low-level GPIO
+ * functions. Its size must therefore be the maximum width of all different
+ * GPIO ports used in the system. For this purpose, each component that
+ * provides GPIO ports must activate the corresponding pseudo module that
+ * specifies the width of its GPIO ports.
+ */
+#if defined(MODULE_GPIO_MASK_32BIT)
+typedef uint32_t gpio_mask_t;
+#elif defined(MODULE_GPIO_MASK_16BIT)
+typedef uint16_t gpio_mask_t;
+#else
+typedef uint8_t gpio_mask_t;
+#endif
+
+/**
+ * @brief   Convert a MCU port number into its register address
+ *
+ * The macro has to be defined by the MCU if the low-level API implementation
+ * of the MCU wants to use the port definitions directly as register addresses.
+ */
+#ifndef GPIO_CPU_PORT
+#define GPIO_CPU_PORT(x)        (x)
+#endif
+
+/**
+ * @brief   Convert a MCU port register address into its port number
+ *
+ * The macro has to be defined by the MCU if the low-level API implementation
+ * of the MCU wants to use the port definitions directly as register addresses.
+ */
+#ifndef GPIO_CPU_PORT_NUM
+#define GPIO_CPU_PORT_NUM(x)    (x)
+#endif
+
+/**
+ * @brief   Mask for GPIO port register addresses
+ *
+ * The macro has to be defined by the MCU if the low-level API implementation
+ * of the MCU wants to use the port definitions directly as register addresses.
+ *
+ * Otherwise the MCU ports are addressed via the port number and the ports of
+ * the MCU are numbered from 0 to 31. The last 5 bits are then used as port
+ * number in #gpio_port_t.
+ *
+ * The AND operation of the #GPIO_CPU_PORT_MASK mask with a port definition
+ * must result in the base GPIO port register address #GPIO_CPU_PORT_BASE.
+ * This is required to uniquely identify whether a port definition of type
+ * #gpio_port_t is a register address or a pointer to the device structure
+ * of type #gpio_dev_t, i.e. whether it is a MCU port or a GPIO expander port.
+ */
+#ifndef GPIO_CPU_PORT_MASK
+#define GPIO_CPU_PORT_MASK      (0xffffffe0)
+#endif
+
+/**
+ * @brief   Base GPIO port register addresses
+ *
+ * The macro has to be defined by the MCU if the low-level API implementation
+ * of the MCU wants to use the port definitions directly as register addresses.
+ *
+ * Otherwise the MCU ports are addressed via the port number and the ports of
+ * the MCU are numbered from 0 to 31. The last 5 bits are then used as port
+ * number in #gpio_port_t.
+ *
+ * The AND operation of the #GPIO_CPU_PORT_MASK mask with a port definition
+ * must result in the base GPIO port register address #GPIO_CPU_PORT_BASE.
+ * This is required to uniquely identify whether a port definition of type
+ * #gpio_port_t is a register address or a pointer to the device structure
+ * of type #gpio_dev_t, i.e. whether it is a MCU port or a GPIO expander port.
+ */
+#ifndef GPIO_CPU_PORT_BASE
+#define GPIO_CPU_PORT_BASE      (0)
+#endif
+
+/**
+ * @brief   Convert a (port, pin) tuple into @ref gpio_t structure
+ */
+#if MODULE_GPIO_EXP || DOXYGEN
+#define GPIO_PIN(x, y)  ((gpio_t){ .port = { .dev = (x < GPIO_EXP_PORT ? (gpio_dev_t *)GPIO_CPU_PORT(x) \
+                                                                       : &gpio_devs[x - GPIO_EXP_PORT]) }, \
+                                   .pin = y })
+#else
+#define GPIO_PIN(x, y)  ((gpio_t){ .port = { .reg = GPIO_CPU_PORT(x) }, .pin = y })
+#endif
+
+/**
+ * @brief   GPIO pin declared as not defined
+ */
+#define GPIO_PIN_UNDEF  ((gpio_pin_t)(UINT_FAST8_MAX))
+
+/**
+ * @brief   GPIO declared as not defined
+ */
+#define GPIO_UNDEF  ((gpio_t){ .port = { .dev = NULL }, .pin = GPIO_PIN_UNDEF })
+
+/**
+ * @brief   Available GPIO modes
+ *
+ * Generally, a GPIO can be configured to be input or output. In output mode, a
+ * pin can further be put into push-pull or open drain configuration. Though
+ * this is supported by most platforms, this is not always the case, so driver
+ * implementations may return an error code if a mode is not supported.
+ */
+#ifndef HAVE_GPIO_MODE_T
+typedef enum {
+    GPIO_IN ,               /**< configure as input without pull resistor */
+    GPIO_IN_PD,             /**< configure as input with pull-down resistor */
+    GPIO_IN_PU,             /**< configure as input with pull-up resistor */
+    GPIO_OUT,               /**< configure as output in push-pull mode */
+    GPIO_OD,                /**< configure as output in open-drain mode without
+                             *   pull resistor */
+    GPIO_OD_PU              /**< configure as output in open-drain mode with
+                             *   pull resistor enabled */
+} gpio_mode_t;
+#endif
+
+/**
+ * @brief   Definition of possible active flanks for external interrupt mode
+ */
+#ifndef HAVE_GPIO_FLANK_T
+typedef enum {
+    GPIO_FALLING = 0,       /**< emit interrupt on falling flank */
+    GPIO_RISING = 1,        /**< emit interrupt on rising flank */
+    GPIO_BOTH = 2           /**< emit interrupt on both flanks */
+} gpio_flank_t;
+#endif
+
+/**
+ * @brief   Signature of event callback functions triggered from interrupts
+ *
+ * @param[in] arg       optional context for the callback
+ */
+typedef void (*gpio_cb_t)(void *arg);
+
+/**
+ * @brief   Default interrupt context for GPIO pins
+ */
+#ifndef HAVE_GPIO_ISR_CTX_T
+typedef struct {
+    gpio_cb_t cb;           /**< interrupt callback */
+    void *arg;              /**< optional argument */
+} gpio_isr_ctx_t;
+#endif
+
+/** forward declaration of GPIO device driver type */
+struct gpio_driver;
+
+/**
+ * @brief   GPIO device type
+ *
+ * A GPIO device is a hardware component that provides a single GPIO port with
+ * a number of GPIO pins, e.g. a single port GPIO expander. It is defined by
+ * a device-specific descriptor that contains the state and parameters of
+ * the device, as well as an associated device driver for using the device.
+ *
+ * @note The GPIO device type is only used for GPIO expander ports but
+ * not for MCU GPIO ports.
+ */
+typedef struct {
+    void *dev;                          /**< device descriptor */
+    const struct gpio_driver *driver;   /**< associated device driver */
+} gpio_dev_t;
+
+/**
+ * @brief   GPIO port type
+ *
+ * A GPIO port allows the access to a number of GPIO pins. It can be either
+ *
+ * - the register address in case of a MCU GPIO port and if all MCU GPIO ports
+ *   follow a consistent address scheme,
+ * - the address of a device descriptor in case of a GPIO expander port or
+ * - the port number.
+ *
+ * Which representation is used is determined by the low-level implementation.
+ *
+ * @note To use the register address representation for MCU GPIO ports, the
+ * MCU has to define the macros #GPIO_CPU_PORT and #GPIO_CPU_PORT_NUM.
+ * Otherwise the port number is used as representation for MCU ports by
+ * default. Furthermore, macros #GPIO_CPU_PORT_BASE and * #GPIO_CPU_PORT_MASK
+ * or alternatively #GPIO_CPU_PORT_IS have to be defined.
+ */
+typedef union gpio_port {
+    gpio_reg_t reg;        /**< register address of a MCU GPIO port */
+    const gpio_dev_t* dev; /**< pointer to a device that provides the port */
+    uintptr_t num;         /**< port number */
+} gpio_port_t;
+
+/**
+ * @anchor  drivers_periph_gpio_exp_low_level_api_functions
+ * @name    Low-level API functions
+ *
+ * The following function prototypes define the low-level GPIO API
+ * that have to be implemented by each GPIO hardware driver. They are used
+ * by high-level GPIO functions `gpio_*`.
+ *
+ * The GPIO device driver interface of type #gpio_driver_t for a GPIO port
+ * contains references to these low-level API functions.
+ *
+ * @note Functions of the low-level API should only be called directly if
+ * several pins of a GPIO port are to be changed simultaneously using the
+ * definition of GPIO pin masks of type #gpio_mask_t.
+ *
+ * @{
+ */
+
+/**
+ * @brief   Initialize the given pin as GPIO
+ *
+ * @param[in] port  port of the GPIO pin to initialize
+ * @param[in] pin   number of the GPIO pin to initialize
+ * @param[in] mode  mode of the pin, see #gpio_mode_t
+ *
+ * @return    0 on success
+ * @return    -1 on error
+ *
+ * @see gpio_init
+ */
+typedef int (*gpio_dev_init_t)(gpio_port_t port, gpio_pin_t pin,
+                               gpio_mode_t mode);
+
+#if MODULE_PERIPH_GPIO_IRQ || DOXYGEN
+
+/**
+ * @brief   Initialize a GPIO pin for external interrupt usage
+ *
+ * @param[in] port  port of the GPIO pin to initialize
+ * @param[in] pin   number of the GPIO pin to initialize
+ * @param[in] mode  mode of the pin, see #gpio_mode_t
+ * @param[in] flank define the active flank(s)
+ * @param[in] cb    callback that is called from interrupt context
+ * @param[in] arg   optional argument passed to the callback
+ *
+ * @return    0 on success
+ * @return    -1 on error
+ *
+ * @see gpio_init_int
+ */
+typedef int (*gpio_dev_init_int_t)(gpio_port_t port, gpio_pin_t pin,
+                                   gpio_mode_t mode, gpio_flank_t flank,
+                                   gpio_cb_t cb, void *arg);
+
+/**
+ * @brief   Enable GPIO pin interrupt if configured as interrupt source
+ *
+ * @param[in] port  port of the GPIO pin
+ * @param[in] pin   number of the GPIO pin
+ *
+ * @see gpio_irq_enable
+ */
+typedef void (*gpio_dev_irq_enable_t)(gpio_port_t port, gpio_pin_t pin);
+
+/**
+ * @brief   Disable GPIO pin interrupt if configured as interrupt source
+ *
+ * @param[in] port  port of the GPIO pin
+ * @param[in] pin   number of the GPIO pin
+ *
+ * @see gpio_irq_disable
+ */
+typedef void (*gpio_dev_irq_disable_t)(gpio_port_t port, gpio_pin_t pin);
+
+#endif /* MODULE_PERIPH_GPIO_IRQ || DOXYGEN */
+
+/**
+ * @brief   Get current values of all pins of the given GPIO port
+ *
+ * @param[in] port  GPIO port
+ *
+ * @return    value of width gpio_mask_t where the bit positions
+ *            represent the current value of the according pin
+ *            (0 when pin is LOW and 1 when pin is HIGH)
+ */
+typedef gpio_mask_t (*gpio_dev_read_t)(gpio_port_t port);
+
+/**
+ * @brief   Set the pins of a port defined by the pin mask to HIGH
+ *
+ * @param[in] port  GPIO port
+ * @param[in] pins  mask of the pins to set
+ *
+ * @see gpio_set
+ */
+typedef void (*gpio_dev_set_t)(gpio_port_t port, gpio_mask_t pins);
+
+/**
+ * @brief   Set the pins of a port defined by the pin mask to LOW
+ *
+ * @param[in] port  GPIO port
+ * @param[in] pins  mask of the pins to clear
+ *
+ * @see gpio_set
+ */
+typedef void (*gpio_dev_clear_t)(gpio_port_t port, gpio_mask_t pins);
+
+/**
+ * @brief   Toggle the value the pins of a port defined by the pin mask
+ *
+ * @param[in] port  GPIO port
+ * @param[in] pins  mask of the pins to toggle
+ *
+ * @see gpio_set
+ */
+typedef void (*gpio_dev_toggle_t)(gpio_port_t port, gpio_mask_t pins);
+
+/**
+ * @brief   Set the values of all pins of the given GPIO port
+ *
+ * @param[in] port  GPIO port
+ * @param[in] pins  values of the pins
+ *                  (according bit is 0 for LOW and 1 for HIGH)
+ *
+ * @see gpio_write
+ */
+typedef void (*gpio_dev_write_t)(gpio_port_t port, gpio_mask_t values);
+
+/**
+ * @}
+ */
+
+/**
+ * @brief   GPIO device driver interface type
+ *
+ * GPIO device drivers are used for port-oriented access to GPIO ports.
+ * #gpio_driver_t contains the references to the functions of the low-level
+ * API, which are implemented by the driver of the hardware component that
+ * provides a GPIO port.
+ */
+typedef struct gpio_driver {
+    gpio_dev_init_t        init;         /**< see #gpio_dev_init_t  */
+#if MODULE_PERIPH_GPIO_IRQ || DOXYGEN
+    gpio_dev_init_int_t    init_int;     /**< see #gpio_dev_init_int_t */
+    gpio_dev_irq_enable_t  irq_enable;   /**< see #gpio_dev_irq_enable_t */
+    gpio_dev_irq_disable_t irq_disable;  /**< see #gpio_dev_irq_disable_t */
+#endif /* MODULE_PERIPH_GPIO_IRQ || DOXYGEN */
+    gpio_dev_read_t        read;         /**< see #gpio_dev_read_t */
+    gpio_dev_set_t         set;          /**< see #gpio_dev_set_t */
+    gpio_dev_clear_t       clear;        /**< see #gpio_dev_clear_t */
+    gpio_dev_toggle_t      toggle;       /**< see #gpio_dev_toggle_t */
+    gpio_dev_write_t       write;        /**< see #gpio_dev_write_t */
+} gpio_driver_t;
+
+/**
+ * @brief   GPIO pin type definition
+ *
+ * A GPIO pin is defined by a port that provides the access to the pin and
+ * the pin number at this port.
+ */
+typedef struct {
+    gpio_port_t port;   /**< GPIO port */
+    gpio_pin_t pin;     /**< pin number */
+} gpio_t;
+
+#if MODULE_GPIO_EXP || DOXYGEN
+/**
+ * @brief   Device table of GPIO expander ports
+ *
+ * The table contains the device descriptors of type #gpio_dev_t for all
+ * existing GPIO expander ports. Each GPIO expander port corresponds to one
+ * entry. This table is created automatically from `GPIO_EXP_PORTS`.
+ * `GPIO_EXP_PORTS` has to be defined in the GPIO expander configuration
+ * file `gpio_exp_conf.h` by the board definition or the application.
+ *
+ * @see See file `tests/periph_gpio_exp` as an example for defining GPIO
+ * expander configurations.
+ *
+ * @note The table is not used for MCU GPIO ports.
+ */
+extern const gpio_dev_t gpio_devs[];
+
+/**
+ * @brief   GPIO device driver interface for MCU GPIO ports.
+ *
+ * The GPIO device driver interface #gpio_cpu_driver contains the references
+ * to the low-level functions `gpio_cpu_*` of the MCU implementation for
+ * accessing GPIO pins of the MCU GPIO ports.
+ */
+extern const gpio_driver_t gpio_cpu_driver;
+#endif
+
+/**
+ * @name    Low-level API functions for MCU GPIO ports
+ * @anchor  drivers_periph_gpio_cpu_low_level_api_impl
+ *
+ * The following functions correspond exactly to the function prototypes of
+ * the low-level GPIO API, but follow a special naming scheme. These functions
+ * are called directly from the high-level GPIO API for MCU GPIO ports
+ * must be implemented by each MCU in `cpu/.../periph/gpio.c`.
+ *
+ * They can also be called directly if several pins of a GPIO port are
+ * to be changed simultaneously using the definition of a GPIO pin masks
+ * of type gpio_mask_t.
+ *
+ * The GPIO device driver interface #gpio_cpu_driver contains references to
+ * these low-level functions of the MCU implementation.
+ *
+ * @see See function prototypes in #gpio_driver_t for detailed information
+ * about these functions.
+ * @{
+ */
+int  gpio_cpu_init(gpio_port_t port, gpio_pin_t pin, gpio_mode_t mode);
+int  gpio_cpu_init_int(gpio_port_t port, gpio_pin_t pin, gpio_mode_t mode,
+                       gpio_flank_t flank, gpio_cb_t cb, void *arg);
+void gpio_cpu_irq_enable(gpio_port_t port, gpio_pin_t pin);
+void gpio_cpu_irq_disable(gpio_port_t port, gpio_pin_t pin);
+
+gpio_mask_t gpio_cpu_read(gpio_port_t port);
+void gpio_cpu_set(gpio_port_t port, gpio_mask_t pins);
+void gpio_cpu_clear(gpio_port_t port, gpio_mask_t pins);
+void gpio_cpu_toggle(gpio_port_t port, gpio_mask_t pins);
+void gpio_cpu_write(gpio_port_t port, gpio_mask_t values);
+/** @} */
+
+/**
+ * @name    High-level API functions
+ * @{
+ */
+
+#if MODULE_GPIO_EXP || DOXYGEN
+/**
+ * @brief   Determine whether a given port is a MCU GPIO port
+ *
+ * The macro defines a test to determine whether a given port is an MCU
+ * GPIO port. By default this is done by masking the port register address
+ * with #GPIO_CPU_PORT_MASK and comparing the result with #GPIO_CPU_PORT_BASE.
+ *
+ * The MCU implementation can override this macro by a more efficient
+ * implementation if possible
+ */
+#ifndef GPIO_CPU_PORT_IS
+#define GPIO_CPU_PORT_IS(x) ((x.reg & GPIO_CPU_PORT_MASK) == GPIO_CPU_PORT_BASE)
+#endif
+
+/**
+ * @brief    Get the driver interface for a GPIO port
+ */
+static inline const gpio_driver_t *gpio_driver_get(gpio_port_t port)
+{
+    if (GPIO_CPU_PORT_IS(port)) {
+        return &gpio_cpu_driver;
+    }
+    else {
+        assert(port.dev);
+        assert(port.dev->driver);
+        return port.dev->driver;
+    }
+}
+#endif /* MODULE_GPIO_EXP || DOXYGEN */
+
+/**
+ * @brief   Initialize the given pin as GPIO
+ *
+ * When configured as output, the pin state after initialization is undefined.
+ * The output pin's state **should** be untouched during the initialization.
+ * This behavior can however **not be guaranteed** by every platform.
+ *
+ * @param[in] gpio  GPIO pin to initialize
+ * @param[in] mode  mode of the pin, see @ref gpio_mode_t
+ *
+ * @return    0 on success
+ * @return    -1 on error
+ */
+static inline int gpio_init(gpio_t gpio, gpio_mode_t mode)
+{
+#ifdef MODULE_GPIO_EXP
+    const gpio_driver_t *driver = gpio_driver_get(gpio.port);
+    return driver->init(gpio.port, gpio.pin, mode);
+#else
+    return gpio_cpu_init(gpio.port, gpio.pin, mode);
+#endif
+}
+
+#if defined(MODULE_PERIPH_GPIO_IRQ) || defined(DOXYGEN)
+/**
+ * @brief   Initialize a GPIO pin for external interrupt usage
+ *
+ * The registered callback function will be called in interrupt context every
+ * time the defined flank(s) are detected.
+ *
+ * The interrupt is activated automatically after the initialization.
+ *
+ * @note    You have to add the module `periph_gpio_irq` to your project to
+ *          enable this function
+ *
+ * @param[in] gpio  GPIO pin to initialize
+ * @param[in] mode  mode of the pin, see @ref gpio_mode_t
+ * @param[in] flank define the active flank(s)
+ * @param[in] cb    callback that is called from interrupt context
+ * @param[in] arg   optional argument passed to the callback
+ *
+ * @return    0 on success
+ * @return    -1 on error
+ */
+static inline int gpio_init_int(gpio_t gpio, gpio_mode_t mode,
+                                gpio_flank_t flank,
+                                gpio_cb_t cb, void *arg)
+{
+#ifdef MODULE_GPIO_EXP
+    const gpio_driver_t *driver = gpio_driver_get(gpio.port);
+    return driver->init_int(gpio.port, gpio.pin, mode, flank, cb, arg);
+#else
+    return gpio_cpu_init_int(gpio.port, gpio.pin, mode, flank, cb, arg);
+#endif
+}
+
+/**
+ * @brief   Enable GPIO pin interrupt if configured as interrupt source
+ *
+ * @note    You have to add the module `periph_gpio_irq` to your project to
+ *          enable this function
+ *
+ * @param[in] gpio  GPIO pin to enable the interrupt for
+ */
+static inline void gpio_irq_enable(gpio_t gpio)
+{
+#ifdef MODULE_GPIO_EXP
+    const gpio_driver_t *driver = gpio_driver_get(gpio.port);
+    driver->irq_enable(gpio.port, gpio.pin);
+#else
+    gpio_cpu_irq_enable(gpio.port, gpio.pin);
+#endif
+}
+
+/**
+ * @brief   Disable the GPIO pin interrupt if configured as interrupt source
+ *
+ * @note    You have to add the module `periph_gpio_irq` to your project to
+ *          enable this function
+ *
+ * @param[in] gpio  GPIO pin to disable the interrupt for
+ */
+static inline void gpio_irq_disable(gpio_t gpio)
+{
+#ifdef MODULE_GPIO_EXP
+    const gpio_driver_t *driver = gpio_driver_get(gpio.port);
+    driver->irq_disable(gpio.port, gpio.pin);
+#else
+    gpio_cpu_irq_disable(gpio.port, gpio.pin);
+#endif
+}
+
+#endif /* defined(MODULE_PERIPH_GPIO_IRQ) || defined(DOXYGEN) */
+
+/**
+ * @brief   Get the current value of the given GPIO pin
+ *
+ * @param[in] gpio  GPIO pin to read
+ *
+ * @return    0 when pin is LOW
+ * @return    1 when pin is HIGH
+ */
+static inline int gpio_read(gpio_t gpio)
+{
+#ifdef MODULE_GPIO_EXP
+    const gpio_driver_t *driver = gpio_driver_get(gpio.port);
+    return driver->read(gpio.port) & (1 << gpio.pin);
+#else
+    return gpio_cpu_read(gpio.port) & (1 << gpio.pin);
+#endif
+}
+
+/**
+ * @brief   Set the given GPIO pin to HIGH
+ *
+ * @param[in] gpio  GPIO pin to set
+ */
+static inline void gpio_set(gpio_t gpio)
+{
+#ifdef MODULE_GPIO_EXP
+    const gpio_driver_t *driver = gpio_driver_get(gpio.port);
+    driver->set(gpio.port, (1 << gpio.pin));
+#else
+    gpio_cpu_set(gpio.port, (1 << gpio.pin));
+#endif
+}
+
+/**
+ * @brief   Set the given GPIO pin to LOW
+ *
+ * @param[in] gpio  GPIO pin to clear
+ */
+static inline void gpio_clear(gpio_t gpio)
+{
+#ifdef MODULE_GPIO_EXP
+    const gpio_driver_t *driver = gpio_driver_get(gpio.port);
+    driver->clear(gpio.port, (1 << gpio.pin));
+#else
+    gpio_cpu_clear(gpio.port, (1 << gpio.pin));
+#endif
+}
+
+/**
+ * @brief   Toggle the value of the given GPIO pin
+ *
+ * @param[in] gpio  GPIO pin to toggle
+ */
+static inline void gpio_toggle(gpio_t gpio)
+{
+#ifdef MODULE_GPIO_EXP
+    const gpio_driver_t *driver = gpio_driver_get(gpio.port);
+    driver->toggle(gpio.port, (1 << gpio.pin));
+#else
+    gpio_cpu_toggle(gpio.port, (1 << gpio.pin));
+#endif
+}
+
+/**
+ * @brief   Set the given GPIO pin to the given value
+ *
+ * @param[in] gpio  GPIO pin to set
+ * @param[in] value value to set the pin to, 0 for LOW, HIGH otherwise
+ */
+static inline void gpio_write(gpio_t gpio, int value)
+{
+    if (value) {
+        gpio_set(gpio);
+    } else {
+        gpio_clear(gpio);
+    }
+}
+
+/**
+ * @brief   Test if a GPIO pin is equal to another GPIO pin
+ *
+ * @param[in] gpio1 First GPIO pin to check
+ * @param[in] gpio2 Second GPIO pin to check
+ */
+static inline int gpio_is_equal(gpio_t gpio1, gpio_t gpio2)
+{
+    return (gpio1.port.dev == gpio2.port.dev) && (gpio1.pin == gpio2.pin);
+}
+
+/**
+ * @brief   Test if a GPIO pin is declared as undefined
+ *
+ * @param[in] gpio GPIO pin to check
+ */
+static inline int gpio_is_undef(gpio_t gpio)
+{
+    return gpio_is_equal(gpio, GPIO_UNDEF);
+}
+
+/**
+ * @brief   Returns the total number of GPIO ports (MCU and other GPIO ports)
+ *
+ * @return  number of GPIO ports
+ */
+int gpio_port_numof(void);
+
+/**
+ * @brief   Returns the port number of a given GPIO pin (MCU and other
+ *          GPIO ports)
+ *
+ * @param[in] gpio  given GPIO pin
+ *
+ * @return  port number for the given GPIO pin on success
+ * @return  -1 on error
+ */
+int gpio_port_num(gpio_t gpio);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* PERIPH_GPIO_EXP_H */

--- a/drivers/include/periph/gpio_exp.h
+++ b/drivers/include/periph/gpio_exp.h
@@ -245,16 +245,17 @@
  * Alternatively, the macro #GPIO_CPU_PORT_IS can be overridden by the MCU
  * implementation with a more efficient implementation if possible.
  *
- * Thus the MCU implementation of the low-level API must define the following
+ * Thus the MCU implementation of the low-level API has to define
  *
  * - the width of its GPIO ports using the according `gpio_mask_*bit` module
- * - if register address are used as port definitions the macros
+ * - if register addresses are used as port definitions the macros
  *   - #GPIO_CPU_PORT and #GPIO_CPU_PORT_NUM
  *   - #GPIO_CPU_PORT_BASE and #GPIO_CPU_PORT_MASK or alternatively
  *     #GPIO_CPU_PORT_IS
  * - the low-level API functions with prefix `gpio_cpu_*`, see section
  *   @ref drivers_periph_gpio_exp_low_level_api_functions
  *   "Low-level API functions".
+ * - the feature `periph_gpio_exp`
  *
  * ## (Low-) Power Implications
  *

--- a/drivers/itg320x/itg320x.c
+++ b/drivers/itg320x/itg320x.c
@@ -97,7 +97,7 @@ int itg320x_init(itg320x_t *dev, const itg320x_params_t *params)
 int itg320x_init_int(const itg320x_t *dev, itg320x_drdy_int_cb_t cb, void *arg)
 {
     assert(dev != NULL);
-    assert(dev->params.int_pin != GPIO_UNDEF);
+    assert(!gpio_is_undef(dev->params.int_pin));
 
     DEBUG_DEV("cb=%p, arg=%p", dev, cb, arg);
 

--- a/drivers/kw2xrf/kw2xrf_spi.c
+++ b/drivers/kw2xrf/kw2xrf_spi.c
@@ -89,9 +89,14 @@ int kw2xrf_spi_init(kw2xrf_t *dev)
         return 1;
     }
     spi_release(SPIDEV);
-
+#ifdef MODULE_PERIPH_GPIO_EXP
+    DEBUG("[kw2xrf_spi] SPI_DEV(%u) initialized: mode: %u, clk: %u, cs_pin: GPIO_PIN(%d, %d)\n",
+          (unsigned)SPIDEV, (unsigned)SPIMODE, (unsigned)SPICLK,
+          gpio_port_num(CSPIN), CSPIN.pin);
+#else
     DEBUG("[kw2xrf_spi] SPI_DEV(%u) initialized: mode: %u, clk: %u, cs_pin: %u\n",
           (unsigned)SPIDEV, (unsigned)SPIMODE, (unsigned)SPICLK, (unsigned)CSPIN);
+#endif
     return 0;
 }
 

--- a/drivers/ltc4150/ltc4150.c
+++ b/drivers/ltc4150/ltc4150.c
@@ -33,7 +33,7 @@ static void pulse_cb(void *_dev)
     ltc4150_dir_t dir;
     ltc4150_dev_t *dev = _dev;
 
-    if ((dev->params.polarity == GPIO_UNDEF) ||
+    if ((gpio_is_undef(dev->params.polarity)) ||
         (!gpio_read(dev->params.polarity))
         ) {
         dev->discharged++;
@@ -66,7 +66,7 @@ int ltc4150_init(ltc4150_dev_t *dev, const ltc4150_params_t *params)
     memset(dev, 0, sizeof(ltc4150_dev_t));
     dev->params = *params;
 
-    if (dev->params.shutdown != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.shutdown)) {
         /* Activate LTC4150 */
         if (gpio_init(dev->params.shutdown, GPIO_OUT)) {
             DEBUG("[ltc4150] Failed to initialize shutdown pin");
@@ -75,7 +75,7 @@ int ltc4150_init(ltc4150_dev_t *dev, const ltc4150_params_t *params)
         gpio_set(dev->params.shutdown);
     }
 
-    if (dev->params.polarity != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.polarity)) {
         gpio_mode_t mode = (dev->params.flags & LTC4150_POL_EXT_PULL_UP) ?
                            GPIO_IN : GPIO_IN_PU;
         if (gpio_init(dev->params.polarity, mode)) {
@@ -132,7 +132,7 @@ int ltc4150_shutdown(ltc4150_dev_t *dev)
 
     gpio_irq_disable(dev->params.interrupt);
 
-    if (dev->params.shutdown != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.shutdown)) {
         gpio_clear(dev->params.shutdown);
     }
 

--- a/drivers/ltc4150/ltc4150_saul.c
+++ b/drivers/ltc4150/ltc4150_saul.c
@@ -35,7 +35,7 @@ static int read_charge(const void *_dev, phydat_t *res)
         res->scale = -3;
         res->unit = UNIT_COULOMB;
         temp[0] = temp[2] - temp[1];
-        int dim = (dev->params.polarity != GPIO_UNDEF) ? 3 : 1;
+        int dim = (!gpio_is_undef(dev->params.polarity)) ? 3 : 1;
         phydat_fit(res, temp, (unsigned)dim);
         return dim;
     }

--- a/drivers/motor_driver/motor_driver.c
+++ b/drivers/motor_driver/motor_driver.c
@@ -51,21 +51,21 @@ int motor_driver_init(motor_driver_t motor_driver)
     }
 
     for (uint8_t i = 0; i < motor_driver_conf->nb_motors; i++) {
-        if ((motor_driver_conf->motors[i].gpio_dir0 != GPIO_UNDEF)
+        if (!gpio_is_undef(motor_driver_conf->motors[i].gpio_dir0)
             && (gpio_init(motor_driver_conf->motors[i].gpio_dir0,
                           GPIO_OUT))) {
             err = EIO;
             LOG_ERROR("gpio_dir0 init failed\n");
             goto motor_init_err;
         }
-        if ((motor_driver_conf->motors[i].gpio_dir1_or_brake != GPIO_UNDEF)
+        if (!gpio_is_undef(motor_driver_conf->motors[i].gpio_dir1_or_brake)
             && (gpio_init(motor_driver_conf->motors[i].gpio_dir1_or_brake,
                           GPIO_OUT))) {
             err = EIO;
             LOG_ERROR("gpio_dir1_or_brake init failed\n");
             goto motor_init_err;
         }
-        if (motor_driver_conf->motors[i].gpio_enable != GPIO_UNDEF) {
+        if (!gpio_is_undef(motor_driver_conf->motors[i].gpio_enable)) {
             if (gpio_init(motor_driver_conf->motors[i].gpio_enable,
                           GPIO_OUT)) {
                 err = EIO;
@@ -105,8 +105,8 @@ int motor_set(const motor_driver_t motor_driver, uint8_t motor_id, \
 
     /* Two direction GPIO, handling brake */
     if (motor_driver_conf->mode == MOTOR_DRIVER_2_DIRS) {
-        if ((dev->gpio_dir0 == GPIO_UNDEF) || \
-            (dev->gpio_dir1_or_brake == GPIO_UNDEF)) {
+        if (gpio_is_undef(dev->gpio_dir0) || \
+            gpio_is_undef(dev->gpio_dir1_or_brake)) {
             err = ENODEV;
             goto motor_set_err;
         }
@@ -124,7 +124,7 @@ int motor_set(const motor_driver_t motor_driver, uint8_t motor_id, \
     }
     /* Single direction GPIO */
     else if (motor_driver_conf->mode == MOTOR_DRIVER_1_DIR) {
-        if (dev->gpio_dir0 == GPIO_UNDEF) {
+        if (gpio_is_undef(dev->gpio_dir0)) {
             err = ENODEV;
             goto motor_set_err;
         }
@@ -141,8 +141,8 @@ int motor_set(const motor_driver_t motor_driver, uint8_t motor_id, \
     }
     /* Single direction GPIO and brake GPIO */
     else if (motor_driver_conf->mode == MOTOR_DRIVER_1_DIR_BRAKE) {
-        if ((dev->gpio_dir0 == GPIO_UNDEF) || \
-            (dev->gpio_dir1_or_brake == GPIO_UNDEF)) {
+        if (gpio_is_undef(dev->gpio_dir0) || \
+            gpio_is_undef(dev->gpio_dir1_or_brake)) {
             err = ENODEV;
             goto motor_set_err;
         }
@@ -204,8 +204,8 @@ int motor_brake(const motor_driver_t motor_driver, uint8_t motor_id)
 
     /* Two direction GPIO, handling brake */
     if (motor_driver_conf->mode == MOTOR_DRIVER_2_DIRS) {
-        if ((dev->gpio_dir0 == GPIO_UNDEF) || \
-            (dev->gpio_dir1_or_brake == GPIO_UNDEF)) {
+        if (gpio_is_undef(dev->gpio_dir0) || \
+            gpio_is_undef(dev->gpio_dir1_or_brake)) {
             err = ENODEV;
             goto motor_brake_err;
         }
@@ -221,7 +221,7 @@ int motor_brake(const motor_driver_t motor_driver, uint8_t motor_id)
     }
     /* Single direction GPIO and brake GPIO */
     else if (motor_driver_conf->mode == MOTOR_DRIVER_1_DIR_BRAKE) {
-        if (dev->gpio_dir1_or_brake == GPIO_UNDEF) {
+        if (gpio_is_undef(dev->gpio_dir1_or_brake)) {
             err = ENODEV;
             goto motor_brake_err;
         }
@@ -256,7 +256,7 @@ void motor_enable(const motor_driver_t motor_driver, uint8_t motor_id)
 
     const motor_t *dev = &motor_driver_conf->motors[motor_id];
 
-    assert(dev->gpio_enable != GPIO_UNDEF);
+    assert(!gpio_is_undef(dev->gpio_enable));
 
     gpio_write(dev->gpio_enable, 1 ^ dev->gpio_enable_invert);
 }
@@ -272,7 +272,7 @@ void motor_disable(const motor_driver_t motor_driver, uint8_t motor_id)
 
     const motor_t *dev = &motor_driver_conf->motors[motor_id];
 
-    assert(dev->gpio_enable != GPIO_UNDEF);
+    assert(!gpio_is_undef(dev->gpio_enable));
 
     gpio_write(dev->gpio_enable, dev->gpio_enable_invert);
 }

--- a/drivers/pca9685/pca9685.c
+++ b/drivers/pca9685/pca9685.c
@@ -104,7 +104,7 @@ int pca9685_init(pca9685_t *dev, const pca9685_params_t *params)
 
     DEBUG_DEV("params=%p", dev, params);
 
-    if (dev->params.oe_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.oe_pin)) {
         /* init the pin an disable outputs first */
         gpio_init(dev->params.oe_pin, GPIO_OUT);
         gpio_set(dev->params.oe_pin);
@@ -232,7 +232,7 @@ void pca9685_pwm_poweron(pca9685_t *dev)
         EXEC(_update(dev, PCA9685_REG_MODE1, PCA9685_MODE1_RESTART, 1));
     }
 
-    if (dev->params.oe_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.oe_pin)) {
         gpio_clear(dev->params.oe_pin);
     }
 
@@ -244,7 +244,7 @@ void pca9685_pwm_poweroff(pca9685_t *dev)
     ASSERT_PARAM(dev != NULL);
     DEBUG_DEV("", dev);
 
-    if (dev->params.oe_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.oe_pin)) {
         gpio_set(dev->params.oe_pin);
     }
 

--- a/drivers/periph_common/gpio.c
+++ b/drivers/periph_common/gpio.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2019 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_periph_gpio
+ * @{
+ *
+ * @file
+ * @brief       Common GPIO driver functions/definitions
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @}
+ */
+
+#ifdef MODULE_PERIPH_GPIO_EXP
+
+#include "periph_cpu.h"
+#include "periph/gpio.h"
+
+#ifdef MODULE_GPIO_EXP
+#include "gpio_exp_conf.h"
+#endif
+
+/* the CPU low level GPIO driver */
+const gpio_driver_t gpio_cpu_driver = {
+    .init = (gpio_dev_init_t)gpio_cpu_init,
+#ifdef MODULE_PERIPH_GPIO_IRQ
+    .init_int = (gpio_dev_init_int_t)gpio_cpu_init_int,
+    .irq_enable = (gpio_dev_irq_enable_t)gpio_cpu_irq_enable,
+    .irq_disable = (gpio_dev_irq_disable_t)gpio_cpu_irq_disable,
+#endif /* MODULE_PERIPH_GPIO_IRQ */
+    .read = (gpio_dev_read_t)gpio_cpu_read,
+    .set = (gpio_dev_set_t)gpio_cpu_set,
+    .clear = (gpio_dev_clear_t)gpio_cpu_clear,
+    .toggle = (gpio_dev_toggle_t)gpio_cpu_toggle,
+    .write = (gpio_dev_write_t)gpio_cpu_write,
+};
+
+#ifdef MODULE_GPIO_EXP
+const gpio_dev_t gpio_devs[] = {
+#ifdef GPIO_EXP_PORTS
+    GPIO_EXP_PORTS
+#endif
+};
+
+#endif /* MODULE_GPIO_EXP */
+
+int gpio_port_numof(void)
+{
+#ifdef MODULE_GPIO_EXP
+    return GPIO_EXP_PORT + ARRAY_SIZE(gpio_devs);
+#else
+    return GPIO_EXP_PORT;
+#endif
+}
+
+int gpio_port_num(gpio_t gpio)
+{
+#ifdef MODULE_GPIO_EXP
+    if ((gpio.port.reg & GPIO_CPU_PORT_MASK) == GPIO_CPU_PORT_BASE) {
+        return GPIO_CPU_PORT_NUM(gpio.port.reg);
+    }
+#ifdef GPIO_EXP_PORTS
+    for (unsigned i = 0; i < ARRAY_SIZE(gpio_devs); i++) {
+        if (gpio.port.dev == gpio_devs[i].dev) {
+            return i;
+        }
+    }
+#endif /* GPIO_EXP_PORTS */
+    return -1;
+#else
+    return GPIO_CPU_PORT_NUM(gpio.port.reg);
+#endif /* MODULE_GPIO_EXP */
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_PERIPH_GPIO_EXP */

--- a/drivers/periph_common/spi.c
+++ b/drivers/periph_common/spi.c
@@ -33,7 +33,7 @@ int spi_init_cs(spi_t bus, spi_cs_t cs)
     if (bus >= SPI_NUMOF) {
         return SPI_NODEV;
     }
-    if ((cs == SPI_CS_UNDEF) || (cs == GPIO_UNDEF)) {
+    if (gpio_is_equal(cs, SPI_CS_UNDEF) || gpio_is_undef(cs)) {
         return SPI_NOCS;
     }
 

--- a/drivers/ph_oem/ph_oem.c
+++ b/drivers/ph_oem/ph_oem.c
@@ -181,7 +181,7 @@ static int _set_interrupt_pin(const ph_oem_t *dev)
 int ph_oem_enable_interrupt(ph_oem_t *dev, ph_oem_interrupt_pin_cb_t cb,
                             void *arg)
 {
-    if (dev->params.interrupt_pin == GPIO_UNDEF) {
+    if (gpio_is_undef(dev->params.interrupt_pin)) {
         return PH_OEM_INTERRUPT_GPIO_UNDEF;
     }
 
@@ -292,7 +292,7 @@ int ph_oem_start_new_reading(const ph_oem_t *dev)
 
     /* if interrupt pin is undefined, poll till new reading was taken and stop
      * device form taking further readings */
-    if (dev->params.interrupt_pin == GPIO_UNDEF) {
+    if (gpio_is_undef(dev->params.interrupt_pin)) {
         int result = _new_reading_available(dev);
         if (result < 0) {
             return result;

--- a/drivers/ph_oem/ph_oem_saul.c
+++ b/drivers/ph_oem/ph_oem_saul.c
@@ -30,7 +30,7 @@ static int read_ph(const void *dev, phydat_t *res)
     const ph_oem_t *mydev = dev;
     uint16_t ph_reading;
 
-    if (mydev->params.interrupt_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(mydev->params.interrupt_pin)) {
         puts("interrupt pin not supported with SAUL yet");
         return -ENOTSUP;
     }

--- a/drivers/qmc5883l/qmc5883l.c
+++ b/drivers/qmc5883l/qmc5883l.c
@@ -178,7 +178,7 @@ int qmc5883l_init_int(const qmc5883l_t *dev, gpio_cb_t cb, void *arg)
     assert(dev);
     assert(cb);
 
-    if (dev->pin_drdy == GPIO_UNDEF) {
+    if (gpio_is_undef(dev->pin_drdy)) {
         return QMC5883L_NOCFG;
     }
     if (gpio_init_int(dev->pin_drdy, GPIO_IN, GPIO_RISING, cb, arg) != 0) {

--- a/drivers/rn2xx3/rn2xx3.c
+++ b/drivers/rn2xx3/rn2xx3.c
@@ -140,7 +140,7 @@ void rn2xx3_setup(rn2xx3_t *dev, const rn2xx3_params_t *params)
     dev->p = *params;
 
     /* initialize pins and perform hardware reset */
-    if (dev->p.pin_reset != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->p.pin_reset)) {
         gpio_init(dev->p.pin_reset, GPIO_OUT);
         gpio_set(dev->p.pin_reset);
     }
@@ -162,7 +162,7 @@ int rn2xx3_init(rn2xx3_t *dev)
     }
 
     /* if reset pin is connected, do a hardware reset */
-    if (dev->p.pin_reset != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->p.pin_reset)) {
         gpio_clear(dev->p.pin_reset);
         xtimer_usleep(RESET_DELAY);
         gpio_set(dev->p.pin_reset);

--- a/drivers/sdcard_spi/sdcard_spi.c
+++ b/drivers/sdcard_spi/sdcard_spi.c
@@ -97,7 +97,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
                 (gpio_init(card->params.clk,  GPIO_OUT) == 0) &&
                 (gpio_init(card->params.cs,   GPIO_OUT) == 0) &&
                 (gpio_init(card->params.miso, GPIO_IN_PU) == 0) &&
-                ( (card->params.power == GPIO_UNDEF) ||
+                ( (gpio_is_undef(card->params.power)) ||
                   (gpio_init(card->params.power, GPIO_OUT) == 0)) ) {
 
                 DEBUG("gpio_init(): [OK]\n");
@@ -110,7 +110,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
         case SD_INIT_SPI_POWER_SEQ:
             DEBUG("SD_INIT_SPI_POWER_SEQ\n");
 
-            if (card->params.power != GPIO_UNDEF) {
+            if (!gpio_is_undef(card->params.power)) {
                 gpio_write(card->params.power, card->params.power_act_high);
                 xtimer_usleep(SD_CARD_WAIT_AFTER_POWER_UP_US);
             }

--- a/drivers/sds011/sds011.c
+++ b/drivers/sds011/sds011.c
@@ -192,7 +192,7 @@ int sds011_init(sds011_t *dev, const sds011_params_t *params)
 {
     assert((dev != NULL) && (params != NULL) && (params->uart < UART_NUMOF));
 
-    if ((params->pwr_pin != GPIO_UNDEF) &&
+    if ((!gpio_is_undef(params->pwr_pin)) &&
         (gpio_init(params->pwr_pin, GPIO_OUT) != 0)) {
         return SDS011_ERROR;
     }
@@ -230,7 +230,7 @@ int sds011_register_callback(sds011_t *dev, sds011_callback_t cb, void *ctx)
 void sds011_power_on(const sds011_t *dev)
 {
     assert(dev != NULL);
-    if(dev->params.pwr_pin != GPIO_UNDEF) {
+    if(!gpio_is_undef(dev->params.pwr_pin)) {
         gpio_write(dev->params.pwr_pin, dev->params.pwr_ah);
     }
 }
@@ -238,7 +238,7 @@ void sds011_power_on(const sds011_t *dev)
 void sds011_power_off(const sds011_t *dev)
 {
     assert(dev != NULL);
-    if(dev->params.pwr_pin != GPIO_UNDEF) {
+    if(!gpio_is_undef(dev->params.pwr_pin)) {
         gpio_write(dev->params.pwr_pin, !dev->params.pwr_ah);
     }
 }

--- a/drivers/soft_spi/include/soft_spi_params.h
+++ b/drivers/soft_spi/include/soft_spi_params.h
@@ -34,11 +34,15 @@ extern "C" {
 #ifndef SOFT_SPI_PARAM_CLK
 #define SOFT_SPI_PARAM_CLK          (GPIO_PIN(0, 1))
 #endif
+#ifndef SOFT_SPI_PARAM_MODE
+#define SOFT_SPI_PARAM_MODE         (SOFT_SPI_MODE_0)
+#endif
 
 #ifndef SOFT_SPI_PARAMS
 #define SOFT_SPI_PARAMS     { .miso_pin = SOFT_SPI_PARAM_MISO, \
                               .mosi_pin = SOFT_SPI_PARAM_MOSI, \
-                              .clk_pin  = SOFT_SPI_PARAM_CLK }
+                              .clk_pin  = SOFT_SPI_PARAM_CLK,  \
+                              .soft_spi_mode = SOFT_SPI_PARAM_MODE }
 #endif
 
 /**

--- a/drivers/soft_spi/soft_spi.c
+++ b/drivers/soft_spi/soft_spi.c
@@ -63,21 +63,22 @@ void soft_spi_init_pins(soft_spi_t bus)
     assert(soft_spi_bus_is_valid(bus));
 
     /* check that miso is not mosi is not clk*/
-    assert(soft_spi_config[bus].mosi_pin != soft_spi_config[bus].miso_pin);
-    assert(soft_spi_config[bus].mosi_pin != soft_spi_config[bus].clk_pin);
-    assert(soft_spi_config[bus].miso_pin != soft_spi_config[bus].clk_pin);
+    assert(!gpio_is_equal(soft_spi_config[bus].mosi_pin, soft_spi_config[bus].miso_pin));
+    assert(!gpio_is_equal(soft_spi_config[bus].mosi_pin, soft_spi_config[bus].clk_pin));
+    assert(!gpio_is_equal(soft_spi_config[bus].miso_pin, soft_spi_config[bus].clk_pin));
     /* mandatory pins */
-    assert((GPIO_UNDEF != soft_spi_config[bus].mosi_pin) || (GPIO_UNDEF != soft_spi_config[bus].miso_pin));
-    assert(GPIO_UNDEF != soft_spi_config[bus].clk_pin);
+    assert(!gpio_is_undef(soft_spi_config[bus].mosi_pin) ||
+           !gpio_is_undef(soft_spi_config[bus].miso_pin));
+    assert(!gpio_is_undef(soft_spi_config[bus].clk_pin));
 
     /* initialize clock pin */
     gpio_init(soft_spi_config[bus].clk_pin, GPIO_OUT);
     /* initialize optional pins */
-    if (GPIO_UNDEF != soft_spi_config[bus].mosi_pin) {
+    if (!gpio_is_undef(soft_spi_config[bus].mosi_pin)) {
         gpio_init(soft_spi_config[bus].mosi_pin, GPIO_OUT);
         gpio_clear(soft_spi_config[bus].mosi_pin);
     }
-    if (GPIO_UNDEF != soft_spi_config[bus].miso_pin) {
+    if (!gpio_is_undef(soft_spi_config[bus].miso_pin)) {
         gpio_init(soft_spi_config[bus].mosi_pin, GPIO_IN);
     }
 }
@@ -90,7 +91,7 @@ int soft_spi_init_cs(soft_spi_t bus, soft_spi_cs_t cs)
         return SOFT_SPI_NODEV;
     }
 
-    if ((cs != GPIO_UNDEF) && (cs != SOFT_SPI_CS_UNDEF)) {
+    if (!gpio_is_undef(cs) && !gpio_is_equal(cs, SOFT_SPI_CS_UNDEF)) {
         DEBUG("Soft SPI set user CS line\n");
         gpio_init(cs, GPIO_OUT);
         gpio_set(cs);
@@ -174,14 +175,14 @@ uint8_t soft_spi_transfer_byte(soft_spi_t bus, soft_spi_cs_t cs, bool cont, uint
     uint8_t retval = 0;
 
     /* activate the given chip select line */
-    if ((cs != GPIO_UNDEF) && (cs != SOFT_SPI_CS_UNDEF)) {
+    if (!gpio_is_undef(cs) && !gpio_is_equal(cs, SOFT_SPI_CS_UNDEF)) {
         gpio_clear((gpio_t)cs);
     }
 
     retval = _transfer_one_byte(bus, out);
 
     if (!cont) {
-        if ((cs != GPIO_UNDEF) && (cs != SOFT_SPI_CS_UNDEF)) {
+        if (!gpio_is_undef(cs) && !gpio_is_equal(cs, SOFT_SPI_CS_UNDEF)) {
             gpio_set((gpio_t)cs);
         }
     }

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -104,7 +104,7 @@ int sx127x_reset(const sx127x_t *dev)
      * 2. Set NReset in Hi-Z state
      * 3. Wait at least 5 milliseconds
      */
-    if (dev->params.reset_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.reset_pin)) {
         gpio_init(dev->params.reset_pin, GPIO_OUT);
 
         /* set reset pin to the state that triggers manual reset */
@@ -137,7 +137,7 @@ int sx127x_init(sx127x_t *dev)
 
     _init_timers(dev);
 
-    if (dev->params.reset_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.reset_pin)) {
         /* reset pin should be left floating during POR */
         gpio_init(dev->params.reset_pin, GPIO_IN);
 
@@ -256,7 +256,7 @@ static int _init_gpios(sx127x_t *dev)
     int res;
 
     /* Check if DIO0 pin is defined */
-    if (dev->params.dio0_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.dio0_pin)) {
         res = gpio_init_int(dev->params.dio0_pin, SX127X_DIO_PULL_MODE,
                             GPIO_RISING, sx127x_on_dio0_isr, dev);
         if (res < 0) {
@@ -271,7 +271,7 @@ static int _init_gpios(sx127x_t *dev)
     }
 
     /* Check if DIO1 pin is defined */
-    if (dev->params.dio1_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.dio1_pin)) {
         res = gpio_init_int(dev->params.dio1_pin, SX127X_DIO_PULL_MODE,
                             GPIO_RISING, sx127x_on_dio1_isr, dev);
         if (res < 0) {
@@ -281,7 +281,7 @@ static int _init_gpios(sx127x_t *dev)
     }
 
     /* check if DIO2 pin is defined */
-    if (dev->params.dio2_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.dio2_pin)) {
         res = gpio_init_int(dev->params.dio2_pin, SX127X_DIO_PULL_MODE,
                             GPIO_RISING, sx127x_on_dio2_isr, dev);
         if (res < 0) {
@@ -295,7 +295,7 @@ static int _init_gpios(sx127x_t *dev)
     }
 
     /* check if DIO3 pin is defined */
-    if (dev->params.dio3_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.dio3_pin)) {
         res = gpio_init_int(dev->params.dio3_pin, SX127X_DIO_PULL_MODE,
                             GPIO_RISING, sx127x_on_dio3_isr, dev);
         if (res < 0) {

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -201,7 +201,7 @@ void sx127x_start_cad(sx127x_t *dev)
                              /* | SX127X_RF_LORA_IRQFLAGS_CADDETECTED*/
                              );
 
-            if (dev->params.dio3_pin != GPIO_UNDEF) {
+            if (!gpio_is_undef(dev->params.dio3_pin)) {
                 /* DIO3 = CADDone */
                 sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
                                  (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &

--- a/drivers/tps6274x/tps6274x.c
+++ b/drivers/tps6274x/tps6274x.c
@@ -31,14 +31,14 @@ int tps6274x_init(tps6274x_t *dev, const tps6274x_params_t *params)
 
     dev->params = *params;
     for (uint8_t i = 0; i < 4; i++) {
-        if (dev->params.vsel[i] != GPIO_UNDEF) {
+        if (!gpio_is_undef(dev->params.vsel[i])) {
             ret = gpio_init(dev->params.vsel[i], GPIO_OUT);
             if(ret < 0) {
                 return TPS6274X_ERR_INIT;
             }
         }
     }
-    if (dev->params.ctrl_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.ctrl_pin)) {
         ret = gpio_init(dev->params.ctrl_pin, GPIO_OUT);
         if(ret < 0) {
             return TPS6274X_ERR_INIT;
@@ -58,7 +58,7 @@ uint16_t tps6274x_switch_voltage(tps6274x_t *dev, uint16_t voltage)
     uint8_t vsel = (voltage - 1800) / 100;
     uint8_t vsel_set = 0;
     for (uint8_t i = 0; i < 4; i++) {
-        if (dev->params.vsel[i] != GPIO_UNDEF) {
+        if (!gpio_is_undef(dev->params.vsel[i])) {
             gpio_write(dev->params.vsel[i], (vsel & (0x01 << i)));
             /* mark pins that could and had to be set */
             vsel_set |= vsel & (1 << i);
@@ -75,7 +75,7 @@ uint16_t tps6274x_switch_voltage(tps6274x_t *dev, uint16_t voltage)
 
 void tps6274x_load_ctrl(tps6274x_t *dev, int status)
 {
-    if (dev->params.ctrl_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->params.ctrl_pin)) {
         gpio_write(dev->params.ctrl_pin, status);
     }
 #if ENABLE_DEBUG

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -484,11 +484,11 @@ void xbee_setup(xbee_t *dev, const xbee_params_t *params)
     dev->p = *params;
 
     /* initialize pins */
-    if (dev->p.pin_reset != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->p.pin_reset)) {
         gpio_init(dev->p.pin_reset, GPIO_OUT);
         gpio_set(dev->p.pin_reset);
     }
-    if (dev->p.pin_sleep != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev->p.pin_sleep)) {
         gpio_init(dev->p.pin_sleep, GPIO_OUT);
         gpio_clear(dev->p.pin_sleep);
     }
@@ -586,7 +586,7 @@ int xbee_init(netdev_t *dev)
         return -ENXIO;
     }
     /* if reset pin is connected, do a hardware reset */
-    if (xbee->p.pin_reset != GPIO_UNDEF) {
+    if (!gpio_is_undef(xbee->p.pin_reset)) {
         gpio_clear(xbee->p.pin_reset);
         xtimer_usleep(RESET_DELAY);
         gpio_set(xbee->p.pin_reset);

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -132,6 +132,11 @@ config HAS_PERIPH_GPIO
     help
         Indicates that a GPIO peripheral is present.
 
+config HAS_PERIPH_GPIO_EXT
+    bool
+    help
+        Indicates that a extendable GPIO peripheral is present.
+
 config HAS_PERIPH_GPIO_IRQ
     bool
     help

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -55,6 +55,9 @@ PSEUDOMODULES += gnrc_sixlowpan_router_default
 PSEUDOMODULES += gnrc_sock_async
 PSEUDOMODULES += gnrc_sock_check_reuse
 PSEUDOMODULES += gnrc_txtsnd
+PSEUDOMODULES += gpio_mask_32bit
+PSEUDOMODULES += gpio_mask_16bit
+PSEUDOMODULES += gpio_mask_8bit
 PSEUDOMODULES += heap_cmd
 PSEUDOMODULES += i2c_scan
 PSEUDOMODULES += ina3221_alerts
@@ -164,6 +167,9 @@ PSEUDOMODULES += ccs811_full
 PSEUDOMODULES += cc1100
 PSEUDOMODULES += cc1100e
 PSEUDOMODULES += cc1101
+
+# GPIO expanders are used, requires feature periph_gpio_exp
+PSEUDOMODULES += gpio_exp
 
 # interrupt variant of the HMC5883L driver
 PSEUDOMODULES += hmc5883l_int

--- a/pkg/u8g2/contrib/u8x8_riotos.c
+++ b/pkg/u8g2/contrib/u8x8_riotos.c
@@ -70,15 +70,15 @@ static void _enable_pins(const u8x8_riotos_t *u8x8_riot_ptr)
         return;
     }
 
-    if (u8x8_riot_ptr->pin_cs != GPIO_UNDEF) {
+    if (!gpio_is_undef(u8x8_riot_ptr->pin_cs)) {
         gpio_init(u8x8_riot_ptr->pin_cs, GPIO_OUT);
     }
 
-    if (u8x8_riot_ptr->pin_dc != GPIO_UNDEF) {
+    if (!gpio_is_undef(u8x8_riot_ptr->pin_dc)) {
         gpio_init(u8x8_riot_ptr->pin_dc, GPIO_OUT);
     }
 
-    if (u8x8_riot_ptr->pin_reset != GPIO_UNDEF) {
+    if (!gpio_is_undef(u8x8_riot_ptr->pin_reset)) {
         gpio_init(u8x8_riot_ptr->pin_reset, GPIO_OUT);
     }
 }
@@ -106,17 +106,17 @@ uint8_t u8x8_gpio_and_delay_riotos(u8x8_t *u8g2, uint8_t msg, uint8_t arg_int, v
             xtimer_nanosleep(arg_int * 100);
             break;
         case U8X8_MSG_GPIO_CS:
-            if (u8x8_riot_ptr != NULL && u8x8_riot_ptr->pin_cs != GPIO_UNDEF) {
+            if (u8x8_riot_ptr != NULL && !gpio_is_undef(u8x8_riot_ptr->pin_cs)) {
                 gpio_write(u8x8_riot_ptr->pin_cs, arg_int);
             }
             break;
         case U8X8_MSG_GPIO_DC:
-            if (u8x8_riot_ptr != NULL && u8x8_riot_ptr->pin_dc != GPIO_UNDEF) {
+            if (u8x8_riot_ptr != NULL && !gpio_is_undef(u8x8_riot_ptr->pin_dc)) {
                 gpio_write(u8x8_riot_ptr->pin_dc, arg_int);
             }
             break;
         case U8X8_MSG_GPIO_RESET:
-            if (u8x8_riot_ptr != NULL &&  u8x8_riot_ptr->pin_reset != GPIO_UNDEF) {
+            if (u8x8_riot_ptr != NULL && !gpio_is_undef(u8x8_riot_ptr->pin_reset)) {
                 gpio_write(u8x8_riot_ptr->pin_reset, arg_int);
             }
             break;

--- a/tests/driver_ph_oem/main.c
+++ b/tests/driver_ph_oem/main.c
@@ -224,7 +224,7 @@ int main(void)
         }
     }
 
-    if (dev.params.interrupt_pin != GPIO_UNDEF) {
+    if (!gpio_is_undef(dev.params.interrupt_pin)) {
         /* Setting up and enabling the interrupt pin of the pH OEM */
         printf("Enabling interrupt pin... ");
         if (ph_oem_enable_interrupt(&dev, interrupt_pin_callback,
@@ -259,7 +259,7 @@ int main(void)
         /* blocking for ~420ms till reading is done if no interrupt pin defined */
         ph_oem_start_new_reading(&dev);
 
-        if (dev.params.interrupt_pin != GPIO_UNDEF) {
+        if (!gpio_is_undef(dev.params.interrupt_pin)) {
             /* when interrupt is defined, wait for the IRQ to fire and
              * the event to be posted, so the "reading_available_event_callback"
              * can be executed after */
@@ -267,7 +267,7 @@ int main(void)
             ev->handler(ev);
         }
 
-        if (dev.params.interrupt_pin == GPIO_UNDEF) {
+        if (gpio_is_undef(dev.params.interrupt_pin)) {
 
             if (ph_oem_read_ph(&dev, &data) == PH_OEM_OK) {
                 printf("pH value raw: %d\n", data);

--- a/tests/driver_pir/main.c
+++ b/tests/driver_pir/main.c
@@ -62,7 +62,12 @@ void* pir_handler(void *arg)
 int main(void)
 {
     puts("PIR motion sensor test application\n");
+#ifdef MODULE_PERIPH_GPIO_EXP
+    printf("Initializing PIR sensor at GPIO_PIN(%d, %d) ... ",
+           gpio_port_num(PIR_PARAM_GPIO), PIR_PARAM_GPIO.pin);
+#else
     printf("Initializing PIR sensor at GPIO_%ld... ", (long)PIR_PARAM_GPIO);
+#endif
     if (pir_init(&dev, &pir_params[0]) == 0) {
         puts("[OK]\n");
     }

--- a/tests/driver_qmc5883l/main.c
+++ b/tests/driver_qmc5883l/main.c
@@ -97,7 +97,7 @@ int main(void)
     }
 #ifdef MODULE_QMC5883L_INT
     printf("Mode:             ");
-    if (qmc5883l_params[0].pin_drdy != GPIO_UNDEF) {
+    if (!gpio_is_undef(qmc5883l_params[0].pin_drdy)) {
         puts("interrupt driven");
     }
     else {
@@ -121,7 +121,7 @@ int main(void)
 
 #ifdef MODULE_QMC5883L_INT
     /* safe a reference to the main thread TCB so we can wait for flags */
-    if (qmc5883l_params[0].pin_drdy != GPIO_UNDEF) {
+    if (!gpio_is_undef(qmc5883l_params[0].pin_drdy)) {
         _tmain = (thread_t *)thread_get(thread_getpid());
 
         if (qmc5883l_init_int(&_dev, _on_drdy, NULL) != QMC5883L_OK) {

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -31,7 +31,8 @@
 #ifdef MODULE_PERIPH_GPIO_IRQ
 static void cb(void *arg)
 {
-    printf("INT: external interrupt from pin %i\n", (int)arg);
+    printf("INT: external interrupt from GPIO_PIN(%i, %i)\n",
+           (int)arg >> 8, (int)arg & 0xff);
 }
 #endif
 
@@ -143,7 +144,7 @@ static int init_int(int argc, char **argv)
         }
     }
 
-    if (gpio_init_int(GPIO_PIN(po, pi), mode, flank, cb, (void *)pi) < 0) {
+    if (gpio_init_int(GPIO_PIN(po, pi), mode, flank, cb, (void *)((po << 8) + pi)) < 0) {
         printf("error: init_int of GPIO_PIN(%i, %i) failed\n", po, pi);
         return 1;
     }

--- a/tests/periph_gpio_exp/Makefile
+++ b/tests/periph_gpio_exp/Makefile
@@ -1,0 +1,14 @@
+include ../Makefile.tests_common
+
+FEATURES_OPTIONAL = periph_gpio_irq
+
+USEMODULE += gpio_exp
+USEMODULE += shell
+USEMODULE += benchmark
+
+INCLUDES += -I$(APPDIR)
+
+include $(RIOTBASE)/Makefile.include
+
+bench:
+	tests/02-bench.py

--- a/tests/periph_gpio_exp/Makefile.ci
+++ b/tests/periph_gpio_exp/Makefile.ci
@@ -1,0 +1,8 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
+    stm32f030f4-demo \
+    #

--- a/tests/periph_gpio_exp/bar_gpio_exp.c
+++ b/tests/periph_gpio_exp/bar_gpio_exp.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests_periph_gpio_exp
+ * @{
+ *
+ * @file
+ * @brief       Example driver for a GPIO expander with multiple ports.
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "bar_gpio_exp.h"
+
+const gpio_driver_t bar_gpio_exp_driver = {
+    .init = bar_gpio_exp_init,
+#ifdef MODULE_PERIPH_GPIO_IRQ
+    .init_int = bar_gpio_exp_init_int,
+    .irq_enable = bar_gpio_exp_irq_enable,
+    .irq_disable = bar_gpio_exp_irq_disable,
+#endif
+    .read = bar_gpio_exp_read,
+    .set = bar_gpio_exp_set,
+    .clear = bar_gpio_exp_clear,
+    .toggle = bar_gpio_exp_toggle,
+    .write = bar_gpio_exp_write,
+};
+
+int bar_exp_init(bar_exp_t *dev, uint8_t port, uint8_t pin, gpio_mode_t mode)
+{
+    (void)mode;
+    assert(dev);
+
+    printf("init dev %p (%s) port %u, pin %u\n", dev, dev->name, port, pin);
+    return 0;
+}
+
+#ifdef MODULE_PERIPH_GPIO_IRQ
+int  bar_exp_init_int(bar_exp_t *dev, uint8_t port, uint8_t pin,
+                      gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
+{
+    (void)mode;
+    (void)flank;
+    (void)cb;
+    (void)arg;
+    assert(dev);
+
+    printf("init_int dev %p (%s) port %u, pin %u\n",
+           dev, dev->name, port, pin);
+    return 0;
+}
+
+void bar_exp_irq_enable(bar_exp_t *dev, uint8_t port, uint8_t pin)
+{
+    assert(dev);
+    printf("irq_enable dev %p (%s) port %u, pin %u\n",
+           dev, dev->name, port, pin);
+}
+
+void bar_exp_irq_disable(bar_exp_t *dev, uint8_t port, uint8_t pin)
+{
+    assert(dev);
+    printf("irq_disable dev %p (%s) port %u, pin %u\n",
+           dev, dev->name, port, pin);
+}
+#endif
+
+gpio_mask_t bar_exp_read(bar_exp_t *dev, uint8_t port)
+{
+    assert(dev);
+    printf("read dev %p (%s) port %u, state 0x%02x\n",
+           dev, dev->name, port, dev->state[port]);
+    return dev->state[port];
+}
+
+void bar_exp_set(bar_exp_t *dev, uint8_t port, gpio_mask_t pins)
+{
+    assert(dev);
+
+    dev->state[port] |= pins;
+    printf("set dev %p (%s) port %u, pins 0x%02x, state 0x%02x\n",
+           dev, dev->name, port, pins, dev->state[port]);
+}
+
+void bar_exp_clear(bar_exp_t *dev, uint8_t port, gpio_mask_t pins)
+{
+    assert(dev);
+
+    dev->state[port] &= ~pins;
+    printf("clear dev %p (%s) port %u, pins 0x%02x, state 0x%02x\n",
+           dev, dev->name, port, pins, dev->state[port]);
+}
+
+void bar_exp_toggle(bar_exp_t *dev, uint8_t port, gpio_mask_t pins)
+{
+    assert(dev);
+
+    dev->state[port] ^= pins;
+    printf("toggle dev %p (%s) port %u, pins 0x%02x, state 0x%02x\n",
+           dev, dev->name, port, pins, dev->state[port]);}
+
+void bar_exp_write(bar_exp_t *dev, uint8_t port, gpio_mask_t values)
+{
+    assert(dev);
+
+    dev->state[port] = values;
+    printf("write dev %p (%s) port %u, values 0x%02x, state 0x%02x\n",
+           dev, dev->name, port, values, dev->state[port]);
+}

--- a/tests/periph_gpio_exp/bar_gpio_exp.h
+++ b/tests/periph_gpio_exp/bar_gpio_exp.h
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests_periph_gpio_exp
+ * @{
+ *
+ * @file
+ * @brief       Example driver for a GPIO expander with multiple ports.
+ *
+ * This example of a GPIO expander driver demonstrates how to implement a
+ * driver for a GPIO expander with multiple ports.
+ *
+ * Since each GPIO expander port is considered as a separate device by the
+ * GPIO API, the low-level API cannot be implemented directly. Instead,
+ * a device-specific driver interface must be implemented, which uses a
+ * device-specific device descriptor and handles the different ports.
+ * The low-level GPIO API is then realized by wrapper functions that
+ * map the low-level GPIO API to the device-specific driver interface
+ * using a separate device descriptor for each port.
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef BAR_GPIO_EXP_H
+#define BAR_GPIO_EXP_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Device-specific descriptor used by the driver for a GPIO expander
+ *          with 4 ports and 8 pins each.
+ */
+typedef struct {
+    const char *name;   /**< name of the GPIO expander */
+    uint8_t state[4];   /**< ports of the GPIO expander with 8 pins */
+} bar_exp_t;
+
+/**
+ * @brief   Device descriptor for a single port as required by the GPIO API.
+ *
+ * This descriptor defines exactly one port of the GPIO expander. References
+ * to such descriptors are used in the GPIO expander port definition of type
+ * #gpio_dev_t by the GPIO API.
+ */
+typedef struct {
+    bar_exp_t *dev;     /**< reference to the device-specific descriptor */
+    uint8_t port;       /**< index of the port */
+} bar_gpio_exp_t;
+
+/**
+ * @name    Device-specific driver interface for the example GPIO expander
+ *
+ * The functions of the device-specific driver interface could also be used
+ * directly by the application without the GPIO API.
+ * @{
+ */
+int bar_exp_init(bar_exp_t *dev, uint8_t port, uint8_t pin, gpio_mode_t mode);
+int bar_exp_init_int(bar_exp_t *dev, uint8_t port, uint8_t pin,
+                     gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg);
+void bar_exp_irq_enable(bar_exp_t *dev, uint8_t port, uint8_t pin);
+void bar_exp_irq_disable(bar_exp_t *dev, uint8_t port, uint8_t pin);
+gpio_mask_t bar_exp_read(bar_exp_t *dev, uint8_t port);
+void bar_exp_set(bar_exp_t *dev, uint8_t port, gpio_mask_t pins);
+void bar_exp_clear(bar_exp_t *dev, uint8_t port, gpio_mask_t pins);
+void bar_exp_toggle(bar_exp_t *dev, uint8_t port, gpio_mask_t pins);
+void bar_exp_write(bar_exp_t *dev, uint8_t port, gpio_mask_t values);
+/** @} */
+
+/**
+ * @name    Device-specific implementation of the low-Level GPIO API.
+ *
+ * The following functions map the low-level GPIO API to the driver interface.
+ * This allows to use the GPIO expander via the GPIO API.
+ * @{
+ */
+static inline int bar_gpio_exp_init(gpio_port_t port, gpio_pin_t pin,
+                                    gpio_mode_t mode)
+{
+    assert(port.dev);
+    bar_gpio_exp_t *bar = (bar_gpio_exp_t *)port.dev->dev;
+    return bar_exp_init(bar->dev, bar->port, pin, mode);
+}
+
+#ifdef MODULE_PERIPH_GPIO_IRQ
+static inline int bar_gpio_exp_init_int(gpio_port_t port, gpio_pin_t pin,
+                                        gpio_mode_t mode, gpio_flank_t flank,
+                                        gpio_cb_t cb, void *arg)
+{
+    assert(port.dev);
+    bar_gpio_exp_t *bar = (bar_gpio_exp_t *)port.dev->dev;
+    return bar_exp_init_int(bar->dev, bar->port, pin, mode, flank, cb, arg);
+}
+
+static inline void bar_gpio_exp_irq_enable(gpio_port_t port, gpio_pin_t pin)
+{
+    assert(port.dev);
+    bar_gpio_exp_t *bar = (bar_gpio_exp_t *)port.dev->dev;
+    bar_exp_irq_enable(bar->dev, bar->port, pin);
+}
+
+static inline void bar_gpio_exp_irq_disable(gpio_port_t port, gpio_pin_t pin)
+{
+    assert(port.dev);
+    bar_gpio_exp_t *bar = (bar_gpio_exp_t *)port.dev->dev;
+    bar_exp_irq_disable(bar->dev, bar->port, pin);
+}
+#endif
+
+static inline gpio_mask_t bar_gpio_exp_read(gpio_port_t port)
+{
+    assert(port.dev);
+    bar_gpio_exp_t *bar = (bar_gpio_exp_t *)port.dev->dev;
+    return bar_exp_read(bar->dev, bar->port);
+}
+
+static inline void bar_gpio_exp_set(gpio_port_t port, gpio_mask_t pins)
+{
+    assert(port.dev);
+    bar_gpio_exp_t *bar = (bar_gpio_exp_t *)port.dev->dev;
+    bar_exp_set(bar->dev, bar->port, pins);
+}
+
+static inline void bar_gpio_exp_clear(gpio_port_t port, gpio_mask_t pins)
+{
+    assert(port.dev);
+    bar_gpio_exp_t *bar = (bar_gpio_exp_t *)port.dev->dev;
+    bar_exp_clear(bar->dev, bar->port, pins);
+}
+
+static inline void bar_gpio_exp_toggle(gpio_port_t port, gpio_mask_t pins)
+{
+    assert(port.dev);
+    bar_gpio_exp_t *bar = (bar_gpio_exp_t *)port.dev->dev;
+    bar_exp_toggle(bar->dev, bar->port, pins);
+}
+
+static inline void bar_gpio_exp_write(gpio_port_t port, gpio_mask_t values)
+{
+    assert(port.dev);
+    bar_gpio_exp_t *bar = (bar_gpio_exp_t *)port.dev->dev;
+    bar_exp_write(bar->dev, bar->port, values);
+}
+
+/** @} */
+
+/**
+ * @brief   GPIO expander driver structure as required by the GPIO API
+ */
+extern const gpio_driver_t bar_gpio_exp_driver;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BAR_GPIO_EXP_H */
+/** @} */

--- a/tests/periph_gpio_exp/foo_gpio_exp.c
+++ b/tests/periph_gpio_exp/foo_gpio_exp.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests_periph_gpio_exp
+ * @{
+ *
+ * @file
+ * @brief       Example driver for a single port GPIO expander
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "foo_gpio_exp.h"
+
+const gpio_driver_t foo_gpio_exp_driver = {
+    .init = foo_gpio_exp_init,
+#ifdef MODULE_PERIPH_GPIO_IRQ
+    .init_int = foo_gpio_exp_init_int,
+    .irq_enable = foo_gpio_exp_irq_enable,
+    .irq_disable = foo_gpio_exp_irq_disable,
+#endif
+    .read = foo_gpio_exp_read,
+    .set = foo_gpio_exp_set,
+    .clear = foo_gpio_exp_clear,
+    .toggle = foo_gpio_exp_toggle,
+    .write = foo_gpio_exp_write,
+};
+
+int foo_gpio_exp_init(gpio_port_t port, gpio_pin_t pin, gpio_mode_t mode)
+{
+    (void)mode;
+    assert(port.dev);
+    assert(port.dev->dev);
+    foo_gpio_exp_t *dev = (foo_gpio_exp_t *)port.dev->dev;
+
+    printf("init dev %p (%s) pin %u\n", dev, dev->name, pin);
+    return 0;
+}
+
+#ifdef MODULE_PERIPH_GPIO_IRQ
+int  foo_gpio_exp_init_int(gpio_port_t port, gpio_pin_t pin, gpio_mode_t mode,
+                           gpio_flank_t flank, gpio_cb_t cb, void *arg)
+{
+    (void)mode;
+    (void)flank;
+    (void)cb;
+    (void)arg;
+    assert(port.dev);
+    assert(port.dev->dev);
+    foo_gpio_exp_t *dev = (foo_gpio_exp_t *)port.dev->dev;
+
+    printf("init_int dev %p (%s) pin %u\n", dev, dev->name, pin);
+    return 0;
+}
+
+void foo_gpio_exp_irq_enable(gpio_port_t port, gpio_pin_t pin)
+{
+    assert(port.dev);
+    assert(port.dev->dev);
+    foo_gpio_exp_t *dev = (foo_gpio_exp_t *)port.dev->dev;
+
+    printf("irq_enable dev %p (%s) pin %u\n", dev, dev->name, pin);
+}
+
+void foo_gpio_exp_irq_disable(gpio_port_t port, gpio_pin_t pin)
+{
+    assert(port.dev);
+    assert(port.dev->dev);
+    foo_gpio_exp_t *dev = (foo_gpio_exp_t *)port.dev->dev;
+
+    printf("irq_disable dev %p (%s) pin %u\n", dev, dev->name, pin);
+}
+#endif
+
+gpio_mask_t foo_gpio_exp_read(gpio_port_t port)
+{
+    assert(port.dev);
+    assert(port.dev->dev);
+    foo_gpio_exp_t *dev = (foo_gpio_exp_t *)port.dev->dev;
+
+    printf("read dev %p (%s) state 0x%02x\n", dev, dev->name, dev->state);
+    return dev->state;
+}
+
+void foo_gpio_exp_set(gpio_port_t port, gpio_mask_t pins)
+{
+    assert(port.dev);
+    assert(port.dev->dev);
+    foo_gpio_exp_t *dev = (foo_gpio_exp_t *)port.dev->dev;
+
+    dev->state |= pins;
+    printf("set dev %p (%s) pins 0x%02x, state 0x%02x\n",
+           dev, dev->name, pins, dev->state);
+}
+
+void foo_gpio_exp_clear(gpio_port_t port, gpio_mask_t pins)
+{
+    assert(port.dev);
+    assert(port.dev->dev);
+    foo_gpio_exp_t *dev = (foo_gpio_exp_t *)port.dev->dev;
+
+    dev->state &= ~pins;
+    printf("clear dev %p (%s) pins 0x%02x, state 0x%02x\n",
+           dev, dev->name, pins, dev->state);
+}
+
+void foo_gpio_exp_toggle(gpio_port_t port, gpio_mask_t pins)
+{
+    assert(port.dev);
+    assert(port.dev->dev);
+    foo_gpio_exp_t *dev = (foo_gpio_exp_t *)port.dev->dev;
+
+    dev->state ^= pins;
+    printf("toggle dev %p (%s) pins 0x%02x, state 0x%02x\n",
+           dev, dev->name, pins, dev->state);}
+
+void foo_gpio_exp_write(gpio_port_t port, gpio_mask_t values)
+{
+    assert(port.dev);
+    assert(port.dev->dev);
+    foo_gpio_exp_t *dev = (foo_gpio_exp_t *)port.dev->dev;
+
+    dev->state = values;
+    printf("write dev %p (%s) values 0x%02x, state 0x%02x\n",
+           dev, dev->name, values, dev->state);
+}

--- a/tests/periph_gpio_exp/foo_gpio_exp.h
+++ b/tests/periph_gpio_exp/foo_gpio_exp.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests_periph_gpio_exp
+ * @{
+ *
+ * @file
+ * @brief       Example driver for a single port GPIO expander
+ *
+ * This example shows how to implement a driver for a GPIO expander with a
+ * single port. The low-level GPIO API can be implemented and used directly
+ * in this case.
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef FOO_GPIO_EXP_H
+#define FOO_GPIO_EXP_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Device-specific descriptor as used by the driver.
+ */
+typedef struct {
+    const char *name;   /**< name of the GPIO expander */
+    gpio_mask_t state;  /**< the port of the GPIO expander */
+} foo_gpio_exp_t;
+
+/**
+ * @name    Device-specific implementation of the low-Level GPIO API.
+ * @{
+ */
+int foo_gpio_exp_init(gpio_port_t port, gpio_pin_t pin, gpio_mode_t mode);
+#ifdef MODULE_PERIPH_GPIO_IRQ
+int foo_gpio_exp_init_int(gpio_port_t port, gpio_pin_t pin, gpio_mode_t mode,
+                     gpio_flank_t flank, gpio_cb_t cb, void *arg);
+void foo_gpio_exp_irq_enable(gpio_port_t port, gpio_pin_t pin);
+void foo_gpio_exp_irq_disable(gpio_port_t port, gpio_pin_t pin);
+#endif
+gpio_mask_t foo_gpio_exp_read(gpio_port_t port);
+void foo_gpio_exp_set(gpio_port_t port, gpio_mask_t pins);
+void foo_gpio_exp_clear(gpio_port_t port, gpio_mask_t pins);
+void foo_gpio_exp_toggle(gpio_port_t port, gpio_mask_t pins);
+void foo_gpio_exp_write(gpio_port_t port, gpio_mask_t values);
+/** @} */
+
+/**
+ * @brief   GPIO expander driver structure as required by the GPIO API
+ */
+extern const gpio_driver_t foo_gpio_exp_driver;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FOO_GPIO_EXP_H */
+/** @} */

--- a/tests/periph_gpio_exp/gpio_exp_conf.c
+++ b/tests/periph_gpio_exp/gpio_exp_conf.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests_periph_gpio_exp
+ * @{
+ *
+ * @file
+ * @brief       Example GPIO expander configuration
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#include "gpio_exp_conf.h"
+
+/**
+ * @brief   Definition of example GPIO expander devices
+ */
+foo_gpio_exp_t foo_gpio_exp_1 = { .name = "foo1" };
+foo_gpio_exp_t foo_gpio_exp_2 = { .name = "foo2" };
+
+bar_exp_t bar_exp = { .name = "bar" };
+bar_gpio_exp_t bar_gpio_exp_1 = { .dev = &bar_exp, .port = 0 };
+bar_gpio_exp_t bar_gpio_exp_2 = { .dev = &bar_exp, .port = 1 };
+bar_gpio_exp_t bar_gpio_exp_3 = { .dev = &bar_exp, .port = 2 };
+bar_gpio_exp_t bar_gpio_exp_4 = { .dev = &bar_exp, .port = 3 };

--- a/tests/periph_gpio_exp/gpio_exp_conf.h
+++ b/tests/periph_gpio_exp/gpio_exp_conf.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2020 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests_periph_gpio_exp
+ *
+ * @{
+ *
+ * @file
+ * @brief       Example GPIO expander configuration
+ *
+ * The configuration of GPIO expanders is either part of the board definition
+ * or of the application. In the latter case, the application's `Makefile` must
+ * add the according include PATH for the configuration before it includes the
+ * default `$(RIOTBASE)/Makefile.include`.
+ * ```
+ * INCLUDES += -I$(APPDIR)
+ * ```
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ */
+
+#ifndef GPIO_EXP_CONF_H
+#define GPIO_EXP_CONF_H
+
+#include <stddef.h>
+
+#include "periph/gpio.h"
+
+#include "foo_gpio_exp.h" /* include header files of GPIO expander drivers */
+#include "bar_gpio_exp.h" /* include header files of GPIO expander drivers */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   Defined the expander device ports
+ * @{
+ */
+extern foo_gpio_exp_t foo_gpio_exp_1; /**< Single port GPIO expander 1 */
+extern foo_gpio_exp_t foo_gpio_exp_2; /**< Single port GPIO expander 2 */
+extern bar_gpio_exp_t bar_gpio_exp_1; /**< Multiple port GPIO expander, Port0 */
+extern bar_gpio_exp_t bar_gpio_exp_2; /**< Multiple port GPIO expander, Port1 */
+extern bar_gpio_exp_t bar_gpio_exp_3; /**< Multiple port GPIO expander, Port2 */
+extern bar_gpio_exp_t bar_gpio_exp_4; /**< Multiple port GPIO expander, Port3 */
+/** @} */
+
+/**
+ * @brief   GPIO expansion default list if not defined
+ */
+#define GPIO_EXP_PORTS \
+    { .dev = &foo_gpio_exp_1, .driver = &foo_gpio_exp_driver }, \
+    { .dev = &foo_gpio_exp_2, .driver = &foo_gpio_exp_driver }, \
+    { .dev = &bar_gpio_exp_1, .driver = &bar_gpio_exp_driver }, \
+    { .dev = &bar_gpio_exp_2, .driver = &bar_gpio_exp_driver }, \
+    { .dev = &bar_gpio_exp_3, .driver = &bar_gpio_exp_driver }, \
+    { .dev = &bar_gpio_exp_4, .driver = &bar_gpio_exp_driver },
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_EXP_CONF_H */
+/** @} */

--- a/tests/periph_gpio_exp/main.c
+++ b/tests/periph_gpio_exp/main.c
@@ -1,0 +1,351 @@
+/*
+ * Copyright (C) 2014,2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     tests
+ * @defgroup    tests_periph_gpio_exp
+ * @{
+ *
+ * @file
+ * @brief       Test application for GPIO peripheral drivers
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "irq.h"
+#include "shell.h"
+#include "benchmark.h"
+#include "periph/gpio.h"
+
+#define BENCH_RUNS_DEFAULT      (1000UL * 1000)
+
+/**
+ * BENCHMARK_FUNC disables the interrupts and does not work correctly on
+ * some platforms, e.g. ATmega. On other platforms, such as STM32, the
+ * benchmark test gives the same results with interrupts not disabled.
+ * Therefore a modified version is used here that does not disable the
+ * interrupts.
+ */
+#define MY_BENCHMARK_FUNC(name, runs, func)                     \
+    {                                                           \
+        uint32_t _benchmark_time = xtimer_now_usec();           \
+        for (unsigned long i = 0; i < runs; i++) {              \
+            func;                                               \
+        }                                                       \
+        _benchmark_time = (xtimer_now_usec() - _benchmark_time);\
+        benchmark_print_time(_benchmark_time, runs, name);      \
+    }
+
+
+#ifdef MODULE_PERIPH_GPIO_IRQ
+static void cb(void *arg)
+{
+    printf("INT: external interrupt from GPIO_PIN(%i, %i)\n",
+           (int)arg >> 8, (int)arg & 0xff);
+}
+#endif
+
+static int str2port(char *port)
+{
+    if (strncmp(port, "exp", 3) == 0) {
+        return GPIO_EXP_PORT + atoi(&port[3]);
+    }
+    else {
+        return atoi(port);
+    }
+}
+
+static int init_pin(int argc, char **argv, gpio_mode_t mode)
+{
+    int po, pi;
+
+    if (argc < 3) {
+        printf("usage: %s <port> <pin>\n", argv[0]);
+        return 1;
+    }
+
+    po = str2port(argv[1]);
+    pi = atoi(argv[2]);
+
+    if (gpio_init(GPIO_PIN(po, pi), mode) < 0) {
+        printf("Error to initialize GPIO_PIN(%i, %i)\n", po, pi);
+        return 1;
+    }
+
+    return 0;
+}
+
+static int init_out(int argc, char **argv)
+{
+    return init_pin(argc, argv, GPIO_OUT);
+}
+
+static int init_in(int argc, char **argv)
+{
+    return init_pin(argc, argv, GPIO_IN);
+}
+
+static int init_in_pu(int argc, char **argv)
+{
+    return init_pin(argc, argv, GPIO_IN_PU);
+}
+
+static int init_in_pd(int argc, char **argv)
+{
+    return init_pin(argc, argv, GPIO_IN_PD);
+}
+
+static int init_od(int argc, char **argv)
+{
+    return init_pin(argc, argv, GPIO_OD);
+}
+
+static int init_od_pu(int argc, char **argv)
+{
+    return init_pin(argc, argv, GPIO_OD_PU);
+}
+
+#ifdef MODULE_PERIPH_GPIO_IRQ
+static int init_int(int argc, char **argv)
+{
+    int po, pi;
+    gpio_mode_t mode = GPIO_IN;
+    gpio_flank_t flank;
+    int fl;
+
+    if (argc < 4) {
+        printf("usage: %s <port> <pin> <flank> [pull_config]\n", argv[0]);
+        puts("\tflank:\n"
+             "\t0: falling\n"
+             "\t1: rising\n"
+             "\t2: both\n"
+             "\tpull_config:\n"
+             "\t0: no pull resistor (default)\n"
+             "\t1: pull up\n"
+             "\t2: pull down");
+        return 1;
+    }
+
+    po = str2port(argv[1]);
+    pi = atoi(argv[2]);
+
+    fl = atoi(argv[3]);
+    switch (fl) {
+        case 0:
+            flank = GPIO_FALLING;
+            break;
+        case 1:
+            flank = GPIO_RISING;
+            break;
+        case 2:
+            flank = GPIO_BOTH;
+            break;
+        default:
+            puts("error: invalid value for active flank");
+            return 1;
+    }
+
+    if (argc >= 5) {
+        int pr = atoi(argv[4]);
+        switch (pr) {
+            case 0:
+                mode = GPIO_IN;
+                break;
+            case 1:
+                mode = GPIO_IN_PU;
+                break;
+            case 2:
+                mode = GPIO_IN_PD;
+                break;
+            default:
+                puts("error: invalid pull resistor option");
+                return 1;
+        }
+    }
+
+    if (gpio_init_int(GPIO_PIN(po, pi), mode, flank, cb, (void *)((po << 8) + pi)) < 0) {
+        printf("error: init_int of GPIO_PIN(%i, %i) failed\n", po, pi);
+        return 1;
+    }
+    printf("GPIO_PIN(%i, %i) successfully initialized as ext int\n", po, pi);
+
+    return 0;
+}
+
+static int enable_int(int argc, char **argv)
+{
+    int po, pi;
+    int status;
+
+    if (argc < 4) {
+        printf("usage: %s <port> <pin> <status>\n", argv[0]);
+        puts("\tstatus:\n"
+             "\t0: disable\n"
+             "\t1: enable\n");
+        return 1;
+    }
+
+    po = str2port(argv[1]);
+    pi = atoi(argv[2]);
+
+    status = atoi(argv[3]);
+
+    switch (status) {
+        case 0:
+            puts("disabling GPIO interrupt");
+            gpio_irq_disable(GPIO_PIN(po, pi));
+            break;
+        case 1:
+            puts("enabling GPIO interrupt");
+            gpio_irq_enable(GPIO_PIN(po, pi));
+            break;
+        default:
+            puts("error: invalid status");
+            return 1;
+    }
+
+    return 0;
+}
+#endif
+
+static int read(int argc, char **argv)
+{
+    int port, pin;
+
+    if (argc < 3) {
+        printf("usage: %s <port> <pin>\n", argv[0]);
+        return 1;
+    }
+
+    port = str2port(argv[1]);
+    pin = atoi(argv[2]);
+
+    if (gpio_read(GPIO_PIN(port, pin))) {
+        printf("GPIO_PIN(%i, %i) is HIGH\n", port, pin);
+    }
+    else {
+        printf("GPIO_PIN(%i, %i) is LOW\n", port, pin);
+    }
+
+    return 0;
+}
+
+static int set(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <port> <pin>\n", argv[0]);
+        return 1;
+    }
+
+    gpio_set(GPIO_PIN(str2port(argv[1]), atoi(argv[2])));
+
+    return 0;
+}
+
+static int clear(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <port> <pin>\n", argv[0]);
+        return 1;
+    }
+
+    gpio_clear(GPIO_PIN(str2port(argv[1]), atoi(argv[2])));
+
+    return 0;
+}
+
+static int toggle(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <port> <pin>\n", argv[0]);
+        return 1;
+    }
+
+    gpio_toggle(GPIO_PIN(str2port(argv[1]), atoi(argv[2])));
+
+    return 0;
+}
+
+static int writep(int argc, char **argv)
+{
+    if (argc < 4) {
+        printf("usage: %s <port> <pin> <value>\n", argv[0]);
+        return 1;
+    }
+
+    gpio_write(GPIO_PIN(str2port(argv[1]), atoi(argv[2])), atoi(argv[3]));
+
+    return 0;
+}
+
+static int bench(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <port> <pin> [# of runs]\n", argv[0]);
+        return 1;
+    }
+
+    gpio_t pin = GPIO_PIN(str2port(argv[1]), atoi(argv[2]));
+    unsigned long runs = BENCH_RUNS_DEFAULT;
+    if (argc > 3) {
+        runs = (unsigned long)atol(argv[3]);
+    }
+
+    puts("\nGPIO driver run-time performance benchmark\n");
+    MY_BENCHMARK_FUNC("nop loop", runs, __asm__ volatile("nop"));
+    MY_BENCHMARK_FUNC("gpio_set", runs, gpio_set(pin));
+    MY_BENCHMARK_FUNC("gpio_clear", runs, gpio_clear(pin));
+    MY_BENCHMARK_FUNC("gpio_toggle", runs, gpio_toggle(pin));
+    MY_BENCHMARK_FUNC("gpio_read", runs, (void)gpio_read(pin));
+    MY_BENCHMARK_FUNC("gpio_write", runs, gpio_write(pin, 1));
+    puts("\n --- DONE ---");
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "init_out", "init as output (push-pull mode)", init_out },
+    { "init_in", "init as input w/o pull resistor", init_in },
+    { "init_in_pu", "init as input with pull-up", init_in_pu },
+    { "init_in_pd", "init as input with pull-down", init_in_pd },
+    { "init_od", "init as output (open-drain without pull resistor)", init_od },
+    { "init_od_pu", "init as output (open-drain with pull-up)", init_od_pu },
+#ifdef MODULE_PERIPH_GPIO_IRQ
+    { "init_int", "init as external INT w/o pull resistor", init_int },
+    { "enable_int", "enable or disable gpio interrupt", enable_int },
+#endif
+    { "read", "read pin status", read },
+    { "set", "set pin to HIGH", set },
+    { "clear", "set pin to LOW", clear },
+    { "toggle", "toggle pin", toggle },
+    { "write", "write pin", writep },
+    { "bench", "run a set of predefined benchmarks", bench },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("GPIO peripheral driver test\n");
+    puts("In this test, pins are specified by integer port and pin numbers.\n"
+         "So if your platform has a pin PA01, it will be port=0 and pin=1,\n"
+         "PC14 would be port=2 and pin=14 etc. When using exp0, exp1, ...\n"
+         "for the port, the virtual GPIO expander ports are addressed.\n\n"
+         "NOTE: make sure the values you use exist on your platform! The\n"
+         "      behavior for not existing ports/pins is not defined!");
+
+    /* start the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/periph_gpio_exp/tests/01-run.py
+++ b/tests/periph_gpio_exp/tests/01-run.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#               2020 Gunar Schorcht <gunar@schorcht.net>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+# On slow platforms, like AVR, this test can take some time to complete.
+TIMEOUT = 30
+
+
+def testfunc(child):
+    child.expect_exact(">")
+
+    # execute bench for a MCU port to verify that MCU ports still work when
+    # GPIO extension is enabled
+    child.sendline("bench 0 0")
+    child.expect(r" *nop loop: +(\d+)us  --- +(\d+\.\d+)us per call  --- +(\d+) calls per sec")
+    child.expect(r" *gpio_set: +(\d+)us  --- +(\d+\.\d+)us per call  --- +(\d+) calls per sec")
+    child.expect(r" *gpio_clear: +(\d+)us  --- +(\d+\.\d+)us per call  --- +(\d+) calls per sec")
+    child.expect(r" *gpio_toggle: +(\d+)us  --- +(\d+\.\d+)us per call  --- +(\d+) calls per sec")
+    child.expect(r" *gpio_read: +(\d+)us  --- +(\d+\.\d+)us per call  --- +(\d+) calls per sec")
+    child.expect(r" *gpio_write: +(\d+)us  --- +(\d+\.\d+)us per call  --- +(\d+) calls per sec")
+    child.expect_exact(" --- DONE ---")
+    child.expect_exact(">")
+
+    # test all functions with first example GPIO extender
+    child.sendline("init_out exp0 3")
+    child.expect(r"init dev (0[xX])?[\dA-Fa-f]+ \(foo1\) pin 3")
+    child.expect_exact(">")
+    child.sendline("init_out exp0 5")
+    child.expect(r"init dev (0[xX])?[\dA-Fa-f]+ \(foo1\) pin 5")
+    child.expect_exact(">")
+    child.sendline("set exp0 3")
+    child.expect(r"set dev (0[xX])?[\dA-Fa-f]+ \(foo1\) pins 0x08, state 0x08")
+    child.expect_exact(">")
+    child.sendline("read exp0 3")
+    child.expect(r"read dev (0[xX])?[\dA-Fa-f]+ \(foo1\) state 0x08")
+    child.expect(r"GPIO_PIN\(\d+, 3\) is HIGH")
+    child.expect_exact(">")
+    child.sendline("read exp0 5")
+    child.expect(r"read dev (0[xX])?[\dA-Fa-f]+ \(foo1\) state 0x08")
+    child.expect(r"GPIO_PIN\(\d+, 5\) is LOW")
+    child.expect_exact(">")
+    child.sendline("toggle exp0 5")
+    child.expect(r"toggle dev (0[xX])?[\dA-Fa-f]+ \(foo1\) pins 0x20, state 0x28")
+    child.expect_exact(">")
+    child.sendline("read exp0 5")
+    child.expect(r"read dev (0[xX])?[\dA-Fa-f]+ \(foo1\) state 0x28")
+    child.expect(r"GPIO_PIN\(\d+, 5\) is HIGH")
+    child.expect_exact(">")
+    child.sendline("write exp0 5 0")
+    child.expect(r"clear dev (0[xX])?[\dA-Fa-f]+ \(foo1\) pins 0x20, state 0x08")
+    child.expect_exact(">")
+    child.sendline("write exp0 5 1")
+    child.expect(r"set dev (0[xX])?[\dA-Fa-f]+ \(foo1\) pins 0x20, state 0x28")
+    child.expect_exact(">")
+
+    # test the correct redirection to the other example GPIO expanders
+    child.sendline("init_out exp1 1")
+    child.expect(r"init dev (0[xX])?[\dA-Fa-f]+ \(foo2\) pin 1")
+    child.expect_exact(">")
+    child.sendline("init_out exp2 2")
+    child.expect(r"init dev (0[xX])?[\dA-Fa-f]+ \(bar\) port 0, pin 2")
+    child.expect_exact(">")
+    child.sendline("init_out exp3 3")
+    child.expect(r"init dev (0[xX])?[\dA-Fa-f]+ \(bar\) port 1, pin 3")
+    child.expect_exact(">")
+    child.sendline("init_out exp4 4")
+    child.expect(r"init dev (0[xX])?[\dA-Fa-f]+ \(bar\) port 2, pin 4")
+    child.expect_exact(">")
+    child.sendline("init_out exp5 5")
+    child.expect(r"init dev (0[xX])?[\dA-Fa-f]+ \(bar\) port 3, pin 5")
+    child.expect_exact(">")
+
+    print("SUCCESS")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc, timeout=TIMEOUT))

--- a/tests/pkg_semtech-loramac/Makefile
+++ b/tests/pkg_semtech-loramac/Makefile
@@ -5,7 +5,9 @@ include ../Makefile.tests_common
 BOARD_WITHOUT_LORAMAC_RX := \
     arduino-mega2560 \
     i-nucleo-lrwan1 \
+    nucleo-l053r8\
     stm32f0discovery \
+    stm32l0538-disco \
     waspmote-pro \
 
 LORA_DRIVER ?= sx1276


### PR DESCRIPTION
### Contribution description

**Please note:** Even if this PR should be compilable with the current master, the new API provided with this PR cannot be tested standalone. At least one MCU implementation is required for testing. Follow-up PRs with two MCU implementations will be provided immediately.

This PR provides a new GPIO API that

- allows the expansion of GPIO ports using GPIO expanders, such as I2C I/O expanders,
- allows consistent access to GPIO pins of the MCU and GPIO expanders with the `GPIO_PIN(port,pin)` macro
- allows a hardware-oriented implementation of access to the pins of a GPIO port and
- does not require any changes to existing applications.

It is the result of the discussion in POC/RFC PR #12877. The new GPIO API consists of a high-level API and a low-level API:

1. The **pin-oriented high-level API** is compatible with the "Legacy GPIO API" and is intended for use by the application to access single GPIO pins. 
2. The **port-oriented low-level API** provides functions for port-oriented access to the GPIO pins. It has to be implemented for each GPIO hardware component (MCU GPIO ports and GPIO expanders). The port-oriented functions of the low-level API are
    ```
    gpio_mask_t read(gpio_port_t port);
    void set(gpio_port_t port, gpio_mask_t pins);
    void clear(gpio_port_t port, gpio_mask_t pins);
    void toggle(gpio_port_t port, gpio_mask_t pins);
    void write(gpio_port_t port, gpio_mask_t values)
    ```
    These functions are used by the high-level API to realize the pin-oriented functions. They can also be used by drivers or the application if several pins of a GPIO port are to be changed simultaneously using the definition of GPIO pin masks.

### Implementation Details

#### GPIO pins

A GPIO pin of type `gpio_t` is now defined as a structure of a GPIO port of type `gpio_port_t` and a pin number of type `gpio_pin_t`. `gpio_t` can't be overridden anymore.

The number of pins per GPIO port is defined by the width of type `gpio_mask_t` which in turn is determined by module  `gpio_mask_8bit`, `gpio_mask_16bit` or `gpio_mask_32bit`. Each driver for GPIO ports including the MCU implementation has to enable the according module. The width of type `gpio_mask_t` is then the maximum width of all different GPIO ports used in the system.

#### GPIO ports

The GPIO port of type `gpio_port_t` and can be either

- the register address in case of a MCU GPIO port and if all MCU GPIO ports follow a consistent address scheme,
- the address of a device descriptor of type `gpio_dev_t` in case of a GPIO expander port, or
- the port number.

The port number is a sequential number that goes from 0 to `GPIO_EXP_PORT-1` for MCU GPIO ports. For GPIO expanders, the port number is derived from `GPIO_EXP_PORT` and their index in the GPIO device table `gpio_devs` as offset.

In the case of GPIO expander ports, the port is defined as a reference to a device descriptor of type `gpio_dev_t`. This device descriptor contains

- a reference to a device-specific descriptor which is used by the associated device driver and
- a reference to a driver interface of type `gpio_driver_t` which contains the references to the low-level GPIO API functions  of the associated device driver.

Device descriptors of type `gpio_dev_t` are stored for all existing GPIO expander ports in a device table for GPIO Ports `gpio_devs`, where each entry contains a device descriptor for exactly one GPIO expander port. If a GPIO expander provides multiple ports, each port has to be defined as separate device of type `gpio_dev_t`. The device table for GPIO expander ports `gpio_devs` is automatically generated from the `GPIO_EXP_PORTS` macro definition which has to be defined either by the board definition or by the application in a separate file `gpio_exp_conf.h`.

In the case of MCU GPIO ports, the port defines just the register address. The mapping to the functions of the low-level API is realized by the special driver interface instance `gpio_cpu_driver` which is created automatically from the MCU low-level functions `gpio_cpu_*`.

#### MCU Low-level API Implementation

The MCU implementation of the low-level API has to define

- the low-level API functions with prefix `gpio_cpu_*`,
- the width of its GPIO ports using module `gpio_mask_8bit`, `gpio_mask_16bit` or `gpio_mask_32bit`,
- if register address are used as port definitions the macros
   - `GPIO_CPU_PORT` and `GPIO_CPU_PORT_NUM`
   - `GPIO_CPU_PORT_BASE` and `GPIO_CPU_PORT_MASK` or alternatively `GPIO_CPU_PORT_IS`
- the feature `periph_gpio_exp`.

### How the new GPIO API works

If the MCU implementation does not support the new GPIO API, that is the `periph_gpio_exp` feature is not provided by the MCU, the legacy GPIO API is used. GPIO expanders can then only be used via the device-specific driver interface.

If the MCU implementation supports the new GPIO API, that is the `periph_gpio_exp` feature is provided by the MCU, the GPIO API works as follows:

1. Default case where GPIO expanders are not used (`gpio_exp` module is not enabled).
    In this case, high-level API functions call the MCU low-level functions `gpio_cpu_*` directly. There is no MCU driver interface `gpio_cpu_driver` and no device table for GPIO expander ports `gpio_devs`. So only slightly more RAM than with the legacy GPIO API is needed for the port member in the GPIO pin variables. The performance is the same as with the old GPIO API or even better, depending on the MCU low-level implementation, such as ATmega and STM32. 

2. GPIO expanders are used (`gpio_exp` module is not enabled)
    The low-level API functions are called indirectly via a driver interface. For this purpose, the high-level API first determines with the macro `GPIO_CPU_PORT_IS` whether the specified port is an MCU port and uses either the driver interface `gpio_cpu_driver` to call the MCU low-level functions indirectly or the driver interface of the corresponding GPIO expander from the device table `gpio_devs`. In this case, on Harvard architectures such as ATmega, additional RAM is required for the MCU driver interface `gpio_cpu_driver` and the device table for GPIO expander ports `gpio_devs`. Of course the performance is lower than with the old GPIO API due to the additional checks and the indirect call of the low-level API functions. But for ATmega it is still better because of the more efficient implementation of the low-level functions.

This is implemented as following:
```c
#if MODULE_GPIO_EXP
static inline const gpio_driver_t *gpio_driver_get(gpio_port_t port)
{
    if (GPIO_CPU_PORT_IS(port)) {
        return &gpio_cpu_driver;
    }
    else {
        assert(port.dev);
        assert(port.dev->driver);
        return port.dev->driver;
    }
}
#endif

static inline void gpio_set(gpio_t gpio)
{
#ifdef MODULE_GPIO_EXP
    const gpio_driver_t *driver = gpio_driver_get(gpio.port);
    driver->set(gpio.port, (1 << gpio.pin));
#else
    gpio_cpu_set(gpio.port, (1 << gpio.pin));
#endif
}
```
This means that if GPIO expanders are used (module `gpio_exp` is enabled), the low-level API functions are always called indirectly, also for the MCU. A slight improvement in performance with slightly higher ROM requirements could be achieved if the test for the MCU port were performed separately in each function, see below. In this case the RAM for the MCU driver interface`gpio_cpu_driver` could also be saved. But in my opinion the best compromise between performance, RAM/ROM requirements and code readability is the above approach.

```c
static inline void gpio_set(gpio_t gpio)
{
#ifdef MODULE_GPIO_EXP
    if (GPIO_CPU_PORT_IS(port)) {
        gpio_cpu_set(gpio.port, (1 << gpio.pin));
    }
    else {
        assert(gpio.port.dev);
        assert(gpio.port.dev->driver);
        gpio.port.dev->driver->set(gpio.port, (1 << gpio.pin));
    }
#else
    gpio_cpu_set(gpio.port, (1 << gpio.pin));
#endif
}
```

### Benchmarks

Performance test using `tests/periph_gpio` and command `bench 0 4`:

| STM32                                                    | set      | clear   | toggle  | read    | write   |
|:------------------------------------------------------|---------:|---------:|----------:|---------:|---------:|
| Master                                                      |  0.166 |  0.187 |  0.416 |  0.187 |  0.208 |
| w/o GPIO expanders (default)                 |  0.145 |  0.156 |  0.177 |  0.156 |  0.145 |
| with GPIO expanders (`gpio_exp` used) |  0.489 |  0.500 |  0.520 |  0.614 |  0.489 |
| <b>ATmega 2560</b> | <b>set</b> | <b>clear</b> | <b>toggle</b> | <b>read</b> | <b>write</b> |
| Master                                                      | 4.940 |  5.315 |  10.505 | 5.315 |  5.377
| w/o GPIO expanders (default)                 | 1.876 |  1.938 |  2.188 |  1.750 |  1.876
| with GPIO expanders (`gpio_exp` used) | 4.565 |  4.627 |  4.877 |  5.440 |  4.565

ROM/RAM requirements for `tests/pkg_semtech-loramac`:

| STM32                                                     | ROM    | RAM | Remark |
|:------------------------------------------------------|----------:|--------:|:----------|
| Master                                                      |  49524 | 7936 | |
| w/o GPIO expanders (default)                 |  49996 | 7968 | additional RAM of 32 bytes is required, because of a complete copy of `sx127x_params` in the device variable (8 pins a 4 byte for `gpio_port_t`) |
| with GPIO expanders (`gpio_exp` used) |  50300 | 7968 | |
| <b>ATmega 2560</b> | <b>ROM</b> | <b>RAM</b> | <b>Remark</b> |
| Master                                                      |  57476 | 7410 | |
| w/o GPIO expanders (default)                 |  57754 | 7437 | additional RAM of 32 bytes is required:<br>16 bytes for static const pin definitions in the Harvard architecture (8 pins a 2 byte for `gpio_port_t`) <br>16 bytes because of a complete copy of `sx127x_params` in the device variable (8 pins a 2 byte for `gpio_port_t`)|
| with GPIO expanders (`gpio_exp` used) |  58208 | 7455 | additional RAM of 18 bytes is required for the MCU driver interface `gpio_cpu_driver` (9 function references a 2 bytes) |

ROM/RAM requirements for `tests/driver_sdcard_spi`:

| STM32                                                     | ROM    | RAM | Remark |
|:------------------------------------------------------|----------:|--------:|:----------|
| Master                                                      | 21648  | 5036 | |
| w/o GPIO expanders (default)                 | 22396  | 5056 | additional RAM of 32 bytes is required, because of a complete copy of `sx127x_params` in the device variable (5 pins a 4 byte for `gpio_port_t`) |
| with GPIO expanders (`gpio_exp` used) | 22436  | 5056 | |
| <b>ATmega 2560</b> | <b>ROM</b> | <b>RAM</b> | <b>Remark</b> |
| Master                                                      | 23218  | 6080 | |
| w/o GPIO expanders (default)                 | 23462  | 6104 | additional RAM of 24 bytes is required:<br>10 bytes for static const pin definitions in the Harvard architecture (5 pins a 2 byte for `gpio_port_t`) <br>10 bytes because of a complete copy of `sx127x_params` in the device variable (5 pins a 2 byte for `gpio_port_t`)|
| with GPIO expanders (`gpio_exp` used) | 23592  | 6116 | additional RAM of 12 bytes is required for the MCU driver interface `gpio_cpu_driver` (6 function references a 2 bytes) |

The additional RAM requirements expose a problem of many, if not most, of our driver implementations. They keep their own copy of the parameters in the device variable instead of simply pointing to the static constant parameters in ROM. I'm not sure if this is always the best compromise between RAM/ROM size and performance.

### Testing procedure

Compilation should succeed. Tests should still work.

The new GPIO API cannot be tested standalone. The test application `tests/periph_gpio_exp`, which implements virtual GPIO expanders and demonstrates how to use singleport and multiport GPIO expanders, requires an MCU implementation. Such an implementation is available for ATmega in PR t.b.d. and for STM in PR t.b.d. Use these PRs for testing. (They will be provided immediatly).

### Issues/PRs references

Replaces PR #12877.

