### PR TITLE
boards/nrf52840-mdk-dongle: add nRF52840 MDK USB Dongle

### DIFF
--- a/boards/nrf52840-mdk-dongle/Kconfig
+++ b/boards/nrf52840-mdk-dongle/Kconfig
@@ -12,6 +12,7 @@ config BOARD_NRF52840_MDK_DONGLE
     default y
     select BOARD_COMMON_NRF52
     select CPU_MODEL_NRF52840XXAA
+    select HAS_PERIPH_PWM
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
     select HAS_HIGHLEVEL_STDIO

--- a/boards/nrf52840-mdk-dongle/Kconfig
+++ b/boards/nrf52840-mdk-dongle/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "nrf52840-mdk-dongle" if BOARD_NRF52840_MDK_DONGLE
+
+config BOARD_NRF52840_MDK_DONGLE
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52840XXAA
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_HIGHLEVEL_STDIO
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/nrf52840-mdk-dongle/Makefile
+++ b/boards/nrf52840-mdk-dongle/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nrf52840-mdk-dongle/Makefile.dep
+++ b/boards/nrf52840-mdk-dongle/Makefile.dep
@@ -1,0 +1,6 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+include $(RIOTBOARD)/common/nrf52/bootloader_nrfutil.dep.mk
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/nrf52840-mdk-dongle/Makefile.dep
+++ b/boards/nrf52840-mdk-dongle/Makefile.dep
@@ -1,5 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += saul_pwm
 endif
 
 include $(RIOTBOARD)/common/nrf52/bootloader_nrfutil.dep.mk

--- a/boards/nrf52840-mdk-dongle/Makefile.features
+++ b/boards/nrf52840-mdk-dongle/Makefile.features
@@ -1,0 +1,10 @@
+CPU_MODEL = nrf52840xxaa
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += highlevel_stdio
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/nrf52840-mdk-dongle/Makefile.features
+++ b/boards/nrf52840-mdk-dongle/Makefile.features
@@ -1,6 +1,7 @@
 CPU_MODEL = nrf52840xxaa
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 

--- a/boards/nrf52840-mdk-dongle/Makefile.include
+++ b/boards/nrf52840-mdk-dongle/Makefile.include
@@ -1,0 +1,19 @@
+# This board uses the vendor's serial bootloader
+
+PROGRAMMER ?= uf2conv
+
+ifeq (uf2conv,$(PROGRAMMER))
+
+  # Using uf2conv implies using the UF2 bootloader
+  #
+  # It has a static MBR at the first 4k, and a 48k UF2 Bootloader at
+  # the end, leaving 972k for the application. This overwrites any SoftDevice,
+  # but that's what the minimal working example for the dongle does as well.
+  ROM_OFFSET = 0x1000
+  ROM_LEN    = 0xf3000
+
+  FFLAGS_OPTS = -f 0xADA52840
+  include $(RIOTMAKE)/tools/usb_board_reset.mk
+endif
+
+include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/nrf52840-mdk-dongle/board.c
+++ b/boards/nrf52840-mdk-dongle/board.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840-mdk-dongle
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the nRF52840-dongle
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the board's RGB LED */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_set(LED0_PIN);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_set(LED1_PIN);
+    gpio_init(LED2_PIN, GPIO_OUT);
+    gpio_set(LED2_PIN);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/nrf52840-mdk-dongle/doc.txt
+++ b/boards/nrf52840-mdk-dongle/doc.txt
@@ -1,0 +1,62 @@
+/**
+@defgroup    boards_nrf52840-mdk-dongle nRF52840 MDK USB Dongle
+@ingroup     boards
+@brief       Support for the nRF52840 MDK USB Dongle
+
+### General information
+
+Refer to [The makerdiary Github repo](https://github.com/makerdiary/nrf52840-mdk-usb-dongle)
+or [The nrf52840-mdk-usb-dongle wiki](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/)
+for more details about the device.
+
+This is pretty much just the nRF52840 with a useful number of pins exposed for
+your pleasure along with one RGB LED and an onboard antenna in a USB stick form
+factor with room for headers on the sides.
+
+Unlike similar sticks (like the @ref boards_nrf52840-mdk), it features no
+dedicated programmer hardware but relies on direct USB communication with a
+built-in bootloader.
+
+The board features an RGB LED, a user/reset button as well as 12 configurable external pins.
+
+### Pinout
+
+\image html https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/assets/images/nrf52840-mdk-usb-dongle-pinout.png width=66%
+
+### Links
+
+- [nRF52840 documentation](https://infocenter.nordicsemi.com/topic/struct_nrf52/struct/nrf52840.html)
+- [Schematic](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/hardware/nrf52840-mdk-usb-dongle-sch_v1_0.pdf)
+
+### Flash the board
+
+The board is flashed using its on-board UF2 boot loader.
+The boot loader will present a mass storage device that has to be mounted to /media/MDK-DONGLE so
+`uf2conv.py` can find it. If you have an auto-mounter installed this will happen automatically.
+
+The rest of the process is automated in the usual `make flash` target.
+
+If RIOT is already running on the board, it will automatically reset the CPU and enter
+the bootloader.
+If some other firmware is running or RIOT crashed, you need to enter the bootloader
+manually by pressing the board's reset button while plugging the device into the USB port.
+
+Readiness of the bootloader is indicated by the LED glowing green.
+
+### Accessing STDIO
+
+The usual way to obtain a console on this board is using an emulated USB serial port (CDC-ACM).
+This is available automatically using the `stdio_cdc_acm` module,
+unless any other stdio module is enabled.
+
+On Linux systems with ModemManager < 1.10 installed,
+`make term` will, in some setups, fail for a few seconds after the device has come up.
+This is [fixed in its 1.12.4 version](https://gitlab.freedesktop.org/mobile-broadband/ModemManager/issues/164),
+but should not be more than a short annoyance in earlier versions.
+
+To ease debugging,
+pins 0.6 and 0.7 are configured as RX and TX, respectively.
+They provide stdio if no CDC-ACM is disabled,
+and can be used as a custom UART otherwise.
+
+ */

