### PR TITLE
core/byteorder: add Big Endian implementations

### DIFF
--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -482,29 +482,52 @@ static inline uint64_t ntohll(uint64_t v)
 
 static inline uint16_t byteorder_bebuftohs(const uint8_t *buf)
 {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     return (uint16_t)((buf[0] << 8) | (buf[1] << 0));
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    return (uint16_t)((buf[1] << 8) | (buf[0] << 0));
+#endif
 }
 
 static inline uint32_t byteorder_bebuftohl(const uint8_t *buf)
 {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     return (((uint32_t) buf[0] << 24)
           | ((uint32_t) buf[1] << 16)
           | ((uint32_t) buf[2] << 8)
           | ((uint32_t) buf[3] << 0));
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    return (((uint32_t) buf[3] << 24)
+          | ((uint32_t) buf[2] << 16)
+          | ((uint32_t) buf[1] << 8)
+          | ((uint32_t) buf[0] << 0));
+#endif
 }
 
 static inline void byteorder_htobebufs(uint8_t *buf, uint16_t val)
 {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     buf[0] = (uint8_t)(val >> 8);
     buf[1] = (uint8_t)(val >> 0);
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    buf[1] = (uint8_t)(val >> 8);
+    buf[0] = (uint8_t)(val >> 0);
+#endif
 }
 
 static inline void byteorder_htobebufl(uint8_t *buf, uint32_t val)
 {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     buf[0] = (uint8_t)(val >> 24);
     buf[1] = (uint8_t)(val >> 16);
     buf[2] = (uint8_t)(val >> 8);
     buf[3] = (uint8_t)(val >> 0);
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    buf[3] = (uint8_t)(val >> 24);
+    buf[2] = (uint8_t)(val >> 16);
+    buf[1] = (uint8_t)(val >> 8);
+    buf[0] = (uint8_t)(val >> 0);
+#endif
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

Some functions in `byteorder.h` do account for Big Endian targets, but the new buffer functions do not.
Fix this by also implementing those functions for the Big Endian case.

### Testing procedure

There are no Big Endian targets (and there probably won't ever be ones).
Maybe running `native` on PowerPC counts.

But this just inverses the little endian logic, so reading should be enough.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
