### PR TITLE
cpu/native/async_read: close fds on cleanup

### DIFF
--- a/cpu/native/async_read.c
+++ b/cpu/native/async_read.c
@@ -52,6 +52,7 @@ void native_async_read_cleanup(void) {
     unregister_interrupt(SIGIO);
 
     for (int i = 0; i < _next_index; i++) {
+        real_close(_fds[i].fd);
         if (pollers[i].child_pid) {
             kill(pollers[i].child_pid, SIGKILL);
         }


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This was lost when moving to `poll()`.
We need to close the fds on `native_async_read_cleanup()`.




### Testing procedure

Start a native instance of `examples/gnrc_networking`
```sh
sudo dist/tools/tapsetup/tapsetup -d
sudo dist/tools/tapsetup/tapsetup
BOARD=native make -C examples/gnrc_networking
BOARD=native make -C examples/gnrc_networking term
```

and type reboot.

```
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking'
/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking/bin/native/gnrc_networking.elf tap0
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-389-gbd2e6c-cpu/native/async_read-cleanup)
RIOT network stack example application
All up, running the shell now
> reboot
reboot


		!! REBOOT !!

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-389-gbd2e6c-cpu/native/async_read-cleanup)
RIOT network stack example application
All up, running the shell now
> help
help
Command              Description
---------------------------------------
udp                  send data over UDP and listen on UDP ports
reboot               Reboot the node
version              Prints current RIOT_VERSION
pm                   interact with layered PM subsystem
ps                   Prints information about running threads.
ping6                Ping via ICMPv6
ping                 Ping via ICMPv6
random_init          initializes the PRNG
random_get           returns 32 bit of pseudo randomness
nib                  Configure neighbor information base
ifconfig             Configure network interfaces
rpl                  rpl configuration tool ('rpl help' for more information)

```


### Issues/PRs references

fixes #14636