### PR TITLE
net/sock: Add access to auxiliary data

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -102,6 +102,7 @@ PSEUDOMODULES += shell_hooks
 PSEUDOMODULES += slipdev_stdio
 PSEUDOMODULES += sock
 PSEUDOMODULES += sock_async
+PSEUDOMODULES += sock_aux%
 PSEUDOMODULES += sock_dtls
 PSEUDOMODULES += sock_ip
 PSEUDOMODULES += sock_tcp

--- a/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
+++ b/pkg/lwip/contrib/sock/ip/lwip_sock_ip.c
@@ -150,8 +150,9 @@ static int _parse_iphdr(struct netbuf *buf, void **data, void **ctx,
     return (ssize_t)data_len;
 }
 
-ssize_t sock_ip_recv(sock_ip_t *sock, void *data, size_t max_len,
-                     uint32_t timeout, sock_ip_ep_t *remote)
+ssize_t sock_ip_recv_aux(sock_ip_t *sock, void *data, size_t max_len,
+                         uint32_t timeout, sock_ip_ep_t *remote,
+                         sock_ip_aux_rx_t *aux)
 {
     void *pkt = NULL;
     struct netbuf *ctx = NULL;
@@ -160,8 +161,8 @@ ssize_t sock_ip_recv(sock_ip_t *sock, void *data, size_t max_len,
     bool nobufs = false;
 
     assert((sock != NULL) && (data != NULL) && (max_len > 0));
-    while ((res = sock_ip_recv_buf(sock, &pkt, (void **)&ctx, timeout,
-                                   remote)) > 0) {
+    while ((res = sock_ip_recv_buf_aux(sock, &pkt, (void **)&ctx, timeout,
+                                       remote, aux)) > 0) {
         if (ctx->p->tot_len > (ssize_t)max_len) {
             nobufs = true;
             /* progress context to last element */
@@ -175,8 +176,9 @@ ssize_t sock_ip_recv(sock_ip_t *sock, void *data, size_t max_len,
     return (nobufs) ? -ENOBUFS : ((res < 0) ? res : ret);
 }
 
-ssize_t sock_ip_recv_buf(sock_ip_t *sock, void **data, void **ctx,
-                         uint32_t timeout, sock_ip_ep_t *remote)
+ssize_t sock_ip_recv_buf_aux(sock_ip_t *sock, void **data, void **ctx,
+                             uint32_t timeout, sock_ip_ep_t *remote,
+                             sock_ip_aux_rx_t *aux)
 {
     struct netbuf *buf;
     int res;
@@ -199,14 +201,21 @@ ssize_t sock_ip_recv_buf(sock_ip_t *sock, void **data, void **ctx,
         return res;
     }
     res = _parse_iphdr(buf, data, ctx, remote);
+    if (aux != NULL) {
+        aux->flags = 0;
+    }
     return res;
 }
 
-ssize_t sock_ip_send(sock_ip_t *sock, const void *data, size_t len,
-                     uint8_t proto, const sock_ip_ep_t *remote)
+ssize_t sock_ip_send_aux(sock_ip_t *sock, const void *data, size_t len,
+                         uint8_t proto, const sock_ip_ep_t *remote,
+                         sock_ip_aux_tx_t *aux)
 {
     assert((sock != NULL) || (remote != NULL));
     assert((len == 0) || (data != NULL)); /* (len != 0) => (data != NULL) */
+    if (aux != NULL) {
+        aux->flags = 0;
+    }
     return lwip_sock_send(sock ? sock->base.conn : NULL, data, len, proto,
                           (struct _sock_tl_ep *)remote, NETCONN_RAW);
 }

--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -22,8 +22,9 @@
 
 #include "lwip/api.h"
 #include "lwip/opt.h"
-#include "lwip/sys.h"
 #include "lwip/sock_internal.h"
+#include "lwip/sys.h"
+#include "lwip/udp.h"
 
 int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
                     const sock_udp_ep_t *remote, uint16_t flags)
@@ -119,32 +120,41 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **ctx,
     if ((res = lwip_sock_recv(sock->base.conn, timeout, &buf)) < 0) {
         return res;
     }
-    if (remote != NULL) {
+    if (aux != NULL) {
+        aux->flags = 0;
+    }
+    if ((remote != NULL) ||
+        ((aux != NULL) && IS_USED(MODULE_SOCK_AUX_LOCAL)
+                       && IS_ACTIVE(LWIP_NETBUF_RECVINFO))) {
         /* convert remote */
-        size_t addr_len;
+        size_t addr_len = sizeof(ipv6_addr_t);
+        int family = AF_INET;
         if (NETCONNTYPE_ISIPV6(sock->base.conn->type)) {
             addr_len = sizeof(ipv6_addr_t);
-            remote->family = AF_INET6;
+            family = AF_INET6;
         }
-        else if (IS_ACTIVE(LWIP_IPV4)) {
-            addr_len = sizeof(ipv4_addr_t);
-            remote->family = AF_INET;
-        }
-        else {
+        else if (!IS_ACTIVE(LWIP_IPV4)) {
             netbuf_delete(buf);
             return -EPROTO;
         }
+        if (remote != NULL) {
+            remote->family = family;
 #if LWIP_NETBUF_RECVINFO
-        remote->netif = lwip_sock_bind_addr_to_netif(&buf->toaddr);
+            remote->netif = lwip_sock_bind_addr_to_netif(&buf->toaddr);
 #else
-        remote->netif = SOCK_ADDR_ANY_NETIF;
+            remote->netif = SOCK_ADDR_ANY_NETIF;
 #endif
-        /* copy address */
-        memcpy(&remote->addr, &buf->addr, addr_len);
-        remote->port = buf->port;
-    }
-    if (aux != NULL) {
-        aux->flags = 0;
+            /* copy address */
+            memcpy(&remote->addr, &buf->addr, addr_len);
+            remote->port = buf->port;
+        }
+        if ((aux != NULL) && IS_USED(MODULE_SOCK_AUX_LOCAL) &&
+            IS_ACTIVE(LWIP_NETBUF_RECVINFO)) {
+            aux->flags |= SOCK_AUX_HAS_LOCAL;
+            aux->local.family = family;
+            memcpy(&aux->local.addr, &buf->toaddr, addr_len);
+            aux->local.port = sock->base.conn->pcb.udp->local_port;
+        }
     }
     *data = buf->ptr->payload;
     *ctx = buf;

--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -127,7 +127,7 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **ctx,
         ((aux != NULL) && IS_USED(MODULE_SOCK_AUX_LOCAL)
                        && IS_ACTIVE(LWIP_NETBUF_RECVINFO))) {
         /* convert remote */
-        size_t addr_len = sizeof(ipv6_addr_t);
+        size_t addr_len = sizeof(ipv4_addr_t);
         int family = AF_INET;
         if (NETCONNTYPE_ISIPV6(sock->base.conn->type)) {
             addr_len = sizeof(ipv6_addr_t);

--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -148,13 +148,14 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **ctx,
             memcpy(&remote->addr, &buf->addr, addr_len);
             remote->port = buf->port;
         }
-        if ((aux != NULL) && IS_USED(MODULE_SOCK_AUX_LOCAL) &&
-            IS_ACTIVE(LWIP_NETBUF_RECVINFO)) {
+#ifdef MODULE_SOCK_AUX_LOCAL
+        if ((aux != NULL) && IS_ACTIVE(LWIP_NETBUF_RECVINFO)) {
             aux->flags |= SOCK_AUX_HAS_LOCAL;
             aux->local.family = family;
             memcpy(&aux->local.addr, &buf->toaddr, addr_len);
             aux->local.port = sock->base.conn->pcb.udp->local_port;
         }
+#endif /* MODULE_SOCK_AUX_LOCAL */
     }
     *data = buf->ptr->payload;
     *ctx = buf;

--- a/sys/include/net/sock.h
+++ b/sys/include/net/sock.h
@@ -245,6 +245,45 @@ struct _sock_tl_ep {
     uint16_t port;          /**< transport layer port (in host byte order) */
 };
 
+/**
+ * @brief   Flags used to indicate which auxiliary data is provided
+ */
+enum {
+    /**
+     * @brief   Flag to indicate that local address/endpoint is provided
+     *
+     * @note    Select module `sock_aux_local` and a compatible network stack
+     *          to use this
+     *
+     * This is the address/endpoint the packet/datagram/segment was received on
+     */
+    SOCK_AUX_HAS_LOCAL = (1LU << 0),
+    /**
+     * @brief   Flag to indicate that a time stamp of transmission / reception
+     *          is available
+     *
+     * @note    Select module `sock_aux_timestamp` and a compatible network
+     *          stack to use this
+     *
+     * Unless otherwise noted, the time stamp is the current system time in
+     * nanoseconds on which the start of frame delimiter or preamble was
+     * sent / received.
+     */
+    SOCK_AUX_HAS_TIMESTAMP = (1LU << 1),
+};
+
+/**
+ * @brief   Type holding the flags indicating which auxiliary data is provided
+ *
+ * This is a bitmask of `SOCK_AUX_HAS_...`, e.g. if the mask contains
+ * @ref SOCK_AUX_HAS_LOCAL, the local address/endpoint is present
+ *
+ * @details The underlying type can be changed without further notice, if more
+ *          flags are needed. Thus, only the `typedef`ed type should be used
+ *          to store the flags.
+ */
+typedef uint8_t sock_aux_flags_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -540,6 +540,26 @@ typedef struct sock_dtls sock_dtls_t;
 typedef struct sock_dtls_session sock_dtls_session_t;
 
 /**
+ * @brief   Auxiliary data provided when receiving using an DTLS sock object
+ *
+ * @details Implementations of this API may rely on this type to be compatible
+ *          with @ref sock_udp_aux_rx_t. These implementations need to be
+ *          updated, if this is no longer the case. Users of this API should
+ *          not rely on this compatibility
+ */
+typedef sock_udp_aux_rx_t sock_dtls_aux_rx_t;
+
+/**
+ * @brief   Auxiliary data provided when sending using an DTLS sock object
+ *
+ * @details Implementations of this API may rely on this type to be compatible
+ *          with @ref sock_udp_aux_rx_t. These implementations need to be
+ *          updated, if this is no longer the case. Users of this API should
+ *          not rely on this compatibility
+ */
+typedef sock_udp_aux_tx_t sock_dtls_aux_tx_t;
+
+/**
  * @brief Called exactly once during `auto_init`.
  *
  * Calls the initialization function required by the DTLS stack used.
@@ -613,6 +633,39 @@ void sock_dtls_session_destroy(sock_dtls_t *sock, sock_dtls_session_t *remote);
 /**
  * @brief Receive handshake messages and application data from remote peer.
  *
+ * @param[in]   sock    DTLS sock to use.
+ * @param[out]  remote  Remote DTLS session of the received data.
+ *                      Cannot be NULL.
+ * @param[out]  data    Pointer where the received data should be stored.
+ * @param[in]   maxlen  Maximum space available at @p data.
+ * @param[in]   timeout Receive timeout in microseconds.
+ *                      If 0 and no data is available, the function returns
+ *                      immediately.
+ *                      May be SOCK_NO_TIMEOUT to wait until data
+ *                      is available.
+ * @param[out]  aux     Auxiliary data about the received datagram.
+ *                      May be `NULL`, if it is not required by the application.
+ *
+ * @note Function may block if data is not available and @p timeout != 0
+ *
+ * @return  The number of bytes received on success
+ * @return  -SOCK_DTLS_HANDSHAKE when new handshake is completed
+ * @return  -EADDRNOTAVAIL, if the local endpoint of @p sock is not set.
+ * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -EINVAL, if @p remote is invalid or @p sock is not properly
+ *          initialized (or closed while sock_dtls_recv() blocks).
+ * @return  -ENOBUFS, if buffer space is not large enough to store received
+ *          data.
+ * @return  -ENOMEM, if no memory was available to receive @p data.
+ * @return  -ETIMEDOUT, if @p timeout expired.
+ */
+ssize_t sock_dtls_recv_aux(sock_dtls_t *sock, sock_dtls_session_t *remote,
+                           void *data, size_t maxlen, uint32_t timeout,
+                           sock_dtls_aux_rx_t *aux);
+
+/**
+ * @brief Receive handshake messages and application data from remote peer.
+ *
  * @param[in] sock      DTLS sock to use.
  * @param[out] remote   Remote DTLS session of the received data.
  *                      Cannot be NULL.
@@ -637,8 +690,59 @@ void sock_dtls_session_destroy(sock_dtls_t *sock, sock_dtls_session_t *remote);
  * @return  -ENOMEM, if no memory was available to receive @p data.
  * @return  -ETIMEDOUT, if @p timeout expired.
  */
-ssize_t sock_dtls_recv(sock_dtls_t *sock, sock_dtls_session_t *remote,
-                       void *data, size_t maxlen, uint32_t timeout);
+static inline ssize_t sock_dtls_recv(sock_dtls_t *sock,
+                                     sock_dtls_session_t *remote,
+                                     void *data, size_t maxlen,
+                                     uint32_t timeout)
+{
+    return sock_dtls_recv_aux(sock, remote, data, maxlen, timeout, NULL);
+}
+
+/**
+ * @brief Decrypts and provides stack-internal buffer space containing a
+ *        message from a remote peer.
+ *
+ * @param[in] sock      DTLS sock to use.
+ * @param[out] remote   Remote DTLS session of the received data.
+ *                      Cannot be NULL.
+ * @param[out] data     Pointer to a stack-internal buffer space containing the
+ *                      received data.
+ * @param[in,out] buf_ctx   Stack-internal buffer context. If it points to a
+ *                      `NULL` pointer, the stack returns a new buffer space for
+ *                      a new packet. If it does not point to a `NULL` pointer,
+ *                      an existing context is assumed to get a next segment in
+ *                      a buffer.
+ * @param[in] timeout   Receive timeout in microseconds.
+ *                      If 0 and no data is available, the function returns
+ *                      immediately.
+ *                      May be SOCK_NO_TIMEOUT to wait until data
+ *                      is available.
+ * @param[out]  aux     Auxiliary data about the received datagram.
+ *                      May be `NULL`, if it is not required by the application.
+ *
+ * @experimental    This function is quite new, not implemented for all stacks
+ *                  yet, and may be subject to sudden API changes. Do not use in
+ *                  production if this is unacceptable.
+ *
+ * @note Function may block if data is not available and @p timeout != 0
+ *
+ * @note    Function blocks if no packet is currently waiting.
+ *
+ * @return  The number of bytes received on success. May not be the complete
+ *          payload. Continue calling with the returned @p buf_ctx to get more
+ *          buffers until result is 0 or an error.
+ * @return  0, if no received data is available, but everything is in order.
+ *          If @p buf_ctx was provided, it was released.
+ * @return  -EADDRNOTAVAIL, if the local endpoint of @p sock is not set.
+ * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -EINVAL, if @p remote is invalid or @p sock is not properly
+ *          initialized (or closed while sock_dtls_recv() blocks).
+ * @return  -ENOMEM, if no memory was available to receive @p data.
+ * @return  -ETIMEDOUT, if @p timeout expired.
+ */
+ssize_t sock_dtls_recv_buf_aux(sock_dtls_t *sock, sock_dtls_session_t *remote,
+                               void **data, void **buf_ctx, uint32_t timeout,
+                               sock_dtls_aux_rx_t *aux);
 
 /**
  * @brief Decrypts and provides stack-internal buffer space containing a
@@ -680,8 +784,51 @@ ssize_t sock_dtls_recv(sock_dtls_t *sock, sock_dtls_session_t *remote,
  * @return  -ENOMEM, if no memory was available to receive @p data.
  * @return  -ETIMEDOUT, if @p timeout expired.
  */
-ssize_t sock_dtls_recv_buf(sock_dtls_t *sock, sock_dtls_session_t *remote,
-                           void **data, void **buf_ctx, uint32_t timeout);
+static inline ssize_t sock_dtls_recv_buf(sock_dtls_t *sock,
+                                         sock_dtls_session_t *remote,
+                                         void **data, void **buf_ctx,
+                                         uint32_t timeout)
+{
+    return sock_dtls_recv_buf_aux(sock, remote, data, buf_ctx, timeout, NULL);
+}
+
+/**
+ * @brief Encrypts and sends a message to a remote peer
+ *
+ * @param[in]   sock    DTLS sock to use
+ * @param[in]   remote  DTLS session to use. A new session will be created
+ *                      if no session exist between client and server.
+ * @param[in]   data    Pointer where the data to be send are stored
+ * @param[in]   len     Length of @p data to be send
+ * @param[in]   timeout Handshake timeout in microseconds.
+ *                      If `timeout > 0`, will start a new handshake if no
+ *                      session exists yet. The function will block until
+ *                      handshake completed or timed out.
+ *                      May be SOCK_NO_TIMEOUT to block indefinitely until
+ *                      handshake complete.
+ * @param[out] aux      Auxiliary data about the transmission.
+ *                      May be `NULL`, if it is not required by the application.
+ *
+ * @note    When blocking, we will need an extra thread to call
+ *          @ref sock_dtls_recv() function to handle the incoming handshake
+ *          messages.
+ *
+ * @return The number of bytes sent on success
+ * @return  -ENOTCONN, if `timeout == 0` and no existing session exists with
+ *          @p remote
+ * @return  -EADDRINUSE, if sock_dtls_t::udp_sock has no local end-point.
+ * @return  -EAFNOSUPPORT, if `remote->ep != NULL` and
+ *          sock_dtls_session_t::ep::family of @p remote is != AF_UNSPEC and
+ *          not supported.
+ * @return  -EINVAL, if sock_udp_ep_t::addr of @p remote->ep is an
+ *          invalid address.
+ * @return  -EINVAL, if sock_udp_ep_t::port of @p remote->ep is 0.
+ * @return  -ENOMEM, if no memory was available to send @p data.
+ * @return  -ETIMEDOUT, `0 < timeout < SOCK_NO_TIMEOUT` and timed out.
+ */
+ssize_t sock_dtls_send_aux(sock_dtls_t *sock, sock_dtls_session_t *remote,
+                           const void *data, size_t len, uint32_t timeout,
+                           sock_dtls_aux_tx_t *aux);
 
 /**
  * @brief Encrypts and sends a message to a remote peer
@@ -715,8 +862,13 @@ ssize_t sock_dtls_recv_buf(sock_dtls_t *sock, sock_dtls_session_t *remote,
  * @return  -ENOMEM, if no memory was available to send @p data.
  * @return  -ETIMEDOUT, `0 < timeout < SOCK_NO_TIMEOUT` and timed out.
  */
-ssize_t sock_dtls_send(sock_dtls_t *sock, sock_dtls_session_t *remote,
-                       const void *data, size_t len, uint32_t timeout);
+static inline ssize_t sock_dtls_send(sock_dtls_t *sock,
+                                     sock_dtls_session_t *remote,
+                                     const void *data, size_t len,
+                                     uint32_t timeout)
+{
+    return sock_dtls_send_aux(sock, remote, data, len, timeout, NULL);
+}
 
 /**
  * @brief Closes a DTLS sock

--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -542,7 +542,7 @@ typedef struct sock_dtls_session sock_dtls_session_t;
 /**
  * @brief   Auxiliary data provided when receiving using an DTLS sock object
  *
- * @details Implementations of this API may rely on this type to be compatible
+ * @warning Implementations of this API may rely on this type to be compatible
  *          with @ref sock_udp_aux_rx_t. These implementations need to be
  *          updated, if this is no longer the case. Users of this API should
  *          not rely on this compatibility
@@ -552,7 +552,7 @@ typedef sock_udp_aux_rx_t sock_dtls_aux_rx_t;
 /**
  * @brief   Auxiliary data provided when sending using an DTLS sock object
  *
- * @details Implementations of this API may rely on this type to be compatible
+ * @warning Implementations of this API may rely on this type to be compatible
  *          with @ref sock_udp_aux_rx_t. These implementations need to be
  *          updated, if this is no longer the case. Users of this API should
  *          not rely on this compatibility

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -299,6 +299,53 @@ typedef struct sock_ip sock_ip_t;
 #endif
 
 /**
+ * @brief   Auxiliary data provided when receiving using an IP sock object
+ */
+typedef struct {
+#if defined(MODULE_SOCK_AUX_LOCAL) || defined(DOXYGEN)
+    /**
+     * @brief   The local address the packet was received on
+     *
+     * Check if sock_ip_aux_tx_t::flags contains SOCK_AUX_HAS_LOCAL. Module
+     * `sock_aux_local` needs to be selected to use this.
+     */
+    sock_ip_ep_t local;
+#endif /* MODULE_SOCK_AUX_ENDPOINT */
+#if defined(MODULE_SOCK_AUX_TIMESTAMP) || defined(DOXYGEN)
+    /**
+     * @brief   System time the packet was received
+     *
+     * Check if sock_ip_aux_tx_t::flags contains SOCK_AUX_HAS_TIMESTAMP. Module
+     * `sock_aux_timestamp` needs to be selected to use this. The timestamp
+     * refers to the reception of start of frame delimiter or preamble of
+     * the frame carrying the IP packet and is given in nanoseconds since
+     * epoch, unless otherwise documented by the underlying implementation.
+     */
+    uint64_t timestamp;
+#endif /* MODULE_SOCK_AUX_TIMESTAP*/
+    sock_aux_flags_t flags; /**< Flags indicating info that is present */
+} sock_ip_aux_rx_t;
+
+/**
+ * @brief   Auxiliary data provided when sending using an IP sock object
+ */
+typedef struct {
+#if defined(MODULE_SOCK_AUX_TIMESTAMP) || defined(DOXYGEN)
+    /**
+     * @brief   System time the packet was send
+     *
+     * Check if sock_ip_aux_tx_t::flags contains SOCK_AUX_HAS_TIMESTAMP. Module
+     * `sock_aux_timestamp` needs to be selected to use this. The timestamp
+     * refers to the transmission of start of frame delimiter or preamble of
+     * the frame carrying the IP packet and is given in nanoseconds since
+     * epoch, unless otherwise documented by the underlying implementation.
+     */
+    uint64_t timestamp;
+#endif /* MODULE_SOCK_AUX_TIMESTAP*/
+    sock_aux_flags_t flags; /**< Flags indicating info that is present */
+} sock_ip_aux_tx_t;
+
+/**
  * @brief   Creates a new raw IPv4/IPv6 sock object
  *
  * @pre `(sock != NULL)`
@@ -407,6 +454,8 @@ int sock_ip_get_remote(sock_ip_t *sock, sock_ip_ep_t *ep);
  *                      data is available).
  * @param[out] remote   Remote end point of the received data.
  *                      May be NULL, if it is not required by the application.
+ * @param[out] aux      Auxiliary data of the reception.
+ *                      May be NULL, if it is not required by the application.
  *
  * @note    Function blocks if no packet is currently waiting.
  *
@@ -423,8 +472,94 @@ int sock_ip_get_remote(sock_ip_t *sock, sock_ip_ep_t *ep);
  *          the remote of @p sock.
  * @return  -ETIMEDOUT, if @p timeout expired.
  */
-ssize_t sock_ip_recv(sock_ip_t *sock, void *data, size_t max_len,
-                     uint32_t timeout, sock_ip_ep_t *remote);
+ssize_t sock_ip_recv_aux(sock_ip_t *sock, void *data, size_t max_len,
+                         uint32_t timeout, sock_ip_ep_t *remote,
+                         sock_ip_aux_rx_t *aux);
+
+/**
+ * @brief   Receives a message over IPv4/IPv6 from remote end point
+ *
+ * @pre `(sock != NULL) && (data != NULL) && (max_len > 0)`
+ *
+ * @param[in] sock      A raw IPv4/IPv6 sock object.
+ * @param[out] data     Pointer where the received data should be stored.
+ * @param[in] max_len   Maximum space available at @p data.
+ * @param[in] timeout   Timeout for receive in microseconds.
+ *                      If 0 and no data is available, the function returns
+ *                      immediately.
+ *                      May be @ref SOCK_NO_TIMEOUT for no timeout (wait until
+ *                      data is available).
+ * @param[out] remote   Remote end point of the received data.
+ *                      May be NULL, if it is not required by the application.
+ *
+ * @note    Function blocks if no packet is currently waiting.
+ *
+ * @return  The number of bytes received on success.
+ * @return  0, if no received data is available, but everything is in order.
+ * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
+ * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -EINVAL, if @p remote is invalid or @p sock is not properly
+ *          initialized (or closed while sock_ip_recv() blocks).
+ * @return  -ENOBUFS, if buffer space is not large enough to store received
+ *          data.
+ * @return  -ENOMEM, if no memory was available to receive @p data.
+ * @return  -EPROTO, if source address of received packet did not equal
+ *          the remote of @p sock.
+ * @return  -ETIMEDOUT, if @p timeout expired.
+ */
+static inline ssize_t sock_ip_recv(sock_ip_t *sock, void *data, size_t max_len,
+                                   uint32_t timeout, sock_ip_ep_t *remote)
+{
+    return sock_ip_recv_aux(sock, data, max_len, timeout, remote, NULL);
+}
+
+/**
+ * @brief   Provides stack-internal buffer space containing an IPv4/IPv6
+ *          message from remote end point
+ *
+ * @pre `(sock != NULL) && (data != NULL) && (buf_ctx != NULL)`
+ *
+ * @param[in] sock      A raw IPv4/IPv6 sock object.
+ * @param[out] data     Pointer to a stack-internal buffer space containing the
+ *                      received data.
+ * @param[in,out] buf_ctx  Stack-internal buffer context. If it points to a
+ *                      `NULL` pointer, the stack returns a new buffer space
+ *                      for a new packet. If it does not point to a `NULL`
+ *                      pointer, an existing context is assumed to get a next
+ *                      segment in a buffer.
+ * @param[in] timeout   Timeout for receive in microseconds.
+ *                      If 0 and no data is available, the function returns
+ *                      immediately.
+ *                      May be @ref SOCK_NO_TIMEOUT for no timeout (wait until
+ *                      data is available).
+ * @param[out] remote   Remote end point of the received data.
+ *                      May be NULL, if it is not required by the application.
+ * @param[out] aux      Auxiliary data of the reception.
+ *                      May be NULL, if it is not required by the application.
+ *
+ * @experimental    This function is quite new, not implemented for all stacks
+ *                  yet, and may be subject to sudden API changes. Do not use in
+ *                  production if this is unacceptable.
+ *
+ * @note    Function blocks if no packet is currently waiting.
+ *
+ * @return  The number of bytes received on success. May not be the complete
+ *          payload. Continue calling with the returned `buf_ctx` to get more
+ *          buffers until result is 0 or an error.
+ * @return  0, if no received data is available, but everything is in order.
+ *          If @p buf_ctx was provided, it was released.
+ * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
+ * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -EINVAL, if @p remote is invalid or @p sock is not properly
+ *          initialized (or closed while sock_ip_recv() blocks).
+ * @return  -ENOMEM, if no memory was available to receive @p data.
+ * @return  -EPROTO, if source address of received packet did not equal
+ *          the remote of @p sock.
+ * @return  -ETIMEDOUT, if @p timeout expired.
+ */
+ssize_t sock_ip_recv_buf_aux(sock_ip_t *sock, void **data, void **buf_ctx,
+                             uint32_t timeout, sock_ip_ep_t *remote,
+                             sock_ip_aux_rx_t *aux);
 
 /**
  * @brief   Provides stack-internal buffer space containing an IPv4/IPv6
@@ -468,8 +603,50 @@ ssize_t sock_ip_recv(sock_ip_t *sock, void *data, size_t max_len,
  *          the remote of @p sock.
  * @return  -ETIMEDOUT, if @p timeout expired.
  */
-ssize_t sock_ip_recv_buf(sock_ip_t *sock, void **data, void **buf_ctx,
-                         uint32_t timeout, sock_ip_ep_t *remote);
+static inline ssize_t sock_ip_recv_buf(sock_ip_t *sock,
+                                       void **data, void **buf_ctx,
+                                       uint32_t timeout, sock_ip_ep_t *remote)
+{
+    return sock_ip_recv_buf_aux(sock, data, buf_ctx, timeout, remote, NULL);
+}
+
+/**
+ * @brief   Sends a message over IPv4/IPv6 to remote end point
+ *
+ * @pre `((sock != NULL || remote != NULL)) && (if (len != 0): (data != NULL))`
+ *
+ * @param[in] sock      A raw IPv4/IPv6 sock object. May be NULL.
+ *                      A sensible local end point should be selected by the
+ *                      implementation in that case.
+ * @param[in] data      Pointer where the received data should be stored.
+ *                      May be `NULL` if `len == 0`.
+ * @param[in] len       Maximum space available at @p data.
+ * @param[in] proto     Protocol to use in the packet sent, in case
+ *                      `sock == NULL`. If `sock != NULL` this parameter will be
+ *                      ignored.
+ * @param[in] remote    Remote end point for the sent data.
+ *                      May be `NULL`, if @p sock has a remote end point.
+ *                      sock_ip_ep_t::family may be AF_UNSPEC, if local
+ *                      end point of @p sock provides this information.
+ * @param[out] aux      Auxiliary data for the transmission.
+ *                      May be `NULL` if not needed by the caller.
+ *
+ * @return  The number of bytes sent on success.
+ * @return  -EAFNOSUPPORT, if `remote != NULL` and sock_ip_ep_t::family of
+ *          @p remote is != AF_UNSPEC and not supported.
+ * @return  -EINVAL, if sock_ip_ep_t::addr of @p remote is an invalid address.
+ * @return  -EINVAL, if sock_ip_ep_t::netif of @p remote is not a
+ *          valid interface or contradicts the local interface of @p sock.
+ * @return  -EHOSTUNREACH, if @p remote or remote end point of @p sock is not
+ *          reachable.
+ * @return  -ENOMEM, if no memory was available to send @p data.
+ * @return  -ENOTCONN, if `remote == NULL`, but @p sock has no remote end point.
+ * @return  -EPROTOTYPE, if `sock == NULL` and @p proto is not by
+ *          sock_ip_ep_t::family of @p remote.
+ */
+ssize_t sock_ip_send_aux(sock_ip_t *sock, const void *data, size_t len,
+                         uint8_t proto, const sock_ip_ep_t *remote,
+                         sock_ip_aux_tx_t *aux);
 
 /**
  * @brief   Sends a message over IPv4/IPv6 to remote end point
@@ -503,8 +680,12 @@ ssize_t sock_ip_recv_buf(sock_ip_t *sock, void **data, void **buf_ctx,
  * @return  -EPROTOTYPE, if `sock == NULL` and @p proto is not by
  *          sock_ip_ep_t::family of @p remote.
  */
-ssize_t sock_ip_send(sock_ip_t *sock, const void *data, size_t len,
-                     uint8_t proto, const sock_ip_ep_t *remote);
+static inline ssize_t sock_ip_send(sock_ip_t *sock,
+                                   const void *data, size_t len,
+                                   uint8_t proto, const sock_ip_ep_t *remote)
+{
+    return sock_ip_send_aux(sock, data, len, proto, remote, NULL);
+}
 
 #include "sock_types.h"
 

--- a/sys/include/net/sock/ip.h
+++ b/sys/include/net/sock/ip.h
@@ -306,7 +306,7 @@ typedef struct {
     /**
      * @brief   The local address the packet was received on
      *
-     * Check if sock_ip_aux_tx_t::flags contains SOCK_AUX_HAS_LOCAL. Module
+     * Check if sock_ip_aux_rx_t::flags contains SOCK_AUX_HAS_LOCAL. Module
      * `sock_aux_local` needs to be selected to use this.
      */
     sock_ip_ep_t local;
@@ -315,7 +315,7 @@ typedef struct {
     /**
      * @brief   System time the packet was received
      *
-     * Check if sock_ip_aux_tx_t::flags contains SOCK_AUX_HAS_TIMESTAMP. Module
+     * Check if sock_ip_aux_rx_t::flags contains SOCK_AUX_HAS_TIMESTAMP. Module
      * `sock_aux_timestamp` needs to be selected to use this. The timestamp
      * refers to the reception of start of frame delimiter or preamble of
      * the frame carrying the IP packet and is given in nanoseconds since

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -308,7 +308,7 @@ typedef struct {
     /**
      * @brief   The local endpoint the datagram was received on
      *
-     * Check if sock_udp_aux_tx_t::flags contains SOCK_AUX_HAS_LOCAL. Module
+     * Check if sock_udp_aux_rx_t::flags contains SOCK_AUX_HAS_LOCAL. Module
      * `sock_aux_local` needs to be selected to use this.
      */
     sock_udp_ep_t local;
@@ -317,7 +317,7 @@ typedef struct {
     /**
      * @brief   System time the datagram was received
      *
-     * Check if sock_udp_aux_tx_t::flags contains SOCK_AUX_HAS_TIMESTAMP. Module
+     * Check if sock_udp_aux_rx_t::flags contains SOCK_AUX_HAS_TIMESTAMP. Module
      * `sock_aux_timestamp` needs to be selected to use this. The timestamp
      * refers to the reception of start of frame delimiter or preamble of
      * the frame carrying the UDP datagram and is given in nanoseconds since

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -301,6 +301,53 @@ typedef struct sock_udp sock_udp_t;
 #endif
 
 /**
+ * @brief   Auxiliary data provided when receiving using an UDP sock object
+ */
+typedef struct {
+#if defined(MODULE_SOCK_AUX_LOCAL) || defined(DOXYGEN)
+    /**
+     * @brief   The local endpoint the datagram was received on
+     *
+     * Check if sock_udp_aux_tx_t::flags contains SOCK_AUX_HAS_LOCAL. Module
+     * `sock_aux_local` needs to be selected to use this.
+     */
+    sock_udp_ep_t local;
+#endif /* MODULE_SOCK_AUX_ENDPOINT */
+#if defined(MODULE_SOCK_AUX_TIMESTAMP) || defined(DOXYGEN)
+    /**
+     * @brief   System time the datagram was received
+     *
+     * Check if sock_udp_aux_tx_t::flags contains SOCK_AUX_HAS_TIMESTAMP. Module
+     * `sock_aux_timestamp` needs to be selected to use this. The timestamp
+     * refers to the reception of start of frame delimiter or preamble of
+     * the frame carrying the UDP datagram and is given in nanoseconds since
+     * epoch, unless otherwise documented by the underlying implementation.
+     */
+    uint64_t timestamp;
+#endif /* MODULE_SOCK_AUX_TIMESTAP*/
+    sock_aux_flags_t flags; /**< Flags indicating info that is present */
+} sock_udp_aux_rx_t;
+
+/**
+ * @brief   Auxiliary data provided when sending using an UDP sock object
+ */
+typedef struct {
+#if defined(MODULE_SOCK_AUX_TIMESTAMP) || defined(DOXYGEN)
+    /**
+     * @brief   System time the datagram was send
+     *
+     * Check if sock_udp_aux_tx_t::flags contains SOCK_AUX_HAS_TIMESTAMP. Module
+     * `sock_aux_timestamp` needs to be selected to use this. The timestamp
+     * refers to the transmission of start of frame delimiter or preamble of
+     * the frame carrying the UDP datagram and is given in nanoseconds since
+     * epoch, unless otherwise documented by the underlying implementation.
+     */
+    uint64_t timestamp;
+#endif /* MODULE_SOCK_AUX_TIMESTAP*/
+    sock_aux_flags_t flags; /**< Flags indicating info that is present */
+} sock_udp_aux_tx_t;
+
+/**
  * @brief   Creates a new UDP sock object
  *
  * @pre `(sock != NULL)`
@@ -394,6 +441,8 @@ int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *ep);
  *                      data is available).
  * @param[out] remote   Remote end point of the received data.
  *                      May be `NULL`, if it is not required by the application.
+ * @param[out] aux      Auxiliary data about the received datagram.
+ *                      May be `NULL`, if it is not required by the application.
  *
  * @note    Function blocks if no packet is currently waiting.
  *
@@ -410,8 +459,95 @@ int sock_udp_get_remote(sock_udp_t *sock, sock_udp_ep_t *ep);
  *          the remote of @p sock.
  * @return  -ETIMEDOUT, if @p timeout expired.
  */
-ssize_t sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len,
-                      uint32_t timeout, sock_udp_ep_t *remote);
+ssize_t sock_udp_recv_aux(sock_udp_t *sock, void *data, size_t max_len,
+                          uint32_t timeout, sock_udp_ep_t *remote,
+                          sock_udp_aux_rx_t *aux);
+
+/**
+ * @brief   Receives a UDP message from a remote end point
+ *
+ * @pre `(sock != NULL) && (data != NULL) && (max_len > 0)`
+ *
+ * @param[in] sock      A UDP sock object.
+ * @param[out] data     Pointer where the received data should be stored.
+ * @param[in] max_len   Maximum space available at @p data.
+ * @param[in] timeout   Timeout for receive in microseconds.
+ *                      If 0 and no data is available, the function returns
+ *                      immediately.
+ *                      May be @ref SOCK_NO_TIMEOUT for no timeout (wait until
+ *                      data is available).
+ * @param[out] remote   Remote end point of the received data.
+ *                      May be `NULL`, if it is not required by the application.
+ *
+ * @note    Function blocks if no packet is currently waiting.
+ *
+ * @return  The number of bytes received on success.
+ * @return  0, if no received data is available, but everything is in order.
+ * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
+ * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -EINVAL, if @p remote is invalid or @p sock is not properly
+ *          initialized (or closed while sock_udp_recv() blocks).
+ * @return  -ENOBUFS, if buffer space is not large enough to store received
+ *          data.
+ * @return  -ENOMEM, if no memory was available to receive @p data.
+ * @return  -EPROTO, if source address of received packet did not equal
+ *          the remote of @p sock.
+ * @return  -ETIMEDOUT, if @p timeout expired.
+ */
+static inline ssize_t sock_udp_recv(sock_udp_t *sock,
+                                    void *data, size_t max_len,
+                                    uint32_t timeout, sock_udp_ep_t *remote)
+{
+    return sock_udp_recv_aux(sock, data, max_len, timeout, remote, NULL);
+}
+
+/**
+ * @brief   Provides stack-internal buffer space containing a UDP message from
+ *          a remote end point
+ *
+ * @pre `(sock != NULL) && (data != NULL) && (buf_ctx != NULL)`
+ *
+ * @param[in] sock      A UDP sock object.
+ * @param[out] data     Pointer to a stack-internal buffer space containing the
+ *                      received data.
+ * @param[in,out] buf_ctx  Stack-internal buffer context. If it points to a
+ *                      `NULL` pointer, the stack returns a new buffer space
+ *                      for a new packet. If it does not point to a `NULL`
+ *                      pointer, an existing context is assumed to get a next
+ *                      segment in a buffer.
+ * @param[in] timeout   Timeout for receive in microseconds.
+ *                      If 0 and no data is available, the function returns
+ *                      immediately.
+ *                      May be @ref SOCK_NO_TIMEOUT for no timeout (wait until
+ *                      data is available).
+ * @param[out] remote   Remote end point of the received data.
+ *                      May be `NULL`, if it is not required by the application.
+ * @param[out] aux      Auxiliary data about the received datagram.
+ *                      May be `NULL`, if it is not required by the application.
+ *
+ * @experimental    This function is quite new, not implemented for all stacks
+ *                  yet, and may be subject to sudden API changes. Do not use in
+ *                  production if this is unacceptable.
+ *
+ * @note    Function blocks if no packet is currently waiting.
+ *
+ * @return  The number of bytes received on success. May not be the complete
+ *          payload. Continue calling with the returned `buf_ctx` to get more
+ *          buffers until result is 0 or an error.
+ * @return  0, if no received data is available, but everything is in order.
+ *          If @p buf_ctx was provided, it was released.
+ * @return  -EADDRNOTAVAIL, if local of @p sock is not given.
+ * @return  -EAGAIN, if @p timeout is `0` and no data is available.
+ * @return  -EINVAL, if @p remote is invalid or @p sock is not properly
+ *          initialized (or closed while sock_udp_recv() blocks).
+ * @return  -ENOMEM, if no memory was available to receive @p data.
+ * @return  -EPROTO, if source address of received packet did not equal
+ *          the remote of @p sock.
+ * @return  -ETIMEDOUT, if @p timeout expired.
+ */
+ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **buf_ctx,
+                              uint32_t timeout, sock_udp_ep_t *remote,
+                              sock_udp_aux_rx_t *aux);
 
 /**
  * @brief   Provides stack-internal buffer space containing a UDP message from
@@ -455,8 +591,51 @@ ssize_t sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len,
  *          the remote of @p sock.
  * @return  -ETIMEDOUT, if @p timeout expired.
  */
-ssize_t sock_udp_recv_buf(sock_udp_t *sock, void **data, void **buf_ctx,
-                          uint32_t timeout, sock_udp_ep_t *remote);
+static inline ssize_t sock_udp_recv_buf(sock_udp_t *sock,
+                                        void **data, void **buf_ctx,
+                                        uint32_t timeout,
+                                        sock_udp_ep_t *remote)
+{
+    return sock_udp_recv_buf_aux(sock, data, buf_ctx, timeout, remote, NULL);
+}
+
+/**
+ * @brief   Sends a UDP message to remote end point
+ *
+ * @pre `((sock != NULL || remote != NULL)) && (if (len != 0): (data != NULL))`
+ *
+ * @param[in] sock      A UDP sock object. May be `NULL`.
+ *                      A sensible local end point should be selected by the
+ *                      implementation in that case.
+ * @param[in] data      Pointer where the received data should be stored.
+ *                      May be `NULL` if `len == 0`.
+ * @param[in] len       Maximum space available at @p data.
+ * @param[in] remote    Remote end point for the sent data.
+ *                      May be `NULL`, if @p sock has a remote end point.
+ *                      sock_udp_ep_t::family may be AF_UNSPEC, if local
+ *                      end point of @p sock provides this information.
+ *                      sock_udp_ep_t::port may not be 0.
+ * @param[out] aux      Auxiliary data about the transmission.
+ *                      May be `NULL`, if it is not required by the application.
+ *
+ * @return  The number of bytes sent on success.
+ * @return  -EADDRINUSE, if `sock` has no local end-point or was `NULL` and the
+ *          pool of available ephemeral ports is depleted.
+ * @return  -EAFNOSUPPORT, if `remote != NULL` and sock_udp_ep_t::family of
+ *          @p remote is != AF_UNSPEC and not supported.
+ * @return  -EHOSTUNREACH, if @p remote or remote end point of @p sock is not
+ *          reachable.
+ * @return  -EINVAL, if sock_udp_ep_t::addr of @p remote is an invalid address.
+ * @return  -EINVAL, if sock_udp_ep_t::netif of @p remote is not a valid
+ *          interface or contradicts the given local interface (i.e.
+ *          neither the local end point of `sock` nor remote are assigned to
+ *          `SOCK_ADDR_ANY_NETIF` but are nevertheless different.
+ * @return  -EINVAL, if sock_udp_ep_t::port of @p remote is 0.
+ * @return  -ENOMEM, if no memory was available to send @p data.
+ * @return  -ENOTCONN, if `remote == NULL`, but @p sock has no remote end point.
+ */
+ssize_t sock_udp_send_aux(sock_udp_t *sock, const void *data, size_t len,
+                          const sock_udp_ep_t *remote, sock_udp_aux_tx_t *aux);
 
 /**
  * @brief   Sends a UDP message to remote end point
@@ -491,8 +670,12 @@ ssize_t sock_udp_recv_buf(sock_udp_t *sock, void **data, void **buf_ctx,
  * @return  -ENOMEM, if no memory was available to send @p data.
  * @return  -ENOTCONN, if `remote == NULL`, but @p sock has no remote end point.
  */
-ssize_t sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
-                      const sock_udp_ep_t *remote);
+static inline ssize_t sock_udp_send(sock_udp_t *sock,
+                                    const void *data, size_t len,
+                                    const sock_udp_ep_t *remote)
+{
+    return sock_udp_send_aux(sock, data, len, remote, NULL);
+}
 
 #include "sock_types.h"
 

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -88,7 +88,8 @@ void gnrc_sock_create(gnrc_sock_reg_t *reg, gnrc_nettype_t type, uint32_t demux_
 }
 
 ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
-                       uint32_t timeout, sock_ip_ep_t *remote)
+                       uint32_t timeout, sock_ip_ep_t *remote,
+                       sock_ip_ep_t *local)
 {
     gnrc_pktsnip_t *pkt, *netif;
     msg_t msg;
@@ -149,6 +150,10 @@ ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
     assert(ipv6_hdr != NULL);
     memcpy(&remote->addr, &ipv6_hdr->src, sizeof(ipv6_addr_t));
     remote->family = AF_INET6;
+    if (local) {
+        memcpy(&local->addr, &ipv6_hdr->dst, sizeof(ipv6_addr_t));
+        local->family = AF_INET6;
+    }
     netif = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
     if (netif == NULL) {
         remote->netif = SOCK_ADDR_ANY_NETIF;

--- a/sys/net/gnrc/sock/include/gnrc_sock_internal.h
+++ b/sys/net/gnrc/sock/include/gnrc_sock_internal.h
@@ -116,7 +116,7 @@ void gnrc_sock_create(gnrc_sock_reg_t *reg, gnrc_nettype_t type, uint32_t demux_
  * @internal
  */
 ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt, uint32_t timeout,
-                       sock_ip_ep_t *remote);
+                       sock_ip_ep_t *remote, sock_ip_ep_t *local);
 
 /**
  * @brief   Send a packet internally

--- a/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
+++ b/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
@@ -127,7 +127,11 @@ ssize_t sock_ip_recv_buf_aux(sock_ip_t *sock, void **data, void **buf_ctx,
         return -EADDRNOTAVAIL;
     }
     tmp.family = sock->local.family;
-    res = gnrc_sock_recv((gnrc_sock_reg_t *)sock, &pkt, timeout, &tmp);
+    sock_ip_ep_t *local = NULL;
+#ifdef MODULE_SOCK_AUX_LOCAL
+    local = (aux != NULL) ? &aux->local : NULL;
+#endif
+    res = gnrc_sock_recv((gnrc_sock_reg_t *)sock, &pkt, timeout, &tmp, local);
     if (res < 0) {
         return res;
     }
@@ -137,6 +141,8 @@ ssize_t sock_ip_recv_buf_aux(sock_ip_t *sock, void **data, void **buf_ctx,
     }
     if (aux != NULL) {
         aux->flags = 0;
+        if (IS_USED(MODULE_SOCK_AUX_LOCAL))
+            aux->flags |= SOCK_AUX_HAS_LOCAL;
     }
     if ((sock->remote.family != AF_UNSPEC) &&   /* check remote end-point if set */
         /* We only have IPv6 for now, so just comparing the whole end point

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -216,7 +216,11 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **buf_ctx,
         return -EADDRNOTAVAIL;
     }
     tmp.family = sock->local.family;
-    res = gnrc_sock_recv((gnrc_sock_reg_t *)sock, &pkt, timeout, &tmp);
+    sock_ip_ep_t *local = NULL;
+#ifdef MODULE_SOCK_AUX_LOCAL
+    local = (aux != NULL) ? (sock_ip_ep_t *)&aux->local : NULL;
+#endif
+    res = gnrc_sock_recv((gnrc_sock_reg_t *)sock, &pkt, timeout, &tmp, local);
     if (res < 0) {
         return res;
     }
@@ -230,6 +234,10 @@ ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **buf_ctx,
     }
     if (aux != NULL) {
         aux->flags = 0;
+#ifdef MODULE_SOCK_AUX_LOCAL
+        aux->flags |= SOCK_AUX_HAS_LOCAL;
+        aux->local.port = sock->local.port;
+#endif
     }
     if ((sock->remote.family != AF_UNSPEC) &&  /* check remote end-point if set */
         ((sock->remote.port != byteorder_ntohs(hdr->src_port)) ||

--- a/tests/gnrc_sock_ip/Makefile
+++ b/tests/gnrc_sock_ip/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 USEMODULE += gnrc_sock_ip
 USEMODULE += gnrc_ipv6
 USEMODULE += ps
+USEMODULE += sock_aux_local
 
 # Set GNRC_PKTBUF_SIZE via CFLAGS if not being set via Kconfig.
 ifndef CONFIG_GNRC_PKTBUF_SIZE

--- a/tests/gnrc_sock_ip/main.c
+++ b/tests/gnrc_sock_ip/main.c
@@ -343,6 +343,31 @@ static void test_sock_ip_recv__non_blocking(void)
     expect(_check_net());
 }
 
+static void test_sock_ip_recv__aux(void)
+{
+    static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR_REMOTE };
+    static const ipv6_addr_t dst_addr = { .u8 = _TEST_ADDR_LOCAL };
+    static const sock_ip_ep_t local = { .family = AF_INET6 };
+    sock_ip_ep_t result;
+    sock_ip_aux_rx_t aux;
+
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+                               SOCK_FLAGS_REUSE_EP));
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+                          sizeof("ABCD"), _TEST_NETIF));
+    expect(sizeof("ABCD") == sock_ip_recv_aux(&_sock, _test_buffer,
+                                              sizeof(_test_buffer), 0, &result,
+                                              &aux));
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_NETIF == result.netif);
+#ifdef MODULE_SOCK_AUX_LOCAL
+    expect(aux.flags & SOCK_AUX_HAS_LOCAL);
+    expect(memcmp(&aux.local.addr, &dst_addr, sizeof(dst_addr)) == 0);
+#endif
+    expect(_check_net());
+}
+
 static void test_sock_ip_recv_buf__success(void)
 {
     static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR_REMOTE };
