### PR TITLE
drivers/netdev: Add info on transmission

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -254,9 +254,10 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t value_
     return res;
 }
 
-static int _send(netdev_t *netdev, const iolist_t *iolist)
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
-    (void) netdev;
+    (void)netdev;
+    (void)info;
 
     int pkt_len = 0;
 

--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -173,8 +173,9 @@ static int _esp_eth_init(netdev_t *netdev)
     return (ret == ESP_OK) ? 0 : -1;
 }
 
-static int _esp_eth_send(netdev_t *netdev, const iolist_t *iolist)
+static int _esp_eth_send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     DEBUG("%s: netdev=%p iolist=%p\n", __func__, netdev, iolist);
 
     CHECK_PARAM_RET (netdev != NULL, -ENODEV);

--- a/cpu/esp_common/esp-now/esp_now_gnrc.c
+++ b/cpu/esp_common/esp-now/esp_now_gnrc.c
@@ -87,7 +87,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     DEBUG("gnrc_esp_now: sending packet to %02x:%02x:%02x:%02x:%02x:%02x with size %u\n",
           mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], (unsigned)payload->size);
 
-    int res = dev->driver->send(dev, &iolist);
+    int res = dev->driver->send(dev, &iolist, NULL);
 
     gnrc_pktbuf_release(pkt);
 

--- a/cpu/esp_common/esp-now/esp_now_netdev.c
+++ b/cpu/esp_common/esp-now/esp_now_netdev.c
@@ -485,8 +485,9 @@ static int _init(netdev_t *netdev)
     return 0;
 }
 
-static int _send(netdev_t *netdev, const iolist_t *iolist)
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
 #if ESP_NOW_UNICAST
     if (!_esp_now_scan_peers_done) {
         return -ENODEV;

--- a/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp_common/esp-wifi/esp_wifi_netdev.c
@@ -502,8 +502,9 @@ static esp_err_t IRAM_ATTR _esp_system_event_handler(void *ctx, system_event_t *
     return ESP_OK;
 }
 
-static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
+static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     ESP_WIFI_DEBUG("netdev=%p iolist=%p", netdev, iolist);
 
     assert(netdev != NULL);

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -66,7 +66,7 @@
 
 /* netdev interface */
 static int _init(netdev_t *netdev);
-static int _send(netdev_t *netdev, const iolist_t *iolist);
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info);
 static int _recv(netdev_t *netdev, void *buf, size_t n, void *info);
 
 static inline void _get_mac_addr(netdev_t *netdev, uint8_t *dst)
@@ -273,8 +273,9 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
     return -1;
 }
 
-static int _send(netdev_t *netdev, const iolist_t *iolist)
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     netdev_tap_t *dev = (netdev_tap_t*)netdev;
 
     struct iovec iov[iolist_count(iolist)];

--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -99,8 +99,9 @@ static size_t _prep_vector(socket_zep_t *dev, const iolist_t *iolist,
     return bytes;
 }
 
-static int _send(netdev_t *netdev, const iolist_t *iolist)
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     socket_zep_t *dev = (socket_zep_t *)netdev;
     unsigned n = iolist_count(iolist);
     struct iovec v[n + 2];

--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -317,9 +317,10 @@ static int _init(netdev_t *dev)
     return 0;
 }
 
-static int _send(netdev_t *dev,  const iolist_t *iolist)
+static int _send(netdev_t *dev,  const iolist_t *iolist, void *info)
 {
     (void)dev;
+    (void)info;
 
     DEBUG("[nrf802154] Send a packet\n");
 

--- a/cpu/nrf5x_common/radio/nrfble/nrfble.c
+++ b/cpu/nrf5x_common/radio/nrfble/nrfble.c
@@ -269,9 +269,10 @@ static int _nrfble_init(netdev_t *dev)
     return 0;
 }
 
-static int _nrfble_send(netdev_t *dev, const iolist_t *data)
+static int _nrfble_send(netdev_t *dev, const iolist_t *data, void *info)
 {
     (void)dev;
+    (void)info;
     assert(data);
 
     NRF_RADIO->PACKETPTR = (uint32_t)data->iol_base;

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -310,9 +310,10 @@ void isr_radio(void)
     cortexm_isr_end();
 }
 
