### PR TITLE
boards/hifive1*: add kconfig options to configure the clock

### DIFF
--- a/boards/hifive1/Kconfig
+++ b/boards/hifive1/Kconfig
@@ -17,3 +17,53 @@ config BOARD_HIFIVE1
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+menu "Hifive1 clock configuration"
+    depends on BOARD_HIFIVE1
+
+choice
+bool "Clock source selection"
+default USE_CLOCK_HFXOSC_PLL
+
+config USE_CLOCK_HFXOSC_PLL
+    bool "PLL clocked by high frequency external oscillator (HFXOSC)"
+
+config USE_CLOCK_HFXOSC
+    bool "Direct High frequency external oscillator (HFXOSC)"
+
+config USE_CLOCK_HFROSC_PLL
+    bool "PLL clocked by High frequency internal oscillator (HFROSC)"
+
+config USE_CLOCK_HFROSC
+    bool "Direct High frequency internal oscillator (HFROSC)"
+endchoice
+
+if USE_CLOCK_HFXOSC_PLL
+config CLOCK_PLL_F
+    int "F: REFR multiply factor"
+    default 39
+
+config CLOCK_PLL_Q
+    int "Q: VCO divide factor"
+    default 1
+endif
+
+config CLOCK_DESIRED_FREQUENCY
+    int "Desired clock frequency"
+    default 320000000
+    range 1000000 320000000
+    depends on USE_CLOCK_HFROSC_PLL
+
+if USE_CLOCK_HFROSC
+config CLOCK_HFROSC_TRIM
+    int "TRIM: input frequency multiplier"
+    default 6
+    range 0 31
+
+config CLOCK_HFROSC_DIV
+    int "DIV: output frequency divider"
+    default 1
+    range 0 63
+endif
+
+endmenu

