### PR TITLE
sys/net/eui64: Simplify type

### DIFF
--- a/drivers/kw41zrf/kw41zrf_getset.c
+++ b/drivers/kw41zrf/kw41zrf_getset.c
@@ -126,8 +126,10 @@ void kw41zrf_set_addr_short(kw41zrf_t *dev, const network_uint16_t *addr)
 void kw41zrf_set_addr_long(kw41zrf_t *dev, const eui64_t *addr)
 {
     (void) dev;
-    ZLL->MACLONGADDRS0_LSB = addr->uint32[0].u32;
-    ZLL->MACLONGADDRS0_MSB = addr->uint32[1].u32;
+    uint32_t tmp[2];
+    memcpy(tmp, addr, sizeof(*addr));
+    ZLL->MACLONGADDRS0_LSB = tmp[0];
+    ZLL->MACLONGADDRS0_MSB = tmp[1];
 }
 
 void kw41zrf_get_addr_short(kw41zrf_t *dev, network_uint16_t *addr)
@@ -142,8 +144,10 @@ void kw41zrf_get_addr_short(kw41zrf_t *dev, network_uint16_t *addr)
 void kw41zrf_get_addr_long(kw41zrf_t *dev, eui64_t *addr)
 {
     (void) dev;
-    addr->uint32[0] = (network_uint32_t)ZLL->MACLONGADDRS0_LSB;
-    addr->uint32[1] = (network_uint32_t)ZLL->MACLONGADDRS0_MSB;
+    uint32_t tmp[2];
+    tmp[0] = ZLL->MACLONGADDRS0_LSB;
+    tmp[1] = ZLL->MACLONGADDRS0_MSB;
+    memcpy(addr, tmp, sizeof(*addr));
 }
 
 int8_t kw41zrf_get_cca_threshold(kw41zrf_t *dev)

--- a/drivers/kw41zrf/kw41zrf_netdev.c
+++ b/drivers/kw41zrf/kw41zrf_netdev.c
@@ -786,10 +786,14 @@ static int kw41zrf_netdev_set(netdev_t *netdev, netopt_t opt, const void *value,
             break;
 
         case NETOPT_ADDRESS_LONG: {
-            eui64_t addr;
+            union {
+                eui64_t addr;
+                uint64_t u64;
+            } tmp;
             assert(len <= sizeof(const eui64_t));
-            addr.uint64.u64 = byteorder_swapll(*(uint64_t*)value);
-            kw41zrf_set_addr_long(dev, &addr);
+            memcpy(&tmp, value, sizeof(tmp));
+            tmp.u64 = byteorder_swapll(tmp.u64);
+            kw41zrf_set_addr_long(dev, &tmp.addr);
             res = sizeof(const eui64_t);
             break;
         }

--- a/sys/include/luid.h
+++ b/sys/include/luid.h
@@ -55,6 +55,7 @@
 
 #include <stddef.h>
 
+#include "byteorder.h"
 #include "net/eui48.h"
 #include "net/eui64.h"
 

--- a/sys/include/net/eui64.h
+++ b/sys/include/net/eui64.h
@@ -25,7 +25,6 @@
 #define NET_EUI64_H
 
 #include <stdint.h>
-#include "byteorder.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -52,11 +51,8 @@ extern "C" {
 /**
  * @brief Data type to represent an EUI-64.
  */
-typedef union {
-    network_uint64_t uint64;     /**< represented as 64 bit value */
+typedef struct {
     uint8_t uint8[8];            /**< split into 8 8-bit words.   */
-    network_uint16_t uint16[4];  /**< split into 4 16-bit words.  */
-    network_uint32_t uint32[2];  /**< split into 2 32-bit words.  */
 } eui64_t;
 
 /**

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -35,7 +35,7 @@ static bool _is_iface_eui64(gnrc_netif_t *netif, const eui64_t *eui64)
     eui64_t iface_eui64;
     int res = gnrc_netif_get_eui64(netif, &iface_eui64);
     return (res == sizeof(eui64_t)) &&
-           (iface_eui64.uint64.u64 == eui64->uint64.u64);
+           !memcmp(&iface_eui64, eui64, sizeof(eui64_t));
 }
 
 bool _resolve_addr_from_ipv6(const ipv6_addr_t *dst, gnrc_netif_t *netif,

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -138,7 +138,7 @@ static bool _try_addr_reconfiguration(gnrc_netif_t *netif)
         if (remove_old) {
             for (unsigned i = 0; i < CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF; i++) {
                 ipv6_addr_t *addr = &netif->ipv6.addrs[i];
-                if (addr->u64[1].u64 == orig_iid.uint64.u64) {
+                if (!memcmp(&addr->u64[1], &orig_iid, sizeof(orig_iid))) {
                     gnrc_netif_ipv6_addr_remove_internal(netif, addr);
                 }
             }

--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -1081,7 +1081,7 @@ static size_t _iphc_ipv6_encode(gnrc_pktsnip_t *pkt,
 
         if ((src_ctx != NULL) || ipv6_addr_is_link_local(&(ipv6_hdr->src))) {
             eui64_t iid;
-            iid.uint64.u64 = 0;
+            memset(&iid, 0, sizeof(iid));
 
             gnrc_netif_acquire(iface);
             if (gnrc_netif_ipv6_get_iid(iface, &iid) < 0) {
@@ -1091,7 +1091,7 @@ static size_t _iphc_ipv6_encode(gnrc_pktsnip_t *pkt,
             }
             gnrc_netif_release(iface);
 
-            if ((ipv6_hdr->src.u64[1].u64 == iid.uint64.u64) ||
+            if (!memcmp(&ipv6_hdr->src.u64[1], &iid, sizeof(iid)) ||
                 _context_overlaps_iid(src_ctx, &ipv6_hdr->src, &iid)) {
                 /* 0 bits. The address is derived from link-layer address */
                 iphc_hdr[IPHC2_IDX] |= IPHC_SAC_SAM_L2;
@@ -1208,7 +1208,7 @@ static size_t _iphc_ipv6_encode(gnrc_pktsnip_t *pkt,
             return 0;
         }
 
-        if ((ipv6_hdr->dst.u64[1].u64 == iid.uint64.u64) ||
+        if (!memcmp(&ipv6_hdr->dst.u64[1], &iid, sizeof(iid)) ||
             _context_overlaps_iid(dst_ctx, &(ipv6_hdr->dst), &iid)) {
             /* 0 bits. The address is derived using the link-layer address */
             iphc_hdr[IPHC2_IDX] |= IPHC_M_DAC_DAM_U_L2;


### PR DESCRIPTION
### Contribution description

For increased portability, don't use fancy type for eui64_t that results in higher alignment requirements.

### Testing procedure

Networking should still work, including NIB.

### Issues/PRs references

Requirement for https://github.com/RIOT-OS/RIOT/pull/12713