### PR TITLE
tests/periph_gpio: reduce benchmark iterations

### DIFF
--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -26,7 +26,7 @@
 #include "benchmark.h"
 #include "periph/gpio.h"
 
-#define BENCH_RUNS_DEFAULT      (1000UL * 1000)
+#define BENCH_RUNS_DEFAULT      (1000UL * 100)
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
 static void cb(void *arg)

--- a/tests/periph_gpio/tests/02-bench.py
+++ b/tests/periph_gpio/tests/02-bench.py
@@ -11,8 +11,6 @@ import os
 from testrunner import run
 
 
-# On slow platforms, like AVR, this test can take some time to complete.
-TIMEOUT = 30
 # Allow setting a specific port to test
 PORT_UNDER_TEST = int(os.environ.get('PORT_UNDER_TEST') or 0)
 
@@ -37,4 +35,4 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc, timeout=TIMEOUT))
+    sys.exit(run(testfunc))


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Our MCU's are predictable enough that 100k iterations should suffice.
No need to wait tens of seconds.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found in #12457, was about to increase test time for z1.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