--- a/boards/nrf52840-mdk-dongle/include/board.h
+++ b/boards/nrf52840-mdk-dongle/include/board.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840-mdk-dongle
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the nRF52840 MDK USB Dongle
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name USB configuration
+ * @{
+ */
+#define INTERNAL_PERIPHERAL_VID         (0x239a)
+#define INTERNAL_PERIPHERAL_PID         (0x0029)
+/** @} */
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+ /** @brief The red channel of the LED */
+#define LED0_PIN            GPIO_PIN(0, 23)
+ /** @brief The green channel of the LED */
+#define LED1_PIN            GPIO_PIN(0, 22)
+ /** @brief The blue channel of the LED */
+#define LED2_PIN            GPIO_PIN(0, 24)
+
+/** @} */
+
+/**
+ * @name    LED access macros
+ * @{
+ */
+
+/** Enable LED's red channel */
+#define LED0_ON gpio_clear(LED0_PIN)
+/** Disable LED's red channel */
+#define LED0_OFF gpio_set(LED0_PIN)
+/** Toggle LED's red channel */
+#define LED0_TOGGLE gpio_toggle(LED0_PIN)
+
+/** Enable LED's green channel */
+#define LED1_ON gpio_clear(LED1_PIN)
+/** Disable LED's green channel */
+#define LED1_OFF gpio_set(LED1_PIN)
+/** Toggle LED's green channel */
+#define LED1_TOGGLE gpio_toggle(LED1_PIN)
+
+/** Enable LED's blue channel */
+#define LED2_ON gpio_clear(LED2_PIN)
+/** Disable LED's blue channel */
+#define LED2_OFF gpio_set(LED2_PIN)
+/** Toggle LED's blue channel */
+#define LED2_TOGGLE gpio_toggle(LED2_PIN)
+
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+/** @brief The button labelled RESET */
+#define BTN0_PIN            GPIO_PIN(0, 18)
+/** @brief The GPIO pin mode of the button labelled RESET */
+#define BTN0_MODE           GPIO_IN_PU
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/nrf52840-mdk-dongle/include/gpio_params.h
+++ b/boards/nrf52840-mdk-dongle/include/gpio_params.h
@@ -31,6 +31,7 @@ extern "C" {
  */
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
+#ifndef MODULE_SAUL_PWM
     {
         .name  = "LED Red",
         .pin   = LED0_PIN,
@@ -49,6 +50,7 @@ static const  saul_gpio_params_t saul_gpio_params[] =
         .mode  = GPIO_OUT,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     },
+#endif
     {
         .name  = "Reset",
         .pin   = BTN0_PIN,

--- a/boards/nrf52840-mdk-dongle/include/gpio_params.h
+++ b/boards/nrf52840-mdk-dongle/include/gpio_params.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840-mdk-dongle
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED and button configuration for SAUL
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LED Red",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED Green",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "LED Blue",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "Reset",
+        .pin   = BTN0_PIN,
+        .mode  = GPIO_IN_PU,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/nrf52840-mdk-dongle/include/periph_conf.h
+++ b/boards/nrf52840-mdk-dongle/include/periph_conf.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840-mdk-dongle
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the nRF52840 MDK USB Dongle
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ *
+ * This board does not have explicit UART pins. These are set as UART 0 to
+ * provide an easy serial debug port when not using (or debugging) USB.
+ *
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0, 6),
+        .tx_pin     = GPIO_PIN(0, 7),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin    = GPIO_UNDEF,
+        .cts_pin    = GPIO_UNDEF,
+#endif
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+};
+
+#define UART_0_ISR          isr_uart0
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/boards/nrf52840-mdk-dongle/include/periph_conf.h
+++ b/boards/nrf52840-mdk-dongle/include/periph_conf.h
@@ -55,6 +55,20 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
+/**
+ * @name   PWM configuration
+ *
+ * For the nRF52840-mdk-dongle board, the PWM0 module is set to drive the RGB LED.
+ * Other PWM outputs are not configured.
+ *
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    { NRF_PWM0, { GPIO_PIN(0, 23), GPIO_PIN(0, 22), GPIO_PIN(0, 24) } }
+};
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nrf52840-mdk-dongle/include/pwm_params.h
+++ b/boards/nrf52840-mdk-dongle/include/pwm_params.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840-mdk-dongle
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped PWM channels
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ */
+
+#ifndef PWM_PARAMS_H
+#define PWM_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    No individual LED that needs dimming
+ */
+#define SAUL_PWM_NO_DIMMER
+
+/**
+ * @brief    The on-board RGB LED
+ */
+static const saul_pwm_rgb_params_t saul_pwm_rgb_params[] =
+{
+    {
+        .name  = "RGB",
+        .channels = {
+            { PWM_DEV(0), 0, SAUL_PWM_INVERTED },
+            { PWM_DEV(0), 1, SAUL_PWM_INVERTED },
+            { PWM_DEV(0), 2, SAUL_PWM_INVERTED }
+        }
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PWM_PARAMS_H */
+/** @} */

--- a/boards/nrf52840-mdk-dongle/reset.c
+++ b/boards/nrf52840-mdk-dongle/reset.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C)  2020 Benjamin Valentin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840-mdk-dongle
+ * @{
+ * @file
+ * @brief       Implementation for managing the UF2 bootloader
+ *
+ * @author      Benjamin Valentin <benpicco@googlemail.com>
+ *
+ * @}
+ */
+
+#ifdef MODULE_USB_BOARD_RESET
+
+#define USB_H_USER_IS_RIOT_INTERNAL
+
+#include "cpu.h"
+#include "usb_board_reset.h"
+
+/* from uf2-bootloader src/main.c */
+#define DFU_MAGIC_UF2_RESET 0x57
+
+void usb_board_reset_in_bootloader(void)
+{
+    NRF_POWER->GPREGRET = DFU_MAGIC_UF2_RESET;
+
+    usb_board_reset_in_application();
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_USB_BOARD_RESET */

--- a/dist/tools/uf2/.gitignore
+++ b/dist/tools/uf2/.gitignore
@@ -1,0 +1,1 @@
+uf2conv.py

--- a/dist/tools/uf2/Makefile
+++ b/dist/tools/uf2/Makefile
@@ -1,0 +1,12 @@
+PKG_NAME=UF2
+PKG_URL=https://github.com/microsoft/uf2.git
+PKG_VERSION=41394bd604e341ebcfdf0a8c4acce9ec8fd73d93
+PKG_LICENSE=MIT
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+all: $(CURDIR)/uf2conv.py
+
+$(CURDIR)/uf2conv.py:
+	cp $(PKG_SOURCE_DIR)/utils/uf2conv.py .
+	chmod a+x uf2conv.py

--- a/makefiles/tools/targets.inc.mk
+++ b/makefiles/tools/targets.inc.mk
@@ -49,3 +49,8 @@ $(RIOTTOOLS)/lpc2k_pgm/bin/lpc2k_pgm: $(RIOTTOOLS)/lpc2k_pgm/Makefile
 	@echo "[INFO] lpc2k_pgm binary not found - building it from source now"
 	@$(MAKE) -C $(RIOTTOOLS)/lpc2k_pgm
 	@echo "[INFO] lpc2k_pgm binary successfully built!"
+
+$(RIOTTOOLS)/uf2/uf2conv.py: $(RIOTTOOLS)/uf2/Makefile
+	@echo "[INFO] uf2conv.py not found - fetching it from GitHub now"
+	CC= CFLAGS= $(MAKE) -C $(RIOTTOOLS)/uf2
+	@echo "[INFO] uf2conv.py successfully fetched!"

--- a/makefiles/tools/uf2conv.inc.mk
+++ b/makefiles/tools/uf2conv.inc.mk
@@ -1,0 +1,10 @@
+FLASHFILE ?= $(HEXFILE)
+
+FLASHER ?= $(RIOTTOOLS)/uf2/uf2conv.py
+FFLAGS  ?= $(FFLAGS_OPTS) $(FLASHFILE)
+
+PREFLASH_DELAY ?= 2
+
+ifeq ($(RIOTTOOLS)/uf2/uf2conv.py,$(FLASHER))
+  FLASHDEPS += $(FLASHER)
+endif


### PR DESCRIPTION
### Contribution description

The [nRF52840 MDK USB Dongle](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/) is another widely available nRF52840 Dongle.
It is ostensibly similar to the reference design (`nrf52840dongle`) but differs in several aspects.
(fewer GPIOs, one less LED, different bootloader and an external voltage regulator that provides up to 1A @ 3.3V)

![pinout](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/assets/images/nrf52840-mdk-usb-dongle-pinout.png)
It comes with the [UF2 bootloader](https://github.com/makerdiary/uf2-bootloader) and is flashed using `uf2conv.py`.
The utility will convert the `.hex` file into a `.uf2` file and copy it to the mass storage device that the bootloader creates for this purpose.

This works well with auto-mount, if you are mounting manually, additional steps are needed.

### Testing procedure

The usual nRF52 things should work.

For the first flashing, you have to enter the bootloader manually by pressing the Reset button while plugging the device in.
Subsequent flashes should perform the bootloader reset automatically.

The `uf2conv.py` utility will be fetched automatically.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
