### PR TITLE
gnrc/rpl: Implement Minimum Rank with Hysteresis Objective Function

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -221,6 +221,8 @@ PSEUDOMODULES += gnrc_nettype_udp
 ## @}
 
 
+PSEUDOMODULES += gnrc_rpl_mrhof%
+PSEUDOMODULES += gnrc_rpl_of0
 PSEUDOMODULES += gnrc_sixloenc
 PSEUDOMODULES += gnrc_sixlowpan_border_router_default
 PSEUDOMODULES += gnrc_sixlowpan_default

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -253,7 +253,9 @@ extern "C" {
 /**
  * @brief   Default Objective Code Point (OF0)
  */
-#define GNRC_RPL_DEFAULT_OCP (0)
+#ifndef CONFIG_GNRC_RPL_DEFAULT_OCP
+#define CONFIG_GNRC_RPL_DEFAULT_OCP (0)
+#endif
 
 /**
  * @brief   Default Instance ID

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -246,11 +246,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Number of implemented Objective Functions
- */
-#define GNRC_RPL_IMPLEMENTED_OFS_NUMOF (2)
-
-/**
  * @brief   Default Objective Code Point (OF0)
  */
 #ifndef CONFIG_GNRC_RPL_DEFAULT_OCP

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -254,7 +254,11 @@ extern "C" {
  * @brief   Default Objective Code Point (OF0)
  */
 #ifndef CONFIG_GNRC_RPL_DEFAULT_OCP
+#ifdef MODULE_GNRC_RPL_MRHOF
+#define CONFIG_GNRC_RPL_DEFAULT_OCP (1)
+#else
 #define CONFIG_GNRC_RPL_DEFAULT_OCP (0)
+#endif
 #endif
 
 /**

--- a/sys/include/net/gnrc/rpl.h
+++ b/sys/include/net/gnrc/rpl.h
@@ -248,7 +248,7 @@ extern "C" {
 /**
  * @brief   Number of implemented Objective Functions
  */
-#define GNRC_RPL_IMPLEMENTED_OFS_NUMOF (1)
+#define GNRC_RPL_IMPLEMENTED_OFS_NUMOF (2)
 
 /**
  * @brief   Default Objective Code Point (OF0)

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -133,7 +133,26 @@ ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
     USEMODULE += xtimer
   endif
   USEMODULE += evtimer
-  USEMODULE += netstats_neighbor_etx
+
+  ifeq (,$(filter gnrc_rpl_mrhof%,$(USEMODULE)))
+    USEMODULE += gnrc_rpl_of0
+  endif
+endif
+
+ifneq (,$(filter gnrc_rpl_mrhof%,$(USEMODULE)))
+  USEMODULE += gnrc_rpl_mrhof
+
+  ifeq (,$(filter gnrc_rpl_mrhof_%,$(USEMODULE)))
+    USEMODULE += gnrc_rpl_mrhof_etx
+  endif
+
+  ifneq (,$(filter gnrc_rpl_mrhof_etx,$(USEMODULE)))
+    USEMODULE += netstats_neighbor_etx
+  endif
+
+  ifneq (,$(filter gnrc_rpl_mrhof_lqi,$(USEMODULE)))
+    USEMODULE += netstats_neighbor_lqi
+  endif
 endif
 
 ifneq (,$(filter gnrc_ipv6_auto_subnets_simple,$(USEMODULE)))

--- a/sys/net/gnrc/Makefile.dep
+++ b/sys/net/gnrc/Makefile.dep
@@ -133,6 +133,7 @@ ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
     USEMODULE += xtimer
   endif
   USEMODULE += evtimer
+  USEMODULE += netstats_neighbor_etx
 endif
 
 ifneq (,$(filter gnrc_ipv6_auto_subnets_simple,$(USEMODULE)))

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -547,7 +547,7 @@ bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt
                 }
                 else {
                     DEBUG("RPL: Unsupported OCP 0x%02x\n", byteorder_ntohs(dc->ocp));
-                    inst->of = gnrc_rpl_get_of_for_ocp(GNRC_RPL_DEFAULT_OCP);
+                    inst->of = gnrc_rpl_get_of_for_ocp(CONFIG_GNRC_RPL_DEFAULT_OCP);
                 }
                 dodag->dio_interval_doubl = dc->dio_int_doubl;
                 dodag->dio_min = dc->dio_int_min;
@@ -760,7 +760,7 @@ void gnrc_rpl_recv_DIO(gnrc_rpl_dio_t *dio, kernel_pid_t iface, ipv6_addr_t *src
         }
 
         inst->mop = (dio->g_mop_prf >> GNRC_RPL_MOP_SHIFT) & GNRC_RPL_SHIFTED_MOP_MASK;
-        inst->of = gnrc_rpl_get_of_for_ocp(GNRC_RPL_DEFAULT_OCP);
+        inst->of = gnrc_rpl_get_of_for_ocp(CONFIG_GNRC_RPL_DEFAULT_OCP);
 
         if (iface == KERNEL_PID_UNDEF) {
             netif = _find_interface_with_rpl_mcast();

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -242,7 +242,7 @@ void gnrc_rpl_send(gnrc_pktsnip_t *pkt, kernel_pid_t iface, ipv6_addr_t *src, ip
     }
 }
 
-gnrc_pktsnip_t *_dio_dodag_conf_build(gnrc_pktsnip_t *pkt, gnrc_rpl_dodag_t *dodag)
+static gnrc_pktsnip_t *_dio_dodag_conf_build(gnrc_pktsnip_t *pkt, gnrc_rpl_dodag_t *dodag)
 {
     gnrc_rpl_opt_dodag_conf_t *dodag_conf;
     gnrc_pktsnip_t *opt_snip;
@@ -268,7 +268,8 @@ gnrc_pktsnip_t *_dio_dodag_conf_build(gnrc_pktsnip_t *pkt, gnrc_rpl_dodag_t *dod
     return opt_snip;
 }
 
-gnrc_pktsnip_t *_dis_solicited_opt_build(gnrc_pktsnip_t *pkt, gnrc_rpl_internal_opt_dis_solicited_t *opt)
+static gnrc_pktsnip_t *_dis_solicited_opt_build(gnrc_pktsnip_t *pkt,
+                                                gnrc_rpl_internal_opt_dis_solicited_t *opt)
 {
     gnrc_pktsnip_t *opt_snip;
     size_t snip_size = sizeof(gnrc_rpl_opt_dis_solicited_t);
@@ -307,7 +308,7 @@ static bool _get_pl_entry(unsigned iface, ipv6_addr_t *pfx,
     return false;
 }
 
-gnrc_pktsnip_t *_dio_prefix_info_build(gnrc_pktsnip_t *pkt, gnrc_rpl_dodag_t *dodag)
+static gnrc_pktsnip_t *_dio_prefix_info_build(gnrc_pktsnip_t *pkt, gnrc_rpl_dodag_t *dodag)
 {
     gnrc_ipv6_nib_pl_t ple;
     gnrc_rpl_opt_prefix_info_t *prefix_info;
@@ -507,10 +508,10 @@ static inline uint32_t _sec_to_ms(uint32_t sec)
 }
 
 /** @todo allow target prefixes in target options to be of variable length */
-bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt, uint16_t len,
-                    ipv6_addr_t *src, uint32_t *included_opts)
+static bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt,
+                           uint16_t len, ipv6_addr_t *src, uint32_t *included_opts)
 {
-    uint16_t l = 0;
+    uint16_t len_parsed = 0;
     gnrc_rpl_opt_target_t *first_target = NULL;
     gnrc_rpl_dodag_t *dodag = &inst->dodag;
     eui64_t iid;
@@ -522,12 +523,12 @@ bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt
         }
     }
 
