### PR TITLE
boards: enable CAN bus on nucleo-f446re & nucleo-f446ze

### DIFF
--- a/boards/nucleo-f446re/Kconfig
+++ b/boards/nucleo-f446re/Kconfig
@@ -18,6 +18,7 @@ config BOARD_NUCLEO_F446RE
     select HAS_PERIPH_ADC
     select HAS_PERIPH_DMA
     select HAS_PERIPH_I2C
+    select HAS_PERIPH_CAN
     select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC
     select HAS_PERIPH_SPI

--- a/boards/nucleo-f446re/Makefile.features
+++ b/boards/nucleo-f446re/Makefile.features
@@ -5,6 +5,7 @@ CPU_MODEL = stm32f446re
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_can
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-f446ze/Kconfig
+++ b/boards/nucleo-f446ze/Kconfig
@@ -17,6 +17,7 @@ config BOARD_NUCLEO_F446ZE
     # Put defined MCU peripherals here (in alphabetical order)
     select HAS_PERIPH_DMA
     select HAS_PERIPH_I2C
+    select HAS_PERIPH_CAN
     select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC
     select HAS_PERIPH_SPI

--- a/boards/nucleo-f446ze/Makefile.features
+++ b/boards/nucleo-f446ze/Makefile.features
@@ -4,6 +4,7 @@ CPU_MODEL = stm32f446ze
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_can
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/cpu/stm32/include/can_params.h
+++ b/cpu/stm32/include/can_params.h
@@ -51,7 +51,7 @@ static const can_conf_t candev_conf[] = {
 #if  defined(CPU_FAM_STM32F1)
         .rx_pin = GPIO_PIN(PORT_A, 11),
         .tx_pin = GPIO_PIN(PORT_A, 12),
-#elif defined(CPU_FAM_STM32L4)
+#elif defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F4)
         .rx_pin = GPIO_PIN(PORT_B, 8),
         .tx_pin = GPIO_PIN(PORT_B, 9),
         .af = GPIO_AF9,


### PR DESCRIPTION
Changed the pinout for the CAN bus:
- CAN RX: PB8
- CAN TX: PB9 

And added periph_can to FEATURES_PROVIDED for
boards nucleo-f446re and nucleo-f446ze

### Contribution description

CAN bus is almost fully supported for those boards, just the final cpu configuration was needed to allow CAN bus.
Maybe some other boards could benefit from CAN bus support too but I cannot test them.

### Testing procedure

The bus is tested with [L9616D](https://www.st.com/resource/en/datasheet/l9616.pdf) CAN transceiver, connected to PB8 and PB9 on two nucleo, a f446re and a f446ze, using the `tests/conn_can` test.  
The transceiver is similar enough to the TJA1042 to use its driver.

On the first board:
```bash
test_can rcv 0 0 20000000 100
```

On the other one:
```bash
test_can send 0 100 01 02 03
```

And you will see ` 0: can_stm32_0 100  [3]  01 02 03` appear on the receiving side