@@ -639,6 +664,7 @@ int main(void)
     CALL(test_sock_ip_recv__unsocketed_with_remote());
     CALL(test_sock_ip_recv__with_timeout());
     CALL(test_sock_ip_recv__non_blocking());
+    CALL(test_sock_ip_recv__aux());
     CALL(test_sock_ip_recv_buf__success());
     _prepare_send_checks();
     CALL(test_sock_ip_send__EAFNOSUPPORT());

--- a/tests/gnrc_sock_udp/Makefile
+++ b/tests/gnrc_sock_udp/Makefile
@@ -4,6 +4,7 @@ USEMODULE += gnrc_sock_check_reuse
 USEMODULE += gnrc_sock_udp
 USEMODULE += gnrc_ipv6
 USEMODULE += ps
+USEMODULE += sock_aux_local
 
 # Set GNRC_PKTBUF_SIZE via CFLAGS if not being set via Kconfig.
 ifndef CONFIG_GNRC_PKTBUF_SIZE

--- a/tests/gnrc_sock_udp/main.c
+++ b/tests/gnrc_sock_udp/main.c
@@ -422,6 +422,34 @@ static void test_sock_udp_recv__non_blocking(void)
     expect(_check_net());
 }
 
+static void test_sock_udp_recv__aux(void)
+{
+    static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR_REMOTE };
+    static const ipv6_addr_t dst_addr = { .u8 = _TEST_ADDR_LOCAL };
+    static const sock_udp_ep_t local = { .family = AF_INET6,
+                                         .port = _TEST_PORT_LOCAL };
+    sock_udp_ep_t result;
+    sock_udp_aux_rx_t aux;
+
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+                          _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
+                          _TEST_NETIF));
+    expect(sizeof("ABCD") == sock_udp_recv_aux(&_sock, _test_buffer,
+                                               sizeof(_test_buffer), 0,
+                                               &result, &aux));
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_PORT_REMOTE == result.port);
+    expect(_TEST_NETIF == result.netif);
+#ifdef MODULE_SOCK_AUX_LOCAL
+    expect(aux.flags & SOCK_AUX_HAS_LOCAL);
+    expect(memcmp(&aux.local.addr, &dst_addr, sizeof(dst_addr)) == 0);
+    expect(_TEST_PORT_LOCAL == aux.local.port);
+#endif
+    expect(_check_net());
+}
+
 static void test_sock_udp_recv_buf__success(void)
 {
     static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR_REMOTE };
