### PR TITLE
kconfig: make sync-deps flag accessible

### DIFF
--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -7,6 +7,9 @@ include $(RIOTMAKE)/tools/kconfiglib.inc.mk
 # Generated dir will contain Kconfig generated configurations
 GENERATED_DIR = $(BINDIR)/generated
 
+# The sync dir will contain a tree of header files that represent Kconfig symbols
+KCONFIG_SYNC_DIR = $(GENERATED_DIR)/deps
+
 # This file will contain all generated configuration from kconfig
 export KCONFIG_GENERATED_AUTOCONF_HEADER_C = $(GENERATED_DIR)/autoconf.h
 
@@ -75,6 +78,10 @@ $(GENERATED_DIR): $(CLEAN)
 SHOULD_RUN_KCONFIG ?= $(or $(wildcard $(APPDIR)/*.config), $(wildcard $(APPDIR)/Kconfig), $(wildcard $(KCONFIG_MERGED_CONFIG)), $(filter menuconfig, $(MAKECMDGOALS)))
 
 ifneq (,$(SHOULD_RUN_KCONFIG))
+
+# Flag to enable the --sync-dir feature of Kconfiglib
+KCONFIG_SYNC_DEPS ?=
+
 # Add configuration header to build dependencies
 BUILDDEPS += $(KCONFIG_GENERATED_AUTOCONF_HEADER_C)
 
@@ -125,5 +132,7 @@ $(KCONFIG_OUT_CONFIG) $(KCONFIG_GENERATED_AUTOCONF_HEADER_C) &: $(KCONFIG_GENERA
 	$(Q) \
 	KCONFIG_CONFIG=$(KCONFIG_MERGED_CONFIG) $(GENCONFIG) \
 	  --config-out=$(KCONFIG_OUT_CONFIG) \
-	  --header-path $(KCONFIG_GENERATED_AUTOCONF_HEADER_C) $(KCONFIG)
+	  --header-path $(KCONFIG_GENERATED_AUTOCONF_HEADER_C) \
+	  $(if $(KCONFIG_SYNC_DEPS),--sync-deps $(KCONFIG_SYNC_DIR)) \
+	  $(KCONFIG)
 endif


### PR DESCRIPTION
### Contribution description
This change allows to use the `sync-deps` flag of the `genconfig.py` script.

### Testing procedure
In `examples/gcoap`:
```sh
SHOULD_RUN_KCONFIG=1 KCONFIG_SYNC_DEPS=1 make
```
This should create several files in `bin/native/generated/deps/*`

Without `KCONFIG_SYNC_DEPS=1`, `deps` shouldn't exist (after a clean).

### Issues/PRs references

