### PR TITLE
Openthread kw41z

### DIFF
--- a/examples/openthread/Makefile
+++ b/examples/openthread/Makefile
@@ -4,7 +4,7 @@ APPLICATION = openthread
 BOARD ?= samr21-xpro
 
 # These are the boards that OpenThread stack has been tested on
-BOARD_WHITELIST := samr21-xpro iotlab-m3 fox iotlab-a8-m3
+BOARD_WHITELIST := samr21-xpro iotlab-m3 fox iotlab-a8-m3 frdm-kw41z openlabs-kw41z-mini-256kib openlabs-kw41z-mini phynode-kw41z usb-kw41z
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
@@ -40,6 +40,9 @@ ifneq (,$(filter samr21-xpro,$(BOARD)))
 endif
 ifneq (,$(filter iotlab-m3 fox iotlab-a8-m3,$(BOARD)))
   DRIVER := at86rf231
+endif
+ifneq (,$(filter frdm-kw41z openlabs-kw41z-mini-256kib openlabs-kw41z-mini phynode-kw41z usb-kw41z,$(BOARD)))
+  DRIVER := kw41zrf
 endif
 
 USEMODULE += $(DRIVER)

--- a/pkg/openthread/contrib/openthread.c
+++ b/pkg/openthread/contrib/openthread.c
@@ -30,6 +30,10 @@
 #include "at86rf2xx_params.h"
 #endif
 
+#ifdef MODULE_KW41ZRF
+#include "kw41zrf.h"
+#endif
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -37,8 +41,16 @@
 #define OPENTHREAD_NETIF_NUMOF        ARRAY_SIZE(at86rf2xx_params)
 #endif
 
+#ifdef MODULE_KW41ZRF
+#define OPENTHREAD_NETIF_NUMOF        (1U)
+#endif
+
 #ifdef MODULE_AT86RF2XX
 static at86rf2xx_t at86rf2xx_dev;
+#endif
+
+#ifdef MODULE_KW41ZRF
+static kw41zrf_t kw41z_dev;
 #endif
 
 static uint8_t rx_buf[OPENTHREAD_NETDEV_BUFLEN];
@@ -54,6 +66,10 @@ void openthread_bootstrap(void)
 #ifdef MODULE_AT86RF2XX
     at86rf2xx_setup(&at86rf2xx_dev, &at86rf2xx_params[0]);
     netdev_t *netdev = (netdev_t *) &at86rf2xx_dev;
+#endif
+#ifdef MODULE_KW41ZRF
+    kw41zrf_setup(&kw41z_dev);
+    netdev_t *netdev = (netdev_t *) &kw41z_dev;
 #endif
 
     openthread_radio_init(netdev, tx_buf, rx_buf);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Changed the openthread example so it can be build for KW41Z based boards. Modified the openthread package to include board specific libraries and instantiated the netdev struct.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
The example can be build for all kw41z based boards. The example is tested on a custom kw41z board (which is very similar to the openlabs-kw41z-mini board) and is able to connect to and ping a border router. The Openthread CLI is used to setup the connection between the border router and the board by setting the panid, channel and masterkey to the same value. I have not gotten commissioning to work yet.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

See also #10045