-static int nrfmin_send(netdev_t *dev, const iolist_t *iolist)
+static int nrfmin_send(netdev_t *dev, const iolist_t *iolist, void *info)
 {
     (void)dev;
+    (void)info;
 
     assert(iolist);
     if (state == STATE_OFF) {

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
@@ -104,7 +104,7 @@ static int gnrc_nrfmin_send(gnrc_netif_t *dev, gnrc_pktsnip_t *pkt)
     };
 
     /* and finally send out the data and release the packet */
-    res = dev->dev->driver->send(dev->dev, &iolist);
+    res = dev->dev->driver->send(dev->dev, &iolist, NULL);
 
 out:
     gnrc_pktbuf_release(pkt);

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -36,7 +36,7 @@
 
 #include "debug.h"
 
-static int _send(netdev_t *netdev, const iolist_t *iolist);
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info);
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *netdev);
 static void _isr(netdev_t *netdev);
@@ -121,8 +121,9 @@ static int _init(netdev_t *netdev)
     return 0;
 }
 
-static int _send(netdev_t *netdev, const iolist_t *iolist)
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     at86rf215_t *dev = (at86rf215_t *)netdev;
     size_t len = 0;
 

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -43,7 +43,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static int _send(netdev_t *netdev, const iolist_t *iolist);
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info);
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *netdev);
 static void _isr(netdev_t *netdev);
@@ -109,8 +109,9 @@ static int _init(netdev_t *netdev)
     return 0;
 }
 
-static int _send(netdev_t *netdev, const iolist_t *iolist)
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     at86rf2xx_t *dev = (at86rf2xx_t *)netdev;
     size_t len = 0;
 

--- a/drivers/atwinc15x0/atwinc15x0_netdev.c
+++ b/drivers/atwinc15x0/atwinc15x0_netdev.c
@@ -227,8 +227,10 @@ static void _atwinc15x0_wifi_cb(uint8_t type, void *msg)
     }
 }
 
-static int _atwinc15x0_send(netdev_t *netdev, const iolist_t *iolist)
+static int _atwinc15x0_send(netdev_t *netdev, const iolist_t *iolist,
+                            void *info)
 {
+    (void)info;
     atwinc15x0_t *dev = (atwinc15x0_t *)netdev;
 
     assert(dev);

--- a/drivers/cc110x/cc110x_netdev.c
+++ b/drivers/cc110x/cc110x_netdev.c
@@ -38,7 +38,7 @@
 
 static int cc110x_init(netdev_t *netdev);
 static int cc110x_recv(netdev_t *netdev, void *buf, size_t len, void *info);
-static int cc110x_send(netdev_t *netdev, const iolist_t *iolist);
+static int cc110x_send(netdev_t *netdev, const iolist_t *iolist, void *info);
 static int cc110x_get(netdev_t *netdev, netopt_t opt,
                       void *val, size_t max_len);
 static int cc110x_set(netdev_t *netdev, netopt_t opt,
@@ -404,8 +404,9 @@ static int cc110x_recv(netdev_t *netdev, void *buf, size_t len, void *info)
     return size;
 }
 
-static int cc110x_send(netdev_t *netdev, const iolist_t *iolist)
+static int cc110x_send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     cc110x_t *dev = (cc110x_t *)netdev;
 
     /* assert that cc110x_send was called with valid parameters */

--- a/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
+++ b/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
@@ -151,7 +151,7 @@ static int cc1xxx_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     };
 
     DEBUG("[cc1xxx-gnrc] send: triggering the drivers send function\n");
-    res = netif->dev->driver->send(netif->dev, &iolist);
+    res = netif->dev->driver->send(netif->dev, &iolist, NULL);
 
     gnrc_pktbuf_release(pkt);
 

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -38,7 +38,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-static int _send(netdev_t *netdev, const iolist_t *iolist);
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info);
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *netdev);
 static void _isr(netdev_t *netdev);
@@ -143,8 +143,9 @@ static void _isr(netdev_t *netdev)
     netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
 }
 
