### PR TITLE
gnrc_netif: replace GNRC_NETIF_SINGLE with gnrc_netif_single pseudo-module

### DIFF
--- a/examples/emcute_mqttsn/Makefile
+++ b/examples/emcute_mqttsn/Makefile
@@ -22,14 +22,13 @@ USEMODULE += shell_commands
 USEMODULE += ps
 # For testing we also include the ping6 command and some stats
 USEMODULE += gnrc_icmpv6_echo
+# Optimize network stack to for use with a single network interface
+USEMODULE += gnrc_netif_single
 
 # Allow for env-var-based override of the nodes name (EMCUTE_ID)
 ifneq (,$(EMCUTE_ID))
   CFLAGS += -DEMCUTE_ID=\"$(EMCUTE_ID)\"
 endif
-
-# Optimize network stack to for use with a single network interface
-CFLAGS += -DGNRC_NETIF_SINGLE
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/examples/gnrc_minimal/Makefile
+++ b/examples/gnrc_minimal/Makefile
@@ -16,6 +16,9 @@ DEVELHELP ?= 0
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
+# Enable single interface optimization.
+# Remove this if more than one interface is present
+USEMODULE += gnrc_netif_single
 # Specify the minimum networking modules for IPv6
 USEMODULE += gnrc_ipv6
 # Additional networking modules that can be dropped if not needed
@@ -31,10 +34,6 @@ endif
 CFLAGS += -DCONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF=2 \
           -DGNRC_NETIF_IPV6_GROUPS_NUMOF=2 -DCONFIG_GNRC_IPV6_NIB_NUMOF=1 \
           -DCONFIG_GNRC_IPV6_NIB_OFFL_NUMOF=1 # be able to configure at least one route
-
-# Enable single interface optimization. Set to 0 if more than one interface is
-# present
-CFLAGS += -DGNRC_NETIF_SINGLE=1
 
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -41,6 +41,7 @@ PSEUDOMODULES += gnrc_pktbuf_cmd
 PSEUDOMODULES += gnrc_netif_6lo
 PSEUDOMODULES += gnrc_netif_ipv6
 PSEUDOMODULES += gnrc_netif_mac
+PSEUDOMODULES += gnrc_netif_single
 PSEUDOMODULES += gnrc_netif_cmd_%
 PSEUDOMODULES += gnrc_netif_dedup
 PSEUDOMODULES += gnrc_nettype_%

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -14,6 +14,11 @@
  * Network interfaces in the context of GNRC are threads for protocols that are
  * below the network layer.
  *
+ * ## Single interface optimizations
+ *
+ * If you only have one network interface on the board, you can select the
+ * `gnrc_netif_single` pseudo-module to enable further optimisations.
+ *
  * @{
  *
  * @file
@@ -330,7 +335,7 @@ unsigned gnrc_netif_numof(void);
  */
 static inline bool gnrc_netif_highlander(void)
 {
-    return IS_ACTIVE(GNRC_NETIF_SINGLE);
+    return IS_USED(MODULE_GNRC_NETIF_SINGLE);
 }
 
 /**

--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -32,18 +32,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Single interface optimizations
- *
- *          Define to 1 to allow GNRC optimizations when only one interface
- *          is available.
- *
- * @note    This MUST NOT be enabled if there's more than one interface.
- */
-#if DOXYGEN
-#define GNRC_NETIF_SINGLE
-#endif
-
-/**
  * @brief   Default priority for network interface threads
  */
 #ifndef GNRC_NETIF_PRIO

--- a/tests/emcute/Makefile
+++ b/tests/emcute/Makefile
@@ -17,6 +17,8 @@ endif
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_sock_udp
+USEMODULE += gnrc_netif_single          # Only one interface used and it makes
+                                        # shell commands easier
 USEMODULE += emcute
 USEMODULE += od
 USEMODULE += shell
@@ -25,8 +27,6 @@ USEMODULE += sock_util
 
 CFLAGS += -DEMCUTE_TOPIC_MAXLEN="249"   # 256 - 7
 CFLAGS += -DSTDIO_UART_RX_BUFSIZE="512" # Adapt to SHELL_BUFSIZE in app
-CFLAGS += -DGNRC_NETIF_SINGLE           # Only one interface used and it makes
-                                        # shell commands easier
 
 # The test requires some setup and to be run as root
 # So it cannot currently be run

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -4,13 +4,12 @@ RIOTBASE ?= $(CURDIR)/../..
 
 export TAP ?= tap0
 
-CFLAGS += -DGNRC_NETIF_SINGLE           # Only one interface used and it makes
-                                        # shell commands easier
-
 USEMODULE += sock_dns
 USEMODULE += gnrc_sock_udp
 USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_ipv6_nib_dns
+USEMODULE += gnrc_netif_single          # Only one interface used and it makes
+                                        # shell commands easier
 # use Ethernet as link-layer protocol
 ifeq (native,$(BOARD))
   TERMFLAGS ?= $(TAP)

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -13,8 +13,6 @@ TIMEOUT_US ?= 3000000
 TEST_ON_CI_BLACKLIST += all
 
 CFLAGS += -DSHELL_NO_ECHO
-CFLAGS += -DGNRC_NETIF_SINGLE           # Only one interface used and it makes
-                                        # shell commands easier
 
 ifeq (native,$(BOARD))
   TERMFLAGS ?= $(TAP)
@@ -30,6 +28,8 @@ USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_tcp
 USEMODULE += gnrc_pktbuf_cmd
+USEMODULE += gnrc_netif_single          # Only one interface used and it makes
+                                        # shell commands easier
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += od


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

To being able to use this information during dependency resolution, make gnrc_netif_single a pseudo-module.

### Testing procedure

File size of the affected examples should not change.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/13746#discussion_r461458518