### PR TITLE
makefiles/kconfig.mk: include KCONFIG_OUT_CONFIG unconditionally

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -678,9 +678,11 @@ pkg-build-%: $(BUILDDEPS)
 	$(QQ)"$(MAKE)" -C $(RIOTPKG)/$*
 
 clean:
+ifndef MAKE_RESTARTS
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i clean ; done
 	-@rm -rf $(BINDIR)
 	-@rm -rf $(SCANBUILD_OUTPUTDIR)
+endif
 
 # Remove intermediates, but keep the .elf, .hex and .map etc.
 clean-intermediates:

--- a/makefiles/kconfig.mk
+++ b/makefiles/kconfig.mk
@@ -38,17 +38,10 @@ KCONFIG_MERGED_CONFIG = $(GENERATED_DIR)/merged.config
 # configuration symbols to the build system.
 KCONFIG_OUT_CONFIG = $(GENERATED_DIR)/out.config
 
-# Include configuration symbols if available, only when not cleaning. This
-# allows to check for Kconfig symbols in makefiles.
-# Make tries to 'remake' all included files
-# (see https://www.gnu.org/software/make/manual/html_node/Remaking-Makefiles.html).
-# So if this file was included even when 'clean' is called, make would enter a
-# loop, as it always is out-of-date.
-# This has the side effect of requiring a Kconfig user to run 'clean' on a
-# separate call (e.g. 'make clean && make all'), to get the symbols correctly.
-ifneq ($(CLEAN),clean)
-  -include $(KCONFIG_OUT_CONFIG)
-endif
+# Include configuration symbols if available. This allows to check for Kconfig
+# symbols in makefiles. Make tries to 'remake' all included files (see
+# https://www.gnu.org/software/make/manual/html_node/Remaking-Makefiles.html).
+-include $(KCONFIG_OUT_CONFIG)
 
 # Flag that indicates that the configuration has been edited
 KCONFIG_EDITED_CONFIG = $(GENERATED_DIR)/.editedconfig
@@ -128,6 +121,9 @@ $(KCONFIG_MERGED_CONFIG): $(MERGECONFIG) $(KCONFIG_GENERATED_DEPENDENCIES) FORCE
 
 # Build a header file with all the Kconfig configurations. genconfig will avoid
 # any unnecessary rewrites of the header file if no configurations changed.
+# The rule is not included when only `make clean` is called in order to keep the
+# $(BINDIR) folder clean
+ifneq (clean,$(MAKECMDGOALS))
 $(KCONFIG_OUT_CONFIG) $(KCONFIG_GENERATED_AUTOCONF_HEADER_C) &: $(KCONFIG_GENERATED_DEPENDENCIES) $(GENCONFIG) $(KCONFIG_MERGED_CONFIG) FORCE
 	$(Q) \
 	KCONFIG_CONFIG=$(KCONFIG_MERGED_CONFIG) $(GENCONFIG) \
@@ -135,4 +131,6 @@ $(KCONFIG_OUT_CONFIG) $(KCONFIG_GENERATED_AUTOCONF_HEADER_C) &: $(KCONFIG_GENERA
 	  --header-path $(KCONFIG_GENERATED_AUTOCONF_HEADER_C) \
 	  $(if $(KCONFIG_SYNC_DEPS),--sync-deps $(KCONFIG_SYNC_DIR)) \
 	  $(KCONFIG)
+endif
+
 endif


### PR DESCRIPTION
### Contribution description
This allows to include the `KCONFIG_OUT_CONFIG` file in Makefile unconditionally, which means that `make clean all` is now allowed when using Kconfig.

For this, the recipe for `clean` is guarded with `MAKE_RESTARTS` so the `BINDIR` folder is not removed once Make restarts scanning the files.

#### The problem and the current workaround
In order to have Kconfig symbols' information in the build system `kconfig.mk` includes `KCONFIG_OUT_CONFIG`, which holds the same information as `autoconf.h` but with Makefile syntax. The way Make works is that it reads all the Makefiles and tries to rebuild them once it's done (see https://www.gnu.org/software/make/manual/html_node/Remaking-Makefiles.html#Remaking-Makefiles). If a file is updated in that process then Make starts scanning from scratch.

This has the issue that, as `KCONFIG_OUT_CONFIG` is generated in the `bin/<board>/generated` folder, clean would be re-triggered, and Make would try to rebuild the file, entering an infinite loop. To avoid this, the inclusion of `KCONFIG_OUT_CONFIG` is guarded in the current master, meaning that the Kconfig information is not available to the build system when calling `make clean all`.

#### This solution
As the recipe for `KCONFIG_OUT_CONFIG` depends ultimately on `$(CLEAN)`, it is guarantied that the target is executed before generating the file. By guarding the recipe for `clean` with `MAKE_RESTARTS` (see https://www.gnu.org/software/make/manual/html_node/Special-Variables.html), once Make starts over (after cleaning and creating `KCONFIG_OUT_CONFIG`) it will not attempt to clean the bin folder again.

This allows to include `KCONFIG_OUT_CONFIG` unconditionally and to call `make clean all` when using Kconfig and still get the symbol information into the build system.  

### Testing procedure
Trying to access a Kconfig symbol from the build system applying this patch would not work on master when calling `make clean all`:
```patch
diff --git a/tests/kconfig/Makefile b/tests/kconfig/Makefile
index e386d876b9..693a086ca9 100644
--- a/tests/kconfig/Makefile
+++ b/tests/kconfig/Makefile
@@ -1,2 +1,6 @@
 include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include
+
+ifdef CONFIG_KCONFIG_APP_MSG_1
+  $(info Msg1!)
+endif
```

With this PR the message should be printed on the second scan of Makefiles.

Cleaning and building should work normally when not using Kconfig as well.

### Issues/PRs references