-static int _send(netdev_t *netdev, const iolist_t *iolist)
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     cc2420_t *dev = (cc2420_t *)netdev;
     return (int)cc2420_send(dev, iolist);
 }

--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -45,7 +45,7 @@ static void _isr(netdev_t *netdev);
 static int _recv(netdev_t *dev, void *buf, size_t len, void *info);
 static uint8_t wait_for_state(dose_t *ctx, uint8_t state);
 static int send_octet(dose_t *ctx, uint8_t c);
-static int _send(netdev_t *dev, const iolist_t *iolist);
+static int _send(netdev_t *dev, const iolist_t *iolist, void *info);
 static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len);
 static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t len);
 static int _init(netdev_t *dev);
@@ -389,9 +389,10 @@ static int send_data_octet(dose_t *ctx, uint8_t c)
     return rc;
 }
 
-static int _send(netdev_t *dev, const iolist_t *iolist)
+static int _send(netdev_t *dev, const iolist_t *iolist, void *info)
 {
-    dose_t *ctx = (dose_t *) dev;
+    (void)info;
+    dose_t *ctx = (dose_t *)dev;
     int8_t retries = 3;
     size_t pktlen;
     uint16_t crc;

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -256,8 +256,9 @@ static void on_int(void *arg)
     netdev_trigger_event_isr(arg);
 }
 
-static int nd_send(netdev_t *netdev, const iolist_t *iolist)
+static int nd_send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     enc28j60_t *dev = (enc28j60_t *)netdev;
     uint8_t ctrl = 0;
     int c = 0;

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -59,7 +59,7 @@ static inline int _packets_available(encx24j600_t *dev);
 static void _get_mac_addr(netdev_t *dev, uint8_t* buf);
 
 /* netdev interface */
-static int _send(netdev_t *netdev, const iolist_t *iolist);
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info);
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *dev);
 static void _isr(netdev_t *dev);
@@ -287,8 +287,9 @@ static int _init(netdev_t *encdev)
     return 0;
 }
 
-static int _send(netdev_t *netdev, const iolist_t *iolist) {
-    encx24j600_t * dev = (encx24j600_t *) netdev;
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info) {
+    (void)info;
+    encx24j600_t *dev = (encx24j600_t *)netdev;
     lock(dev);
 
     /* wait until previous packet has been sent */

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -263,10 +263,10 @@ void ethos_send_frame(ethos_t *dev, const uint8_t *data, size_t len, unsigned fr
     }
 }
 