@@ -750,6 +778,7 @@ int main(void)
     CALL(test_sock_udp_recv__unsocketed_with_remote());
     CALL(test_sock_udp_recv__with_timeout());
     CALL(test_sock_udp_recv__non_blocking());
+    CALL(test_sock_udp_recv__aux());
     CALL(test_sock_udp_recv_buf__success());
     _prepare_send_checks();
     CALL(test_sock_udp_send__EAFNOSUPPORT());

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -24,6 +24,7 @@ USEMODULE += lwip_sock_ip
 USEMODULE += netdev_eth
 USEMODULE += netdev_test
 USEMODULE += ps
+USEMODULE += sock_aux_local
 
 DISABLE_MODULE += auto_init_lwip
 

--- a/tests/lwip_sock_ip/main.c
+++ b/tests/lwip_sock_ip/main.c
@@ -303,6 +303,30 @@ static void test_sock_ip_recv4__non_blocking(void)
     expect(_check_net());
 }
 
+static void test_sock_ip_recv4__aux(void)
+{
+    static const sock_ip_ep_t local = { .family = AF_INET };
+    sock_ip_ep_t result;
+    sock_ip_aux_rx_t aux;
+
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+                               SOCK_FLAGS_REUSE_EP));
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PROTO, "ABCD",
+                           sizeof("ABCD"), _TEST_NETIF));
+    expect(sizeof("ABCD") == sock_ip_recv_aux(&_sock, _test_buffer,
+                                              sizeof(_test_buffer), 0, &result,
+                                              &aux));
+    expect(AF_INET == result.family);
+    expect(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
+    expect(_TEST_NETIF == result.netif);
+#if defined(MODULE_SOCK_AUX_LOCAL)
+    expect(aux.flags & SOCK_AUX_HAS_LOCAL);
+    expect(aux.local.family == AF_INET );
+    expect(aux.local.addr.ipv4_u32 == _TEST_ADDR4_LOCAL );
+#endif
+    expect(_check_net());
+}
+
 static void test_sock_ip_recv_buf4__success(void)
 {
     static const sock_ip_ep_t local = { .family = AF_INET };
@@ -844,6 +868,32 @@ static void test_sock_ip_recv6__non_blocking(void)
     expect(_check_net());
 }
 
