### PR TITLE
make: only build MacOS-specific tool on MacOS

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -649,11 +649,13 @@ endef
 
 # Check if setsid command is available on the system for debug target
 # This is not the case on MacOSX, so it must be built on the fly
-ifneq (,$(filter debug, $(MAKECMDGOALS)))
-  ifneq (0,$(shell which setsid 2>&1 > /dev/null ; echo $$?))
-    SETSID = $(RIOTTOOLS)/setsid/setsid
-    $(call target-export-variables,debug,$(SETSID))
-    DEBUGDEPS += $(SETSID)
+ifeq ($(OS),Darwin)
+  ifneq (,$(filter debug, $(MAKECMDGOALS)))
+    ifneq (0,$(shell command -v setsid 2>&1 > /dev/null ; echo $$?))
+      SETSID = $(RIOTTOOLS)/setsid/setsid
+      $(call target-export-variables,debug,$(SETSID))
+      DEBUGDEPS += $(SETSID)
+    endif
   endif
 endif
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The comment says as much, the tool in question even has `macosx` in its name [[1]], and it does not build for other non-Linux-POSIX systems such as FreeBSD.

[1]: https://github.com/tzvetkoff/setsid-macosx
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`make debug` should work on Mac OSX and FreeBSD (see #14458)
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Discovered in https://github.com/RIOT-OS/RIOT/pull/14631#issuecomment-665133440
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