-static int _send(netdev_t *netdev, const iolist_t *iolist)
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
-    ethos_t * dev = (ethos_t *) netdev;
-    (void)dev;
+    (void)info;
+    ethos_t *dev = (ethos_t *)netdev;
 
     /* count total packet length */
     size_t pktlen = iolist_count_total(iolist);

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -304,17 +304,20 @@ typedef struct netdev_driver {
      *
      * @pre `(dev != NULL) && (iolist != NULL`
      *
-     * @param[in] dev       Network device descriptor. Must not be NULL.
-     * @param[in] iolist    IO vector list to send. Elements of this list may
+     * @param[in]   dev     Network device descriptor. Must not be NULL.
+     * @param[in]   iolist  IO vector list to send. Elements of this list may
      *                      have iolist_t::iol_data == NULL or
      *                      iolist_t::iol_size == 0. However, unless otherwise
      *                      specified by the device, the *first* element
      *                      must contain data.
+     * @param[out]  info    Status information of the transmission. Might
+     *                      be of different type for different netdev devices.
+     *                      May be NULL if not needed or applicable.
      *
      * @return negative errno on error
      * @return number of bytes sent
      */
-    int (*send)(netdev_t *dev, const iolist_t *iolist);
+    int (*send)(netdev_t *dev, const iolist_t *iolist, void *info);
 
     /**
      * @brief Drop a received frame, **OR** get the length of a received frame,
@@ -343,7 +346,7 @@ typedef struct netdev_driver {
      * @param[in]   len     maximum number of bytes to read. If @p buf is NULL
      *                      the currently buffered packet is dropped when
      *                      @p len > 0. Must not be 0 when @p buf != NULL.
-     * @param[out] info     status information for the received packet. Might
+     * @param[out]  info    status information for the received packet. Might
      *                      be of different type for different netdev devices.
      *                      May be NULL if not needed or applicable.
      *

--- a/drivers/include/net/netdev/ble.h
+++ b/drivers/include/net/netdev/ble.h
@@ -141,7 +141,7 @@ typedef struct {
 static inline int netdev_ble_send(netdev_t *dev, netdev_ble_pkt_t *pkt)
 {
     struct iolist data = { NULL, pkt, sizeof(netdev_ble_pkt_t) };
-    return dev->driver->send(dev, &data);
+    return dev->driver->send(dev, &data, NULL);
 }
 
 /**

--- a/drivers/include/net/netdev/layer.h
+++ b/drivers/include/net/netdev/layer.h
@@ -70,12 +70,15 @@ void netdev_isr_pass(netdev_t *dev);
  * See also @ref netdev_driver for the extended description of this functions
  * behaviour
  *
- * @param[in] dev       network device descriptor
- * @param[in] iolist    io vector list to send
+ * @param[in]   dev     network device descriptor
+ * @param[in]   iolist  io vector list to send
+ * @param[out]  info    Status information for the transmission. Might
+ *                      be of different type for different netdev devices.
+ *                      May be NULL if not needed or applicable.
  *
  * @return              number of bytes sent, or `< 0` on error
  */
-int netdev_send_pass(netdev_t *dev, const iolist_t *iolist);
+int netdev_send_pass(netdev_t *dev, const iolist_t *iolist, void *info);
 
 /**
  * @brief   Passthrough recv function.

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -134,8 +134,9 @@ static void kw2xrf_wait_idle(kw2xrf_t *dev)
     }
 }
 
-static int _send(netdev_t *netdev, const iolist_t *iolist)
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     kw2xrf_t *dev = (kw2xrf_t *)netdev;
     uint8_t *pkt_buf = &(dev->buf[1]);
     size_t len = 0;

--- a/drivers/kw41zrf/kw41zrf_netdev.c
+++ b/drivers/kw41zrf/kw41zrf_netdev.c
@@ -214,8 +214,10 @@ int kw41zrf_cca(kw41zrf_t *dev)
     return dev->cca_result;
 }
 
-static int kw41zrf_netdev_send(netdev_t *netdev, const iolist_t *iolist)
+static int kw41zrf_netdev_send(netdev_t *netdev, const iolist_t *iolist,
+                               void *info)
 {
+    (void)info;
     kw41zrf_t *dev = (kw41zrf_t *)netdev;
     size_t len = 0;
 

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -64,8 +64,9 @@ static int _init(netdev_t *netdev)
     return 0;
 }
 
-static int _send(netdev_t *netdev, const iolist_t *iolist)
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     mrf24j40_t *dev = (mrf24j40_t *)netdev;
     size_t len = 0;
 

--- a/drivers/netdev_layer/netdev_layer.c
+++ b/drivers/netdev_layer/netdev_layer.c
@@ -18,9 +18,9 @@ void netdev_isr_pass(netdev_t *dev)
     dev->lower->driver->isr(dev->lower);
 }
 
-int netdev_send_pass(netdev_t *dev, const iolist_t *iolist)
+int netdev_send_pass(netdev_t *dev, const iolist_t *iolist, void *info)
 {
-    return dev->lower->driver->send(dev->lower, iolist);
+    return dev->lower->driver->send(dev->lower, iolist, info);
 }
 
 int netdev_recv_pass(netdev_t *dev, void *buf, size_t len, void *info)

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -143,8 +143,9 @@ unsigned slipdev_unstuff_readbyte(uint8_t *buf, uint8_t byte, bool *escaped)
     return res;
 }
 
-static int _send(netdev_t *netdev, const iolist_t *iolist)
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     slipdev_t *dev = (slipdev_t *)netdev;
     int bytes = 0;
 

--- a/drivers/stm32_eth/stm32_eth.c
+++ b/drivers/stm32_eth/stm32_eth.c
@@ -79,9 +79,10 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
     return ret;
 }
 
-static int _send(netdev_t *netdev, const struct iolist *iolist)
+static int _send(netdev_t *netdev, const struct iolist *iolist, void *info)
 {
     (void)netdev;
+    (void)info;
     int ret = 0;
     if(stm32_eth_get_rx_status_owned()) {
         mutex_lock(&_tx);

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -42,9 +42,10 @@ void _on_dio1_irq(void *arg);
 void _on_dio2_irq(void *arg);
 void _on_dio3_irq(void *arg);
 
-static int _send(netdev_t *netdev, const iolist_t *iolist)
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
-    sx127x_t *dev = (sx127x_t*) netdev;
+    (void)info;
+    sx127x_t *dev = (sx127x_t*)netdev;
 
     if (sx127x_get_state(dev) == SX127X_RF_TX_RUNNING) {
         DEBUG("[sx127x] Cannot send packet: radio already in transmitting "

--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -192,8 +192,9 @@ static uint16_t tx_upload(w5100_t *dev, uint16_t start, void *data, size_t len)
     }
 }
 
-static int send(netdev_t *netdev, const iolist_t *iolist)
+static int send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     w5100_t *dev = (w5100_t *)netdev;
     int sum = 0;
 

--- a/drivers/xbee/gnrc_xbee.c
+++ b/drivers/xbee/gnrc_xbee.c
@@ -152,7 +152,7 @@ static int xbee_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     };
 
     DEBUG("[xbee-gnrc] send: triggering the drivers send function\n");
-    res = netif->dev->driver->send(netif->dev, &iolist);
+    res = netif->dev->driver->send(netif->dev, &iolist, NULL);
 
     gnrc_pktbuf_release(pkt);
 

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -640,8 +640,9 @@ int xbee_init(netdev_t *dev)
     return 0;
 }
 
-static int xbee_send(netdev_t *dev, const iolist_t *iolist)
+static int xbee_send(netdev_t *dev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     xbee_t *xbee = (xbee_t *)dev;
     size_t size;
     uint8_t csum;

--- a/pkg/lwip/contrib/netdev/lwip_netdev.c
+++ b/pkg/lwip/contrib/netdev/lwip_netdev.c
@@ -220,7 +220,7 @@ static err_t _eth_link_output(struct netif *netif, struct pbuf *p)
 #if ETH_PAD_SIZE
     pbuf_header(p, ETH_PAD_SIZE); /* reclaim the padding word */
 #endif
-    return (netdev->driver->send(netdev, iolist) > 0) ? ERR_OK : ERR_BUF;
+    return (netdev->driver->send(netdev, iolist, NULL) > 0) ? ERR_OK : ERR_BUF;
 }
 #endif
 