+static void test_sock_ip_recv6__aux(void)
+{
+    static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR6_REMOTE };
+    static const ipv6_addr_t dst_addr = { .u8 = _TEST_ADDR6_LOCAL };
+    static const sock_ip_ep_t local = { .family = AF_INET6 };
+    sock_ip_ep_t result;
+    sock_ip_aux_rx_t aux;
+
+    expect(0 == sock_ip_create(&_sock, &local, NULL, _TEST_PROTO,
+                               SOCK_FLAGS_REUSE_EP));
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PROTO, "ABCD",
+                           sizeof("ABCD"), _TEST_NETIF));
+    expect(sizeof("ABCD") == sock_ip_recv_aux(&_sock, _test_buffer,
+                                              sizeof(_test_buffer), 0, &result,
+                                              &aux));
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_NETIF == result.netif);
+#if defined(MODULE_SOCK_AUX_LOCAL)
+    expect(aux.flags & SOCK_AUX_HAS_LOCAL);
+    expect(aux.local.family == AF_INET6 );
+    expect(memcmp(&aux.local.addr, &dst_addr, sizeof(dst_addr)) == 0);
+#endif
+    expect(_check_net());
+}
+
 static void test_sock_ip_recv_buf6__success(void)
 {
     static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR6_REMOTE };
