### PR TITLE
net/netif : Expose configurations to Kconfig

### DIFF
--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -45,8 +45,8 @@ extern "C" {
 /**
  * @brief   Maximum length for an interface name
  */
-#ifndef NETIF_NAMELENMAX
-#define NETIF_NAMELENMAX    (8U)
+#ifndef CONFIG_NETIF_NAMELENMAX
+#define CONFIG_NETIF_NAMELENMAX    (8U)
 #endif
 
 /**
@@ -75,14 +75,14 @@ netif_t *netif_iter(netif_t *last);
  * @brief   Gets name of an interface
  *
  * @pre `name != NULL`
- * @pre name holds at least @ref NETIF_NAMELENMAX characters
+ * @pre name holds at least @ref CONFIG_NETIF_NAMELENMAX characters
  *
  * @note    Supposed to be implemented by the networking module. `name` must be
  *          zero-terminated in the result!
  *
  * @param[in] netif A network interface.
  * @param[out] name The name of the interface. Must not be `NULL`. Must at least
- *                  hold @ref NETIF_NAMELENMAX bytes.
+ *                  hold @ref CONFIG_NETIF_NAMELENMAX bytes.
  *
  * @return  length of @p name on success
  */

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -43,11 +43,17 @@ extern "C" {
 #endif
 
 /**
- * @brief   Maximum length for an interface name
+ * @defgroup net_netif_conf Network interfaces compile configurations
+ * @ingroup  config
+ * @{
+ */
+/**
+ * @brief    Maximum length for an interface name
  */
 #ifndef CONFIG_NETIF_NAMELENMAX
 #define CONFIG_NETIF_NAMELENMAX    (8U)
 #endif
+/** @} */
 
 /**
  * @brief Network interface descriptor.

--- a/sys/net/Kconfig
+++ b/sys/net/Kconfig
@@ -11,5 +11,6 @@ rsource "credman/Kconfig"
 rsource "gnrc/Kconfig"
 rsource "sock/Kconfig"
 rsource "link_layer/Kconfig"
+rsource "netif/Kconfig"
 
 endmenu # Networking

--- a/sys/net/netif/Kconfig
+++ b/sys/net/netif/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_NETIF
+    bool "Configure Network Interfaces"
+    depends on MODULE_NETIF
+    help
+        Configure Network Interfaces (NETIF) using Kconfig.
+
+if KCONFIG_MODULE_NETIF
+
+config NETIF_NAMELENMAX
+    int "Maximum length for an interface name"
+    default 8
+
+endif # KCONFIG_MODULE_NETIF

--- a/sys/net/netif/netif.c
+++ b/sys/net/netif/netif.c
@@ -56,11 +56,11 @@ netif_t *netif_get_by_name(const char *name)
     assert(name);
     list_node_t *node = netif_list.next;
 
-    char tmp[NETIF_NAMELENMAX];
+    char tmp[CONFIG_NETIF_NAMELENMAX];
 
     while(node) {
        netif_get_name((netif_t *)node, tmp);
-       if(strncmp(name, tmp, NETIF_NAMELENMAX) == 0) {
+       if(strncmp(name, tmp, CONFIG_NETIF_NAMELENMAX) == 0) {
            return (netif_t *)node;
        }
        node = node->next;

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -82,7 +82,7 @@ static const struct {
 /* utility functions */
 static void _print_iface_name(netif_t *iface)
 {
-    char name[NETIF_NAMELENMAX];
+    char name[CONFIG_NETIF_NAMELENMAX];
     netif_get_name(iface, name);
     printf("%s", name);
 }

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -1117,8 +1117,8 @@ static void test_netif_iter(void)
 
 static void test_netif_get_name(void)
 {
-    char exp_name[NETIF_NAMELENMAX + 1];
-    char name[NETIF_NAMELENMAX];
+    char exp_name[CONFIG_NETIF_NAMELENMAX + 1];
+    char name[CONFIG_NETIF_NAMELENMAX];
     int res;
     netif_t *netif = netif_iter(NULL);
     /* there must be at least one interface */
@@ -1132,7 +1132,7 @@ static void test_netif_get_name(void)
 
 static void test_netif_get_by_name(void)
 {
-    char name[NETIF_NAMELENMAX] = "6nPRK28";
+    char name[CONFIG_NETIF_NAMELENMAX] = "6nPRK28";
     netif_t *netif = netif_iter(NULL);
 
     TEST_ASSERT(netif_get_by_name(name) == NULL);


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in **net/netif** to Kconfig.

### Testing procedure

1. New documentation was built using Doxygen 

   The build works fine.

  2. Test files were added to tests/net_netif/

      The test file can be found [here](https://github.com/akshaim/RIOT/commit/f067cb75cd6fff82dc411e4f4dea7820555fde32)

      Compiled binaries for native

#### Default State:

##### Firmware Output

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-422-g72a39-Kconfig_netif_tests)
CONFIG_NETIF_NAMELENMAX=(8U)

```
#### Usage with CFLAGS :
```
CFLAGS += -DCONFIG_NETIF_NAMELENMAX=6
```

##### Firmware Output

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-422-g72a39-Kconfig_netif_tests)
CONFIG_NETIF_NAMELENMAX=6
```

#### Usage with menuconfig :


`make menuconfig`

#### Default values

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-422-g72a39-Kconfig_netif_tests)
CONFIG_NETIF_NAMELENMAX=8
```
##### Macros Configured output

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-422-g72a39-Kconfig_netif_tests)
CONFIG_NETIF_NAMELENMAX=10
```


**MACROS were successfully configured.**

### Issues/PRs references

#12888 