@@ -234,7 +234,7 @@ static err_t _ieee802154_link_output(struct netif *netif, struct pbuf *p)
         .iol_len = (p->len - IEEE802154_FCS_LEN),   /* FCS is written by driver */
     };
 
-    return (netdev->driver->send(netdev, &pkt) > 0) ? ERR_OK : ERR_BUF;
+    return (netdev->driver->send(netdev, &pkt, NULL) > 0) ? ERR_OK : ERR_BUF;
 }
 #endif
 

--- a/pkg/openthread/contrib/platform_radio.c
+++ b/pkg/openthread/contrib/platform_radio.c
@@ -356,7 +356,7 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aPacket)
     _set_channel(aPacket->mChannel);
 
     /* send packet though netdev */
-    _dev->driver->send(_dev, &iolist);
+    _dev->driver->send(_dev, &iolist, NULL);
     otPlatRadioTxStarted(aInstance, aPacket);
 
     return OT_ERROR_NONE;

--- a/pkg/openwsn/contrib/radio.c
+++ b/pkg/openwsn/contrib/radio.c
@@ -151,7 +151,7 @@ void radio_loadPacket(uint8_t *packet, uint16_t len)
         .iol_len = (size_t)(len - IEEE802154_FCS_LEN),
     };
 
-    if (openwsn_radio.dev->driver->send(openwsn_radio.dev, &pkt) < 0) {
+    if (openwsn_radio.dev->driver->send(openwsn_radio.dev, &pkt, NULL) < 0) {
         LOG_DEBUG("[openwsn/radio]: couldn't load pkt\n");
     }
     LOG_DEBUG("[openwsn/radio]: loaded radio packet\n");

--- a/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
@@ -138,7 +138,7 @@ void SX127XSend(uint8_t *buffer, uint8_t size)
         .iol_base = buffer,
         .iol_len = size
     };
