### PR TITLE
sys: shell: deduplicate help text for ping command

### DIFF
--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -224,7 +224,7 @@ const shell_command_t _shell_command_list[] = {
 #ifdef MODULE_GNRC_ICMPV6_ECHO
 #ifdef MODULE_XTIMER
     { "ping6", "Ping via ICMPv6", _gnrc_icmpv6_ping },
-    { "ping", "Ping via ICMPv6", _gnrc_icmpv6_ping },
+    { "ping", "Alias for ping6", _gnrc_icmpv6_ping },
 #endif
 #endif
 #ifdef MODULE_RANDOM


### PR DESCRIPTION
### Contribution description
In the current implementation, the `ping` shell command has the exact same help text as the `ping6` shell command.

This PR deduplicates this by using `Alias for ping6` as a help text for `ping` (as suggested by @miri64).

See https://github.com/RIOT-OS/Tutorials/pull/72#pullrequestreview-456103365


### Testing procedure
Look at the `help` output fo the `gnrc_networking` example.

### Issues/PRs references
--