@@ -1163,6 +1213,7 @@ int main(void)
     CALL(test_sock_ip_recv4__unsocketed_with_remote());
     CALL(test_sock_ip_recv4__with_timeout());
     CALL(test_sock_ip_recv4__non_blocking());
+    CALL(test_sock_ip_recv4__aux());
     CALL(test_sock_ip_recv_buf4__success());
     _prepare_send_checks();
     CALL(test_sock_ip_send4__EAFNOSUPPORT());
@@ -1208,6 +1259,7 @@ int main(void)
     CALL(test_sock_ip_recv6__unsocketed_with_remote());
     CALL(test_sock_ip_recv6__with_timeout());
     CALL(test_sock_ip_recv6__non_blocking());
+    CALL(test_sock_ip_recv6__aux());
     CALL(test_sock_ip_recv_buf6__success());
     _prepare_send_checks();
     CALL(test_sock_ip_send6__EAFNOSUPPORT());

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -24,10 +24,12 @@ USEMODULE += lwip_sock_udp
 USEMODULE += netdev_eth
 USEMODULE += netdev_test
 USEMODULE += ps
+USEMODULE += sock_aux_local
 
 DISABLE_MODULE += auto_init_lwip
 
 CFLAGS += -DSO_REUSE
 CFLAGS += -DLWIP_SO_RCVTIMEO