-    dev->driver->send(dev, &iol);
+    dev->driver->send(dev, &iol, NULL);
 }
 
 void SX127XSleep(void)

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -114,10 +114,10 @@ int _gnrc_gomach_transmit(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         res = csma_sender_csma_ca_send(dev, &iolist, &netif->mac.csma_conf);
     }
     else {
-        res = dev->driver->send(dev, &iolist);
+        res = dev->driver->send(dev, &iolist, NULL);
     }
 #else
-    res = dev->driver->send(dev, &iolist);
+    res = dev->driver->send(dev, &iolist, NULL);
 #endif
 
     /* release old data */

--- a/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
+++ b/sys/net/gnrc/link_layer/lorawan/gnrc_lorawan.c
@@ -243,7 +243,7 @@ void gnrc_lorawan_send_pkt(gnrc_lorawan_t *mac, gnrc_pktsnip_t *pkt, uint8_t dr)
 
     mac->toa = lora_time_on_air(gnrc_pkt_len(pkt), dr, cr + 4);
 
-    if (dev->driver->send(dev, &iolist) == -ENOTSUP) {
+    if (dev->driver->send(dev, &iolist, NULL) == -ENOTSUP) {
         DEBUG("gnrc_lorawan: Cannot send: radio is still transmitting");
     }
 

--- a/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
@@ -101,10 +101,10 @@ int _gnrc_lwmac_transmit(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         res = csma_sender_csma_ca_send(dev, &iolist, &netif->mac.csma_conf);
     }
     else {
-        res = dev->driver->send(dev, &iolist);
+        res = dev->driver->send(dev, &iolist, NULL);
     }
 #else
-    res = dev->driver->send(dev, &iolist);
+    res = dev->driver->send(dev, &iolist, NULL);
 #endif
 
     /* release old data */

--- a/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
@@ -158,7 +158,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         netif->stats.tx_unicast_count++;
     }
 #endif
-    res = dev->driver->send(dev, &iolist);
+    res = dev->driver->send(dev, &iolist, NULL);
 
     gnrc_pktbuf_release(pkt);
 

--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -110,7 +110,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     netif->stats.tx_unicast_count++;
 #endif
 
-    res = dev->driver->send(dev, (iolist_t *)pkt);
+    res = dev->driver->send(dev, (iolist_t *)pkt, NULL);
     /* release old data */
     gnrc_pktbuf_release(pkt);
     return res;

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -290,10 +290,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         res = csma_sender_csma_ca_send(dev, &iolist, &netif->mac.csma_conf);
     }
     else {
-        res = dev->driver->send(dev, &iolist);
+        res = dev->driver->send(dev, &iolist, NULL);
     }
 #else
-    res = dev->driver->send(dev, &iolist);
+    res = dev->driver->send(dev, &iolist, NULL);
 #endif
 
     /* release old data */

--- a/sys/net/link_layer/csma_sender/csma_sender.c
+++ b/sys/net/link_layer/csma_sender/csma_sender.c
@@ -106,7 +106,7 @@ static int send_if_cca(netdev_t *device, iolist_t *iolist)
     /* if medium is clear, send the packet and return */
     if (hwfeat == NETOPT_ENABLE) {
         DEBUG("csma: Radio medium available: sending packet.\n");
-        return device->driver->send(device, iolist);
+        return device->driver->send(device, iolist, NULL);
     }
 
     /* if we arrive here, medium was not available for transmission */
