### PR TITLE
cpu/atmega_common: Increase idle stack size with xtimer

### DIFF
--- a/cpu/atmega_common/include/cpu_conf.h
+++ b/cpu/atmega_common/include/cpu_conf.h
@@ -49,7 +49,15 @@ extern "C" {
  * to avoid not printing of debug in interrupts
  */
 #ifndef THREAD_STACKSIZE_IDLE
+#ifdef MODULE_XTIMER
+/* xtimer's 64 bit arithmetic doesn't perform well on 8 bit archs. In order to
+ * prevent a stack overflow when an timer triggers while the idle thread is
+ * running, we have to increase the stack size then
+ */
+#define THREAD_STACKSIZE_IDLE      (192)
+#else
 #define THREAD_STACKSIZE_IDLE      (128)
+#endif
 #endif
 /** @} */
 

--- a/examples/gnrc_lorawan/Makefile.ci
+++ b/examples/gnrc_lorawan/Makefile.ci
@@ -5,14 +5,14 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    msb-430 \
+    msb-430h \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l031k6 \
     stm32f030f4-demo \
     stm32f0discovery \
-    msb-430 \
-    msb-430h \
     telosb \
     waspmote-pro \
     z1 \
-#
+    #

--- a/tests/bench_msg_pingpong/Makefile.ci
+++ b/tests/bench_msg_pingpong/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/bench_mutex_pingpong/Makefile.ci
+++ b/tests/bench_mutex_pingpong/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/bench_sys_base64/Makefile.ci
+++ b/tests/bench_sys_base64/Makefile.ci
@@ -1,9 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
-    arduino-leonardo \
     arduino-nano \
     arduino-uno \
     atmega328p \
-    nucleo-f031k6 \
-    stm32f030f4-demo \
     #

--- a/tests/bench_thread_flags_pingpong/Makefile.ci
+++ b/tests/bench_thread_flags_pingpong/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/bench_thread_yield_pingpong/Makefile.ci
+++ b/tests/bench_thread_yield_pingpong/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/bench_xtimer/Makefile.ci
+++ b/tests/bench_xtimer/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     im880b \
     olimexino-stm32 \
     #

--- a/tests/driver_at24cxxx/Makefile.ci
+++ b/tests/driver_at24cxxx/Makefile.ci
@@ -1,9 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
-    arduino-leonardo \
     arduino-nano \
     arduino-uno \
     atmega328p \
-    nucleo-f031k6 \
-    stm32f030f4-demo \
     #

--- a/tests/driver_atwinc15x0/Makefile.ci
+++ b/tests/driver_atwinc15x0/Makefile.ci
@@ -2,8 +2,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
     arduino-leonardo \
     arduino-mega2560 \
-    arduino-uno \
     arduino-nano \
+    arduino-uno \
     atmega328p \
     i-nucleo-lrwan1 \
     msb-430 \

--- a/tests/driver_ds1307/Makefile.ci
+++ b/tests/driver_ds1307/Makefile.ci
@@ -1,9 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
-    arduino-leonardo \
     arduino-nano \
     arduino-uno \
     atmega328p \
-    nucleo-f031k6 \
-    stm32f030f4-demo \
     #

--- a/tests/driver_sps30/Makefile.ci
+++ b/tests/driver_sps30/Makefile.ci
@@ -1,9 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
-    arduino-leonardo \
     arduino-nano \
     arduino-uno \
     atmega328p \
-    nucleo-f031k6 \
-    stm32f030f4-demo \
     #

--- a/tests/emcute/Makefile.ci
+++ b/tests/emcute/Makefile.ci
@@ -8,10 +8,10 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega1284p \
     atmega328p \
     b-l072z-lrwan1 \
-    blackpill-128kib \
     blackpill \
-    bluepill-128kib \
+    blackpill-128kib \
     bluepill \
+    bluepill-128kib \
     calliope-mini \
     cc2650-launchpad \
     cc2650stk \

--- a/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
@@ -8,10 +8,10 @@ BOARD_INSUFFICIENT_MEMORY := \
     atmega1284p \
     atmega328p \
     b-l072z-lrwan1 \
-    blackpill-128kib \
     blackpill \
-    bluepill-128kib \
+    blackpill-128kib \
     bluepill \
+    bluepill-128kib \
     calliope-mini \
     cc2650-launchpad \
     cc2650stk \

--- a/tests/gnrc_ipv6_ext/Makefile.ci
+++ b/tests/gnrc_ipv6_ext/Makefile.ci
@@ -9,8 +9,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     derfmega128 \
     hifive1 \
     hifive1b \
-    im880b \
     i-nucleo-lrwan1 \
+    im880b \
     mega-xplained \
     microduino-corerf \
     msb-430 \

--- a/tests/msg_try_receive/Makefile.ci
+++ b/tests/msg_try_receive/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/periph_wdt/Makefile.ci
+++ b/tests/periph_wdt/Makefile.ci
@@ -1,9 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
-    arduino-leonardo \
     arduino-nano \
     arduino-uno \
     atmega328p \
-    nucleo-f031k6 \
-    stm32f030f4-demo \
     #

--- a/tests/pkg_littlefs2/Makefile.ci
+++ b/tests/pkg_littlefs2/Makefile.ci
@@ -5,12 +5,12 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     atmega328p \
     i-nucleo-lrwan1 \
+    nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \
     nucleo-l031k6 \
     nucleo-l053r8 \
-    nucleo-f030r8 \
-    stm32f030f4-demo\
+    stm32f030f4-demo \
     stm32f0discovery \
     stm32l0538-disco \
     waspmote-pro \

--- a/tests/thread_msg_block_w_queue/Makefile.ci
+++ b/tests/thread_msg_block_w_queue/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/thread_msg_block_wo_queue/Makefile.ci
+++ b/tests/thread_msg_block_wo_queue/Makefile.ci
@@ -1,4 +1,8 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     nucleo-f031k6 \
     stm32f030f4-demo \
     #

--- a/tests/usbus/Makefile.ci
+++ b/tests/usbus/Makefile.ci
@@ -1,3 +1,7 @@
 BOARD_INSUFFICIENT_MEMORY := \
+    arduino-duemilanove \
+    arduino-nano \
+    arduino-uno \
+    atmega328p \
     stm32f030f4-demo \
     #

--- a/tests/xtimer_rmutex_lock_timeout/Makefile.ci
+++ b/tests/xtimer_rmutex_lock_timeout/Makefile.ci
@@ -1,9 +1,6 @@
 BOARD_INSUFFICIENT_MEMORY := \
     arduino-duemilanove \
-    arduino-leonardo \
     arduino-nano \
     arduino-uno \
     atmega328p \
-    nucleo-f031k6 \
-    stm32f030f4-demo \
     #


### PR DESCRIPTION
### Contribution description

If a timer triggers while the idle thread is running, previously a stack overflow was triggered. This PR increases the idle threads stack size if xtimer is used.

### Testing procedure

`tests/ps_schedstatistics` should no longer crash on the Arduino Mega2560

### Issues/PRs references

Tracker in https://github.com/RIOT-OS/RIOT/issues/12651