### PR TITLE
Kconfig: enable incremental compilation on config changes

### DIFF
--- a/.github/workflows/tools-buildtest.yml
+++ b/.github/workflows/tools-buildtest.yml
@@ -67,3 +67,7 @@ jobs:
       uses: aabadie/riot-action@v1
       with:
         cmd: make -C cpu/kinetis/dist/calc_spi_scalers
+    - name: Build fixdep tool
+      uses: aabadie/riot-action@v1
+      with:
+        cmd: make -C dist/tools/fixdep

--- a/Makefile.base
+++ b/Makefile.base
@@ -84,6 +84,7 @@ OBJ := $(OBJC) $(OBJCXX) $(ASMOBJ) $(ASSMOBJ) $(GENOBJC)
 DEP := $(OBJC:.o=.d) $(OBJCXX:.o=.d) $(ASSMOBJ:.o=.d)
 
 include $(RIOTMAKE)/blob.inc.mk
+include $(RIOTMAKE)/tools/fixdep.inc.mk
 
 $(BINDIR)/$(MODULE)/:
 	$(Q)mkdir -p $@

--- a/Makefile.base
+++ b/Makefile.base
@@ -107,33 +107,46 @@ $(OBJC_LTO): CFLAGS+=$(LTOFLAGS)
 
 # Define dependencies for object files
 OBJ_DEPS += $(RIOTBUILD_CONFIG_HEADER_C)
-ifneq (,$(SHOULD_RUN_KCONFIG))
-  OBJ_DEPS += $(KCONFIG_GENERATED_AUTOCONF_HEADER_C)
-endif
 
-$(OBJC): $(BINDIR)/$(MODULE)/%.o: %.c $(OBJ_DEPS)
+$(OBJC): $(BINDIR)/$(MODULE)/%.o: %.c $(OBJ_DEPS) | $(if $(SHOULD_RUN_KCONFIG),$(KCONFIG_GENERATED_AUTOCONF_HEADER_C))
 	$(Q)$(CCACHE) $(CC) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
+ifneq (,$(SHOULD_RUN_KCONFIG))
+	$(Q)$(FIXDEP) $(@:.o=.d) $@ $(KCONFIG_SYNC_DIR) > $(@:.o=.tmp)
+	$(Q)mv $(@:.o=.tmp) $(@:.o=.d)
+endif
 
-$(GENOBJC): %.o: %.c $(OBJ_DEPS)
+$(GENOBJC): %.o: %.c $(OBJ_DEPS) | $(if $(SHOULD_RUN_KCONFIG),$(KCONFIG_GENERATED_AUTOCONF_HEADER_C))
 	$(Q) $(CCACHE) $(CC) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$<)\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $<
+ifneq (,$(SHOULD_RUN_KCONFIG))
+	$(Q)$(FIXDEP) $(@:.o=.d) $@ $(KCONFIG_SYNC_DIR) > $(@:.o=.tmp)
+	$(Q)mv $(@:.o=.tmp) $(@:.o=.d)
+endif
 