@@ -152,7 +152,7 @@ int csma_sender_csma_ca_send(netdev_t *dev, iolist_t *iolist,
     if (ok) {
         /* device does CSMA/CA all by itself: let it do its job */
         DEBUG("csma: Network device does hardware CSMA/CA\n");
-        return dev->driver->send(dev, iolist);
+        return dev->driver->send(dev, iolist, NULL);
     }
 
     /* if we arrive here, then we must perform the CSMA/CA procedure
@@ -225,7 +225,7 @@ int csma_sender_cca_send(netdev_t *dev, iolist_t *iolist)
     if (ok) {
         /* device does auto-CCA: let him do its job */
         DEBUG("csma: Network device does auto-CCA checking.\n");
-        return dev->driver->send(dev, iolist);
+        return dev->driver->send(dev, iolist, NULL);
     }
 
     /* if we arrive here, we must do CCA ourselves to see if radio medium

--- a/sys/net/netdev_test/netdev_test.c
+++ b/sys/net/netdev_test/netdev_test.c
@@ -31,8 +31,9 @@ void netdev_test_reset(netdev_test_t *dev)
     mutex_unlock(&dev->mutex);
 }
 
-static int _send(netdev_t *netdev, const iolist_t *iolist)
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     netdev_test_t *dev = (netdev_test_t *)netdev;
     int res = -EINVAL;
 

--- a/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
+++ b/sys/usb/usbus/cdc/ecm/cdc_ecm_netdev.c
@@ -54,8 +54,9 @@ void cdcecm_netdev_setup(usbus_cdcecm_device_t *cdcecm)
     cdcecm->netdev.driver = &netdev_driver_cdcecm;
 }
 
-static int _send(netdev_t *netdev, const iolist_t *iolist)
+static int _send(netdev_t *netdev, const iolist_t *iolist, void *info)
 {
+    (void)info;
     assert(iolist);
     usbus_cdcecm_device_t *cdcecm = _netdev_to_cdcecm(netdev);
     uint8_t *buf = cdcecm->ep_in->ep->buf;

--- a/tests/driver_at86rf2xx/cmd.c
+++ b/tests/driver_at86rf2xx/cmd.c
@@ -288,7 +288,7 @@ static int send(int iface, le_uint16_t dst_pan, uint8_t *dst, size_t dst_len,
         .iol_len = (size_t)res
     };
 
-    res = dev->netdev.driver->send((netdev_t *)dev, &iol_hdr);
+    res = dev->netdev.driver->send((netdev_t *)dev, &iol_hdr, NULL);
     if (res < 0) {
         puts("txtsnd: Error on sending");
         return 1;

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -245,7 +245,7 @@ int send_cmd(int argc, char **argv)
     };
 
     netdev_t *netdev = (netdev_t *)&sx127x;
-    if (netdev->driver->send(netdev, &iolist) == -ENOTSUP) {
+    if (netdev->driver->send(netdev, &iolist, NULL) == -ENOTSUP) {
         puts("Cannot send: radio is still transmitting");
     }
 

--- a/tests/socket_zep/main.c
+++ b/tests/socket_zep/main.c
@@ -61,7 +61,7 @@ static void test_send__iolist_NULL(void)
     netdev_t *netdev = (netdev_t *)(&_dev);
 
     puts("Send zero-length packet");
-    int res = netdev->driver->send(netdev, NULL);
+    int res = netdev->driver->send(netdev, NULL, NULL);
     expect((res < 0) || (res == 0));
     if ((res < 0) && (errno == ECONNREFUSED)) {
         puts("No remote socket exists (use scripts in `tests/` to have proper tests)");
@@ -78,7 +78,7 @@ static void test_send__iolist_not_NULL(void)
     netdev_t *netdev = (netdev_t *)(&_dev);
 
     puts("Send 'Hello\\0World\\0'");
-    int res =  netdev->driver->send(netdev, iolist);
+    int res =  netdev->driver->send(netdev, iolist, NULL);
     expect((res < 0) || (res == (sizeof("Hello")) + sizeof("World")));
     if ((res < 0) && (errno == ECONNREFUSED)) {
         puts("No remote socket exists (use scripts in `tests/` to have proper tests)");


### PR DESCRIPTION
### Contribution description

Extend `netdev_driver_t::send()` to take an additional `void *info` parameter to allow passing info on the transmission in the same fashion `netdev_driver_t::recv()` passes info about the received frame.

### Testing procedure

1. Murdock
2. Network operation should still work as usual

### Issues/PRs references

