### PR TITLE
tests/shell: allow not using socat, do so on z1

### DIFF
--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -6,10 +6,13 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 
+# for z1, socat doesn't work (unknown reason)
+ifeq (z1, $(BOARD))
+  RIOT_TERMINAL ?= pyterm
+endif
+
 # Use a terminal that does not introduce extra characters into the stream.
 RIOT_TERMINAL ?= socat
-
-DISABLE_MODULE += test_utils_interactive_sync
 
 # chronos is missing a getchar implementation
 BOARD_BLACKLIST += chronos
@@ -17,3 +20,6 @@ BOARD_BLACKLIST += chronos
 APP_SHELL_FMT ?= NONE
 
 include $(RIOTBASE)/Makefile.include
+
+# the test script skips tests if socat is not used
+$(call target-export-variables,$(RIOT_TERMINAL),RIOT_TERMINAL)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

For some reason, socat doesn't work properly on z1.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
