### PR TITLE
tests/float: reduce iterations to 1000

### DIFF
--- a/tests/float/Makefile
+++ b/tests/float/Makefile
@@ -1,8 +1,3 @@
 include ../Makefile.tests_common
 
-# for native we can go do a couple of more operations in reasonable time...
-ifneq (,$(filter native,$(BOARD)))
-  CFLAGS += -DTEST_ITER=100000000
-endif
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/float/main.c
+++ b/tests/float/main.c
@@ -25,9 +25,9 @@
 
 #include "board.h"
 
-/* as default we run the test 100k times */
+/* as default we run the test 1k times */
 #ifndef TEST_ITER
-#define TEST_ITER           (100000UL)
+#define TEST_ITER           (1000UL)
 #endif
 
 #define STEP                (0.1)

--- a/tests/float/tests/01-run.py
+++ b/tests/float/tests/01-run.py
@@ -9,13 +9,10 @@
 import sys
 from testrunner import run
 
-# It takes 35 seconds on msp430, so add some margin
-TIMEOUT = 45
-
 
 def testfunc(child):
     child.expect_exact("Testing floating point arithmetic...")
-    child.expect_exact("[SUCCESS]", timeout=TIMEOUT)
+    child.expect_exact("[SUCCESS]")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description

The linked bug report [1] says "2 out of 5 computations fail", so there
should be no need to wait tens of seconds.

[1] https://sourceware.org/legacy-ml/newlib/2010/msg00149.html

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->



<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

tests didn't fail in years anywhere, so I don't expect any change with less iterations.
Previous timeout was 45 seconds, now the default of 10 seconds is used. Should be alright with 100 times less iterations.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
