### PR TITLE
tests/bench_*: Add ticks per iteration results

### DIFF
--- a/tests/bench_msg_pingpong/main.c
+++ b/tests/bench_msg_pingpong/main.c
@@ -19,6 +19,7 @@
  */
 
 #include <stdio.h>
+#include "macros/units.h"
 #include "thread.h"
 
 #include "msg.h"
@@ -75,7 +76,12 @@ int main(void)
         n++;
     }
 
-    printf("{ \"result\" : %"PRIu32" }\n", n);
+    printf("{ \"result\" : %"PRIu32, n);
+#ifdef CLOCK_CORECLOCK
+    printf(", \"ticks\" : %"PRIu32,
+           (uint32_t)((TEST_DURATION/US_PER_MS) * (CLOCK_CORECLOCK/KHZ(1)))/n);
+#endif
+    puts(" }");
 
     return 0;
 }

--- a/tests/bench_msg_pingpong/tests/01-run.py
+++ b/tests/bench_msg_pingpong/tests/01-run.py
@@ -12,7 +12,7 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect(r"{ \"result\" : \d+ }")
+    child.expect(r"{ \"result\" : \d+(, \"ticks\" : \d+)? }")
 
 
 if __name__ == "__main__":

--- a/tests/bench_mutex_pingpong/main.c
+++ b/tests/bench_mutex_pingpong/main.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 
+#include "macros/units.h"
 #include "mutex.h"
 #include "thread.h"
 #include "xtimer.h"
@@ -78,7 +79,12 @@ int main(void)
         n++;
     }
 
-    printf("{ \"result\" : %"PRIu32" }\n", n);
+    printf("{ \"result\" : %"PRIu32, n);
+#ifdef CLOCK_CORECLOCK
+    printf(", \"ticks\" : %"PRIu32,
+           (uint32_t)((TEST_DURATION/US_PER_MS) * (CLOCK_CORECLOCK/KHZ(1)))/n);
+#endif
+    puts(" }");
 
     return 0;
 }

--- a/tests/bench_mutex_pingpong/tests/01-run.py
+++ b/tests/bench_mutex_pingpong/tests/01-run.py
@@ -12,7 +12,7 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect(r"{ \"result\" : \d+ }")
+    child.expect(r"{ \"result\" : \d+(, \"ticks\" : \d+)? }")
 
 
 if __name__ == "__main__":

--- a/tests/bench_sched_nop/main.c
+++ b/tests/bench_sched_nop/main.c
@@ -19,6 +19,7 @@
  */
 
 #include <stdio.h>
+#include "macros/units.h"
 #include "thread.h"
 
 #include "xtimer.h"
@@ -51,7 +52,12 @@ int main(void)
         n++;
     }
 
-    printf("{ \"result\" : %"PRIu32" }\n", n);
+    printf("{ \"result\" : %"PRIu32, n);
+#ifdef CLOCK_CORECLOCK
+    printf(", \"ticks\" : %"PRIu32,
+           (uint32_t)((TEST_DURATION/US_PER_MS) * (CLOCK_CORECLOCK/KHZ(1)))/n);
+#endif
+    puts(" }");
 
     return 0;
 }

--- a/tests/bench_sched_nop/tests/01-run.py
+++ b/tests/bench_sched_nop/tests/01-run.py
@@ -12,7 +12,7 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect(r"{ \"result\" : \d+ }")
+    child.expect(r"{ \"result\" : \d+(, \"ticks\" : \d+)? }")
 
 
 if __name__ == "__main__":

--- a/tests/bench_thread_flags_pingpong/main.c
+++ b/tests/bench_thread_flags_pingpong/main.c
@@ -19,6 +19,7 @@
  */
 
 #include <stdio.h>
+#include "macros/units.h"
 #include "thread.h"
 
 #include "thread_flags.h"
@@ -74,7 +75,12 @@ int main(void)
         n++;
     }
 
-    printf("{ \"result\" : %"PRIu32" }\n", n);
+    printf("{ \"result\" : %"PRIu32, n);
+#ifdef CLOCK_CORECLOCK
+    printf(", \"ticks\" : %"PRIu32,
+           (uint32_t)((TEST_DURATION/US_PER_MS) * (CLOCK_CORECLOCK/KHZ(1)))/n);
+#endif
+    puts(" }");
 
     return 0;
 }

--- a/tests/bench_thread_flags_pingpong/tests/01-run.py
+++ b/tests/bench_thread_flags_pingpong/tests/01-run.py
@@ -12,7 +12,7 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect(r"{ \"result\" : \d+ }")
+    child.expect(r"{ \"result\" : \d+(, \"ticks\" : \d+)? }")
 
 
 if __name__ == "__main__":

--- a/tests/bench_thread_yield_pingpong/main.c
+++ b/tests/bench_thread_yield_pingpong/main.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 
+#include "macros/units.h"
 #include "thread.h"
 #include "xtimer.h"
 
@@ -71,7 +72,12 @@ int main(void)
         n++;
     }
 
-    printf("{ \"result\" : %"PRIu32" }\n", n);
+    printf("{ \"result\" : %"PRIu32, n);
+#ifdef CLOCK_CORECLOCK
+    printf(", \"ticks\" : %"PRIu32,
+           (uint32_t)((TEST_DURATION/US_PER_MS) * (CLOCK_CORECLOCK/KHZ(1)))/n);
+#endif
+    puts(" }");
 
     return 0;
 }

--- a/tests/bench_thread_yield_pingpong/tests/01-run.py
+++ b/tests/bench_thread_yield_pingpong/tests/01-run.py
@@ -12,7 +12,7 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect(r"{ \"result\" : \d+ }")
+    child.expect(r"{ \"result\" : \d+(, \"ticks\" : \d+)? }")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description

This PR extends the benchmark tests that print a direct result for the number of iterations with the number of clock ticks per iteration. This allows for better comparison of benchmark between commits by showing the exact number of clock ticks gained or lost.

The value is intentionally not divided by two for the pingpong test where the result is effectively half the number of context switches.

On platforms such as native where the clock speed is not available, the extra result is not printed.

The python tests scripts are adapted to match the added string content.

### Testing procedure

Every affected benchmark should print an additional value calculated as the test duration (in seconds) multiplied by the CPU clock speed of the node and divided by the number of iterations per second (the original `result`). The value should be unaffected by the duration of the test (except for getting more accurate).

### Issues/PRs references

None