### PR TITLE
sys/include/net: Add possibility to define custom ethertype

### DIFF
--- a/sys/include/net/ethertype.h
+++ b/sys/include/net/ethertype.h
@@ -38,6 +38,23 @@ extern "C" {
 #define ETHERTYPE_NDN           (0x8624)    /**< NDN Protocol (http://named-data.net/) */
 #define ETHERTYPE_IPV6          (0x86dd)    /**< Internet protocol version 6 */
 #define ETHERTYPE_6LOENC        (0xa0ed)    /**< 6LoWPAN encapsulation */
+
+/**
+ * @defgroup    net_ethertype_custom_config Custom ethertype
+ * @ingroup     config
+ * @brief       Custom ethertype definition
+ * @warning     Do not use a IANA assigned number
+ * @see         https://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml
+ *
+ * @{
+ */
+#ifndef ETHERTYPE_CUSTOM
+#define ETHERTYPE_CUSTOM        (0x0101)    /**< Custom ethertype */
+#endif
+/**
+ * @}
+ */
+
 #define ETHERTYPE_UNKNOWN       (0xffff)    /**< Reserved (no protocol specified) */
 
 #ifdef __cplusplus

--- a/sys/include/net/gnrc/nettype.h
+++ b/sys/include/net/gnrc/nettype.h
@@ -92,6 +92,17 @@ typedef enum {
 
     /**
      * @{
+     * @name Link layer
+     */
+#if IS_USED(MODULE_GNRC_NETTYPE_CUSTOM) || defined(DOXYGEN)
+    GNRC_NETTYPE_CUSTOM,            /**< Custom ethertype */
+#endif
+    /**
+     * @}
+     */
+
+    /**
+     * @{
      * @name Network layer
      */
 #if IS_USED(MODULE_GNRC_NETTYPE_IPV6) || defined(DOXYGEN)
@@ -178,6 +189,10 @@ static inline gnrc_nettype_t gnrc_nettype_from_ethertype(uint16_t type)
         case ETHERTYPE_6LOENC:
             return GNRC_NETTYPE_SIXLOWPAN;
 #endif
+#if IS_USED(MODULE_GNRC_NETTYPE_CUSTOM)
+        case ETHERTYPE_CUSTOM:
+            return GNRC_NETTYPE_CUSTOM;
+#endif
         default:
             return GNRC_NETTYPE_UNDEF;
     }
@@ -211,6 +226,10 @@ static inline uint16_t gnrc_nettype_to_ethertype(gnrc_nettype_t type)
 #if IS_USED(MODULE_GNRC_NETTYPE_NDN)
         case GNRC_NETTYPE_NDN:
             return ETHERTYPE_NDN;
+#endif
+#if IS_USED(MODULE_GNRC_NETTYPE_CUSTOM)
+        case GNRC_NETTYPE_CUSTOM:
+            return ETHERTYPE_CUSTOM;
 #endif
         default:
             return ETHERTYPE_UNKNOWN;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR offers the possibility to define custom ethertypes. So it is possible to send and receive packets with a custom ethertype.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Testing can be done with the example under `/examples/default` using `txtsnd`. Add `USEMODULE += gnrc_nettype_custom` to the Makefile, define a custom ethertype and register for `GNRC_NETTYPE_CUSTOM` in `main.c`. Finally the protocol type `GNRC_NETTYPE_CUSTOM` must be passed to `gnrc_pktbuf_add` in `_gnrc_netif_send`.

It should be possible to send and receive packets using this defined ethertype.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