+CFLAGS += -DLWIP_NETBUF_RECVINFO
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/lwip_sock_udp/main.c
+++ b/tests/lwip_sock_udp/main.c
@@ -393,6 +393,36 @@ static void test_sock_udp_recv4__non_blocking(void)
     expect(_check_net());
 }
 
+static void test_sock_udp_recv4__aux(void)
+{
+    static const sock_udp_ep_t local = { .family = AF_INET,
+                                         .port = _TEST_PORT_LOCAL };
+    sock_udp_ep_t result;
+    sock_udp_aux_rx_t aux;
+
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_4packet(_TEST_ADDR4_REMOTE, _TEST_ADDR4_LOCAL, _TEST_PORT_REMOTE,
+                           _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
+                           _TEST_NETIF));
+    expect(sizeof("ABCD") == sock_udp_recv_aux(&_sock, _test_buffer,
+                                               sizeof(_test_buffer), 0, &result,
+                                               &aux));
+    expect(AF_INET == result.family);
+    expect(_TEST_ADDR4_REMOTE == result.addr.ipv4_u32);
+    expect(_TEST_PORT_REMOTE == result.port);
+#if LWIP_NETBUF_RECVINFO
+    expect(_TEST_NETIF == result.netif);
+#ifdef MODULE_SOCK_AUX_LOCAL
+    expect(aux.flags & SOCK_AUX_HAS_LOCAL);
+    expect(aux.local.addr.ipv4_u32 == _TEST_ADDR4_LOCAL);
+    expect(aux.local.port == _TEST_PORT_LOCAL);
+    expect(aux.local.family == AF_INET);
+#endif /* MODULE_SOCK_AUX_LOCAL */
+#endif /* LWIP_NETBUF_RECVINFO */
+    expect(_check_net());
+}
+
+
 static void test_sock_udp_recv_buf4__success(void)
 {
     static const sock_udp_ep_t local = { .family = AF_INET,
@@ -1056,6 +1086,37 @@ static void test_sock_udp_recv6__non_blocking(void)
     expect(_check_net());
 }
 
+static void test_sock_udp_recv6__aux(void)
+{
+    static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR6_REMOTE };
+    static const ipv6_addr_t dst_addr = { .u8 = _TEST_ADDR6_LOCAL };
+    static const sock_udp_ep_t local = { .family = AF_INET6,
+                                         .port = _TEST_PORT_LOCAL };
+    sock_udp_ep_t result;
+    sock_udp_aux_rx_t aux;
+
+    expect(0 == sock_udp_create(&_sock, &local, NULL, SOCK_FLAGS_REUSE_EP));
+    expect(_inject_6packet(&src_addr, &dst_addr, _TEST_PORT_REMOTE,
+                           _TEST_PORT_LOCAL, "ABCD", sizeof("ABCD"),
+                           _TEST_NETIF));
+    expect(sizeof("ABCD") == sock_udp_recv_aux(&_sock, _test_buffer,
+                                               sizeof(_test_buffer), 0, &result,
+                                               &aux));
+    expect(AF_INET6 == result.family);
+    expect(memcmp(&result.addr, &src_addr, sizeof(result.addr)) == 0);
+    expect(_TEST_PORT_REMOTE == result.port);
+#if LWIP_NETBUF_RECVINFO
+    expect(_TEST_NETIF == result.netif);
+#ifdef MODULE_SOCK_AUX_LOCAL
+    expect(aux.flags & SOCK_AUX_HAS_LOCAL);
+    expect(memcmp(&aux.local.addr, &dst_addr, sizeof(dst_addr)) == 0);
+    expect(aux.local.port == _TEST_PORT_LOCAL);
+    expect(aux.local.family == AF_INET6);
+#endif /* MODULE_SOCK_AUX_LOCAL */
+#endif /* LWIP_NETBUF_RECVINFO */
+    expect(_check_net());
+}
+
 static void test_sock_udp_recv_buf6__success(void)
 {
     static const ipv6_addr_t src_addr = { .u8 = _TEST_ADDR6_REMOTE };
@@ -1408,6 +1469,7 @@ int main(void)
     CALL(test_sock_udp_recv4__unsocketed_with_remote());
     CALL(test_sock_udp_recv4__with_timeout());
     CALL(test_sock_udp_recv4__non_blocking());
+    CALL(test_sock_udp_recv4__aux());
     CALL(test_sock_udp_recv_buf4__success());
     _prepare_send_checks();
     CALL(test_sock_udp_send4__EAFNOSUPPORT());
@@ -1456,6 +1518,7 @@ int main(void)
     CALL(test_sock_udp_recv6__unsocketed_with_remote());
     CALL(test_sock_udp_recv6__with_timeout());
     CALL(test_sock_udp_recv6__non_blocking());
+    CALL(test_sock_udp_recv6__aux());
     CALL(test_sock_udp_recv_buf6__success());
     _prepare_send_checks();
     CALL(test_sock_udp_send6__EAFNOSUPPORT());


### PR DESCRIPTION
### Contribution description

Add variants of `sock_<PROTO>_send()` and  `sock_<PROTO>_recv()` that allow fetching auxiliary data. As a motivating example, the local address is provided to allow virtual hosting to be implemented on top of the sock API. Additionally, the API for timestamps as auxiliary data is implemented; but the corresponding feature is not yet implemented by any network stack.

These are the functions that were added for the UDP protocol:

```C
ssize_t sock_udp_recv_aux(sock_udp_t *sock, void *data, size_t max_len,
                          uint32_t timeout, sock_udp_ep_t *remote,
                          sock_udp_aux_rx_t *aux);
ssize_t sock_udp_recv_buf_aux(sock_udp_t *sock, void **data, void **buf_ctx,
                              uint32_t timeout, sock_udp_ep_t *remote,
                              sock_udp_aux_rx_t *aux);
ssize_t sock_udp_send_aux(sock_udp_t *sock, const void *data, size_t len,
                          const sock_udp_ep_t *remote, sock_udp_aux_tx_t *aux);
```

The same was provided for IP and DTLS.

### Testing procedure

- `make -C tests/gnrc_sock_udp flash test`
- `make -C tests/gnrc_sock_ip flash test`
- `LWIP_IPV4=1 LWIP_IPV6=1 make -C tests/lwip_sock_udp flash test`
- `LWIP_IPV4=1 LWIP_IPV6=1 make -C tests/lwip_sock_ip flash test`


### Issues/PRs references

Supersedes: https://github.com/RIOT-OS/RIOT/pull/14402