### PR TITLE
makefiles/buspirate: add Bus Pirate as Debug Adapter

### DIFF
--- a/makefiles/tools/openocd-adapters/buspirate.inc.mk
+++ b/makefiles/tools/openocd-adapters/buspirate.inc.mk
@@ -1,0 +1,14 @@
+# Bus Pirate debug adapter
+#
+# For SWD mode connect:
+#  MOSI - SWDIO
+#   CLK - SWCLK
+
+ifeq ($(OS),Darwin)
+  PROG_DEV ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+else
+  PROG_DEV ?= /dev/ttyUSB0
+endif
+
+OPENOCD_ADAPTER_INIT ?= -c 'source [find interface/buspirate.cfg]' \
+                        -c 'buspirate_port $(PROG_DEV)'


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Bus Pirate is a multi-protocol analyzer that can be also used to generate signals.
It's pretty slow as it only supports software-bit banging for SWD, but if it's the only tool at hand it's better than nothing.


### Testing procedure

Flash any board with `PROGRAMMER=openocd DEBUG_ADAPTER=buspirate`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
