### PR TITLE
driver/sdp3x: Resolved init condition fail

### DIFF
--- a/drivers/sdp3x/sdp3x.c
+++ b/drivers/sdp3x/sdp3x.c
@@ -446,7 +446,7 @@ static bool _check_product_number(uint8_t *readData)
     if (readData[1] != SDP31_PRODUCT_NO_BYTE_1) {
         return false;
     }
-    if ((readData[3] != SDP3X_MODEL_31) || (readData[3] != SDP3X_MODEL_32)) {
+    if ((readData[3] != SDP3X_MODEL_31) && (readData[3] != SDP3X_MODEL_32)) {
         return false;
     }
     if (readData[4] != SDP31_PRODUCT_NO_BYTE_3) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Init condition for sdp3x driver was failing due to improper check condition 

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
- ENABLE_DEBUG in sdp3x.c file
- Run test driver using : `BOARD=... make clean flash term -C tests/driver_sdp3x`

The init function reaches end and returns 1, denoting check condition being satisfied correctly


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #14601 