### PR TITLE
drivers/periph/timer: add note about TIM_FLAG_RESET_ON_MATCH

### DIFF
--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -163,6 +163,9 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value);
  * @brief Set an absolute timeout value for the given channel of the given timer
  *        The timeout will be called periodically for each iteration
  *
+ * @note  Only one channel with `TIM_FLAG_RESET_ON_MATCH` can be active.
+ *        Some platforms (Atmel) only allow to use the first channel as TOP value.
+ *
  * @param[in] dev           the timer device to set
  * @param[in] channel       the channel to set
  * @param[in] value         the absolute compare value when the callback will be


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This extends the documentation of `timer_set_periodic()` by clarifying that only one channel with `TIM_FLAG_RESET_ON_MATCH` can be active.
(Which also makes logical sense, the timer will reset when this channel matches, so no other channel match will be executed as long as this channel is enabled.)


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14391#discussion_r459537706
