### PR TITLE
boards: enable gnrc_netif_single by default 

### DIFF
--- a/boards/avr-rss2/Makefile.dep
+++ b/boards/avr-rss2/Makefile.dep
@@ -4,3 +4,6 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += bme280_i2c
   USEMODULE += saul_gpio
 endif
+
+# board only has a single network interface
+DEFAULT_MODULE += gnrc_netif_single

--- a/boards/derfmega128/Makefile.dep
+++ b/boards/derfmega128/Makefile.dep
@@ -1,1 +1,4 @@
 USEMODULE += boards_common_atmega
+
+# board only has a single network interface
+DEFAULT_MODULE += gnrc_netif_single

--- a/boards/derfmega256/Makefile.dep
+++ b/boards/derfmega256/Makefile.dep
@@ -1,1 +1,4 @@
 USEMODULE += boards_common_atmega
+
+# board only has a single network interface
+DEFAULT_MODULE += gnrc_netif_single

--- a/boards/microduino-corerf/Makefile.dep
+++ b/boards/microduino-corerf/Makefile.dep
@@ -1,1 +1,4 @@
 USEMODULE += boards_common_atmega
+
+# board only has a single network interface
+DEFAULT_MODULE += gnrc_netif_single

--- a/boards/samr21-xpro/Makefile.dep
+++ b/boards/samr21-xpro/Makefile.dep
@@ -5,3 +5,6 @@ endif
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+# board only has a single network interface
+DEFAULT_MODULE += gnrc_netif_single

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -32,6 +32,9 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
+# a router needs at least two interfaces
+DISABLE_MODULE += gnrc_netif_single
+
 # Optionally include RPL as a routing protocol. When includede gnrc_uhcpc will
 # configure the node as a RPL DODAG root when receiving a prefix.
 #USEMODULE += gnrc_rpl


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Most boards only have a single network interface.
On such boards, select the `gnrc_netif_single` pseudo-module as `DEFAULT_MODULE`.
If an application now wants to use an additional network interface (e.g. `ethos`), it must disable `gnrc_netif_single`.

*This is merely a demonstrator*

Only a hand full of boards have been edited and there are more tests that need `DISABLE_MODULE += gnrc_netif_single`.

My first idea was to automatically determine if more than the default netif was selected, but that would need to happen *after* dependency resolution.
So I went with this more tedious approach now.

### Testing procedure

`gnrc_networking` should consume less memory by default:

#### master

```
   text	   data	    bss	    dec	    hex	filename
 114196	  13576	  13417	 141189	  22785	/home/benpicco/dev/RIOT/examples/gnrc_networking/bin/avr-rss2/gnrc_networking.elf
```

#### this PR

```
   text	   data	    bss	    dec	    hex	filename
 113848	  13688	  13417	 140953	  22699	/home/benpicco/dev/RIOT/examples/gnrc_networking/bin/avr-rss2/gnrc_networking.elf
```

For `gnrc_border_router` the numbers do not change, as expected.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
