### PR TITLE
sys/benchmark: don't disable interrupts

### DIFF
--- a/sys/include/benchmark.h
+++ b/sys/include/benchmark.h
@@ -43,13 +43,11 @@ extern "C" {
  */
 #define BENCHMARK_FUNC(name, runs, func)                    \
     {                                                           \
-        unsigned _benchmark_irqstate = irq_disable();           \
         uint32_t _benchmark_time = xtimer_now_usec();           \
         for (unsigned long i = 0; i < runs; i++) {              \
             func;                                               \
         }                                                       \
         _benchmark_time = (xtimer_now_usec() - _benchmark_time);\
-        irq_restore(_benchmark_irqstate);                       \
         benchmark_print_time(_benchmark_time, runs, name);      \
     }
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The function uses xtimer, which breaks with disabled interrupts.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try any benchmark that runs longer than an xtimer period.
E.g., the tests/periph_gpio bench command, on a z1.
Without this PR, total time and thus results are corrupt when using the default number of iterations, which are enough to trigger the issue.
E.g., try one million, then two million. Per-call values should be roughly the same.

With this PR, they are.


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