-    while(l < len) {
+    while (len_parsed < len) {
         switch(opt->type) {
             case (GNRC_RPL_OPT_PAD1):
                 DEBUG("RPL: PAD1 option parsed\n");
                 *included_opts |= ((uint32_t) 1) << GNRC_RPL_OPT_PAD1;
-                l += 1;
+                len_parsed += 1;
                 opt = (gnrc_rpl_opt_t *) (((uint8_t *) opt) + 1);
                 continue;
 
@@ -676,7 +677,7 @@ bool _parse_options(int msg_type, gnrc_rpl_instance_t *inst, gnrc_rpl_opt_t *opt
                 break;
 #endif
         }
-        l += opt->length + sizeof(gnrc_rpl_opt_t);
+        len_parsed += opt->length + sizeof(gnrc_rpl_opt_t);
         opt = (gnrc_rpl_opt_t *) (((uint8_t *) (opt + 1)) + opt->length);
     }
     return true;
@@ -718,7 +719,7 @@ void gnrc_rpl_recv_DIS(gnrc_rpl_dis_t *dis, kernel_pid_t iface, ipv6_addr_t *src
 
                 uint32_t included_opts = 0;
                 size_t opt_len = len - sizeof(gnrc_rpl_dis_t) - sizeof(icmpv6_hdr_t);
-                if(!_parse_options(GNRC_RPL_ICMPV6_CODE_DIS, &gnrc_rpl_instances[i],
+                if (!_parse_options(GNRC_RPL_ICMPV6_CODE_DIS, &gnrc_rpl_instances[i],
                                    (gnrc_rpl_opt_t *)(dis + 1), opt_len, src, &included_opts)) {
                     DEBUG("RPL: DIS option parsing error - skip processing the DIS\n");
                     continue;
@@ -792,8 +793,8 @@ void gnrc_rpl_recv_DIO(gnrc_rpl_dio_t *dio, kernel_pid_t iface, ipv6_addr_t *src
         parent->rank = byteorder_ntohs(dio->rank);
 
         uint32_t included_opts = 0;
-        if(!_parse_options(GNRC_RPL_ICMPV6_CODE_DIO, inst, (gnrc_rpl_opt_t *)(dio + 1), len,
-                           src, &included_opts)) {
+        if (!_parse_options(GNRC_RPL_ICMPV6_CODE_DIO, inst, (gnrc_rpl_opt_t *)(dio + 1), len,
+                            src, &included_opts)) {
             DEBUG("RPL: Error encountered during DIO option parsing - remove DODAG\n");
             gnrc_rpl_instance_remove(inst);
             return;
@@ -919,8 +920,8 @@ void gnrc_rpl_recv_DIO(gnrc_rpl_dio_t *dio, kernel_pid_t iface, ipv6_addr_t *src
         dodag->grounded = dio->g_mop_prf >> GNRC_RPL_GROUNDED_SHIFT;
         dodag->prf = dio->g_mop_prf & GNRC_RPL_PRF_MASK;
         uint32_t included_opts = 0;
-        if(!_parse_options(GNRC_RPL_ICMPV6_CODE_DIO, inst, (gnrc_rpl_opt_t *)(dio + 1), len,
-                           src, &included_opts)) {
+        if (!_parse_options(GNRC_RPL_ICMPV6_CODE_DIO, inst, (gnrc_rpl_opt_t *)(dio + 1), len,
+                            src, &included_opts)) {
             DEBUG("RPL: Error encountered during DIO option parsing - remove DODAG\n");
             gnrc_rpl_instance_remove(inst);
             return;
@@ -928,7 +929,7 @@ void gnrc_rpl_recv_DIO(gnrc_rpl_dio_t *dio, kernel_pid_t iface, ipv6_addr_t *src
     }
 }
 
-gnrc_pktsnip_t *_dao_target_build(gnrc_pktsnip_t *pkt, ipv6_addr_t *addr, uint8_t prefix_length)
+static gnrc_pktsnip_t *_dao_target_build(gnrc_pktsnip_t *pkt, ipv6_addr_t *addr, uint8_t prefix_length)
 {
     gnrc_rpl_opt_target_t *target;
     gnrc_pktsnip_t *opt_snip;
@@ -947,7 +948,7 @@ gnrc_pktsnip_t *_dao_target_build(gnrc_pktsnip_t *pkt, ipv6_addr_t *addr, uint8_
     return opt_snip;
 }
 
-gnrc_pktsnip_t *_dao_transit_build(gnrc_pktsnip_t *pkt, uint8_t lifetime, bool external)
+static gnrc_pktsnip_t *_dao_transit_build(gnrc_pktsnip_t *pkt, uint8_t lifetime, bool external)
 {
     gnrc_rpl_opt_transit_t *transit;
     gnrc_pktsnip_t *opt_snip;
@@ -1021,7 +1022,7 @@ void gnrc_rpl_send_DAO(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination, uint
     /* TODO: nib: dropped support for external transit options for now */
     void *ft_state = NULL;
     gnrc_ipv6_nib_ft_t fte;
-    while(gnrc_ipv6_nib_ft_iter(NULL, dodag->iface, &ft_state, &fte)) {
+    while (gnrc_ipv6_nib_ft_iter(NULL, dodag->iface, &ft_state, &fte)) {
         DEBUG("RPL: Send DAO - building transit option\n");
 
         if ((pkt = _dao_transit_build(pkt, lifetime, false)) == NULL) {
@@ -1120,7 +1121,7 @@ void gnrc_rpl_send_DAO_ACK(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination, 
         size += sizeof(ipv6_addr_t);
     }
 
-    if ((pkt = gnrc_icmpv6_build(NULL, ICMPV6_RPL_CTRL, GNRC_RPL_ICMPV6_CODE_DAO_ACK, size)) == NULL) {
+    if (!(pkt = gnrc_icmpv6_build(NULL, ICMPV6_RPL_CTRL, GNRC_RPL_ICMPV6_CODE_DAO_ACK, size))) {
         DEBUG("RPL: Send DAOACK - no space left in packet buffer\n");
         return;
     }
@@ -1202,7 +1203,7 @@ void gnrc_rpl_recv_DAO(gnrc_rpl_dao_t *dao, kernel_pid_t iface, ipv6_addr_t *src
 #endif
 
     uint32_t included_opts = 0;
-    if(!_parse_options(GNRC_RPL_ICMPV6_CODE_DAO, inst, opts, len, src, &included_opts)) {
+    if (!_parse_options(GNRC_RPL_ICMPV6_CODE_DAO, inst, opts, len, src, &included_opts)) {
         DEBUG("RPL: Error encountered during DAO option parsing - ignore DAO\n");
         return;
     }

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -398,7 +398,7 @@ gnrc_rpl_instance_t *gnrc_rpl_root_instance_init(uint8_t instance_id, const ipv6
     }
 
     if (gnrc_rpl_instance_add(instance_id, &inst)) {
-        inst->of = (gnrc_rpl_of_t *) gnrc_rpl_get_of_for_ocp(GNRC_RPL_DEFAULT_OCP);
+        inst->of = (gnrc_rpl_of_t *) gnrc_rpl_get_of_for_ocp(CONFIG_GNRC_RPL_DEFAULT_OCP);
         inst->mop = mop;
         inst->min_hop_rank_inc = CONFIG_GNRC_RPL_DEFAULT_MIN_HOP_RANK_INCREASE;
         inst->max_rank_inc = CONFIG_GNRC_RPL_DEFAULT_MAX_RANK_INCREASE;

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_of_manager.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_of_manager.c
@@ -31,8 +31,12 @@ static gnrc_rpl_of_t *objective_functions[GNRC_RPL_IMPLEMENTED_OFS_NUMOF];
 void gnrc_rpl_of_manager_init(void)
 {
     /* insert new objective functions here */
-    objective_functions[0] = gnrc_rpl_get_of0();
-    objective_functions[1] = gnrc_rpl_get_of_mrhof();
+    if (IS_USED(MODULE_GNRC_RPL_OF0)) {
+        objective_functions[0] = gnrc_rpl_get_of0();
+    }
+    if (IS_USED(MODULE_GNRC_RPL_MRHOF)) {
+        objective_functions[1] = gnrc_rpl_get_of_mrhof();
+    }
 }
 
 /* find implemented OF via objective code point */
@@ -40,12 +44,16 @@ gnrc_rpl_of_t *gnrc_rpl_get_of_for_ocp(uint16_t ocp)
 {
     for (uint16_t i = 0; i < GNRC_RPL_IMPLEMENTED_OFS_NUMOF; i++) {
         if (objective_functions[i] == NULL) {
-            /* fallback if something goes wrong */
-            return gnrc_rpl_get_of0();
+            continue;
         }
         else if (ocp == objective_functions[i]->ocp) {
             return objective_functions[i];
         }
+    }
+
+    /* fallback if something goes wrong */
+    if (IS_USED(MODULE_GNRC_RPL_OF0)) {
+        return gnrc_rpl_get_of0();
     }
 
     return NULL;

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_of_manager.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_of_manager.c
@@ -21,10 +21,10 @@
 #include "net/gnrc/rpl.h"
 #include "net/gnrc/rpl/of_manager.h"
 #include "of0.h"
+#include "mrhof.h"
 
 #define ENABLE_DEBUG 0
 #include "debug.h"
-/* !!! TODO: port etx/mrhof to the new network stack */
 
 static gnrc_rpl_of_t *objective_functions[GNRC_RPL_IMPLEMENTED_OFS_NUMOF];
 
@@ -32,7 +32,7 @@ void gnrc_rpl_of_manager_init(void)
 {
     /* insert new objective functions here */
     objective_functions[0] = gnrc_rpl_get_of0();
-    /*objective_functions[1] = gnrc_rpl_get_of_mrhof(); */
+    objective_functions[1] = gnrc_rpl_get_of_mrhof();
 }
 
 /* find implemented OF via objective code point */

--- a/sys/net/gnrc/routing/rpl/mrhof.c
+++ b/sys/net/gnrc/routing/rpl/mrhof.c
@@ -1,0 +1,287 @@
+/*
+ * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_gnrc_rpl
+ * @{
+ * @file
+ * @brief       Minimum Rank with Hysteresis Objective Function
+ *
+ * Defines all functions for the implementation of Minimum Rank
+ * with Hysteresis Objective Function. (RFC 6719)
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ * @author      Benjamin Valentin <benpicco@beuth-hochschule.de>
+ * @}
+ */
+
+#include <string.h>
+#include "mrhof.h"
+#include "net/gnrc/rpl.h"
+#include "net/gnrc/rpl/structs.h"
+#include "net/netstats.h"
+#include "net/netstats/neighbor.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/**
+ * Retrieve parent statistics from the netstats neighbor module
+ */
+static bool _mrhof_get_stats(gnrc_rpl_parent_t *parent, netstats_nb_t *out)
+{
+    gnrc_ipv6_nib_nc_t nce;
+
+    gnrc_netif_t *iface = gnrc_netif_get_by_pid(parent->dodag->iface);
+
+    if (gnrc_ipv6_nib_get_next_hop_l2addr(&parent->addr, iface, NULL, &nce)) {
+        return false;
+    }
+
+    return netstats_nb_get(&iface->netif, nce.l2addr, nce.l2addr_len, out);
+}
+
+/**
+ * Retrieve parent etx from the netstats neighbor module
+ */
+static uint16_t _mrhof_get_etx(netstats_nb_t *stats)
+{
+    if (stats == NULL) {
+        return MRHOF_MAX_PATH_COST;
+    }
+    return stats->etx;
+}
+
+/**
+ * Retrieve the full path cost of a parent
+ */
+static uint16_t _mrhof_get_path_cost(gnrc_rpl_parent_t *parent, netstats_nb_t *stats)
+{
+    uint16_t etx = _mrhof_get_etx(stats);
+
+    if (etx == MRHOF_MAX_PATH_COST) {
+        return etx;
+    }
+    return parent->rank + etx;
+}
+
+/**
+ * Check if a parent is within MAX_LINK_METRIC and MAX_PATH_COST
+ */
+static bool _mrhof_is_acceptable(gnrc_rpl_parent_t *parent, netstats_nb_t *stats)
+{
+    uint16_t etx = _mrhof_get_etx(stats);
+
+    return (etx < MRHOF_MAX_LINK_METRIC &&
+            _mrhof_get_path_cost(parent, stats) < MRHOF_MAX_PATH_COST);
+}
+
+/**
+ * Check if a parent is fresh
+ */
+static bool _mrhof_isfresh(netif_t *netif, netstats_nb_t *stats)
+{
+    /* No statistics is not fresh */
+    if (stats == NULL) {
+        return false;
+    }
+    return netstats_nb_isfresh(netif, stats);
+}
+
+/* Compare acceptability of two parents */
+static int _mrhof_cmp_acceptable(gnrc_rpl_parent_t *p1, netstats_nb_t *p1_stats,
+                                 gnrc_rpl_parent_t *p2, netstats_nb_t *p2_stats)
+{
+    bool p1_acceptable = _mrhof_is_acceptable(p1, p1_stats);
+    bool p2_acceptable = _mrhof_is_acceptable(p2, p2_stats);
+
+    if (p1_acceptable == p2_acceptable) {
+        return 0;
+    }
+
+    /* One of the two parents is not acceptable */
+    if (p1_acceptable == false) {
+        /* p2 is acceptable and p1 not */
+        return 1;
+    }
+
+    if (p2_acceptable == false) {
+        /* p1 is acceptable and p2 not */
+        return -1;
+    }
+
+    return 0;
+}
+
+/* Compare freshness of two parents */
+static int _mrhof_cmp_fresh(netif_t *netif,
+                            netstats_nb_t *p1_stats,
+                            netstats_nb_t *p2_stats)
+{
+    bool p1_isfresh = _mrhof_isfresh(netif, p1_stats);
+    bool p2_isfresh = _mrhof_isfresh(netif, p2_stats);
+
+    if (p1_isfresh == p2_isfresh) {
+        return 0;
+    }
+
+    /* One of the two parents is not acceptable */
+    if (p1_isfresh == false) {
+        /* p2 is acceptable and p1 not */
+        return 1;
+    }
+
+    if (p2_isfresh == false) {
+        /* p1 is acceptable and p2 not */
+        return -1;
+    }
+
+    return 0;
+}
+
+void reset(gnrc_rpl_dodag_t *dodag)
+{
+    /* Nothing to do in MRHOF */
+    (void) dodag;
+}
+
+/**
+ * Calculate rank additive based on the rank of the parent and the etx to the parent
+ * computed via MAX(pref_parent->rank, 1 + floor(MAX(parents->rank)/MinHopRankIncrease),
+ */
+uint16_t calc_rank(gnrc_rpl_dodag_t *dodag, uint16_t base_rank)
+{
+    (void) base_rank;
+    DEBUG("MRHOF: Calculating rank\n");
+
+    /* TODO: consider a parent set of more than 1 parent */
+    if (dodag == NULL) {
+        DEBUG("MRHOF: No dodag, assuming max rank\n");
+        return GNRC_RPL_INFINITE_RANK;
+    }
+    else {
+        gnrc_rpl_parent_t *elt = NULL;
+        netstats_nb_t elt_stats;
+        uint8_t cnt = 0;
+        uint8_t max_dagrank = 0;
+        uint16_t cost_rank, minhoprankincr = dodag->instance->min_hop_rank_inc;
+
+        /* Determine the path cost through the preferred parent */
+        if (!_mrhof_get_stats(dodag->parents, &elt_stats)) {
+            DEBUG("MRHOF: No stats for parent, assuming max rank\n");
+            return GNRC_RPL_INFINITE_RANK;
+        }
+        cost_rank = _mrhof_get_path_cost(dodag->parents, &elt_stats);
+
+        /* Determine the largest dagrank in the parent set */
+        LL_FOREACH(dodag->parents, elt) {
+            if (cnt >= MRHOF_PARENT_SET_SIZE) {
+                break;
+            }
+            _mrhof_get_stats(elt, &elt_stats);
+            /* Only include parent in the parent set if the statistics are acceptable
+             * and the path cost is not significantly worse than the current preferred parent */
+            if (_mrhof_is_acceptable(elt, &elt_stats) && \
+                (_mrhof_get_path_cost(elt, &elt_stats) <= cost_rank + MRHOF_PARENT_SWITCH_THRESHOLD)) {
+                uint8_t new_dagrank = DAGRANK(elt->rank, minhoprankincr);
+                if (max_dagrank < new_dagrank) {
+                    max_dagrank = new_dagrank;
+                }
+            }
+            else {
+                /* Break when parents are no longer acceptable */
+                break;
+            }
+            cnt++;
+        }
+        uint16_t monotonic_rank = minhoprankincr * (max_dagrank + 1);
+        DEBUG("MRHOF: Path cost: %u, monotonic cost: %u\n", cost_rank, monotonic_rank);
+        return (cost_rank > monotonic_rank) ? cost_rank : monotonic_rank;
+    }
+}
+
+/**
+ * Decision based on
+ * * If one parent is not acceptable, the other is better
+ * * If one parent is not fresh, the other is better
+ * * ETX
+ */
+int which_parent(gnrc_rpl_parent_t *p1, gnrc_rpl_parent_t *p2)
+{
+    /* Only return p2 if the rank (full etx path) is better than p1 and better
+     * than the preferred parent full path etx by PARENT_SWITCH_THRESHOLD */
+    int cmp;
+    netstats_nb_t p1_stats, p2_stats;
+
+    assert(p1->dodag->iface == p2->dodag->iface);
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(p1->dodag->iface);
+
+    if (!_mrhof_get_stats(p1, &p1_stats) || !_mrhof_get_stats(p2, &p2_stats)) {
+        return 0;
+    }
+
+    /* Compare acceptability of parents */
+    cmp = _mrhof_cmp_acceptable(p1, &p1_stats, p2, &p2_stats);
+    if (cmp != 0) {
+        return cmp;
+    }
+
+    /* Compare freshness of parents */
+    cmp = _mrhof_cmp_fresh(&netif->netif, &p1_stats, &p2_stats);
+    if (cmp != 0) {
+        return cmp;
+    }
+
+    uint16_t p1_path_cost = _mrhof_get_path_cost(p1, &p1_stats);
+    uint16_t p2_path_cost = _mrhof_get_path_cost(p2, &p2_stats);
+
+    /* Compare ETX of parents */
+    if (p1_path_cost > p2_path_cost) {
+        if (p1 == p1->dodag->parents) {
+            /* p1 is the preferred parent */
+            if (p2_path_cost + MRHOF_PARENT_SWITCH_THRESHOLD < p1_path_cost) {
+                return 1;
+            }
+            else {
+                return -1;
+            }
+        }
+        else {
+            return 1;
+        }
+    }
+    else if (p1_path_cost == p2_path_cost) {
+        return 0;
+    }
+    return -1;
+}
+
+/* Prefer d2 if d2 is grounded and d1 is not */
+gnrc_rpl_dodag_t *which_dodag(gnrc_rpl_dodag_t *d1, gnrc_rpl_dodag_t *d2)
+{
+    if (!(d1->grounded) && d2->grounded) {
+        return d2;
+    }
+    return d1;
+}
+
+static gnrc_rpl_of_t gnrc_rpl_mrhof = {
+    .ocp         = 0x1,
+    .calc_rank   = calc_rank,
+    .parent_cmp  = which_parent,
+    .which_dodag = which_dodag,
+    .reset       = reset,
+    .parent_state_callback = NULL,
+    .init        = NULL,
+    .process_dio = NULL
+};
+
+gnrc_rpl_of_t *gnrc_rpl_get_of_mrhof(void)
+{
+    return &gnrc_rpl_mrhof;
+}

--- a/sys/net/gnrc/routing/rpl/mrhof.h
+++ b/sys/net/gnrc/routing/rpl/mrhof.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2017 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_gnrc_rpl
+ * @{
+ * @file
+ * @brief       Minimum Rank with Hysteresis Objective Function
+ *
+ * Header-file, which defines all functions for the implementation of Minimum Rank with Hysteresis Objective Function.
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef MRHOF_H
+#define MRHOF_H
+
+#include "net/gnrc/rpl/structs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Minimal improvement over old route needed to switch parent
+ */
+#define MRHOF_PARENT_SWITCH_THRESHOLD   192
+
+/**
+ * @brief   Highest per-hop cost
+ */
+#define MRHOF_MAX_LINK_METRIC           512
+
+/**
+ * @brief   Highest path cost
+ */
+#define MRHOF_MAX_PATH_COST           32768
+
+/**
+ * @brief   Number of possible parents
+ */
+#define MRHOF_PARENT_SET_SIZE             3
+
+/**
+ * @brief   Return the address to the MRH objective function
+ *
+ * @return  Address of the MRH objective function
+ */
+gnrc_rpl_of_t *gnrc_rpl_get_of_mrhof(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MRHOF_H */
+/**
+ * @}
+ */


### PR DESCRIPTION
### Contribution description

This is a rebase of a previous PR to add the Minimum Rank with Hysteresis Objective Function ([rfc 6719](https://tools.ietf.org/html/rfc6719)) for RPL.

Currently RIOT only implements the 'zero' objective function for RPL. Here always the path with the least hops will be selected.
If two nodes can see each other just barely, they would still rather chose the direct link instead of using an additional hop over a third node that both can see well.

MR-HOF adds link metrics to the rank calculation to solve this situation. 

### Testing procedure

A test application is provided in `examples/gnrc_networking_rpl`. Each node flashed with it will periodically (once per second) try to send a HELLO message to the DODAG root.
One node can be selected as the root node with the `test start` command. This starts the experiment.
The root node will count the HELLO messages from each node, the current results can be displayed with `test info`.

Under ideal conditions, the root node should receive as many HELLO messages per second as there are nodes in the mesh.

The experiment was conducted on the IoT-Lab using `iotlab-m3` on the `grenoble` site. I used 50 mesh nodes as well as 5 sniffer nodes to visualize the resulting DODAG using [foren6](https://cetic.github.io/foren6/).

#### OF0

This is the default behavior and the only available objective function currently in `master`.
It will always select the shortest path, disregarding any link metrics.

![OF0](https://user-images.githubusercontent.com/1301112/104781794-66164580-5783-11eb-9cc1-0f0580c9f362.png)

<details><summary>test results</summary>

```
node address			count	TTL	RSSI	LQI
dead:beef::a4d1:30cc:a00d:1c81	159	64	-37	254
dead:beef::5c0f:9995:1957:47e5	146	64	-78	254
dead:beef::bcf1:935c:5bf0:704	156	63	-82	254
dead:beef::5880:3c4d:ec49:584d	96	63	-89	186
dead:beef::a472:9bc4:5997:7a5	159	64	-66	254
dead:beef::6452:e96b:a33c:af70	157	64	-67	254
dead:beef::ec1a:a605:46d1:c2d9	149	64	-85	238
dead:beef::b854:c1c:349c:b612	148	63	-66	254
dead:beef::6c79:499f:b1bf:efbd	52	63	-89	212
dead:beef::a8c8:5d92:b35:c9fb	159	64	-63	254
dead:beef::ec8e:8c2b:109d:8c11	152	64	-41	254
dead:beef::accd:b48e:20cb:2443	155	64	-65	254
dead:beef::a493:5d69:c593:83a1	157	64	-49	254
dead:beef::7874:f46f:9433:80e3	157	63	-66	254
dead:beef::a461:e4e9:18d3:c5b	157	64	-67	254
dead:beef::a48b:d9e5:5903:7769	155	64	-64	254
dead:beef::a46e:5204:724c:a062	158	64	-81	254
dead:beef::e449:92fa:8265:160d	124	64	-78	254
dead:beef::bcce:d5:ac5b:98db	156	64	-42	254
dead:beef::a808:c377:cd58:7918	155	64	-66	254
dead:beef::a858:6ff6:6913:6799	161	64	-51	254
dead:beef::ec39:47e6:e72e:23a6	166	63	-81	254
dead:beef::a4da:e993:b3cc:9f60	110	64	-89	188
dead:beef::bcb2:caf3:7a23:96b7	151	63	-66	254
dead:beef::dce5:5c81:4c98:361e	99	63	-89	210
dead:beef::a4a1:f4a4:54c1:d0d5	152	63	-81	254
dead:beef::ac76:9ad:ab62:df6a	162	64	-51	254
dead:beef::5cde:3003:d441:5055	79	63	-89	192
dead:beef::58ec:5b2:53d9:891f	139	64	-82	254
dead:beef::5c5f:c08b:28db:6c13	158	64	-72	188
dead:beef::78f4:2d4d:d3ec:ff40	140	64	-78	254
dead:beef::78fc:7f35:b18a:1d2e	160	64	-46	254
dead:beef::b870:eda5:93b8:4fbc	159	64	-67	254
dead:beef::a49a:2891:748e:22a4	160	63	-66	254
dead:beef::7890:b0a2:20d2:2e58	144	63	-82	254
dead:beef::ec89:5bb4:308:bfcc	97	63	-81	254
dead:beef::78f0:356f:f34e:27ae	141	63	-82	251
dead:beef::bc55:e417:ed:7c21	100	63	-89	168
dead:beef::f8dc:ed8c:23df:551d	154	63	-81	254
dead:beef::ac1d:64ff:90fe:8e3c	136	64	-69	254
dead:beef::bc6d:9e53:ba10:2066	90	63	-89	187
dead:beef::d8c0:5ba4:ed59:171f	98	63	-89	199
dead:beef::645d:eb28:53f8:f7c	28	64	-89	151
dead:beef::e4e2:fc97:38b5:a479	82	64	-89	172
dead:beef::5c6e:7b9e:514d:8363	78	63	-89	204
dead:beef::b8d0:5b74:8db9:373f	2	64	-68	68
dead:beef::a40d:a3e8:4bc0:f714	12	63	-89	200
nodes: 47
running for 157 s
6065 received (38 / s)
```
</details>

#### MR-HOF (LQI)

The at86r231 on the testbed does not support ETX reporting (and `at86rf2xx` is not using the new radio HAL for a software fallback yet) so I used the LQI as metric instead. (`gnrc_rpl_mrhof_lqi`)

![MR-HOF with LQI metric](https://user-images.githubusercontent.com/1301112/104781801-6a426300-5783-11eb-9b39-00431f9e9828.png)

<details><summary>test results</summary>

```
node address			count	TTL	RSSI	LQI
dead:beef::78fc:7f35:b18a:1d2e	282	64	-46	254
dead:beef::a4d1:30cc:a00d:1c81	260	64	-37	254
dead:beef::ec8e:8c2b:109d:8c11	264	63	-67	254
dead:beef::5c0f:9995:1957:47e5	229	64	-78	254
dead:beef::6452:e96b:a33c:af70	258	63	-64	254
dead:beef::d8c0:5ba4:ed59:171f	233	63	-82	254
dead:beef::ec1a:a605:46d1:c2d9	244	63	-65	254
dead:beef::accd:b48e:20cb:2443	233	64	-65	254
dead:beef::b870:eda5:93b8:4fbc	261	64	-67	254
dead:beef::a8c8:5d92:b35:c9fb	267	64	-63	254
dead:beef::bcf1:935c:5bf0:704	234	62	-52	254
dead:beef::a4a1:f4a4:54c1:d0d5	237	63	-73	254
dead:beef::a472:9bc4:5997:7a5	264	63	-65	254
dead:beef::a493:5d69:c593:83a1	259	64	-49	254
dead:beef::bcce:d5:ac5b:98db	258	64	-43	254
dead:beef::7890:b0a2:20d2:2e58	220	63	-78	254
dead:beef::7874:f46f:9433:80e3	215	63	-72	185
dead:beef::a808:c377:cd58:7918	260	63	-49	254
dead:beef::ac76:9ad:ab62:df6a	264	64	-52	254
dead:beef::ec39:47e6:e72e:23a6	183	63	-72	249
dead:beef::a461:e4e9:18d3:c5b	262	64	-66	254
dead:beef::bc55:e417:ed:7c21	202	63	-72	251
dead:beef::a858:6ff6:6913:6799	252	64	-51	254
dead:beef::b8d0:5b74:8db9:373f	217	63	-82	254
dead:beef::a4da:e993:b3cc:9f60	234	62	-72	177
dead:beef::6c79:499f:b1bf:efbd	227	63	-82	247
dead:beef::5c5f:c08b:28db:6c13	182	64	-73	254
dead:beef::58ec:5b2:53d9:891f	219	64	-82	253
dead:beef::5cde:3003:d441:5055	220	62	-72	252
dead:beef::5880:3c4d:ec49:584d	228	62	-78	254
dead:beef::ac1d:64ff:90fe:8e3c	254	63	-64	254
dead:beef::bcb2:caf3:7a23:96b7	214	63	-73	254
dead:beef::e449:92fa:8265:160d	188	63	-78	254
dead:beef::a48b:d9e5:5903:7769	255	64	-64	254
dead:beef::bc6d:9e53:ba10:2066	212	63	-78	254
dead:beef::78f4:2d4d:d3ec:ff40	214	64	-78	254
dead:beef::dce5:5c81:4c98:361e	252	63	-78	254
dead:beef::e4e2:fc97:38b5:a479	215	63	-67	254
dead:beef::a40d:a3e8:4bc0:f714	230	63	-78	254
dead:beef::a46e:5204:724c:a062	200	64	-81	254
dead:beef::78f0:356f:f34e:27ae	195	63	-73	254
dead:beef::645d:eb28:53f8:f7c	203	62	-72	246
dead:beef::b854:c1c:349c:b612	198	63	-78	254
dead:beef::a49a:2891:748e:22a4	243	63	-72	254
dead:beef::ec89:5bb4:308:bfcc	121	63	-73	254
dead:beef::5c6e:7b9e:514d:8363	153	62	-73	254
dead:beef::f8dc:ed8c:23df:551d	193	63	-52	254
nodes: 47
running for 261 s
10708 received (41 / s)
```

</details>

### Issues/PRs references

taken over from #7450
depends on and includes #14448

I noticed that the DODAG would degrade after several minutes independent of the objective function. This lead to a drop in the packets/s received on the root node.
In foren6 it seemed like some nodes would select parent nodes with a higher rank than they themselves had.

I did not attempt to debug this yet, but with `socket_zep` we should soon be able to simulate a mesh entirely on `native`, which should make that easier. 

