### PR TITLE
driver/sdp3x: Resolved irq pin code used even if irq pin not connected

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -105,6 +105,10 @@ ifneq (,$(filter rn2%3,$(USEMODULE)))
   USEMODULE += rn2xx3
 endif
 
+ifneq (,$(filter sdp3x_%,$(USEMODULE)))
+  USEMODULE += sdp3x
+endif
+
 ifneq (,$(filter sht1%,$(USEMODULE)))
   USEMODULE += sht1x
 endif

--- a/drivers/sdp3x/Makefile.dep
+++ b/drivers/sdp3x/Makefile.dep
@@ -1,4 +1,7 @@
 FEATURES_REQUIRED += periph_i2c
-FEATURES_REQUIRED += periph_gpio_irq
 USEMODULE += checksum
 USEMODULE += xtimer
+
+ifneq (,$(filter sdp3x_irq,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio_irq
+endif

--- a/drivers/sdp3x/include/sdp3x_params.h
+++ b/drivers/sdp3x/include/sdp3x_params.h
@@ -62,7 +62,7 @@ extern "C" {
 #define SDP3X_PARAM_I2C_ADDR        SDP3X_ADDR1
 #endif
 #ifndef SDP3X_PARAM_IRQ_PIN
-#define SDP3X_PARAM_IRQ_PIN         (GPIO_PIN(0, 2))
+#define SDP3X_PARAM_IRQ_PIN         GPIO_UNDEF
 #endif
 
 #ifndef SDP3X_PARAMS

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -187,6 +187,9 @@ PSEUDOMODULES += ina220
 # include variants of mrf24j40 drivers as pseudo modules
 PSEUDOMODULES += mrf24j40m%
 
+# include variants of sdp3x drivers as pseudo modules
+PSEUDOMODULES += sdp3x_irq
+
 # include variants of SX127X drivers as pseudo modules
 PSEUDOMODULES += sx1272
 PSEUDOMODULES += sx1276

--- a/tests/driver_sdp3x/Makefile
+++ b/tests/driver_sdp3x/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-DRIVER ?= sdp3x
+DRIVER ?= sdp3x_irq
 
 USEMODULE += $(DRIVER)
 USEMODULE += printf_float

--- a/tests/driver_sdp3x/README.md
+++ b/tests/driver_sdp3x/README.md
@@ -19,3 +19,5 @@ The sensor has an IRQn pin which indicates data ready on the sensor. This pin ca
 connected on the GPIO ports and configured in the variable `SDP3X_PARAM_IRQ_PIN`. This
 helps getting measurements as soon as they are ready instead of the 46ms wait (which is
 the maximum time the sensor might take the get the measurement ready).
+
+When not using irq pin, instead of `USEMODULE = sdp3x_irq`, use `USEMODULE = sdp3x`.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Adds functionality to only compile and run IRQ pin part of code if sensor is connected with the interrupt pin and `sdp3x_irq` MODULE is used.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
To run sensor with interrupt pin, change Makefile to:
```
include ../Makefile.tests_common

DRIVER ?= sdp3x_irq

USEMODULE += $(DRIVER)
USEMODULE += printf_float

TEST_ITERATIONS ?= 10
# export iterations for continuous measurements
CFLAGS += -DTEST_ITERATIONS=$(TEST_ITERATIONS)

include $(RIOTBASE)/Makefile.include

```
To run sensor without interrupt pin, change Makefile to:
```
include ../Makefile.tests_common

DRIVER ?= sdp3x

USEMODULE += $(DRIVER)
USEMODULE += printf_float

TEST_ITERATIONS ?= 10
# export iterations for continuous measurements
CFLAGS += -DTEST_ITERATIONS=$(TEST_ITERATIONS)

include $(RIOTBASE)/Makefile.include

```

Then compile, flash and run the test file with: `BOARD=... make clean flash term -C tests/driver_sdp3x`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #14603 