--- a/boards/hifive1/include/periph_conf.h
+++ b/boards/hifive1/include/periph_conf.h
@@ -30,27 +30,60 @@ extern "C" {
  * @name    Core Clock configuration
  * @{
  */
-#define USE_CLOCK_HFXOSC_PLL        (1)
-#define USE_CLOCK_HFXOSC            (0)
-#define USE_CLOCK_HFROSC_PLL        (0)
+#ifndef CONFIG_USE_CLOCK_HFXOSC_PLL
+#if IS_ACTIVE(CONFIG_USE_CLOCK_HFXOSC) || IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC_PLL) || \
+    IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC)
+#define CONFIG_USE_CLOCK_HFXOSC_PLL         (0)
+#else
+#define CONFIG_USE_CLOCK_HFXOSC_PLL         (1)     /* Use PLL clocked by HFXOSC by default */
+#endif
+#endif /* CONFIG_USE_CLOCK_HFXOSC_PLL */
 
-#if USE_CLOCK_HFROSC_PLL && (USE_CLOCK_HFXOSC_PLL || USE_CLOCK_HFXOSC)
-#error "Cannot use HFROSC_PLL with HFXOSC based configurations"
+#ifndef CONFIG_USE_CLOCK_HFXOSC
+#define CONFIG_USE_CLOCK_HFXOSC             (0)
+#endif /* CONFIG_USE_CLOCK_HFXOSC */
+
+#ifndef CONFIG_USE_CLOCK_HFROSC_PLL
+#define CONFIG_USE_CLOCK_HFROSC_PLL         (0)
+#endif /* CONFIG_USE_CLOCK_HFROSC_PLL */
+
+#ifndef CONFIG_USE_CLOCK_HFROSC
+#define CONFIG_USE_CLOCK_HFROSC             (0)
+#endif /* CONFIG_USE_CLOCK_HFROSC */
+
+#if CONFIG_USE_CLOCK_HFXOSC_PLL && \
+    (CONFIG_USE_CLOCK_HFROSC_PLL || CONFIG_USE_CLOCK_HFROSC || CONFIG_USE_CLOCK_HFXOSC)
+#error "Cannot use HFXOSC_PLL with other clock configurations"
 #endif
 
-#if USE_CLOCK_HFXOSC_PLL && USE_CLOCK_HFXOSC
-#error "Cannot use HFXOSC with HFXOSC_PLL"
+#if CONFIG_USE_CLOCK_HFXOSC && \
+    (CONFIG_USE_CLOCK_HFROSC_PLL || CONFIG_USE_CLOCK_HFROSC || CONFIG_USE_CLOCK_HFXOSC_PLL)
+#error "Cannot use HFXOSC with other clock configurations"
 #endif
 
-#if USE_CLOCK_HFXOSC_PLL
-#define CLOCK_PLL_R                 (1)             /* Divide input clock by 2, mandatory with HFXOSC */
-#define CLOCK_PLL_F                 (39)            /* Multiply REFR by 80, e.g 2 * (39 + 1) */
-#define CLOCK_PLL_Q                 (1)             /* Divide VCO by 2, e.g 2^1 */
-#define CLOCK_PLL_INPUT_CLOCK       (16000000UL)
-#define CLOCK_PLL_REFR              (CLOCK_PLL_INPUT_CLOCK / (CLOCK_PLL_R + 1))
-#define CLOCK_PLL_VCO               (CLOCK_PLL_REFR * (2 * (CLOCK_PLL_F + 1)))
-#define CLOCK_PLL_OUT               (CLOCK_PLL_VCO / (1 << CLOCK_PLL_Q))
-#define CLOCK_CORECLOCK             (CLOCK_PLL_OUT) /* 320000000Hz with the values used above */
+#if CONFIG_USE_CLOCK_HFROSC_PLL && \
+    (CONFIG_USE_CLOCK_HFXOSC_PLL || CONFIG_USE_CLOCK_HFXOSC || CONFIG_USE_CLOCK_HFROSC)
+#error "Cannot use HFROSC_PLL with other clock configurations"
+#endif
+
+#if CONFIG_USE_CLOCK_HFROSC && \
+    (CONFIG_USE_CLOCK_HFXOSC_PLL || CONFIG_USE_CLOCK_HFXOSC || CONFIG_USE_CLOCK_HFROSC_PLL)
+#error "Cannot use HFROSC with other clock configurations"
+#endif
+
+#if CONFIG_USE_CLOCK_HFXOSC_PLL
+#define CONFIG_CLOCK_PLL_R                  (1)     /* Divide input clock by 2, mandatory with HFXOSC */
+#ifndef CONFIG_CLOCK_PLL_F
+#define CONFIG_CLOCK_PLL_F                  (39)    /* Multiply REFR by 80, e.g 2 * (39 + 1) */
+#endif
+#ifndef CONFIG_CLOCK_PLL_Q
+#define CONFIG_CLOCK_PLL_Q                  (1)     /* Divide VCO by 2, e.g 2^1 */
+#endif
+#define CLOCK_PLL_INPUT_CLOCK               (16000000UL)
+#define CLOCK_PLL_REFR                      (CLOCK_PLL_INPUT_CLOCK / (CONFIG_CLOCK_PLL_R + 1))
+#define CLOCK_PLL_VCO                       (CLOCK_PLL_REFR * (2 * (CONFIG_CLOCK_PLL_F + 1)))
+#define CLOCK_PLL_OUT                       (CLOCK_PLL_VCO / (1 << CONFIG_CLOCK_PLL_Q))
+#define CLOCK_CORECLOCK                     (CLOCK_PLL_OUT) /* 320000000Hz with the values used above */
 
 /* Check PLL settings */
 #if CLOCK_PLL_REFR != 8000000
@@ -63,19 +96,28 @@ extern "C" {
 #error "PLL output frequency must be in the range [48MHz - 384MHz], check the CLOCK_PLL_Q value"
 #endif
 
-#elif USE_CLOCK_HFXOSC
-#define CLOCK_CORECLOCK             (16000000UL)
+#elif CONFIG_USE_CLOCK_HFXOSC
+#define CLOCK_CORECLOCK                     (16000000UL)
 
 /*
   When using HFROSC input clock, the core clock cannot be computed from settings,
   call cpu_freq() to get the configured CPU frequency.
 */
-#elif USE_CLOCK_HFROSC_PLL
-#define CLOCK_DESIRED_FREQUENCY     (320000000UL)
+#elif CONFIG_USE_CLOCK_HFROSC_PLL
+#ifndef CONFIG_CLOCK_DESIRED_FREQUENCY
+#define CONFIG_CLOCK_DESIRED_FREQUENCY     (320000000UL)
+#endif
+
+#elif CONFIG_USE_CLOCK_HFROSC
+#ifndef CONFIG_CLOCK_HFROSC_TRIM
+#define CONFIG_CLOCK_HFROSC_TRIM           (6)      /* ~72000000Hz input freq */
+#endif
+#ifndef CONFIG_CLOCK_HFROSC_DIV
+#define CONFIG_CLOCK_HFROSC_DIV            (1)      /* Divide by 2 */
+#endif
 
 #else
-#define CLOCK_HFROSC_TRIM           (6)             /* ~72000000Hz input freq */
-#define CLOCK_HFROSC_DIV            (1)             /* Divide by 2 */
+#error "Invalid clock configuration"
 #endif
 /** @} */
 

--- a/boards/hifive1b/Kconfig
+++ b/boards/hifive1b/Kconfig
@@ -19,3 +19,53 @@ config BOARD_HIFIVE1B
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_ARDUINO
+
+menu "Hifive1b clock configuration"
+    depends on BOARD_HIFIVE1B
+
+choice
+bool "Clock source selection"
+default USE_CLOCK_HFXOSC_PLL
+
+config USE_CLOCK_HFXOSC_PLL
+    bool "PLL clocked by high frequency external oscillator (HFXOSC)"
+
+config USE_CLOCK_HFXOSC
+    bool "Direct High frequency external oscillator (HFXOSC)"
+
+config USE_CLOCK_HFROSC_PLL
+    bool "PLL clocked by High frequency internal oscillator (HFROSC)"
+
+config USE_CLOCK_HFROSC
+    bool "Direct High frequency internal oscillator (HFROSC)"
+endchoice
+
+if USE_CLOCK_HFXOSC_PLL
+config CLOCK_PLL_F
+    int "F: REFR multiply factor"
+    default 39
+
+config CLOCK_PLL_Q
+    int "Q: VCO divide factor"
+    default 1
+endif
+
+config CLOCK_DESIRED_FREQUENCY
+    int "Desired clock frequency"
+    default 320000000
+    range 1000000 320000000
+    depends on USE_CLOCK_HFROSC_PLL
+
+if USE_CLOCK_HFROSC
+config CLOCK_HFROSC_TRIM
+    int "TRIM: input frequency multiplier"
+    default 6
+    range 0 31
+
+config CLOCK_HFROSC_DIV
+    int "DIV: output frequency divider"
+    default 1
+    range 0 63
+endif
+
+endmenu

--- a/boards/hifive1b/include/periph_conf.h
+++ b/boards/hifive1b/include/periph_conf.h
@@ -31,27 +31,60 @@ extern "C" {
  * @name    Core Clock configuration
  * @{
  */
-#define USE_CLOCK_HFXOSC_PLL        (1)
-#define USE_CLOCK_HFXOSC            (0)
-#define USE_CLOCK_HFROSC_PLL        (0)
+#ifndef CONFIG_USE_CLOCK_HFXOSC_PLL
+#if IS_ACTIVE(CONFIG_USE_CLOCK_HFXOSC) || IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC_PLL) || \
+    IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC)
+#define CONFIG_USE_CLOCK_HFXOSC_PLL         (0)
+#else
+#define CONFIG_USE_CLOCK_HFXOSC_PLL         (1)     /* Use PLL clocked by HFXOSC by default */
+#endif
+#endif /* CONFIG_USE_CLOCK_HFXOSC_PLL */
 
-#if USE_CLOCK_HFROSC_PLL && (USE_CLOCK_HFXOSC_PLL || USE_CLOCK_HFXOSC)
-#error "Cannot use HFROSC_PLL with HFXOSC based configurations"
+#ifndef CONFIG_USE_CLOCK_HFXOSC
+#define CONFIG_USE_CLOCK_HFXOSC             (0)
+#endif /* CONFIG_USE_CLOCK_HFXOSC */
+
+#ifndef CONFIG_USE_CLOCK_HFROSC_PLL
+#define CONFIG_USE_CLOCK_HFROSC_PLL         (0)
+#endif /* CONFIG_USE_CLOCK_HFROSC_PLL */
+
+#ifndef CONFIG_USE_CLOCK_HFROSC
+#define CONFIG_USE_CLOCK_HFROSC             (0)
+#endif /* CONFIG_USE_CLOCK_HFROSC */
+
+#if CONFIG_USE_CLOCK_HFXOSC_PLL && \
+    (CONFIG_USE_CLOCK_HFROSC_PLL || CONFIG_USE_CLOCK_HFROSC || CONFIG_USE_CLOCK_HFXOSC)
+#error "Cannot use HFXOSC_PLL with other clock configurations"
 #endif
 
-#if USE_CLOCK_HFXOSC_PLL && USE_CLOCK_HFXOSC
-#error "Cannot use HFXOSC with HFXOSC_PLL"
+#if CONFIG_USE_CLOCK_HFXOSC && \
+    (CONFIG_USE_CLOCK_HFROSC_PLL || CONFIG_USE_CLOCK_HFROSC || CONFIG_USE_CLOCK_HFXOSC_PLL)
+#error "Cannot use HFXOSC with other clock configurations"
 #endif
 
-#if USE_CLOCK_HFXOSC_PLL
-#define CLOCK_PLL_R                 (1)             /* Divide input clock by 2, mandatory with HFXOSC */
-#define CLOCK_PLL_F                 (39)            /* Multiply REFR by 80, e.g 2 * (39 + 1) */
-#define CLOCK_PLL_Q                 (1)             /* Divide VCO by 2, e.g 2^1 */
-#define CLOCK_PLL_INPUT_CLOCK       (16000000UL)
-#define CLOCK_PLL_REFR              (CLOCK_PLL_INPUT_CLOCK / (CLOCK_PLL_R + 1))
-#define CLOCK_PLL_VCO               (CLOCK_PLL_REFR * (2 * (CLOCK_PLL_F + 1)))
-#define CLOCK_PLL_OUT               (CLOCK_PLL_VCO / (1 << CLOCK_PLL_Q))
-#define CLOCK_CORECLOCK             (CLOCK_PLL_OUT) /* 320000000Hz with the values used above */
+#if CONFIG_USE_CLOCK_HFROSC_PLL && \
+    (CONFIG_USE_CLOCK_HFXOSC_PLL || CONFIG_USE_CLOCK_HFXOSC || CONFIG_USE_CLOCK_HFROSC)
+#error "Cannot use HFROSC_PLL with other clock configurations"
+#endif
+
+#if CONFIG_USE_CLOCK_HFROSC && \
+    (CONFIG_USE_CLOCK_HFXOSC_PLL || CONFIG_USE_CLOCK_HFXOSC || CONFIG_USE_CLOCK_HFROSC_PLL)
+#error "Cannot use HFROSC with other clock configurations"
+#endif
+
+#if CONFIG_USE_CLOCK_HFXOSC_PLL
+#define CONFIG_CLOCK_PLL_R                  (1)     /* Divide input clock by 2, mandatory with HFXOSC */
+#ifndef CONFIG_CLOCK_PLL_F
+#define CONFIG_CLOCK_PLL_F                  (39)    /* Multiply REFR by 80, e.g 2 * (39 + 1) */
+#endif
+#ifndef CONFIG_CLOCK_PLL_Q
+#define CONFIG_CLOCK_PLL_Q                  (1)     /* Divide VCO by 2, e.g 2^1 */
+#endif
+#define CLOCK_PLL_INPUT_CLOCK               (16000000UL)
+#define CLOCK_PLL_REFR                      (CLOCK_PLL_INPUT_CLOCK / (CONFIG_CLOCK_PLL_R + 1))
+#define CLOCK_PLL_VCO                       (CLOCK_PLL_REFR * (2 * (CONFIG_CLOCK_PLL_F + 1)))
+#define CLOCK_PLL_OUT                       (CLOCK_PLL_VCO / (1 << CONFIG_CLOCK_PLL_Q))
+#define CLOCK_CORECLOCK                     (CLOCK_PLL_OUT) /* 320000000Hz with the values used above */
 
 /* Check PLL settings */
 #if CLOCK_PLL_REFR != 8000000
@@ -64,19 +97,28 @@ extern "C" {
 #error "PLL output frequency must be in the range [48MHz - 384MHz], check the CLOCK_PLL_Q value"
 #endif
 
-#elif USE_CLOCK_HFXOSC
-#define CLOCK_CORECLOCK             (16000000UL)
+#elif CONFIG_USE_CLOCK_HFXOSC
+#define CLOCK_CORECLOCK                     (16000000UL)
 
 /*
   When using HFROSC input clock, the core clock cannot be computed from settings,
   call cpu_freq() to get the configured CPU frequency.
 */
-#elif USE_CLOCK_HFROSC_PLL
-#define CLOCK_DESIRED_FREQUENCY     (320000000UL)
+#elif CONFIG_USE_CLOCK_HFROSC_PLL
+#ifndef CONFIG_CLOCK_DESIRED_FREQUENCY
+#define CONFIG_CLOCK_DESIRED_FREQUENCY     (320000000UL)
+#endif
+
+#elif CONFIG_USE_CLOCK_HFROSC
+#ifndef CONFIG_CLOCK_HFROSC_TRIM
+#define CONFIG_CLOCK_HFROSC_TRIM           (6)      /* ~72000000Hz input freq */
+#endif
+#ifndef CONFIG_CLOCK_HFROSC_DIV
+#define CONFIG_CLOCK_HFROSC_DIV            (1)      /* Divide by 2 */
+#endif
 
 #else
-#define CLOCK_HFROSC_TRIM           (6)             /* ~72000000Hz input freq */
-#define CLOCK_HFROSC_DIV            (1)             /* Divide by 2 */
+#error "Invalid clock configuration"
 #endif
 /** @} */
 

--- a/cpu/fe310/clock.c
+++ b/cpu/fe310/clock.c
@@ -22,7 +22,7 @@
 
 #include "vendor/prci_driver.h"
 
-#if !(USE_CLOCK_HFXOSC || USE_CLOCK_HFXOSC_PLL)
+#if !(CONFIG_USE_CLOCK_HFXOSC || CONFIG_USE_CLOCK_HFXOSC_PLL)
 static uint32_t _cpu_frequency = 0;
 #endif
 
@@ -41,7 +41,7 @@ void clock_init(void)
         PRCI_REG(PRCI_PLLCFG) &= ~PLL_SEL(PLL_SEL_PLL);
     }
 
-#if USE_CLOCK_HFXOSC || USE_CLOCK_HFXOSC_PLL
+#if CONFIG_USE_CLOCK_HFXOSC || CONFIG_USE_CLOCK_HFXOSC_PLL
     /* Ensure HFXOSC is enabled */
     PRCI_REG(PRCI_HFXOSCCFG) = XOSC_EN(1);
 
@@ -51,12 +51,12 @@ void clock_init(void)
     /* Select HFXOSC as reference frequency and bypass PLL */
     PRCI_REG(PRCI_PLLCFG) = PLL_REFSEL(PLL_REFSEL_HFXOSC) | PLL_BYPASS(1);
 
-#if USE_CLOCK_HFXOSC_PLL
+#if CONFIG_USE_CLOCK_HFXOSC_PLL
     /* Divide final output frequency by 1 */
     PRCI_REG(PRCI_PLLDIV) = (PLL_FINAL_DIV_BY_1(1) | PLL_FINAL_DIV(0));
 
     /* Configure PLL */
-    PRCI_REG(PRCI_PLLCFG) |= PLL_R(CLOCK_PLL_R) | PLL_F(CLOCK_PLL_F) | PLL_Q(CLOCK_PLL_Q);
+    PRCI_REG(PRCI_PLLCFG) |= PLL_R(CONFIG_CLOCK_PLL_R) | PLL_F(CONFIG_CLOCK_PLL_F) | PLL_Q(CONFIG_CLOCK_PLL_Q);
 
     /* Disable PLL Bypass */
     PRCI_REG(PRCI_PLLCFG) &= ~PLL_BYPASS(1);
@@ -70,14 +70,14 @@ void clock_init(void)
 
     /* Turn off the HFROSC */
     PRCI_REG(PRCI_HFROSCCFG) &= ~ROSC_EN(1);
-#elif USE_CLOCK_HFROSC_PLL
-    PRCI_set_hfrosctrim_for_f_cpu(CLOCK_DESIRED_FREQUENCY, PRCI_FREQ_UNDERSHOOT);
+#elif CONFIG_USE_CLOCK_HFROSC_PLL
+    PRCI_set_hfrosctrim_for_f_cpu(CONFIG_CLOCK_DESIRED_FREQUENCY, PRCI_FREQ_UNDERSHOOT);
 #else /* Clock HFROSC */
     /* Disable Bypass */
     PRCI_REG(PRCI_PLLCFG) &= ~PLL_BYPASS(1);
 
     /* Configure trim and divider values of HFROSC */
-    PRCI_REG(PRCI_HFROSCCFG) = (ROSC_DIV(CLOCK_HFROSC_DIV) | ROSC_TRIM(CLOCK_HFROSC_TRIM) | ROSC_EN(1));
+    PRCI_REG(PRCI_HFROSCCFG) = (ROSC_DIV(CONFIG_CLOCK_HFROSC_DIV) | ROSC_TRIM(CONFIG_CLOCK_HFROSC_TRIM) | ROSC_EN(1));
 
     /* Wait for HFROSC to be ready */
     while ((PRCI_REG(PRCI_HFROSCCFG) & ROSC_RDY(1)) == 0);
@@ -89,7 +89,7 @@ void clock_init(void)
 
 uint32_t cpu_freq(void)
 {
-#if USE_CLOCK_HFXOSC || USE_CLOCK_HFXOSC_PLL
+#if CONFIG_USE_CLOCK_HFXOSC || CONFIG_USE_CLOCK_HFXOSC_PLL
     return CLOCK_CORECLOCK;
 #else /* Clock frequency with HFROSC cannot be determined precisely from
          settings */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR add a Kconfig menu to configure the clock of hifive1* boards. To be able to do that, this PR also improves the configuration of hifive1b and hifive1 boards so that important parameters (defines) can be overridden.

The configurable parameters are:
- selection of input clock source: HFXOSC, HFXOSC + PLL (default), HFROSC, HFROSC_PLL
- for HFXOSC + PLL, it's possible to configure the F and Q factors
- for HFROSC: it's possible to configure the TRIM and DIV factors (ranges are provided that follows the numbers described in the manual)
- for HFROSC + PLL: it's only possible to select the desired clock frequency since parameters are computed at runtime to reach this value.

I'm not sure what is the correct location for board level configurations like this. Maybe there should be a `Board` top-level menu and under it the configurations ?

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Run make `BOARD=hifive1b -C examples/hello-world menuconfig` and verify that a menu item is added that allows to configure the clock:

![image](https://user-images.githubusercontent.com/1375137/88478930-4c224580-cf4c-11ea-8512-05298362474c.png)

Check the default value is HFXOSC + PLL and there are 2 options to configure F and Q factors (R has to be 2 so it's not configurable):

![image](https://user-images.githubusercontent.com/1375137/88478987-855ab580-cf4c-11ea-94df-a6acac84b411.png)

- With the diff below, select the HFXOSC clock source (or play with other parameters) and verify that the expected clock value (for HFXOSC, it should be 16000000Hz) is correct when running `examples/hello-world` (use `make `BOARD=hifive1b -C examples/hello-world flash term`)

```diff
diff --git a/examples/hello-world/main.c b/examples/hello-world/main.c
index f51bf8c0a0..d6f6bc0729 100644
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -20,6 +20,7 @@
  */
 
 #include <stdio.h>
+#include "cpu.h"
 
 int main(void)
 {
@@ -28,5 +29,7 @@ int main(void)
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);
 
+    printf("Clock frequency: %luHz\n", cpu_freq());
+
     return 0;
 }
```

- One should also verify that I2C and SPI are still functional (since they depend on the cpu core clock frequency configured).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