-$(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.$(SRCXXEXT) $(OBJ_DEPS)
+$(OBJCXX): $(BINDIR)/$(MODULE)/%.o: %.$(SRCXXEXT) $(OBJ_DEPS) | $(if $(SHOULD_RUN_KCONFIG),$(KCONFIG_GENERATED_AUTOCONF_HEADER_C))
 	$(Q)$(CCACHE) $(CXX) \
 		-DRIOT_FILE_RELATIVE=\"$(patsubst $(RIOTBASE)/%,%,$(abspath $<))\" \
 		-DRIOT_FILE_NOPATH=\"$(notdir $<)\" \
 		$(CXXFLAGS) $(CXXINCLUDES) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
+ifneq (,$(SHOULD_RUN_KCONFIG))
+	$(Q)$(FIXDEP) $(@:.o=.d) $@ $(KCONFIG_SYNC_DIR) > $(@:.o=.tmp)
+	$(Q)mv $(@:.o=.tmp) $(@:.o=.d)
+endif
 
 $(ASMOBJ): $(BINDIR)/$(MODULE)/%.o: %.s
 	$(Q)$(AS) $(ASFLAGS) -o $@ $(abspath $<)
 
-$(ASSMOBJ): $(BINDIR)/$(MODULE)/%.o: %.S $(OBJ_DEPS)
+$(ASSMOBJ): $(BINDIR)/$(MODULE)/%.o: %.S $(OBJ_DEPS) | $(if $(SHOULD_RUN_KCONFIG),$(KCONFIG_GENERATED_AUTOCONF_HEADER_C))
 	$(Q)$(CCAS) $(CCASFLAGS) $(INCLUDES) -MQ '$@' -MD -MP -c -o $@ $(abspath $<)
+ifneq (,$(SHOULD_RUN_KCONFIG))
+	$(Q)$(FIXDEP) $(@:.o=.d) $@ $(KCONFIG_SYNC_DIR) > $(@:.o=.tmp)
+	$(Q)mv $(@:.o=.tmp) $(@:.o=.d)
+endif
 
 # pull in dependency info for *existing* .o files
 # deleted header files will be silently ignored

--- a/dist/tools/ci/changed_files.sh
+++ b/dist/tools/ci/changed_files.sh
@@ -8,7 +8,7 @@
 
 changed_files() {
     : ${FILEREGEX:='\.([CcHh]|[ch]pp)$'}
-    : ${EXCLUDE:='^(.+/vendor/|dist/tools/coccinelle/include|boards/common/msba2/tools/src)'}
+    : ${EXCLUDE:='^(.+/vendor/|dist/tools/coccinelle/include|dist/tools/fixdep/fixdep.c|boards/common/msba2/tools/src)'}
     : ${DIFFFILTER:='ACMR'}
 
     DIFFFILTER="--diff-filter=${DIFFFILTER}"

--- a/dist/tools/fixdep/.gitignore
+++ b/dist/tools/fixdep/.gitignore
@@ -1,0 +1,2 @@
+fixdep
+fixdep_patched.c

--- a/dist/tools/fixdep/Makefile
+++ b/dist/tools/fixdep/Makefile
@@ -1,0 +1,11 @@
+all: fixdep
+
+fixdep_patched.c: fixdep.c
+	patch $^ fixdep_riot.patch -o $@
+
+fixdep: fixdep_patched.c
+	$(CC) -O3 -Wall $^ -o $@
+
+clean:
+	$(RM) fixdep_patched.c
+	$(RM) fixdep

--- a/dist/tools/fixdep/README.md
+++ b/dist/tools/fixdep/README.md
@@ -1,0 +1,29 @@
+## Rationale
+
+- Kconfig with the `--sync-deps` flag creates a directory tree in the $(BINDIR) folder
+- This directory tree contains dummy header files for each Kconfig configuration symbol
+- `fixdep` is a tool from the linux kernel [1] to rewrite dependency
+  files (`*.d`) to include the corresponding dummy header files
+- This way, `make` is able to draw correct dependencies between
+  compilation units and configuration symbols
+- => `--sync-deps` and `fixdep` enable incremental compilations, i.e.,
+  only those compilation units are rebuilt, which are affected by
+  configuration changes.
+
+[1] https://github.com/torvalds/linux/blob/83bdc7275e6206f560d247be856bceba3e1ed8f2/scripts/basic/fixdep.c
+
+## Changes to the original script
+
+The patch file `fixdep_riot.patch` contains a few necessary changes
+and enhancements to `fixdep.c` in order to make the generated `*.d`
+dependency files compatible with our build system.
+
+- The input parameters of `fixdep` are changed to:
+    ```
+    ./fixdep <dependency_file> <target> <sync_deps_dir>
+    ```
+- The hardcoded `include/config` folder location in `fixdep.c` is
+  changed to be configurable (passed from the command line)
+- Our Kconfig integration does not use the `_MODULE` suffix for
+  configurations. This is reflected in the parsing functionality of
+  `fixdep.c`

--- a/dist/tools/fixdep/fixdep.c
+++ b/dist/tools/fixdep/fixdep.c
@@ -1,0 +1,404 @@
+/*
+ * "Optimize" a list of dependencies as spit out by gcc -MD
+ * for the kernel build
+ * ===========================================================================
+ *
+ * Author       Kai Germaschewski
+ * Copyright    2002 by Kai Germaschewski  <kai.germaschewski@gmx.de>
+ *
+ * This software may be used and distributed according to the terms
+ * of the GNU General Public License, incorporated herein by reference.
+ *
+ *
+ * Introduction:
+ *
+ * gcc produces a very nice and correct list of dependencies which
+ * tells make when to remake a file.
+ *
+ * To use this list as-is however has the drawback that virtually
+ * every file in the kernel includes autoconf.h.
+ *
+ * If the user re-runs make *config, autoconf.h will be
+ * regenerated.  make notices that and will rebuild every file which
+ * includes autoconf.h, i.e. basically all files. This is extremely
+ * annoying if the user just changed CONFIG_HIS_DRIVER from n to m.
+ *
+ * So we play the same trick that "mkdep" played before. We replace
+ * the dependency on autoconf.h by a dependency on every config
+ * option which is mentioned in any of the listed prerequisites.
+ *
+ * kconfig populates a tree in include/config/ with an empty file
+ * for each config symbol and when the configuration is updated
+ * the files representing changed config options are touched
+ * which then let make pick up the changes and the files that use
+ * the config symbols are rebuilt.
+ *
+ * So if the user changes his CONFIG_HIS_DRIVER option, only the objects
+ * which depend on "include/config/his/driver.h" will be rebuilt,
+ * so most likely only his driver ;-)
+ *
+ * The idea above dates, by the way, back to Michael E Chastain, AFAIK.
+ *
+ * So to get dependencies right, there are two issues:
+ * o if any of the files the compiler read changed, we need to rebuild
+ * o if the command line given to the compile the file changed, we
+ *   better rebuild as well.
+ *
+ * The former is handled by using the -MD output, the later by saving
+ * the command line used to compile the old object and comparing it
+ * to the one we would now use.
+ *
+ * Again, also this idea is pretty old and has been discussed on
+ * kbuild-devel a long time ago. I don't have a sensibly working
+ * internet connection right now, so I rather don't mention names
+ * without double checking.
+ *
+ * This code here has been based partially based on mkdep.c, which
+ * says the following about its history:
+ *
+ *   Copyright abandoned, Michael Chastain, <mailto:mec@shout.net>.
+ *   This is a C version of syncdep.pl by Werner Almesberger.
+ *
+ *
+ * It is invoked as
+ *
+ *   fixdep <depfile> <target> <cmdline>
+ *
+ * and will read the dependency file <depfile>
+ *
+ * The transformed dependency snipped is written to stdout.
+ *
+ * It first generates a line
+ *
+ *   cmd_<target> = <cmdline>
+ *
+ * and then basically copies the .<target>.d file to stdout, in the
+ * process filtering out the dependency on autoconf.h and adding
+ * dependencies on include/config/my/option.h for every
+ * CONFIG_MY_OPTION encountered in any of the prerequisites.
+ *
+ * We don't even try to really parse the header files, but
+ * merely grep, i.e. if CONFIG_FOO is mentioned in a comment, it will
+ * be picked up as well. It's not a problem with respect to
+ * correctness, since that can only give too many dependencies, thus
+ * we cannot miss a rebuild. Since people tend to not mention totally
+ * unrelated CONFIG_ options all over the place, it's not an
+ * efficiency problem either.
+ *
+ * (Note: it'd be easy to port over the complete mkdep state machine,
+ *  but I don't think the added complexity is worth it)
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+
+static void usage(void)
+{
+	fprintf(stderr, "Usage: fixdep <depfile> <target> <cmdline>\n");
+	exit(1);
+}
+
+/*
+ * In the intended usage of this program, the stdout is redirected to .*.cmd
+ * files. The return value of printf() and putchar() must be checked to catch
+ * any error, e.g. "No space left on device".
+ */
+static void xprintf(const char *format, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, format);
+	ret = vprintf(format, ap);
+	if (ret < 0) {
+		perror("fixdep");
+		exit(1);
+	}
+	va_end(ap);
+}
+
+static void xputchar(int c)
+{
+	int ret;
+
+	ret = putchar(c);
+	if (ret == EOF) {
+		perror("fixdep");
+		exit(1);
+	}
+}
+
+/*
+ * Print out a dependency path from a symbol name
+ */
+static void print_dep(const char *m, int slen, const char *dir)
+{
+	int c, prev_c = '/', i;
+
+	xprintf("    $(wildcard %s/", dir);
+	for (i = 0; i < slen; i++) {
+		c = m[i];
+		if (c == '_')
+			c = '/';
+		else
+			c = tolower(c);
+		if (c != '/' || prev_c != '/')
+			xputchar(c);
+		prev_c = c;
+	}
+	xprintf(".h) \\\n");
+}
+
+struct item {
+	struct item	*next;
+	unsigned int	len;
+	unsigned int	hash;
+	char		name[];
+};
+
+#define HASHSZ 256
+static struct item *hashtab[HASHSZ];
+
+static unsigned int strhash(const char *str, unsigned int sz)
+{
+	/* fnv32 hash */
+	unsigned int i, hash = 2166136261U;
+
+	for (i = 0; i < sz; i++)
+		hash = (hash ^ str[i]) * 0x01000193;
+	return hash;
+}
+
+/*
+ * Lookup a value in the configuration string.
+ */
+static int is_defined_config(const char *name, int len, unsigned int hash)
+{
+	struct item *aux;
+
+	for (aux = hashtab[hash % HASHSZ]; aux; aux = aux->next) {
+		if (aux->hash == hash && aux->len == len &&
+		    memcmp(aux->name, name, len) == 0)
+			return 1;
+	}
+	return 0;
+}
+
+/*
+ * Add a new value to the configuration string.
+ */
+static void define_config(const char *name, int len, unsigned int hash)
+{
+	struct item *aux = malloc(sizeof(*aux) + len);
+
+	if (!aux) {
+		perror("fixdep:malloc");
+		exit(1);
+	}
+	memcpy(aux->name, name, len);
+	aux->len = len;
+	aux->hash = hash;
+	aux->next = hashtab[hash % HASHSZ];
+	hashtab[hash % HASHSZ] = aux;
+}
+
+/*
+ * Record the use of a CONFIG_* word.
+ */
+static void use_config(const char *m, int slen)
+{
+	unsigned int hash = strhash(m, slen);
+
+	if (is_defined_config(m, slen, hash))
+	    return;
+
+	define_config(m, slen, hash);
+	print_dep(m, slen, "include/config");
+}
+
+/* test if s ends in sub */
+static int str_ends_with(const char *s, int slen, const char *sub)
+{
+	int sublen = strlen(sub);
+
+	if (sublen > slen)
+		return 0;
+
+	return !memcmp(s + slen - sublen, sub, sublen);
+}
+
+static void parse_config_file(const char *p)
+{
+	const char *q, *r;
+	const char *start = p;
+
+	while ((p = strstr(p, "CONFIG_"))) {
+		if (p > start && (isalnum(p[-1]) || p[-1] == '_')) {
+			p += 7;
+			continue;
+		}
+		p += 7;
+		q = p;
+		while (isalnum(*q) || *q == '_')
+			q++;
+		if (str_ends_with(p, q - p, "_MODULE"))
+			r = q - 7;
+		else
+			r = q;
+		if (r > p)
+			use_config(p, r - p);
+		p = q;
+	}
+}
+
+static void *read_file(const char *filename)
+{
+	struct stat st;
+	int fd;
+	char *buf;
+
+	fd = open(filename, O_RDONLY);
+	if (fd < 0) {
+		fprintf(stderr, "fixdep: error opening file: ");
+		perror(filename);
+		exit(2);
+	}
+	if (fstat(fd, &st) < 0) {
+		fprintf(stderr, "fixdep: error fstat'ing file: ");
+		perror(filename);
+		exit(2);
+	}
+	buf = malloc(st.st_size + 1);
+	if (!buf) {
+		perror("fixdep: malloc");
+		exit(2);
+	}
+	if (read(fd, buf, st.st_size) != st.st_size) {
+		perror("fixdep: read");
+		exit(2);
+	}
+	buf[st.st_size] = '\0';
+	close(fd);
+
+	return buf;
+}
+
+/* Ignore certain dependencies */
+static int is_ignored_file(const char *s, int len)
+{
+	return str_ends_with(s, len, "include/generated/autoconf.h") ||
+	       str_ends_with(s, len, "include/generated/autoksyms.h");
+}
+
+/*
+ * Important: The below generated source_foo.o and deps_foo.o variable
+ * assignments are parsed not only by make, but also by the rather simple
+ * parser in scripts/mod/sumversion.c.
+ */
+static void parse_dep_file(char *m, const char *target)
+{
+	char *p;
+	int is_last, is_target;
+	int saw_any_target = 0;
+	int is_first_dep = 0;
+	void *buf;
+
+	while (1) {
+		/* Skip any "white space" */
+		while (*m == ' ' || *m == '\\' || *m == '\n')
+			m++;
+
+		if (!*m)
+			break;
+
+		/* Find next "white space" */
+		p = m;
+		while (*p && *p != ' ' && *p != '\\' && *p != '\n')
+			p++;
+		is_last = (*p == '\0');
+		/* Is the token we found a target name? */
+		is_target = (*(p-1) == ':');
+		/* Don't write any target names into the dependency file */
+		if (is_target) {
+			/* The /next/ file is the first dependency */
+			is_first_dep = 1;
+		} else if (!is_ignored_file(m, p - m)) {
+			*p = '\0';
+
+			/*
+			 * Do not list the source file as dependency, so that
+			 * kbuild is not confused if a .c file is rewritten
+			 * into .S or vice versa. Storing it in source_* is
+			 * needed for modpost to compute srcversions.
+			 */
+			if (is_first_dep) {
+				/*
+				 * If processing the concatenation of multiple
+				 * dependency files, only process the first
+				 * target name, which will be the original
+				 * source name, and ignore any other target
+				 * names, which will be intermediate temporary
+				 * files.
+				 */
+				if (!saw_any_target) {
+					saw_any_target = 1;
+					xprintf("source_%s := %s\n\n",
+						target, m);
+					xprintf("deps_%s := \\\n", target);
+				}
+				is_first_dep = 0;
+			} else {
+				xprintf("  %s \\\n", m);
+			}
+
+			buf = read_file(m);
+			parse_config_file(buf);
+			free(buf);
+		}
+
+		if (is_last)
+			break;
+
+		/*
+		 * Start searching for next token immediately after the first
+		 * "whitespace" character that follows this token.
+		 */
+		m = p + 1;
+	}
+
+	if (!saw_any_target) {
+		fprintf(stderr, "fixdep: parse error; no targets found\n");
+		exit(1);
+	}
+
+	xprintf("\n%s: $(deps_%s)\n\n", target, target);
+	xprintf("$(deps_%s):\n", target);
+}
+
+int main(int argc, char *argv[])
+{
+	const char *depfile, *target, *cmdline;
+	void *buf;
+
+	if (argc != 4)
+		usage();
+
+	depfile = argv[1];
+	target = argv[2];
+	cmdline = argv[3];
+
+	xprintf("cmd_%s := %s\n\n", target, cmdline);
+
+	buf = read_file(depfile);
+	parse_dep_file(buf, target);
+	free(buf);
+
+	return 0;
+}

--- a/dist/tools/fixdep/fixdep_riot.patch
+++ b/dist/tools/fixdep/fixdep_riot.patch
@@ -1,0 +1,63 @@
+104c104
+< 	fprintf(stderr, "Usage: fixdep <depfile> <target> <cmdline>\n");
+---
+> 	fprintf(stderr, "Usage: fixdep <depfile> <target> <depsdir>\n");
+215c215
+< static void use_config(const char *m, int slen)
+---
+> static void use_config(const char *m, int slen, const char *depsdir)
+223c223
+< 	print_dep(m, slen, "include/config");
+---
+> 	print_dep(m, slen, depsdir);
+237c237
+< static void parse_config_file(const char *p)
+---
+> static void parse_config_file(const char *p, const char *depsdir)
+239c239
+< 	const char *q, *r;
+---
+>        const char *q;
+251,256c251,252
+< 		if (str_ends_with(p, q - p, "_MODULE"))
+< 			r = q - 7;
+< 		else
+< 			r = q;
+< 		if (r > p)
+< 			use_config(p, r - p);
+---
+> 		if (q > p)
+>                        use_config(p, q - p, depsdir);
+296,297c292
+< 	return str_ends_with(s, len, "include/generated/autoconf.h") ||
+< 	       str_ends_with(s, len, "include/generated/autoksyms.h");
+---
+> 	return str_ends_with(s, len, "generated/autoconf.h");
+305c300
+< static void parse_dep_file(char *m, const char *target)
+---
+> static void parse_dep_file(char *m, const char *target, const char *depsdir)
+352c347
+< 					xprintf("source_%s := %s\n\n",
+---
+> 					xprintf("deps_%s :=\\\n  %s \\\n",
+354d348
+< 					xprintf("deps_%s := \\\n", target);
+362c356
+< 			parse_config_file(buf);
+---
+> 			parse_config_file(buf, depsdir);
+387c381
+< 	const char *depfile, *target, *cmdline;
+---
+>        const char *depfile, *target, *depsdir;
+395,397c389
+< 	cmdline = argv[3];
+< 
+< 	xprintf("cmd_%s := %s\n\n", target, cmdline);
+---
+> 	depsdir = argv[3];
+400c392
+< 	parse_dep_file(buf, target);
+---
+> 	parse_dep_file(buf, target, depsdir);

--- a/dist/tools/whitespacecheck/ignore_list.txt
+++ b/dist/tools/whitespacecheck/ignore_list.txt
@@ -1,1 +1,2 @@
 */vendor/*
+dist/tools/fixdep/fixdep.c

--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -4,11 +4,14 @@ KCONFIG ?= $(RIOTBASE)/Kconfig
 # Include tools targets
 include $(RIOTMAKE)/tools/kconfiglib.inc.mk
 
+# Include fixdep tool
+include $(RIOTMAKE)/tools/fixdep.inc.mk
+
 # Generated dir will contain Kconfig generated configurations
 GENERATED_DIR = $(BINDIR)/generated
 
 # The sync dir will contain a tree of header files that represent Kconfig symbols
-KCONFIG_SYNC_DIR = $(GENERATED_DIR)/deps
+export KCONFIG_SYNC_DIR = $(GENERATED_DIR)/deps
 
 # This file will contain all generated configuration from kconfig
 export KCONFIG_GENERATED_AUTOCONF_HEADER_C = $(GENERATED_DIR)/autoconf.h
@@ -72,13 +75,13 @@ SHOULD_RUN_KCONFIG ?= $(or $(wildcard $(APPDIR)/*.config), \
                            $(if $(CLEAN),,$(wildcard $(KCONFIG_OUT_CONFIG))), \
                            $(filter menuconfig, $(MAKECMDGOALS)))
 
+# export variable to make it visible in other Makefiles
+export SHOULD_RUN_KCONFIG
+
 ifneq (,$(SHOULD_RUN_KCONFIG))
 
-# Flag to enable the --sync-dir feature of Kconfiglib
-KCONFIG_SYNC_DEPS ?=
-
 # Add configuration header to build dependencies
-BUILDDEPS += $(KCONFIG_GENERATED_AUTOCONF_HEADER_C)
+BUILDDEPS += $(KCONFIG_GENERATED_AUTOCONF_HEADER_C) $(FIXDEP)
 
 # Include configuration header when building
 CFLAGS += -imacros '$(KCONFIG_GENERATED_AUTOCONF_HEADER_C)'
@@ -126,12 +129,11 @@ endif # eq (clean, $(MAKECMDGOALS))
 # as KCONFIG_OUT_CONFIG, and is used to inject the configurations during
 # compilation.
 #
-# This will optionally generate the 'dummy' header files needed for incremental
-# builds.
+# This will generate the 'dummy' header files needed for incremental builds.
 $(KCONFIG_GENERATED_AUTOCONF_HEADER_C): $(KCONFIG_OUT_CONFIG)
 	$(Q) $(GENCONFIG) \
 	  --header-path $(KCONFIG_GENERATED_AUTOCONF_HEADER_C) \
-	  $(if $(KCONFIG_SYNC_DEPS),--sync-deps $(KCONFIG_SYNC_DIR)) \
+	  --sync-deps $(KCONFIG_SYNC_DIR) \
 	  --kconfig-filename $(KCONFIG) \
 	  --config-sources $(KCONFIG_OUT_CONFIG) && \
 	  touch $(KCONFIG_GENERATED_AUTOCONF_HEADER_C)

--- a/makefiles/tools/fixdep.inc.mk
+++ b/makefiles/tools/fixdep.inc.mk
@@ -1,0 +1,7 @@
+# Define tools to use
+FIXDEP_DIR ?= $(RIOTTOOLS)/fixdep
+FIXDEP ?= $(FIXDEP_DIR)/fixdep
+
+$(FIXDEP):
+	@echo "[INFO] fixdep not found - building it"
+	$(Q)env -u CC -u CFLAGS $(MAKE) -C $(FIXDEP_DIR)


### PR DESCRIPTION
### Contribution description
This change enables incremental compilation with Kconfig on configuration changes.

#### Current state
`autoconf.h` includes all configurations and is injected into each `gcc` call (like `riotbuild.h`) when compiling object files.
This means: every time a configuration is changed in Kconfig, then all object files are rebuilt, even if the config symbol is irrelevant for the object.

#### Solution
Similar to the linux kernel, this PR modifies the dependency file (`*.d`) of the object files (`*.o`) using the [`fixdep`](https://github.com/torvalds/linux/blob/master/scripts/basic/fixdep.c) tool from the linux kernel. The `fixdep` tool is imported into `dist/tools` and slightly enhanced to work with our build system.

##### Kconfig:
1. `--sync-deps` creates a directory tree in `$(BINDIR)/generated/deps` with dummy header files organized with the following logic:
    ```sh
    CONFIG_COAP_ACK_TIMEOUT => coap/ack/timeout.h
    CONFIG_GCOAP_PORT       => gcoap/port.h
    ```
2. everytime a config symbol is changed, then the corresponding dummy header file is touched.

##### The `fixdep` tool does two things:
1. it removes `autoconf.h` from the dependencies of the object file
2. it scans the `*.[c|h]` files that appear in the `*.d` files for `CONFIG_*` symbols.
    It then builds new dependency rules by replacing `_` with `/` and adds them to the `*.d` dependency files.

##### Example for `examples/gcoap/`
Before: `$(BINDIR)/native/gcoap/gcoap.d`
```make
RIOT/examples/gcoap/bin/native/gcoap/gcoap.o: \
 RIOT/sys/net/application_layer/gcoap/gcoap.c \
 RIOT/examples/gcoap/bin/native/generated/autoconf.h \
 /usr/include/stdc-predef.h \
...
```

After: `$(BINDIR)/native/gcoap/gcoap.d`
```make
deps_RIOT/examples/gcoap/bin/native/gcoap/gcoap.o :=\
 RIOT/sys/net/application_layer/gcoap/gcoap.c \
    $(wildcard RIOT/examples/gcoap/bin/native/generated/deps/coap/ack/timeout.h) \
    $(wildcard RIOT/examples/gcoap/bin/native/generated/deps/gcoap/port.h) \
...
RIOT/examples/gcoap/bin/native/gcoap/gcoap.o: $(deps_RIOT/examples/gcoap/bin/native/gcoap/gcoap.o)

$(deps_RIOT/examples/gcoap/bin/native/gcoap/gcoap.o):
```
### Testing procedure
1.
    ```sh
    SHOULD_RUN_KCONFIG=1 make all
    ```
    This should create a directory tree in `$(BINDIR)/generated/deps`.
2. change a configuration with
    ```sh
    SHOULD_RUN_KCONFIG=1 make menuconfig
    ```
3. Rebuild:
    ```sh
    SHOULD_RUN_KCONFIG=1 make all
    ```
The second compilation should only rebuild files that are affected by the configuration change.

### Issues/PRs references
depends on #14727