### PR TITLE
cpu/samd21: add support for SAMD20 & SAM D20 Xplained Pro board

### DIFF
--- a/boards/samd20-xpro/Kconfig
+++ b/boards/samd20-xpro/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "samd20-xpro" if BOARD_SAMD20_XPRO
+
+config BOARD_SAMD20_XPRO
+    bool
+    default y
+    select CPU_MODEL_SAMD20J18
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_DAC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/samd20-xpro/Makefile
+++ b/boards/samd20-xpro/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/samd20-xpro/Makefile.dep
+++ b/boards/samd20-xpro/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/samd20-xpro/Makefile.features
+++ b/boards/samd20-xpro/Makefile.features
@@ -1,0 +1,13 @@
+CPU = samd21
+CPU_MODEL = samd20j18
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dac
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart

--- a/boards/samd20-xpro/Makefile.include
+++ b/boards/samd20-xpro/Makefile.include
@@ -1,0 +1,1 @@
+include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/samd20-xpro/board.c
+++ b/boards/samd20-xpro/board.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_samd20-xpro
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the Atmel SAM D20 Xplained
+ *              Pro board
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the on-board LED */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    LED0_OFF;
+
+    /* initialize the on-board button */
+    gpio_init(BTN0_PIN, BTN0_MODE);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/samd20-xpro/dist/openocd.cfg
+++ b/boards/samd20-xpro/dist/openocd.cfg
@@ -1,0 +1,2 @@
+source [find target/at91samdXX.cfg]
+$_TARGETNAME configure -rtos auto

--- a/boards/samd20-xpro/doc.txt
+++ b/boards/samd20-xpro/doc.txt
@@ -1,0 +1,85 @@
+/**
+@defgroup    boards_samd20-xpro Atmel SAM D20 Xplained Pro
+@ingroup     boards
+@brief       Support for the Atmel SAM D20 Xplained Pro board.
+
+## Overview
+
+The `SAMD20 Xplained Pro` is an ultra-low power evaluation board by Atmel
+featuring an ATSAMD20J18 SoC. The SoC includes a SAMD20 ARM Cortex-M0+ micro-
+controller. For programming the MCU comes with 32Kb of RAM and 256Kb of flash
+memory.
+
+## Hardware
+
+![samd20-xpro image](https://keilpack.azureedge.net/content/Keil.SAMD20_DFP.1.1.1/Boards/Atmel/SAMD20-XPRO/Documents/SAMD20-XPRO_large.png)
+
+
+### MCU
+| MCU            | ATSAMD20J18A      |
+|:-------------- |:--------------------------------- |
+| Family         | ARM Cortex-M0+                    |
+| Vendor         | Atmel                             |
+| RAM            | 32 KiB                            |
+| Flash          | 256 KiB                           |
+| Frequency      | up to 48MHz                       |
+| FPU            | no                                |
+| Timers         | 8 (16-bit)                        |
+| ADCs           | 1x 12-bit (20 channels)           |
+| UARTs          | max 6 (shared with SPI and I2C)   |
+| SPIs           | max 6 (see UART)                  |
+| I2Cs           | max 6 (see UART)                  |
+| Vcc            | 1.62V - 3.63V                     |
+| Datasheet      | [Datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM_D20_%20Family_Datasheet_DS60001504C.pdf) |
+| Board Manual   | [Board Manual](http://ww1.microchip.com/downloads/en/DeviceDoc/Atmel-42102-SAMD20-Xplained-Pro_User-Guide.pdf)|
+
+### User Interface
+
+1 User button and 1 LED:
+
+| Device        | PIN   |
+|:------------- |:----- |
+| LED0          | PA14  |
+| SW0 (button)  | PA15  |
+
+## Flashing the device
+
+Connect the device to your Micro-USB cable using the port labeled as *DEBUG
+USB*.
+
+The standard method for flashing RIOT to the samd20-xpro is using OpenOCD.
+
+Refer to https://github.com/RIOT-OS/RIOT/wiki/OpenOCD for general
+instructions on building OpenOCD and make sure "cmsis-dap" and "hidapi-libusb"
+are enabled.
+
+On Linux you will have to add a **udev** rule for hidraw, like
+```
+bash
+echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0664", GROUP="plugdev"' \
+    | sudo tee -a /etc/udev/rules.d/99-usb.rules
+sudo service udev restart
+```
+
+### Arch Linux
+With yaourt:
+```
+yaourt -S hidapi-git
+yaourt -S openocd-git
+# edit PKGBUILD, add "cmsis-dap hidapi-libusb" to "_features"
+```
+
+### Ubuntu
+Although this refers to setting up the SAMR21, this guide is still very
+helpful to understanding how to set up a solid RIOT development environment for
+the SAMD20: http://watr.li/samr21-dev-setup-ubuntu.html
+
+## Supported Toolchains
+
+For using the samd20-xpro board we strongly recommend the usage of the
+[GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
+toolchain.
+
+## Known Issues / Problems
+
+ */

--- a/boards/samd20-xpro/include/board.h
+++ b/boards/samd20-xpro/include/board.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_samd20-xpro
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Atmel SAM D20 Xplained Pro
+ *              board
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_DEV          TIMER_DEV(0)
+#define XTIMER_CHAN         (0)
+/** @} */
+
+/**
+ * @name   LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PA, 14)
+
+#define LED_PORT            PORT->Group[PA]
+#define LED0_MASK           (1 << 14)
+
+#define LED0_ON             (LED_PORT.OUTCLR.reg = LED0_MASK)
+#define LED0_OFF            (LED_PORT.OUTSET.reg = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)
+/** @} */
+
+/**
+ * @name SW0 (Button) pin definitions
+ * @{
+ */
+#define BTN0_PORT           PORT->Group[PA]
+#define BTN0_PIN            GPIO_PIN(PA, 15)
+#define BTN0_MODE           GPIO_IN_PU
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/samd20-xpro/include/gpio_params.h
+++ b/boards/samd20-xpro/include/gpio_params.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_samd20-xpro
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(orange)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .name = "Button(SW0)",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/samd20-xpro/include/periph_conf.h
+++ b/boards/samd20-xpro/include/periph_conf.h
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_samd20-xpro
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for the Atmel SAM D20 Xplained
+ *              Pro board
+ *
+ * @author      Travis Griggs <travisgriggs@gmail.com>
+ * @author      Dan Evans <photonthunder@gmail.com>
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   External oscillator and clock configuration
+ *
+ * There are three choices for selection of CORECLOCK:
+ *
+ * - usage of the 48 MHz DFLL fed by external oscillator running at 32 kHz
+ * - usage of the PLL fed by the internal 8MHz oscillator divided by 8
+ * - usage of the internal 8MHz oscillator directly, divided by N if needed
+ *
+ *
+ * The PLL option allows for the usage of a wider frequency range and a more
+ * stable clock with less jitter. This is why this option is default.
+ *
+ * The target frequency is computed from the PLL multiplier and the PLL divisor.
+ * Use the following formula to compute your values:
+ *
+ * CORECLOCK = ((PLL_MUL + 1) * 1MHz) / PLL_DIV
+ *
+ * NOTE: The PLL circuit does not run with less than 32MHz while the maximum PLL
+ *       frequency is 96MHz. So PLL_MULL must be between 31 and 95!
+ *
+ *
+ * The internal Oscillator used directly can lead to a slightly better power
+ * efficiency to the cost of a less stable clock. Use this option when you know
+ * what you are doing! The actual core frequency is adjusted as follows:
+ *
+ * CORECLOCK = 8MHz / DIV
+ *
+ * NOTE: A core clock frequency below 1MHz is not recommended
+ *
+ * @{
+ */
+#define CLOCK_USE_PLL               (0)
+#define CLOCK_USE_XOSC32_DFLL       (1)
+/*
+ * 0: use XOSC32K (always 32.768kHz) to clock GCLK2
+ * 1: use OSCULP32K factory calibrated (~32.768kHz) to clock GCLK2
+ *
+ * OSCULP32K is factory calibrated to be around 32.768kHz but this values can
+ * be of by a couple off % points, so prefer XOSC32K as default configuration.
+ */
+#define GEN2_ULP32K                 (0)
+
+#if CLOCK_USE_PLL
+/* edit these values to adjust the PLL output frequency */
+#define CLOCK_PLL_MUL       (47U)               /* must be >= 31 & <= 95 */
+#define CLOCK_PLL_DIV       (1U)                /* adjust to your needs */
+/* generate the actual used core clock frequency */
+#define CLOCK_CORECLOCK     (((CLOCK_PLL_MUL + 1) * 1000000U) / CLOCK_PLL_DIV)
+#elif CLOCK_USE_XOSC32_DFLL
+/* Settings for 32 kHz external oscillator and 48 MHz DFLL */
+#define CLOCK_CORECLOCK     (48000000U)
+#define CLOCK_XOSC32K       (32768UL)
+#define CLOCK_8MHZ          (1)
+#else
+/* edit this value to your needs */
+#define CLOCK_DIV           (1U)
+/* generate the actual core clock frequency */
+#define CLOCK_CORECLOCK     (8000000 / CLOCK_DIV)
+#endif
+/** @} */
+
+/**
+ * @name Timer peripheral configuration
+ * @{
+ */
+static const tc32_conf_t timer_config[] = {
+    {   /* Timer 0 - System Clock */
+        .dev            = TC0,
+        .irq            = TC0_IRQn,
+        .pm_mask        = PM_APBCMASK_TC0 | PM_APBCMASK_TC1,
+        .gclk_ctrl      = GCLK_CLKCTRL_ID_TC0_TC1,
+#if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
+        .gclk_src       = SAM0_GCLK_1MHZ,
+#else
+        .gclk_src       = SAM0_GCLK_MAIN,
+#endif
+        .flags          = TC_CTRLA_MODE_COUNT32,
+    },
+    {   /* Timer 1 */
+        .dev            = TC4,
+        .irq            = TC4_IRQn,
+        .pm_mask        = PM_APBCMASK_TC4 | PM_APBCMASK_TC5,
+        .gclk_ctrl      = GCLK_CLKCTRL_ID_TC4_TC5,
+#if CLOCK_USE_PLL || CLOCK_USE_XOSC32_DFLL
+        .gclk_src       = SAM0_GCLK_1MHZ,
+#else
+        .gclk_src       = SAM0_GCLK_MAIN,
+#endif
+        .flags          = TC_CTRLA_MODE_COUNT32,
+    }
+};
+
+/* interrupt function name mapping */
+#define TIMER_0_ISR         isr_tc0
+#define TIMER_1_ISR         isr_tc4
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {    /* Virtual COM Port */
+        .dev      = &SERCOM3->USART,
+        .rx_pin   = GPIO_PIN(PA,25),
+        .tx_pin   = GPIO_PIN(PA,24),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_C,
+        .rx_pad   = UART_PAD_RX_3,
+        .tx_pad   = UART_PAD_TX_2,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_MAIN,
+    },
+    {    /* EXT1 */
+        .dev      = &SERCOM4->USART,
+        .rx_pin   = GPIO_PIN(PB,9),
+        .tx_pin   = GPIO_PIN(PB,8),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_MAIN,
+    },
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom3
+#define UART_1_ISR          isr_sercom4
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {   /* EXT1 */
+        .dev      = &SERCOM0->SPI,
+        .miso_pin = GPIO_PIN(PA, 4),
+        .mosi_pin = GPIO_PIN(PA, 6),
+        .clk_pin  = GPIO_PIN(PA, 7),
+        .miso_mux = GPIO_MUX_D,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux  = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = SAM0_GCLK_MAIN,
+    },
+    {   /* EXT2 */
+        .dev      = &SERCOM1->SPI,
+        .miso_pin = GPIO_PIN(PA, 16),
+        .mosi_pin = GPIO_PIN(PA, 18),
+        .clk_pin  = GPIO_PIN(PA, 19),
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_C,
+        .clk_mux  = GPIO_MUX_C,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = SAM0_GCLK_MAIN,
+    },
+    {   /* EXT3 */
+        .dev      = &SERCOM5->SPI,
+        .miso_pin = GPIO_PIN(PB, 16),
+        .mosi_pin = GPIO_PIN(PB, 22),
+        .clk_pin  = GPIO_PIN(PB, 23),
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux  = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = SAM0_GCLK_MAIN,
+    },
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM2->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PA, 9),
+        .sda_pin  = GPIO_PIN(PA, 8),
+        .mux      = GPIO_MUX_D,
+        .gclk_src = SAM0_GCLK_MAIN,
+        .flags    = I2C_FLAG_NONE
+     }
+};
+#define I2C_NUMOF          ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @name RTT configuration
+ * @{
+ */
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
+#endif
+/** @} */
+
+/**
+ * @name PWM configuration
+ * @{
+ */
+#define PWM_0_EN            1
+
+#if PWM_0_EN
+/* PWM0 channels */
+static const pwm_conf_chan_t pwm_chan0_config[] = {
+    /* GPIO pin, MUX value, TCC channel */
+    { GPIO_PIN(PA, 14), GPIO_MUX_E, 0 },
+};
+#endif
+
+/* PWM device configuration */
+static const pwm_conf_t pwm_config[] = {
+#if PWM_0_EN
+    { .tim  = TC_CONFIG(TC3),
+      .chan = pwm_chan0_config,
+      .chan_numof = ARRAY_SIZE(pwm_chan0_config),
+      .gclk_src = SAM0_GCLK_1MHZ,
+    },
+#endif
+};
+
+/* number of devices that are actually defined */
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
+/**
+ * @name ADC Configuration
+ * @{
+ */
+
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV128
+
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_GAIN_FACTOR_DEFAULT             ADC_INPUTCTRL_GAIN_1X
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INT1V
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos */
+    {GPIO_PIN(PB, 0), ADC_INPUTCTRL_MUXPOS_PIN8},      /* EXT1, pin 3 */
+    {GPIO_PIN(PB, 1), ADC_INPUTCTRL_MUXPOS_PIN9},      /* EXT1, pin 4 */
+    {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS_PIN18},    /* EXT2, pin 3 */
+    {GPIO_PIN(PA, 11), ADC_INPUTCTRL_MUXPOS_PIN19},    /* EXT2, pin 4 */
+    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},      /* EXT3, pin 3 */
+    {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS_PIN1}       /* EXT3, pin 4.*/
+};
+
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
+/** @} */
+
+/**
+ * @name DAC configuration
+ * @{
+ */
+#define DAC_CLOCK           SAM0_GCLK_1MHZ
+                            /* use Vcc as reference voltage */
+#define DAC_VREF            DAC_CTRLB_REFSEL_AVCC
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/sam0_common/Kconfig
+++ b/cpu/sam0_common/Kconfig
@@ -8,7 +8,6 @@
 config CPU_COMMON_SAM0
     bool
     select HAS_PERIPH_CPUID
-    select HAS_PERIPH_DMA
     select HAS_PERIPH_FLASHPAGE
     select HAS_PERIPH_FLASHPAGE_PAGEWISE
     select HAS_PERIPH_FLASHPAGE_RWEE

--- a/cpu/sam0_common/Makefile.features
+++ b/cpu/sam0_common/Makefile.features
@@ -1,7 +1,12 @@
 CPU_FAM := $(shell echo $(CPU_MODEL) | cut -c -6)
 
 FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_dma
+
+CPU_MODELS_WITHOUT_DMA = samd20%
+ifeq (,$(filter $(CPU_MODELS_WITHOUT_DMA),$(CPU_MODEL)))
+  FEATURES_PROVIDED += periph_dma
+endif
+
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_pagewise
 FEATURES_PROVIDED += periph_flashpage_rwee

--- a/cpu/sam0_common/Makefile.include
+++ b/cpu/sam0_common/Makefile.include
@@ -5,7 +5,7 @@ CFLAGS += -DCPU_FAM_$(call uppercase_and_underscore,$(CPU_FAM))
 CFLAGS += -D__$(call uppercase_and_underscore,$(CPU_MODEL))__
 
 # Compute CPU_LINE
-LINE   := $(shell echo $(CPU_MODEL) | sed -E -e 's/^sam([a-z][0-9][0-9])(.)([0-9][0-9])(.)/\1 \2 \3 \4/')
+LINE   := $(shell echo $(CPU_MODEL) | sed -E -e 's/^sam([a-z][0-9][0-9])(.)([0-9][0-9])(.)*/\1 \2 \3 \4/')
 FAMILY := $(word 1, $(LINE))
 TYPE1  := $(word 2, $(LINE))
 MEMORY := $(word 3, $(LINE))
@@ -16,7 +16,7 @@ ROM_LEN := $(shell echo $$((1 << $(MEMORY))))
 
 # get vendor file to extract RAM length
 VENDOR_FILE := $(shell find $(RIOTCPU)/sam0_common/include/vendor/sam$(FAMILY) -name $(CPU_MODEL).h | grep include.*/sam)
-RAM_LEN := $(shell sed -E -n 's/\#define (HMCRAMC0_SIZE|HSRAM_SIZE).*(0x[[:xdigit:]]*).*/\2/p' $(VENDOR_FILE))
+RAM_LEN := $(shell sed -E -n 's/\#define (HRAMC0_SIZE|HMCRAMC0_SIZE|HSRAM_SIZE).*(0x[[:xdigit:]]*).*/\2/p' $(VENDOR_FILE))
 
 ROM_START_ADDR ?= 0x00000000
 RAM_START_ADDR ?= 0x20000000

--- a/cpu/sam0_common/include/cpu_conf.h
+++ b/cpu/sam0_common/include/cpu_conf.h
@@ -31,6 +31,10 @@
 
 #if defined(CPU_SAMD10)
 #include "vendor/samd10/include/samd10.h"
+#elif defined(CPU_SAMD20)
+#include "vendor/samd20/include/samd20.h"
+#elif defined(CPU_SAMD20B)
+#include "vendor/samd20/include_b/samd20.h"
 #elif defined(CPU_SAMD21A)
 #include "vendor/samd21/include_a/samd21.h"
 #elif defined(CPU_SAMD21B)

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -849,6 +849,7 @@ typedef struct {
  */
 #define WDT_HAS_INIT                   (1)
 
+#if defined(REV_DMAC) || DOXYGEN
 /**
  * @name sam0 DMA peripheral
  * @{
@@ -1117,6 +1118,7 @@ void dma_wait(dma_t dma);
  */
 void dma_cancel(dma_t dma);
 /** @} */
+#endif /* REV_DMAC || DOXYGEN */
 
 /**
  * @name sam0 RTC Tamper Detection

--- a/cpu/sam0_common/include/vendor/README.md
+++ b/cpu/sam0_common/include/vendor/README.md
@@ -45,6 +45,10 @@ resolve  any CPU family specific includes required.
 
 samd10: `Atmel.SAMD10_DFP.1.1.77.atpack`
 
+## SAMD20 files
+
+samd20: `Atmel.SAMD20_DFP.1.3.165.atpack`
+
 Each atpack has an include subdirectory with the files we copy into
 RIOT. The files are copied unmodified.
 

--- a/cpu/sam0_common/include/vendor/samd20/include/component-version.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component-version.h
@@ -1,0 +1,64 @@
+/**
+ * \file
+ *
+ * \brief Component version header file
+ *
+ * Copyright (c) 2020 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+#ifndef _COMPONENT_VERSION_H_INCLUDED
+#define _COMPONENT_VERSION_H_INCLUDED
+
+#define COMPONENT_VERSION_MAJOR 1
+#define COMPONENT_VERSION_MINOR 3
+
+//
+// The COMPONENT_VERSION define is composed of the major and the minor version number.
+//
+// The last four digits of the COMPONENT_VERSION is the minor version with leading zeros.
+// The rest of the COMPONENT_VERSION is the major version.
+//
+#define COMPONENT_VERSION 10003
+
+//
+// The build number does not refer to the component, but to the build number
+// of the device pack that provides the component.
+//
+#define BUILD_NUMBER 165
+
+//
+// The COMPONENT_VERSION_STRING is a string (enclosed in ") that can be used for logging or embedding.
+//
+#define COMPONENT_VERSION_STRING "1.3"
+
+//
+// The COMPONENT_DATE_STRING contains a timestamp of when the pack was generated.
+//
+// The COMPONENT_DATE_STRING is written out using the following strftime pattern.
+//
+//     "%Y-%m-%d %H:%M:%S"
+//
+//
+#define COMPONENT_DATE_STRING "2020-01-20 13:50:55"
+
+#endif/* #ifndef _COMPONENT_VERSION_H_INCLUDED */
+

--- a/cpu/sam0_common/include/vendor/samd20/include/component/ac.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/ac.h
@@ -1,0 +1,545 @@
+/**
+ * \file
+ *
+ * \brief Component description for AC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_AC_COMPONENT_
+#define _SAMD20_AC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR AC */
+/* ========================================================================== */
+/** \addtogroup SAMD20_AC Analog Comparators */
+/*@{*/
+
+#define AC_U2205
+#define REV_AC                      0x111
+
+/* -------- AC_CTRLA : (AC Offset: 0x00) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  RUNSTDBY:1;       /*!< bit:      2  Run in Standby                     */
+    uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  LPMUX:1;          /*!< bit:      7  Low-Power Mux                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_CTRLA_OFFSET             0x00         /**< \brief (AC_CTRLA offset) Control A */
+#define AC_CTRLA_RESETVALUE         _U_(0x00)    /**< \brief (AC_CTRLA reset_value) Control A */
+
+#define AC_CTRLA_SWRST_Pos          0            /**< \brief (AC_CTRLA) Software Reset */
+#define AC_CTRLA_SWRST              (_U_(0x1) << AC_CTRLA_SWRST_Pos)
+#define AC_CTRLA_ENABLE_Pos         1            /**< \brief (AC_CTRLA) Enable */
+#define AC_CTRLA_ENABLE             (_U_(0x1) << AC_CTRLA_ENABLE_Pos)
+#define AC_CTRLA_RUNSTDBY_Pos       2            /**< \brief (AC_CTRLA) Run in Standby */
+#define AC_CTRLA_RUNSTDBY_Msk       (_U_(0x1) << AC_CTRLA_RUNSTDBY_Pos)
+#define AC_CTRLA_RUNSTDBY(value)    (AC_CTRLA_RUNSTDBY_Msk & ((value) << AC_CTRLA_RUNSTDBY_Pos))
+#define AC_CTRLA_LPMUX_Pos          7            /**< \brief (AC_CTRLA) Low-Power Mux */
+#define AC_CTRLA_LPMUX              (_U_(0x1) << AC_CTRLA_LPMUX_Pos)
+#define AC_CTRLA_MASK               _U_(0x87)    /**< \brief (AC_CTRLA) MASK Register */
+
+/* -------- AC_CTRLB : (AC Offset: 0x01) ( /W  8) Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  START0:1;         /*!< bit:      0  Comparator 0 Start Comparison      */
+    uint8_t  START1:1;         /*!< bit:      1  Comparator 1 Start Comparison      */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  START:2;          /*!< bit:  0.. 1  Comparator x Start Comparison      */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_CTRLB_OFFSET             0x01         /**< \brief (AC_CTRLB offset) Control B */
+#define AC_CTRLB_RESETVALUE         _U_(0x00)    /**< \brief (AC_CTRLB reset_value) Control B */
+
+#define AC_CTRLB_START0_Pos         0            /**< \brief (AC_CTRLB) Comparator 0 Start Comparison */
+#define AC_CTRLB_START0             (_U_(1) << AC_CTRLB_START0_Pos)
+#define AC_CTRLB_START1_Pos         1            /**< \brief (AC_CTRLB) Comparator 1 Start Comparison */
+#define AC_CTRLB_START1             (_U_(1) << AC_CTRLB_START1_Pos)
+#define AC_CTRLB_START_Pos          0            /**< \brief (AC_CTRLB) Comparator x Start Comparison */
+#define AC_CTRLB_START_Msk          (_U_(0x3) << AC_CTRLB_START_Pos)
+#define AC_CTRLB_START(value)       (AC_CTRLB_START_Msk & ((value) << AC_CTRLB_START_Pos))
+#define AC_CTRLB_MASK               _U_(0x03)    /**< \brief (AC_CTRLB) MASK Register */
+
+/* -------- AC_EVCTRL : (AC Offset: 0x02) (R/W 16) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t COMPEO0:1;        /*!< bit:      0  Comparator 0 Event Output Enable   */
+    uint16_t COMPEO1:1;        /*!< bit:      1  Comparator 1 Event Output Enable   */
+    uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t WINEO0:1;         /*!< bit:      4  Window 0 Event Output Enable       */
+    uint16_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint16_t COMPEI0:1;        /*!< bit:      8  Comparator 0 Event Input           */
+    uint16_t COMPEI1:1;        /*!< bit:      9  Comparator 1 Event Input           */
+    uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t COMPEO:2;         /*!< bit:  0.. 1  Comparator x Event Output Enable   */
+    uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t WINEO:1;          /*!< bit:      4  Window x Event Output Enable       */
+    uint16_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint16_t COMPEI:2;         /*!< bit:  8.. 9  Comparator x Event Input           */
+    uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} AC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_EVCTRL_OFFSET            0x02         /**< \brief (AC_EVCTRL offset) Event Control */
+#define AC_EVCTRL_RESETVALUE        _U_(0x0000)  /**< \brief (AC_EVCTRL reset_value) Event Control */
+
+#define AC_EVCTRL_COMPEO0_Pos       0            /**< \brief (AC_EVCTRL) Comparator 0 Event Output Enable */
+#define AC_EVCTRL_COMPEO0           (_U_(1) << AC_EVCTRL_COMPEO0_Pos)
+#define AC_EVCTRL_COMPEO1_Pos       1            /**< \brief (AC_EVCTRL) Comparator 1 Event Output Enable */
+#define AC_EVCTRL_COMPEO1           (_U_(1) << AC_EVCTRL_COMPEO1_Pos)
+#define AC_EVCTRL_COMPEO_Pos        0            /**< \brief (AC_EVCTRL) Comparator x Event Output Enable */
+#define AC_EVCTRL_COMPEO_Msk        (_U_(0x3) << AC_EVCTRL_COMPEO_Pos)
+#define AC_EVCTRL_COMPEO(value)     (AC_EVCTRL_COMPEO_Msk & ((value) << AC_EVCTRL_COMPEO_Pos))
+#define AC_EVCTRL_WINEO0_Pos        4            /**< \brief (AC_EVCTRL) Window 0 Event Output Enable */
+#define AC_EVCTRL_WINEO0            (_U_(1) << AC_EVCTRL_WINEO0_Pos)
+#define AC_EVCTRL_WINEO_Pos         4            /**< \brief (AC_EVCTRL) Window x Event Output Enable */
+#define AC_EVCTRL_WINEO_Msk         (_U_(0x1) << AC_EVCTRL_WINEO_Pos)
+#define AC_EVCTRL_WINEO(value)      (AC_EVCTRL_WINEO_Msk & ((value) << AC_EVCTRL_WINEO_Pos))
+#define AC_EVCTRL_COMPEI0_Pos       8            /**< \brief (AC_EVCTRL) Comparator 0 Event Input */
+#define AC_EVCTRL_COMPEI0           (_U_(1) << AC_EVCTRL_COMPEI0_Pos)
+#define AC_EVCTRL_COMPEI1_Pos       9            /**< \brief (AC_EVCTRL) Comparator 1 Event Input */
+#define AC_EVCTRL_COMPEI1           (_U_(1) << AC_EVCTRL_COMPEI1_Pos)
+#define AC_EVCTRL_COMPEI_Pos        8            /**< \brief (AC_EVCTRL) Comparator x Event Input */
+#define AC_EVCTRL_COMPEI_Msk        (_U_(0x3) << AC_EVCTRL_COMPEI_Pos)
+#define AC_EVCTRL_COMPEI(value)     (AC_EVCTRL_COMPEI_Msk & ((value) << AC_EVCTRL_COMPEI_Pos))
+#define AC_EVCTRL_MASK              _U_(0x0313)  /**< \brief (AC_EVCTRL) MASK Register */
+
+/* -------- AC_INTENCLR : (AC Offset: 0x04) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0 Interrupt Enable      */
+    uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1 Interrupt Enable      */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WIN0:1;           /*!< bit:      4  Window 0 Interrupt Enable          */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x Interrupt Enable      */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WIN:1;            /*!< bit:      4  Window x Interrupt Enable          */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_INTENCLR_OFFSET          0x04         /**< \brief (AC_INTENCLR offset) Interrupt Enable Clear */
+#define AC_INTENCLR_RESETVALUE      _U_(0x00)    /**< \brief (AC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define AC_INTENCLR_COMP0_Pos       0            /**< \brief (AC_INTENCLR) Comparator 0 Interrupt Enable */
+#define AC_INTENCLR_COMP0           (_U_(1) << AC_INTENCLR_COMP0_Pos)
+#define AC_INTENCLR_COMP1_Pos       1            /**< \brief (AC_INTENCLR) Comparator 1 Interrupt Enable */
+#define AC_INTENCLR_COMP1           (_U_(1) << AC_INTENCLR_COMP1_Pos)
+#define AC_INTENCLR_COMP_Pos        0            /**< \brief (AC_INTENCLR) Comparator x Interrupt Enable */
+#define AC_INTENCLR_COMP_Msk        (_U_(0x3) << AC_INTENCLR_COMP_Pos)
+#define AC_INTENCLR_COMP(value)     (AC_INTENCLR_COMP_Msk & ((value) << AC_INTENCLR_COMP_Pos))
+#define AC_INTENCLR_WIN0_Pos        4            /**< \brief (AC_INTENCLR) Window 0 Interrupt Enable */
+#define AC_INTENCLR_WIN0            (_U_(1) << AC_INTENCLR_WIN0_Pos)
+#define AC_INTENCLR_WIN_Pos         4            /**< \brief (AC_INTENCLR) Window x Interrupt Enable */
+#define AC_INTENCLR_WIN_Msk         (_U_(0x1) << AC_INTENCLR_WIN_Pos)
+#define AC_INTENCLR_WIN(value)      (AC_INTENCLR_WIN_Msk & ((value) << AC_INTENCLR_WIN_Pos))
+#define AC_INTENCLR_MASK            _U_(0x13)    /**< \brief (AC_INTENCLR) MASK Register */
+
+/* -------- AC_INTENSET : (AC Offset: 0x05) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0 Interrupt Enable      */
+    uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1 Interrupt Enable      */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WIN0:1;           /*!< bit:      4  Window 0 Interrupt Enable          */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x Interrupt Enable      */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WIN:1;            /*!< bit:      4  Window x Interrupt Enable          */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_INTENSET_OFFSET          0x05         /**< \brief (AC_INTENSET offset) Interrupt Enable Set */
+#define AC_INTENSET_RESETVALUE      _U_(0x00)    /**< \brief (AC_INTENSET reset_value) Interrupt Enable Set */
+
+#define AC_INTENSET_COMP0_Pos       0            /**< \brief (AC_INTENSET) Comparator 0 Interrupt Enable */
+#define AC_INTENSET_COMP0           (_U_(1) << AC_INTENSET_COMP0_Pos)
+#define AC_INTENSET_COMP1_Pos       1            /**< \brief (AC_INTENSET) Comparator 1 Interrupt Enable */
+#define AC_INTENSET_COMP1           (_U_(1) << AC_INTENSET_COMP1_Pos)
+#define AC_INTENSET_COMP_Pos        0            /**< \brief (AC_INTENSET) Comparator x Interrupt Enable */
+#define AC_INTENSET_COMP_Msk        (_U_(0x3) << AC_INTENSET_COMP_Pos)
+#define AC_INTENSET_COMP(value)     (AC_INTENSET_COMP_Msk & ((value) << AC_INTENSET_COMP_Pos))
+#define AC_INTENSET_WIN0_Pos        4            /**< \brief (AC_INTENSET) Window 0 Interrupt Enable */
+#define AC_INTENSET_WIN0            (_U_(1) << AC_INTENSET_WIN0_Pos)
+#define AC_INTENSET_WIN_Pos         4            /**< \brief (AC_INTENSET) Window x Interrupt Enable */
+#define AC_INTENSET_WIN_Msk         (_U_(0x1) << AC_INTENSET_WIN_Pos)
+#define AC_INTENSET_WIN(value)      (AC_INTENSET_WIN_Msk & ((value) << AC_INTENSET_WIN_Pos))
+#define AC_INTENSET_MASK            _U_(0x13)    /**< \brief (AC_INTENSET) MASK Register */
+
+/* -------- AC_INTFLAG : (AC Offset: 0x06) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
+    __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
+    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
+    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
+    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
+    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_INTFLAG_OFFSET           0x06         /**< \brief (AC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define AC_INTFLAG_RESETVALUE       _U_(0x00)    /**< \brief (AC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define AC_INTFLAG_COMP0_Pos        0            /**< \brief (AC_INTFLAG) Comparator 0 */
+#define AC_INTFLAG_COMP0            (_U_(1) << AC_INTFLAG_COMP0_Pos)
+#define AC_INTFLAG_COMP1_Pos        1            /**< \brief (AC_INTFLAG) Comparator 1 */
+#define AC_INTFLAG_COMP1            (_U_(1) << AC_INTFLAG_COMP1_Pos)
+#define AC_INTFLAG_COMP_Pos         0            /**< \brief (AC_INTFLAG) Comparator x */
+#define AC_INTFLAG_COMP_Msk         (_U_(0x3) << AC_INTFLAG_COMP_Pos)
+#define AC_INTFLAG_COMP(value)      (AC_INTFLAG_COMP_Msk & ((value) << AC_INTFLAG_COMP_Pos))
+#define AC_INTFLAG_WIN0_Pos         4            /**< \brief (AC_INTFLAG) Window 0 */
+#define AC_INTFLAG_WIN0             (_U_(1) << AC_INTFLAG_WIN0_Pos)
+#define AC_INTFLAG_WIN_Pos          4            /**< \brief (AC_INTFLAG) Window x */
+#define AC_INTFLAG_WIN_Msk          (_U_(0x1) << AC_INTFLAG_WIN_Pos)
+#define AC_INTFLAG_WIN(value)       (AC_INTFLAG_WIN_Msk & ((value) << AC_INTFLAG_WIN_Pos))
+#define AC_INTFLAG_MASK             _U_(0x13)    /**< \brief (AC_INTFLAG) MASK Register */
+
+/* -------- AC_STATUSA : (AC Offset: 0x08) (R/   8) Status A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  STATE0:1;         /*!< bit:      0  Comparator 0 Current State         */
+    uint8_t  STATE1:1;         /*!< bit:      1  Comparator 1 Current State         */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WSTATE0:2;        /*!< bit:  4.. 5  Window 0 Current State             */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  STATE:2;          /*!< bit:  0.. 1  Comparator x Current State         */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_STATUSA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_STATUSA_OFFSET           0x08         /**< \brief (AC_STATUSA offset) Status A */
+#define AC_STATUSA_RESETVALUE       _U_(0x00)    /**< \brief (AC_STATUSA reset_value) Status A */
+
+#define AC_STATUSA_STATE0_Pos       0            /**< \brief (AC_STATUSA) Comparator 0 Current State */
+#define AC_STATUSA_STATE0           (_U_(1) << AC_STATUSA_STATE0_Pos)
+#define AC_STATUSA_STATE1_Pos       1            /**< \brief (AC_STATUSA) Comparator 1 Current State */
+#define AC_STATUSA_STATE1           (_U_(1) << AC_STATUSA_STATE1_Pos)
+#define AC_STATUSA_STATE_Pos        0            /**< \brief (AC_STATUSA) Comparator x Current State */
+#define AC_STATUSA_STATE_Msk        (_U_(0x3) << AC_STATUSA_STATE_Pos)
+#define AC_STATUSA_STATE(value)     (AC_STATUSA_STATE_Msk & ((value) << AC_STATUSA_STATE_Pos))
+#define AC_STATUSA_WSTATE0_Pos      4            /**< \brief (AC_STATUSA) Window 0 Current State */
+#define AC_STATUSA_WSTATE0_Msk      (_U_(0x3) << AC_STATUSA_WSTATE0_Pos)
+#define AC_STATUSA_WSTATE0(value)   (AC_STATUSA_WSTATE0_Msk & ((value) << AC_STATUSA_WSTATE0_Pos))
+#define   AC_STATUSA_WSTATE0_ABOVE_Val    _U_(0x0)   /**< \brief (AC_STATUSA) Signal is above window */
+#define   AC_STATUSA_WSTATE0_INSIDE_Val   _U_(0x1)   /**< \brief (AC_STATUSA) Signal is inside window */
+#define   AC_STATUSA_WSTATE0_BELOW_Val    _U_(0x2)   /**< \brief (AC_STATUSA) Signal is below window */
+#define AC_STATUSA_WSTATE0_ABOVE    (AC_STATUSA_WSTATE0_ABOVE_Val  << AC_STATUSA_WSTATE0_Pos)
+#define AC_STATUSA_WSTATE0_INSIDE   (AC_STATUSA_WSTATE0_INSIDE_Val << AC_STATUSA_WSTATE0_Pos)
+#define AC_STATUSA_WSTATE0_BELOW    (AC_STATUSA_WSTATE0_BELOW_Val  << AC_STATUSA_WSTATE0_Pos)
+#define AC_STATUSA_MASK             _U_(0x33)    /**< \brief (AC_STATUSA) MASK Register */
+
+/* -------- AC_STATUSB : (AC Offset: 0x09) (R/   8) Status B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  READY0:1;         /*!< bit:      0  Comparator 0 Ready                 */
+    uint8_t  READY1:1;         /*!< bit:      1  Comparator 1 Ready                 */
+    uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  READY:2;          /*!< bit:  0.. 1  Comparator x Ready                 */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_STATUSB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_STATUSB_OFFSET           0x09         /**< \brief (AC_STATUSB offset) Status B */
+#define AC_STATUSB_RESETVALUE       _U_(0x00)    /**< \brief (AC_STATUSB reset_value) Status B */
+
+#define AC_STATUSB_READY0_Pos       0            /**< \brief (AC_STATUSB) Comparator 0 Ready */
+#define AC_STATUSB_READY0           (_U_(1) << AC_STATUSB_READY0_Pos)
+#define AC_STATUSB_READY1_Pos       1            /**< \brief (AC_STATUSB) Comparator 1 Ready */
+#define AC_STATUSB_READY1           (_U_(1) << AC_STATUSB_READY1_Pos)
+#define AC_STATUSB_READY_Pos        0            /**< \brief (AC_STATUSB) Comparator x Ready */
+#define AC_STATUSB_READY_Msk        (_U_(0x3) << AC_STATUSB_READY_Pos)
+#define AC_STATUSB_READY(value)     (AC_STATUSB_READY_Msk & ((value) << AC_STATUSB_READY_Pos))
+#define AC_STATUSB_SYNCBUSY_Pos     7            /**< \brief (AC_STATUSB) Synchronization Busy */
+#define AC_STATUSB_SYNCBUSY         (_U_(0x1) << AC_STATUSB_SYNCBUSY_Pos)
+#define AC_STATUSB_MASK             _U_(0x83)    /**< \brief (AC_STATUSB) MASK Register */
+
+/* -------- AC_STATUSC : (AC Offset: 0x0A) (R/   8) Status C -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  STATE0:1;         /*!< bit:      0  Comparator 0 Current State         */
+    uint8_t  STATE1:1;         /*!< bit:      1  Comparator 1 Current State         */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WSTATE0:2;        /*!< bit:  4.. 5  Window 0 Current State             */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  STATE:2;          /*!< bit:  0.. 1  Comparator x Current State         */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_STATUSC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_STATUSC_OFFSET           0x0A         /**< \brief (AC_STATUSC offset) Status C */
+#define AC_STATUSC_RESETVALUE       _U_(0x00)    /**< \brief (AC_STATUSC reset_value) Status C */
+
+#define AC_STATUSC_STATE0_Pos       0            /**< \brief (AC_STATUSC) Comparator 0 Current State */
+#define AC_STATUSC_STATE0           (_U_(1) << AC_STATUSC_STATE0_Pos)
+#define AC_STATUSC_STATE1_Pos       1            /**< \brief (AC_STATUSC) Comparator 1 Current State */
+#define AC_STATUSC_STATE1           (_U_(1) << AC_STATUSC_STATE1_Pos)
+#define AC_STATUSC_STATE_Pos        0            /**< \brief (AC_STATUSC) Comparator x Current State */
+#define AC_STATUSC_STATE_Msk        (_U_(0x3) << AC_STATUSC_STATE_Pos)
+#define AC_STATUSC_STATE(value)     (AC_STATUSC_STATE_Msk & ((value) << AC_STATUSC_STATE_Pos))
+#define AC_STATUSC_WSTATE0_Pos      4            /**< \brief (AC_STATUSC) Window 0 Current State */
+#define AC_STATUSC_WSTATE0_Msk      (_U_(0x3) << AC_STATUSC_WSTATE0_Pos)
+#define AC_STATUSC_WSTATE0(value)   (AC_STATUSC_WSTATE0_Msk & ((value) << AC_STATUSC_WSTATE0_Pos))
+#define   AC_STATUSC_WSTATE0_ABOVE_Val    _U_(0x0)   /**< \brief (AC_STATUSC) Signal is above window */
+#define   AC_STATUSC_WSTATE0_INSIDE_Val   _U_(0x1)   /**< \brief (AC_STATUSC) Signal is inside window */
+#define   AC_STATUSC_WSTATE0_BELOW_Val    _U_(0x2)   /**< \brief (AC_STATUSC) Signal is below window */
+#define AC_STATUSC_WSTATE0_ABOVE    (AC_STATUSC_WSTATE0_ABOVE_Val  << AC_STATUSC_WSTATE0_Pos)
+#define AC_STATUSC_WSTATE0_INSIDE   (AC_STATUSC_WSTATE0_INSIDE_Val << AC_STATUSC_WSTATE0_Pos)
+#define AC_STATUSC_WSTATE0_BELOW    (AC_STATUSC_WSTATE0_BELOW_Val  << AC_STATUSC_WSTATE0_Pos)
+#define AC_STATUSC_MASK             _U_(0x33)    /**< \brief (AC_STATUSC) MASK Register */
+
+/* -------- AC_WINCTRL : (AC Offset: 0x0C) (R/W  8) Window Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  WEN0:1;           /*!< bit:      0  Window 0 Mode Enable               */
+    uint8_t  WINTSEL0:2;       /*!< bit:  1.. 2  Window 0 Interrupt Selection       */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_WINCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_WINCTRL_OFFSET           0x0C         /**< \brief (AC_WINCTRL offset) Window Control */
+#define AC_WINCTRL_RESETVALUE       _U_(0x00)    /**< \brief (AC_WINCTRL reset_value) Window Control */
+
+#define AC_WINCTRL_WEN0_Pos         0            /**< \brief (AC_WINCTRL) Window 0 Mode Enable */
+#define AC_WINCTRL_WEN0             (_U_(0x1) << AC_WINCTRL_WEN0_Pos)
+#define AC_WINCTRL_WINTSEL0_Pos     1            /**< \brief (AC_WINCTRL) Window 0 Interrupt Selection */
+#define AC_WINCTRL_WINTSEL0_Msk     (_U_(0x3) << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_WINTSEL0(value)  (AC_WINCTRL_WINTSEL0_Msk & ((value) << AC_WINCTRL_WINTSEL0_Pos))
+#define   AC_WINCTRL_WINTSEL0_ABOVE_Val   _U_(0x0)   /**< \brief (AC_WINCTRL) Interrupt on signal above window */
+#define   AC_WINCTRL_WINTSEL0_INSIDE_Val  _U_(0x1)   /**< \brief (AC_WINCTRL) Interrupt on signal inside window */
+#define   AC_WINCTRL_WINTSEL0_BELOW_Val   _U_(0x2)   /**< \brief (AC_WINCTRL) Interrupt on signal below window */
+#define   AC_WINCTRL_WINTSEL0_OUTSIDE_Val _U_(0x3)   /**< \brief (AC_WINCTRL) Interrupt on signal outside window */
+#define AC_WINCTRL_WINTSEL0_ABOVE   (AC_WINCTRL_WINTSEL0_ABOVE_Val << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_WINTSEL0_INSIDE  (AC_WINCTRL_WINTSEL0_INSIDE_Val << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_WINTSEL0_BELOW   (AC_WINCTRL_WINTSEL0_BELOW_Val << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_WINTSEL0_OUTSIDE (AC_WINCTRL_WINTSEL0_OUTSIDE_Val << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_MASK             _U_(0x07)    /**< \brief (AC_WINCTRL) MASK Register */
+
+/* -------- AC_COMPCTRL : (AC Offset: 0x10) (R/W 32) Comparator Control n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ENABLE:1;         /*!< bit:      0  Enable                             */
+    uint32_t SINGLE:1;         /*!< bit:      1  Single-Shot Mode                   */
+    uint32_t SPEED:2;          /*!< bit:  2.. 3  Speed Selection                    */
+    uint32_t :1;               /*!< bit:      4  Reserved                           */
+    uint32_t INTSEL:2;         /*!< bit:  5.. 6  Interrupt Selection                */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t MUXNEG:3;         /*!< bit:  8..10  Negative Input Mux Selection       */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t MUXPOS:2;         /*!< bit: 12..13  Positive Input Mux Selection       */
+    uint32_t :1;               /*!< bit:     14  Reserved                           */
+    uint32_t SWAP:1;           /*!< bit:     15  Swap Inputs and Invert             */
+    uint32_t OUT:2;            /*!< bit: 16..17  Output                             */
+    uint32_t :1;               /*!< bit:     18  Reserved                           */
+    uint32_t HYST:1;           /*!< bit:     19  Hysteresis Enable                  */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t FLEN:3;           /*!< bit: 24..26  Filter Length                      */
+    uint32_t :5;               /*!< bit: 27..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AC_COMPCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_COMPCTRL_OFFSET          0x10         /**< \brief (AC_COMPCTRL offset) Comparator Control n */
+#define AC_COMPCTRL_RESETVALUE      _U_(0x00000000) /**< \brief (AC_COMPCTRL reset_value) Comparator Control n */
+
+#define AC_COMPCTRL_ENABLE_Pos      0            /**< \brief (AC_COMPCTRL) Enable */
+#define AC_COMPCTRL_ENABLE          (_U_(0x1) << AC_COMPCTRL_ENABLE_Pos)
+#define AC_COMPCTRL_SINGLE_Pos      1            /**< \brief (AC_COMPCTRL) Single-Shot Mode */
+#define AC_COMPCTRL_SINGLE          (_U_(0x1) << AC_COMPCTRL_SINGLE_Pos)
+#define AC_COMPCTRL_SPEED_Pos       2            /**< \brief (AC_COMPCTRL) Speed Selection */
+#define AC_COMPCTRL_SPEED_Msk       (_U_(0x3) << AC_COMPCTRL_SPEED_Pos)
+#define AC_COMPCTRL_SPEED(value)    (AC_COMPCTRL_SPEED_Msk & ((value) << AC_COMPCTRL_SPEED_Pos))
+#define   AC_COMPCTRL_SPEED_LOW_Val       _U_(0x0)   /**< \brief (AC_COMPCTRL) Low speed */
+#define   AC_COMPCTRL_SPEED_HIGH_Val      _U_(0x1)   /**< \brief (AC_COMPCTRL) High speed */
+#define AC_COMPCTRL_SPEED_LOW       (AC_COMPCTRL_SPEED_LOW_Val     << AC_COMPCTRL_SPEED_Pos)
+#define AC_COMPCTRL_SPEED_HIGH      (AC_COMPCTRL_SPEED_HIGH_Val    << AC_COMPCTRL_SPEED_Pos)
+#define AC_COMPCTRL_INTSEL_Pos      5            /**< \brief (AC_COMPCTRL) Interrupt Selection */
+#define AC_COMPCTRL_INTSEL_Msk      (_U_(0x3) << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_INTSEL(value)   (AC_COMPCTRL_INTSEL_Msk & ((value) << AC_COMPCTRL_INTSEL_Pos))
+#define   AC_COMPCTRL_INTSEL_TOGGLE_Val   _U_(0x0)   /**< \brief (AC_COMPCTRL) Interrupt on comparator output toggle */
+#define   AC_COMPCTRL_INTSEL_RISING_Val   _U_(0x1)   /**< \brief (AC_COMPCTRL) Interrupt on comparator output rising */
+#define   AC_COMPCTRL_INTSEL_FALLING_Val  _U_(0x2)   /**< \brief (AC_COMPCTRL) Interrupt on comparator output falling */
+#define   AC_COMPCTRL_INTSEL_EOC_Val      _U_(0x3)   /**< \brief (AC_COMPCTRL) Interrupt on end of comparison (single-shot mode only) */
+#define AC_COMPCTRL_INTSEL_TOGGLE   (AC_COMPCTRL_INTSEL_TOGGLE_Val << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_INTSEL_RISING   (AC_COMPCTRL_INTSEL_RISING_Val << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_INTSEL_FALLING  (AC_COMPCTRL_INTSEL_FALLING_Val << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_INTSEL_EOC      (AC_COMPCTRL_INTSEL_EOC_Val    << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_MUXNEG_Pos      8            /**< \brief (AC_COMPCTRL) Negative Input Mux Selection */
+#define AC_COMPCTRL_MUXNEG_Msk      (_U_(0x7) << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG(value)   (AC_COMPCTRL_MUXNEG_Msk & ((value) << AC_COMPCTRL_MUXNEG_Pos))
+#define   AC_COMPCTRL_MUXNEG_PIN0_Val     _U_(0x0)   /**< \brief (AC_COMPCTRL) I/O pin 0 */
+#define   AC_COMPCTRL_MUXNEG_PIN1_Val     _U_(0x1)   /**< \brief (AC_COMPCTRL) I/O pin 1 */
+#define   AC_COMPCTRL_MUXNEG_PIN2_Val     _U_(0x2)   /**< \brief (AC_COMPCTRL) I/O pin 2 */
+#define   AC_COMPCTRL_MUXNEG_PIN3_Val     _U_(0x3)   /**< \brief (AC_COMPCTRL) I/O pin 3 */
+#define   AC_COMPCTRL_MUXNEG_GND_Val      _U_(0x4)   /**< \brief (AC_COMPCTRL) Ground */
+#define   AC_COMPCTRL_MUXNEG_VSCALE_Val   _U_(0x5)   /**< \brief (AC_COMPCTRL) VDD scaler */
+#define   AC_COMPCTRL_MUXNEG_BANDGAP_Val  _U_(0x6)   /**< \brief (AC_COMPCTRL) Internal bandgap voltage */
+#define   AC_COMPCTRL_MUXNEG_DAC_Val      _U_(0x7)   /**< \brief (AC_COMPCTRL) DAC output */
+#define AC_COMPCTRL_MUXNEG_PIN0     (AC_COMPCTRL_MUXNEG_PIN0_Val   << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_PIN1     (AC_COMPCTRL_MUXNEG_PIN1_Val   << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_PIN2     (AC_COMPCTRL_MUXNEG_PIN2_Val   << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_PIN3     (AC_COMPCTRL_MUXNEG_PIN3_Val   << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_GND      (AC_COMPCTRL_MUXNEG_GND_Val    << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_VSCALE   (AC_COMPCTRL_MUXNEG_VSCALE_Val << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_BANDGAP  (AC_COMPCTRL_MUXNEG_BANDGAP_Val << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_DAC      (AC_COMPCTRL_MUXNEG_DAC_Val    << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXPOS_Pos      12           /**< \brief (AC_COMPCTRL) Positive Input Mux Selection */
+#define AC_COMPCTRL_MUXPOS_Msk      (_U_(0x3) << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_MUXPOS(value)   (AC_COMPCTRL_MUXPOS_Msk & ((value) << AC_COMPCTRL_MUXPOS_Pos))
+#define   AC_COMPCTRL_MUXPOS_PIN0_Val     _U_(0x0)   /**< \brief (AC_COMPCTRL) I/O pin 0 */
+#define   AC_COMPCTRL_MUXPOS_PIN1_Val     _U_(0x1)   /**< \brief (AC_COMPCTRL) I/O pin 1 */
+#define   AC_COMPCTRL_MUXPOS_PIN2_Val     _U_(0x2)   /**< \brief (AC_COMPCTRL) I/O pin 2 */
+#define   AC_COMPCTRL_MUXPOS_PIN3_Val     _U_(0x3)   /**< \brief (AC_COMPCTRL) I/O pin 3 */
+#define AC_COMPCTRL_MUXPOS_PIN0     (AC_COMPCTRL_MUXPOS_PIN0_Val   << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_MUXPOS_PIN1     (AC_COMPCTRL_MUXPOS_PIN1_Val   << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_MUXPOS_PIN2     (AC_COMPCTRL_MUXPOS_PIN2_Val   << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_MUXPOS_PIN3     (AC_COMPCTRL_MUXPOS_PIN3_Val   << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_SWAP_Pos        15           /**< \brief (AC_COMPCTRL) Swap Inputs and Invert */
+#define AC_COMPCTRL_SWAP            (_U_(0x1) << AC_COMPCTRL_SWAP_Pos)
+#define AC_COMPCTRL_OUT_Pos         16           /**< \brief (AC_COMPCTRL) Output */
+#define AC_COMPCTRL_OUT_Msk         (_U_(0x3) << AC_COMPCTRL_OUT_Pos)
+#define AC_COMPCTRL_OUT(value)      (AC_COMPCTRL_OUT_Msk & ((value) << AC_COMPCTRL_OUT_Pos))
+#define   AC_COMPCTRL_OUT_OFF_Val         _U_(0x0)   /**< \brief (AC_COMPCTRL) The output of COMPn is not routed to the COMPn I/O port */
+#define   AC_COMPCTRL_OUT_ASYNC_Val       _U_(0x1)   /**< \brief (AC_COMPCTRL) The asynchronous output of COMPn is routed to the COMPn I/O port */
+#define   AC_COMPCTRL_OUT_SYNC_Val        _U_(0x2)   /**< \brief (AC_COMPCTRL) The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port */
+#define AC_COMPCTRL_OUT_OFF         (AC_COMPCTRL_OUT_OFF_Val       << AC_COMPCTRL_OUT_Pos)
+#define AC_COMPCTRL_OUT_ASYNC       (AC_COMPCTRL_OUT_ASYNC_Val     << AC_COMPCTRL_OUT_Pos)
+#define AC_COMPCTRL_OUT_SYNC        (AC_COMPCTRL_OUT_SYNC_Val      << AC_COMPCTRL_OUT_Pos)
+#define AC_COMPCTRL_HYST_Pos        19           /**< \brief (AC_COMPCTRL) Hysteresis Enable */
+#define AC_COMPCTRL_HYST            (_U_(0x1) << AC_COMPCTRL_HYST_Pos)
+#define AC_COMPCTRL_FLEN_Pos        24           /**< \brief (AC_COMPCTRL) Filter Length */
+#define AC_COMPCTRL_FLEN_Msk        (_U_(0x7) << AC_COMPCTRL_FLEN_Pos)
+#define AC_COMPCTRL_FLEN(value)     (AC_COMPCTRL_FLEN_Msk & ((value) << AC_COMPCTRL_FLEN_Pos))
+#define   AC_COMPCTRL_FLEN_OFF_Val        _U_(0x0)   /**< \brief (AC_COMPCTRL) No filtering */
+#define   AC_COMPCTRL_FLEN_MAJ3_Val       _U_(0x1)   /**< \brief (AC_COMPCTRL) 3-bit majority function (2 of 3) */
+#define   AC_COMPCTRL_FLEN_MAJ5_Val       _U_(0x2)   /**< \brief (AC_COMPCTRL) 5-bit majority function (3 of 5) */
+#define AC_COMPCTRL_FLEN_OFF        (AC_COMPCTRL_FLEN_OFF_Val      << AC_COMPCTRL_FLEN_Pos)
+#define AC_COMPCTRL_FLEN_MAJ3       (AC_COMPCTRL_FLEN_MAJ3_Val     << AC_COMPCTRL_FLEN_Pos)
+#define AC_COMPCTRL_FLEN_MAJ5       (AC_COMPCTRL_FLEN_MAJ5_Val     << AC_COMPCTRL_FLEN_Pos)
+#define AC_COMPCTRL_MASK            _U_(0x070BB76F) /**< \brief (AC_COMPCTRL) MASK Register */
+
+/* -------- AC_SCALER : (AC Offset: 0x20) (R/W  8) Scaler n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  VALUE:6;          /*!< bit:  0.. 5  Scaler Value                       */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_SCALER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_SCALER_OFFSET            0x20         /**< \brief (AC_SCALER offset) Scaler n */
+#define AC_SCALER_RESETVALUE        _U_(0x00)    /**< \brief (AC_SCALER reset_value) Scaler n */
+
+#define AC_SCALER_VALUE_Pos         0            /**< \brief (AC_SCALER) Scaler Value */
+#define AC_SCALER_VALUE_Msk         (_U_(0x3F) << AC_SCALER_VALUE_Pos)
+#define AC_SCALER_VALUE(value)      (AC_SCALER_VALUE_Msk & ((value) << AC_SCALER_VALUE_Pos))
+#define AC_SCALER_MASK              _U_(0x3F)    /**< \brief (AC_SCALER) MASK Register */
+
+/** \brief AC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO AC_CTRLA_Type             CTRLA;       /**< \brief Offset: 0x00 (R/W  8) Control A */
+  __O  AC_CTRLB_Type             CTRLB;       /**< \brief Offset: 0x01 ( /W  8) Control B */
+  __IO AC_EVCTRL_Type            EVCTRL;      /**< \brief Offset: 0x02 (R/W 16) Event Control */
+  __IO AC_INTENCLR_Type          INTENCLR;    /**< \brief Offset: 0x04 (R/W  8) Interrupt Enable Clear */
+  __IO AC_INTENSET_Type          INTENSET;    /**< \brief Offset: 0x05 (R/W  8) Interrupt Enable Set */
+  __IO AC_INTFLAG_Type           INTFLAG;     /**< \brief Offset: 0x06 (R/W  8) Interrupt Flag Status and Clear */
+       RoReg8                    Reserved1[0x1];
+  __I  AC_STATUSA_Type           STATUSA;     /**< \brief Offset: 0x08 (R/   8) Status A */
+  __I  AC_STATUSB_Type           STATUSB;     /**< \brief Offset: 0x09 (R/   8) Status B */
+  __I  AC_STATUSC_Type           STATUSC;     /**< \brief Offset: 0x0A (R/   8) Status C */
+       RoReg8                    Reserved2[0x1];
+  __IO AC_WINCTRL_Type           WINCTRL;     /**< \brief Offset: 0x0C (R/W  8) Window Control */
+       RoReg8                    Reserved3[0x3];
+  __IO AC_COMPCTRL_Type          COMPCTRL[2]; /**< \brief Offset: 0x10 (R/W 32) Comparator Control n */
+       RoReg8                    Reserved4[0x8];
+  __IO AC_SCALER_Type            SCALER[2];   /**< \brief Offset: 0x20 (R/W  8) Scaler n */
+} Ac;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_AC_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/component/adc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/adc.h
@@ -1,0 +1,685 @@
+/**
+ * \file
+ *
+ * \brief Component description for ADC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_ADC_COMPONENT_
+#define _SAMD20_ADC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR ADC */
+/* ========================================================================== */
+/** \addtogroup SAMD20_ADC Analog Digital Converter */
+/*@{*/
+
+#define ADC_U2204
+#define REV_ADC                     0x111
+
+/* -------- ADC_CTRLA : (ADC Offset: 0x00) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  RUNSTDBY:1;       /*!< bit:      2  Run in Standby                     */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CTRLA_OFFSET            0x00         /**< \brief (ADC_CTRLA offset) Control A */
+#define ADC_CTRLA_RESETVALUE        _U_(0x00)    /**< \brief (ADC_CTRLA reset_value) Control A */
+
+#define ADC_CTRLA_SWRST_Pos         0            /**< \brief (ADC_CTRLA) Software Reset */
+#define ADC_CTRLA_SWRST             (_U_(0x1) << ADC_CTRLA_SWRST_Pos)
+#define ADC_CTRLA_ENABLE_Pos        1            /**< \brief (ADC_CTRLA) Enable */
+#define ADC_CTRLA_ENABLE            (_U_(0x1) << ADC_CTRLA_ENABLE_Pos)
+#define ADC_CTRLA_RUNSTDBY_Pos      2            /**< \brief (ADC_CTRLA) Run in Standby */
+#define ADC_CTRLA_RUNSTDBY          (_U_(0x1) << ADC_CTRLA_RUNSTDBY_Pos)
+#define ADC_CTRLA_MASK              _U_(0x07)    /**< \brief (ADC_CTRLA) MASK Register */
+
+/* -------- ADC_REFCTRL : (ADC Offset: 0x01) (R/W  8) Reference Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  REFSEL:4;         /*!< bit:  0.. 3  Reference Selection                */
+    uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  REFCOMP:1;        /*!< bit:      7  Reference Buffer Offset Compensation Enable */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_REFCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_REFCTRL_OFFSET          0x01         /**< \brief (ADC_REFCTRL offset) Reference Control */
+#define ADC_REFCTRL_RESETVALUE      _U_(0x00)    /**< \brief (ADC_REFCTRL reset_value) Reference Control */
+
+#define ADC_REFCTRL_REFSEL_Pos      0            /**< \brief (ADC_REFCTRL) Reference Selection */
+#define ADC_REFCTRL_REFSEL_Msk      (_U_(0xF) << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL(value)   (ADC_REFCTRL_REFSEL_Msk & ((value) << ADC_REFCTRL_REFSEL_Pos))
+#define   ADC_REFCTRL_REFSEL_INT1V_Val    _U_(0x0)   /**< \brief (ADC_REFCTRL) 1.0V voltage reference */
+#define   ADC_REFCTRL_REFSEL_INTVCC0_Val  _U_(0x1)   /**< \brief (ADC_REFCTRL) 1/1.48 VDDANA */
+#define   ADC_REFCTRL_REFSEL_INTVCC1_Val  _U_(0x2)   /**< \brief (ADC_REFCTRL) 1/2 VDDANA (only for VDDANA > 2.0V) */
+#define   ADC_REFCTRL_REFSEL_AREFA_Val    _U_(0x3)   /**< \brief (ADC_REFCTRL) External reference */
+#define   ADC_REFCTRL_REFSEL_AREFB_Val    _U_(0x4)   /**< \brief (ADC_REFCTRL) External reference */
+#define ADC_REFCTRL_REFSEL_INT1V    (ADC_REFCTRL_REFSEL_INT1V_Val  << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL_INTVCC0  (ADC_REFCTRL_REFSEL_INTVCC0_Val << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL_INTVCC1  (ADC_REFCTRL_REFSEL_INTVCC1_Val << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL_AREFA    (ADC_REFCTRL_REFSEL_AREFA_Val  << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL_AREFB    (ADC_REFCTRL_REFSEL_AREFB_Val  << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFCOMP_Pos     7            /**< \brief (ADC_REFCTRL) Reference Buffer Offset Compensation Enable */
+#define ADC_REFCTRL_REFCOMP         (_U_(0x1) << ADC_REFCTRL_REFCOMP_Pos)
+#define ADC_REFCTRL_MASK            _U_(0x8F)    /**< \brief (ADC_REFCTRL) MASK Register */
+
+/* -------- ADC_AVGCTRL : (ADC Offset: 0x02) (R/W  8) Average Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SAMPLENUM:4;      /*!< bit:  0.. 3  Number of Samples to be Collected  */
+    uint8_t  ADJRES:3;         /*!< bit:  4.. 6  Adjusting Result / Division Coefficient */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_AVGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_AVGCTRL_OFFSET          0x02         /**< \brief (ADC_AVGCTRL offset) Average Control */
+#define ADC_AVGCTRL_RESETVALUE      _U_(0x00)    /**< \brief (ADC_AVGCTRL reset_value) Average Control */
+
+#define ADC_AVGCTRL_SAMPLENUM_Pos   0            /**< \brief (ADC_AVGCTRL) Number of Samples to be Collected */
+#define ADC_AVGCTRL_SAMPLENUM_Msk   (_U_(0xF) << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM(value) (ADC_AVGCTRL_SAMPLENUM_Msk & ((value) << ADC_AVGCTRL_SAMPLENUM_Pos))
+#define   ADC_AVGCTRL_SAMPLENUM_1_Val     _U_(0x0)   /**< \brief (ADC_AVGCTRL) 1 sample */
+#define   ADC_AVGCTRL_SAMPLENUM_2_Val     _U_(0x1)   /**< \brief (ADC_AVGCTRL) 2 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_4_Val     _U_(0x2)   /**< \brief (ADC_AVGCTRL) 4 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_8_Val     _U_(0x3)   /**< \brief (ADC_AVGCTRL) 8 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_16_Val    _U_(0x4)   /**< \brief (ADC_AVGCTRL) 16 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_32_Val    _U_(0x5)   /**< \brief (ADC_AVGCTRL) 32 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_64_Val    _U_(0x6)   /**< \brief (ADC_AVGCTRL) 64 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_128_Val   _U_(0x7)   /**< \brief (ADC_AVGCTRL) 128 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_256_Val   _U_(0x8)   /**< \brief (ADC_AVGCTRL) 256 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_512_Val   _U_(0x9)   /**< \brief (ADC_AVGCTRL) 512 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_1024_Val  _U_(0xA)   /**< \brief (ADC_AVGCTRL) 1024 samples */
+#define ADC_AVGCTRL_SAMPLENUM_1     (ADC_AVGCTRL_SAMPLENUM_1_Val   << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_2     (ADC_AVGCTRL_SAMPLENUM_2_Val   << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_4     (ADC_AVGCTRL_SAMPLENUM_4_Val   << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_8     (ADC_AVGCTRL_SAMPLENUM_8_Val   << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_16    (ADC_AVGCTRL_SAMPLENUM_16_Val  << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_32    (ADC_AVGCTRL_SAMPLENUM_32_Val  << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_64    (ADC_AVGCTRL_SAMPLENUM_64_Val  << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_128   (ADC_AVGCTRL_SAMPLENUM_128_Val << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_256   (ADC_AVGCTRL_SAMPLENUM_256_Val << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_512   (ADC_AVGCTRL_SAMPLENUM_512_Val << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_1024  (ADC_AVGCTRL_SAMPLENUM_1024_Val << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_ADJRES_Pos      4            /**< \brief (ADC_AVGCTRL) Adjusting Result / Division Coefficient */
+#define ADC_AVGCTRL_ADJRES_Msk      (_U_(0x7) << ADC_AVGCTRL_ADJRES_Pos)
+#define ADC_AVGCTRL_ADJRES(value)   (ADC_AVGCTRL_ADJRES_Msk & ((value) << ADC_AVGCTRL_ADJRES_Pos))
+#define ADC_AVGCTRL_MASK            _U_(0x7F)    /**< \brief (ADC_AVGCTRL) MASK Register */
+
+/* -------- ADC_SAMPCTRL : (ADC Offset: 0x03) (R/W  8) Sampling Time Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SAMPLEN:6;        /*!< bit:  0.. 5  Sampling Time Length               */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_SAMPCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SAMPCTRL_OFFSET         0x03         /**< \brief (ADC_SAMPCTRL offset) Sampling Time Control */
+#define ADC_SAMPCTRL_RESETVALUE     _U_(0x00)    /**< \brief (ADC_SAMPCTRL reset_value) Sampling Time Control */
+
+#define ADC_SAMPCTRL_SAMPLEN_Pos    0            /**< \brief (ADC_SAMPCTRL) Sampling Time Length */
+#define ADC_SAMPCTRL_SAMPLEN_Msk    (_U_(0x3F) << ADC_SAMPCTRL_SAMPLEN_Pos)
+#define ADC_SAMPCTRL_SAMPLEN(value) (ADC_SAMPCTRL_SAMPLEN_Msk & ((value) << ADC_SAMPCTRL_SAMPLEN_Pos))
+#define ADC_SAMPCTRL_MASK           _U_(0x3F)    /**< \brief (ADC_SAMPCTRL) MASK Register */
+
+/* -------- ADC_CTRLB : (ADC Offset: 0x04) (R/W 16) Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DIFFMODE:1;       /*!< bit:      0  Differential Mode                  */
+    uint16_t LEFTADJ:1;        /*!< bit:      1  Left Adjusted Result               */
+    uint16_t FREERUN:1;        /*!< bit:      2  Free Running Mode                  */
+    uint16_t CORREN:1;         /*!< bit:      3  Digital Correction Logic Enabled   */
+    uint16_t RESSEL:2;         /*!< bit:  4.. 5  Conversion Result Resolution       */
+    uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t PRESCALER:3;      /*!< bit:  8..10  Prescaler Configuration            */
+    uint16_t :5;               /*!< bit: 11..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CTRLB_OFFSET            0x04         /**< \brief (ADC_CTRLB offset) Control B */
+#define ADC_CTRLB_RESETVALUE        _U_(0x0000)  /**< \brief (ADC_CTRLB reset_value) Control B */
+
+#define ADC_CTRLB_DIFFMODE_Pos      0            /**< \brief (ADC_CTRLB) Differential Mode */
+#define ADC_CTRLB_DIFFMODE          (_U_(0x1) << ADC_CTRLB_DIFFMODE_Pos)
+#define ADC_CTRLB_LEFTADJ_Pos       1            /**< \brief (ADC_CTRLB) Left Adjusted Result */
+#define ADC_CTRLB_LEFTADJ           (_U_(0x1) << ADC_CTRLB_LEFTADJ_Pos)
+#define ADC_CTRLB_FREERUN_Pos       2            /**< \brief (ADC_CTRLB) Free Running Mode */
+#define ADC_CTRLB_FREERUN           (_U_(0x1) << ADC_CTRLB_FREERUN_Pos)
+#define ADC_CTRLB_CORREN_Pos        3            /**< \brief (ADC_CTRLB) Digital Correction Logic Enabled */
+#define ADC_CTRLB_CORREN            (_U_(0x1) << ADC_CTRLB_CORREN_Pos)
+#define ADC_CTRLB_RESSEL_Pos        4            /**< \brief (ADC_CTRLB) Conversion Result Resolution */
+#define ADC_CTRLB_RESSEL_Msk        (_U_(0x3) << ADC_CTRLB_RESSEL_Pos)
+#define ADC_CTRLB_RESSEL(value)     (ADC_CTRLB_RESSEL_Msk & ((value) << ADC_CTRLB_RESSEL_Pos))
+#define   ADC_CTRLB_RESSEL_12BIT_Val      _U_(0x0)   /**< \brief (ADC_CTRLB) 12-bit result */
+#define   ADC_CTRLB_RESSEL_16BIT_Val      _U_(0x1)   /**< \brief (ADC_CTRLB) For averaging mode output */
+#define   ADC_CTRLB_RESSEL_10BIT_Val      _U_(0x2)   /**< \brief (ADC_CTRLB) 10-bit result */
+#define   ADC_CTRLB_RESSEL_8BIT_Val       _U_(0x3)   /**< \brief (ADC_CTRLB) 8-bit result */
+#define ADC_CTRLB_RESSEL_12BIT      (ADC_CTRLB_RESSEL_12BIT_Val    << ADC_CTRLB_RESSEL_Pos)
+#define ADC_CTRLB_RESSEL_16BIT      (ADC_CTRLB_RESSEL_16BIT_Val    << ADC_CTRLB_RESSEL_Pos)
+#define ADC_CTRLB_RESSEL_10BIT      (ADC_CTRLB_RESSEL_10BIT_Val    << ADC_CTRLB_RESSEL_Pos)
+#define ADC_CTRLB_RESSEL_8BIT       (ADC_CTRLB_RESSEL_8BIT_Val     << ADC_CTRLB_RESSEL_Pos)
+#define ADC_CTRLB_PRESCALER_Pos     8            /**< \brief (ADC_CTRLB) Prescaler Configuration */
+#define ADC_CTRLB_PRESCALER_Msk     (_U_(0x7) << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER(value)  (ADC_CTRLB_PRESCALER_Msk & ((value) << ADC_CTRLB_PRESCALER_Pos))
+#define   ADC_CTRLB_PRESCALER_DIV4_Val    _U_(0x0)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 4 */
+#define   ADC_CTRLB_PRESCALER_DIV8_Val    _U_(0x1)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 8 */
+#define   ADC_CTRLB_PRESCALER_DIV16_Val   _U_(0x2)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 16 */
+#define   ADC_CTRLB_PRESCALER_DIV32_Val   _U_(0x3)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 32 */
+#define   ADC_CTRLB_PRESCALER_DIV64_Val   _U_(0x4)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 64 */
+#define   ADC_CTRLB_PRESCALER_DIV128_Val  _U_(0x5)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 128 */
+#define   ADC_CTRLB_PRESCALER_DIV256_Val  _U_(0x6)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 256 */
+#define   ADC_CTRLB_PRESCALER_DIV512_Val  _U_(0x7)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 512 */
+#define ADC_CTRLB_PRESCALER_DIV4    (ADC_CTRLB_PRESCALER_DIV4_Val  << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV8    (ADC_CTRLB_PRESCALER_DIV8_Val  << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV16   (ADC_CTRLB_PRESCALER_DIV16_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV32   (ADC_CTRLB_PRESCALER_DIV32_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV64   (ADC_CTRLB_PRESCALER_DIV64_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV128  (ADC_CTRLB_PRESCALER_DIV128_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV256  (ADC_CTRLB_PRESCALER_DIV256_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV512  (ADC_CTRLB_PRESCALER_DIV512_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_MASK              _U_(0x073F)  /**< \brief (ADC_CTRLB) MASK Register */
+
+/* -------- ADC_WINCTRL : (ADC Offset: 0x08) (R/W  8) Window Monitor Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  WINMODE:3;        /*!< bit:  0.. 2  Window Monitor Mode                */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_WINCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_WINCTRL_OFFSET          0x08         /**< \brief (ADC_WINCTRL offset) Window Monitor Control */
+#define ADC_WINCTRL_RESETVALUE      _U_(0x00)    /**< \brief (ADC_WINCTRL reset_value) Window Monitor Control */
+
+#define ADC_WINCTRL_WINMODE_Pos     0            /**< \brief (ADC_WINCTRL) Window Monitor Mode */
+#define ADC_WINCTRL_WINMODE_Msk     (_U_(0x7) << ADC_WINCTRL_WINMODE_Pos)
+#define ADC_WINCTRL_WINMODE(value)  (ADC_WINCTRL_WINMODE_Msk & ((value) << ADC_WINCTRL_WINMODE_Pos))
+#define   ADC_WINCTRL_WINMODE_DISABLE_Val _U_(0x0)   /**< \brief (ADC_WINCTRL) No window mode (default) */
+#define   ADC_WINCTRL_WINMODE_MODE1_Val   _U_(0x1)   /**< \brief (ADC_WINCTRL) Mode 1: RESULT > WINLT */
+#define   ADC_WINCTRL_WINMODE_MODE2_Val   _U_(0x2)   /**< \brief (ADC_WINCTRL) Mode 2: RESULT < WINUT */
+#define   ADC_WINCTRL_WINMODE_MODE3_Val   _U_(0x3)   /**< \brief (ADC_WINCTRL) Mode 3: WINLT < RESULT < WINUT */
+#define   ADC_WINCTRL_WINMODE_MODE4_Val   _U_(0x4)   /**< \brief (ADC_WINCTRL) Mode 4: !(WINLT < RESULT < WINUT) */
+#define ADC_WINCTRL_WINMODE_DISABLE (ADC_WINCTRL_WINMODE_DISABLE_Val << ADC_WINCTRL_WINMODE_Pos)
+#define ADC_WINCTRL_WINMODE_MODE1   (ADC_WINCTRL_WINMODE_MODE1_Val << ADC_WINCTRL_WINMODE_Pos)
+#define ADC_WINCTRL_WINMODE_MODE2   (ADC_WINCTRL_WINMODE_MODE2_Val << ADC_WINCTRL_WINMODE_Pos)
+#define ADC_WINCTRL_WINMODE_MODE3   (ADC_WINCTRL_WINMODE_MODE3_Val << ADC_WINCTRL_WINMODE_Pos)
+#define ADC_WINCTRL_WINMODE_MODE4   (ADC_WINCTRL_WINMODE_MODE4_Val << ADC_WINCTRL_WINMODE_Pos)
+#define ADC_WINCTRL_MASK            _U_(0x07)    /**< \brief (ADC_WINCTRL) MASK Register */
+
+/* -------- ADC_SWTRIG : (ADC Offset: 0x0C) (R/W  8) Software Trigger -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  FLUSH:1;          /*!< bit:      0  ADC Conversion Flush               */
+    uint8_t  START:1;          /*!< bit:      1  ADC Start Conversion               */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_SWTRIG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SWTRIG_OFFSET           0x0C         /**< \brief (ADC_SWTRIG offset) Software Trigger */
+#define ADC_SWTRIG_RESETVALUE       _U_(0x00)    /**< \brief (ADC_SWTRIG reset_value) Software Trigger */
+
+#define ADC_SWTRIG_FLUSH_Pos        0            /**< \brief (ADC_SWTRIG) ADC Conversion Flush */
+#define ADC_SWTRIG_FLUSH            (_U_(0x1) << ADC_SWTRIG_FLUSH_Pos)
+#define ADC_SWTRIG_START_Pos        1            /**< \brief (ADC_SWTRIG) ADC Start Conversion */
+#define ADC_SWTRIG_START            (_U_(0x1) << ADC_SWTRIG_START_Pos)
+#define ADC_SWTRIG_MASK             _U_(0x03)    /**< \brief (ADC_SWTRIG) MASK Register */
+
+/* -------- ADC_INPUTCTRL : (ADC Offset: 0x10) (R/W 32) Inputs Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MUXPOS:5;         /*!< bit:  0.. 4  Positive MUX Input Selection       */
+    uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint32_t MUXNEG:5;         /*!< bit:  8..12  Negative MUX Input Selection       */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t INPUTSCAN:4;      /*!< bit: 16..19  Number of Input Channels Included in Scan */
+    uint32_t INPUTOFFSET:4;    /*!< bit: 20..23  Positive MUX Setting Offset        */
+    uint32_t GAIN:4;           /*!< bit: 24..27  Gain Factor Selection              */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADC_INPUTCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INPUTCTRL_OFFSET        0x10         /**< \brief (ADC_INPUTCTRL offset) Inputs Control */
+#define ADC_INPUTCTRL_RESETVALUE    _U_(0x00000000) /**< \brief (ADC_INPUTCTRL reset_value) Inputs Control */
+
+#define ADC_INPUTCTRL_MUXPOS_Pos    0            /**< \brief (ADC_INPUTCTRL) Positive MUX Input Selection */
+#define ADC_INPUTCTRL_MUXPOS_Msk    (_U_(0x1F) << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS(value) (ADC_INPUTCTRL_MUXPOS_Msk & ((value) << ADC_INPUTCTRL_MUXPOS_Pos))
+#define   ADC_INPUTCTRL_MUXPOS_PIN0_Val   _U_(0x0)   /**< \brief (ADC_INPUTCTRL) ADC AIN0 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN1_Val   _U_(0x1)   /**< \brief (ADC_INPUTCTRL) ADC AIN1 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN2_Val   _U_(0x2)   /**< \brief (ADC_INPUTCTRL) ADC AIN2 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN3_Val   _U_(0x3)   /**< \brief (ADC_INPUTCTRL) ADC AIN3 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN4_Val   _U_(0x4)   /**< \brief (ADC_INPUTCTRL) ADC AIN4 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN5_Val   _U_(0x5)   /**< \brief (ADC_INPUTCTRL) ADC AIN5 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN6_Val   _U_(0x6)   /**< \brief (ADC_INPUTCTRL) ADC AIN6 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN7_Val   _U_(0x7)   /**< \brief (ADC_INPUTCTRL) ADC AIN7 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN8_Val   _U_(0x8)   /**< \brief (ADC_INPUTCTRL) ADC AIN8 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN9_Val   _U_(0x9)   /**< \brief (ADC_INPUTCTRL) ADC AIN9 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN10_Val  _U_(0xA)   /**< \brief (ADC_INPUTCTRL) ADC AIN10 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN11_Val  _U_(0xB)   /**< \brief (ADC_INPUTCTRL) ADC AIN11 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN12_Val  _U_(0xC)   /**< \brief (ADC_INPUTCTRL) ADC AIN12 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN13_Val  _U_(0xD)   /**< \brief (ADC_INPUTCTRL) ADC AIN13 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN14_Val  _U_(0xE)   /**< \brief (ADC_INPUTCTRL) ADC AIN14 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN15_Val  _U_(0xF)   /**< \brief (ADC_INPUTCTRL) ADC AIN15 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN16_Val  _U_(0x10)   /**< \brief (ADC_INPUTCTRL) ADC AIN16 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN17_Val  _U_(0x11)   /**< \brief (ADC_INPUTCTRL) ADC AIN17 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN18_Val  _U_(0x12)   /**< \brief (ADC_INPUTCTRL) ADC AIN18 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN19_Val  _U_(0x13)   /**< \brief (ADC_INPUTCTRL) ADC AIN19 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_TEMP_Val   _U_(0x18)   /**< \brief (ADC_INPUTCTRL) Temperature Reference */
+#define   ADC_INPUTCTRL_MUXPOS_BANDGAP_Val _U_(0x19)   /**< \brief (ADC_INPUTCTRL) Bandgap Voltage */
+#define   ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC_Val _U_(0x1A)   /**< \brief (ADC_INPUTCTRL) 1/4  Scaled Core Supply */
+#define   ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val _U_(0x1B)   /**< \brief (ADC_INPUTCTRL) 1/4  Scaled I/O Supply */
+#define   ADC_INPUTCTRL_MUXPOS_DAC_Val    _U_(0x1C)   /**< \brief (ADC_INPUTCTRL) DAC Output */
+#define ADC_INPUTCTRL_MUXPOS_PIN0   (ADC_INPUTCTRL_MUXPOS_PIN0_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN1   (ADC_INPUTCTRL_MUXPOS_PIN1_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN2   (ADC_INPUTCTRL_MUXPOS_PIN2_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN3   (ADC_INPUTCTRL_MUXPOS_PIN3_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN4   (ADC_INPUTCTRL_MUXPOS_PIN4_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN5   (ADC_INPUTCTRL_MUXPOS_PIN5_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN6   (ADC_INPUTCTRL_MUXPOS_PIN6_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN7   (ADC_INPUTCTRL_MUXPOS_PIN7_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN8   (ADC_INPUTCTRL_MUXPOS_PIN8_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN9   (ADC_INPUTCTRL_MUXPOS_PIN9_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN10  (ADC_INPUTCTRL_MUXPOS_PIN10_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN11  (ADC_INPUTCTRL_MUXPOS_PIN11_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN12  (ADC_INPUTCTRL_MUXPOS_PIN12_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN13  (ADC_INPUTCTRL_MUXPOS_PIN13_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN14  (ADC_INPUTCTRL_MUXPOS_PIN14_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN15  (ADC_INPUTCTRL_MUXPOS_PIN15_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN16  (ADC_INPUTCTRL_MUXPOS_PIN16_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN17  (ADC_INPUTCTRL_MUXPOS_PIN17_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN18  (ADC_INPUTCTRL_MUXPOS_PIN18_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN19  (ADC_INPUTCTRL_MUXPOS_PIN19_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_TEMP   (ADC_INPUTCTRL_MUXPOS_TEMP_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_BANDGAP (ADC_INPUTCTRL_MUXPOS_BANDGAP_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC (ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC (ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_DAC    (ADC_INPUTCTRL_MUXPOS_DAC_Val  << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXNEG_Pos    8            /**< \brief (ADC_INPUTCTRL) Negative MUX Input Selection */
+#define ADC_INPUTCTRL_MUXNEG_Msk    (_U_(0x1F) << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG(value) (ADC_INPUTCTRL_MUXNEG_Msk & ((value) << ADC_INPUTCTRL_MUXNEG_Pos))
+#define   ADC_INPUTCTRL_MUXNEG_PIN0_Val   _U_(0x0)   /**< \brief (ADC_INPUTCTRL) ADC AIN0 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN1_Val   _U_(0x1)   /**< \brief (ADC_INPUTCTRL) ADC AIN1 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN2_Val   _U_(0x2)   /**< \brief (ADC_INPUTCTRL) ADC AIN2 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN3_Val   _U_(0x3)   /**< \brief (ADC_INPUTCTRL) ADC AIN3 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN4_Val   _U_(0x4)   /**< \brief (ADC_INPUTCTRL) ADC AIN4 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN5_Val   _U_(0x5)   /**< \brief (ADC_INPUTCTRL) ADC AIN5 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN6_Val   _U_(0x6)   /**< \brief (ADC_INPUTCTRL) ADC AIN6 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN7_Val   _U_(0x7)   /**< \brief (ADC_INPUTCTRL) ADC AIN7 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_GND_Val    _U_(0x18)   /**< \brief (ADC_INPUTCTRL) Internal ground */
+#define   ADC_INPUTCTRL_MUXNEG_IOGND_Val  _U_(0x19)   /**< \brief (ADC_INPUTCTRL) IO ground */
+#define ADC_INPUTCTRL_MUXNEG_PIN0   (ADC_INPUTCTRL_MUXNEG_PIN0_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_PIN1   (ADC_INPUTCTRL_MUXNEG_PIN1_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_PIN2   (ADC_INPUTCTRL_MUXNEG_PIN2_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_PIN3   (ADC_INPUTCTRL_MUXNEG_PIN3_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_PIN4   (ADC_INPUTCTRL_MUXNEG_PIN4_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_PIN5   (ADC_INPUTCTRL_MUXNEG_PIN5_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_PIN6   (ADC_INPUTCTRL_MUXNEG_PIN6_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_PIN7   (ADC_INPUTCTRL_MUXNEG_PIN7_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_GND    (ADC_INPUTCTRL_MUXNEG_GND_Val  << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_IOGND  (ADC_INPUTCTRL_MUXNEG_IOGND_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_INPUTSCAN_Pos 16           /**< \brief (ADC_INPUTCTRL) Number of Input Channels Included in Scan */
+#define ADC_INPUTCTRL_INPUTSCAN_Msk (_U_(0xF) << ADC_INPUTCTRL_INPUTSCAN_Pos)
+#define ADC_INPUTCTRL_INPUTSCAN(value) (ADC_INPUTCTRL_INPUTSCAN_Msk & ((value) << ADC_INPUTCTRL_INPUTSCAN_Pos))
+#define ADC_INPUTCTRL_INPUTOFFSET_Pos 20           /**< \brief (ADC_INPUTCTRL) Positive MUX Setting Offset */
+#define ADC_INPUTCTRL_INPUTOFFSET_Msk (_U_(0xF) << ADC_INPUTCTRL_INPUTOFFSET_Pos)
+#define ADC_INPUTCTRL_INPUTOFFSET(value) (ADC_INPUTCTRL_INPUTOFFSET_Msk & ((value) << ADC_INPUTCTRL_INPUTOFFSET_Pos))
+#define ADC_INPUTCTRL_GAIN_Pos      24           /**< \brief (ADC_INPUTCTRL) Gain Factor Selection */
+#define ADC_INPUTCTRL_GAIN_Msk      (_U_(0xF) << ADC_INPUTCTRL_GAIN_Pos)
+#define ADC_INPUTCTRL_GAIN(value)   (ADC_INPUTCTRL_GAIN_Msk & ((value) << ADC_INPUTCTRL_GAIN_Pos))
+#define   ADC_INPUTCTRL_GAIN_1X_Val       _U_(0x0)   /**< \brief (ADC_INPUTCTRL) 1x */
+#define   ADC_INPUTCTRL_GAIN_2X_Val       _U_(0x1)   /**< \brief (ADC_INPUTCTRL) 2x */
+#define   ADC_INPUTCTRL_GAIN_4X_Val       _U_(0x2)   /**< \brief (ADC_INPUTCTRL) 4x */
+#define   ADC_INPUTCTRL_GAIN_8X_Val       _U_(0x3)   /**< \brief (ADC_INPUTCTRL) 8x */
+#define   ADC_INPUTCTRL_GAIN_16X_Val      _U_(0x4)   /**< \brief (ADC_INPUTCTRL) 16x */
+#define   ADC_INPUTCTRL_GAIN_DIV2_Val     _U_(0xF)   /**< \brief (ADC_INPUTCTRL) 1/2x */
+#define ADC_INPUTCTRL_GAIN_1X       (ADC_INPUTCTRL_GAIN_1X_Val     << ADC_INPUTCTRL_GAIN_Pos)
+#define ADC_INPUTCTRL_GAIN_2X       (ADC_INPUTCTRL_GAIN_2X_Val     << ADC_INPUTCTRL_GAIN_Pos)
+#define ADC_INPUTCTRL_GAIN_4X       (ADC_INPUTCTRL_GAIN_4X_Val     << ADC_INPUTCTRL_GAIN_Pos)
+#define ADC_INPUTCTRL_GAIN_8X       (ADC_INPUTCTRL_GAIN_8X_Val     << ADC_INPUTCTRL_GAIN_Pos)
+#define ADC_INPUTCTRL_GAIN_16X      (ADC_INPUTCTRL_GAIN_16X_Val    << ADC_INPUTCTRL_GAIN_Pos)
+#define ADC_INPUTCTRL_GAIN_DIV2     (ADC_INPUTCTRL_GAIN_DIV2_Val   << ADC_INPUTCTRL_GAIN_Pos)
+#define ADC_INPUTCTRL_MASK          _U_(0x0FFF1F1F) /**< \brief (ADC_INPUTCTRL) MASK Register */
+
+/* -------- ADC_EVCTRL : (ADC Offset: 0x14) (R/W  8) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  STARTEI:1;        /*!< bit:      0  Start Conversion Event In          */
+    uint8_t  SYNCEI:1;         /*!< bit:      1  Synchronization Event In           */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  RESRDYEO:1;       /*!< bit:      4  Result Ready Event Out             */
+    uint8_t  WINMONEO:1;       /*!< bit:      5  Window Monitor Event Out           */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_EVCTRL_OFFSET           0x14         /**< \brief (ADC_EVCTRL offset) Event Control */
+#define ADC_EVCTRL_RESETVALUE       _U_(0x00)    /**< \brief (ADC_EVCTRL reset_value) Event Control */
+
+#define ADC_EVCTRL_STARTEI_Pos      0            /**< \brief (ADC_EVCTRL) Start Conversion Event In */
+#define ADC_EVCTRL_STARTEI          (_U_(0x1) << ADC_EVCTRL_STARTEI_Pos)
+#define ADC_EVCTRL_SYNCEI_Pos       1            /**< \brief (ADC_EVCTRL) Synchronization Event In */
+#define ADC_EVCTRL_SYNCEI           (_U_(0x1) << ADC_EVCTRL_SYNCEI_Pos)
+#define ADC_EVCTRL_RESRDYEO_Pos     4            /**< \brief (ADC_EVCTRL) Result Ready Event Out */
+#define ADC_EVCTRL_RESRDYEO         (_U_(0x1) << ADC_EVCTRL_RESRDYEO_Pos)
+#define ADC_EVCTRL_WINMONEO_Pos     5            /**< \brief (ADC_EVCTRL) Window Monitor Event Out */
+#define ADC_EVCTRL_WINMONEO         (_U_(0x1) << ADC_EVCTRL_WINMONEO_Pos)
+#define ADC_EVCTRL_MASK             _U_(0x33)    /**< \brief (ADC_EVCTRL) MASK Register */
+
+/* -------- ADC_INTENCLR : (ADC Offset: 0x16) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Enable      */
+    uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Enable           */
+    uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Enable    */
+    uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready Interrupt Enable */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INTENCLR_OFFSET         0x16         /**< \brief (ADC_INTENCLR offset) Interrupt Enable Clear */
+#define ADC_INTENCLR_RESETVALUE     _U_(0x00)    /**< \brief (ADC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define ADC_INTENCLR_RESRDY_Pos     0            /**< \brief (ADC_INTENCLR) Result Ready Interrupt Enable */
+#define ADC_INTENCLR_RESRDY         (_U_(0x1) << ADC_INTENCLR_RESRDY_Pos)
+#define ADC_INTENCLR_OVERRUN_Pos    1            /**< \brief (ADC_INTENCLR) Overrun Interrupt Enable */
+#define ADC_INTENCLR_OVERRUN        (_U_(0x1) << ADC_INTENCLR_OVERRUN_Pos)
+#define ADC_INTENCLR_WINMON_Pos     2            /**< \brief (ADC_INTENCLR) Window Monitor Interrupt Enable */
+#define ADC_INTENCLR_WINMON         (_U_(0x1) << ADC_INTENCLR_WINMON_Pos)
+#define ADC_INTENCLR_SYNCRDY_Pos    3            /**< \brief (ADC_INTENCLR) Synchronization Ready Interrupt Enable */
+#define ADC_INTENCLR_SYNCRDY        (_U_(0x1) << ADC_INTENCLR_SYNCRDY_Pos)
+#define ADC_INTENCLR_MASK           _U_(0x0F)    /**< \brief (ADC_INTENCLR) MASK Register */
+
+/* -------- ADC_INTENSET : (ADC Offset: 0x17) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Enable      */
+    uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Enable           */
+    uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Enable    */
+    uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready Interrupt Enable */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INTENSET_OFFSET         0x17         /**< \brief (ADC_INTENSET offset) Interrupt Enable Set */
+#define ADC_INTENSET_RESETVALUE     _U_(0x00)    /**< \brief (ADC_INTENSET reset_value) Interrupt Enable Set */
+
+#define ADC_INTENSET_RESRDY_Pos     0            /**< \brief (ADC_INTENSET) Result Ready Interrupt Enable */
+#define ADC_INTENSET_RESRDY         (_U_(0x1) << ADC_INTENSET_RESRDY_Pos)
+#define ADC_INTENSET_OVERRUN_Pos    1            /**< \brief (ADC_INTENSET) Overrun Interrupt Enable */
+#define ADC_INTENSET_OVERRUN        (_U_(0x1) << ADC_INTENSET_OVERRUN_Pos)
+#define ADC_INTENSET_WINMON_Pos     2            /**< \brief (ADC_INTENSET) Window Monitor Interrupt Enable */
+#define ADC_INTENSET_WINMON         (_U_(0x1) << ADC_INTENSET_WINMON_Pos)
+#define ADC_INTENSET_SYNCRDY_Pos    3            /**< \brief (ADC_INTENSET) Synchronization Ready Interrupt Enable */
+#define ADC_INTENSET_SYNCRDY        (_U_(0x1) << ADC_INTENSET_SYNCRDY_Pos)
+#define ADC_INTENSET_MASK           _U_(0x0F)    /**< \brief (ADC_INTENSET) MASK Register */
+
+/* -------- ADC_INTFLAG : (ADC Offset: 0x18) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready                       */
+    __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun                            */
+    __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor                     */
+    __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
+    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INTFLAG_OFFSET          0x18         /**< \brief (ADC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define ADC_INTFLAG_RESETVALUE      _U_(0x00)    /**< \brief (ADC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define ADC_INTFLAG_RESRDY_Pos      0            /**< \brief (ADC_INTFLAG) Result Ready */
+#define ADC_INTFLAG_RESRDY          (_U_(0x1) << ADC_INTFLAG_RESRDY_Pos)
+#define ADC_INTFLAG_OVERRUN_Pos     1            /**< \brief (ADC_INTFLAG) Overrun */
+#define ADC_INTFLAG_OVERRUN         (_U_(0x1) << ADC_INTFLAG_OVERRUN_Pos)
+#define ADC_INTFLAG_WINMON_Pos      2            /**< \brief (ADC_INTFLAG) Window Monitor */
+#define ADC_INTFLAG_WINMON          (_U_(0x1) << ADC_INTFLAG_WINMON_Pos)
+#define ADC_INTFLAG_SYNCRDY_Pos     3            /**< \brief (ADC_INTFLAG) Synchronization Ready */
+#define ADC_INTFLAG_SYNCRDY         (_U_(0x1) << ADC_INTFLAG_SYNCRDY_Pos)
+#define ADC_INTFLAG_MASK            _U_(0x0F)    /**< \brief (ADC_INTFLAG) MASK Register */
+
+/* -------- ADC_STATUS : (ADC Offset: 0x19) (R/   8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_STATUS_OFFSET           0x19         /**< \brief (ADC_STATUS offset) Status */
+#define ADC_STATUS_RESETVALUE       _U_(0x00)    /**< \brief (ADC_STATUS reset_value) Status */
+
+#define ADC_STATUS_SYNCBUSY_Pos     7            /**< \brief (ADC_STATUS) Synchronization Busy */
+#define ADC_STATUS_SYNCBUSY         (_U_(0x1) << ADC_STATUS_SYNCBUSY_Pos)
+#define ADC_STATUS_MASK             _U_(0x80)    /**< \brief (ADC_STATUS) MASK Register */
+
+/* -------- ADC_RESULT : (ADC Offset: 0x1A) (R/  16) Result -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t RESULT:16;        /*!< bit:  0..15  Result Conversion Value            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_RESULT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_RESULT_OFFSET           0x1A         /**< \brief (ADC_RESULT offset) Result */
+#define ADC_RESULT_RESETVALUE       _U_(0x0000)  /**< \brief (ADC_RESULT reset_value) Result */
+
+#define ADC_RESULT_RESULT_Pos       0            /**< \brief (ADC_RESULT) Result Conversion Value */
+#define ADC_RESULT_RESULT_Msk       (_U_(0xFFFF) << ADC_RESULT_RESULT_Pos)
+#define ADC_RESULT_RESULT(value)    (ADC_RESULT_RESULT_Msk & ((value) << ADC_RESULT_RESULT_Pos))
+#define ADC_RESULT_MASK             _U_(0xFFFF)  /**< \brief (ADC_RESULT) MASK Register */
+
+/* -------- ADC_WINLT : (ADC Offset: 0x1C) (R/W 16) Window Monitor Lower Threshold -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t WINLT:16;         /*!< bit:  0..15  Window Lower Threshold             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_WINLT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_WINLT_OFFSET            0x1C         /**< \brief (ADC_WINLT offset) Window Monitor Lower Threshold */
+#define ADC_WINLT_RESETVALUE        _U_(0x0000)  /**< \brief (ADC_WINLT reset_value) Window Monitor Lower Threshold */
+
+#define ADC_WINLT_WINLT_Pos         0            /**< \brief (ADC_WINLT) Window Lower Threshold */
+#define ADC_WINLT_WINLT_Msk         (_U_(0xFFFF) << ADC_WINLT_WINLT_Pos)
+#define ADC_WINLT_WINLT(value)      (ADC_WINLT_WINLT_Msk & ((value) << ADC_WINLT_WINLT_Pos))
+#define ADC_WINLT_MASK              _U_(0xFFFF)  /**< \brief (ADC_WINLT) MASK Register */
+
+/* -------- ADC_WINUT : (ADC Offset: 0x20) (R/W 16) Window Monitor Upper Threshold -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t WINUT:16;         /*!< bit:  0..15  Window Upper Threshold             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_WINUT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_WINUT_OFFSET            0x20         /**< \brief (ADC_WINUT offset) Window Monitor Upper Threshold */
+#define ADC_WINUT_RESETVALUE        _U_(0x0000)  /**< \brief (ADC_WINUT reset_value) Window Monitor Upper Threshold */
+
+#define ADC_WINUT_WINUT_Pos         0            /**< \brief (ADC_WINUT) Window Upper Threshold */
+#define ADC_WINUT_WINUT_Msk         (_U_(0xFFFF) << ADC_WINUT_WINUT_Pos)
+#define ADC_WINUT_WINUT(value)      (ADC_WINUT_WINUT_Msk & ((value) << ADC_WINUT_WINUT_Pos))
+#define ADC_WINUT_MASK              _U_(0xFFFF)  /**< \brief (ADC_WINUT) MASK Register */
+
+/* -------- ADC_GAINCORR : (ADC Offset: 0x24) (R/W 16) Gain Correction -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t GAINCORR:12;      /*!< bit:  0..11  Gain Correction Value              */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_GAINCORR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_GAINCORR_OFFSET         0x24         /**< \brief (ADC_GAINCORR offset) Gain Correction */
+#define ADC_GAINCORR_RESETVALUE     _U_(0x0000)  /**< \brief (ADC_GAINCORR reset_value) Gain Correction */
+
+#define ADC_GAINCORR_GAINCORR_Pos   0            /**< \brief (ADC_GAINCORR) Gain Correction Value */
+#define ADC_GAINCORR_GAINCORR_Msk   (_U_(0xFFF) << ADC_GAINCORR_GAINCORR_Pos)
+#define ADC_GAINCORR_GAINCORR(value) (ADC_GAINCORR_GAINCORR_Msk & ((value) << ADC_GAINCORR_GAINCORR_Pos))
+#define ADC_GAINCORR_MASK           _U_(0x0FFF)  /**< \brief (ADC_GAINCORR) MASK Register */
+
+/* -------- ADC_OFFSETCORR : (ADC Offset: 0x26) (R/W 16) Offset Correction -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t OFFSETCORR:12;    /*!< bit:  0..11  Offset Correction Value            */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_OFFSETCORR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_OFFSETCORR_OFFSET       0x26         /**< \brief (ADC_OFFSETCORR offset) Offset Correction */
+#define ADC_OFFSETCORR_RESETVALUE   _U_(0x0000)  /**< \brief (ADC_OFFSETCORR reset_value) Offset Correction */
+
+#define ADC_OFFSETCORR_OFFSETCORR_Pos 0            /**< \brief (ADC_OFFSETCORR) Offset Correction Value */
+#define ADC_OFFSETCORR_OFFSETCORR_Msk (_U_(0xFFF) << ADC_OFFSETCORR_OFFSETCORR_Pos)
+#define ADC_OFFSETCORR_OFFSETCORR(value) (ADC_OFFSETCORR_OFFSETCORR_Msk & ((value) << ADC_OFFSETCORR_OFFSETCORR_Pos))
+#define ADC_OFFSETCORR_MASK         _U_(0x0FFF)  /**< \brief (ADC_OFFSETCORR) MASK Register */
+
+/* -------- ADC_CALIB : (ADC Offset: 0x28) (R/W 16) Calibration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t LINEARITY_CAL:8;  /*!< bit:  0.. 7  Linearity Calibration Value        */
+    uint16_t BIAS_CAL:3;       /*!< bit:  8..10  Bias Calibration Value             */
+    uint16_t :5;               /*!< bit: 11..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_CALIB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CALIB_OFFSET            0x28         /**< \brief (ADC_CALIB offset) Calibration */
+#define ADC_CALIB_RESETVALUE        _U_(0x0000)  /**< \brief (ADC_CALIB reset_value) Calibration */
+
+#define ADC_CALIB_LINEARITY_CAL_Pos 0            /**< \brief (ADC_CALIB) Linearity Calibration Value */
+#define ADC_CALIB_LINEARITY_CAL_Msk (_U_(0xFF) << ADC_CALIB_LINEARITY_CAL_Pos)
+#define ADC_CALIB_LINEARITY_CAL(value) (ADC_CALIB_LINEARITY_CAL_Msk & ((value) << ADC_CALIB_LINEARITY_CAL_Pos))
+#define ADC_CALIB_BIAS_CAL_Pos      8            /**< \brief (ADC_CALIB) Bias Calibration Value */
+#define ADC_CALIB_BIAS_CAL_Msk      (_U_(0x7) << ADC_CALIB_BIAS_CAL_Pos)
+#define ADC_CALIB_BIAS_CAL(value)   (ADC_CALIB_BIAS_CAL_Msk & ((value) << ADC_CALIB_BIAS_CAL_Pos))
+#define ADC_CALIB_MASK              _U_(0x07FF)  /**< \brief (ADC_CALIB) MASK Register */
+
+/* -------- ADC_DBGCTRL : (ADC Offset: 0x2A) (R/W  8) Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGRUN:1;         /*!< bit:      0  Debug Run                          */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_DBGCTRL_OFFSET          0x2A         /**< \brief (ADC_DBGCTRL offset) Debug Control */
+#define ADC_DBGCTRL_RESETVALUE      _U_(0x00)    /**< \brief (ADC_DBGCTRL reset_value) Debug Control */
+
+#define ADC_DBGCTRL_DBGRUN_Pos      0            /**< \brief (ADC_DBGCTRL) Debug Run */
+#define ADC_DBGCTRL_DBGRUN          (_U_(0x1) << ADC_DBGCTRL_DBGRUN_Pos)
+#define ADC_DBGCTRL_MASK            _U_(0x01)    /**< \brief (ADC_DBGCTRL) MASK Register */
+
+/** \brief ADC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO ADC_CTRLA_Type            CTRLA;       /**< \brief Offset: 0x00 (R/W  8) Control A */
+  __IO ADC_REFCTRL_Type          REFCTRL;     /**< \brief Offset: 0x01 (R/W  8) Reference Control */
+  __IO ADC_AVGCTRL_Type          AVGCTRL;     /**< \brief Offset: 0x02 (R/W  8) Average Control */
+  __IO ADC_SAMPCTRL_Type         SAMPCTRL;    /**< \brief Offset: 0x03 (R/W  8) Sampling Time Control */
+  __IO ADC_CTRLB_Type            CTRLB;       /**< \brief Offset: 0x04 (R/W 16) Control B */
+       RoReg8                    Reserved1[0x2];
+  __IO ADC_WINCTRL_Type          WINCTRL;     /**< \brief Offset: 0x08 (R/W  8) Window Monitor Control */
+       RoReg8                    Reserved2[0x3];
+  __IO ADC_SWTRIG_Type           SWTRIG;      /**< \brief Offset: 0x0C (R/W  8) Software Trigger */
+       RoReg8                    Reserved3[0x3];
+  __IO ADC_INPUTCTRL_Type        INPUTCTRL;   /**< \brief Offset: 0x10 (R/W 32) Inputs Control */
+  __IO ADC_EVCTRL_Type           EVCTRL;      /**< \brief Offset: 0x14 (R/W  8) Event Control */
+       RoReg8                    Reserved4[0x1];
+  __IO ADC_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x16 (R/W  8) Interrupt Enable Clear */
+  __IO ADC_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x17 (R/W  8) Interrupt Enable Set */
+  __IO ADC_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x18 (R/W  8) Interrupt Flag Status and Clear */
+  __I  ADC_STATUS_Type           STATUS;      /**< \brief Offset: 0x19 (R/   8) Status */
+  __I  ADC_RESULT_Type           RESULT;      /**< \brief Offset: 0x1A (R/  16) Result */
+  __IO ADC_WINLT_Type            WINLT;       /**< \brief Offset: 0x1C (R/W 16) Window Monitor Lower Threshold */
+       RoReg8                    Reserved5[0x2];
+  __IO ADC_WINUT_Type            WINUT;       /**< \brief Offset: 0x20 (R/W 16) Window Monitor Upper Threshold */
+       RoReg8                    Reserved6[0x2];
+  __IO ADC_GAINCORR_Type         GAINCORR;    /**< \brief Offset: 0x24 (R/W 16) Gain Correction */
+  __IO ADC_OFFSETCORR_Type       OFFSETCORR;  /**< \brief Offset: 0x26 (R/W 16) Offset Correction */
+  __IO ADC_CALIB_Type            CALIB;       /**< \brief Offset: 0x28 (R/W 16) Calibration */
+  __IO ADC_DBGCTRL_Type          DBGCTRL;     /**< \brief Offset: 0x2A (R/W  8) Debug Control */
+} Adc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_ADC_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/component/dac.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/dac.h
@@ -1,0 +1,269 @@
+/**
+ * \file
+ *
+ * \brief Component description for DAC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_DAC_COMPONENT_
+#define _SAMD20_DAC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DAC */
+/* ========================================================================== */
+/** \addtogroup SAMD20_DAC Digital Analog Converter */
+/*@{*/
+
+#define DAC_U2214
+#define REV_DAC                     0x101
+
+/* -------- DAC_CTRLA : (DAC Offset: 0x0) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  RUNSTDBY:1;       /*!< bit:      2  Run in Standby                     */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_CTRLA_OFFSET            0x0          /**< \brief (DAC_CTRLA offset) Control A */
+#define DAC_CTRLA_RESETVALUE        _U_(0x00)    /**< \brief (DAC_CTRLA reset_value) Control A */
+
+#define DAC_CTRLA_SWRST_Pos         0            /**< \brief (DAC_CTRLA) Software Reset */
+#define DAC_CTRLA_SWRST             (_U_(0x1) << DAC_CTRLA_SWRST_Pos)
+#define DAC_CTRLA_ENABLE_Pos        1            /**< \brief (DAC_CTRLA) Enable */
+#define DAC_CTRLA_ENABLE            (_U_(0x1) << DAC_CTRLA_ENABLE_Pos)
+#define DAC_CTRLA_RUNSTDBY_Pos      2            /**< \brief (DAC_CTRLA) Run in Standby */
+#define DAC_CTRLA_RUNSTDBY          (_U_(0x1) << DAC_CTRLA_RUNSTDBY_Pos)
+#define DAC_CTRLA_MASK              _U_(0x07)    /**< \brief (DAC_CTRLA) MASK Register */
+
+/* -------- DAC_CTRLB : (DAC Offset: 0x1) (R/W  8) Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  EOEN:1;           /*!< bit:      0  External Output Enable             */
+    uint8_t  IOEN:1;           /*!< bit:      1  Internal Output Enable             */
+    uint8_t  LEFTADJ:1;        /*!< bit:      2  Left Adjusted Data                 */
+    uint8_t  VPD:1;            /*!< bit:      3  Voltage Pump Disable               */
+    uint8_t  :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint8_t  REFSEL:2;         /*!< bit:  6.. 7  Reference Selection                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_CTRLB_OFFSET            0x1          /**< \brief (DAC_CTRLB offset) Control B */
+#define DAC_CTRLB_RESETVALUE        _U_(0x00)    /**< \brief (DAC_CTRLB reset_value) Control B */
+
+#define DAC_CTRLB_EOEN_Pos          0            /**< \brief (DAC_CTRLB) External Output Enable */
+#define DAC_CTRLB_EOEN              (_U_(0x1) << DAC_CTRLB_EOEN_Pos)
+#define DAC_CTRLB_IOEN_Pos          1            /**< \brief (DAC_CTRLB) Internal Output Enable */
+#define DAC_CTRLB_IOEN              (_U_(0x1) << DAC_CTRLB_IOEN_Pos)
+#define DAC_CTRLB_LEFTADJ_Pos       2            /**< \brief (DAC_CTRLB) Left Adjusted Data */
+#define DAC_CTRLB_LEFTADJ           (_U_(0x1) << DAC_CTRLB_LEFTADJ_Pos)
+#define DAC_CTRLB_VPD_Pos           3            /**< \brief (DAC_CTRLB) Voltage Pump Disable */
+#define DAC_CTRLB_VPD               (_U_(0x1) << DAC_CTRLB_VPD_Pos)
+#define DAC_CTRLB_REFSEL_Pos        6            /**< \brief (DAC_CTRLB) Reference Selection */
+#define DAC_CTRLB_REFSEL_Msk        (_U_(0x3) << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_REFSEL(value)     (DAC_CTRLB_REFSEL_Msk & ((value) << DAC_CTRLB_REFSEL_Pos))
+#define   DAC_CTRLB_REFSEL_INT1V_Val      _U_(0x0)   /**< \brief (DAC_CTRLB) Internal 1.0V reference */
+#define   DAC_CTRLB_REFSEL_AVCC_Val       _U_(0x1)   /**< \brief (DAC_CTRLB) AVCC */
+#define   DAC_CTRLB_REFSEL_VREFP_Val      _U_(0x2)   /**< \brief (DAC_CTRLB) External reference */
+#define DAC_CTRLB_REFSEL_INT1V      (DAC_CTRLB_REFSEL_INT1V_Val    << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_REFSEL_AVCC       (DAC_CTRLB_REFSEL_AVCC_Val     << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_REFSEL_VREFP      (DAC_CTRLB_REFSEL_VREFP_Val    << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_MASK              _U_(0xCF)    /**< \brief (DAC_CTRLB) MASK Register */
+
+/* -------- DAC_EVCTRL : (DAC Offset: 0x2) (R/W  8) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  STARTEI:1;        /*!< bit:      0  Start Conversion Event Input       */
+    uint8_t  EMPTYEO:1;        /*!< bit:      1  Data Buffer Empty Event Output     */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_EVCTRL_OFFSET           0x2          /**< \brief (DAC_EVCTRL offset) Event Control */
+#define DAC_EVCTRL_RESETVALUE       _U_(0x00)    /**< \brief (DAC_EVCTRL reset_value) Event Control */
+
+#define DAC_EVCTRL_STARTEI_Pos      0            /**< \brief (DAC_EVCTRL) Start Conversion Event Input */
+#define DAC_EVCTRL_STARTEI          (_U_(0x1) << DAC_EVCTRL_STARTEI_Pos)
+#define DAC_EVCTRL_EMPTYEO_Pos      1            /**< \brief (DAC_EVCTRL) Data Buffer Empty Event Output */
+#define DAC_EVCTRL_EMPTYEO          (_U_(0x1) << DAC_EVCTRL_EMPTYEO_Pos)
+#define DAC_EVCTRL_MASK             _U_(0x03)    /**< \brief (DAC_EVCTRL) MASK Register */
+
+/* -------- DAC_INTENCLR : (DAC Offset: 0x4) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
+    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready Interrupt Enable */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTENCLR_OFFSET         0x4          /**< \brief (DAC_INTENCLR offset) Interrupt Enable Clear */
+#define DAC_INTENCLR_RESETVALUE     _U_(0x00)    /**< \brief (DAC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define DAC_INTENCLR_UNDERRUN_Pos   0            /**< \brief (DAC_INTENCLR) Underrun Interrupt Enable */
+#define DAC_INTENCLR_UNDERRUN       (_U_(0x1) << DAC_INTENCLR_UNDERRUN_Pos)
+#define DAC_INTENCLR_EMPTY_Pos      1            /**< \brief (DAC_INTENCLR) Data Buffer Empty Interrupt Enable */
+#define DAC_INTENCLR_EMPTY          (_U_(0x1) << DAC_INTENCLR_EMPTY_Pos)
+#define DAC_INTENCLR_SYNCRDY_Pos    2            /**< \brief (DAC_INTENCLR) Synchronization Ready Interrupt Enable */
+#define DAC_INTENCLR_SYNCRDY        (_U_(0x1) << DAC_INTENCLR_SYNCRDY_Pos)
+#define DAC_INTENCLR_MASK           _U_(0x07)    /**< \brief (DAC_INTENCLR) MASK Register */
+
+/* -------- DAC_INTENSET : (DAC Offset: 0x5) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
+    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready Interrupt Enable */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTENSET_OFFSET         0x5          /**< \brief (DAC_INTENSET offset) Interrupt Enable Set */
+#define DAC_INTENSET_RESETVALUE     _U_(0x00)    /**< \brief (DAC_INTENSET reset_value) Interrupt Enable Set */
+
+#define DAC_INTENSET_UNDERRUN_Pos   0            /**< \brief (DAC_INTENSET) Underrun Interrupt Enable */
+#define DAC_INTENSET_UNDERRUN       (_U_(0x1) << DAC_INTENSET_UNDERRUN_Pos)
+#define DAC_INTENSET_EMPTY_Pos      1            /**< \brief (DAC_INTENSET) Data Buffer Empty Interrupt Enable */
+#define DAC_INTENSET_EMPTY          (_U_(0x1) << DAC_INTENSET_EMPTY_Pos)
+#define DAC_INTENSET_SYNCRDY_Pos    2            /**< \brief (DAC_INTENSET) Synchronization Ready Interrupt Enable */
+#define DAC_INTENSET_SYNCRDY        (_U_(0x1) << DAC_INTENSET_SYNCRDY_Pos)
+#define DAC_INTENSET_MASK           _U_(0x07)    /**< \brief (DAC_INTENSET) MASK Register */
+
+/* -------- DAC_INTFLAG : (DAC Offset: 0x6) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
+    __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
+    __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
+    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTFLAG_OFFSET          0x6          /**< \brief (DAC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define DAC_INTFLAG_RESETVALUE      _U_(0x00)    /**< \brief (DAC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define DAC_INTFLAG_UNDERRUN_Pos    0            /**< \brief (DAC_INTFLAG) Underrun */
+#define DAC_INTFLAG_UNDERRUN        (_U_(0x1) << DAC_INTFLAG_UNDERRUN_Pos)
+#define DAC_INTFLAG_EMPTY_Pos       1            /**< \brief (DAC_INTFLAG) Data Buffer Empty */
+#define DAC_INTFLAG_EMPTY           (_U_(0x1) << DAC_INTFLAG_EMPTY_Pos)
+#define DAC_INTFLAG_SYNCRDY_Pos     2            /**< \brief (DAC_INTFLAG) Synchronization Ready */
+#define DAC_INTFLAG_SYNCRDY         (_U_(0x1) << DAC_INTFLAG_SYNCRDY_Pos)
+#define DAC_INTFLAG_MASK            _U_(0x07)    /**< \brief (DAC_INTFLAG) MASK Register */
+
+/* -------- DAC_STATUS : (DAC Offset: 0x7) (R/   8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy Status        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_STATUS_OFFSET           0x7          /**< \brief (DAC_STATUS offset) Status */
+#define DAC_STATUS_RESETVALUE       _U_(0x00)    /**< \brief (DAC_STATUS reset_value) Status */
+
+#define DAC_STATUS_SYNCBUSY_Pos     7            /**< \brief (DAC_STATUS) Synchronization Busy Status */
+#define DAC_STATUS_SYNCBUSY         (_U_(0x1) << DAC_STATUS_SYNCBUSY_Pos)
+#define DAC_STATUS_MASK             _U_(0x80)    /**< \brief (DAC_STATUS) MASK Register */
+
+/* -------- DAC_DATA : (DAC Offset: 0x8) (R/W 16) Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DATA:16;          /*!< bit:  0..15  Data to be converted               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} DAC_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DATA_OFFSET             0x8          /**< \brief (DAC_DATA offset) Data */
+#define DAC_DATA_RESETVALUE         _U_(0x0000)  /**< \brief (DAC_DATA reset_value) Data */
+
+#define DAC_DATA_DATA_Pos           0            /**< \brief (DAC_DATA) Data to be converted */
+#define DAC_DATA_DATA_Msk           (_U_(0xFFFF) << DAC_DATA_DATA_Pos)
+#define DAC_DATA_DATA(value)        (DAC_DATA_DATA_Msk & ((value) << DAC_DATA_DATA_Pos))
+#define DAC_DATA_MASK               _U_(0xFFFF)  /**< \brief (DAC_DATA) MASK Register */
+
+/* -------- DAC_DATABUF : (DAC Offset: 0xC) (R/W 16) Data Buffer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DATABUF:16;       /*!< bit:  0..15  Data Buffer                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} DAC_DATABUF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DATABUF_OFFSET          0xC          /**< \brief (DAC_DATABUF offset) Data Buffer */
+#define DAC_DATABUF_RESETVALUE      _U_(0x0000)  /**< \brief (DAC_DATABUF reset_value) Data Buffer */
+
+#define DAC_DATABUF_DATABUF_Pos     0            /**< \brief (DAC_DATABUF) Data Buffer */
+#define DAC_DATABUF_DATABUF_Msk     (_U_(0xFFFF) << DAC_DATABUF_DATABUF_Pos)
+#define DAC_DATABUF_DATABUF(value)  (DAC_DATABUF_DATABUF_Msk & ((value) << DAC_DATABUF_DATABUF_Pos))
+#define DAC_DATABUF_MASK            _U_(0xFFFF)  /**< \brief (DAC_DATABUF) MASK Register */
+
+/** \brief DAC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO DAC_CTRLA_Type            CTRLA;       /**< \brief Offset: 0x0 (R/W  8) Control A */
+  __IO DAC_CTRLB_Type            CTRLB;       /**< \brief Offset: 0x1 (R/W  8) Control B */
+  __IO DAC_EVCTRL_Type           EVCTRL;      /**< \brief Offset: 0x2 (R/W  8) Event Control */
+       RoReg8                    Reserved1[0x1];
+  __IO DAC_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x4 (R/W  8) Interrupt Enable Clear */
+  __IO DAC_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x5 (R/W  8) Interrupt Enable Set */
+  __IO DAC_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x6 (R/W  8) Interrupt Flag Status and Clear */
+  __I  DAC_STATUS_Type           STATUS;      /**< \brief Offset: 0x7 (R/   8) Status */
+  __IO DAC_DATA_Type             DATA;        /**< \brief Offset: 0x8 (R/W 16) Data */
+       RoReg8                    Reserved2[0x2];
+  __IO DAC_DATABUF_Type          DATABUF;     /**< \brief Offset: 0xC (R/W 16) Data Buffer */
+} Dac;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_DAC_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/component/dsu.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/dsu.h
@@ -1,0 +1,629 @@
+/**
+ * \file
+ *
+ * \brief Component description for DSU
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_DSU_COMPONENT_
+#define _SAMD20_DSU_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DSU */
+/* ========================================================================== */
+/** \addtogroup SAMD20_DSU Device Service Unit */
+/*@{*/
+
+#define DSU_U2209
+#define REV_DSU                     0x103
+
+/* -------- DSU_CTRL : (DSU Offset: 0x0000) ( /W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  :1;               /*!< bit:      1  Reserved                           */
+    uint8_t  CRC:1;            /*!< bit:      2  32-bit Cyclic Redundancy Code      */
+    uint8_t  MBIST:1;          /*!< bit:      3  Memory built-in self-test          */
+    uint8_t  CE:1;             /*!< bit:      4  Chip-Erase                         */
+    uint8_t  :1;               /*!< bit:      5  Reserved                           */
+    uint8_t  ARR:1;            /*!< bit:      6  Auxiliary Row Read                 */
+    uint8_t  SMSA:1;           /*!< bit:      7  Start Memory Stream Access         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DSU_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CTRL_OFFSET             0x0000       /**< \brief (DSU_CTRL offset) Control */
+#define DSU_CTRL_RESETVALUE         _U_(0x00)    /**< \brief (DSU_CTRL reset_value) Control */
+
+#define DSU_CTRL_SWRST_Pos          0            /**< \brief (DSU_CTRL) Software Reset */
+#define DSU_CTRL_SWRST              (_U_(0x1) << DSU_CTRL_SWRST_Pos)
+#define DSU_CTRL_CRC_Pos            2            /**< \brief (DSU_CTRL) 32-bit Cyclic Redundancy Code */
+#define DSU_CTRL_CRC                (_U_(0x1) << DSU_CTRL_CRC_Pos)
+#define DSU_CTRL_MBIST_Pos          3            /**< \brief (DSU_CTRL) Memory built-in self-test */
+#define DSU_CTRL_MBIST              (_U_(0x1) << DSU_CTRL_MBIST_Pos)
+#define DSU_CTRL_CE_Pos             4            /**< \brief (DSU_CTRL) Chip-Erase */
+#define DSU_CTRL_CE                 (_U_(0x1) << DSU_CTRL_CE_Pos)
+#define DSU_CTRL_ARR_Pos            6            /**< \brief (DSU_CTRL) Auxiliary Row Read */
+#define DSU_CTRL_ARR                (_U_(0x1) << DSU_CTRL_ARR_Pos)
+#define DSU_CTRL_SMSA_Pos           7            /**< \brief (DSU_CTRL) Start Memory Stream Access */
+#define DSU_CTRL_SMSA               (_U_(0x1) << DSU_CTRL_SMSA_Pos)
+#define DSU_CTRL_MASK               _U_(0xDD)    /**< \brief (DSU_CTRL) MASK Register */
+
+/* -------- DSU_STATUSA : (DSU Offset: 0x0001) (R/W  8) Status A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DONE:1;           /*!< bit:      0  Done                               */
+    uint8_t  CRSTEXT:1;        /*!< bit:      1  CPU Reset Phase Extension          */
+    uint8_t  BERR:1;           /*!< bit:      2  Bus Error                          */
+    uint8_t  FAIL:1;           /*!< bit:      3  Failure                            */
+    uint8_t  PERR:1;           /*!< bit:      4  Protection Error                   */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DSU_STATUSA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_STATUSA_OFFSET          0x0001       /**< \brief (DSU_STATUSA offset) Status A */
+#define DSU_STATUSA_RESETVALUE      _U_(0x00)    /**< \brief (DSU_STATUSA reset_value) Status A */
+
+#define DSU_STATUSA_DONE_Pos        0            /**< \brief (DSU_STATUSA) Done */
+#define DSU_STATUSA_DONE            (_U_(0x1) << DSU_STATUSA_DONE_Pos)
+#define DSU_STATUSA_CRSTEXT_Pos     1            /**< \brief (DSU_STATUSA) CPU Reset Phase Extension */
+#define DSU_STATUSA_CRSTEXT         (_U_(0x1) << DSU_STATUSA_CRSTEXT_Pos)
+#define DSU_STATUSA_BERR_Pos        2            /**< \brief (DSU_STATUSA) Bus Error */
+#define DSU_STATUSA_BERR            (_U_(0x1) << DSU_STATUSA_BERR_Pos)
+#define DSU_STATUSA_FAIL_Pos        3            /**< \brief (DSU_STATUSA) Failure */
+#define DSU_STATUSA_FAIL            (_U_(0x1) << DSU_STATUSA_FAIL_Pos)
+#define DSU_STATUSA_PERR_Pos        4            /**< \brief (DSU_STATUSA) Protection Error */
+#define DSU_STATUSA_PERR            (_U_(0x1) << DSU_STATUSA_PERR_Pos)
+#define DSU_STATUSA_MASK            _U_(0x1F)    /**< \brief (DSU_STATUSA) MASK Register */
+
+/* -------- DSU_STATUSB : (DSU Offset: 0x0002) (R/   8) Status B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PROT:1;           /*!< bit:      0  Protected                          */
+    uint8_t  DBGPRES:1;        /*!< bit:      1  Debugger Present                   */
+    uint8_t  DCCD0:1;          /*!< bit:      2  Debug Communication Channel 0 Dirty */
+    uint8_t  DCCD1:1;          /*!< bit:      3  Debug Communication Channel 1 Dirty */
+    uint8_t  HPE:1;            /*!< bit:      4  Hot-Plugging Enable                */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint8_t  DCCD:2;           /*!< bit:  2.. 3  Debug Communication Channel x Dirty */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DSU_STATUSB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_STATUSB_OFFSET          0x0002       /**< \brief (DSU_STATUSB offset) Status B */
+#define DSU_STATUSB_RESETVALUE      _U_(0x00)    /**< \brief (DSU_STATUSB reset_value) Status B */
+
+#define DSU_STATUSB_PROT_Pos        0            /**< \brief (DSU_STATUSB) Protected */
+#define DSU_STATUSB_PROT            (_U_(0x1) << DSU_STATUSB_PROT_Pos)
+#define DSU_STATUSB_DBGPRES_Pos     1            /**< \brief (DSU_STATUSB) Debugger Present */
+#define DSU_STATUSB_DBGPRES         (_U_(0x1) << DSU_STATUSB_DBGPRES_Pos)
+#define DSU_STATUSB_DCCD0_Pos       2            /**< \brief (DSU_STATUSB) Debug Communication Channel 0 Dirty */
+#define DSU_STATUSB_DCCD0           (_U_(1) << DSU_STATUSB_DCCD0_Pos)
+#define DSU_STATUSB_DCCD1_Pos       3            /**< \brief (DSU_STATUSB) Debug Communication Channel 1 Dirty */
+#define DSU_STATUSB_DCCD1           (_U_(1) << DSU_STATUSB_DCCD1_Pos)
+#define DSU_STATUSB_DCCD_Pos        2            /**< \brief (DSU_STATUSB) Debug Communication Channel x Dirty */
+#define DSU_STATUSB_DCCD_Msk        (_U_(0x3) << DSU_STATUSB_DCCD_Pos)
+#define DSU_STATUSB_DCCD(value)     (DSU_STATUSB_DCCD_Msk & ((value) << DSU_STATUSB_DCCD_Pos))
+#define DSU_STATUSB_HPE_Pos         4            /**< \brief (DSU_STATUSB) Hot-Plugging Enable */
+#define DSU_STATUSB_HPE             (_U_(0x1) << DSU_STATUSB_HPE_Pos)
+#define DSU_STATUSB_MASK            _U_(0x1F)    /**< \brief (DSU_STATUSB) MASK Register */
+
+/* -------- DSU_ADDR : (DSU Offset: 0x0004) (R/W 32) Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t AMOD:2;           /*!< bit:  0.. 1  Access Mode                        */
+    uint32_t ADDR:30;          /*!< bit:  2..31  Address                            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_ADDR_OFFSET             0x0004       /**< \brief (DSU_ADDR offset) Address */
+#define DSU_ADDR_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_ADDR reset_value) Address */
+
+#define DSU_ADDR_AMOD_Pos           0            /**< \brief (DSU_ADDR) Access Mode */
+#define DSU_ADDR_AMOD_Msk           (_U_(0x3) << DSU_ADDR_AMOD_Pos)
+#define DSU_ADDR_AMOD(value)        (DSU_ADDR_AMOD_Msk & ((value) << DSU_ADDR_AMOD_Pos))
+#define DSU_ADDR_ADDR_Pos           2            /**< \brief (DSU_ADDR) Address */
+#define DSU_ADDR_ADDR_Msk           (_U_(0x3FFFFFFF) << DSU_ADDR_ADDR_Pos)
+#define DSU_ADDR_ADDR(value)        (DSU_ADDR_ADDR_Msk & ((value) << DSU_ADDR_ADDR_Pos))
+#define DSU_ADDR_MASK               _U_(0xFFFFFFFF) /**< \brief (DSU_ADDR) MASK Register */
+
+/* -------- DSU_LENGTH : (DSU Offset: 0x0008) (R/W 32) Length -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t LENGTH:30;        /*!< bit:  2..31  Length                             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_LENGTH_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_LENGTH_OFFSET           0x0008       /**< \brief (DSU_LENGTH offset) Length */
+#define DSU_LENGTH_RESETVALUE       _U_(0x00000000) /**< \brief (DSU_LENGTH reset_value) Length */
+
+#define DSU_LENGTH_LENGTH_Pos       2            /**< \brief (DSU_LENGTH) Length */
+#define DSU_LENGTH_LENGTH_Msk       (_U_(0x3FFFFFFF) << DSU_LENGTH_LENGTH_Pos)
+#define DSU_LENGTH_LENGTH(value)    (DSU_LENGTH_LENGTH_Msk & ((value) << DSU_LENGTH_LENGTH_Pos))
+#define DSU_LENGTH_MASK             _U_(0xFFFFFFFC) /**< \brief (DSU_LENGTH) MASK Register */
+
+/* -------- DSU_DATA : (DSU Offset: 0x000C) (R/W 32) Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Data                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DATA_OFFSET             0x000C       /**< \brief (DSU_DATA offset) Data */
+#define DSU_DATA_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_DATA reset_value) Data */
+
+#define DSU_DATA_DATA_Pos           0            /**< \brief (DSU_DATA) Data */
+#define DSU_DATA_DATA_Msk           (_U_(0xFFFFFFFF) << DSU_DATA_DATA_Pos)
+#define DSU_DATA_DATA(value)        (DSU_DATA_DATA_Msk & ((value) << DSU_DATA_DATA_Pos))
+#define DSU_DATA_MASK               _U_(0xFFFFFFFF) /**< \brief (DSU_DATA) MASK Register */
+
+/* -------- DSU_DCC : (DSU Offset: 0x0010) (R/W 32) Debug Communication Channel n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Data                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_DCC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DCC_OFFSET              0x0010       /**< \brief (DSU_DCC offset) Debug Communication Channel n */
+#define DSU_DCC_RESETVALUE          _U_(0x00000000) /**< \brief (DSU_DCC reset_value) Debug Communication Channel n */
+
+#define DSU_DCC_DATA_Pos            0            /**< \brief (DSU_DCC) Data */
+#define DSU_DCC_DATA_Msk            (_U_(0xFFFFFFFF) << DSU_DCC_DATA_Pos)
+#define DSU_DCC_DATA(value)         (DSU_DCC_DATA_Msk & ((value) << DSU_DCC_DATA_Pos))
+#define DSU_DCC_MASK                _U_(0xFFFFFFFF) /**< \brief (DSU_DCC) MASK Register */
+
+/* -------- DSU_DID : (DSU Offset: 0x0018) (R/  32) Device Identification -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DEVSEL:8;         /*!< bit:  0.. 7  Device Select                      */
+    uint32_t REVISION:4;       /*!< bit:  8..11  Revision Number                    */
+    uint32_t DIE:4;            /*!< bit: 12..15  Die Number                         */
+    uint32_t SERIES:6;         /*!< bit: 16..21  Series                             */
+    uint32_t :1;               /*!< bit:     22  Reserved                           */
+    uint32_t FAMILY:5;         /*!< bit: 23..27  Family                             */
+    uint32_t PROCESSOR:4;      /*!< bit: 28..31  Processor                          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_DID_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DID_OFFSET              0x0018       /**< \brief (DSU_DID offset) Device Identification */
+
+#define DSU_DID_DEVSEL_Pos          0            /**< \brief (DSU_DID) Device Select */
+#define DSU_DID_DEVSEL_Msk          (_U_(0xFF) << DSU_DID_DEVSEL_Pos)
+#define DSU_DID_DEVSEL(value)       (DSU_DID_DEVSEL_Msk & ((value) << DSU_DID_DEVSEL_Pos))
+#define DSU_DID_REVISION_Pos        8            /**< \brief (DSU_DID) Revision Number */
+#define DSU_DID_REVISION_Msk        (_U_(0xF) << DSU_DID_REVISION_Pos)
+#define DSU_DID_REVISION(value)     (DSU_DID_REVISION_Msk & ((value) << DSU_DID_REVISION_Pos))
+#define DSU_DID_DIE_Pos             12           /**< \brief (DSU_DID) Die Number */
+#define DSU_DID_DIE_Msk             (_U_(0xF) << DSU_DID_DIE_Pos)
+#define DSU_DID_DIE(value)          (DSU_DID_DIE_Msk & ((value) << DSU_DID_DIE_Pos))
+#define DSU_DID_SERIES_Pos          16           /**< \brief (DSU_DID) Series */
+#define DSU_DID_SERIES_Msk          (_U_(0x3F) << DSU_DID_SERIES_Pos)
+#define DSU_DID_SERIES(value)       (DSU_DID_SERIES_Msk & ((value) << DSU_DID_SERIES_Pos))
+#define   DSU_DID_SERIES_0_Val            _U_(0x0)   /**< \brief (DSU_DID) Cortex-M0+ processor, basic feature set */
+#define   DSU_DID_SERIES_1_Val            _U_(0x1)   /**< \brief (DSU_DID) Cortex-M0+ processor, USB */
+#define DSU_DID_SERIES_0            (DSU_DID_SERIES_0_Val          << DSU_DID_SERIES_Pos)
+#define DSU_DID_SERIES_1            (DSU_DID_SERIES_1_Val          << DSU_DID_SERIES_Pos)
+#define DSU_DID_FAMILY_Pos          23           /**< \brief (DSU_DID) Family */
+#define DSU_DID_FAMILY_Msk          (_U_(0x1F) << DSU_DID_FAMILY_Pos)
+#define DSU_DID_FAMILY(value)       (DSU_DID_FAMILY_Msk & ((value) << DSU_DID_FAMILY_Pos))
+#define   DSU_DID_FAMILY_0_Val            _U_(0x0)   /**< \brief (DSU_DID) General purpose microcontroller */
+#define   DSU_DID_FAMILY_1_Val            _U_(0x1)   /**< \brief (DSU_DID) PicoPower */
+#define DSU_DID_FAMILY_0            (DSU_DID_FAMILY_0_Val          << DSU_DID_FAMILY_Pos)
+#define DSU_DID_FAMILY_1            (DSU_DID_FAMILY_1_Val          << DSU_DID_FAMILY_Pos)
+#define DSU_DID_PROCESSOR_Pos       28           /**< \brief (DSU_DID) Processor */
+#define DSU_DID_PROCESSOR_Msk       (_U_(0xF) << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_PROCESSOR(value)    (DSU_DID_PROCESSOR_Msk & ((value) << DSU_DID_PROCESSOR_Pos))
+#define   DSU_DID_PROCESSOR_0_Val         _U_(0x0)   /**< \brief (DSU_DID) Cortex-M0 */
+#define   DSU_DID_PROCESSOR_1_Val         _U_(0x1)   /**< \brief (DSU_DID) Cortex-M0+ */
+#define   DSU_DID_PROCESSOR_2_Val         _U_(0x2)   /**< \brief (DSU_DID) Cortex-M3 */
+#define   DSU_DID_PROCESSOR_3_Val         _U_(0x3)   /**< \brief (DSU_DID) Cortex-M4 */
+#define DSU_DID_PROCESSOR_0         (DSU_DID_PROCESSOR_0_Val       << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_PROCESSOR_1         (DSU_DID_PROCESSOR_1_Val       << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_PROCESSOR_2         (DSU_DID_PROCESSOR_2_Val       << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_PROCESSOR_3         (DSU_DID_PROCESSOR_3_Val       << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_MASK                _U_(0xFFBFFFFF) /**< \brief (DSU_DID) MASK Register */
+
+/* -------- DSU_DCFG : (DSU Offset: 0x00F0) (R/W 32) Device Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DCFG:32;          /*!< bit:  0..31  Device Configuration               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_DCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DCFG_OFFSET             0x00F0       /**< \brief (DSU_DCFG offset) Device Configuration */
+#define DSU_DCFG_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_DCFG reset_value) Device Configuration */
+
+#define DSU_DCFG_DCFG_Pos           0            /**< \brief (DSU_DCFG) Device Configuration */
+#define DSU_DCFG_DCFG_Msk           (_U_(0xFFFFFFFF) << DSU_DCFG_DCFG_Pos)
+#define DSU_DCFG_DCFG(value)        (DSU_DCFG_DCFG_Msk & ((value) << DSU_DCFG_DCFG_Pos))
+#define DSU_DCFG_MASK               _U_(0xFFFFFFFF) /**< \brief (DSU_DCFG) MASK Register */
+
+/* -------- DSU_ENTRY0 : (DSU Offset: 0x1000) (R/  32) CoreSight ROM Table Entry 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EPRES:1;          /*!< bit:      0  Entry Present                      */
+    uint32_t FMT:1;            /*!< bit:      1  Format                             */
+    uint32_t :10;              /*!< bit:  2..11  Reserved                           */
+    uint32_t ADDOFF:20;        /*!< bit: 12..31  Address Offset                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_ENTRY0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_ENTRY0_OFFSET           0x1000       /**< \brief (DSU_ENTRY0 offset) CoreSight ROM Table Entry 0 */
+#define DSU_ENTRY0_RESETVALUE       _U_(0x9F0FC002) /**< \brief (DSU_ENTRY0 reset_value) CoreSight ROM Table Entry 0 */
+
+#define DSU_ENTRY0_EPRES_Pos        0            /**< \brief (DSU_ENTRY0) Entry Present */
+#define DSU_ENTRY0_EPRES            (_U_(0x1) << DSU_ENTRY0_EPRES_Pos)
+#define DSU_ENTRY0_FMT_Pos          1            /**< \brief (DSU_ENTRY0) Format */
+#define DSU_ENTRY0_FMT              (_U_(0x1) << DSU_ENTRY0_FMT_Pos)
+#define DSU_ENTRY0_ADDOFF_Pos       12           /**< \brief (DSU_ENTRY0) Address Offset */
+#define DSU_ENTRY0_ADDOFF_Msk       (_U_(0xFFFFF) << DSU_ENTRY0_ADDOFF_Pos)
+#define DSU_ENTRY0_ADDOFF(value)    (DSU_ENTRY0_ADDOFF_Msk & ((value) << DSU_ENTRY0_ADDOFF_Pos))
+#define DSU_ENTRY0_MASK             _U_(0xFFFFF003) /**< \brief (DSU_ENTRY0) MASK Register */
+
+/* -------- DSU_ENTRY1 : (DSU Offset: 0x1004) (R/  32) CoreSight ROM Table Entry 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_ENTRY1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_ENTRY1_OFFSET           0x1004       /**< \brief (DSU_ENTRY1 offset) CoreSight ROM Table Entry 1 */
+#define DSU_ENTRY1_RESETVALUE       _U_(0x00000000) /**< \brief (DSU_ENTRY1 reset_value) CoreSight ROM Table Entry 1 */
+#define DSU_ENTRY1_MASK             _U_(0xFFFFFFFF) /**< \brief (DSU_ENTRY1) MASK Register */
+
+/* -------- DSU_END : (DSU Offset: 0x1008) (R/  32) CoreSight ROM Table End -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t END:32;           /*!< bit:  0..31  End Marker                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_END_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_END_OFFSET              0x1008       /**< \brief (DSU_END offset) CoreSight ROM Table End */
+#define DSU_END_RESETVALUE          _U_(0x00000000) /**< \brief (DSU_END reset_value) CoreSight ROM Table End */
+
+#define DSU_END_END_Pos             0            /**< \brief (DSU_END) End Marker */
+#define DSU_END_END_Msk             (_U_(0xFFFFFFFF) << DSU_END_END_Pos)
+#define DSU_END_END(value)          (DSU_END_END_Msk & ((value) << DSU_END_END_Pos))
+#define DSU_END_MASK                _U_(0xFFFFFFFF) /**< \brief (DSU_END) MASK Register */
+
+/* -------- DSU_MEMTYPE : (DSU Offset: 0x1FCC) (R/  32) CoreSight ROM Table Memory Type -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SMEMP:1;          /*!< bit:      0  System Memory Present              */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_MEMTYPE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_MEMTYPE_OFFSET          0x1FCC       /**< \brief (DSU_MEMTYPE offset) CoreSight ROM Table Memory Type */
+#define DSU_MEMTYPE_RESETVALUE      _U_(0x00000000) /**< \brief (DSU_MEMTYPE reset_value) CoreSight ROM Table Memory Type */
+
+#define DSU_MEMTYPE_SMEMP_Pos       0            /**< \brief (DSU_MEMTYPE) System Memory Present */
+#define DSU_MEMTYPE_SMEMP           (_U_(0x1) << DSU_MEMTYPE_SMEMP_Pos)
+#define DSU_MEMTYPE_MASK            _U_(0x00000001) /**< \brief (DSU_MEMTYPE) MASK Register */
+
+/* -------- DSU_PID4 : (DSU Offset: 0x1FD0) (R/  32) Peripheral Identification 4 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t JEPCC:4;          /*!< bit:  0.. 3  JEP-106 Continuation Code          */
+    uint32_t FKBC:4;           /*!< bit:  4.. 7  4KB count                          */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID4_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID4_OFFSET             0x1FD0       /**< \brief (DSU_PID4 offset) Peripheral Identification 4 */
+#define DSU_PID4_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_PID4 reset_value) Peripheral Identification 4 */
+
+#define DSU_PID4_JEPCC_Pos          0            /**< \brief (DSU_PID4) JEP-106 Continuation Code */
+#define DSU_PID4_JEPCC_Msk          (_U_(0xF) << DSU_PID4_JEPCC_Pos)
+#define DSU_PID4_JEPCC(value)       (DSU_PID4_JEPCC_Msk & ((value) << DSU_PID4_JEPCC_Pos))
+#define DSU_PID4_FKBC_Pos           4            /**< \brief (DSU_PID4) 4KB count */
+#define DSU_PID4_FKBC_Msk           (_U_(0xF) << DSU_PID4_FKBC_Pos)
+#define DSU_PID4_FKBC(value)        (DSU_PID4_FKBC_Msk & ((value) << DSU_PID4_FKBC_Pos))
+#define DSU_PID4_MASK               _U_(0x000000FF) /**< \brief (DSU_PID4) MASK Register */
+
+/* -------- DSU_PID5 : (DSU Offset: 0x1FD4) (R/  32) Peripheral Identification 5 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID5_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID5_OFFSET             0x1FD4       /**< \brief (DSU_PID5 offset) Peripheral Identification 5 */
+#define DSU_PID5_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_PID5 reset_value) Peripheral Identification 5 */
+#define DSU_PID5_MASK               _U_(0x00000000) /**< \brief (DSU_PID5) MASK Register */
+
+/* -------- DSU_PID6 : (DSU Offset: 0x1FD8) (R/  32) Peripheral Identification 6 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID6_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID6_OFFSET             0x1FD8       /**< \brief (DSU_PID6 offset) Peripheral Identification 6 */
+#define DSU_PID6_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_PID6 reset_value) Peripheral Identification 6 */
+#define DSU_PID6_MASK               _U_(0x00000000) /**< \brief (DSU_PID6) MASK Register */
+
+/* -------- DSU_PID7 : (DSU Offset: 0x1FDC) (R/  32) Peripheral Identification 7 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID7_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID7_OFFSET             0x1FDC       /**< \brief (DSU_PID7 offset) Peripheral Identification 7 */
+#define DSU_PID7_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_PID7 reset_value) Peripheral Identification 7 */
+#define DSU_PID7_MASK               _U_(0x00000000) /**< \brief (DSU_PID7) MASK Register */
+
+/* -------- DSU_PID0 : (DSU Offset: 0x1FE0) (R/  32) Peripheral Identification 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PARTNBL:8;        /*!< bit:  0.. 7  Part Number Low                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID0_OFFSET             0x1FE0       /**< \brief (DSU_PID0 offset) Peripheral Identification 0 */
+#define DSU_PID0_RESETVALUE         _U_(0x000000D0) /**< \brief (DSU_PID0 reset_value) Peripheral Identification 0 */
+
+#define DSU_PID0_PARTNBL_Pos        0            /**< \brief (DSU_PID0) Part Number Low */
+#define DSU_PID0_PARTNBL_Msk        (_U_(0xFF) << DSU_PID0_PARTNBL_Pos)
+#define DSU_PID0_PARTNBL(value)     (DSU_PID0_PARTNBL_Msk & ((value) << DSU_PID0_PARTNBL_Pos))
+#define DSU_PID0_MASK               _U_(0x000000FF) /**< \brief (DSU_PID0) MASK Register */
+
+/* -------- DSU_PID1 : (DSU Offset: 0x1FE4) (R/  32) Peripheral Identification 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PARTNBH:4;        /*!< bit:  0.. 3  Part Number High                   */
+    uint32_t JEPIDCL:4;        /*!< bit:  4.. 7  Low part of the JEP-106 Identity Code */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID1_OFFSET             0x1FE4       /**< \brief (DSU_PID1 offset) Peripheral Identification 1 */
+#define DSU_PID1_RESETVALUE         _U_(0x000000FC) /**< \brief (DSU_PID1 reset_value) Peripheral Identification 1 */
+
+#define DSU_PID1_PARTNBH_Pos        0            /**< \brief (DSU_PID1) Part Number High */
+#define DSU_PID1_PARTNBH_Msk        (_U_(0xF) << DSU_PID1_PARTNBH_Pos)
+#define DSU_PID1_PARTNBH(value)     (DSU_PID1_PARTNBH_Msk & ((value) << DSU_PID1_PARTNBH_Pos))
+#define DSU_PID1_JEPIDCL_Pos        4            /**< \brief (DSU_PID1) Low part of the JEP-106 Identity Code */
+#define DSU_PID1_JEPIDCL_Msk        (_U_(0xF) << DSU_PID1_JEPIDCL_Pos)
+#define DSU_PID1_JEPIDCL(value)     (DSU_PID1_JEPIDCL_Msk & ((value) << DSU_PID1_JEPIDCL_Pos))
+#define DSU_PID1_MASK               _U_(0x000000FF) /**< \brief (DSU_PID1) MASK Register */
+
+/* -------- DSU_PID2 : (DSU Offset: 0x1FE8) (R/  32) Peripheral Identification 2 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t JEPIDCH:3;        /*!< bit:  0.. 2  JEP-106 Identity Code High         */
+    uint32_t JEPU:1;           /*!< bit:      3  JEP-106 Identity Code is used      */
+    uint32_t REVISION:4;       /*!< bit:  4.. 7  Revision Number                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID2_OFFSET             0x1FE8       /**< \brief (DSU_PID2 offset) Peripheral Identification 2 */
+#define DSU_PID2_RESETVALUE         _U_(0x00000009) /**< \brief (DSU_PID2 reset_value) Peripheral Identification 2 */
+
+#define DSU_PID2_JEPIDCH_Pos        0            /**< \brief (DSU_PID2) JEP-106 Identity Code High */
+#define DSU_PID2_JEPIDCH_Msk        (_U_(0x7) << DSU_PID2_JEPIDCH_Pos)
+#define DSU_PID2_JEPIDCH(value)     (DSU_PID2_JEPIDCH_Msk & ((value) << DSU_PID2_JEPIDCH_Pos))
+#define DSU_PID2_JEPU_Pos           3            /**< \brief (DSU_PID2) JEP-106 Identity Code is used */
+#define DSU_PID2_JEPU               (_U_(0x1) << DSU_PID2_JEPU_Pos)
+#define DSU_PID2_REVISION_Pos       4            /**< \brief (DSU_PID2) Revision Number */
+#define DSU_PID2_REVISION_Msk       (_U_(0xF) << DSU_PID2_REVISION_Pos)
+#define DSU_PID2_REVISION(value)    (DSU_PID2_REVISION_Msk & ((value) << DSU_PID2_REVISION_Pos))
+#define DSU_PID2_MASK               _U_(0x000000FF) /**< \brief (DSU_PID2) MASK Register */
+
+/* -------- DSU_PID3 : (DSU Offset: 0x1FEC) (R/  32) Peripheral Identification 3 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CUSMOD:4;         /*!< bit:  0.. 3  ARM CUSMOD                         */
+    uint32_t REVAND:4;         /*!< bit:  4.. 7  Revision Number                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID3_OFFSET             0x1FEC       /**< \brief (DSU_PID3 offset) Peripheral Identification 3 */
+#define DSU_PID3_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_PID3 reset_value) Peripheral Identification 3 */
+
+#define DSU_PID3_CUSMOD_Pos         0            /**< \brief (DSU_PID3) ARM CUSMOD */
+#define DSU_PID3_CUSMOD_Msk         (_U_(0xF) << DSU_PID3_CUSMOD_Pos)
+#define DSU_PID3_CUSMOD(value)      (DSU_PID3_CUSMOD_Msk & ((value) << DSU_PID3_CUSMOD_Pos))
+#define DSU_PID3_REVAND_Pos         4            /**< \brief (DSU_PID3) Revision Number */
+#define DSU_PID3_REVAND_Msk         (_U_(0xF) << DSU_PID3_REVAND_Pos)
+#define DSU_PID3_REVAND(value)      (DSU_PID3_REVAND_Msk & ((value) << DSU_PID3_REVAND_Pos))
+#define DSU_PID3_MASK               _U_(0x000000FF) /**< \brief (DSU_PID3) MASK Register */
+
+/* -------- DSU_CID0 : (DSU Offset: 0x1FF0) (R/  32) Component Identification 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PREAMBLEB0:8;     /*!< bit:  0.. 7  Preamble Byte 0                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_CID0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID0_OFFSET             0x1FF0       /**< \brief (DSU_CID0 offset) Component Identification 0 */
+#define DSU_CID0_RESETVALUE         _U_(0x0000000D) /**< \brief (DSU_CID0 reset_value) Component Identification 0 */
+
+#define DSU_CID0_PREAMBLEB0_Pos     0            /**< \brief (DSU_CID0) Preamble Byte 0 */
+#define DSU_CID0_PREAMBLEB0_Msk     (_U_(0xFF) << DSU_CID0_PREAMBLEB0_Pos)
+#define DSU_CID0_PREAMBLEB0(value)  (DSU_CID0_PREAMBLEB0_Msk & ((value) << DSU_CID0_PREAMBLEB0_Pos))
+#define DSU_CID0_MASK               _U_(0x000000FF) /**< \brief (DSU_CID0) MASK Register */
+
+/* -------- DSU_CID1 : (DSU Offset: 0x1FF4) (R/  32) Component Identification 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PREAMBLE:4;       /*!< bit:  0.. 3  Preamble                           */
+    uint32_t CCLASS:4;         /*!< bit:  4.. 7  Component Class                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_CID1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID1_OFFSET             0x1FF4       /**< \brief (DSU_CID1 offset) Component Identification 1 */
+#define DSU_CID1_RESETVALUE         _U_(0x00000010) /**< \brief (DSU_CID1 reset_value) Component Identification 1 */
+
+#define DSU_CID1_PREAMBLE_Pos       0            /**< \brief (DSU_CID1) Preamble */
+#define DSU_CID1_PREAMBLE_Msk       (_U_(0xF) << DSU_CID1_PREAMBLE_Pos)
+#define DSU_CID1_PREAMBLE(value)    (DSU_CID1_PREAMBLE_Msk & ((value) << DSU_CID1_PREAMBLE_Pos))
+#define DSU_CID1_CCLASS_Pos         4            /**< \brief (DSU_CID1) Component Class */
+#define DSU_CID1_CCLASS_Msk         (_U_(0xF) << DSU_CID1_CCLASS_Pos)
+#define DSU_CID1_CCLASS(value)      (DSU_CID1_CCLASS_Msk & ((value) << DSU_CID1_CCLASS_Pos))
+#define DSU_CID1_MASK               _U_(0x000000FF) /**< \brief (DSU_CID1) MASK Register */
+
+/* -------- DSU_CID2 : (DSU Offset: 0x1FF8) (R/  32) Component Identification 2 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PREAMBLEB2:8;     /*!< bit:  0.. 7  Preamble Byte 2                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_CID2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID2_OFFSET             0x1FF8       /**< \brief (DSU_CID2 offset) Component Identification 2 */
+#define DSU_CID2_RESETVALUE         _U_(0x00000005) /**< \brief (DSU_CID2 reset_value) Component Identification 2 */
+
+#define DSU_CID2_PREAMBLEB2_Pos     0            /**< \brief (DSU_CID2) Preamble Byte 2 */
+#define DSU_CID2_PREAMBLEB2_Msk     (_U_(0xFF) << DSU_CID2_PREAMBLEB2_Pos)
+#define DSU_CID2_PREAMBLEB2(value)  (DSU_CID2_PREAMBLEB2_Msk & ((value) << DSU_CID2_PREAMBLEB2_Pos))
+#define DSU_CID2_MASK               _U_(0x000000FF) /**< \brief (DSU_CID2) MASK Register */
+
+/* -------- DSU_CID3 : (DSU Offset: 0x1FFC) (R/  32) Component Identification 3 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PREAMBLEB3:8;     /*!< bit:  0.. 7  Preamble Byte 3                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_CID3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID3_OFFSET             0x1FFC       /**< \brief (DSU_CID3 offset) Component Identification 3 */
+#define DSU_CID3_RESETVALUE         _U_(0x000000B1) /**< \brief (DSU_CID3 reset_value) Component Identification 3 */
+
+#define DSU_CID3_PREAMBLEB3_Pos     0            /**< \brief (DSU_CID3) Preamble Byte 3 */
+#define DSU_CID3_PREAMBLEB3_Msk     (_U_(0xFF) << DSU_CID3_PREAMBLEB3_Pos)
+#define DSU_CID3_PREAMBLEB3(value)  (DSU_CID3_PREAMBLEB3_Msk & ((value) << DSU_CID3_PREAMBLEB3_Pos))
+#define DSU_CID3_MASK               _U_(0x000000FF) /**< \brief (DSU_CID3) MASK Register */
+
+/** \brief DSU hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __O  DSU_CTRL_Type             CTRL;        /**< \brief Offset: 0x0000 ( /W  8) Control */
+  __IO DSU_STATUSA_Type          STATUSA;     /**< \brief Offset: 0x0001 (R/W  8) Status A */
+  __I  DSU_STATUSB_Type          STATUSB;     /**< \brief Offset: 0x0002 (R/   8) Status B */
+       RoReg8                    Reserved1[0x1];
+  __IO DSU_ADDR_Type             ADDR;        /**< \brief Offset: 0x0004 (R/W 32) Address */
+  __IO DSU_LENGTH_Type           LENGTH;      /**< \brief Offset: 0x0008 (R/W 32) Length */
+  __IO DSU_DATA_Type             DATA;        /**< \brief Offset: 0x000C (R/W 32) Data */
+  __IO DSU_DCC_Type              DCC[2];      /**< \brief Offset: 0x0010 (R/W 32) Debug Communication Channel n */
+  __I  DSU_DID_Type              DID;         /**< \brief Offset: 0x0018 (R/  32) Device Identification */
+       RoReg8                    Reserved2[0xD4];
+  __IO DSU_DCFG_Type             DCFG[2];     /**< \brief Offset: 0x00F0 (R/W 32) Device Configuration */
+       RoReg8                    Reserved3[0xF08];
+  __I  DSU_ENTRY0_Type           ENTRY0;      /**< \brief Offset: 0x1000 (R/  32) CoreSight ROM Table Entry 0 */
+  __I  DSU_ENTRY1_Type           ENTRY1;      /**< \brief Offset: 0x1004 (R/  32) CoreSight ROM Table Entry 1 */
+  __I  DSU_END_Type              END;         /**< \brief Offset: 0x1008 (R/  32) CoreSight ROM Table End */
+       RoReg8                    Reserved4[0xFC0];
+  __I  DSU_MEMTYPE_Type          MEMTYPE;     /**< \brief Offset: 0x1FCC (R/  32) CoreSight ROM Table Memory Type */
+  __I  DSU_PID4_Type             PID4;        /**< \brief Offset: 0x1FD0 (R/  32) Peripheral Identification 4 */
+  __I  DSU_PID5_Type             PID5;        /**< \brief Offset: 0x1FD4 (R/  32) Peripheral Identification 5 */
+  __I  DSU_PID6_Type             PID6;        /**< \brief Offset: 0x1FD8 (R/  32) Peripheral Identification 6 */
+  __I  DSU_PID7_Type             PID7;        /**< \brief Offset: 0x1FDC (R/  32) Peripheral Identification 7 */
+  __I  DSU_PID0_Type             PID0;        /**< \brief Offset: 0x1FE0 (R/  32) Peripheral Identification 0 */
+  __I  DSU_PID1_Type             PID1;        /**< \brief Offset: 0x1FE4 (R/  32) Peripheral Identification 1 */
+  __I  DSU_PID2_Type             PID2;        /**< \brief Offset: 0x1FE8 (R/  32) Peripheral Identification 2 */
+  __I  DSU_PID3_Type             PID3;        /**< \brief Offset: 0x1FEC (R/  32) Peripheral Identification 3 */
+  __I  DSU_CID0_Type             CID0;        /**< \brief Offset: 0x1FF0 (R/  32) Component Identification 0 */
+  __I  DSU_CID1_Type             CID1;        /**< \brief Offset: 0x1FF4 (R/  32) Component Identification 1 */
+  __I  DSU_CID2_Type             CID2;        /**< \brief Offset: 0x1FF8 (R/  32) Component Identification 2 */
+  __I  DSU_CID3_Type             CID3;        /**< \brief Offset: 0x1FFC (R/  32) Component Identification 3 */
+} Dsu;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_DSU_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/component/eic.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/eic.h
@@ -1,0 +1,667 @@
+/**
+ * \file
+ *
+ * \brief Component description for EIC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_EIC_COMPONENT_
+#define _SAMD20_EIC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR EIC */
+/* ========================================================================== */
+/** \addtogroup SAMD20_EIC External Interrupt Controller */
+/*@{*/
+
+#define EIC_U2217
+#define REV_EIC                     0x101
+
+/* -------- EIC_CTRL : (EIC Offset: 0x00) (R/W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} EIC_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_CTRL_OFFSET             0x00         /**< \brief (EIC_CTRL offset) Control */
+#define EIC_CTRL_RESETVALUE         _U_(0x00)    /**< \brief (EIC_CTRL reset_value) Control */
+
+#define EIC_CTRL_SWRST_Pos          0            /**< \brief (EIC_CTRL) Software Reset */
+#define EIC_CTRL_SWRST              (_U_(0x1) << EIC_CTRL_SWRST_Pos)
+#define EIC_CTRL_ENABLE_Pos         1            /**< \brief (EIC_CTRL) Enable */
+#define EIC_CTRL_ENABLE             (_U_(0x1) << EIC_CTRL_ENABLE_Pos)
+#define EIC_CTRL_MASK               _U_(0x03)    /**< \brief (EIC_CTRL) MASK Register */
+
+/* -------- EIC_STATUS : (EIC Offset: 0x01) (R/   8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} EIC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_STATUS_OFFSET           0x01         /**< \brief (EIC_STATUS offset) Status */
+#define EIC_STATUS_RESETVALUE       _U_(0x00)    /**< \brief (EIC_STATUS reset_value) Status */
+
+#define EIC_STATUS_SYNCBUSY_Pos     7            /**< \brief (EIC_STATUS) Synchronization Busy */
+#define EIC_STATUS_SYNCBUSY         (_U_(0x1) << EIC_STATUS_SYNCBUSY_Pos)
+#define EIC_STATUS_MASK             _U_(0x80)    /**< \brief (EIC_STATUS) MASK Register */
+
+/* -------- EIC_NMICTRL : (EIC Offset: 0x02) (R/W  8) Non-Maskable Interrupt Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  NMISENSE:3;       /*!< bit:  0.. 2  Non-Maskable Interrupt Sense       */
+    uint8_t  NMIFILTEN:1;      /*!< bit:      3  Non-Maskable Interrupt Filter Enable */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} EIC_NMICTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_NMICTRL_OFFSET          0x02         /**< \brief (EIC_NMICTRL offset) Non-Maskable Interrupt Control */
+#define EIC_NMICTRL_RESETVALUE      _U_(0x00)    /**< \brief (EIC_NMICTRL reset_value) Non-Maskable Interrupt Control */
+
+#define EIC_NMICTRL_NMISENSE_Pos    0            /**< \brief (EIC_NMICTRL) Non-Maskable Interrupt Sense */
+#define EIC_NMICTRL_NMISENSE_Msk    (_U_(0x7) << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE(value) (EIC_NMICTRL_NMISENSE_Msk & ((value) << EIC_NMICTRL_NMISENSE_Pos))
+#define   EIC_NMICTRL_NMISENSE_NONE_Val   _U_(0x0)   /**< \brief (EIC_NMICTRL) No detection */
+#define   EIC_NMICTRL_NMISENSE_RISE_Val   _U_(0x1)   /**< \brief (EIC_NMICTRL) Rising-edge detection */
+#define   EIC_NMICTRL_NMISENSE_FALL_Val   _U_(0x2)   /**< \brief (EIC_NMICTRL) Falling-edge detection */
+#define   EIC_NMICTRL_NMISENSE_BOTH_Val   _U_(0x3)   /**< \brief (EIC_NMICTRL) Both-edges detection */
+#define   EIC_NMICTRL_NMISENSE_HIGH_Val   _U_(0x4)   /**< \brief (EIC_NMICTRL) High-level detection */
+#define   EIC_NMICTRL_NMISENSE_LOW_Val    _U_(0x5)   /**< \brief (EIC_NMICTRL) Low-level detection */
+#define EIC_NMICTRL_NMISENSE_NONE   (EIC_NMICTRL_NMISENSE_NONE_Val << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_RISE   (EIC_NMICTRL_NMISENSE_RISE_Val << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_FALL   (EIC_NMICTRL_NMISENSE_FALL_Val << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_BOTH   (EIC_NMICTRL_NMISENSE_BOTH_Val << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_HIGH   (EIC_NMICTRL_NMISENSE_HIGH_Val << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_LOW    (EIC_NMICTRL_NMISENSE_LOW_Val  << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMIFILTEN_Pos   3            /**< \brief (EIC_NMICTRL) Non-Maskable Interrupt Filter Enable */
+#define EIC_NMICTRL_NMIFILTEN       (_U_(0x1) << EIC_NMICTRL_NMIFILTEN_Pos)
+#define EIC_NMICTRL_MASK            _U_(0x0F)    /**< \brief (EIC_NMICTRL) MASK Register */
+
+/* -------- EIC_NMIFLAG : (EIC Offset: 0x03) (R/W  8) Non-Maskable Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  NMI:1;            /*!< bit:      0  Non-Maskable Interrupt             */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} EIC_NMIFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_NMIFLAG_OFFSET          0x03         /**< \brief (EIC_NMIFLAG offset) Non-Maskable Interrupt Flag Status and Clear */
+#define EIC_NMIFLAG_RESETVALUE      _U_(0x00)    /**< \brief (EIC_NMIFLAG reset_value) Non-Maskable Interrupt Flag Status and Clear */
+
+#define EIC_NMIFLAG_NMI_Pos         0            /**< \brief (EIC_NMIFLAG) Non-Maskable Interrupt */
+#define EIC_NMIFLAG_NMI             (_U_(0x1) << EIC_NMIFLAG_NMI_Pos)
+#define EIC_NMIFLAG_MASK            _U_(0x01)    /**< \brief (EIC_NMIFLAG) MASK Register */
+
+/* -------- EIC_EVCTRL : (EIC Offset: 0x04) (R/W 32) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EXTINTEO0:1;      /*!< bit:      0  External Interrupt 0 Event Output Enable */
+    uint32_t EXTINTEO1:1;      /*!< bit:      1  External Interrupt 1 Event Output Enable */
+    uint32_t EXTINTEO2:1;      /*!< bit:      2  External Interrupt 2 Event Output Enable */
+    uint32_t EXTINTEO3:1;      /*!< bit:      3  External Interrupt 3 Event Output Enable */
+    uint32_t EXTINTEO4:1;      /*!< bit:      4  External Interrupt 4 Event Output Enable */
+    uint32_t EXTINTEO5:1;      /*!< bit:      5  External Interrupt 5 Event Output Enable */
+    uint32_t EXTINTEO6:1;      /*!< bit:      6  External Interrupt 6 Event Output Enable */
+    uint32_t EXTINTEO7:1;      /*!< bit:      7  External Interrupt 7 Event Output Enable */
+    uint32_t EXTINTEO8:1;      /*!< bit:      8  External Interrupt 8 Event Output Enable */
+    uint32_t EXTINTEO9:1;      /*!< bit:      9  External Interrupt 9 Event Output Enable */
+    uint32_t EXTINTEO10:1;     /*!< bit:     10  External Interrupt 10 Event Output Enable */
+    uint32_t EXTINTEO11:1;     /*!< bit:     11  External Interrupt 11 Event Output Enable */
+    uint32_t EXTINTEO12:1;     /*!< bit:     12  External Interrupt 12 Event Output Enable */
+    uint32_t EXTINTEO13:1;     /*!< bit:     13  External Interrupt 13 Event Output Enable */
+    uint32_t EXTINTEO14:1;     /*!< bit:     14  External Interrupt 14 Event Output Enable */
+    uint32_t EXTINTEO15:1;     /*!< bit:     15  External Interrupt 15 Event Output Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t EXTINTEO:16;      /*!< bit:  0..15  External Interrupt x Event Output Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_EVCTRL_OFFSET           0x04         /**< \brief (EIC_EVCTRL offset) Event Control */
+#define EIC_EVCTRL_RESETVALUE       _U_(0x00000000) /**< \brief (EIC_EVCTRL reset_value) Event Control */
+
+#define EIC_EVCTRL_EXTINTEO0_Pos    0            /**< \brief (EIC_EVCTRL) External Interrupt 0 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO0        (_U_(1) << EIC_EVCTRL_EXTINTEO0_Pos)
+#define EIC_EVCTRL_EXTINTEO1_Pos    1            /**< \brief (EIC_EVCTRL) External Interrupt 1 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO1        (_U_(1) << EIC_EVCTRL_EXTINTEO1_Pos)
+#define EIC_EVCTRL_EXTINTEO2_Pos    2            /**< \brief (EIC_EVCTRL) External Interrupt 2 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO2        (_U_(1) << EIC_EVCTRL_EXTINTEO2_Pos)
+#define EIC_EVCTRL_EXTINTEO3_Pos    3            /**< \brief (EIC_EVCTRL) External Interrupt 3 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO3        (_U_(1) << EIC_EVCTRL_EXTINTEO3_Pos)
+#define EIC_EVCTRL_EXTINTEO4_Pos    4            /**< \brief (EIC_EVCTRL) External Interrupt 4 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO4        (_U_(1) << EIC_EVCTRL_EXTINTEO4_Pos)
+#define EIC_EVCTRL_EXTINTEO5_Pos    5            /**< \brief (EIC_EVCTRL) External Interrupt 5 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO5        (_U_(1) << EIC_EVCTRL_EXTINTEO5_Pos)
+#define EIC_EVCTRL_EXTINTEO6_Pos    6            /**< \brief (EIC_EVCTRL) External Interrupt 6 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO6        (_U_(1) << EIC_EVCTRL_EXTINTEO6_Pos)
+#define EIC_EVCTRL_EXTINTEO7_Pos    7            /**< \brief (EIC_EVCTRL) External Interrupt 7 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO7        (_U_(1) << EIC_EVCTRL_EXTINTEO7_Pos)
+#define EIC_EVCTRL_EXTINTEO8_Pos    8            /**< \brief (EIC_EVCTRL) External Interrupt 8 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO8        (_U_(1) << EIC_EVCTRL_EXTINTEO8_Pos)
+#define EIC_EVCTRL_EXTINTEO9_Pos    9            /**< \brief (EIC_EVCTRL) External Interrupt 9 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO9        (_U_(1) << EIC_EVCTRL_EXTINTEO9_Pos)
+#define EIC_EVCTRL_EXTINTEO10_Pos   10           /**< \brief (EIC_EVCTRL) External Interrupt 10 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO10       (_U_(1) << EIC_EVCTRL_EXTINTEO10_Pos)
+#define EIC_EVCTRL_EXTINTEO11_Pos   11           /**< \brief (EIC_EVCTRL) External Interrupt 11 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO11       (_U_(1) << EIC_EVCTRL_EXTINTEO11_Pos)
+#define EIC_EVCTRL_EXTINTEO12_Pos   12           /**< \brief (EIC_EVCTRL) External Interrupt 12 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO12       (_U_(1) << EIC_EVCTRL_EXTINTEO12_Pos)
+#define EIC_EVCTRL_EXTINTEO13_Pos   13           /**< \brief (EIC_EVCTRL) External Interrupt 13 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO13       (_U_(1) << EIC_EVCTRL_EXTINTEO13_Pos)
+#define EIC_EVCTRL_EXTINTEO14_Pos   14           /**< \brief (EIC_EVCTRL) External Interrupt 14 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO14       (_U_(1) << EIC_EVCTRL_EXTINTEO14_Pos)
+#define EIC_EVCTRL_EXTINTEO15_Pos   15           /**< \brief (EIC_EVCTRL) External Interrupt 15 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO15       (_U_(1) << EIC_EVCTRL_EXTINTEO15_Pos)
+#define EIC_EVCTRL_EXTINTEO_Pos     0            /**< \brief (EIC_EVCTRL) External Interrupt x Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO_Msk     (_U_(0xFFFF) << EIC_EVCTRL_EXTINTEO_Pos)
+#define EIC_EVCTRL_EXTINTEO(value)  (EIC_EVCTRL_EXTINTEO_Msk & ((value) << EIC_EVCTRL_EXTINTEO_Pos))
+#define EIC_EVCTRL_MASK             _U_(0x0000FFFF) /**< \brief (EIC_EVCTRL) MASK Register */
+
+/* -------- EIC_INTENCLR : (EIC Offset: 0x08) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EXTINT0:1;        /*!< bit:      0  External Interrupt 0 Enable        */
+    uint32_t EXTINT1:1;        /*!< bit:      1  External Interrupt 1 Enable        */
+    uint32_t EXTINT2:1;        /*!< bit:      2  External Interrupt 2 Enable        */
+    uint32_t EXTINT3:1;        /*!< bit:      3  External Interrupt 3 Enable        */
+    uint32_t EXTINT4:1;        /*!< bit:      4  External Interrupt 4 Enable        */
+    uint32_t EXTINT5:1;        /*!< bit:      5  External Interrupt 5 Enable        */
+    uint32_t EXTINT6:1;        /*!< bit:      6  External Interrupt 6 Enable        */
+    uint32_t EXTINT7:1;        /*!< bit:      7  External Interrupt 7 Enable        */
+    uint32_t EXTINT8:1;        /*!< bit:      8  External Interrupt 8 Enable        */
+    uint32_t EXTINT9:1;        /*!< bit:      9  External Interrupt 9 Enable        */
+    uint32_t EXTINT10:1;       /*!< bit:     10  External Interrupt 10 Enable       */
+    uint32_t EXTINT11:1;       /*!< bit:     11  External Interrupt 11 Enable       */
+    uint32_t EXTINT12:1;       /*!< bit:     12  External Interrupt 12 Enable       */
+    uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13 Enable       */
+    uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14 Enable       */
+    uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15 Enable       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x Enable        */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_INTENCLR_OFFSET         0x08         /**< \brief (EIC_INTENCLR offset) Interrupt Enable Clear */
+#define EIC_INTENCLR_RESETVALUE     _U_(0x00000000) /**< \brief (EIC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define EIC_INTENCLR_EXTINT0_Pos    0            /**< \brief (EIC_INTENCLR) External Interrupt 0 Enable */
+#define EIC_INTENCLR_EXTINT0        (_U_(1) << EIC_INTENCLR_EXTINT0_Pos)
+#define EIC_INTENCLR_EXTINT1_Pos    1            /**< \brief (EIC_INTENCLR) External Interrupt 1 Enable */
+#define EIC_INTENCLR_EXTINT1        (_U_(1) << EIC_INTENCLR_EXTINT1_Pos)
+#define EIC_INTENCLR_EXTINT2_Pos    2            /**< \brief (EIC_INTENCLR) External Interrupt 2 Enable */
+#define EIC_INTENCLR_EXTINT2        (_U_(1) << EIC_INTENCLR_EXTINT2_Pos)
+#define EIC_INTENCLR_EXTINT3_Pos    3            /**< \brief (EIC_INTENCLR) External Interrupt 3 Enable */
+#define EIC_INTENCLR_EXTINT3        (_U_(1) << EIC_INTENCLR_EXTINT3_Pos)
+#define EIC_INTENCLR_EXTINT4_Pos    4            /**< \brief (EIC_INTENCLR) External Interrupt 4 Enable */
+#define EIC_INTENCLR_EXTINT4        (_U_(1) << EIC_INTENCLR_EXTINT4_Pos)
+#define EIC_INTENCLR_EXTINT5_Pos    5            /**< \brief (EIC_INTENCLR) External Interrupt 5 Enable */
+#define EIC_INTENCLR_EXTINT5        (_U_(1) << EIC_INTENCLR_EXTINT5_Pos)
+#define EIC_INTENCLR_EXTINT6_Pos    6            /**< \brief (EIC_INTENCLR) External Interrupt 6 Enable */
+#define EIC_INTENCLR_EXTINT6        (_U_(1) << EIC_INTENCLR_EXTINT6_Pos)
+#define EIC_INTENCLR_EXTINT7_Pos    7            /**< \brief (EIC_INTENCLR) External Interrupt 7 Enable */
+#define EIC_INTENCLR_EXTINT7        (_U_(1) << EIC_INTENCLR_EXTINT7_Pos)
+#define EIC_INTENCLR_EXTINT8_Pos    8            /**< \brief (EIC_INTENCLR) External Interrupt 8 Enable */
+#define EIC_INTENCLR_EXTINT8        (_U_(1) << EIC_INTENCLR_EXTINT8_Pos)
+#define EIC_INTENCLR_EXTINT9_Pos    9            /**< \brief (EIC_INTENCLR) External Interrupt 9 Enable */
+#define EIC_INTENCLR_EXTINT9        (_U_(1) << EIC_INTENCLR_EXTINT9_Pos)
+#define EIC_INTENCLR_EXTINT10_Pos   10           /**< \brief (EIC_INTENCLR) External Interrupt 10 Enable */
+#define EIC_INTENCLR_EXTINT10       (_U_(1) << EIC_INTENCLR_EXTINT10_Pos)
+#define EIC_INTENCLR_EXTINT11_Pos   11           /**< \brief (EIC_INTENCLR) External Interrupt 11 Enable */
+#define EIC_INTENCLR_EXTINT11       (_U_(1) << EIC_INTENCLR_EXTINT11_Pos)
+#define EIC_INTENCLR_EXTINT12_Pos   12           /**< \brief (EIC_INTENCLR) External Interrupt 12 Enable */
+#define EIC_INTENCLR_EXTINT12       (_U_(1) << EIC_INTENCLR_EXTINT12_Pos)
+#define EIC_INTENCLR_EXTINT13_Pos   13           /**< \brief (EIC_INTENCLR) External Interrupt 13 Enable */
+#define EIC_INTENCLR_EXTINT13       (_U_(1) << EIC_INTENCLR_EXTINT13_Pos)
+#define EIC_INTENCLR_EXTINT14_Pos   14           /**< \brief (EIC_INTENCLR) External Interrupt 14 Enable */
+#define EIC_INTENCLR_EXTINT14       (_U_(1) << EIC_INTENCLR_EXTINT14_Pos)
+#define EIC_INTENCLR_EXTINT15_Pos   15           /**< \brief (EIC_INTENCLR) External Interrupt 15 Enable */
+#define EIC_INTENCLR_EXTINT15       (_U_(1) << EIC_INTENCLR_EXTINT15_Pos)
+#define EIC_INTENCLR_EXTINT_Pos     0            /**< \brief (EIC_INTENCLR) External Interrupt x Enable */
+#define EIC_INTENCLR_EXTINT_Msk     (_U_(0xFFFF) << EIC_INTENCLR_EXTINT_Pos)
+#define EIC_INTENCLR_EXTINT(value)  (EIC_INTENCLR_EXTINT_Msk & ((value) << EIC_INTENCLR_EXTINT_Pos))
+#define EIC_INTENCLR_MASK           _U_(0x0000FFFF) /**< \brief (EIC_INTENCLR) MASK Register */
+
+/* -------- EIC_INTENSET : (EIC Offset: 0x0C) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EXTINT0:1;        /*!< bit:      0  External Interrupt 0 Enable        */
+    uint32_t EXTINT1:1;        /*!< bit:      1  External Interrupt 1 Enable        */
+    uint32_t EXTINT2:1;        /*!< bit:      2  External Interrupt 2 Enable        */
+    uint32_t EXTINT3:1;        /*!< bit:      3  External Interrupt 3 Enable        */
+    uint32_t EXTINT4:1;        /*!< bit:      4  External Interrupt 4 Enable        */
+    uint32_t EXTINT5:1;        /*!< bit:      5  External Interrupt 5 Enable        */
+    uint32_t EXTINT6:1;        /*!< bit:      6  External Interrupt 6 Enable        */
+    uint32_t EXTINT7:1;        /*!< bit:      7  External Interrupt 7 Enable        */
+    uint32_t EXTINT8:1;        /*!< bit:      8  External Interrupt 8 Enable        */
+    uint32_t EXTINT9:1;        /*!< bit:      9  External Interrupt 9 Enable        */
+    uint32_t EXTINT10:1;       /*!< bit:     10  External Interrupt 10 Enable       */
+    uint32_t EXTINT11:1;       /*!< bit:     11  External Interrupt 11 Enable       */
+    uint32_t EXTINT12:1;       /*!< bit:     12  External Interrupt 12 Enable       */
+    uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13 Enable       */
+    uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14 Enable       */
+    uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15 Enable       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x Enable        */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_INTENSET_OFFSET         0x0C         /**< \brief (EIC_INTENSET offset) Interrupt Enable Set */
+#define EIC_INTENSET_RESETVALUE     _U_(0x00000000) /**< \brief (EIC_INTENSET reset_value) Interrupt Enable Set */
+
+#define EIC_INTENSET_EXTINT0_Pos    0            /**< \brief (EIC_INTENSET) External Interrupt 0 Enable */
+#define EIC_INTENSET_EXTINT0        (_U_(1) << EIC_INTENSET_EXTINT0_Pos)
+#define EIC_INTENSET_EXTINT1_Pos    1            /**< \brief (EIC_INTENSET) External Interrupt 1 Enable */
+#define EIC_INTENSET_EXTINT1        (_U_(1) << EIC_INTENSET_EXTINT1_Pos)
+#define EIC_INTENSET_EXTINT2_Pos    2            /**< \brief (EIC_INTENSET) External Interrupt 2 Enable */
+#define EIC_INTENSET_EXTINT2        (_U_(1) << EIC_INTENSET_EXTINT2_Pos)
+#define EIC_INTENSET_EXTINT3_Pos    3            /**< \brief (EIC_INTENSET) External Interrupt 3 Enable */
+#define EIC_INTENSET_EXTINT3        (_U_(1) << EIC_INTENSET_EXTINT3_Pos)
+#define EIC_INTENSET_EXTINT4_Pos    4            /**< \brief (EIC_INTENSET) External Interrupt 4 Enable */
+#define EIC_INTENSET_EXTINT4        (_U_(1) << EIC_INTENSET_EXTINT4_Pos)
+#define EIC_INTENSET_EXTINT5_Pos    5            /**< \brief (EIC_INTENSET) External Interrupt 5 Enable */
+#define EIC_INTENSET_EXTINT5        (_U_(1) << EIC_INTENSET_EXTINT5_Pos)
+#define EIC_INTENSET_EXTINT6_Pos    6            /**< \brief (EIC_INTENSET) External Interrupt 6 Enable */
+#define EIC_INTENSET_EXTINT6        (_U_(1) << EIC_INTENSET_EXTINT6_Pos)
+#define EIC_INTENSET_EXTINT7_Pos    7            /**< \brief (EIC_INTENSET) External Interrupt 7 Enable */
+#define EIC_INTENSET_EXTINT7        (_U_(1) << EIC_INTENSET_EXTINT7_Pos)
+#define EIC_INTENSET_EXTINT8_Pos    8            /**< \brief (EIC_INTENSET) External Interrupt 8 Enable */
+#define EIC_INTENSET_EXTINT8        (_U_(1) << EIC_INTENSET_EXTINT8_Pos)
+#define EIC_INTENSET_EXTINT9_Pos    9            /**< \brief (EIC_INTENSET) External Interrupt 9 Enable */
+#define EIC_INTENSET_EXTINT9        (_U_(1) << EIC_INTENSET_EXTINT9_Pos)
+#define EIC_INTENSET_EXTINT10_Pos   10           /**< \brief (EIC_INTENSET) External Interrupt 10 Enable */
+#define EIC_INTENSET_EXTINT10       (_U_(1) << EIC_INTENSET_EXTINT10_Pos)
+#define EIC_INTENSET_EXTINT11_Pos   11           /**< \brief (EIC_INTENSET) External Interrupt 11 Enable */
+#define EIC_INTENSET_EXTINT11       (_U_(1) << EIC_INTENSET_EXTINT11_Pos)
+#define EIC_INTENSET_EXTINT12_Pos   12           /**< \brief (EIC_INTENSET) External Interrupt 12 Enable */
+#define EIC_INTENSET_EXTINT12       (_U_(1) << EIC_INTENSET_EXTINT12_Pos)
+#define EIC_INTENSET_EXTINT13_Pos   13           /**< \brief (EIC_INTENSET) External Interrupt 13 Enable */
+#define EIC_INTENSET_EXTINT13       (_U_(1) << EIC_INTENSET_EXTINT13_Pos)
+#define EIC_INTENSET_EXTINT14_Pos   14           /**< \brief (EIC_INTENSET) External Interrupt 14 Enable */
+#define EIC_INTENSET_EXTINT14       (_U_(1) << EIC_INTENSET_EXTINT14_Pos)
+#define EIC_INTENSET_EXTINT15_Pos   15           /**< \brief (EIC_INTENSET) External Interrupt 15 Enable */
+#define EIC_INTENSET_EXTINT15       (_U_(1) << EIC_INTENSET_EXTINT15_Pos)
+#define EIC_INTENSET_EXTINT_Pos     0            /**< \brief (EIC_INTENSET) External Interrupt x Enable */
+#define EIC_INTENSET_EXTINT_Msk     (_U_(0xFFFF) << EIC_INTENSET_EXTINT_Pos)
+#define EIC_INTENSET_EXTINT(value)  (EIC_INTENSET_EXTINT_Msk & ((value) << EIC_INTENSET_EXTINT_Pos))
+#define EIC_INTENSET_MASK           _U_(0x0000FFFF) /**< \brief (EIC_INTENSET) MASK Register */
+
+/* -------- EIC_INTFLAG : (EIC Offset: 0x10) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t EXTINT0:1;        /*!< bit:      0  External Interrupt 0               */
+    __I uint32_t EXTINT1:1;        /*!< bit:      1  External Interrupt 1               */
+    __I uint32_t EXTINT2:1;        /*!< bit:      2  External Interrupt 2               */
+    __I uint32_t EXTINT3:1;        /*!< bit:      3  External Interrupt 3               */
+    __I uint32_t EXTINT4:1;        /*!< bit:      4  External Interrupt 4               */
+    __I uint32_t EXTINT5:1;        /*!< bit:      5  External Interrupt 5               */
+    __I uint32_t EXTINT6:1;        /*!< bit:      6  External Interrupt 6               */
+    __I uint32_t EXTINT7:1;        /*!< bit:      7  External Interrupt 7               */
+    __I uint32_t EXTINT8:1;        /*!< bit:      8  External Interrupt 8               */
+    __I uint32_t EXTINT9:1;        /*!< bit:      9  External Interrupt 9               */
+    __I uint32_t EXTINT10:1;       /*!< bit:     10  External Interrupt 10              */
+    __I uint32_t EXTINT11:1;       /*!< bit:     11  External Interrupt 11              */
+    __I uint32_t EXTINT12:1;       /*!< bit:     12  External Interrupt 12              */
+    __I uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13              */
+    __I uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14              */
+    __I uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15              */
+    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x               */
+    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_INTFLAG_OFFSET          0x10         /**< \brief (EIC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define EIC_INTFLAG_RESETVALUE      _U_(0x00000000) /**< \brief (EIC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define EIC_INTFLAG_EXTINT0_Pos     0            /**< \brief (EIC_INTFLAG) External Interrupt 0 */
+#define EIC_INTFLAG_EXTINT0         (_U_(1) << EIC_INTFLAG_EXTINT0_Pos)
+#define EIC_INTFLAG_EXTINT1_Pos     1            /**< \brief (EIC_INTFLAG) External Interrupt 1 */
+#define EIC_INTFLAG_EXTINT1         (_U_(1) << EIC_INTFLAG_EXTINT1_Pos)
+#define EIC_INTFLAG_EXTINT2_Pos     2            /**< \brief (EIC_INTFLAG) External Interrupt 2 */
+#define EIC_INTFLAG_EXTINT2         (_U_(1) << EIC_INTFLAG_EXTINT2_Pos)
+#define EIC_INTFLAG_EXTINT3_Pos     3            /**< \brief (EIC_INTFLAG) External Interrupt 3 */
+#define EIC_INTFLAG_EXTINT3         (_U_(1) << EIC_INTFLAG_EXTINT3_Pos)
+#define EIC_INTFLAG_EXTINT4_Pos     4            /**< \brief (EIC_INTFLAG) External Interrupt 4 */
+#define EIC_INTFLAG_EXTINT4         (_U_(1) << EIC_INTFLAG_EXTINT4_Pos)
+#define EIC_INTFLAG_EXTINT5_Pos     5            /**< \brief (EIC_INTFLAG) External Interrupt 5 */
+#define EIC_INTFLAG_EXTINT5         (_U_(1) << EIC_INTFLAG_EXTINT5_Pos)
+#define EIC_INTFLAG_EXTINT6_Pos     6            /**< \brief (EIC_INTFLAG) External Interrupt 6 */
+#define EIC_INTFLAG_EXTINT6         (_U_(1) << EIC_INTFLAG_EXTINT6_Pos)
+#define EIC_INTFLAG_EXTINT7_Pos     7            /**< \brief (EIC_INTFLAG) External Interrupt 7 */
+#define EIC_INTFLAG_EXTINT7         (_U_(1) << EIC_INTFLAG_EXTINT7_Pos)
+#define EIC_INTFLAG_EXTINT8_Pos     8            /**< \brief (EIC_INTFLAG) External Interrupt 8 */
+#define EIC_INTFLAG_EXTINT8         (_U_(1) << EIC_INTFLAG_EXTINT8_Pos)
+#define EIC_INTFLAG_EXTINT9_Pos     9            /**< \brief (EIC_INTFLAG) External Interrupt 9 */
+#define EIC_INTFLAG_EXTINT9         (_U_(1) << EIC_INTFLAG_EXTINT9_Pos)
+#define EIC_INTFLAG_EXTINT10_Pos    10           /**< \brief (EIC_INTFLAG) External Interrupt 10 */
+#define EIC_INTFLAG_EXTINT10        (_U_(1) << EIC_INTFLAG_EXTINT10_Pos)
+#define EIC_INTFLAG_EXTINT11_Pos    11           /**< \brief (EIC_INTFLAG) External Interrupt 11 */
+#define EIC_INTFLAG_EXTINT11        (_U_(1) << EIC_INTFLAG_EXTINT11_Pos)
+#define EIC_INTFLAG_EXTINT12_Pos    12           /**< \brief (EIC_INTFLAG) External Interrupt 12 */
+#define EIC_INTFLAG_EXTINT12        (_U_(1) << EIC_INTFLAG_EXTINT12_Pos)
+#define EIC_INTFLAG_EXTINT13_Pos    13           /**< \brief (EIC_INTFLAG) External Interrupt 13 */
+#define EIC_INTFLAG_EXTINT13        (_U_(1) << EIC_INTFLAG_EXTINT13_Pos)
+#define EIC_INTFLAG_EXTINT14_Pos    14           /**< \brief (EIC_INTFLAG) External Interrupt 14 */
+#define EIC_INTFLAG_EXTINT14        (_U_(1) << EIC_INTFLAG_EXTINT14_Pos)
+#define EIC_INTFLAG_EXTINT15_Pos    15           /**< \brief (EIC_INTFLAG) External Interrupt 15 */
+#define EIC_INTFLAG_EXTINT15        (_U_(1) << EIC_INTFLAG_EXTINT15_Pos)
+#define EIC_INTFLAG_EXTINT_Pos      0            /**< \brief (EIC_INTFLAG) External Interrupt x */
+#define EIC_INTFLAG_EXTINT_Msk      (_U_(0xFFFF) << EIC_INTFLAG_EXTINT_Pos)
+#define EIC_INTFLAG_EXTINT(value)   (EIC_INTFLAG_EXTINT_Msk & ((value) << EIC_INTFLAG_EXTINT_Pos))
+#define EIC_INTFLAG_MASK            _U_(0x0000FFFF) /**< \brief (EIC_INTFLAG) MASK Register */
+
+/* -------- EIC_WAKEUP : (EIC Offset: 0x14) (R/W 32) Wake-Up Enable -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WAKEUPEN0:1;      /*!< bit:      0  External Interrupt 0 Wake-up Enable */
+    uint32_t WAKEUPEN1:1;      /*!< bit:      1  External Interrupt 1 Wake-up Enable */
+    uint32_t WAKEUPEN2:1;      /*!< bit:      2  External Interrupt 2 Wake-up Enable */
+    uint32_t WAKEUPEN3:1;      /*!< bit:      3  External Interrupt 3 Wake-up Enable */
+    uint32_t WAKEUPEN4:1;      /*!< bit:      4  External Interrupt 4 Wake-up Enable */
+    uint32_t WAKEUPEN5:1;      /*!< bit:      5  External Interrupt 5 Wake-up Enable */
+    uint32_t WAKEUPEN6:1;      /*!< bit:      6  External Interrupt 6 Wake-up Enable */
+    uint32_t WAKEUPEN7:1;      /*!< bit:      7  External Interrupt 7 Wake-up Enable */
+    uint32_t WAKEUPEN8:1;      /*!< bit:      8  External Interrupt 8 Wake-up Enable */
+    uint32_t WAKEUPEN9:1;      /*!< bit:      9  External Interrupt 9 Wake-up Enable */
+    uint32_t WAKEUPEN10:1;     /*!< bit:     10  External Interrupt 10 Wake-up Enable */
+    uint32_t WAKEUPEN11:1;     /*!< bit:     11  External Interrupt 11 Wake-up Enable */
+    uint32_t WAKEUPEN12:1;     /*!< bit:     12  External Interrupt 12 Wake-up Enable */
+    uint32_t WAKEUPEN13:1;     /*!< bit:     13  External Interrupt 13 Wake-up Enable */
+    uint32_t WAKEUPEN14:1;     /*!< bit:     14  External Interrupt 14 Wake-up Enable */
+    uint32_t WAKEUPEN15:1;     /*!< bit:     15  External Interrupt 15 Wake-up Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t WAKEUPEN:16;      /*!< bit:  0..15  External Interrupt x Wake-up Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_WAKEUP_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_WAKEUP_OFFSET           0x14         /**< \brief (EIC_WAKEUP offset) Wake-Up Enable */
+#define EIC_WAKEUP_RESETVALUE       _U_(0x00000000) /**< \brief (EIC_WAKEUP reset_value) Wake-Up Enable */
+
+#define EIC_WAKEUP_WAKEUPEN0_Pos    0            /**< \brief (EIC_WAKEUP) External Interrupt 0 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN0        (_U_(1) << EIC_WAKEUP_WAKEUPEN0_Pos)
+#define EIC_WAKEUP_WAKEUPEN1_Pos    1            /**< \brief (EIC_WAKEUP) External Interrupt 1 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN1        (_U_(1) << EIC_WAKEUP_WAKEUPEN1_Pos)
+#define EIC_WAKEUP_WAKEUPEN2_Pos    2            /**< \brief (EIC_WAKEUP) External Interrupt 2 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN2        (_U_(1) << EIC_WAKEUP_WAKEUPEN2_Pos)
+#define EIC_WAKEUP_WAKEUPEN3_Pos    3            /**< \brief (EIC_WAKEUP) External Interrupt 3 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN3        (_U_(1) << EIC_WAKEUP_WAKEUPEN3_Pos)
+#define EIC_WAKEUP_WAKEUPEN4_Pos    4            /**< \brief (EIC_WAKEUP) External Interrupt 4 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN4        (_U_(1) << EIC_WAKEUP_WAKEUPEN4_Pos)
+#define EIC_WAKEUP_WAKEUPEN5_Pos    5            /**< \brief (EIC_WAKEUP) External Interrupt 5 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN5        (_U_(1) << EIC_WAKEUP_WAKEUPEN5_Pos)
+#define EIC_WAKEUP_WAKEUPEN6_Pos    6            /**< \brief (EIC_WAKEUP) External Interrupt 6 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN6        (_U_(1) << EIC_WAKEUP_WAKEUPEN6_Pos)
+#define EIC_WAKEUP_WAKEUPEN7_Pos    7            /**< \brief (EIC_WAKEUP) External Interrupt 7 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN7        (_U_(1) << EIC_WAKEUP_WAKEUPEN7_Pos)
+#define EIC_WAKEUP_WAKEUPEN8_Pos    8            /**< \brief (EIC_WAKEUP) External Interrupt 8 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN8        (_U_(1) << EIC_WAKEUP_WAKEUPEN8_Pos)
+#define EIC_WAKEUP_WAKEUPEN9_Pos    9            /**< \brief (EIC_WAKEUP) External Interrupt 9 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN9        (_U_(1) << EIC_WAKEUP_WAKEUPEN9_Pos)
+#define EIC_WAKEUP_WAKEUPEN10_Pos   10           /**< \brief (EIC_WAKEUP) External Interrupt 10 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN10       (_U_(1) << EIC_WAKEUP_WAKEUPEN10_Pos)
+#define EIC_WAKEUP_WAKEUPEN11_Pos   11           /**< \brief (EIC_WAKEUP) External Interrupt 11 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN11       (_U_(1) << EIC_WAKEUP_WAKEUPEN11_Pos)
+#define EIC_WAKEUP_WAKEUPEN12_Pos   12           /**< \brief (EIC_WAKEUP) External Interrupt 12 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN12       (_U_(1) << EIC_WAKEUP_WAKEUPEN12_Pos)
+#define EIC_WAKEUP_WAKEUPEN13_Pos   13           /**< \brief (EIC_WAKEUP) External Interrupt 13 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN13       (_U_(1) << EIC_WAKEUP_WAKEUPEN13_Pos)
+#define EIC_WAKEUP_WAKEUPEN14_Pos   14           /**< \brief (EIC_WAKEUP) External Interrupt 14 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN14       (_U_(1) << EIC_WAKEUP_WAKEUPEN14_Pos)
+#define EIC_WAKEUP_WAKEUPEN15_Pos   15           /**< \brief (EIC_WAKEUP) External Interrupt 15 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN15       (_U_(1) << EIC_WAKEUP_WAKEUPEN15_Pos)
+#define EIC_WAKEUP_WAKEUPEN_Pos     0            /**< \brief (EIC_WAKEUP) External Interrupt x Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN_Msk     (_U_(0xFFFF) << EIC_WAKEUP_WAKEUPEN_Pos)
+#define EIC_WAKEUP_WAKEUPEN(value)  (EIC_WAKEUP_WAKEUPEN_Msk & ((value) << EIC_WAKEUP_WAKEUPEN_Pos))
+#define EIC_WAKEUP_MASK             _U_(0x0000FFFF) /**< \brief (EIC_WAKEUP) MASK Register */
+
+/* -------- EIC_CONFIG : (EIC Offset: 0x18) (R/W 32) Configuration n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SENSE0:3;         /*!< bit:  0.. 2  Input Sense 0 Configuration        */
+    uint32_t FILTEN0:1;        /*!< bit:      3  Filter 0 Enable                    */
+    uint32_t SENSE1:3;         /*!< bit:  4.. 6  Input Sense 1 Configuration        */
+    uint32_t FILTEN1:1;        /*!< bit:      7  Filter 1 Enable                    */
+    uint32_t SENSE2:3;         /*!< bit:  8..10  Input Sense 2 Configuration        */
+    uint32_t FILTEN2:1;        /*!< bit:     11  Filter 2 Enable                    */
+    uint32_t SENSE3:3;         /*!< bit: 12..14  Input Sense 3 Configuration        */
+    uint32_t FILTEN3:1;        /*!< bit:     15  Filter 3 Enable                    */
+    uint32_t SENSE4:3;         /*!< bit: 16..18  Input Sense 4 Configuration        */
+    uint32_t FILTEN4:1;        /*!< bit:     19  Filter 4 Enable                    */
+    uint32_t SENSE5:3;         /*!< bit: 20..22  Input Sense 5 Configuration        */
+    uint32_t FILTEN5:1;        /*!< bit:     23  Filter 5 Enable                    */
+    uint32_t SENSE6:3;         /*!< bit: 24..26  Input Sense 6 Configuration        */
+    uint32_t FILTEN6:1;        /*!< bit:     27  Filter 6 Enable                    */
+    uint32_t SENSE7:3;         /*!< bit: 28..30  Input Sense 7 Configuration        */
+    uint32_t FILTEN7:1;        /*!< bit:     31  Filter 7 Enable                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_CONFIG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_CONFIG_OFFSET           0x18         /**< \brief (EIC_CONFIG offset) Configuration n */
+#define EIC_CONFIG_RESETVALUE       _U_(0x00000000) /**< \brief (EIC_CONFIG reset_value) Configuration n */
+
+#define EIC_CONFIG_SENSE0_Pos       0            /**< \brief (EIC_CONFIG) Input Sense 0 Configuration */
+#define EIC_CONFIG_SENSE0_Msk       (_U_(0x7) << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0(value)    (EIC_CONFIG_SENSE0_Msk & ((value) << EIC_CONFIG_SENSE0_Pos))
+#define   EIC_CONFIG_SENSE0_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE0_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising-edge detection */
+#define   EIC_CONFIG_SENSE0_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling-edge detection */
+#define   EIC_CONFIG_SENSE0_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both-edges detection */
+#define   EIC_CONFIG_SENSE0_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High-level detection */
+#define   EIC_CONFIG_SENSE0_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low-level detection */
+#define EIC_CONFIG_SENSE0_NONE      (EIC_CONFIG_SENSE0_NONE_Val    << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_RISE      (EIC_CONFIG_SENSE0_RISE_Val    << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_FALL      (EIC_CONFIG_SENSE0_FALL_Val    << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_BOTH      (EIC_CONFIG_SENSE0_BOTH_Val    << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_HIGH      (EIC_CONFIG_SENSE0_HIGH_Val    << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_LOW       (EIC_CONFIG_SENSE0_LOW_Val     << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_FILTEN0_Pos      3            /**< \brief (EIC_CONFIG) Filter 0 Enable */
+#define EIC_CONFIG_FILTEN0          (_U_(0x1) << EIC_CONFIG_FILTEN0_Pos)
+#define EIC_CONFIG_SENSE1_Pos       4            /**< \brief (EIC_CONFIG) Input Sense 1 Configuration */
+#define EIC_CONFIG_SENSE1_Msk       (_U_(0x7) << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1(value)    (EIC_CONFIG_SENSE1_Msk & ((value) << EIC_CONFIG_SENSE1_Pos))
+#define   EIC_CONFIG_SENSE1_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE1_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE1_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE1_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE1_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE1_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE1_NONE      (EIC_CONFIG_SENSE1_NONE_Val    << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_RISE      (EIC_CONFIG_SENSE1_RISE_Val    << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_FALL      (EIC_CONFIG_SENSE1_FALL_Val    << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_BOTH      (EIC_CONFIG_SENSE1_BOTH_Val    << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_HIGH      (EIC_CONFIG_SENSE1_HIGH_Val    << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_LOW       (EIC_CONFIG_SENSE1_LOW_Val     << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_FILTEN1_Pos      7            /**< \brief (EIC_CONFIG) Filter 1 Enable */
+#define EIC_CONFIG_FILTEN1          (_U_(0x1) << EIC_CONFIG_FILTEN1_Pos)
+#define EIC_CONFIG_SENSE2_Pos       8            /**< \brief (EIC_CONFIG) Input Sense 2 Configuration */
+#define EIC_CONFIG_SENSE2_Msk       (_U_(0x7) << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2(value)    (EIC_CONFIG_SENSE2_Msk & ((value) << EIC_CONFIG_SENSE2_Pos))
+#define   EIC_CONFIG_SENSE2_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE2_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE2_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE2_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE2_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE2_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE2_NONE      (EIC_CONFIG_SENSE2_NONE_Val    << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_RISE      (EIC_CONFIG_SENSE2_RISE_Val    << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_FALL      (EIC_CONFIG_SENSE2_FALL_Val    << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_BOTH      (EIC_CONFIG_SENSE2_BOTH_Val    << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_HIGH      (EIC_CONFIG_SENSE2_HIGH_Val    << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_LOW       (EIC_CONFIG_SENSE2_LOW_Val     << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_FILTEN2_Pos      11           /**< \brief (EIC_CONFIG) Filter 2 Enable */
+#define EIC_CONFIG_FILTEN2          (_U_(0x1) << EIC_CONFIG_FILTEN2_Pos)
+#define EIC_CONFIG_SENSE3_Pos       12           /**< \brief (EIC_CONFIG) Input Sense 3 Configuration */
+#define EIC_CONFIG_SENSE3_Msk       (_U_(0x7) << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3(value)    (EIC_CONFIG_SENSE3_Msk & ((value) << EIC_CONFIG_SENSE3_Pos))
+#define   EIC_CONFIG_SENSE3_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE3_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE3_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE3_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE3_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE3_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE3_NONE      (EIC_CONFIG_SENSE3_NONE_Val    << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_RISE      (EIC_CONFIG_SENSE3_RISE_Val    << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_FALL      (EIC_CONFIG_SENSE3_FALL_Val    << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_BOTH      (EIC_CONFIG_SENSE3_BOTH_Val    << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_HIGH      (EIC_CONFIG_SENSE3_HIGH_Val    << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_LOW       (EIC_CONFIG_SENSE3_LOW_Val     << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_FILTEN3_Pos      15           /**< \brief (EIC_CONFIG) Filter 3 Enable */
+#define EIC_CONFIG_FILTEN3          (_U_(0x1) << EIC_CONFIG_FILTEN3_Pos)
+#define EIC_CONFIG_SENSE4_Pos       16           /**< \brief (EIC_CONFIG) Input Sense 4 Configuration */
+#define EIC_CONFIG_SENSE4_Msk       (_U_(0x7) << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4(value)    (EIC_CONFIG_SENSE4_Msk & ((value) << EIC_CONFIG_SENSE4_Pos))
+#define   EIC_CONFIG_SENSE4_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE4_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE4_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE4_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE4_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE4_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE4_NONE      (EIC_CONFIG_SENSE4_NONE_Val    << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_RISE      (EIC_CONFIG_SENSE4_RISE_Val    << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_FALL      (EIC_CONFIG_SENSE4_FALL_Val    << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_BOTH      (EIC_CONFIG_SENSE4_BOTH_Val    << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_HIGH      (EIC_CONFIG_SENSE4_HIGH_Val    << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_LOW       (EIC_CONFIG_SENSE4_LOW_Val     << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_FILTEN4_Pos      19           /**< \brief (EIC_CONFIG) Filter 4 Enable */
+#define EIC_CONFIG_FILTEN4          (_U_(0x1) << EIC_CONFIG_FILTEN4_Pos)
+#define EIC_CONFIG_SENSE5_Pos       20           /**< \brief (EIC_CONFIG) Input Sense 5 Configuration */
+#define EIC_CONFIG_SENSE5_Msk       (_U_(0x7) << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5(value)    (EIC_CONFIG_SENSE5_Msk & ((value) << EIC_CONFIG_SENSE5_Pos))
+#define   EIC_CONFIG_SENSE5_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE5_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE5_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE5_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE5_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE5_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE5_NONE      (EIC_CONFIG_SENSE5_NONE_Val    << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_RISE      (EIC_CONFIG_SENSE5_RISE_Val    << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_FALL      (EIC_CONFIG_SENSE5_FALL_Val    << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_BOTH      (EIC_CONFIG_SENSE5_BOTH_Val    << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_HIGH      (EIC_CONFIG_SENSE5_HIGH_Val    << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_LOW       (EIC_CONFIG_SENSE5_LOW_Val     << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_FILTEN5_Pos      23           /**< \brief (EIC_CONFIG) Filter 5 Enable */
+#define EIC_CONFIG_FILTEN5          (_U_(0x1) << EIC_CONFIG_FILTEN5_Pos)
+#define EIC_CONFIG_SENSE6_Pos       24           /**< \brief (EIC_CONFIG) Input Sense 6 Configuration */
+#define EIC_CONFIG_SENSE6_Msk       (_U_(0x7) << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6(value)    (EIC_CONFIG_SENSE6_Msk & ((value) << EIC_CONFIG_SENSE6_Pos))
+#define   EIC_CONFIG_SENSE6_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE6_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE6_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE6_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE6_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE6_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE6_NONE      (EIC_CONFIG_SENSE6_NONE_Val    << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_RISE      (EIC_CONFIG_SENSE6_RISE_Val    << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_FALL      (EIC_CONFIG_SENSE6_FALL_Val    << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_BOTH      (EIC_CONFIG_SENSE6_BOTH_Val    << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_HIGH      (EIC_CONFIG_SENSE6_HIGH_Val    << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_LOW       (EIC_CONFIG_SENSE6_LOW_Val     << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_FILTEN6_Pos      27           /**< \brief (EIC_CONFIG) Filter 6 Enable */
+#define EIC_CONFIG_FILTEN6          (_U_(0x1) << EIC_CONFIG_FILTEN6_Pos)
+#define EIC_CONFIG_SENSE7_Pos       28           /**< \brief (EIC_CONFIG) Input Sense 7 Configuration */
+#define EIC_CONFIG_SENSE7_Msk       (_U_(0x7) << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7(value)    (EIC_CONFIG_SENSE7_Msk & ((value) << EIC_CONFIG_SENSE7_Pos))
+#define   EIC_CONFIG_SENSE7_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE7_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE7_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE7_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE7_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE7_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE7_NONE      (EIC_CONFIG_SENSE7_NONE_Val    << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_RISE      (EIC_CONFIG_SENSE7_RISE_Val    << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_FALL      (EIC_CONFIG_SENSE7_FALL_Val    << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_BOTH      (EIC_CONFIG_SENSE7_BOTH_Val    << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_HIGH      (EIC_CONFIG_SENSE7_HIGH_Val    << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_LOW       (EIC_CONFIG_SENSE7_LOW_Val     << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_FILTEN7_Pos      31           /**< \brief (EIC_CONFIG) Filter 7 Enable */
+#define EIC_CONFIG_FILTEN7          (_U_(0x1) << EIC_CONFIG_FILTEN7_Pos)
+#define EIC_CONFIG_MASK             _U_(0xFFFFFFFF) /**< \brief (EIC_CONFIG) MASK Register */
+
+/** \brief EIC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO EIC_CTRL_Type             CTRL;        /**< \brief Offset: 0x00 (R/W  8) Control */
+  __I  EIC_STATUS_Type           STATUS;      /**< \brief Offset: 0x01 (R/   8) Status */
+  __IO EIC_NMICTRL_Type          NMICTRL;     /**< \brief Offset: 0x02 (R/W  8) Non-Maskable Interrupt Control */
+  __IO EIC_NMIFLAG_Type          NMIFLAG;     /**< \brief Offset: 0x03 (R/W  8) Non-Maskable Interrupt Flag Status and Clear */
+  __IO EIC_EVCTRL_Type           EVCTRL;      /**< \brief Offset: 0x04 (R/W 32) Event Control */
+  __IO EIC_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x08 (R/W 32) Interrupt Enable Clear */
+  __IO EIC_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x0C (R/W 32) Interrupt Enable Set */
+  __IO EIC_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x10 (R/W 32) Interrupt Flag Status and Clear */
+  __IO EIC_WAKEUP_Type           WAKEUP;      /**< \brief Offset: 0x14 (R/W 32) Wake-Up Enable */
+  __IO EIC_CONFIG_Type           CONFIG[2];   /**< \brief Offset: 0x18 (R/W 32) Configuration n */
+} Eic;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_EIC_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/evsys.h
@@ -1,0 +1,452 @@
+/**
+ * \file
+ *
+ * \brief Component description for EVSYS
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_EVSYS_COMPONENT_
+#define _SAMD20_EVSYS_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR EVSYS */
+/* ========================================================================== */
+/** \addtogroup SAMD20_EVSYS Event System Interface */
+/*@{*/
+
+#define EVSYS_U2208
+#define REV_EVSYS                   0x101
+
+/* -------- EVSYS_CTRL : (EVSYS Offset: 0x00) ( /W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  :3;               /*!< bit:  1.. 3  Reserved                           */
+    uint8_t  GCLKREQ:1;        /*!< bit:      4  Generic Clock Requests             */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} EVSYS_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CTRL_OFFSET           0x00         /**< \brief (EVSYS_CTRL offset) Control */
+#define EVSYS_CTRL_RESETVALUE       _U_(0x00)    /**< \brief (EVSYS_CTRL reset_value) Control */
+
+#define EVSYS_CTRL_SWRST_Pos        0            /**< \brief (EVSYS_CTRL) Software Reset */
+#define EVSYS_CTRL_SWRST            (_U_(0x1) << EVSYS_CTRL_SWRST_Pos)
+#define EVSYS_CTRL_GCLKREQ_Pos      4            /**< \brief (EVSYS_CTRL) Generic Clock Requests */
+#define EVSYS_CTRL_GCLKREQ          (_U_(0x1) << EVSYS_CTRL_GCLKREQ_Pos)
+#define EVSYS_CTRL_MASK             _U_(0x11)    /**< \brief (EVSYS_CTRL) MASK Register */
+
+/* -------- EVSYS_CHANNEL : (EVSYS Offset: 0x04) (R/W 32) Channel -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CHANNEL:3;        /*!< bit:  0.. 2  Channel Selection                  */
+    uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint32_t SWEVT:1;          /*!< bit:      8  Software Event                     */
+    uint32_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint32_t EVGEN:6;          /*!< bit: 16..21  Event Generator Selection          */
+    uint32_t :2;               /*!< bit: 22..23  Reserved                           */
+    uint32_t PATH:2;           /*!< bit: 24..25  Path Selection                     */
+    uint32_t EDGSEL:2;         /*!< bit: 26..27  Edge Detection Selection           */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_CHANNEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHANNEL_OFFSET        0x04         /**< \brief (EVSYS_CHANNEL offset) Channel */
+#define EVSYS_CHANNEL_RESETVALUE    _U_(0x00000000) /**< \brief (EVSYS_CHANNEL reset_value) Channel */
+
+#define EVSYS_CHANNEL_CHANNEL_Pos   0            /**< \brief (EVSYS_CHANNEL) Channel Selection */
+#define EVSYS_CHANNEL_CHANNEL_Msk   (_U_(0x7) << EVSYS_CHANNEL_CHANNEL_Pos)
+#define EVSYS_CHANNEL_CHANNEL(value) (EVSYS_CHANNEL_CHANNEL_Msk & ((value) << EVSYS_CHANNEL_CHANNEL_Pos))
+#define EVSYS_CHANNEL_SWEVT_Pos     8            /**< \brief (EVSYS_CHANNEL) Software Event */
+#define EVSYS_CHANNEL_SWEVT         (_U_(0x1) << EVSYS_CHANNEL_SWEVT_Pos)
+#define EVSYS_CHANNEL_EVGEN_Pos     16           /**< \brief (EVSYS_CHANNEL) Event Generator Selection */
+#define EVSYS_CHANNEL_EVGEN_Msk     (_U_(0x3F) << EVSYS_CHANNEL_EVGEN_Pos)
+#define EVSYS_CHANNEL_EVGEN(value)  (EVSYS_CHANNEL_EVGEN_Msk & ((value) << EVSYS_CHANNEL_EVGEN_Pos))
+#define EVSYS_CHANNEL_PATH_Pos      24           /**< \brief (EVSYS_CHANNEL) Path Selection */
+#define EVSYS_CHANNEL_PATH_Msk      (_U_(0x3) << EVSYS_CHANNEL_PATH_Pos)
+#define EVSYS_CHANNEL_PATH(value)   (EVSYS_CHANNEL_PATH_Msk & ((value) << EVSYS_CHANNEL_PATH_Pos))
+#define   EVSYS_CHANNEL_PATH_SYNCHRONOUS_Val _U_(0x0)   /**< \brief (EVSYS_CHANNEL) Synchronous path */
+#define   EVSYS_CHANNEL_PATH_RESYNCHRONIZED_Val _U_(0x1)   /**< \brief (EVSYS_CHANNEL) Resynchronized path */
+#define   EVSYS_CHANNEL_PATH_ASYNCHRONOUS_Val _U_(0x2)   /**< \brief (EVSYS_CHANNEL) Asynchronous path */
+#define EVSYS_CHANNEL_PATH_SYNCHRONOUS (EVSYS_CHANNEL_PATH_SYNCHRONOUS_Val << EVSYS_CHANNEL_PATH_Pos)
+#define EVSYS_CHANNEL_PATH_RESYNCHRONIZED (EVSYS_CHANNEL_PATH_RESYNCHRONIZED_Val << EVSYS_CHANNEL_PATH_Pos)
+#define EVSYS_CHANNEL_PATH_ASYNCHRONOUS (EVSYS_CHANNEL_PATH_ASYNCHRONOUS_Val << EVSYS_CHANNEL_PATH_Pos)
+#define EVSYS_CHANNEL_EDGSEL_Pos    26           /**< \brief (EVSYS_CHANNEL) Edge Detection Selection */
+#define EVSYS_CHANNEL_EDGSEL_Msk    (_U_(0x3) << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_EDGSEL(value) (EVSYS_CHANNEL_EDGSEL_Msk & ((value) << EVSYS_CHANNEL_EDGSEL_Pos))
+#define   EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT_Val _U_(0x0)   /**< \brief (EVSYS_CHANNEL) No event output when using the resynchronized or synchronous path */
+#define   EVSYS_CHANNEL_EDGSEL_RISING_EDGE_Val _U_(0x1)   /**< \brief (EVSYS_CHANNEL) Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path */
+#define   EVSYS_CHANNEL_EDGSEL_FALLING_EDGE_Val _U_(0x2)   /**< \brief (EVSYS_CHANNEL) Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path */
+#define   EVSYS_CHANNEL_EDGSEL_BOTH_EDGES_Val _U_(0x3)   /**< \brief (EVSYS_CHANNEL) Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path */
+#define EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT (EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT_Val << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_EDGSEL_RISING_EDGE (EVSYS_CHANNEL_EDGSEL_RISING_EDGE_Val << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_EDGSEL_FALLING_EDGE (EVSYS_CHANNEL_EDGSEL_FALLING_EDGE_Val << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_EDGSEL_BOTH_EDGES (EVSYS_CHANNEL_EDGSEL_BOTH_EDGES_Val << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_MASK          _U_(0x0F3F0107) /**< \brief (EVSYS_CHANNEL) MASK Register */
+
+/* -------- EVSYS_USER : (EVSYS Offset: 0x08) (R/W 16) User Multiplexer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t USER:4;           /*!< bit:  0.. 3  User Multiplexer Selection         */
+    uint16_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint16_t CHANNEL:4;        /*!< bit:  8..11  Channel Event Selection            */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} EVSYS_USER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_USER_OFFSET           0x08         /**< \brief (EVSYS_USER offset) User Multiplexer */
+#define EVSYS_USER_RESETVALUE       _U_(0x0000)  /**< \brief (EVSYS_USER reset_value) User Multiplexer */
+
+#define EVSYS_USER_USER_Pos         0            /**< \brief (EVSYS_USER) User Multiplexer Selection */
+#define EVSYS_USER_USER_Msk         (_U_(0xF) << EVSYS_USER_USER_Pos)
+#define EVSYS_USER_USER(value)      (EVSYS_USER_USER_Msk & ((value) << EVSYS_USER_USER_Pos))
+#define EVSYS_USER_CHANNEL_Pos      8            /**< \brief (EVSYS_USER) Channel Event Selection */
+#define EVSYS_USER_CHANNEL_Msk      (_U_(0xF) << EVSYS_USER_CHANNEL_Pos)
+#define EVSYS_USER_CHANNEL(value)   (EVSYS_USER_CHANNEL_Msk & ((value) << EVSYS_USER_CHANNEL_Pos))
+#define EVSYS_USER_MASK             _U_(0x0F0F)  /**< \brief (EVSYS_USER) MASK Register */
+
+/* -------- EVSYS_CHSTATUS : (EVSYS Offset: 0x0C) (R/  32) Channel Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t USRRDY0:1;        /*!< bit:      0  Channel 0 User Ready               */
+    uint32_t USRRDY1:1;        /*!< bit:      1  Channel 1 User Ready               */
+    uint32_t USRRDY2:1;        /*!< bit:      2  Channel 2 User Ready               */
+    uint32_t USRRDY3:1;        /*!< bit:      3  Channel 3 User Ready               */
+    uint32_t USRRDY4:1;        /*!< bit:      4  Channel 4 User Ready               */
+    uint32_t USRRDY5:1;        /*!< bit:      5  Channel 5 User Ready               */
+    uint32_t USRRDY6:1;        /*!< bit:      6  Channel 6 User Ready               */
+    uint32_t USRRDY7:1;        /*!< bit:      7  Channel 7 User Ready               */
+    uint32_t CHBUSY0:1;        /*!< bit:      8  Channel 0 Busy                     */
+    uint32_t CHBUSY1:1;        /*!< bit:      9  Channel 1 Busy                     */
+    uint32_t CHBUSY2:1;        /*!< bit:     10  Channel 2 Busy                     */
+    uint32_t CHBUSY3:1;        /*!< bit:     11  Channel 3 Busy                     */
+    uint32_t CHBUSY4:1;        /*!< bit:     12  Channel 4 Busy                     */
+    uint32_t CHBUSY5:1;        /*!< bit:     13  Channel 5 Busy                     */
+    uint32_t CHBUSY6:1;        /*!< bit:     14  Channel 6 Busy                     */
+    uint32_t CHBUSY7:1;        /*!< bit:     15  Channel 7 Busy                     */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t USRRDY:8;         /*!< bit:  0.. 7  Channel x User Ready               */
+    uint32_t CHBUSY:8;         /*!< bit:  8..15  Channel x Busy                     */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_CHSTATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHSTATUS_OFFSET       0x0C         /**< \brief (EVSYS_CHSTATUS offset) Channel Status */
+#define EVSYS_CHSTATUS_RESETVALUE   _U_(0x00000000) /**< \brief (EVSYS_CHSTATUS reset_value) Channel Status */
+
+#define EVSYS_CHSTATUS_USRRDY0_Pos  0            /**< \brief (EVSYS_CHSTATUS) Channel 0 User Ready */
+#define EVSYS_CHSTATUS_USRRDY0      (_U_(1) << EVSYS_CHSTATUS_USRRDY0_Pos)
+#define EVSYS_CHSTATUS_USRRDY1_Pos  1            /**< \brief (EVSYS_CHSTATUS) Channel 1 User Ready */
+#define EVSYS_CHSTATUS_USRRDY1      (_U_(1) << EVSYS_CHSTATUS_USRRDY1_Pos)
+#define EVSYS_CHSTATUS_USRRDY2_Pos  2            /**< \brief (EVSYS_CHSTATUS) Channel 2 User Ready */
+#define EVSYS_CHSTATUS_USRRDY2      (_U_(1) << EVSYS_CHSTATUS_USRRDY2_Pos)
+#define EVSYS_CHSTATUS_USRRDY3_Pos  3            /**< \brief (EVSYS_CHSTATUS) Channel 3 User Ready */
+#define EVSYS_CHSTATUS_USRRDY3      (_U_(1) << EVSYS_CHSTATUS_USRRDY3_Pos)
+#define EVSYS_CHSTATUS_USRRDY4_Pos  4            /**< \brief (EVSYS_CHSTATUS) Channel 4 User Ready */
+#define EVSYS_CHSTATUS_USRRDY4      (_U_(1) << EVSYS_CHSTATUS_USRRDY4_Pos)
+#define EVSYS_CHSTATUS_USRRDY5_Pos  5            /**< \brief (EVSYS_CHSTATUS) Channel 5 User Ready */
+#define EVSYS_CHSTATUS_USRRDY5      (_U_(1) << EVSYS_CHSTATUS_USRRDY5_Pos)
+#define EVSYS_CHSTATUS_USRRDY6_Pos  6            /**< \brief (EVSYS_CHSTATUS) Channel 6 User Ready */
+#define EVSYS_CHSTATUS_USRRDY6      (_U_(1) << EVSYS_CHSTATUS_USRRDY6_Pos)
+#define EVSYS_CHSTATUS_USRRDY7_Pos  7            /**< \brief (EVSYS_CHSTATUS) Channel 7 User Ready */
+#define EVSYS_CHSTATUS_USRRDY7      (_U_(1) << EVSYS_CHSTATUS_USRRDY7_Pos)
+#define EVSYS_CHSTATUS_USRRDY_Pos   0            /**< \brief (EVSYS_CHSTATUS) Channel x User Ready */
+#define EVSYS_CHSTATUS_USRRDY_Msk   (_U_(0xFF) << EVSYS_CHSTATUS_USRRDY_Pos)
+#define EVSYS_CHSTATUS_USRRDY(value) (EVSYS_CHSTATUS_USRRDY_Msk & ((value) << EVSYS_CHSTATUS_USRRDY_Pos))
+#define EVSYS_CHSTATUS_CHBUSY0_Pos  8            /**< \brief (EVSYS_CHSTATUS) Channel 0 Busy */
+#define EVSYS_CHSTATUS_CHBUSY0      (_U_(1) << EVSYS_CHSTATUS_CHBUSY0_Pos)
+#define EVSYS_CHSTATUS_CHBUSY1_Pos  9            /**< \brief (EVSYS_CHSTATUS) Channel 1 Busy */
+#define EVSYS_CHSTATUS_CHBUSY1      (_U_(1) << EVSYS_CHSTATUS_CHBUSY1_Pos)
+#define EVSYS_CHSTATUS_CHBUSY2_Pos  10           /**< \brief (EVSYS_CHSTATUS) Channel 2 Busy */
+#define EVSYS_CHSTATUS_CHBUSY2      (_U_(1) << EVSYS_CHSTATUS_CHBUSY2_Pos)
+#define EVSYS_CHSTATUS_CHBUSY3_Pos  11           /**< \brief (EVSYS_CHSTATUS) Channel 3 Busy */
+#define EVSYS_CHSTATUS_CHBUSY3      (_U_(1) << EVSYS_CHSTATUS_CHBUSY3_Pos)
+#define EVSYS_CHSTATUS_CHBUSY4_Pos  12           /**< \brief (EVSYS_CHSTATUS) Channel 4 Busy */
+#define EVSYS_CHSTATUS_CHBUSY4      (_U_(1) << EVSYS_CHSTATUS_CHBUSY4_Pos)
+#define EVSYS_CHSTATUS_CHBUSY5_Pos  13           /**< \brief (EVSYS_CHSTATUS) Channel 5 Busy */
+#define EVSYS_CHSTATUS_CHBUSY5      (_U_(1) << EVSYS_CHSTATUS_CHBUSY5_Pos)
+#define EVSYS_CHSTATUS_CHBUSY6_Pos  14           /**< \brief (EVSYS_CHSTATUS) Channel 6 Busy */
+#define EVSYS_CHSTATUS_CHBUSY6      (_U_(1) << EVSYS_CHSTATUS_CHBUSY6_Pos)
+#define EVSYS_CHSTATUS_CHBUSY7_Pos  15           /**< \brief (EVSYS_CHSTATUS) Channel 7 Busy */
+#define EVSYS_CHSTATUS_CHBUSY7      (_U_(1) << EVSYS_CHSTATUS_CHBUSY7_Pos)
+#define EVSYS_CHSTATUS_CHBUSY_Pos   8            /**< \brief (EVSYS_CHSTATUS) Channel x Busy */
+#define EVSYS_CHSTATUS_CHBUSY_Msk   (_U_(0xFF) << EVSYS_CHSTATUS_CHBUSY_Pos)
+#define EVSYS_CHSTATUS_CHBUSY(value) (EVSYS_CHSTATUS_CHBUSY_Msk & ((value) << EVSYS_CHSTATUS_CHBUSY_Pos))
+#define EVSYS_CHSTATUS_MASK         _U_(0x0000FFFF) /**< \brief (EVSYS_CHSTATUS) MASK Register */
+
+/* -------- EVSYS_INTENCLR : (EVSYS Offset: 0x10) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVR0:1;           /*!< bit:      0  Channel 0 Overrun Interrupt Enable */
+    uint32_t OVR1:1;           /*!< bit:      1  Channel 1 Overrun Interrupt Enable */
+    uint32_t OVR2:1;           /*!< bit:      2  Channel 2 Overrun Interrupt Enable */
+    uint32_t OVR3:1;           /*!< bit:      3  Channel 3 Overrun Interrupt Enable */
+    uint32_t OVR4:1;           /*!< bit:      4  Channel 4 Overrun Interrupt Enable */
+    uint32_t OVR5:1;           /*!< bit:      5  Channel 5 Overrun Interrupt Enable */
+    uint32_t OVR6:1;           /*!< bit:      6  Channel 6 Overrun Interrupt Enable */
+    uint32_t OVR7:1;           /*!< bit:      7  Channel 7 Overrun Interrupt Enable */
+    uint32_t EVD0:1;           /*!< bit:      8  Channel 0 Event Detection Interrupt Enable */
+    uint32_t EVD1:1;           /*!< bit:      9  Channel 1 Event Detection Interrupt Enable */
+    uint32_t EVD2:1;           /*!< bit:     10  Channel 2 Event Detection Interrupt Enable */
+    uint32_t EVD3:1;           /*!< bit:     11  Channel 3 Event Detection Interrupt Enable */
+    uint32_t EVD4:1;           /*!< bit:     12  Channel 4 Event Detection Interrupt Enable */
+    uint32_t EVD5:1;           /*!< bit:     13  Channel 5 Event Detection Interrupt Enable */
+    uint32_t EVD6:1;           /*!< bit:     14  Channel 6 Event Detection Interrupt Enable */
+    uint32_t EVD7:1;           /*!< bit:     15  Channel 7 Event Detection Interrupt Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun Interrupt Enable */
+    uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection Interrupt Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTENCLR_OFFSET       0x10         /**< \brief (EVSYS_INTENCLR offset) Interrupt Enable Clear */
+#define EVSYS_INTENCLR_RESETVALUE   _U_(0x00000000) /**< \brief (EVSYS_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define EVSYS_INTENCLR_OVR0_Pos     0            /**< \brief (EVSYS_INTENCLR) Channel 0 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR0         (_U_(1) << EVSYS_INTENCLR_OVR0_Pos)
+#define EVSYS_INTENCLR_OVR1_Pos     1            /**< \brief (EVSYS_INTENCLR) Channel 1 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR1         (_U_(1) << EVSYS_INTENCLR_OVR1_Pos)
+#define EVSYS_INTENCLR_OVR2_Pos     2            /**< \brief (EVSYS_INTENCLR) Channel 2 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR2         (_U_(1) << EVSYS_INTENCLR_OVR2_Pos)
+#define EVSYS_INTENCLR_OVR3_Pos     3            /**< \brief (EVSYS_INTENCLR) Channel 3 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR3         (_U_(1) << EVSYS_INTENCLR_OVR3_Pos)
+#define EVSYS_INTENCLR_OVR4_Pos     4            /**< \brief (EVSYS_INTENCLR) Channel 4 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR4         (_U_(1) << EVSYS_INTENCLR_OVR4_Pos)
+#define EVSYS_INTENCLR_OVR5_Pos     5            /**< \brief (EVSYS_INTENCLR) Channel 5 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR5         (_U_(1) << EVSYS_INTENCLR_OVR5_Pos)
+#define EVSYS_INTENCLR_OVR6_Pos     6            /**< \brief (EVSYS_INTENCLR) Channel 6 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR6         (_U_(1) << EVSYS_INTENCLR_OVR6_Pos)
+#define EVSYS_INTENCLR_OVR7_Pos     7            /**< \brief (EVSYS_INTENCLR) Channel 7 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR7         (_U_(1) << EVSYS_INTENCLR_OVR7_Pos)
+#define EVSYS_INTENCLR_OVR_Pos      0            /**< \brief (EVSYS_INTENCLR) Channel x Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR_Msk      (_U_(0xFF) << EVSYS_INTENCLR_OVR_Pos)
+#define EVSYS_INTENCLR_OVR(value)   (EVSYS_INTENCLR_OVR_Msk & ((value) << EVSYS_INTENCLR_OVR_Pos))
+#define EVSYS_INTENCLR_EVD0_Pos     8            /**< \brief (EVSYS_INTENCLR) Channel 0 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD0         (_U_(1) << EVSYS_INTENCLR_EVD0_Pos)
+#define EVSYS_INTENCLR_EVD1_Pos     9            /**< \brief (EVSYS_INTENCLR) Channel 1 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD1         (_U_(1) << EVSYS_INTENCLR_EVD1_Pos)
+#define EVSYS_INTENCLR_EVD2_Pos     10           /**< \brief (EVSYS_INTENCLR) Channel 2 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD2         (_U_(1) << EVSYS_INTENCLR_EVD2_Pos)
+#define EVSYS_INTENCLR_EVD3_Pos     11           /**< \brief (EVSYS_INTENCLR) Channel 3 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD3         (_U_(1) << EVSYS_INTENCLR_EVD3_Pos)
+#define EVSYS_INTENCLR_EVD4_Pos     12           /**< \brief (EVSYS_INTENCLR) Channel 4 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD4         (_U_(1) << EVSYS_INTENCLR_EVD4_Pos)
+#define EVSYS_INTENCLR_EVD5_Pos     13           /**< \brief (EVSYS_INTENCLR) Channel 5 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD5         (_U_(1) << EVSYS_INTENCLR_EVD5_Pos)
+#define EVSYS_INTENCLR_EVD6_Pos     14           /**< \brief (EVSYS_INTENCLR) Channel 6 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD6         (_U_(1) << EVSYS_INTENCLR_EVD6_Pos)
+#define EVSYS_INTENCLR_EVD7_Pos     15           /**< \brief (EVSYS_INTENCLR) Channel 7 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD7         (_U_(1) << EVSYS_INTENCLR_EVD7_Pos)
+#define EVSYS_INTENCLR_EVD_Pos      8            /**< \brief (EVSYS_INTENCLR) Channel x Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD_Msk      (_U_(0xFF) << EVSYS_INTENCLR_EVD_Pos)
+#define EVSYS_INTENCLR_EVD(value)   (EVSYS_INTENCLR_EVD_Msk & ((value) << EVSYS_INTENCLR_EVD_Pos))
+#define EVSYS_INTENCLR_MASK         _U_(0x0000FFFF) /**< \brief (EVSYS_INTENCLR) MASK Register */
+
+/* -------- EVSYS_INTENSET : (EVSYS Offset: 0x14) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVR0:1;           /*!< bit:      0  Channel 0 Overrun Interrupt Enable */
+    uint32_t OVR1:1;           /*!< bit:      1  Channel 1 Overrun Interrupt Enable */
+    uint32_t OVR2:1;           /*!< bit:      2  Channel 2 Overrun Interrupt Enable */
+    uint32_t OVR3:1;           /*!< bit:      3  Channel 3 Overrun Interrupt Enable */
+    uint32_t OVR4:1;           /*!< bit:      4  Channel 4 Overrun Interrupt Enable */
+    uint32_t OVR5:1;           /*!< bit:      5  Channel 5 Overrun Interrupt Enable */
+    uint32_t OVR6:1;           /*!< bit:      6  Channel 6 Overrun Interrupt Enable */
+    uint32_t OVR7:1;           /*!< bit:      7  Channel 7 Overrun Interrupt Enable */
+    uint32_t EVD0:1;           /*!< bit:      8  Channel 0 Event Detection Interrupt Enable */
+    uint32_t EVD1:1;           /*!< bit:      9  Channel 1 Event Detection Interrupt Enable */
+    uint32_t EVD2:1;           /*!< bit:     10  Channel 2 Event Detection Interrupt Enable */
+    uint32_t EVD3:1;           /*!< bit:     11  Channel 3 Event Detection Interrupt Enable */
+    uint32_t EVD4:1;           /*!< bit:     12  Channel 4 Event Detection Interrupt Enable */
+    uint32_t EVD5:1;           /*!< bit:     13  Channel 5 Event Detection Interrupt Enable */
+    uint32_t EVD6:1;           /*!< bit:     14  Channel 6 Event Detection Interrupt Enable */
+    uint32_t EVD7:1;           /*!< bit:     15  Channel 7 Event Detection Interrupt Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun Interrupt Enable */
+    uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection Interrupt Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTENSET_OFFSET       0x14         /**< \brief (EVSYS_INTENSET offset) Interrupt Enable Set */
+#define EVSYS_INTENSET_RESETVALUE   _U_(0x00000000) /**< \brief (EVSYS_INTENSET reset_value) Interrupt Enable Set */
+
+#define EVSYS_INTENSET_OVR0_Pos     0            /**< \brief (EVSYS_INTENSET) Channel 0 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR0         (_U_(1) << EVSYS_INTENSET_OVR0_Pos)
+#define EVSYS_INTENSET_OVR1_Pos     1            /**< \brief (EVSYS_INTENSET) Channel 1 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR1         (_U_(1) << EVSYS_INTENSET_OVR1_Pos)
+#define EVSYS_INTENSET_OVR2_Pos     2            /**< \brief (EVSYS_INTENSET) Channel 2 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR2         (_U_(1) << EVSYS_INTENSET_OVR2_Pos)
+#define EVSYS_INTENSET_OVR3_Pos     3            /**< \brief (EVSYS_INTENSET) Channel 3 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR3         (_U_(1) << EVSYS_INTENSET_OVR3_Pos)
+#define EVSYS_INTENSET_OVR4_Pos     4            /**< \brief (EVSYS_INTENSET) Channel 4 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR4         (_U_(1) << EVSYS_INTENSET_OVR4_Pos)
+#define EVSYS_INTENSET_OVR5_Pos     5            /**< \brief (EVSYS_INTENSET) Channel 5 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR5         (_U_(1) << EVSYS_INTENSET_OVR5_Pos)
+#define EVSYS_INTENSET_OVR6_Pos     6            /**< \brief (EVSYS_INTENSET) Channel 6 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR6         (_U_(1) << EVSYS_INTENSET_OVR6_Pos)
+#define EVSYS_INTENSET_OVR7_Pos     7            /**< \brief (EVSYS_INTENSET) Channel 7 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR7         (_U_(1) << EVSYS_INTENSET_OVR7_Pos)
+#define EVSYS_INTENSET_OVR_Pos      0            /**< \brief (EVSYS_INTENSET) Channel x Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR_Msk      (_U_(0xFF) << EVSYS_INTENSET_OVR_Pos)
+#define EVSYS_INTENSET_OVR(value)   (EVSYS_INTENSET_OVR_Msk & ((value) << EVSYS_INTENSET_OVR_Pos))
+#define EVSYS_INTENSET_EVD0_Pos     8            /**< \brief (EVSYS_INTENSET) Channel 0 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD0         (_U_(1) << EVSYS_INTENSET_EVD0_Pos)
+#define EVSYS_INTENSET_EVD1_Pos     9            /**< \brief (EVSYS_INTENSET) Channel 1 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD1         (_U_(1) << EVSYS_INTENSET_EVD1_Pos)
+#define EVSYS_INTENSET_EVD2_Pos     10           /**< \brief (EVSYS_INTENSET) Channel 2 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD2         (_U_(1) << EVSYS_INTENSET_EVD2_Pos)
+#define EVSYS_INTENSET_EVD3_Pos     11           /**< \brief (EVSYS_INTENSET) Channel 3 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD3         (_U_(1) << EVSYS_INTENSET_EVD3_Pos)
+#define EVSYS_INTENSET_EVD4_Pos     12           /**< \brief (EVSYS_INTENSET) Channel 4 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD4         (_U_(1) << EVSYS_INTENSET_EVD4_Pos)
+#define EVSYS_INTENSET_EVD5_Pos     13           /**< \brief (EVSYS_INTENSET) Channel 5 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD5         (_U_(1) << EVSYS_INTENSET_EVD5_Pos)
+#define EVSYS_INTENSET_EVD6_Pos     14           /**< \brief (EVSYS_INTENSET) Channel 6 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD6         (_U_(1) << EVSYS_INTENSET_EVD6_Pos)
+#define EVSYS_INTENSET_EVD7_Pos     15           /**< \brief (EVSYS_INTENSET) Channel 7 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD7         (_U_(1) << EVSYS_INTENSET_EVD7_Pos)
+#define EVSYS_INTENSET_EVD_Pos      8            /**< \brief (EVSYS_INTENSET) Channel x Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD_Msk      (_U_(0xFF) << EVSYS_INTENSET_EVD_Pos)
+#define EVSYS_INTENSET_EVD(value)   (EVSYS_INTENSET_EVD_Msk & ((value) << EVSYS_INTENSET_EVD_Pos))
+#define EVSYS_INTENSET_MASK         _U_(0x0000FFFF) /**< \brief (EVSYS_INTENSET) MASK Register */
+
+/* -------- EVSYS_INTFLAG : (EVSYS Offset: 0x18) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t OVR0:1;           /*!< bit:      0  Channel 0 Overrun                  */
+    __I uint32_t OVR1:1;           /*!< bit:      1  Channel 1 Overrun                  */
+    __I uint32_t OVR2:1;           /*!< bit:      2  Channel 2 Overrun                  */
+    __I uint32_t OVR3:1;           /*!< bit:      3  Channel 3 Overrun                  */
+    __I uint32_t OVR4:1;           /*!< bit:      4  Channel 4 Overrun                  */
+    __I uint32_t OVR5:1;           /*!< bit:      5  Channel 5 Overrun                  */
+    __I uint32_t OVR6:1;           /*!< bit:      6  Channel 6 Overrun                  */
+    __I uint32_t OVR7:1;           /*!< bit:      7  Channel 7 Overrun                  */
+    __I uint32_t EVD0:1;           /*!< bit:      8  Channel 0 Event Detection          */
+    __I uint32_t EVD1:1;           /*!< bit:      9  Channel 1 Event Detection          */
+    __I uint32_t EVD2:1;           /*!< bit:     10  Channel 2 Event Detection          */
+    __I uint32_t EVD3:1;           /*!< bit:     11  Channel 3 Event Detection          */
+    __I uint32_t EVD4:1;           /*!< bit:     12  Channel 4 Event Detection          */
+    __I uint32_t EVD5:1;           /*!< bit:     13  Channel 5 Event Detection          */
+    __I uint32_t EVD6:1;           /*!< bit:     14  Channel 6 Event Detection          */
+    __I uint32_t EVD7:1;           /*!< bit:     15  Channel 7 Event Detection          */
+    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun                  */
+    __I uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection          */
+    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTFLAG_OFFSET        0x18         /**< \brief (EVSYS_INTFLAG offset) Interrupt Flag Status and Clear */
+#define EVSYS_INTFLAG_RESETVALUE    _U_(0x00000000) /**< \brief (EVSYS_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define EVSYS_INTFLAG_OVR0_Pos      0            /**< \brief (EVSYS_INTFLAG) Channel 0 Overrun */
+#define EVSYS_INTFLAG_OVR0          (_U_(1) << EVSYS_INTFLAG_OVR0_Pos)
+#define EVSYS_INTFLAG_OVR1_Pos      1            /**< \brief (EVSYS_INTFLAG) Channel 1 Overrun */
+#define EVSYS_INTFLAG_OVR1          (_U_(1) << EVSYS_INTFLAG_OVR1_Pos)
+#define EVSYS_INTFLAG_OVR2_Pos      2            /**< \brief (EVSYS_INTFLAG) Channel 2 Overrun */
+#define EVSYS_INTFLAG_OVR2          (_U_(1) << EVSYS_INTFLAG_OVR2_Pos)
+#define EVSYS_INTFLAG_OVR3_Pos      3            /**< \brief (EVSYS_INTFLAG) Channel 3 Overrun */
+#define EVSYS_INTFLAG_OVR3          (_U_(1) << EVSYS_INTFLAG_OVR3_Pos)
+#define EVSYS_INTFLAG_OVR4_Pos      4            /**< \brief (EVSYS_INTFLAG) Channel 4 Overrun */
+#define EVSYS_INTFLAG_OVR4          (_U_(1) << EVSYS_INTFLAG_OVR4_Pos)
+#define EVSYS_INTFLAG_OVR5_Pos      5            /**< \brief (EVSYS_INTFLAG) Channel 5 Overrun */
+#define EVSYS_INTFLAG_OVR5          (_U_(1) << EVSYS_INTFLAG_OVR5_Pos)
+#define EVSYS_INTFLAG_OVR6_Pos      6            /**< \brief (EVSYS_INTFLAG) Channel 6 Overrun */
+#define EVSYS_INTFLAG_OVR6          (_U_(1) << EVSYS_INTFLAG_OVR6_Pos)
+#define EVSYS_INTFLAG_OVR7_Pos      7            /**< \brief (EVSYS_INTFLAG) Channel 7 Overrun */
+#define EVSYS_INTFLAG_OVR7          (_U_(1) << EVSYS_INTFLAG_OVR7_Pos)
+#define EVSYS_INTFLAG_OVR_Pos       0            /**< \brief (EVSYS_INTFLAG) Channel x Overrun */
+#define EVSYS_INTFLAG_OVR_Msk       (_U_(0xFF) << EVSYS_INTFLAG_OVR_Pos)
+#define EVSYS_INTFLAG_OVR(value)    (EVSYS_INTFLAG_OVR_Msk & ((value) << EVSYS_INTFLAG_OVR_Pos))
+#define EVSYS_INTFLAG_EVD0_Pos      8            /**< \brief (EVSYS_INTFLAG) Channel 0 Event Detection */
+#define EVSYS_INTFLAG_EVD0          (_U_(1) << EVSYS_INTFLAG_EVD0_Pos)
+#define EVSYS_INTFLAG_EVD1_Pos      9            /**< \brief (EVSYS_INTFLAG) Channel 1 Event Detection */
+#define EVSYS_INTFLAG_EVD1          (_U_(1) << EVSYS_INTFLAG_EVD1_Pos)
+#define EVSYS_INTFLAG_EVD2_Pos      10           /**< \brief (EVSYS_INTFLAG) Channel 2 Event Detection */
+#define EVSYS_INTFLAG_EVD2          (_U_(1) << EVSYS_INTFLAG_EVD2_Pos)
+#define EVSYS_INTFLAG_EVD3_Pos      11           /**< \brief (EVSYS_INTFLAG) Channel 3 Event Detection */
+#define EVSYS_INTFLAG_EVD3          (_U_(1) << EVSYS_INTFLAG_EVD3_Pos)
+#define EVSYS_INTFLAG_EVD4_Pos      12           /**< \brief (EVSYS_INTFLAG) Channel 4 Event Detection */
+#define EVSYS_INTFLAG_EVD4          (_U_(1) << EVSYS_INTFLAG_EVD4_Pos)
+#define EVSYS_INTFLAG_EVD5_Pos      13           /**< \brief (EVSYS_INTFLAG) Channel 5 Event Detection */
+#define EVSYS_INTFLAG_EVD5          (_U_(1) << EVSYS_INTFLAG_EVD5_Pos)
+#define EVSYS_INTFLAG_EVD6_Pos      14           /**< \brief (EVSYS_INTFLAG) Channel 6 Event Detection */
+#define EVSYS_INTFLAG_EVD6          (_U_(1) << EVSYS_INTFLAG_EVD6_Pos)
+#define EVSYS_INTFLAG_EVD7_Pos      15           /**< \brief (EVSYS_INTFLAG) Channel 7 Event Detection */
+#define EVSYS_INTFLAG_EVD7          (_U_(1) << EVSYS_INTFLAG_EVD7_Pos)
+#define EVSYS_INTFLAG_EVD_Pos       8            /**< \brief (EVSYS_INTFLAG) Channel x Event Detection */
+#define EVSYS_INTFLAG_EVD_Msk       (_U_(0xFF) << EVSYS_INTFLAG_EVD_Pos)
+#define EVSYS_INTFLAG_EVD(value)    (EVSYS_INTFLAG_EVD_Msk & ((value) << EVSYS_INTFLAG_EVD_Pos))
+#define EVSYS_INTFLAG_MASK          _U_(0x0000FFFF) /**< \brief (EVSYS_INTFLAG) MASK Register */
+
+/** \brief EVSYS hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __O  EVSYS_CTRL_Type           CTRL;        /**< \brief Offset: 0x00 ( /W  8) Control */
+       RoReg8                    Reserved1[0x3];
+  __IO EVSYS_CHANNEL_Type        CHANNEL;     /**< \brief Offset: 0x04 (R/W 32) Channel */
+  __IO EVSYS_USER_Type           USER;        /**< \brief Offset: 0x08 (R/W 16) User Multiplexer */
+       RoReg8                    Reserved2[0x2];
+  __I  EVSYS_CHSTATUS_Type       CHSTATUS;    /**< \brief Offset: 0x0C (R/  32) Channel Status */
+  __IO EVSYS_INTENCLR_Type       INTENCLR;    /**< \brief Offset: 0x10 (R/W 32) Interrupt Enable Clear */
+  __IO EVSYS_INTENSET_Type       INTENSET;    /**< \brief Offset: 0x14 (R/W 32) Interrupt Enable Set */
+  __IO EVSYS_INTFLAG_Type        INTFLAG;     /**< \brief Offset: 0x18 (R/W 32) Interrupt Flag Status and Clear */
+} Evsys;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_EVSYS_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/component/gclk.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/gclk.h
@@ -1,0 +1,308 @@
+/**
+ * \file
+ *
+ * \brief Component description for GCLK
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_GCLK_COMPONENT_
+#define _SAMD20_GCLK_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR GCLK */
+/* ========================================================================== */
+/** \addtogroup SAMD20_GCLK Generic Clock Generator */
+/*@{*/
+
+#define GCLK_U2102
+#define REV_GCLK                    0x210
+
+/* -------- GCLK_CTRL : (GCLK Offset: 0x0) (R/W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} GCLK_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_CTRL_OFFSET            0x0          /**< \brief (GCLK_CTRL offset) Control */
+#define GCLK_CTRL_RESETVALUE        _U_(0x00)    /**< \brief (GCLK_CTRL reset_value) Control */
+
+#define GCLK_CTRL_SWRST_Pos         0            /**< \brief (GCLK_CTRL) Software Reset */
+#define GCLK_CTRL_SWRST             (_U_(0x1) << GCLK_CTRL_SWRST_Pos)
+#define GCLK_CTRL_MASK              _U_(0x01)    /**< \brief (GCLK_CTRL) MASK Register */
+
+/* -------- GCLK_STATUS : (GCLK Offset: 0x1) (R/   8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy Status        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} GCLK_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_STATUS_OFFSET          0x1          /**< \brief (GCLK_STATUS offset) Status */
+#define GCLK_STATUS_RESETVALUE      _U_(0x00)    /**< \brief (GCLK_STATUS reset_value) Status */
+
+#define GCLK_STATUS_SYNCBUSY_Pos    7            /**< \brief (GCLK_STATUS) Synchronization Busy Status */
+#define GCLK_STATUS_SYNCBUSY        (_U_(0x1) << GCLK_STATUS_SYNCBUSY_Pos)
+#define GCLK_STATUS_MASK            _U_(0x80)    /**< \brief (GCLK_STATUS) MASK Register */
+
+/* -------- GCLK_CLKCTRL : (GCLK Offset: 0x2) (R/W 16) Generic Clock Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t ID:6;             /*!< bit:  0.. 5  Generic Clock Selection ID         */
+    uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t GEN:4;            /*!< bit:  8..11  Generic Clock Generator            */
+    uint16_t :2;               /*!< bit: 12..13  Reserved                           */
+    uint16_t CLKEN:1;          /*!< bit:     14  Clock Enable                       */
+    uint16_t WRTLOCK:1;        /*!< bit:     15  Write Lock                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} GCLK_CLKCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_CLKCTRL_OFFSET         0x2          /**< \brief (GCLK_CLKCTRL offset) Generic Clock Control */
+#define GCLK_CLKCTRL_RESETVALUE     _U_(0x0000)  /**< \brief (GCLK_CLKCTRL reset_value) Generic Clock Control */
+
+#define GCLK_CLKCTRL_ID_Pos         0            /**< \brief (GCLK_CLKCTRL) Generic Clock Selection ID */
+#define GCLK_CLKCTRL_ID_Msk         (_U_(0x3F) << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID(value)      (GCLK_CLKCTRL_ID_Msk & ((value) << GCLK_CLKCTRL_ID_Pos))
+#define   GCLK_CLKCTRL_ID_DFLL48M_Val     _U_(0x0)   /**< \brief (GCLK_CLKCTRL) DFLL48M Reference */
+#define   GCLK_CLKCTRL_ID_WDT_Val         _U_(0x1)   /**< \brief (GCLK_CLKCTRL) WDT */
+#define   GCLK_CLKCTRL_ID_RTC_Val         _U_(0x2)   /**< \brief (GCLK_CLKCTRL) RTC */
+#define   GCLK_CLKCTRL_ID_EIC_Val         _U_(0x3)   /**< \brief (GCLK_CLKCTRL) EIC */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_0_Val _U_(0x4)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_0 */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_1_Val _U_(0x5)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_1 */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_2_Val _U_(0x6)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_2 */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_3_Val _U_(0x7)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_3 */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_4_Val _U_(0x8)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_4 */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_5_Val _U_(0x9)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_5 */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_6_Val _U_(0xA)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_6 */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_7_Val _U_(0xB)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_7 */
+#define   GCLK_CLKCTRL_ID_SERCOMX_SLOW_Val _U_(0xC)   /**< \brief (GCLK_CLKCTRL) SERCOMx_SLOW */
+#define   GCLK_CLKCTRL_ID_SERCOM0_CORE_Val _U_(0xD)   /**< \brief (GCLK_CLKCTRL) SERCOM0_CORE */
+#define   GCLK_CLKCTRL_ID_SERCOM1_CORE_Val _U_(0xE)   /**< \brief (GCLK_CLKCTRL) SERCOM1_CORE */
+#define   GCLK_CLKCTRL_ID_SERCOM2_CORE_Val _U_(0xF)   /**< \brief (GCLK_CLKCTRL) SERCOM2_CORE */
+#define   GCLK_CLKCTRL_ID_SERCOM3_CORE_Val _U_(0x10)   /**< \brief (GCLK_CLKCTRL) SERCOM3_CORE */
+#define   GCLK_CLKCTRL_ID_SERCOM4_CORE_Val _U_(0x11)   /**< \brief (GCLK_CLKCTRL) SERCOM4_CORE */
+#define   GCLK_CLKCTRL_ID_SERCOM5_CORE_Val _U_(0x12)   /**< \brief (GCLK_CLKCTRL) SERCOM5_CORE */
+#define   GCLK_CLKCTRL_ID_TC0_TC1_Val     _U_(0x13)   /**< \brief (GCLK_CLKCTRL) TC0,TC1 */
+#define   GCLK_CLKCTRL_ID_TC2_TC3_Val     _U_(0x14)   /**< \brief (GCLK_CLKCTRL) TC2,TC3 */
+#define   GCLK_CLKCTRL_ID_TC4_TC5_Val     _U_(0x15)   /**< \brief (GCLK_CLKCTRL) TC4,TC5 */
+#define   GCLK_CLKCTRL_ID_TC6_TC7_Val     _U_(0x16)   /**< \brief (GCLK_CLKCTRL) TC6,TC7 */
+#define   GCLK_CLKCTRL_ID_ADC_Val         _U_(0x17)   /**< \brief (GCLK_CLKCTRL) ADC */
+#define   GCLK_CLKCTRL_ID_AC_DIG_Val      _U_(0x18)   /**< \brief (GCLK_CLKCTRL) AC_DIG */
+#define   GCLK_CLKCTRL_ID_AC_ANA_Val      _U_(0x19)   /**< \brief (GCLK_CLKCTRL) AC_ANA */
+#define   GCLK_CLKCTRL_ID_DAC_Val         _U_(0x1A)   /**< \brief (GCLK_CLKCTRL) DAC */
+#define   GCLK_CLKCTRL_ID_PTC_Val         _U_(0x1B)   /**< \brief (GCLK_CLKCTRL) PTC */
+#define GCLK_CLKCTRL_ID_DFLL48M     (GCLK_CLKCTRL_ID_DFLL48M_Val   << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_WDT         (GCLK_CLKCTRL_ID_WDT_Val       << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_RTC         (GCLK_CLKCTRL_ID_RTC_Val       << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EIC         (GCLK_CLKCTRL_ID_EIC_Val       << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_0 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_0_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_1 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_1_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_2 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_2_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_3 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_3_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_4 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_4_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_5 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_5_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_6 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_6_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_7 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_7_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_SERCOMX_SLOW (GCLK_CLKCTRL_ID_SERCOMX_SLOW_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_SERCOM0_CORE (GCLK_CLKCTRL_ID_SERCOM0_CORE_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_SERCOM1_CORE (GCLK_CLKCTRL_ID_SERCOM1_CORE_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_SERCOM2_CORE (GCLK_CLKCTRL_ID_SERCOM2_CORE_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_SERCOM3_CORE (GCLK_CLKCTRL_ID_SERCOM3_CORE_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_SERCOM4_CORE (GCLK_CLKCTRL_ID_SERCOM4_CORE_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_SERCOM5_CORE (GCLK_CLKCTRL_ID_SERCOM5_CORE_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_TC0_TC1     (GCLK_CLKCTRL_ID_TC0_TC1_Val   << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_TC2_TC3     (GCLK_CLKCTRL_ID_TC2_TC3_Val   << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_TC4_TC5     (GCLK_CLKCTRL_ID_TC4_TC5_Val   << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_TC6_TC7     (GCLK_CLKCTRL_ID_TC6_TC7_Val   << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_ADC         (GCLK_CLKCTRL_ID_ADC_Val       << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_AC_DIG      (GCLK_CLKCTRL_ID_AC_DIG_Val    << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_AC_ANA      (GCLK_CLKCTRL_ID_AC_ANA_Val    << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_DAC         (GCLK_CLKCTRL_ID_DAC_Val       << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_PTC         (GCLK_CLKCTRL_ID_PTC_Val       << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_GEN_Pos        8            /**< \brief (GCLK_CLKCTRL) Generic Clock Generator */
+#define GCLK_CLKCTRL_GEN_Msk        (_U_(0xF) << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN(value)     (GCLK_CLKCTRL_GEN_Msk & ((value) << GCLK_CLKCTRL_GEN_Pos))
+#define   GCLK_CLKCTRL_GEN_GCLK0_Val      _U_(0x0)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 0 */
+#define   GCLK_CLKCTRL_GEN_GCLK1_Val      _U_(0x1)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 1 */
+#define   GCLK_CLKCTRL_GEN_GCLK2_Val      _U_(0x2)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 2 */
+#define   GCLK_CLKCTRL_GEN_GCLK3_Val      _U_(0x3)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 3 */
+#define   GCLK_CLKCTRL_GEN_GCLK4_Val      _U_(0x4)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 4 */
+#define   GCLK_CLKCTRL_GEN_GCLK5_Val      _U_(0x5)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 5 */
+#define   GCLK_CLKCTRL_GEN_GCLK6_Val      _U_(0x6)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 6 */
+#define   GCLK_CLKCTRL_GEN_GCLK7_Val      _U_(0x7)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 7 */
+#define GCLK_CLKCTRL_GEN_GCLK0      (GCLK_CLKCTRL_GEN_GCLK0_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN_GCLK1      (GCLK_CLKCTRL_GEN_GCLK1_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN_GCLK2      (GCLK_CLKCTRL_GEN_GCLK2_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN_GCLK3      (GCLK_CLKCTRL_GEN_GCLK3_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN_GCLK4      (GCLK_CLKCTRL_GEN_GCLK4_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN_GCLK5      (GCLK_CLKCTRL_GEN_GCLK5_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN_GCLK6      (GCLK_CLKCTRL_GEN_GCLK6_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN_GCLK7      (GCLK_CLKCTRL_GEN_GCLK7_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_CLKEN_Pos      14           /**< \brief (GCLK_CLKCTRL) Clock Enable */
+#define GCLK_CLKCTRL_CLKEN          (_U_(0x1) << GCLK_CLKCTRL_CLKEN_Pos)
+#define GCLK_CLKCTRL_WRTLOCK_Pos    15           /**< \brief (GCLK_CLKCTRL) Write Lock */
+#define GCLK_CLKCTRL_WRTLOCK        (_U_(0x1) << GCLK_CLKCTRL_WRTLOCK_Pos)
+#define GCLK_CLKCTRL_MASK           _U_(0xCF3F)  /**< \brief (GCLK_CLKCTRL) MASK Register */
+
+/* -------- GCLK_GENCTRL : (GCLK Offset: 0x4) (R/W 32) Generic Clock Generator Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ID:4;             /*!< bit:  0.. 3  Generic Clock Generator Selection  */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t SRC:5;            /*!< bit:  8..12  Source Select                      */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t GENEN:1;          /*!< bit:     16  Generic Clock Generator Enable     */
+    uint32_t IDC:1;            /*!< bit:     17  Improve Duty Cycle                 */
+    uint32_t OOV:1;            /*!< bit:     18  Output Off Value                   */
+    uint32_t OE:1;             /*!< bit:     19  Output Enable                      */
+    uint32_t DIVSEL:1;         /*!< bit:     20  Divide Selection                   */
+    uint32_t RUNSTDBY:1;       /*!< bit:     21  Run in Standby                     */
+    uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GCLK_GENCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_GENCTRL_OFFSET         0x4          /**< \brief (GCLK_GENCTRL offset) Generic Clock Generator Control */
+#define GCLK_GENCTRL_RESETVALUE     _U_(0x00000000) /**< \brief (GCLK_GENCTRL reset_value) Generic Clock Generator Control */
+
+#define GCLK_GENCTRL_ID_Pos         0            /**< \brief (GCLK_GENCTRL) Generic Clock Generator Selection */
+#define GCLK_GENCTRL_ID_Msk         (_U_(0xF) << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID(value)      (GCLK_GENCTRL_ID_Msk & ((value) << GCLK_GENCTRL_ID_Pos))
+#define   GCLK_GENCTRL_ID_GCLK0_Val       _U_(0x0)   /**< \brief (GCLK_GENCTRL) Generic clock generator 0 */
+#define   GCLK_GENCTRL_ID_GCLK1_Val       _U_(0x1)   /**< \brief (GCLK_GENCTRL) Generic clock generator 1 */
+#define   GCLK_GENCTRL_ID_GCLK2_Val       _U_(0x2)   /**< \brief (GCLK_GENCTRL) Generic clock generator 2 */
+#define   GCLK_GENCTRL_ID_GCLK3_Val       _U_(0x3)   /**< \brief (GCLK_GENCTRL) Generic clock generator 3 */
+#define   GCLK_GENCTRL_ID_GCLK4_Val       _U_(0x4)   /**< \brief (GCLK_GENCTRL) Generic clock generator 4 */
+#define   GCLK_GENCTRL_ID_GCLK5_Val       _U_(0x5)   /**< \brief (GCLK_GENCTRL) Generic clock generator 5 */
+#define   GCLK_GENCTRL_ID_GCLK6_Val       _U_(0x6)   /**< \brief (GCLK_GENCTRL) Generic clock generator 6 */
+#define   GCLK_GENCTRL_ID_GCLK7_Val       _U_(0x7)   /**< \brief (GCLK_GENCTRL) Generic clock generator 7 */
+#define GCLK_GENCTRL_ID_GCLK0       (GCLK_GENCTRL_ID_GCLK0_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID_GCLK1       (GCLK_GENCTRL_ID_GCLK1_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID_GCLK2       (GCLK_GENCTRL_ID_GCLK2_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID_GCLK3       (GCLK_GENCTRL_ID_GCLK3_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID_GCLK4       (GCLK_GENCTRL_ID_GCLK4_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID_GCLK5       (GCLK_GENCTRL_ID_GCLK5_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID_GCLK6       (GCLK_GENCTRL_ID_GCLK6_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID_GCLK7       (GCLK_GENCTRL_ID_GCLK7_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_SRC_Pos        8            /**< \brief (GCLK_GENCTRL) Source Select */
+#define GCLK_GENCTRL_SRC_Msk        (_U_(0x1F) << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC(value)     (GCLK_GENCTRL_SRC_Msk & ((value) << GCLK_GENCTRL_SRC_Pos))
+#define   GCLK_GENCTRL_SRC_XOSC_Val       _U_(0x0)   /**< \brief (GCLK_GENCTRL) XOSC oscillator output */
+#define   GCLK_GENCTRL_SRC_GCLKIN_Val     _U_(0x1)   /**< \brief (GCLK_GENCTRL) Generator input pad */
+#define   GCLK_GENCTRL_SRC_GCLKGEN1_Val   _U_(0x2)   /**< \brief (GCLK_GENCTRL) Generic clock generator 1 output */
+#define   GCLK_GENCTRL_SRC_OSCULP32K_Val  _U_(0x3)   /**< \brief (GCLK_GENCTRL) OSCULP32K oscillator output */
+#define   GCLK_GENCTRL_SRC_OSC32K_Val     _U_(0x4)   /**< \brief (GCLK_GENCTRL) OSC32K oscillator output */
+#define   GCLK_GENCTRL_SRC_XOSC32K_Val    _U_(0x5)   /**< \brief (GCLK_GENCTRL) XOSC32K oscillator output */
+#define   GCLK_GENCTRL_SRC_OSC8M_Val      _U_(0x6)   /**< \brief (GCLK_GENCTRL) OSC8M oscillator output */
+#define   GCLK_GENCTRL_SRC_DFLL48M_Val    _U_(0x7)   /**< \brief (GCLK_GENCTRL) DFLL48M output */
+#define GCLK_GENCTRL_SRC_XOSC       (GCLK_GENCTRL_SRC_XOSC_Val     << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_GCLKIN     (GCLK_GENCTRL_SRC_GCLKIN_Val   << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_GCLKGEN1   (GCLK_GENCTRL_SRC_GCLKGEN1_Val << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_OSCULP32K  (GCLK_GENCTRL_SRC_OSCULP32K_Val << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_OSC32K     (GCLK_GENCTRL_SRC_OSC32K_Val   << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_XOSC32K    (GCLK_GENCTRL_SRC_XOSC32K_Val  << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_OSC8M      (GCLK_GENCTRL_SRC_OSC8M_Val    << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_DFLL48M    (GCLK_GENCTRL_SRC_DFLL48M_Val  << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_GENEN_Pos      16           /**< \brief (GCLK_GENCTRL) Generic Clock Generator Enable */
+#define GCLK_GENCTRL_GENEN          (_U_(0x1) << GCLK_GENCTRL_GENEN_Pos)
+#define GCLK_GENCTRL_IDC_Pos        17           /**< \brief (GCLK_GENCTRL) Improve Duty Cycle */
+#define GCLK_GENCTRL_IDC            (_U_(0x1) << GCLK_GENCTRL_IDC_Pos)
+#define GCLK_GENCTRL_OOV_Pos        18           /**< \brief (GCLK_GENCTRL) Output Off Value */
+#define GCLK_GENCTRL_OOV            (_U_(0x1) << GCLK_GENCTRL_OOV_Pos)
+#define GCLK_GENCTRL_OE_Pos         19           /**< \brief (GCLK_GENCTRL) Output Enable */
+#define GCLK_GENCTRL_OE             (_U_(0x1) << GCLK_GENCTRL_OE_Pos)
+#define GCLK_GENCTRL_DIVSEL_Pos     20           /**< \brief (GCLK_GENCTRL) Divide Selection */
+#define GCLK_GENCTRL_DIVSEL         (_U_(0x1) << GCLK_GENCTRL_DIVSEL_Pos)
+#define GCLK_GENCTRL_RUNSTDBY_Pos   21           /**< \brief (GCLK_GENCTRL) Run in Standby */
+#define GCLK_GENCTRL_RUNSTDBY       (_U_(0x1) << GCLK_GENCTRL_RUNSTDBY_Pos)
+#define GCLK_GENCTRL_MASK           _U_(0x003F1F0F) /**< \brief (GCLK_GENCTRL) MASK Register */
+
+/* -------- GCLK_GENDIV : (GCLK Offset: 0x8) (R/W 32) Generic Clock Generator Division -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ID:4;             /*!< bit:  0.. 3  Generic Clock Generator Selection  */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t DIV:16;           /*!< bit:  8..23  Division Factor                    */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GCLK_GENDIV_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_GENDIV_OFFSET          0x8          /**< \brief (GCLK_GENDIV offset) Generic Clock Generator Division */
+#define GCLK_GENDIV_RESETVALUE      _U_(0x00000000) /**< \brief (GCLK_GENDIV reset_value) Generic Clock Generator Division */
+
+#define GCLK_GENDIV_ID_Pos          0            /**< \brief (GCLK_GENDIV) Generic Clock Generator Selection */
+#define GCLK_GENDIV_ID_Msk          (_U_(0xF) << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID(value)       (GCLK_GENDIV_ID_Msk & ((value) << GCLK_GENDIV_ID_Pos))
+#define   GCLK_GENDIV_ID_GCLK0_Val        _U_(0x0)   /**< \brief (GCLK_GENDIV) Generic clock generator 0 */
+#define   GCLK_GENDIV_ID_GCLK1_Val        _U_(0x1)   /**< \brief (GCLK_GENDIV) Generic clock generator 1 */
+#define   GCLK_GENDIV_ID_GCLK2_Val        _U_(0x2)   /**< \brief (GCLK_GENDIV) Generic clock generator 2 */
+#define   GCLK_GENDIV_ID_GCLK3_Val        _U_(0x3)   /**< \brief (GCLK_GENDIV) Generic clock generator 3 */
+#define   GCLK_GENDIV_ID_GCLK4_Val        _U_(0x4)   /**< \brief (GCLK_GENDIV) Generic clock generator 4 */
+#define   GCLK_GENDIV_ID_GCLK5_Val        _U_(0x5)   /**< \brief (GCLK_GENDIV) Generic clock generator 5 */
+#define   GCLK_GENDIV_ID_GCLK6_Val        _U_(0x6)   /**< \brief (GCLK_GENDIV) Generic clock generator 6 */
+#define   GCLK_GENDIV_ID_GCLK7_Val        _U_(0x7)   /**< \brief (GCLK_GENDIV) Generic clock generator 7 */
+#define GCLK_GENDIV_ID_GCLK0        (GCLK_GENDIV_ID_GCLK0_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID_GCLK1        (GCLK_GENDIV_ID_GCLK1_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID_GCLK2        (GCLK_GENDIV_ID_GCLK2_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID_GCLK3        (GCLK_GENDIV_ID_GCLK3_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID_GCLK4        (GCLK_GENDIV_ID_GCLK4_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID_GCLK5        (GCLK_GENDIV_ID_GCLK5_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID_GCLK6        (GCLK_GENDIV_ID_GCLK6_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID_GCLK7        (GCLK_GENDIV_ID_GCLK7_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_DIV_Pos         8            /**< \brief (GCLK_GENDIV) Division Factor */
+#define GCLK_GENDIV_DIV_Msk         (_U_(0xFFFF) << GCLK_GENDIV_DIV_Pos)
+#define GCLK_GENDIV_DIV(value)      (GCLK_GENDIV_DIV_Msk & ((value) << GCLK_GENDIV_DIV_Pos))
+#define GCLK_GENDIV_MASK            _U_(0x00FFFF0F) /**< \brief (GCLK_GENDIV) MASK Register */
+
+/** \brief GCLK hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO GCLK_CTRL_Type            CTRL;        /**< \brief Offset: 0x0 (R/W  8) Control */
+  __I  GCLK_STATUS_Type          STATUS;      /**< \brief Offset: 0x1 (R/   8) Status */
+  __IO GCLK_CLKCTRL_Type         CLKCTRL;     /**< \brief Offset: 0x2 (R/W 16) Generic Clock Control */
+  __IO GCLK_GENCTRL_Type         GENCTRL;     /**< \brief Offset: 0x4 (R/W 32) Generic Clock Generator Control */
+  __IO GCLK_GENDIV_Type          GENDIV;      /**< \brief Offset: 0x8 (R/W 32) Generic Clock Generator Division */
+} Gclk;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_GCLK_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/nvmctrl.h
@@ -1,0 +1,493 @@
+/**
+ * \file
+ *
+ * \brief Component description for NVMCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_NVMCTRL_COMPONENT_
+#define _SAMD20_NVMCTRL_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR NVMCTRL */
+/* ========================================================================== */
+/** \addtogroup SAMD20_NVMCTRL Non-Volatile Memory Controller */
+/*@{*/
+
+#define NVMCTRL_U2207
+#define REV_NVMCTRL                 0x106
+
+/* -------- NVMCTRL_CTRLA : (NVMCTRL Offset: 0x00) (R/W 16) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t CMD:7;            /*!< bit:  0.. 6  Command                            */
+    uint16_t :1;               /*!< bit:      7  Reserved                           */
+    uint16_t CMDEX:8;          /*!< bit:  8..15  Command Execution                  */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_CTRLA_OFFSET        0x00         /**< \brief (NVMCTRL_CTRLA offset) Control A */
+#define NVMCTRL_CTRLA_RESETVALUE    _U_(0x0000)  /**< \brief (NVMCTRL_CTRLA reset_value) Control A */
+
+#define NVMCTRL_CTRLA_CMD_Pos       0            /**< \brief (NVMCTRL_CTRLA) Command */
+#define NVMCTRL_CTRLA_CMD_Msk       (_U_(0x7F) << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD(value)    (NVMCTRL_CTRLA_CMD_Msk & ((value) << NVMCTRL_CTRLA_CMD_Pos))
+#define   NVMCTRL_CTRLA_CMD_ER_Val        _U_(0x2)   /**< \brief (NVMCTRL_CTRLA) Erase Row - Erases the row addressed by the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_WP_Val        _U_(0x4)   /**< \brief (NVMCTRL_CTRLA) Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_EAR_Val       _U_(0x5)   /**< \brief (NVMCTRL_CTRLA) Erase Auxiliary Row - Erases the auxiliary row addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row. */
+#define   NVMCTRL_CTRLA_CMD_WAP_Val       _U_(0x6)   /**< \brief (NVMCTRL_CTRLA) Write Auxiliary Page - Writes the contents of the page buffer to the page addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row. */
+#define   NVMCTRL_CTRLA_CMD_SF_Val        _U_(0xA)   /**< \brief (NVMCTRL_CTRLA) Security Flow Command */
+#define   NVMCTRL_CTRLA_CMD_WL_Val        _U_(0xF)   /**< \brief (NVMCTRL_CTRLA) Write lockbits */
+#define   NVMCTRL_CTRLA_CMD_LR_Val        _U_(0x40)   /**< \brief (NVMCTRL_CTRLA) Lock Region - Locks the region containing the address location in the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_UR_Val        _U_(0x41)   /**< \brief (NVMCTRL_CTRLA) Unlock Region - Unlocks the region containing the address location in the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_SPRM_Val      _U_(0x42)   /**< \brief (NVMCTRL_CTRLA) Sets the power reduction mode. */
+#define   NVMCTRL_CTRLA_CMD_CPRM_Val      _U_(0x43)   /**< \brief (NVMCTRL_CTRLA) Clears the power reduction mode. */
+#define   NVMCTRL_CTRLA_CMD_PBC_Val       _U_(0x44)   /**< \brief (NVMCTRL_CTRLA) Page Buffer Clear - Clears the page buffer. */
+#define   NVMCTRL_CTRLA_CMD_SSB_Val       _U_(0x45)   /**< \brief (NVMCTRL_CTRLA) Set Security Bit - Sets the security bit by writing 0x00 to the first byte in the lockbit row. */
+#define   NVMCTRL_CTRLA_CMD_INVALL_Val    _U_(0x46)   /**< \brief (NVMCTRL_CTRLA) Invalidate all cache lines. */
+#define NVMCTRL_CTRLA_CMD_ER        (NVMCTRL_CTRLA_CMD_ER_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_WP        (NVMCTRL_CTRLA_CMD_WP_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_EAR       (NVMCTRL_CTRLA_CMD_EAR_Val     << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_WAP       (NVMCTRL_CTRLA_CMD_WAP_Val     << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_SF        (NVMCTRL_CTRLA_CMD_SF_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_WL        (NVMCTRL_CTRLA_CMD_WL_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_LR        (NVMCTRL_CTRLA_CMD_LR_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_UR        (NVMCTRL_CTRLA_CMD_UR_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_SPRM      (NVMCTRL_CTRLA_CMD_SPRM_Val    << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_CPRM      (NVMCTRL_CTRLA_CMD_CPRM_Val    << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_PBC       (NVMCTRL_CTRLA_CMD_PBC_Val     << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_SSB       (NVMCTRL_CTRLA_CMD_SSB_Val     << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_INVALL    (NVMCTRL_CTRLA_CMD_INVALL_Val  << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMDEX_Pos     8            /**< \brief (NVMCTRL_CTRLA) Command Execution */
+#define NVMCTRL_CTRLA_CMDEX_Msk     (_U_(0xFF) << NVMCTRL_CTRLA_CMDEX_Pos)
+#define NVMCTRL_CTRLA_CMDEX(value)  (NVMCTRL_CTRLA_CMDEX_Msk & ((value) << NVMCTRL_CTRLA_CMDEX_Pos))
+#define   NVMCTRL_CTRLA_CMDEX_KEY_Val     _U_(0xA5)   /**< \brief (NVMCTRL_CTRLA) Execution Key */
+#define NVMCTRL_CTRLA_CMDEX_KEY     (NVMCTRL_CTRLA_CMDEX_KEY_Val   << NVMCTRL_CTRLA_CMDEX_Pos)
+#define NVMCTRL_CTRLA_MASK          _U_(0xFF7F)  /**< \brief (NVMCTRL_CTRLA) MASK Register */
+
+/* -------- NVMCTRL_CTRLB : (NVMCTRL Offset: 0x04) (R/W 32) Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t RWS:4;            /*!< bit:  1.. 4  NVM Read Wait States               */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t MANW:1;           /*!< bit:      7  Manual Write                       */
+    uint32_t SLEEPPRM:2;       /*!< bit:  8.. 9  Power Reduction Mode during Sleep  */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t READMODE:2;       /*!< bit: 16..17  NVMCTRL Read Mode                  */
+    uint32_t CACHEDIS:1;       /*!< bit:     18  Cache Disable                      */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_CTRLB_OFFSET        0x04         /**< \brief (NVMCTRL_CTRLB offset) Control B */
+#define NVMCTRL_CTRLB_RESETVALUE    _U_(0x00000000) /**< \brief (NVMCTRL_CTRLB reset_value) Control B */
+
+#define NVMCTRL_CTRLB_RWS_Pos       1            /**< \brief (NVMCTRL_CTRLB) NVM Read Wait States */
+#define NVMCTRL_CTRLB_RWS_Msk       (_U_(0xF) << NVMCTRL_CTRLB_RWS_Pos)
+#define NVMCTRL_CTRLB_RWS(value)    (NVMCTRL_CTRLB_RWS_Msk & ((value) << NVMCTRL_CTRLB_RWS_Pos))
+#define   NVMCTRL_CTRLB_RWS_SINGLE_Val    _U_(0x0)   /**< \brief (NVMCTRL_CTRLB) Single Auto Wait State */
+#define   NVMCTRL_CTRLB_RWS_HALF_Val      _U_(0x1)   /**< \brief (NVMCTRL_CTRLB) Half Auto Wait State */
+#define   NVMCTRL_CTRLB_RWS_DUAL_Val      _U_(0x2)   /**< \brief (NVMCTRL_CTRLB) Dual Auto Wait State */
+#define NVMCTRL_CTRLB_RWS_SINGLE    (NVMCTRL_CTRLB_RWS_SINGLE_Val  << NVMCTRL_CTRLB_RWS_Pos)
+#define NVMCTRL_CTRLB_RWS_HALF      (NVMCTRL_CTRLB_RWS_HALF_Val    << NVMCTRL_CTRLB_RWS_Pos)
+#define NVMCTRL_CTRLB_RWS_DUAL      (NVMCTRL_CTRLB_RWS_DUAL_Val    << NVMCTRL_CTRLB_RWS_Pos)
+#define NVMCTRL_CTRLB_MANW_Pos      7            /**< \brief (NVMCTRL_CTRLB) Manual Write */
+#define NVMCTRL_CTRLB_MANW          (_U_(0x1) << NVMCTRL_CTRLB_MANW_Pos)
+#define NVMCTRL_CTRLB_SLEEPPRM_Pos  8            /**< \brief (NVMCTRL_CTRLB) Power Reduction Mode during Sleep */
+#define NVMCTRL_CTRLB_SLEEPPRM_Msk  (_U_(0x3) << NVMCTRL_CTRLB_SLEEPPRM_Pos)
+#define NVMCTRL_CTRLB_SLEEPPRM(value) (NVMCTRL_CTRLB_SLEEPPRM_Msk & ((value) << NVMCTRL_CTRLB_SLEEPPRM_Pos))
+#define   NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS_Val _U_(0x0)   /**< \brief (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access. */
+#define   NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT_Val _U_(0x1)   /**< \brief (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep. */
+#define   NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val _U_(0x3)   /**< \brief (NVMCTRL_CTRLB) Auto power reduction disabled. */
+#define NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS (NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)
+#define NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT (NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)
+#define NVMCTRL_CTRLB_SLEEPPRM_DISABLED (NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)
+#define NVMCTRL_CTRLB_READMODE_Pos  16           /**< \brief (NVMCTRL_CTRLB) NVMCTRL Read Mode */
+#define NVMCTRL_CTRLB_READMODE_Msk  (_U_(0x3) << NVMCTRL_CTRLB_READMODE_Pos)
+#define NVMCTRL_CTRLB_READMODE(value) (NVMCTRL_CTRLB_READMODE_Msk & ((value) << NVMCTRL_CTRLB_READMODE_Pos))
+#define   NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY_Val _U_(0x0)   /**< \brief (NVMCTRL_CTRLB) The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance. */
+#define   NVMCTRL_CTRLB_READMODE_LOW_POWER_Val _U_(0x1)   /**< \brief (NVMCTRL_CTRLB) Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time. */
+#define   NVMCTRL_CTRLB_READMODE_DETERMINISTIC_Val _U_(0x2)   /**< \brief (NVMCTRL_CTRLB) The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings. */
+#define NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY (NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY_Val << NVMCTRL_CTRLB_READMODE_Pos)
+#define NVMCTRL_CTRLB_READMODE_LOW_POWER (NVMCTRL_CTRLB_READMODE_LOW_POWER_Val << NVMCTRL_CTRLB_READMODE_Pos)
+#define NVMCTRL_CTRLB_READMODE_DETERMINISTIC (NVMCTRL_CTRLB_READMODE_DETERMINISTIC_Val << NVMCTRL_CTRLB_READMODE_Pos)
+#define NVMCTRL_CTRLB_CACHEDIS_Pos  18           /**< \brief (NVMCTRL_CTRLB) Cache Disable */
+#define NVMCTRL_CTRLB_CACHEDIS      (_U_(0x1) << NVMCTRL_CTRLB_CACHEDIS_Pos)
+#define NVMCTRL_CTRLB_MASK          _U_(0x0007039E) /**< \brief (NVMCTRL_CTRLB) MASK Register */
+
+/* -------- NVMCTRL_PARAM : (NVMCTRL Offset: 0x08) (R/W 32) NVM Parameter -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NVMP:16;          /*!< bit:  0..15  NVM Pages                          */
+    uint32_t PSZ:3;            /*!< bit: 16..18  Page Size                          */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_PARAM_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_PARAM_OFFSET        0x08         /**< \brief (NVMCTRL_PARAM offset) NVM Parameter */
+#define NVMCTRL_PARAM_RESETVALUE    _U_(0x00000000) /**< \brief (NVMCTRL_PARAM reset_value) NVM Parameter */
+
+#define NVMCTRL_PARAM_NVMP_Pos      0            /**< \brief (NVMCTRL_PARAM) NVM Pages */
+#define NVMCTRL_PARAM_NVMP_Msk      (_U_(0xFFFF) << NVMCTRL_PARAM_NVMP_Pos)
+#define NVMCTRL_PARAM_NVMP(value)   (NVMCTRL_PARAM_NVMP_Msk & ((value) << NVMCTRL_PARAM_NVMP_Pos))
+#define NVMCTRL_PARAM_PSZ_Pos       16           /**< \brief (NVMCTRL_PARAM) Page Size */
+#define NVMCTRL_PARAM_PSZ_Msk       (_U_(0x7) << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ(value)    (NVMCTRL_PARAM_PSZ_Msk & ((value) << NVMCTRL_PARAM_PSZ_Pos))
+#define   NVMCTRL_PARAM_PSZ_8_Val         _U_(0x0)   /**< \brief (NVMCTRL_PARAM) 8 bytes */
+#define   NVMCTRL_PARAM_PSZ_16_Val        _U_(0x1)   /**< \brief (NVMCTRL_PARAM) 16 bytes */
+#define   NVMCTRL_PARAM_PSZ_32_Val        _U_(0x2)   /**< \brief (NVMCTRL_PARAM) 32 bytes */
+#define   NVMCTRL_PARAM_PSZ_64_Val        _U_(0x3)   /**< \brief (NVMCTRL_PARAM) 64 bytes */
+#define   NVMCTRL_PARAM_PSZ_128_Val       _U_(0x4)   /**< \brief (NVMCTRL_PARAM) 128 bytes */
+#define   NVMCTRL_PARAM_PSZ_256_Val       _U_(0x5)   /**< \brief (NVMCTRL_PARAM) 256 bytes */
+#define   NVMCTRL_PARAM_PSZ_512_Val       _U_(0x6)   /**< \brief (NVMCTRL_PARAM) 512 bytes */
+#define   NVMCTRL_PARAM_PSZ_1024_Val      _U_(0x7)   /**< \brief (NVMCTRL_PARAM) 1024 bytes */
+#define NVMCTRL_PARAM_PSZ_8         (NVMCTRL_PARAM_PSZ_8_Val       << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_16        (NVMCTRL_PARAM_PSZ_16_Val      << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_32        (NVMCTRL_PARAM_PSZ_32_Val      << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_64        (NVMCTRL_PARAM_PSZ_64_Val      << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_128       (NVMCTRL_PARAM_PSZ_128_Val     << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_256       (NVMCTRL_PARAM_PSZ_256_Val     << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_512       (NVMCTRL_PARAM_PSZ_512_Val     << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_1024      (NVMCTRL_PARAM_PSZ_1024_Val    << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_MASK          _U_(0x0007FFFF) /**< \brief (NVMCTRL_PARAM) MASK Register */
+
+/* -------- NVMCTRL_INTENCLR : (NVMCTRL Offset: 0x0C) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  READY:1;          /*!< bit:      0  NVM Ready Interrupt Enable         */
+    uint8_t  ERROR:1;          /*!< bit:      1  Error Interrupt Enable             */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} NVMCTRL_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_INTENCLR_OFFSET     0x0C         /**< \brief (NVMCTRL_INTENCLR offset) Interrupt Enable Clear */
+#define NVMCTRL_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (NVMCTRL_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define NVMCTRL_INTENCLR_READY_Pos  0            /**< \brief (NVMCTRL_INTENCLR) NVM Ready Interrupt Enable */
+#define NVMCTRL_INTENCLR_READY      (_U_(0x1) << NVMCTRL_INTENCLR_READY_Pos)
+#define NVMCTRL_INTENCLR_ERROR_Pos  1            /**< \brief (NVMCTRL_INTENCLR) Error Interrupt Enable */
+#define NVMCTRL_INTENCLR_ERROR      (_U_(0x1) << NVMCTRL_INTENCLR_ERROR_Pos)
+#define NVMCTRL_INTENCLR_MASK       _U_(0x03)    /**< \brief (NVMCTRL_INTENCLR) MASK Register */
+
+/* -------- NVMCTRL_INTENSET : (NVMCTRL Offset: 0x10) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  READY:1;          /*!< bit:      0  NVM Ready Interrupt Enable         */
+    uint8_t  ERROR:1;          /*!< bit:      1  Error Interrupt Enable             */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} NVMCTRL_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_INTENSET_OFFSET     0x10         /**< \brief (NVMCTRL_INTENSET offset) Interrupt Enable Set */
+#define NVMCTRL_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (NVMCTRL_INTENSET reset_value) Interrupt Enable Set */
+
+#define NVMCTRL_INTENSET_READY_Pos  0            /**< \brief (NVMCTRL_INTENSET) NVM Ready Interrupt Enable */
+#define NVMCTRL_INTENSET_READY      (_U_(0x1) << NVMCTRL_INTENSET_READY_Pos)
+#define NVMCTRL_INTENSET_ERROR_Pos  1            /**< \brief (NVMCTRL_INTENSET) Error Interrupt Enable */
+#define NVMCTRL_INTENSET_ERROR      (_U_(0x1) << NVMCTRL_INTENSET_ERROR_Pos)
+#define NVMCTRL_INTENSET_MASK       _U_(0x03)    /**< \brief (NVMCTRL_INTENSET) MASK Register */
+
+/* -------- NVMCTRL_INTFLAG : (NVMCTRL Offset: 0x14) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
+    __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
+    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} NVMCTRL_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_INTFLAG_OFFSET      0x14         /**< \brief (NVMCTRL_INTFLAG offset) Interrupt Flag Status and Clear */
+#define NVMCTRL_INTFLAG_RESETVALUE  _U_(0x00)    /**< \brief (NVMCTRL_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define NVMCTRL_INTFLAG_READY_Pos   0            /**< \brief (NVMCTRL_INTFLAG) NVM Ready */
+#define NVMCTRL_INTFLAG_READY       (_U_(0x1) << NVMCTRL_INTFLAG_READY_Pos)
+#define NVMCTRL_INTFLAG_ERROR_Pos   1            /**< \brief (NVMCTRL_INTFLAG) Error */
+#define NVMCTRL_INTFLAG_ERROR       (_U_(0x1) << NVMCTRL_INTFLAG_ERROR_Pos)
+#define NVMCTRL_INTFLAG_MASK        _U_(0x03)    /**< \brief (NVMCTRL_INTFLAG) MASK Register */
+
+/* -------- NVMCTRL_STATUS : (NVMCTRL Offset: 0x18) (R/W 16) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PRM:1;            /*!< bit:      0  Power Reduction Mode               */
+    uint16_t LOAD:1;           /*!< bit:      1  NVM Page Buffer Active Loading     */
+    uint16_t PROGE:1;          /*!< bit:      2  Programming Error Status           */
+    uint16_t LOCKE:1;          /*!< bit:      3  Lock Error Status                  */
+    uint16_t NVME:1;           /*!< bit:      4  NVM Error                          */
+    uint16_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint16_t SB:1;             /*!< bit:      8  Security Bit Status                */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_STATUS_OFFSET       0x18         /**< \brief (NVMCTRL_STATUS offset) Status */
+#define NVMCTRL_STATUS_RESETVALUE   _U_(0x0000)  /**< \brief (NVMCTRL_STATUS reset_value) Status */
+
+#define NVMCTRL_STATUS_PRM_Pos      0            /**< \brief (NVMCTRL_STATUS) Power Reduction Mode */
+#define NVMCTRL_STATUS_PRM          (_U_(0x1) << NVMCTRL_STATUS_PRM_Pos)
+#define NVMCTRL_STATUS_LOAD_Pos     1            /**< \brief (NVMCTRL_STATUS) NVM Page Buffer Active Loading */
+#define NVMCTRL_STATUS_LOAD         (_U_(0x1) << NVMCTRL_STATUS_LOAD_Pos)
+#define NVMCTRL_STATUS_PROGE_Pos    2            /**< \brief (NVMCTRL_STATUS) Programming Error Status */
+#define NVMCTRL_STATUS_PROGE        (_U_(0x1) << NVMCTRL_STATUS_PROGE_Pos)
+#define NVMCTRL_STATUS_LOCKE_Pos    3            /**< \brief (NVMCTRL_STATUS) Lock Error Status */
+#define NVMCTRL_STATUS_LOCKE        (_U_(0x1) << NVMCTRL_STATUS_LOCKE_Pos)
+#define NVMCTRL_STATUS_NVME_Pos     4            /**< \brief (NVMCTRL_STATUS) NVM Error */
+#define NVMCTRL_STATUS_NVME         (_U_(0x1) << NVMCTRL_STATUS_NVME_Pos)
+#define NVMCTRL_STATUS_SB_Pos       8            /**< \brief (NVMCTRL_STATUS) Security Bit Status */
+#define NVMCTRL_STATUS_SB           (_U_(0x1) << NVMCTRL_STATUS_SB_Pos)
+#define NVMCTRL_STATUS_MASK         _U_(0x011F)  /**< \brief (NVMCTRL_STATUS) MASK Register */
+
+/* -------- NVMCTRL_ADDR : (NVMCTRL Offset: 0x1C) (R/W 32) Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ADDR:22;          /*!< bit:  0..21  NVM Address                        */
+    uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_ADDR_OFFSET         0x1C         /**< \brief (NVMCTRL_ADDR offset) Address */
+#define NVMCTRL_ADDR_RESETVALUE     _U_(0x00000000) /**< \brief (NVMCTRL_ADDR reset_value) Address */
+
+#define NVMCTRL_ADDR_ADDR_Pos       0            /**< \brief (NVMCTRL_ADDR) NVM Address */
+#define NVMCTRL_ADDR_ADDR_Msk       (_U_(0x3FFFFF) << NVMCTRL_ADDR_ADDR_Pos)
+#define NVMCTRL_ADDR_ADDR(value)    (NVMCTRL_ADDR_ADDR_Msk & ((value) << NVMCTRL_ADDR_ADDR_Pos))
+#define NVMCTRL_ADDR_MASK           _U_(0x003FFFFF) /**< \brief (NVMCTRL_ADDR) MASK Register */
+
+/* -------- NVMCTRL_LOCK : (NVMCTRL Offset: 0x20) (R/W 16) Lock Section -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t LOCK:16;          /*!< bit:  0..15  Region Lock Bits                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_LOCK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_LOCK_OFFSET         0x20         /**< \brief (NVMCTRL_LOCK offset) Lock Section */
+#define NVMCTRL_LOCK_RESETVALUE     _U_(0x0000)  /**< \brief (NVMCTRL_LOCK reset_value) Lock Section */
+
+#define NVMCTRL_LOCK_LOCK_Pos       0            /**< \brief (NVMCTRL_LOCK) Region Lock Bits */
+#define NVMCTRL_LOCK_LOCK_Msk       (_U_(0xFFFF) << NVMCTRL_LOCK_LOCK_Pos)
+#define NVMCTRL_LOCK_LOCK(value)    (NVMCTRL_LOCK_LOCK_Msk & ((value) << NVMCTRL_LOCK_LOCK_Pos))
+#define NVMCTRL_LOCK_MASK           _U_(0xFFFF)  /**< \brief (NVMCTRL_LOCK) MASK Register */
+
+/** \brief NVMCTRL APB hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO NVMCTRL_CTRLA_Type        CTRLA;       /**< \brief Offset: 0x00 (R/W 16) Control A */
+       RoReg8                    Reserved1[0x2];
+  __IO NVMCTRL_CTRLB_Type        CTRLB;       /**< \brief Offset: 0x04 (R/W 32) Control B */
+  __IO NVMCTRL_PARAM_Type        PARAM;       /**< \brief Offset: 0x08 (R/W 32) NVM Parameter */
+  __IO NVMCTRL_INTENCLR_Type     INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) Interrupt Enable Clear */
+       RoReg8                    Reserved2[0x3];
+  __IO NVMCTRL_INTENSET_Type     INTENSET;    /**< \brief Offset: 0x10 (R/W  8) Interrupt Enable Set */
+       RoReg8                    Reserved3[0x3];
+  __IO NVMCTRL_INTFLAG_Type      INTFLAG;     /**< \brief Offset: 0x14 (R/W  8) Interrupt Flag Status and Clear */
+       RoReg8                    Reserved4[0x3];
+  __IO NVMCTRL_STATUS_Type       STATUS;      /**< \brief Offset: 0x18 (R/W 16) Status */
+       RoReg8                    Reserved5[0x2];
+  __IO NVMCTRL_ADDR_Type         ADDR;        /**< \brief Offset: 0x1C (R/W 32) Address */
+  __IO NVMCTRL_LOCK_Type         LOCK;        /**< \brief Offset: 0x20 (R/W 16) Lock Section */
+} Nvmctrl;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SECTION_NVMCTRL_CAL
+#define SECTION_NVMCTRL_LOCKBIT
+#define SECTION_NVMCTRL_OTP1
+#define SECTION_NVMCTRL_OTP2
+#define SECTION_NVMCTRL_OTP4
+#define SECTION_NVMCTRL_TEMP_LOG
+#define SECTION_NVMCTRL_USER
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR NON-VOLATILE FUSES */
+/* ************************************************************************** */
+/** \addtogroup fuses_api Peripheral Software API */
+/*@{*/
+
+
+#define ADC_FUSES_BIASCAL_ADDR      (NVMCTRL_OTP4 + 4)
+#define ADC_FUSES_BIASCAL_Pos       3            /**< \brief (NVMCTRL_OTP4) ADC Bias Calibration */
+#define ADC_FUSES_BIASCAL_Msk       (_U_(0x7) << ADC_FUSES_BIASCAL_Pos)
+#define ADC_FUSES_BIASCAL(value)    (ADC_FUSES_BIASCAL_Msk & ((value) << ADC_FUSES_BIASCAL_Pos))
+
+#define ADC_FUSES_LINEARITY_0_ADDR  NVMCTRL_OTP4
+#define ADC_FUSES_LINEARITY_0_Pos   27           /**< \brief (NVMCTRL_OTP4) ADC Linearity bits 4:0 */
+#define ADC_FUSES_LINEARITY_0_Msk   (_U_(0x1F) << ADC_FUSES_LINEARITY_0_Pos)
+#define ADC_FUSES_LINEARITY_0(value) (ADC_FUSES_LINEARITY_0_Msk & ((value) << ADC_FUSES_LINEARITY_0_Pos))
+
+#define ADC_FUSES_LINEARITY_1_ADDR  (NVMCTRL_OTP4 + 4)
+#define ADC_FUSES_LINEARITY_1_Pos   0            /**< \brief (NVMCTRL_OTP4) ADC Linearity bits 7:5 */
+#define ADC_FUSES_LINEARITY_1_Msk   (_U_(0x7) << ADC_FUSES_LINEARITY_1_Pos)
+#define ADC_FUSES_LINEARITY_1(value) (ADC_FUSES_LINEARITY_1_Msk & ((value) << ADC_FUSES_LINEARITY_1_Pos))
+
+#define FUSES_BOD33USERLEVEL_ADDR   NVMCTRL_USER
+#define FUSES_BOD33USERLEVEL_Pos    8            /**< \brief (NVMCTRL_USER) BOD33 User Level */
+#define FUSES_BOD33USERLEVEL_Msk    (_U_(0x3F) << FUSES_BOD33USERLEVEL_Pos)
+#define FUSES_BOD33USERLEVEL(value) (FUSES_BOD33USERLEVEL_Msk & ((value) << FUSES_BOD33USERLEVEL_Pos))
+
+#define FUSES_BOD33_ACTION_ADDR     NVMCTRL_USER
+#define FUSES_BOD33_ACTION_Pos      15           /**< \brief (NVMCTRL_USER) BOD33 Action */
+#define FUSES_BOD33_ACTION_Msk      (_U_(0x3) << FUSES_BOD33_ACTION_Pos)
+#define FUSES_BOD33_ACTION(value)   (FUSES_BOD33_ACTION_Msk & ((value) << FUSES_BOD33_ACTION_Pos))
+
+#define FUSES_BOD33_EN_ADDR         NVMCTRL_USER
+#define FUSES_BOD33_EN_Pos          14           /**< \brief (NVMCTRL_USER) BOD33 Enable */
+#define FUSES_BOD33_EN_Msk          (_U_(0x1) << FUSES_BOD33_EN_Pos)
+
+#define FUSES_BOD33_HYST_ADDR       (NVMCTRL_USER + 4)
+#define FUSES_BOD33_HYST_Pos        8            /**< \brief (NVMCTRL_USER) BOD33 Hysteresis */
+#define FUSES_BOD33_HYST_Msk        (_U_(0x1) << FUSES_BOD33_HYST_Pos)
+
+#define FUSES_DFLL48M_COARSE_CAL_ADDR (NVMCTRL_OTP4 + 4)
+#define FUSES_DFLL48M_COARSE_CAL_Pos 26           /**< \brief (NVMCTRL_OTP4) DFLL48M Coarse Calibration */
+#define FUSES_DFLL48M_COARSE_CAL_Msk (_U_(0x3F) << FUSES_DFLL48M_COARSE_CAL_Pos)
+#define FUSES_DFLL48M_COARSE_CAL(value) (FUSES_DFLL48M_COARSE_CAL_Msk & ((value) << FUSES_DFLL48M_COARSE_CAL_Pos))
+
+#define FUSES_DFLL48M_FINE_CAL_ADDR (NVMCTRL_OTP4 + 8)
+#define FUSES_DFLL48M_FINE_CAL_Pos  0            /**< \brief (NVMCTRL_OTP4) DFLL48M Fine Calibration */
+#define FUSES_DFLL48M_FINE_CAL_Msk  (_U_(0x3FF) << FUSES_DFLL48M_FINE_CAL_Pos)
+#define FUSES_DFLL48M_FINE_CAL(value) (FUSES_DFLL48M_FINE_CAL_Msk & ((value) << FUSES_DFLL48M_FINE_CAL_Pos))
+
+#define FUSES_OSC32KCAL_ADDR        (NVMCTRL_OTP4 + 4)
+#define FUSES_OSC32KCAL_Pos         6            /**< \brief (NVMCTRL_OTP4) OSC32K Calibration */
+#define FUSES_OSC32KCAL_Msk         (_U_(0x7F) << FUSES_OSC32KCAL_Pos)
+#define FUSES_OSC32KCAL(value)      (FUSES_OSC32KCAL_Msk & ((value) << FUSES_OSC32KCAL_Pos))
+
+#define NVMCTRL_FUSES_BOOTPROT_ADDR NVMCTRL_USER
+#define NVMCTRL_FUSES_BOOTPROT_Pos  0            /**< \brief (NVMCTRL_USER) Bootloader Size */
+#define NVMCTRL_FUSES_BOOTPROT_Msk  (_U_(0x7) << NVMCTRL_FUSES_BOOTPROT_Pos)
+#define NVMCTRL_FUSES_BOOTPROT(value) (NVMCTRL_FUSES_BOOTPROT_Msk & ((value) << NVMCTRL_FUSES_BOOTPROT_Pos))
+
+#define NVMCTRL_FUSES_EEPROM_SIZE_ADDR NVMCTRL_USER
+#define NVMCTRL_FUSES_EEPROM_SIZE_Pos 4            /**< \brief (NVMCTRL_USER) EEPROM Size */
+#define NVMCTRL_FUSES_EEPROM_SIZE_Msk (_U_(0x7) << NVMCTRL_FUSES_EEPROM_SIZE_Pos)
+#define NVMCTRL_FUSES_EEPROM_SIZE(value) (NVMCTRL_FUSES_EEPROM_SIZE_Msk & ((value) << NVMCTRL_FUSES_EEPROM_SIZE_Pos))
+
+#define NVMCTRL_FUSES_HOT_ADC_VAL_ADDR (NVMCTRL_TEMP_LOG + 4)
+#define NVMCTRL_FUSES_HOT_ADC_VAL_Pos 20           /**< \brief (NVMCTRL_TEMP_LOG) 12-bit ADC conversion at hot temperature */
+#define NVMCTRL_FUSES_HOT_ADC_VAL_Msk (_U_(0xFFF) << NVMCTRL_FUSES_HOT_ADC_VAL_Pos)
+#define NVMCTRL_FUSES_HOT_ADC_VAL(value) (NVMCTRL_FUSES_HOT_ADC_VAL_Msk & ((value) << NVMCTRL_FUSES_HOT_ADC_VAL_Pos))
+
+#define NVMCTRL_FUSES_HOT_INT1V_VAL_ADDR (NVMCTRL_TEMP_LOG + 4)
+#define NVMCTRL_FUSES_HOT_INT1V_VAL_Pos 0            /**< \brief (NVMCTRL_TEMP_LOG) 2's complement of the internal 1V reference drift at hot temperature (versus a 1.0 centered value) */
+#define NVMCTRL_FUSES_HOT_INT1V_VAL_Msk (_U_(0xFF) << NVMCTRL_FUSES_HOT_INT1V_VAL_Pos)
+#define NVMCTRL_FUSES_HOT_INT1V_VAL(value) (NVMCTRL_FUSES_HOT_INT1V_VAL_Msk & ((value) << NVMCTRL_FUSES_HOT_INT1V_VAL_Pos))
+
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_DEC_ADDR NVMCTRL_TEMP_LOG
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_DEC_Pos 20           /**< \brief (NVMCTRL_TEMP_LOG) Decimal part of hot temperature */
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_DEC_Msk (_U_(0xF) << NVMCTRL_FUSES_HOT_TEMP_VAL_DEC_Pos)
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_DEC(value) (NVMCTRL_FUSES_HOT_TEMP_VAL_DEC_Msk & ((value) << NVMCTRL_FUSES_HOT_TEMP_VAL_DEC_Pos))
+
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_INT_ADDR NVMCTRL_TEMP_LOG
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_INT_Pos 12           /**< \brief (NVMCTRL_TEMP_LOG) Integer part of hot temperature in oC */
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_INT_Msk (_U_(0xFF) << NVMCTRL_FUSES_HOT_TEMP_VAL_INT_Pos)
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_INT(value) (NVMCTRL_FUSES_HOT_TEMP_VAL_INT_Msk & ((value) << NVMCTRL_FUSES_HOT_TEMP_VAL_INT_Pos))
+
+#define NVMCTRL_FUSES_REGION_LOCKS_ADDR (NVMCTRL_USER + 4)
+#define NVMCTRL_FUSES_REGION_LOCKS_Pos 16           /**< \brief (NVMCTRL_USER) NVM Region Locks */
+#define NVMCTRL_FUSES_REGION_LOCKS_Msk (_U_(0xFFFF) << NVMCTRL_FUSES_REGION_LOCKS_Pos)
+#define NVMCTRL_FUSES_REGION_LOCKS(value) (NVMCTRL_FUSES_REGION_LOCKS_Msk & ((value) << NVMCTRL_FUSES_REGION_LOCKS_Pos))
+
+#define NVMCTRL_FUSES_ROOM_ADC_VAL_ADDR (NVMCTRL_TEMP_LOG + 4)
+#define NVMCTRL_FUSES_ROOM_ADC_VAL_Pos 8            /**< \brief (NVMCTRL_TEMP_LOG) 12-bit ADC conversion at room temperature */
+#define NVMCTRL_FUSES_ROOM_ADC_VAL_Msk (_U_(0xFFF) << NVMCTRL_FUSES_ROOM_ADC_VAL_Pos)
+#define NVMCTRL_FUSES_ROOM_ADC_VAL(value) (NVMCTRL_FUSES_ROOM_ADC_VAL_Msk & ((value) << NVMCTRL_FUSES_ROOM_ADC_VAL_Pos))
+
+#define NVMCTRL_FUSES_ROOM_INT1V_VAL_ADDR NVMCTRL_TEMP_LOG
+#define NVMCTRL_FUSES_ROOM_INT1V_VAL_Pos 24           /**< \brief (NVMCTRL_TEMP_LOG) 2's complement of the internal 1V reference drift at room temperature (versus a 1.0 centered value) */
+#define NVMCTRL_FUSES_ROOM_INT1V_VAL_Msk (_U_(0xFF) << NVMCTRL_FUSES_ROOM_INT1V_VAL_Pos)
+#define NVMCTRL_FUSES_ROOM_INT1V_VAL(value) (NVMCTRL_FUSES_ROOM_INT1V_VAL_Msk & ((value) << NVMCTRL_FUSES_ROOM_INT1V_VAL_Pos))
+
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_DEC_ADDR NVMCTRL_TEMP_LOG
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_DEC_Pos 8            /**< \brief (NVMCTRL_TEMP_LOG) Decimal part of room temperature */
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_DEC_Msk (_U_(0xF) << NVMCTRL_FUSES_ROOM_TEMP_VAL_DEC_Pos)
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_DEC(value) (NVMCTRL_FUSES_ROOM_TEMP_VAL_DEC_Msk & ((value) << NVMCTRL_FUSES_ROOM_TEMP_VAL_DEC_Pos))
+
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_INT_ADDR NVMCTRL_TEMP_LOG
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_INT_Pos 0            /**< \brief (NVMCTRL_TEMP_LOG) Integer part of room temperature in oC */
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_INT_Msk (_U_(0xFF) << NVMCTRL_FUSES_ROOM_TEMP_VAL_INT_Pos)
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_INT(value) (NVMCTRL_FUSES_ROOM_TEMP_VAL_INT_Msk & ((value) << NVMCTRL_FUSES_ROOM_TEMP_VAL_INT_Pos))
+
+#define WDT_FUSES_ALWAYSON_ADDR     NVMCTRL_USER
+#define WDT_FUSES_ALWAYSON_Pos      26           /**< \brief (NVMCTRL_USER) WDT Always On */
+#define WDT_FUSES_ALWAYSON_Msk      (_U_(0x1) << WDT_FUSES_ALWAYSON_Pos)
+
+#define WDT_FUSES_ENABLE_ADDR       NVMCTRL_USER
+#define WDT_FUSES_ENABLE_Pos        25           /**< \brief (NVMCTRL_USER) WDT Enable */
+#define WDT_FUSES_ENABLE_Msk        (_U_(0x1) << WDT_FUSES_ENABLE_Pos)
+
+#define WDT_FUSES_EWOFFSET_ADDR     (NVMCTRL_USER + 4)
+#define WDT_FUSES_EWOFFSET_Pos      3            /**< \brief (NVMCTRL_USER) WDT Early Warning Offset */
+#define WDT_FUSES_EWOFFSET_Msk      (_U_(0xF) << WDT_FUSES_EWOFFSET_Pos)
+#define WDT_FUSES_EWOFFSET(value)   (WDT_FUSES_EWOFFSET_Msk & ((value) << WDT_FUSES_EWOFFSET_Pos))
+
+#define WDT_FUSES_PER_ADDR          NVMCTRL_USER
+#define WDT_FUSES_PER_Pos           27           /**< \brief (NVMCTRL_USER) WDT Period */
+#define WDT_FUSES_PER_Msk           (_U_(0xF) << WDT_FUSES_PER_Pos)
+#define WDT_FUSES_PER(value)        (WDT_FUSES_PER_Msk & ((value) << WDT_FUSES_PER_Pos))
+
+#define WDT_FUSES_WEN_ADDR          (NVMCTRL_USER + 4)
+#define WDT_FUSES_WEN_Pos           7            /**< \brief (NVMCTRL_USER) WDT Window Mode Enable */
+#define WDT_FUSES_WEN_Msk           (_U_(0x1) << WDT_FUSES_WEN_Pos)
+
+#define WDT_FUSES_WINDOW_0_ADDR     NVMCTRL_USER
+#define WDT_FUSES_WINDOW_0_Pos      31           /**< \brief (NVMCTRL_USER) WDT Window bit 0 */
+#define WDT_FUSES_WINDOW_0_Msk      (_U_(0x1) << WDT_FUSES_WINDOW_0_Pos)
+
+#define WDT_FUSES_WINDOW_1_ADDR     (NVMCTRL_USER + 4)
+#define WDT_FUSES_WINDOW_1_Pos      0            /**< \brief (NVMCTRL_USER) WDT Window bits 3:1 */
+#define WDT_FUSES_WINDOW_1_Msk      (_U_(0x7) << WDT_FUSES_WINDOW_1_Pos)
+#define WDT_FUSES_WINDOW_1(value)   (WDT_FUSES_WINDOW_1_Msk & ((value) << WDT_FUSES_WINDOW_1_Pos))
+
+/*@}*/
+
+#endif /* _SAMD20_NVMCTRL_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/component/pac.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/pac.h
@@ -1,0 +1,90 @@
+/**
+ * \file
+ *
+ * \brief Component description for PAC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PAC_COMPONENT_
+#define _SAMD20_PAC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PAC */
+/* ========================================================================== */
+/** \addtogroup SAMD20_PAC Peripheral Access Controller */
+/*@{*/
+
+#define PAC_U2211
+#define REV_PAC                     0x101
+
+/* -------- PAC_WPCLR : (PAC Offset: 0x0) (R/W 32) Write Protection Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t WP:31;            /*!< bit:  1..31  Write Protection Clear             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_WPCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_WPCLR_OFFSET            0x0          /**< \brief (PAC_WPCLR offset) Write Protection Clear */
+#define PAC_WPCLR_RESETVALUE        _U_(0x00000000) /**< \brief (PAC_WPCLR reset_value) Write Protection Clear */
+
+#define PAC_WPCLR_WP_Pos            1            /**< \brief (PAC_WPCLR) Write Protection Clear */
+#define PAC_WPCLR_WP_Msk            (_U_(0x7FFFFFFF) << PAC_WPCLR_WP_Pos)
+#define PAC_WPCLR_WP(value)         (PAC_WPCLR_WP_Msk & ((value) << PAC_WPCLR_WP_Pos))
+#define PAC_WPCLR_MASK              _U_(0xFFFFFFFE) /**< \brief (PAC_WPCLR) MASK Register */
+
+/* -------- PAC_WPSET : (PAC Offset: 0x4) (R/W 32) Write Protection Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t WP:31;            /*!< bit:  1..31  Write Protection Set               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_WPSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_WPSET_OFFSET            0x4          /**< \brief (PAC_WPSET offset) Write Protection Set */
+#define PAC_WPSET_RESETVALUE        _U_(0x00000000) /**< \brief (PAC_WPSET reset_value) Write Protection Set */
+
+#define PAC_WPSET_WP_Pos            1            /**< \brief (PAC_WPSET) Write Protection Set */
+#define PAC_WPSET_WP_Msk            (_U_(0x7FFFFFFF) << PAC_WPSET_WP_Pos)
+#define PAC_WPSET_WP(value)         (PAC_WPSET_WP_Msk & ((value) << PAC_WPSET_WP_Pos))
+#define PAC_WPSET_MASK              _U_(0xFFFFFFFE) /**< \brief (PAC_WPSET) MASK Register */
+
+/** \brief PAC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO PAC_WPCLR_Type            WPCLR;       /**< \brief Offset: 0x0 (R/W 32) Write Protection Clear */
+  __IO PAC_WPSET_Type            WPSET;       /**< \brief Offset: 0x4 (R/W 32) Write Protection Set */
+} Pac;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_PAC_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/component/pm.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/pm.h
@@ -1,0 +1,501 @@
+/**
+ * \file
+ *
+ * \brief Component description for PM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PM_COMPONENT_
+#define _SAMD20_PM_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PM */
+/* ========================================================================== */
+/** \addtogroup SAMD20_PM Power Manager */
+/*@{*/
+
+#define PM_U2206
+#define REV_PM                      0x202
+
+/* -------- PM_CTRL : (PM Offset: 0x00) (R/W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_CTRL_OFFSET              0x00         /**< \brief (PM_CTRL offset) Control */
+#define PM_CTRL_RESETVALUE          _U_(0x00)    /**< \brief (PM_CTRL reset_value) Control */
+
+#define PM_CTRL_MASK                _U_(0x00)    /**< \brief (PM_CTRL) MASK Register */
+
+/* -------- PM_SLEEP : (PM Offset: 0x01) (R/W  8) Sleep Mode -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  IDLE:2;           /*!< bit:  0.. 1  Idle Mode Configuration            */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_SLEEP_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_SLEEP_OFFSET             0x01         /**< \brief (PM_SLEEP offset) Sleep Mode */
+#define PM_SLEEP_RESETVALUE         _U_(0x00)    /**< \brief (PM_SLEEP reset_value) Sleep Mode */
+
+#define PM_SLEEP_IDLE_Pos           0            /**< \brief (PM_SLEEP) Idle Mode Configuration */
+#define PM_SLEEP_IDLE_Msk           (_U_(0x3) << PM_SLEEP_IDLE_Pos)
+#define PM_SLEEP_IDLE(value)        (PM_SLEEP_IDLE_Msk & ((value) << PM_SLEEP_IDLE_Pos))
+#define   PM_SLEEP_IDLE_CPU_Val           _U_(0x0)   /**< \brief (PM_SLEEP) The CPU clock domain is stopped */
+#define   PM_SLEEP_IDLE_AHB_Val           _U_(0x1)   /**< \brief (PM_SLEEP) The CPU and AHB clock domains are stopped */
+#define   PM_SLEEP_IDLE_APB_Val           _U_(0x2)   /**< \brief (PM_SLEEP) The CPU, AHB and APB clock domains are stopped */
+#define PM_SLEEP_IDLE_CPU           (PM_SLEEP_IDLE_CPU_Val         << PM_SLEEP_IDLE_Pos)
+#define PM_SLEEP_IDLE_AHB           (PM_SLEEP_IDLE_AHB_Val         << PM_SLEEP_IDLE_Pos)
+#define PM_SLEEP_IDLE_APB           (PM_SLEEP_IDLE_APB_Val         << PM_SLEEP_IDLE_Pos)
+#define PM_SLEEP_MASK               _U_(0x03)    /**< \brief (PM_SLEEP) MASK Register */
+
+/* -------- PM_CPUSEL : (PM Offset: 0x08) (R/W  8) CPU Clock Select -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CPUDIV:3;         /*!< bit:  0.. 2  CPU Prescaler Selection            */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_CPUSEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_CPUSEL_OFFSET            0x08         /**< \brief (PM_CPUSEL offset) CPU Clock Select */
+#define PM_CPUSEL_RESETVALUE        _U_(0x00)    /**< \brief (PM_CPUSEL reset_value) CPU Clock Select */
+
+#define PM_CPUSEL_CPUDIV_Pos        0            /**< \brief (PM_CPUSEL) CPU Prescaler Selection */
+#define PM_CPUSEL_CPUDIV_Msk        (_U_(0x7) << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV(value)     (PM_CPUSEL_CPUDIV_Msk & ((value) << PM_CPUSEL_CPUDIV_Pos))
+#define   PM_CPUSEL_CPUDIV_DIV1_Val       _U_(0x0)   /**< \brief (PM_CPUSEL) Divide by 1 */
+#define   PM_CPUSEL_CPUDIV_DIV2_Val       _U_(0x1)   /**< \brief (PM_CPUSEL) Divide by 2 */
+#define   PM_CPUSEL_CPUDIV_DIV4_Val       _U_(0x2)   /**< \brief (PM_CPUSEL) Divide by 4 */
+#define   PM_CPUSEL_CPUDIV_DIV8_Val       _U_(0x3)   /**< \brief (PM_CPUSEL) Divide by 8 */
+#define   PM_CPUSEL_CPUDIV_DIV16_Val      _U_(0x4)   /**< \brief (PM_CPUSEL) Divide by 16 */
+#define   PM_CPUSEL_CPUDIV_DIV32_Val      _U_(0x5)   /**< \brief (PM_CPUSEL) Divide by 32 */
+#define   PM_CPUSEL_CPUDIV_DIV64_Val      _U_(0x6)   /**< \brief (PM_CPUSEL) Divide by 64 */
+#define   PM_CPUSEL_CPUDIV_DIV128_Val     _U_(0x7)   /**< \brief (PM_CPUSEL) Divide by 128 */
+#define PM_CPUSEL_CPUDIV_DIV1       (PM_CPUSEL_CPUDIV_DIV1_Val     << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV_DIV2       (PM_CPUSEL_CPUDIV_DIV2_Val     << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV_DIV4       (PM_CPUSEL_CPUDIV_DIV4_Val     << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV_DIV8       (PM_CPUSEL_CPUDIV_DIV8_Val     << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV_DIV16      (PM_CPUSEL_CPUDIV_DIV16_Val    << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV_DIV32      (PM_CPUSEL_CPUDIV_DIV32_Val    << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV_DIV64      (PM_CPUSEL_CPUDIV_DIV64_Val    << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV_DIV128     (PM_CPUSEL_CPUDIV_DIV128_Val   << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_MASK              _U_(0x07)    /**< \brief (PM_CPUSEL) MASK Register */
+
+/* -------- PM_APBASEL : (PM Offset: 0x09) (R/W  8) APBA Clock Select -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  APBADIV:3;        /*!< bit:  0.. 2  APBA Prescaler Selection           */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_APBASEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_APBASEL_OFFSET           0x09         /**< \brief (PM_APBASEL offset) APBA Clock Select */
+#define PM_APBASEL_RESETVALUE       _U_(0x00)    /**< \brief (PM_APBASEL reset_value) APBA Clock Select */
+
+#define PM_APBASEL_APBADIV_Pos      0            /**< \brief (PM_APBASEL) APBA Prescaler Selection */
+#define PM_APBASEL_APBADIV_Msk      (_U_(0x7) << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV(value)   (PM_APBASEL_APBADIV_Msk & ((value) << PM_APBASEL_APBADIV_Pos))
+#define   PM_APBASEL_APBADIV_DIV1_Val     _U_(0x0)   /**< \brief (PM_APBASEL) Divide by 1 */
+#define   PM_APBASEL_APBADIV_DIV2_Val     _U_(0x1)   /**< \brief (PM_APBASEL) Divide by 2 */
+#define   PM_APBASEL_APBADIV_DIV4_Val     _U_(0x2)   /**< \brief (PM_APBASEL) Divide by 4 */
+#define   PM_APBASEL_APBADIV_DIV8_Val     _U_(0x3)   /**< \brief (PM_APBASEL) Divide by 8 */
+#define   PM_APBASEL_APBADIV_DIV16_Val    _U_(0x4)   /**< \brief (PM_APBASEL) Divide by 16 */
+#define   PM_APBASEL_APBADIV_DIV32_Val    _U_(0x5)   /**< \brief (PM_APBASEL) Divide by 32 */
+#define   PM_APBASEL_APBADIV_DIV64_Val    _U_(0x6)   /**< \brief (PM_APBASEL) Divide by 64 */
+#define   PM_APBASEL_APBADIV_DIV128_Val   _U_(0x7)   /**< \brief (PM_APBASEL) Divide by 128 */
+#define PM_APBASEL_APBADIV_DIV1     (PM_APBASEL_APBADIV_DIV1_Val   << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV_DIV2     (PM_APBASEL_APBADIV_DIV2_Val   << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV_DIV4     (PM_APBASEL_APBADIV_DIV4_Val   << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV_DIV8     (PM_APBASEL_APBADIV_DIV8_Val   << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV_DIV16    (PM_APBASEL_APBADIV_DIV16_Val  << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV_DIV32    (PM_APBASEL_APBADIV_DIV32_Val  << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV_DIV64    (PM_APBASEL_APBADIV_DIV64_Val  << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV_DIV128   (PM_APBASEL_APBADIV_DIV128_Val << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_MASK             _U_(0x07)    /**< \brief (PM_APBASEL) MASK Register */
+
+/* -------- PM_APBBSEL : (PM Offset: 0x0A) (R/W  8) APBB Clock Select -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  APBBDIV:3;        /*!< bit:  0.. 2  APBB Prescaler Selection           */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_APBBSEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_APBBSEL_OFFSET           0x0A         /**< \brief (PM_APBBSEL offset) APBB Clock Select */
+#define PM_APBBSEL_RESETVALUE       _U_(0x00)    /**< \brief (PM_APBBSEL reset_value) APBB Clock Select */
+
+#define PM_APBBSEL_APBBDIV_Pos      0            /**< \brief (PM_APBBSEL) APBB Prescaler Selection */
+#define PM_APBBSEL_APBBDIV_Msk      (_U_(0x7) << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV(value)   (PM_APBBSEL_APBBDIV_Msk & ((value) << PM_APBBSEL_APBBDIV_Pos))
+#define   PM_APBBSEL_APBBDIV_DIV1_Val     _U_(0x0)   /**< \brief (PM_APBBSEL) Divide by 1 */
+#define   PM_APBBSEL_APBBDIV_DIV2_Val     _U_(0x1)   /**< \brief (PM_APBBSEL) Divide by 2 */
+#define   PM_APBBSEL_APBBDIV_DIV4_Val     _U_(0x2)   /**< \brief (PM_APBBSEL) Divide by 4 */
+#define   PM_APBBSEL_APBBDIV_DIV8_Val     _U_(0x3)   /**< \brief (PM_APBBSEL) Divide by 8 */
+#define   PM_APBBSEL_APBBDIV_DIV16_Val    _U_(0x4)   /**< \brief (PM_APBBSEL) Divide by 16 */
+#define   PM_APBBSEL_APBBDIV_DIV32_Val    _U_(0x5)   /**< \brief (PM_APBBSEL) Divide by 32 */
+#define   PM_APBBSEL_APBBDIV_DIV64_Val    _U_(0x6)   /**< \brief (PM_APBBSEL) Divide by 64 */
+#define   PM_APBBSEL_APBBDIV_DIV128_Val   _U_(0x7)   /**< \brief (PM_APBBSEL) Divide by 128 */
+#define PM_APBBSEL_APBBDIV_DIV1     (PM_APBBSEL_APBBDIV_DIV1_Val   << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV_DIV2     (PM_APBBSEL_APBBDIV_DIV2_Val   << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV_DIV4     (PM_APBBSEL_APBBDIV_DIV4_Val   << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV_DIV8     (PM_APBBSEL_APBBDIV_DIV8_Val   << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV_DIV16    (PM_APBBSEL_APBBDIV_DIV16_Val  << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV_DIV32    (PM_APBBSEL_APBBDIV_DIV32_Val  << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV_DIV64    (PM_APBBSEL_APBBDIV_DIV64_Val  << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV_DIV128   (PM_APBBSEL_APBBDIV_DIV128_Val << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_MASK             _U_(0x07)    /**< \brief (PM_APBBSEL) MASK Register */
+
+/* -------- PM_APBCSEL : (PM Offset: 0x0B) (R/W  8) APBC Clock Select -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  APBCDIV:3;        /*!< bit:  0.. 2  APBC Prescaler Selection           */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_APBCSEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_APBCSEL_OFFSET           0x0B         /**< \brief (PM_APBCSEL offset) APBC Clock Select */
+#define PM_APBCSEL_RESETVALUE       _U_(0x00)    /**< \brief (PM_APBCSEL reset_value) APBC Clock Select */
+
+#define PM_APBCSEL_APBCDIV_Pos      0            /**< \brief (PM_APBCSEL) APBC Prescaler Selection */
+#define PM_APBCSEL_APBCDIV_Msk      (_U_(0x7) << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV(value)   (PM_APBCSEL_APBCDIV_Msk & ((value) << PM_APBCSEL_APBCDIV_Pos))
+#define   PM_APBCSEL_APBCDIV_DIV1_Val     _U_(0x0)   /**< \brief (PM_APBCSEL) Divide by 1 */
+#define   PM_APBCSEL_APBCDIV_DIV2_Val     _U_(0x1)   /**< \brief (PM_APBCSEL) Divide by 2 */
+#define   PM_APBCSEL_APBCDIV_DIV4_Val     _U_(0x2)   /**< \brief (PM_APBCSEL) Divide by 4 */
+#define   PM_APBCSEL_APBCDIV_DIV8_Val     _U_(0x3)   /**< \brief (PM_APBCSEL) Divide by 8 */
+#define   PM_APBCSEL_APBCDIV_DIV16_Val    _U_(0x4)   /**< \brief (PM_APBCSEL) Divide by 16 */
+#define   PM_APBCSEL_APBCDIV_DIV32_Val    _U_(0x5)   /**< \brief (PM_APBCSEL) Divide by 32 */
+#define   PM_APBCSEL_APBCDIV_DIV64_Val    _U_(0x6)   /**< \brief (PM_APBCSEL) Divide by 64 */
+#define   PM_APBCSEL_APBCDIV_DIV128_Val   _U_(0x7)   /**< \brief (PM_APBCSEL) Divide by 128 */
+#define PM_APBCSEL_APBCDIV_DIV1     (PM_APBCSEL_APBCDIV_DIV1_Val   << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV_DIV2     (PM_APBCSEL_APBCDIV_DIV2_Val   << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV_DIV4     (PM_APBCSEL_APBCDIV_DIV4_Val   << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV_DIV8     (PM_APBCSEL_APBCDIV_DIV8_Val   << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV_DIV16    (PM_APBCSEL_APBCDIV_DIV16_Val  << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV_DIV32    (PM_APBCSEL_APBCDIV_DIV32_Val  << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV_DIV64    (PM_APBCSEL_APBCDIV_DIV64_Val  << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV_DIV128   (PM_APBCSEL_APBCDIV_DIV128_Val << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_MASK             _U_(0x07)    /**< \brief (PM_APBCSEL) MASK Register */
+
+/* -------- PM_AHBMASK : (PM Offset: 0x14) (R/W 32) AHB Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t HPB0_:1;          /*!< bit:      0  HPB0 AHB Clock Mask                */
+    uint32_t HPB1_:1;          /*!< bit:      1  HPB1 AHB Clock Mask                */
+    uint32_t HPB2_:1;          /*!< bit:      2  HPB2 AHB Clock Mask                */
+    uint32_t DSU_:1;           /*!< bit:      3  DSU AHB Clock Mask                 */
+    uint32_t NVMCTRL_:1;       /*!< bit:      4  NVMCTRL AHB Clock Mask             */
+    uint32_t :27;              /*!< bit:  5..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_AHBMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_AHBMASK_OFFSET           0x14         /**< \brief (PM_AHBMASK offset) AHB Mask */
+#define PM_AHBMASK_RESETVALUE       _U_(0x0000001F) /**< \brief (PM_AHBMASK reset_value) AHB Mask */
+
+#define PM_AHBMASK_HPB0_Pos         0            /**< \brief (PM_AHBMASK) HPB0 AHB Clock Mask */
+#define PM_AHBMASK_HPB0             (_U_(0x1) << PM_AHBMASK_HPB0_Pos)
+#define PM_AHBMASK_HPB1_Pos         1            /**< \brief (PM_AHBMASK) HPB1 AHB Clock Mask */
+#define PM_AHBMASK_HPB1             (_U_(0x1) << PM_AHBMASK_HPB1_Pos)
+#define PM_AHBMASK_HPB2_Pos         2            /**< \brief (PM_AHBMASK) HPB2 AHB Clock Mask */
+#define PM_AHBMASK_HPB2             (_U_(0x1) << PM_AHBMASK_HPB2_Pos)
+#define PM_AHBMASK_DSU_Pos          3            /**< \brief (PM_AHBMASK) DSU AHB Clock Mask */
+#define PM_AHBMASK_DSU              (_U_(0x1) << PM_AHBMASK_DSU_Pos)
+#define PM_AHBMASK_NVMCTRL_Pos      4            /**< \brief (PM_AHBMASK) NVMCTRL AHB Clock Mask */
+#define PM_AHBMASK_NVMCTRL          (_U_(0x1) << PM_AHBMASK_NVMCTRL_Pos)
+#define PM_AHBMASK_MASK             _U_(0x0000001F) /**< \brief (PM_AHBMASK) MASK Register */
+
+/* -------- PM_APBAMASK : (PM Offset: 0x18) (R/W 32) APBA Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PAC0_:1;          /*!< bit:      0  PAC0 APB Clock Enable              */
+    uint32_t PM_:1;            /*!< bit:      1  PM APB Clock Enable                */
+    uint32_t SYSCTRL_:1;       /*!< bit:      2  SYSCTRL APB Clock Enable           */
+    uint32_t GCLK_:1;          /*!< bit:      3  GCLK APB Clock Enable              */
+    uint32_t WDT_:1;           /*!< bit:      4  WDT APB Clock Enable               */
+    uint32_t RTC_:1;           /*!< bit:      5  RTC APB Clock Enable               */
+    uint32_t EIC_:1;           /*!< bit:      6  EIC APB Clock Enable               */
+    uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_APBAMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_APBAMASK_OFFSET          0x18         /**< \brief (PM_APBAMASK offset) APBA Mask */
+#define PM_APBAMASK_RESETVALUE      _U_(0x0000007F) /**< \brief (PM_APBAMASK reset_value) APBA Mask */
+
+#define PM_APBAMASK_PAC0_Pos        0            /**< \brief (PM_APBAMASK) PAC0 APB Clock Enable */
+#define PM_APBAMASK_PAC0            (_U_(0x1) << PM_APBAMASK_PAC0_Pos)
+#define PM_APBAMASK_PM_Pos          1            /**< \brief (PM_APBAMASK) PM APB Clock Enable */
+#define PM_APBAMASK_PM              (_U_(0x1) << PM_APBAMASK_PM_Pos)
+#define PM_APBAMASK_SYSCTRL_Pos     2            /**< \brief (PM_APBAMASK) SYSCTRL APB Clock Enable */
+#define PM_APBAMASK_SYSCTRL         (_U_(0x1) << PM_APBAMASK_SYSCTRL_Pos)
+#define PM_APBAMASK_GCLK_Pos        3            /**< \brief (PM_APBAMASK) GCLK APB Clock Enable */
+#define PM_APBAMASK_GCLK            (_U_(0x1) << PM_APBAMASK_GCLK_Pos)
+#define PM_APBAMASK_WDT_Pos         4            /**< \brief (PM_APBAMASK) WDT APB Clock Enable */
+#define PM_APBAMASK_WDT             (_U_(0x1) << PM_APBAMASK_WDT_Pos)
+#define PM_APBAMASK_RTC_Pos         5            /**< \brief (PM_APBAMASK) RTC APB Clock Enable */
+#define PM_APBAMASK_RTC             (_U_(0x1) << PM_APBAMASK_RTC_Pos)
+#define PM_APBAMASK_EIC_Pos         6            /**< \brief (PM_APBAMASK) EIC APB Clock Enable */
+#define PM_APBAMASK_EIC             (_U_(0x1) << PM_APBAMASK_EIC_Pos)
+#define PM_APBAMASK_MASK            _U_(0x0000007F) /**< \brief (PM_APBAMASK) MASK Register */
+
+/* -------- PM_APBBMASK : (PM Offset: 0x1C) (R/W 32) APBB Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PAC1_:1;          /*!< bit:      0  PAC1 APB Clock Enable              */
+    uint32_t DSU_:1;           /*!< bit:      1  DSU APB Clock Enable               */
+    uint32_t NVMCTRL_:1;       /*!< bit:      2  NVMCTRL APB Clock Enable           */
+    uint32_t PORT_:1;          /*!< bit:      3  PORT APB Clock Enable              */
+    uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_APBBMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_APBBMASK_OFFSET          0x1C         /**< \brief (PM_APBBMASK offset) APBB Mask */
+#define PM_APBBMASK_RESETVALUE      _U_(0x0000001F) /**< \brief (PM_APBBMASK reset_value) APBB Mask */
+
+#define PM_APBBMASK_PAC1_Pos        0            /**< \brief (PM_APBBMASK) PAC1 APB Clock Enable */
+#define PM_APBBMASK_PAC1            (_U_(0x1) << PM_APBBMASK_PAC1_Pos)
+#define PM_APBBMASK_DSU_Pos         1            /**< \brief (PM_APBBMASK) DSU APB Clock Enable */
+#define PM_APBBMASK_DSU             (_U_(0x1) << PM_APBBMASK_DSU_Pos)
+#define PM_APBBMASK_NVMCTRL_Pos     2            /**< \brief (PM_APBBMASK) NVMCTRL APB Clock Enable */
+#define PM_APBBMASK_NVMCTRL         (_U_(0x1) << PM_APBBMASK_NVMCTRL_Pos)
+#define PM_APBBMASK_PORT_Pos        3            /**< \brief (PM_APBBMASK) PORT APB Clock Enable */
+#define PM_APBBMASK_PORT            (_U_(0x1) << PM_APBBMASK_PORT_Pos)
+#define PM_APBBMASK_MASK            _U_(0x0000000F) /**< \brief (PM_APBBMASK) MASK Register */
+
+/* -------- PM_APBCMASK : (PM Offset: 0x20) (R/W 32) APBC Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PAC2_:1;          /*!< bit:      0  PAC2 APB Clock Enable              */
+    uint32_t EVSYS_:1;         /*!< bit:      1  EVSYS APB Clock Enable             */
+    uint32_t SERCOM0_:1;       /*!< bit:      2  SERCOM0 APB Clock Enable           */
+    uint32_t SERCOM1_:1;       /*!< bit:      3  SERCOM1 APB Clock Enable           */
+    uint32_t SERCOM2_:1;       /*!< bit:      4  SERCOM2 APB Clock Enable           */
+    uint32_t SERCOM3_:1;       /*!< bit:      5  SERCOM3 APB Clock Enable           */
+    uint32_t SERCOM4_:1;       /*!< bit:      6  SERCOM4 APB Clock Enable           */
+    uint32_t SERCOM5_:1;       /*!< bit:      7  SERCOM5 APB Clock Enable           */
+    uint32_t TC0_:1;           /*!< bit:      8  TC0 APB Clock Enable               */
+    uint32_t TC1_:1;           /*!< bit:      9  TC1 APB Clock Enable               */
+    uint32_t TC2_:1;           /*!< bit:     10  TC2 APB Clock Enable               */
+    uint32_t TC3_:1;           /*!< bit:     11  TC3 APB Clock Enable               */
+    uint32_t TC4_:1;           /*!< bit:     12  TC4 APB Clock Enable               */
+    uint32_t TC5_:1;           /*!< bit:     13  TC5 APB Clock Enable               */
+    uint32_t TC6_:1;           /*!< bit:     14  TC6 APB Clock Enable               */
+    uint32_t TC7_:1;           /*!< bit:     15  TC7 APB Clock Enable               */
+    uint32_t ADC_:1;           /*!< bit:     16  ADC APB Clock Enable               */
+    uint32_t AC_:1;            /*!< bit:     17  AC APB Clock Enable                */
+    uint32_t DAC_:1;           /*!< bit:     18  DAC APB Clock Enable               */
+    uint32_t PTC_:1;           /*!< bit:     19  PTC APB Clock Enable               */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_APBCMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_APBCMASK_OFFSET          0x20         /**< \brief (PM_APBCMASK offset) APBC Mask */
+#define PM_APBCMASK_RESETVALUE      _U_(0x00010000) /**< \brief (PM_APBCMASK reset_value) APBC Mask */
+
+#define PM_APBCMASK_PAC2_Pos        0            /**< \brief (PM_APBCMASK) PAC2 APB Clock Enable */
+#define PM_APBCMASK_PAC2            (_U_(0x1) << PM_APBCMASK_PAC2_Pos)
+#define PM_APBCMASK_EVSYS_Pos       1            /**< \brief (PM_APBCMASK) EVSYS APB Clock Enable */
+#define PM_APBCMASK_EVSYS           (_U_(0x1) << PM_APBCMASK_EVSYS_Pos)
+#define PM_APBCMASK_SERCOM0_Pos     2            /**< \brief (PM_APBCMASK) SERCOM0 APB Clock Enable */
+#define PM_APBCMASK_SERCOM0         (_U_(0x1) << PM_APBCMASK_SERCOM0_Pos)
+#define PM_APBCMASK_SERCOM1_Pos     3            /**< \brief (PM_APBCMASK) SERCOM1 APB Clock Enable */
+#define PM_APBCMASK_SERCOM1         (_U_(0x1) << PM_APBCMASK_SERCOM1_Pos)
+#define PM_APBCMASK_SERCOM2_Pos     4            /**< \brief (PM_APBCMASK) SERCOM2 APB Clock Enable */
+#define PM_APBCMASK_SERCOM2         (_U_(0x1) << PM_APBCMASK_SERCOM2_Pos)
+#define PM_APBCMASK_SERCOM3_Pos     5            /**< \brief (PM_APBCMASK) SERCOM3 APB Clock Enable */
+#define PM_APBCMASK_SERCOM3         (_U_(0x1) << PM_APBCMASK_SERCOM3_Pos)
+#define PM_APBCMASK_SERCOM4_Pos     6            /**< \brief (PM_APBCMASK) SERCOM4 APB Clock Enable */
+#define PM_APBCMASK_SERCOM4         (_U_(0x1) << PM_APBCMASK_SERCOM4_Pos)
+#define PM_APBCMASK_SERCOM5_Pos     7            /**< \brief (PM_APBCMASK) SERCOM5 APB Clock Enable */
+#define PM_APBCMASK_SERCOM5         (_U_(0x1) << PM_APBCMASK_SERCOM5_Pos)
+#define PM_APBCMASK_TC0_Pos         8            /**< \brief (PM_APBCMASK) TC0 APB Clock Enable */
+#define PM_APBCMASK_TC0             (_U_(0x1) << PM_APBCMASK_TC0_Pos)
+#define PM_APBCMASK_TC1_Pos         9            /**< \brief (PM_APBCMASK) TC1 APB Clock Enable */
+#define PM_APBCMASK_TC1             (_U_(0x1) << PM_APBCMASK_TC1_Pos)
+#define PM_APBCMASK_TC2_Pos         10           /**< \brief (PM_APBCMASK) TC2 APB Clock Enable */
+#define PM_APBCMASK_TC2             (_U_(0x1) << PM_APBCMASK_TC2_Pos)
+#define PM_APBCMASK_TC3_Pos         11           /**< \brief (PM_APBCMASK) TC3 APB Clock Enable */
+#define PM_APBCMASK_TC3             (_U_(0x1) << PM_APBCMASK_TC3_Pos)
+#define PM_APBCMASK_TC4_Pos         12           /**< \brief (PM_APBCMASK) TC4 APB Clock Enable */
+#define PM_APBCMASK_TC4             (_U_(0x1) << PM_APBCMASK_TC4_Pos)
+#define PM_APBCMASK_TC5_Pos         13           /**< \brief (PM_APBCMASK) TC5 APB Clock Enable */
+#define PM_APBCMASK_TC5             (_U_(0x1) << PM_APBCMASK_TC5_Pos)
+#define PM_APBCMASK_TC6_Pos         14           /**< \brief (PM_APBCMASK) TC6 APB Clock Enable */
+#define PM_APBCMASK_TC6             (_U_(0x1) << PM_APBCMASK_TC6_Pos)
+#define PM_APBCMASK_TC7_Pos         15           /**< \brief (PM_APBCMASK) TC7 APB Clock Enable */
+#define PM_APBCMASK_TC7             (_U_(0x1) << PM_APBCMASK_TC7_Pos)
+#define PM_APBCMASK_ADC_Pos         16           /**< \brief (PM_APBCMASK) ADC APB Clock Enable */
+#define PM_APBCMASK_ADC             (_U_(0x1) << PM_APBCMASK_ADC_Pos)
+#define PM_APBCMASK_AC_Pos          17           /**< \brief (PM_APBCMASK) AC APB Clock Enable */
+#define PM_APBCMASK_AC              (_U_(0x1) << PM_APBCMASK_AC_Pos)
+#define PM_APBCMASK_DAC_Pos         18           /**< \brief (PM_APBCMASK) DAC APB Clock Enable */
+#define PM_APBCMASK_DAC             (_U_(0x1) << PM_APBCMASK_DAC_Pos)
+#define PM_APBCMASK_PTC_Pos         19           /**< \brief (PM_APBCMASK) PTC APB Clock Enable */
+#define PM_APBCMASK_PTC             (_U_(0x1) << PM_APBCMASK_PTC_Pos)
+#define PM_APBCMASK_MASK            _U_(0x000FFFFF) /**< \brief (PM_APBCMASK) MASK Register */
+
+/* -------- PM_INTENCLR : (PM Offset: 0x34) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready Interrupt Enable       */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_INTENCLR_OFFSET          0x34         /**< \brief (PM_INTENCLR offset) Interrupt Enable Clear */
+#define PM_INTENCLR_RESETVALUE      _U_(0x00)    /**< \brief (PM_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define PM_INTENCLR_CKRDY_Pos       0            /**< \brief (PM_INTENCLR) Clock Ready Interrupt Enable */
+#define PM_INTENCLR_CKRDY           (_U_(0x1) << PM_INTENCLR_CKRDY_Pos)
+#define PM_INTENCLR_MASK            _U_(0x01)    /**< \brief (PM_INTENCLR) MASK Register */
+
+/* -------- PM_INTENSET : (PM Offset: 0x35) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready Interrupt Enable       */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_INTENSET_OFFSET          0x35         /**< \brief (PM_INTENSET offset) Interrupt Enable Set */
+#define PM_INTENSET_RESETVALUE      _U_(0x00)    /**< \brief (PM_INTENSET reset_value) Interrupt Enable Set */
+
+#define PM_INTENSET_CKRDY_Pos       0            /**< \brief (PM_INTENSET) Clock Ready Interrupt Enable */
+#define PM_INTENSET_CKRDY           (_U_(0x1) << PM_INTENSET_CKRDY_Pos)
+#define PM_INTENSET_MASK            _U_(0x01)    /**< \brief (PM_INTENSET) MASK Register */
+
+/* -------- PM_INTFLAG : (PM Offset: 0x36) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
+    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_INTFLAG_OFFSET           0x36         /**< \brief (PM_INTFLAG offset) Interrupt Flag Status and Clear */
+#define PM_INTFLAG_RESETVALUE       _U_(0x00)    /**< \brief (PM_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define PM_INTFLAG_CKRDY_Pos        0            /**< \brief (PM_INTFLAG) Clock Ready */
+#define PM_INTFLAG_CKRDY            (_U_(0x1) << PM_INTFLAG_CKRDY_Pos)
+#define PM_INTFLAG_MASK             _U_(0x01)    /**< \brief (PM_INTFLAG) MASK Register */
+
+/* -------- PM_RCAUSE : (PM Offset: 0x38) (R/   8) Reset Cause -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  POR:1;            /*!< bit:      0  Power On Reset                     */
+    uint8_t  BOD12:1;          /*!< bit:      1  Brown Out 12 Detector Reset        */
+    uint8_t  BOD33:1;          /*!< bit:      2  Brown Out 33 Detector Reset        */
+    uint8_t  :1;               /*!< bit:      3  Reserved                           */
+    uint8_t  EXT:1;            /*!< bit:      4  External Reset                     */
+    uint8_t  WDT:1;            /*!< bit:      5  Watchdog Reset                     */
+    uint8_t  SYST:1;           /*!< bit:      6  System Reset Request               */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_RCAUSE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_RCAUSE_OFFSET            0x38         /**< \brief (PM_RCAUSE offset) Reset Cause */
+#define PM_RCAUSE_RESETVALUE        _U_(0x01)    /**< \brief (PM_RCAUSE reset_value) Reset Cause */
+
+#define PM_RCAUSE_POR_Pos           0            /**< \brief (PM_RCAUSE) Power On Reset */
+#define PM_RCAUSE_POR               (_U_(0x1) << PM_RCAUSE_POR_Pos)
+#define PM_RCAUSE_BOD12_Pos         1            /**< \brief (PM_RCAUSE) Brown Out 12 Detector Reset */
+#define PM_RCAUSE_BOD12             (_U_(0x1) << PM_RCAUSE_BOD12_Pos)
+#define PM_RCAUSE_BOD33_Pos         2            /**< \brief (PM_RCAUSE) Brown Out 33 Detector Reset */
+#define PM_RCAUSE_BOD33             (_U_(0x1) << PM_RCAUSE_BOD33_Pos)
+#define PM_RCAUSE_EXT_Pos           4            /**< \brief (PM_RCAUSE) External Reset */
+#define PM_RCAUSE_EXT               (_U_(0x1) << PM_RCAUSE_EXT_Pos)
+#define PM_RCAUSE_WDT_Pos           5            /**< \brief (PM_RCAUSE) Watchdog Reset */
+#define PM_RCAUSE_WDT               (_U_(0x1) << PM_RCAUSE_WDT_Pos)
+#define PM_RCAUSE_SYST_Pos          6            /**< \brief (PM_RCAUSE) System Reset Request */
+#define PM_RCAUSE_SYST              (_U_(0x1) << PM_RCAUSE_SYST_Pos)
+#define PM_RCAUSE_MASK              _U_(0x77)    /**< \brief (PM_RCAUSE) MASK Register */
+
+/** \brief PM hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO PM_CTRL_Type              CTRL;        /**< \brief Offset: 0x00 (R/W  8) Control */
+  __IO PM_SLEEP_Type             SLEEP;       /**< \brief Offset: 0x01 (R/W  8) Sleep Mode */
+       RoReg8                    Reserved1[0x6];
+  __IO PM_CPUSEL_Type            CPUSEL;      /**< \brief Offset: 0x08 (R/W  8) CPU Clock Select */
+  __IO PM_APBASEL_Type           APBASEL;     /**< \brief Offset: 0x09 (R/W  8) APBA Clock Select */
+  __IO PM_APBBSEL_Type           APBBSEL;     /**< \brief Offset: 0x0A (R/W  8) APBB Clock Select */
+  __IO PM_APBCSEL_Type           APBCSEL;     /**< \brief Offset: 0x0B (R/W  8) APBC Clock Select */
+       RoReg8                    Reserved2[0x8];
+  __IO PM_AHBMASK_Type           AHBMASK;     /**< \brief Offset: 0x14 (R/W 32) AHB Mask */
+  __IO PM_APBAMASK_Type          APBAMASK;    /**< \brief Offset: 0x18 (R/W 32) APBA Mask */
+  __IO PM_APBBMASK_Type          APBBMASK;    /**< \brief Offset: 0x1C (R/W 32) APBB Mask */
+  __IO PM_APBCMASK_Type          APBCMASK;    /**< \brief Offset: 0x20 (R/W 32) APBC Mask */
+       RoReg8                    Reserved3[0x10];
+  __IO PM_INTENCLR_Type          INTENCLR;    /**< \brief Offset: 0x34 (R/W  8) Interrupt Enable Clear */
+  __IO PM_INTENSET_Type          INTENSET;    /**< \brief Offset: 0x35 (R/W  8) Interrupt Enable Set */
+  __IO PM_INTFLAG_Type           INTFLAG;     /**< \brief Offset: 0x36 (R/W  8) Interrupt Flag Status and Clear */
+       RoReg8                    Reserved4[0x1];
+  __I  PM_RCAUSE_Type            RCAUSE;      /**< \brief Offset: 0x38 (R/   8) Reset Cause */
+} Pm;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_PM_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/component/port.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/port.h
@@ -1,0 +1,380 @@
+/**
+ * \file
+ *
+ * \brief Component description for PORT
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PORT_COMPONENT_
+#define _SAMD20_PORT_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PORT */
+/* ========================================================================== */
+/** \addtogroup SAMD20_PORT Port Module */
+/*@{*/
+
+#define PORT_U2210
+#define REV_PORT                    0x100
+
+/* -------- PORT_DIR : (PORT Offset: 0x00) (R/W 32) GROUP Data Direction -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DIR:32;           /*!< bit:  0..31  Port Data Direction                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIR_OFFSET             0x00         /**< \brief (PORT_DIR offset) Data Direction */
+#define PORT_DIR_RESETVALUE         _U_(0x00000000) /**< \brief (PORT_DIR reset_value) Data Direction */
+
+#define PORT_DIR_DIR_Pos            0            /**< \brief (PORT_DIR) Port Data Direction */
+#define PORT_DIR_DIR_Msk            (_U_(0xFFFFFFFF) << PORT_DIR_DIR_Pos)
+#define PORT_DIR_DIR(value)         (PORT_DIR_DIR_Msk & ((value) << PORT_DIR_DIR_Pos))
+#define PORT_DIR_MASK               _U_(0xFFFFFFFF) /**< \brief (PORT_DIR) MASK Register */
+
+/* -------- PORT_DIRCLR : (PORT Offset: 0x04) (R/W 32) GROUP Data Direction Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DIRCLR:32;        /*!< bit:  0..31  Port Data Direction Clear          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIRCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIRCLR_OFFSET          0x04         /**< \brief (PORT_DIRCLR offset) Data Direction Clear */
+#define PORT_DIRCLR_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_DIRCLR reset_value) Data Direction Clear */
+
+#define PORT_DIRCLR_DIRCLR_Pos      0            /**< \brief (PORT_DIRCLR) Port Data Direction Clear */
+#define PORT_DIRCLR_DIRCLR_Msk      (_U_(0xFFFFFFFF) << PORT_DIRCLR_DIRCLR_Pos)
+#define PORT_DIRCLR_DIRCLR(value)   (PORT_DIRCLR_DIRCLR_Msk & ((value) << PORT_DIRCLR_DIRCLR_Pos))
+#define PORT_DIRCLR_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_DIRCLR) MASK Register */
+
+/* -------- PORT_DIRSET : (PORT Offset: 0x08) (R/W 32) GROUP Data Direction Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DIRSET:32;        /*!< bit:  0..31  Port Data Direction Set            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIRSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIRSET_OFFSET          0x08         /**< \brief (PORT_DIRSET offset) Data Direction Set */
+#define PORT_DIRSET_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_DIRSET reset_value) Data Direction Set */
+
+#define PORT_DIRSET_DIRSET_Pos      0            /**< \brief (PORT_DIRSET) Port Data Direction Set */
+#define PORT_DIRSET_DIRSET_Msk      (_U_(0xFFFFFFFF) << PORT_DIRSET_DIRSET_Pos)
+#define PORT_DIRSET_DIRSET(value)   (PORT_DIRSET_DIRSET_Msk & ((value) << PORT_DIRSET_DIRSET_Pos))
+#define PORT_DIRSET_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_DIRSET) MASK Register */
+
+/* -------- PORT_DIRTGL : (PORT Offset: 0x0C) (R/W 32) GROUP Data Direction Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DIRTGL:32;        /*!< bit:  0..31  Port Data Direction Toggle         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIRTGL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIRTGL_OFFSET          0x0C         /**< \brief (PORT_DIRTGL offset) Data Direction Toggle */
+#define PORT_DIRTGL_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_DIRTGL reset_value) Data Direction Toggle */
+
+#define PORT_DIRTGL_DIRTGL_Pos      0            /**< \brief (PORT_DIRTGL) Port Data Direction Toggle */
+#define PORT_DIRTGL_DIRTGL_Msk      (_U_(0xFFFFFFFF) << PORT_DIRTGL_DIRTGL_Pos)
+#define PORT_DIRTGL_DIRTGL(value)   (PORT_DIRTGL_DIRTGL_Msk & ((value) << PORT_DIRTGL_DIRTGL_Pos))
+#define PORT_DIRTGL_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_DIRTGL) MASK Register */
+
+/* -------- PORT_OUT : (PORT Offset: 0x10) (R/W 32) GROUP Data Output Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OUT:32;           /*!< bit:  0..31  Port Data Output Value             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUT_OFFSET             0x10         /**< \brief (PORT_OUT offset) Data Output Value */
+#define PORT_OUT_RESETVALUE         _U_(0x00000000) /**< \brief (PORT_OUT reset_value) Data Output Value */
+
+#define PORT_OUT_OUT_Pos            0            /**< \brief (PORT_OUT) Port Data Output Value */
+#define PORT_OUT_OUT_Msk            (_U_(0xFFFFFFFF) << PORT_OUT_OUT_Pos)
+#define PORT_OUT_OUT(value)         (PORT_OUT_OUT_Msk & ((value) << PORT_OUT_OUT_Pos))
+#define PORT_OUT_MASK               _U_(0xFFFFFFFF) /**< \brief (PORT_OUT) MASK Register */
+
+/* -------- PORT_OUTCLR : (PORT Offset: 0x14) (R/W 32) GROUP Data Output Value Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OUTCLR:32;        /*!< bit:  0..31  Port Data Output Value Clear       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUTCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUTCLR_OFFSET          0x14         /**< \brief (PORT_OUTCLR offset) Data Output Value Clear */
+#define PORT_OUTCLR_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_OUTCLR reset_value) Data Output Value Clear */
+
+#define PORT_OUTCLR_OUTCLR_Pos      0            /**< \brief (PORT_OUTCLR) Port Data Output Value Clear */
+#define PORT_OUTCLR_OUTCLR_Msk      (_U_(0xFFFFFFFF) << PORT_OUTCLR_OUTCLR_Pos)
+#define PORT_OUTCLR_OUTCLR(value)   (PORT_OUTCLR_OUTCLR_Msk & ((value) << PORT_OUTCLR_OUTCLR_Pos))
+#define PORT_OUTCLR_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_OUTCLR) MASK Register */
+
+/* -------- PORT_OUTSET : (PORT Offset: 0x18) (R/W 32) GROUP Data Output Value Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OUTSET:32;        /*!< bit:  0..31  Port Data Output Value Set         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUTSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUTSET_OFFSET          0x18         /**< \brief (PORT_OUTSET offset) Data Output Value Set */
+#define PORT_OUTSET_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_OUTSET reset_value) Data Output Value Set */
+
+#define PORT_OUTSET_OUTSET_Pos      0            /**< \brief (PORT_OUTSET) Port Data Output Value Set */
+#define PORT_OUTSET_OUTSET_Msk      (_U_(0xFFFFFFFF) << PORT_OUTSET_OUTSET_Pos)
+#define PORT_OUTSET_OUTSET(value)   (PORT_OUTSET_OUTSET_Msk & ((value) << PORT_OUTSET_OUTSET_Pos))
+#define PORT_OUTSET_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_OUTSET) MASK Register */
+
+/* -------- PORT_OUTTGL : (PORT Offset: 0x1C) (R/W 32) GROUP Data Output Value Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OUTTGL:32;        /*!< bit:  0..31  Port Data Output Value Toggle      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUTTGL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUTTGL_OFFSET          0x1C         /**< \brief (PORT_OUTTGL offset) Data Output Value Toggle */
+#define PORT_OUTTGL_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_OUTTGL reset_value) Data Output Value Toggle */
+
+#define PORT_OUTTGL_OUTTGL_Pos      0            /**< \brief (PORT_OUTTGL) Port Data Output Value Toggle */
+#define PORT_OUTTGL_OUTTGL_Msk      (_U_(0xFFFFFFFF) << PORT_OUTTGL_OUTTGL_Pos)
+#define PORT_OUTTGL_OUTTGL(value)   (PORT_OUTTGL_OUTTGL_Msk & ((value) << PORT_OUTTGL_OUTTGL_Pos))
+#define PORT_OUTTGL_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_OUTTGL) MASK Register */
+
+/* -------- PORT_IN : (PORT Offset: 0x20) (R/  32) GROUP Data Input Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t IN:32;            /*!< bit:  0..31  Port Data Input Value              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_IN_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_IN_OFFSET              0x20         /**< \brief (PORT_IN offset) Data Input Value */
+#define PORT_IN_RESETVALUE          _U_(0x00000000) /**< \brief (PORT_IN reset_value) Data Input Value */
+
+#define PORT_IN_IN_Pos              0            /**< \brief (PORT_IN) Port Data Input Value */
+#define PORT_IN_IN_Msk              (_U_(0xFFFFFFFF) << PORT_IN_IN_Pos)
+#define PORT_IN_IN(value)           (PORT_IN_IN_Msk & ((value) << PORT_IN_IN_Pos))
+#define PORT_IN_MASK                _U_(0xFFFFFFFF) /**< \brief (PORT_IN) MASK Register */
+
+/* -------- PORT_CTRL : (PORT Offset: 0x24) (R/W 32) GROUP Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SAMPLING:32;      /*!< bit:  0..31  Input Sampling Mode                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_CTRL_OFFSET            0x24         /**< \brief (PORT_CTRL offset) Control */
+#define PORT_CTRL_RESETVALUE        _U_(0x00000000) /**< \brief (PORT_CTRL reset_value) Control */
+
+#define PORT_CTRL_SAMPLING_Pos      0            /**< \brief (PORT_CTRL) Input Sampling Mode */
+#define PORT_CTRL_SAMPLING_Msk      (_U_(0xFFFFFFFF) << PORT_CTRL_SAMPLING_Pos)
+#define PORT_CTRL_SAMPLING(value)   (PORT_CTRL_SAMPLING_Msk & ((value) << PORT_CTRL_SAMPLING_Pos))
+#define PORT_CTRL_MASK              _U_(0xFFFFFFFF) /**< \brief (PORT_CTRL) MASK Register */
+
+/* -------- PORT_WRCONFIG : (PORT Offset: 0x28) ( /W 32) GROUP Write Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PINMASK:16;       /*!< bit:  0..15  Pin Mask for Multiple Pin Configuration */
+    uint32_t PMUXEN:1;         /*!< bit:     16  Peripheral Multiplexer Enable      */
+    uint32_t INEN:1;           /*!< bit:     17  Input Enable                       */
+    uint32_t PULLEN:1;         /*!< bit:     18  Pull Enable                        */
+    uint32_t :3;               /*!< bit: 19..21  Reserved                           */
+    uint32_t DRVSTR:1;         /*!< bit:     22  Output Driver Strength Selection   */
+    uint32_t :1;               /*!< bit:     23  Reserved                           */
+    uint32_t PMUX:4;           /*!< bit: 24..27  Peripheral Multiplexing            */
+    uint32_t WRPMUX:1;         /*!< bit:     28  Write PMUX                         */
+    uint32_t :1;               /*!< bit:     29  Reserved                           */
+    uint32_t WRPINCFG:1;       /*!< bit:     30  Write PINCFG                       */
+    uint32_t HWSEL:1;          /*!< bit:     31  Half-Word Select                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_WRCONFIG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_WRCONFIG_OFFSET        0x28         /**< \brief (PORT_WRCONFIG offset) Write Configuration */
+#define PORT_WRCONFIG_RESETVALUE    _U_(0x00000000) /**< \brief (PORT_WRCONFIG reset_value) Write Configuration */
+
+#define PORT_WRCONFIG_PINMASK_Pos   0            /**< \brief (PORT_WRCONFIG) Pin Mask for Multiple Pin Configuration */
+#define PORT_WRCONFIG_PINMASK_Msk   (_U_(0xFFFF) << PORT_WRCONFIG_PINMASK_Pos)
+#define PORT_WRCONFIG_PINMASK(value) (PORT_WRCONFIG_PINMASK_Msk & ((value) << PORT_WRCONFIG_PINMASK_Pos))
+#define PORT_WRCONFIG_PMUXEN_Pos    16           /**< \brief (PORT_WRCONFIG) Peripheral Multiplexer Enable */
+#define PORT_WRCONFIG_PMUXEN        (_U_(0x1) << PORT_WRCONFIG_PMUXEN_Pos)
+#define PORT_WRCONFIG_INEN_Pos      17           /**< \brief (PORT_WRCONFIG) Input Enable */
+#define PORT_WRCONFIG_INEN          (_U_(0x1) << PORT_WRCONFIG_INEN_Pos)
+#define PORT_WRCONFIG_PULLEN_Pos    18           /**< \brief (PORT_WRCONFIG) Pull Enable */
+#define PORT_WRCONFIG_PULLEN        (_U_(0x1) << PORT_WRCONFIG_PULLEN_Pos)
+#define PORT_WRCONFIG_DRVSTR_Pos    22           /**< \brief (PORT_WRCONFIG) Output Driver Strength Selection */
+#define PORT_WRCONFIG_DRVSTR        (_U_(0x1) << PORT_WRCONFIG_DRVSTR_Pos)
+#define PORT_WRCONFIG_PMUX_Pos      24           /**< \brief (PORT_WRCONFIG) Peripheral Multiplexing */
+#define PORT_WRCONFIG_PMUX_Msk      (_U_(0xF) << PORT_WRCONFIG_PMUX_Pos)
+#define PORT_WRCONFIG_PMUX(value)   (PORT_WRCONFIG_PMUX_Msk & ((value) << PORT_WRCONFIG_PMUX_Pos))
+#define PORT_WRCONFIG_WRPMUX_Pos    28           /**< \brief (PORT_WRCONFIG) Write PMUX */
+#define PORT_WRCONFIG_WRPMUX        (_U_(0x1) << PORT_WRCONFIG_WRPMUX_Pos)
+#define PORT_WRCONFIG_WRPINCFG_Pos  30           /**< \brief (PORT_WRCONFIG) Write PINCFG */
+#define PORT_WRCONFIG_WRPINCFG      (_U_(0x1) << PORT_WRCONFIG_WRPINCFG_Pos)
+#define PORT_WRCONFIG_HWSEL_Pos     31           /**< \brief (PORT_WRCONFIG) Half-Word Select */
+#define PORT_WRCONFIG_HWSEL         (_U_(0x1) << PORT_WRCONFIG_HWSEL_Pos)
+#define PORT_WRCONFIG_MASK          _U_(0xDF47FFFF) /**< \brief (PORT_WRCONFIG) MASK Register */
+
+/* -------- PORT_PMUX : (PORT Offset: 0x30) (R/W  8) GROUP Peripheral Multiplexing n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PMUXE:4;          /*!< bit:  0.. 3  Peripheral Multiplexing Even       */
+    uint8_t  PMUXO:4;          /*!< bit:  4.. 7  Peripheral Multiplexing Odd        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PORT_PMUX_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_PMUX_OFFSET            0x30         /**< \brief (PORT_PMUX offset) Peripheral Multiplexing n */
+#define PORT_PMUX_RESETVALUE        _U_(0x00)    /**< \brief (PORT_PMUX reset_value) Peripheral Multiplexing n */
+
+#define PORT_PMUX_PMUXE_Pos         0            /**< \brief (PORT_PMUX) Peripheral Multiplexing Even */
+#define PORT_PMUX_PMUXE_Msk         (_U_(0xF) << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE(value)      (PORT_PMUX_PMUXE_Msk & ((value) << PORT_PMUX_PMUXE_Pos))
+#define   PORT_PMUX_PMUXE_A_Val           _U_(0x0)   /**< \brief (PORT_PMUX) Peripheral function A selected */
+#define   PORT_PMUX_PMUXE_B_Val           _U_(0x1)   /**< \brief (PORT_PMUX) Peripheral function B selected */
+#define   PORT_PMUX_PMUXE_C_Val           _U_(0x2)   /**< \brief (PORT_PMUX) Peripheral function C selected */
+#define   PORT_PMUX_PMUXE_D_Val           _U_(0x3)   /**< \brief (PORT_PMUX) Peripheral function D selected */
+#define   PORT_PMUX_PMUXE_E_Val           _U_(0x4)   /**< \brief (PORT_PMUX) Peripheral function E selected */
+#define   PORT_PMUX_PMUXE_F_Val           _U_(0x5)   /**< \brief (PORT_PMUX) Peripheral function F selected */
+#define   PORT_PMUX_PMUXE_G_Val           _U_(0x6)   /**< \brief (PORT_PMUX) Peripheral function G selected */
+#define   PORT_PMUX_PMUXE_H_Val           _U_(0x7)   /**< \brief (PORT_PMUX) Peripheral function H selected */
+#define PORT_PMUX_PMUXE_A           (PORT_PMUX_PMUXE_A_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE_B           (PORT_PMUX_PMUXE_B_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE_C           (PORT_PMUX_PMUXE_C_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE_D           (PORT_PMUX_PMUXE_D_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE_E           (PORT_PMUX_PMUXE_E_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE_F           (PORT_PMUX_PMUXE_F_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE_G           (PORT_PMUX_PMUXE_G_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE_H           (PORT_PMUX_PMUXE_H_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXO_Pos         4            /**< \brief (PORT_PMUX) Peripheral Multiplexing Odd */
+#define PORT_PMUX_PMUXO_Msk         (_U_(0xF) << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO(value)      (PORT_PMUX_PMUXO_Msk & ((value) << PORT_PMUX_PMUXO_Pos))
+#define   PORT_PMUX_PMUXO_A_Val           _U_(0x0)   /**< \brief (PORT_PMUX) Peripheral function A selected */
+#define   PORT_PMUX_PMUXO_B_Val           _U_(0x1)   /**< \brief (PORT_PMUX) Peripheral function B selected */
+#define   PORT_PMUX_PMUXO_C_Val           _U_(0x2)   /**< \brief (PORT_PMUX) Peripheral function C selected */
+#define   PORT_PMUX_PMUXO_D_Val           _U_(0x3)   /**< \brief (PORT_PMUX) Peripheral function D selected */
+#define   PORT_PMUX_PMUXO_E_Val           _U_(0x4)   /**< \brief (PORT_PMUX) Peripheral function E selected */
+#define   PORT_PMUX_PMUXO_F_Val           _U_(0x5)   /**< \brief (PORT_PMUX) Peripheral function F selected */
+#define   PORT_PMUX_PMUXO_G_Val           _U_(0x6)   /**< \brief (PORT_PMUX) Peripheral function G selected */
+#define   PORT_PMUX_PMUXO_H_Val           _U_(0x7)   /**< \brief (PORT_PMUX) Peripheral function H selected */
+#define PORT_PMUX_PMUXO_A           (PORT_PMUX_PMUXO_A_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO_B           (PORT_PMUX_PMUXO_B_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO_C           (PORT_PMUX_PMUXO_C_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO_D           (PORT_PMUX_PMUXO_D_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO_E           (PORT_PMUX_PMUXO_E_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO_F           (PORT_PMUX_PMUXO_F_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO_G           (PORT_PMUX_PMUXO_G_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO_H           (PORT_PMUX_PMUXO_H_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_MASK              _U_(0xFF)    /**< \brief (PORT_PMUX) MASK Register */
+
+/* -------- PORT_PINCFG : (PORT Offset: 0x40) (R/W  8) GROUP Pin Configuration n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PMUXEN:1;         /*!< bit:      0  Peripheral Multiplexer Enable      */
+    uint8_t  INEN:1;           /*!< bit:      1  Input Enable                       */
+    uint8_t  PULLEN:1;         /*!< bit:      2  Pull Enable                        */
+    uint8_t  :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint8_t  DRVSTR:1;         /*!< bit:      6  Output Driver Strength Selection   */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PORT_PINCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_PINCFG_OFFSET          0x40         /**< \brief (PORT_PINCFG offset) Pin Configuration n */
+#define PORT_PINCFG_RESETVALUE      _U_(0x00)    /**< \brief (PORT_PINCFG reset_value) Pin Configuration n */
+
+#define PORT_PINCFG_PMUXEN_Pos      0            /**< \brief (PORT_PINCFG) Peripheral Multiplexer Enable */
+#define PORT_PINCFG_PMUXEN          (_U_(0x1) << PORT_PINCFG_PMUXEN_Pos)
+#define PORT_PINCFG_INEN_Pos        1            /**< \brief (PORT_PINCFG) Input Enable */
+#define PORT_PINCFG_INEN            (_U_(0x1) << PORT_PINCFG_INEN_Pos)
+#define PORT_PINCFG_PULLEN_Pos      2            /**< \brief (PORT_PINCFG) Pull Enable */
+#define PORT_PINCFG_PULLEN          (_U_(0x1) << PORT_PINCFG_PULLEN_Pos)
+#define PORT_PINCFG_DRVSTR_Pos      6            /**< \brief (PORT_PINCFG) Output Driver Strength Selection */
+#define PORT_PINCFG_DRVSTR          (_U_(0x1) << PORT_PINCFG_DRVSTR_Pos)
+#define PORT_PINCFG_MASK            _U_(0x47)    /**< \brief (PORT_PINCFG) MASK Register */
+
+/** \brief PortGroup hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO PORT_DIR_Type             DIR;         /**< \brief Offset: 0x00 (R/W 32) Data Direction */
+  __IO PORT_DIRCLR_Type          DIRCLR;      /**< \brief Offset: 0x04 (R/W 32) Data Direction Clear */
+  __IO PORT_DIRSET_Type          DIRSET;      /**< \brief Offset: 0x08 (R/W 32) Data Direction Set */
+  __IO PORT_DIRTGL_Type          DIRTGL;      /**< \brief Offset: 0x0C (R/W 32) Data Direction Toggle */
+  __IO PORT_OUT_Type             OUT;         /**< \brief Offset: 0x10 (R/W 32) Data Output Value */
+  __IO PORT_OUTCLR_Type          OUTCLR;      /**< \brief Offset: 0x14 (R/W 32) Data Output Value Clear */
+  __IO PORT_OUTSET_Type          OUTSET;      /**< \brief Offset: 0x18 (R/W 32) Data Output Value Set */
+  __IO PORT_OUTTGL_Type          OUTTGL;      /**< \brief Offset: 0x1C (R/W 32) Data Output Value Toggle */
+  __I  PORT_IN_Type              IN;          /**< \brief Offset: 0x20 (R/  32) Data Input Value */
+  __IO PORT_CTRL_Type            CTRL;        /**< \brief Offset: 0x24 (R/W 32) Control */
+  __O  PORT_WRCONFIG_Type        WRCONFIG;    /**< \brief Offset: 0x28 ( /W 32) Write Configuration */
+       RoReg8                    Reserved1[0x4];
+  __IO PORT_PMUX_Type            PMUX[16];    /**< \brief Offset: 0x30 (R/W  8) Peripheral Multiplexing n */
+  __IO PORT_PINCFG_Type          PINCFG[32];  /**< \brief Offset: 0x40 (R/W  8) Pin Configuration n */
+       RoReg8                    Reserved2[0x20];
+} PortGroup;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief PORT hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+       PortGroup                 Group[2];    /**< \brief Offset: 0x00 PortGroup groups [GROUPS] */
+} Port;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_PORT_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/rtc.h
@@ -1,0 +1,1054 @@
+/**
+ * \file
+ *
+ * \brief Component description for RTC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_RTC_COMPONENT_
+#define _SAMD20_RTC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RTC */
+/* ========================================================================== */
+/** \addtogroup SAMD20_RTC Real-Time Counter */
+/*@{*/
+
+#define RTC_U2202
+#define REV_RTC                     0x101
+
+/* -------- RTC_MODE0_CTRL : (RTC Offset: 0x00) (R/W 16) MODE0 MODE0 Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t MODE:2;           /*!< bit:  2.. 3  Operating Mode                     */
+    uint16_t :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint16_t MATCHCLR:1;       /*!< bit:      7  Clear on Match                     */
+    uint16_t PRESCALER:4;      /*!< bit:  8..11  Prescaler                          */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_CTRL_OFFSET       0x00         /**< \brief (RTC_MODE0_CTRL offset) MODE0 Control */
+#define RTC_MODE0_CTRL_RESETVALUE   _U_(0x0000)  /**< \brief (RTC_MODE0_CTRL reset_value) MODE0 Control */
+
+#define RTC_MODE0_CTRL_SWRST_Pos    0            /**< \brief (RTC_MODE0_CTRL) Software Reset */
+#define RTC_MODE0_CTRL_SWRST        (_U_(0x1) << RTC_MODE0_CTRL_SWRST_Pos)
+#define RTC_MODE0_CTRL_ENABLE_Pos   1            /**< \brief (RTC_MODE0_CTRL) Enable */
+#define RTC_MODE0_CTRL_ENABLE       (_U_(0x1) << RTC_MODE0_CTRL_ENABLE_Pos)
+#define RTC_MODE0_CTRL_MODE_Pos     2            /**< \brief (RTC_MODE0_CTRL) Operating Mode */
+#define RTC_MODE0_CTRL_MODE_Msk     (_U_(0x3) << RTC_MODE0_CTRL_MODE_Pos)
+#define RTC_MODE0_CTRL_MODE(value)  (RTC_MODE0_CTRL_MODE_Msk & ((value) << RTC_MODE0_CTRL_MODE_Pos))
+#define   RTC_MODE0_CTRL_MODE_COUNT32_Val _U_(0x0)   /**< \brief (RTC_MODE0_CTRL) Mode 0: 32-bit Counter */
+#define   RTC_MODE0_CTRL_MODE_COUNT16_Val _U_(0x1)   /**< \brief (RTC_MODE0_CTRL) Mode 1: 16-bit Counter */
+#define   RTC_MODE0_CTRL_MODE_CLOCK_Val   _U_(0x2)   /**< \brief (RTC_MODE0_CTRL) Mode 2: Clock/Calendar */
+#define RTC_MODE0_CTRL_MODE_COUNT32 (RTC_MODE0_CTRL_MODE_COUNT32_Val << RTC_MODE0_CTRL_MODE_Pos)
+#define RTC_MODE0_CTRL_MODE_COUNT16 (RTC_MODE0_CTRL_MODE_COUNT16_Val << RTC_MODE0_CTRL_MODE_Pos)
+#define RTC_MODE0_CTRL_MODE_CLOCK   (RTC_MODE0_CTRL_MODE_CLOCK_Val << RTC_MODE0_CTRL_MODE_Pos)
+#define RTC_MODE0_CTRL_MATCHCLR_Pos 7            /**< \brief (RTC_MODE0_CTRL) Clear on Match */
+#define RTC_MODE0_CTRL_MATCHCLR     (_U_(0x1) << RTC_MODE0_CTRL_MATCHCLR_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_Pos 8            /**< \brief (RTC_MODE0_CTRL) Prescaler */
+#define RTC_MODE0_CTRL_PRESCALER_Msk (_U_(0xF) << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER(value) (RTC_MODE0_CTRL_PRESCALER_Msk & ((value) << RTC_MODE0_CTRL_PRESCALER_Pos))
+#define   RTC_MODE0_CTRL_PRESCALER_DIV1_Val _U_(0x0)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/1 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV2_Val _U_(0x1)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/2 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV4_Val _U_(0x2)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/4 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV8_Val _U_(0x3)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/8 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV16_Val _U_(0x4)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/16 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV32_Val _U_(0x5)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/32 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV64_Val _U_(0x6)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/64 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV128_Val _U_(0x7)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/128 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV256_Val _U_(0x8)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/256 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV512_Val _U_(0x9)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/512 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV1024_Val _U_(0xA)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/1024 */
+#define RTC_MODE0_CTRL_PRESCALER_DIV1 (RTC_MODE0_CTRL_PRESCALER_DIV1_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV2 (RTC_MODE0_CTRL_PRESCALER_DIV2_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV4 (RTC_MODE0_CTRL_PRESCALER_DIV4_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV8 (RTC_MODE0_CTRL_PRESCALER_DIV8_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV16 (RTC_MODE0_CTRL_PRESCALER_DIV16_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV32 (RTC_MODE0_CTRL_PRESCALER_DIV32_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV64 (RTC_MODE0_CTRL_PRESCALER_DIV64_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV128 (RTC_MODE0_CTRL_PRESCALER_DIV128_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV256 (RTC_MODE0_CTRL_PRESCALER_DIV256_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV512 (RTC_MODE0_CTRL_PRESCALER_DIV512_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV1024 (RTC_MODE0_CTRL_PRESCALER_DIV1024_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_MASK         _U_(0x0F8F)  /**< \brief (RTC_MODE0_CTRL) MASK Register */
+
+/* -------- RTC_MODE1_CTRL : (RTC Offset: 0x00) (R/W 16) MODE1 MODE1 Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t MODE:2;           /*!< bit:  2.. 3  Operating Mode                     */
+    uint16_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint16_t PRESCALER:4;      /*!< bit:  8..11  Prescaler                          */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_CTRL_OFFSET       0x00         /**< \brief (RTC_MODE1_CTRL offset) MODE1 Control */
+#define RTC_MODE1_CTRL_RESETVALUE   _U_(0x0000)  /**< \brief (RTC_MODE1_CTRL reset_value) MODE1 Control */
+
+#define RTC_MODE1_CTRL_SWRST_Pos    0            /**< \brief (RTC_MODE1_CTRL) Software Reset */
+#define RTC_MODE1_CTRL_SWRST        (_U_(0x1) << RTC_MODE1_CTRL_SWRST_Pos)
+#define RTC_MODE1_CTRL_ENABLE_Pos   1            /**< \brief (RTC_MODE1_CTRL) Enable */
+#define RTC_MODE1_CTRL_ENABLE       (_U_(0x1) << RTC_MODE1_CTRL_ENABLE_Pos)
+#define RTC_MODE1_CTRL_MODE_Pos     2            /**< \brief (RTC_MODE1_CTRL) Operating Mode */
+#define RTC_MODE1_CTRL_MODE_Msk     (_U_(0x3) << RTC_MODE1_CTRL_MODE_Pos)
+#define RTC_MODE1_CTRL_MODE(value)  (RTC_MODE1_CTRL_MODE_Msk & ((value) << RTC_MODE1_CTRL_MODE_Pos))
+#define   RTC_MODE1_CTRL_MODE_COUNT32_Val _U_(0x0)   /**< \brief (RTC_MODE1_CTRL) Mode 0: 32-bit Counter */
+#define   RTC_MODE1_CTRL_MODE_COUNT16_Val _U_(0x1)   /**< \brief (RTC_MODE1_CTRL) Mode 1: 16-bit Counter */
+#define   RTC_MODE1_CTRL_MODE_CLOCK_Val   _U_(0x2)   /**< \brief (RTC_MODE1_CTRL) Mode 2: Clock/Calendar */
+#define RTC_MODE1_CTRL_MODE_COUNT32 (RTC_MODE1_CTRL_MODE_COUNT32_Val << RTC_MODE1_CTRL_MODE_Pos)
+#define RTC_MODE1_CTRL_MODE_COUNT16 (RTC_MODE1_CTRL_MODE_COUNT16_Val << RTC_MODE1_CTRL_MODE_Pos)
+#define RTC_MODE1_CTRL_MODE_CLOCK   (RTC_MODE1_CTRL_MODE_CLOCK_Val << RTC_MODE1_CTRL_MODE_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_Pos 8            /**< \brief (RTC_MODE1_CTRL) Prescaler */
+#define RTC_MODE1_CTRL_PRESCALER_Msk (_U_(0xF) << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER(value) (RTC_MODE1_CTRL_PRESCALER_Msk & ((value) << RTC_MODE1_CTRL_PRESCALER_Pos))
+#define   RTC_MODE1_CTRL_PRESCALER_DIV1_Val _U_(0x0)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/1 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV2_Val _U_(0x1)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/2 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV4_Val _U_(0x2)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/4 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV8_Val _U_(0x3)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/8 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV16_Val _U_(0x4)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/16 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV32_Val _U_(0x5)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/32 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV64_Val _U_(0x6)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/64 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV128_Val _U_(0x7)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/128 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV256_Val _U_(0x8)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/256 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV512_Val _U_(0x9)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/512 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV1024_Val _U_(0xA)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/1024 */
+#define RTC_MODE1_CTRL_PRESCALER_DIV1 (RTC_MODE1_CTRL_PRESCALER_DIV1_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV2 (RTC_MODE1_CTRL_PRESCALER_DIV2_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV4 (RTC_MODE1_CTRL_PRESCALER_DIV4_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV8 (RTC_MODE1_CTRL_PRESCALER_DIV8_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV16 (RTC_MODE1_CTRL_PRESCALER_DIV16_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV32 (RTC_MODE1_CTRL_PRESCALER_DIV32_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV64 (RTC_MODE1_CTRL_PRESCALER_DIV64_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV128 (RTC_MODE1_CTRL_PRESCALER_DIV128_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV256 (RTC_MODE1_CTRL_PRESCALER_DIV256_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV512 (RTC_MODE1_CTRL_PRESCALER_DIV512_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV1024 (RTC_MODE1_CTRL_PRESCALER_DIV1024_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_MASK         _U_(0x0F0F)  /**< \brief (RTC_MODE1_CTRL) MASK Register */
+
+/* -------- RTC_MODE2_CTRL : (RTC Offset: 0x00) (R/W 16) MODE2 MODE2 Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t MODE:2;           /*!< bit:  2.. 3  Operating Mode                     */
+    uint16_t :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint16_t CLKREP:1;         /*!< bit:      6  Clock Representation               */
+    uint16_t MATCHCLR:1;       /*!< bit:      7  Clear on Match                     */
+    uint16_t PRESCALER:4;      /*!< bit:  8..11  Prescaler                          */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_CTRL_OFFSET       0x00         /**< \brief (RTC_MODE2_CTRL offset) MODE2 Control */
+#define RTC_MODE2_CTRL_RESETVALUE   _U_(0x0000)  /**< \brief (RTC_MODE2_CTRL reset_value) MODE2 Control */
+
+#define RTC_MODE2_CTRL_SWRST_Pos    0            /**< \brief (RTC_MODE2_CTRL) Software Reset */
+#define RTC_MODE2_CTRL_SWRST        (_U_(0x1) << RTC_MODE2_CTRL_SWRST_Pos)
+#define RTC_MODE2_CTRL_ENABLE_Pos   1            /**< \brief (RTC_MODE2_CTRL) Enable */
+#define RTC_MODE2_CTRL_ENABLE       (_U_(0x1) << RTC_MODE2_CTRL_ENABLE_Pos)
+#define RTC_MODE2_CTRL_MODE_Pos     2            /**< \brief (RTC_MODE2_CTRL) Operating Mode */
+#define RTC_MODE2_CTRL_MODE_Msk     (_U_(0x3) << RTC_MODE2_CTRL_MODE_Pos)
+#define RTC_MODE2_CTRL_MODE(value)  (RTC_MODE2_CTRL_MODE_Msk & ((value) << RTC_MODE2_CTRL_MODE_Pos))
+#define   RTC_MODE2_CTRL_MODE_COUNT32_Val _U_(0x0)   /**< \brief (RTC_MODE2_CTRL) Mode 0: 32-bit Counter */
+#define   RTC_MODE2_CTRL_MODE_COUNT16_Val _U_(0x1)   /**< \brief (RTC_MODE2_CTRL) Mode 1: 16-bit Counter */
+#define   RTC_MODE2_CTRL_MODE_CLOCK_Val   _U_(0x2)   /**< \brief (RTC_MODE2_CTRL) Mode 2: Clock/Calendar */
+#define RTC_MODE2_CTRL_MODE_COUNT32 (RTC_MODE2_CTRL_MODE_COUNT32_Val << RTC_MODE2_CTRL_MODE_Pos)
+#define RTC_MODE2_CTRL_MODE_COUNT16 (RTC_MODE2_CTRL_MODE_COUNT16_Val << RTC_MODE2_CTRL_MODE_Pos)
+#define RTC_MODE2_CTRL_MODE_CLOCK   (RTC_MODE2_CTRL_MODE_CLOCK_Val << RTC_MODE2_CTRL_MODE_Pos)
+#define RTC_MODE2_CTRL_CLKREP_Pos   6            /**< \brief (RTC_MODE2_CTRL) Clock Representation */
+#define RTC_MODE2_CTRL_CLKREP       (_U_(0x1) << RTC_MODE2_CTRL_CLKREP_Pos)
+#define RTC_MODE2_CTRL_MATCHCLR_Pos 7            /**< \brief (RTC_MODE2_CTRL) Clear on Match */
+#define RTC_MODE2_CTRL_MATCHCLR     (_U_(0x1) << RTC_MODE2_CTRL_MATCHCLR_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_Pos 8            /**< \brief (RTC_MODE2_CTRL) Prescaler */
+#define RTC_MODE2_CTRL_PRESCALER_Msk (_U_(0xF) << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER(value) (RTC_MODE2_CTRL_PRESCALER_Msk & ((value) << RTC_MODE2_CTRL_PRESCALER_Pos))
+#define   RTC_MODE2_CTRL_PRESCALER_DIV1_Val _U_(0x0)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/1 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV2_Val _U_(0x1)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/2 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV4_Val _U_(0x2)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/4 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV8_Val _U_(0x3)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/8 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV16_Val _U_(0x4)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/16 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV32_Val _U_(0x5)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/32 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV64_Val _U_(0x6)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/64 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV128_Val _U_(0x7)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/128 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV256_Val _U_(0x8)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/256 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV512_Val _U_(0x9)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/512 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV1024_Val _U_(0xA)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/1024 */
+#define RTC_MODE2_CTRL_PRESCALER_DIV1 (RTC_MODE2_CTRL_PRESCALER_DIV1_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV2 (RTC_MODE2_CTRL_PRESCALER_DIV2_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV4 (RTC_MODE2_CTRL_PRESCALER_DIV4_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV8 (RTC_MODE2_CTRL_PRESCALER_DIV8_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV16 (RTC_MODE2_CTRL_PRESCALER_DIV16_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV32 (RTC_MODE2_CTRL_PRESCALER_DIV32_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV64 (RTC_MODE2_CTRL_PRESCALER_DIV64_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV128 (RTC_MODE2_CTRL_PRESCALER_DIV128_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV256 (RTC_MODE2_CTRL_PRESCALER_DIV256_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV512 (RTC_MODE2_CTRL_PRESCALER_DIV512_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV1024 (RTC_MODE2_CTRL_PRESCALER_DIV1024_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_MASK         _U_(0x0FCF)  /**< \brief (RTC_MODE2_CTRL) MASK Register */
+
+/* -------- RTC_READREQ : (RTC Offset: 0x02) (R/W 16) Read Request -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t ADDR:6;           /*!< bit:  0.. 5  Address                            */
+    uint16_t :8;               /*!< bit:  6..13  Reserved                           */
+    uint16_t RCONT:1;          /*!< bit:     14  Read Continuously                  */
+    uint16_t RREQ:1;           /*!< bit:     15  Read Request                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_READREQ_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_READREQ_OFFSET          0x02         /**< \brief (RTC_READREQ offset) Read Request */
+#define RTC_READREQ_RESETVALUE      _U_(0x0010)  /**< \brief (RTC_READREQ reset_value) Read Request */
+
+#define RTC_READREQ_ADDR_Pos        0            /**< \brief (RTC_READREQ) Address */
+#define RTC_READREQ_ADDR_Msk        (_U_(0x3F) << RTC_READREQ_ADDR_Pos)
+#define RTC_READREQ_ADDR(value)     (RTC_READREQ_ADDR_Msk & ((value) << RTC_READREQ_ADDR_Pos))
+#define RTC_READREQ_RCONT_Pos       14           /**< \brief (RTC_READREQ) Read Continuously */
+#define RTC_READREQ_RCONT           (_U_(0x1) << RTC_READREQ_RCONT_Pos)
+#define RTC_READREQ_RREQ_Pos        15           /**< \brief (RTC_READREQ) Read Request */
+#define RTC_READREQ_RREQ            (_U_(0x1) << RTC_READREQ_RREQ_Pos)
+#define RTC_READREQ_MASK            _U_(0xC03F)  /**< \brief (RTC_READREQ) MASK Register */
+
+/* -------- RTC_MODE0_EVCTRL : (RTC Offset: 0x04) (R/W 16) MODE0 MODE0 Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PEREO0:1;         /*!< bit:      0  Periodic Interval 0 Event Output Enable */
+    uint16_t PEREO1:1;         /*!< bit:      1  Periodic Interval 1 Event Output Enable */
+    uint16_t PEREO2:1;         /*!< bit:      2  Periodic Interval 2 Event Output Enable */
+    uint16_t PEREO3:1;         /*!< bit:      3  Periodic Interval 3 Event Output Enable */
+    uint16_t PEREO4:1;         /*!< bit:      4  Periodic Interval 4 Event Output Enable */
+    uint16_t PEREO5:1;         /*!< bit:      5  Periodic Interval 5 Event Output Enable */
+    uint16_t PEREO6:1;         /*!< bit:      6  Periodic Interval 6 Event Output Enable */
+    uint16_t PEREO7:1;         /*!< bit:      7  Periodic Interval 7 Event Output Enable */
+    uint16_t CMPEO0:1;         /*!< bit:      8  Compare 0 Event Output Enable      */
+    uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t OVFEO:1;          /*!< bit:     15  Overflow Event Output Enable       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t PEREO:8;          /*!< bit:  0.. 7  Periodic Interval x Event Output Enable */
+    uint16_t CMPEO:1;          /*!< bit:      8  Compare x Event Output Enable      */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_EVCTRL_OFFSET     0x04         /**< \brief (RTC_MODE0_EVCTRL offset) MODE0 Event Control */
+#define RTC_MODE0_EVCTRL_RESETVALUE _U_(0x0000)  /**< \brief (RTC_MODE0_EVCTRL reset_value) MODE0 Event Control */
+
+#define RTC_MODE0_EVCTRL_PEREO0_Pos 0            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 0 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO0     (_U_(1) << RTC_MODE0_EVCTRL_PEREO0_Pos)
+#define RTC_MODE0_EVCTRL_PEREO1_Pos 1            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 1 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO1     (_U_(1) << RTC_MODE0_EVCTRL_PEREO1_Pos)
+#define RTC_MODE0_EVCTRL_PEREO2_Pos 2            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 2 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO2     (_U_(1) << RTC_MODE0_EVCTRL_PEREO2_Pos)
+#define RTC_MODE0_EVCTRL_PEREO3_Pos 3            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 3 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO3     (_U_(1) << RTC_MODE0_EVCTRL_PEREO3_Pos)
+#define RTC_MODE0_EVCTRL_PEREO4_Pos 4            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 4 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO4     (_U_(1) << RTC_MODE0_EVCTRL_PEREO4_Pos)
+#define RTC_MODE0_EVCTRL_PEREO5_Pos 5            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 5 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO5     (_U_(1) << RTC_MODE0_EVCTRL_PEREO5_Pos)
+#define RTC_MODE0_EVCTRL_PEREO6_Pos 6            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 6 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO6     (_U_(1) << RTC_MODE0_EVCTRL_PEREO6_Pos)
+#define RTC_MODE0_EVCTRL_PEREO7_Pos 7            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 7 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO7     (_U_(1) << RTC_MODE0_EVCTRL_PEREO7_Pos)
+#define RTC_MODE0_EVCTRL_PEREO_Pos  0            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval x Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO_Msk  (_U_(0xFF) << RTC_MODE0_EVCTRL_PEREO_Pos)
+#define RTC_MODE0_EVCTRL_PEREO(value) (RTC_MODE0_EVCTRL_PEREO_Msk & ((value) << RTC_MODE0_EVCTRL_PEREO_Pos))
+#define RTC_MODE0_EVCTRL_CMPEO0_Pos 8            /**< \brief (RTC_MODE0_EVCTRL) Compare 0 Event Output Enable */
+#define RTC_MODE0_EVCTRL_CMPEO0     (_U_(1) << RTC_MODE0_EVCTRL_CMPEO0_Pos)
+#define RTC_MODE0_EVCTRL_CMPEO_Pos  8            /**< \brief (RTC_MODE0_EVCTRL) Compare x Event Output Enable */
+#define RTC_MODE0_EVCTRL_CMPEO_Msk  (_U_(0x1) << RTC_MODE0_EVCTRL_CMPEO_Pos)
+#define RTC_MODE0_EVCTRL_CMPEO(value) (RTC_MODE0_EVCTRL_CMPEO_Msk & ((value) << RTC_MODE0_EVCTRL_CMPEO_Pos))
+#define RTC_MODE0_EVCTRL_OVFEO_Pos  15           /**< \brief (RTC_MODE0_EVCTRL) Overflow Event Output Enable */
+#define RTC_MODE0_EVCTRL_OVFEO      (_U_(0x1) << RTC_MODE0_EVCTRL_OVFEO_Pos)
+#define RTC_MODE0_EVCTRL_MASK       _U_(0x81FF)  /**< \brief (RTC_MODE0_EVCTRL) MASK Register */
+
+/* -------- RTC_MODE1_EVCTRL : (RTC Offset: 0x04) (R/W 16) MODE1 MODE1 Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PEREO0:1;         /*!< bit:      0  Periodic Interval 0 Event Output Enable */
+    uint16_t PEREO1:1;         /*!< bit:      1  Periodic Interval 1 Event Output Enable */
+    uint16_t PEREO2:1;         /*!< bit:      2  Periodic Interval 2 Event Output Enable */
+    uint16_t PEREO3:1;         /*!< bit:      3  Periodic Interval 3 Event Output Enable */
+    uint16_t PEREO4:1;         /*!< bit:      4  Periodic Interval 4 Event Output Enable */
+    uint16_t PEREO5:1;         /*!< bit:      5  Periodic Interval 5 Event Output Enable */
+    uint16_t PEREO6:1;         /*!< bit:      6  Periodic Interval 6 Event Output Enable */
+    uint16_t PEREO7:1;         /*!< bit:      7  Periodic Interval 7 Event Output Enable */
+    uint16_t CMPEO0:1;         /*!< bit:      8  Compare 0 Event Output Enable      */
+    uint16_t CMPEO1:1;         /*!< bit:      9  Compare 1 Event Output Enable      */
+    uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    uint16_t OVFEO:1;          /*!< bit:     15  Overflow Event Output Enable       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t PEREO:8;          /*!< bit:  0.. 7  Periodic Interval x Event Output Enable */
+    uint16_t CMPEO:2;          /*!< bit:  8.. 9  Compare x Event Output Enable      */
+    uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_EVCTRL_OFFSET     0x04         /**< \brief (RTC_MODE1_EVCTRL offset) MODE1 Event Control */
+#define RTC_MODE1_EVCTRL_RESETVALUE _U_(0x0000)  /**< \brief (RTC_MODE1_EVCTRL reset_value) MODE1 Event Control */
+
+#define RTC_MODE1_EVCTRL_PEREO0_Pos 0            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 0 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO0     (_U_(1) << RTC_MODE1_EVCTRL_PEREO0_Pos)
+#define RTC_MODE1_EVCTRL_PEREO1_Pos 1            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 1 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO1     (_U_(1) << RTC_MODE1_EVCTRL_PEREO1_Pos)
+#define RTC_MODE1_EVCTRL_PEREO2_Pos 2            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 2 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO2     (_U_(1) << RTC_MODE1_EVCTRL_PEREO2_Pos)
+#define RTC_MODE1_EVCTRL_PEREO3_Pos 3            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 3 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO3     (_U_(1) << RTC_MODE1_EVCTRL_PEREO3_Pos)
+#define RTC_MODE1_EVCTRL_PEREO4_Pos 4            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 4 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO4     (_U_(1) << RTC_MODE1_EVCTRL_PEREO4_Pos)
+#define RTC_MODE1_EVCTRL_PEREO5_Pos 5            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 5 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO5     (_U_(1) << RTC_MODE1_EVCTRL_PEREO5_Pos)
+#define RTC_MODE1_EVCTRL_PEREO6_Pos 6            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 6 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO6     (_U_(1) << RTC_MODE1_EVCTRL_PEREO6_Pos)
+#define RTC_MODE1_EVCTRL_PEREO7_Pos 7            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 7 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO7     (_U_(1) << RTC_MODE1_EVCTRL_PEREO7_Pos)
+#define RTC_MODE1_EVCTRL_PEREO_Pos  0            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval x Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO_Msk  (_U_(0xFF) << RTC_MODE1_EVCTRL_PEREO_Pos)
+#define RTC_MODE1_EVCTRL_PEREO(value) (RTC_MODE1_EVCTRL_PEREO_Msk & ((value) << RTC_MODE1_EVCTRL_PEREO_Pos))
+#define RTC_MODE1_EVCTRL_CMPEO0_Pos 8            /**< \brief (RTC_MODE1_EVCTRL) Compare 0 Event Output Enable */
+#define RTC_MODE1_EVCTRL_CMPEO0     (_U_(1) << RTC_MODE1_EVCTRL_CMPEO0_Pos)
+#define RTC_MODE1_EVCTRL_CMPEO1_Pos 9            /**< \brief (RTC_MODE1_EVCTRL) Compare 1 Event Output Enable */
+#define RTC_MODE1_EVCTRL_CMPEO1     (_U_(1) << RTC_MODE1_EVCTRL_CMPEO1_Pos)
+#define RTC_MODE1_EVCTRL_CMPEO_Pos  8            /**< \brief (RTC_MODE1_EVCTRL) Compare x Event Output Enable */
+#define RTC_MODE1_EVCTRL_CMPEO_Msk  (_U_(0x3) << RTC_MODE1_EVCTRL_CMPEO_Pos)
+#define RTC_MODE1_EVCTRL_CMPEO(value) (RTC_MODE1_EVCTRL_CMPEO_Msk & ((value) << RTC_MODE1_EVCTRL_CMPEO_Pos))
+#define RTC_MODE1_EVCTRL_OVFEO_Pos  15           /**< \brief (RTC_MODE1_EVCTRL) Overflow Event Output Enable */
+#define RTC_MODE1_EVCTRL_OVFEO      (_U_(0x1) << RTC_MODE1_EVCTRL_OVFEO_Pos)
+#define RTC_MODE1_EVCTRL_MASK       _U_(0x83FF)  /**< \brief (RTC_MODE1_EVCTRL) MASK Register */
+
+/* -------- RTC_MODE2_EVCTRL : (RTC Offset: 0x04) (R/W 16) MODE2 MODE2 Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PEREO0:1;         /*!< bit:      0  Periodic Interval 0 Event Output Enable */
+    uint16_t PEREO1:1;         /*!< bit:      1  Periodic Interval 1 Event Output Enable */
+    uint16_t PEREO2:1;         /*!< bit:      2  Periodic Interval 2 Event Output Enable */
+    uint16_t PEREO3:1;         /*!< bit:      3  Periodic Interval 3 Event Output Enable */
+    uint16_t PEREO4:1;         /*!< bit:      4  Periodic Interval 4 Event Output Enable */
+    uint16_t PEREO5:1;         /*!< bit:      5  Periodic Interval 5 Event Output Enable */
+    uint16_t PEREO6:1;         /*!< bit:      6  Periodic Interval 6 Event Output Enable */
+    uint16_t PEREO7:1;         /*!< bit:      7  Periodic Interval 7 Event Output Enable */
+    uint16_t ALARMEO0:1;       /*!< bit:      8  Alarm 0 Event Output Enable        */
+    uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t OVFEO:1;          /*!< bit:     15  Overflow Event Output Enable       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t PEREO:8;          /*!< bit:  0.. 7  Periodic Interval x Event Output Enable */
+    uint16_t ALARMEO:1;        /*!< bit:      8  Alarm x Event Output Enable        */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_EVCTRL_OFFSET     0x04         /**< \brief (RTC_MODE2_EVCTRL offset) MODE2 Event Control */
+#define RTC_MODE2_EVCTRL_RESETVALUE _U_(0x0000)  /**< \brief (RTC_MODE2_EVCTRL reset_value) MODE2 Event Control */
+
+#define RTC_MODE2_EVCTRL_PEREO0_Pos 0            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 0 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO0     (_U_(1) << RTC_MODE2_EVCTRL_PEREO0_Pos)
+#define RTC_MODE2_EVCTRL_PEREO1_Pos 1            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 1 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO1     (_U_(1) << RTC_MODE2_EVCTRL_PEREO1_Pos)
+#define RTC_MODE2_EVCTRL_PEREO2_Pos 2            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 2 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO2     (_U_(1) << RTC_MODE2_EVCTRL_PEREO2_Pos)
+#define RTC_MODE2_EVCTRL_PEREO3_Pos 3            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 3 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO3     (_U_(1) << RTC_MODE2_EVCTRL_PEREO3_Pos)
+#define RTC_MODE2_EVCTRL_PEREO4_Pos 4            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 4 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO4     (_U_(1) << RTC_MODE2_EVCTRL_PEREO4_Pos)
+#define RTC_MODE2_EVCTRL_PEREO5_Pos 5            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 5 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO5     (_U_(1) << RTC_MODE2_EVCTRL_PEREO5_Pos)
+#define RTC_MODE2_EVCTRL_PEREO6_Pos 6            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 6 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO6     (_U_(1) << RTC_MODE2_EVCTRL_PEREO6_Pos)
+#define RTC_MODE2_EVCTRL_PEREO7_Pos 7            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 7 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO7     (_U_(1) << RTC_MODE2_EVCTRL_PEREO7_Pos)
+#define RTC_MODE2_EVCTRL_PEREO_Pos  0            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval x Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO_Msk  (_U_(0xFF) << RTC_MODE2_EVCTRL_PEREO_Pos)
+#define RTC_MODE2_EVCTRL_PEREO(value) (RTC_MODE2_EVCTRL_PEREO_Msk & ((value) << RTC_MODE2_EVCTRL_PEREO_Pos))
+#define RTC_MODE2_EVCTRL_ALARMEO0_Pos 8            /**< \brief (RTC_MODE2_EVCTRL) Alarm 0 Event Output Enable */
+#define RTC_MODE2_EVCTRL_ALARMEO0   (_U_(1) << RTC_MODE2_EVCTRL_ALARMEO0_Pos)
+#define RTC_MODE2_EVCTRL_ALARMEO_Pos 8            /**< \brief (RTC_MODE2_EVCTRL) Alarm x Event Output Enable */
+#define RTC_MODE2_EVCTRL_ALARMEO_Msk (_U_(0x1) << RTC_MODE2_EVCTRL_ALARMEO_Pos)
+#define RTC_MODE2_EVCTRL_ALARMEO(value) (RTC_MODE2_EVCTRL_ALARMEO_Msk & ((value) << RTC_MODE2_EVCTRL_ALARMEO_Pos))
+#define RTC_MODE2_EVCTRL_OVFEO_Pos  15           /**< \brief (RTC_MODE2_EVCTRL) Overflow Event Output Enable */
+#define RTC_MODE2_EVCTRL_OVFEO      (_U_(0x1) << RTC_MODE2_EVCTRL_OVFEO_Pos)
+#define RTC_MODE2_EVCTRL_MASK       _U_(0x81FF)  /**< \brief (RTC_MODE2_EVCTRL) MASK Register */
+
+/* -------- RTC_MODE0_INTENCLR : (RTC Offset: 0x06) (R/W  8) MODE0 MODE0 Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CMP0:1;           /*!< bit:      0  Compare 0 Interrupt Enable         */
+    uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready Interrupt Enable */
+    uint8_t  OVF:1;            /*!< bit:      7  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  CMP:1;            /*!< bit:      0  Compare x Interrupt Enable         */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE0_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_INTENCLR_OFFSET   0x06         /**< \brief (RTC_MODE0_INTENCLR offset) MODE0 Interrupt Enable Clear */
+#define RTC_MODE0_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE0_INTENCLR reset_value) MODE0 Interrupt Enable Clear */
+
+#define RTC_MODE0_INTENCLR_CMP0_Pos 0            /**< \brief (RTC_MODE0_INTENCLR) Compare 0 Interrupt Enable */
+#define RTC_MODE0_INTENCLR_CMP0     (_U_(1) << RTC_MODE0_INTENCLR_CMP0_Pos)
+#define RTC_MODE0_INTENCLR_CMP_Pos  0            /**< \brief (RTC_MODE0_INTENCLR) Compare x Interrupt Enable */
+#define RTC_MODE0_INTENCLR_CMP_Msk  (_U_(0x1) << RTC_MODE0_INTENCLR_CMP_Pos)
+#define RTC_MODE0_INTENCLR_CMP(value) (RTC_MODE0_INTENCLR_CMP_Msk & ((value) << RTC_MODE0_INTENCLR_CMP_Pos))
+#define RTC_MODE0_INTENCLR_SYNCRDY_Pos 6            /**< \brief (RTC_MODE0_INTENCLR) Synchronization Ready Interrupt Enable */
+#define RTC_MODE0_INTENCLR_SYNCRDY  (_U_(0x1) << RTC_MODE0_INTENCLR_SYNCRDY_Pos)
+#define RTC_MODE0_INTENCLR_OVF_Pos  7            /**< \brief (RTC_MODE0_INTENCLR) Overflow Interrupt Enable */
+#define RTC_MODE0_INTENCLR_OVF      (_U_(0x1) << RTC_MODE0_INTENCLR_OVF_Pos)
+#define RTC_MODE0_INTENCLR_MASK     _U_(0xC1)    /**< \brief (RTC_MODE0_INTENCLR) MASK Register */
+
+/* -------- RTC_MODE1_INTENCLR : (RTC Offset: 0x06) (R/W  8) MODE1 MODE1 Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CMP0:1;           /*!< bit:      0  Compare 0 Interrupt Enable         */
+    uint8_t  CMP1:1;           /*!< bit:      1  Compare 1 Interrupt Enable         */
+    uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready Interrupt Enable */
+    uint8_t  OVF:1;            /*!< bit:      7  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x Interrupt Enable         */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE1_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_INTENCLR_OFFSET   0x06         /**< \brief (RTC_MODE1_INTENCLR offset) MODE1 Interrupt Enable Clear */
+#define RTC_MODE1_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE1_INTENCLR reset_value) MODE1 Interrupt Enable Clear */
+
+#define RTC_MODE1_INTENCLR_CMP0_Pos 0            /**< \brief (RTC_MODE1_INTENCLR) Compare 0 Interrupt Enable */
+#define RTC_MODE1_INTENCLR_CMP0     (_U_(1) << RTC_MODE1_INTENCLR_CMP0_Pos)
+#define RTC_MODE1_INTENCLR_CMP1_Pos 1            /**< \brief (RTC_MODE1_INTENCLR) Compare 1 Interrupt Enable */
+#define RTC_MODE1_INTENCLR_CMP1     (_U_(1) << RTC_MODE1_INTENCLR_CMP1_Pos)
+#define RTC_MODE1_INTENCLR_CMP_Pos  0            /**< \brief (RTC_MODE1_INTENCLR) Compare x Interrupt Enable */
+#define RTC_MODE1_INTENCLR_CMP_Msk  (_U_(0x3) << RTC_MODE1_INTENCLR_CMP_Pos)
+#define RTC_MODE1_INTENCLR_CMP(value) (RTC_MODE1_INTENCLR_CMP_Msk & ((value) << RTC_MODE1_INTENCLR_CMP_Pos))
+#define RTC_MODE1_INTENCLR_SYNCRDY_Pos 6            /**< \brief (RTC_MODE1_INTENCLR) Synchronization Ready Interrupt Enable */
+#define RTC_MODE1_INTENCLR_SYNCRDY  (_U_(0x1) << RTC_MODE1_INTENCLR_SYNCRDY_Pos)
+#define RTC_MODE1_INTENCLR_OVF_Pos  7            /**< \brief (RTC_MODE1_INTENCLR) Overflow Interrupt Enable */
+#define RTC_MODE1_INTENCLR_OVF      (_U_(0x1) << RTC_MODE1_INTENCLR_OVF_Pos)
+#define RTC_MODE1_INTENCLR_MASK     _U_(0xC3)    /**< \brief (RTC_MODE1_INTENCLR) MASK Register */
+
+/* -------- RTC_MODE2_INTENCLR : (RTC Offset: 0x06) (R/W  8) MODE2 MODE2 Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0 Interrupt Enable           */
+    uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready Interrupt Enable */
+    uint8_t  OVF:1;            /*!< bit:      7  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  ALARM:1;          /*!< bit:      0  Alarm x Interrupt Enable           */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE2_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_INTENCLR_OFFSET   0x06         /**< \brief (RTC_MODE2_INTENCLR offset) MODE2 Interrupt Enable Clear */
+#define RTC_MODE2_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE2_INTENCLR reset_value) MODE2 Interrupt Enable Clear */
+
+#define RTC_MODE2_INTENCLR_ALARM0_Pos 0            /**< \brief (RTC_MODE2_INTENCLR) Alarm 0 Interrupt Enable */
+#define RTC_MODE2_INTENCLR_ALARM0   (_U_(1) << RTC_MODE2_INTENCLR_ALARM0_Pos)
+#define RTC_MODE2_INTENCLR_ALARM_Pos 0            /**< \brief (RTC_MODE2_INTENCLR) Alarm x Interrupt Enable */
+#define RTC_MODE2_INTENCLR_ALARM_Msk (_U_(0x1) << RTC_MODE2_INTENCLR_ALARM_Pos)
+#define RTC_MODE2_INTENCLR_ALARM(value) (RTC_MODE2_INTENCLR_ALARM_Msk & ((value) << RTC_MODE2_INTENCLR_ALARM_Pos))
+#define RTC_MODE2_INTENCLR_SYNCRDY_Pos 6            /**< \brief (RTC_MODE2_INTENCLR) Synchronization Ready Interrupt Enable */
+#define RTC_MODE2_INTENCLR_SYNCRDY  (_U_(0x1) << RTC_MODE2_INTENCLR_SYNCRDY_Pos)
+#define RTC_MODE2_INTENCLR_OVF_Pos  7            /**< \brief (RTC_MODE2_INTENCLR) Overflow Interrupt Enable */
+#define RTC_MODE2_INTENCLR_OVF      (_U_(0x1) << RTC_MODE2_INTENCLR_OVF_Pos)
+#define RTC_MODE2_INTENCLR_MASK     _U_(0xC1)    /**< \brief (RTC_MODE2_INTENCLR) MASK Register */
+
+/* -------- RTC_MODE0_INTENSET : (RTC Offset: 0x07) (R/W  8) MODE0 MODE0 Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CMP0:1;           /*!< bit:      0  Compare 0 Interrupt Enable         */
+    uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready Interrupt Enable */
+    uint8_t  OVF:1;            /*!< bit:      7  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  CMP:1;            /*!< bit:      0  Compare x Interrupt Enable         */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE0_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_INTENSET_OFFSET   0x07         /**< \brief (RTC_MODE0_INTENSET offset) MODE0 Interrupt Enable Set */
+#define RTC_MODE0_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE0_INTENSET reset_value) MODE0 Interrupt Enable Set */
+
+#define RTC_MODE0_INTENSET_CMP0_Pos 0            /**< \brief (RTC_MODE0_INTENSET) Compare 0 Interrupt Enable */
+#define RTC_MODE0_INTENSET_CMP0     (_U_(1) << RTC_MODE0_INTENSET_CMP0_Pos)
+#define RTC_MODE0_INTENSET_CMP_Pos  0            /**< \brief (RTC_MODE0_INTENSET) Compare x Interrupt Enable */
+#define RTC_MODE0_INTENSET_CMP_Msk  (_U_(0x1) << RTC_MODE0_INTENSET_CMP_Pos)
+#define RTC_MODE0_INTENSET_CMP(value) (RTC_MODE0_INTENSET_CMP_Msk & ((value) << RTC_MODE0_INTENSET_CMP_Pos))
+#define RTC_MODE0_INTENSET_SYNCRDY_Pos 6            /**< \brief (RTC_MODE0_INTENSET) Synchronization Ready Interrupt Enable */
+#define RTC_MODE0_INTENSET_SYNCRDY  (_U_(0x1) << RTC_MODE0_INTENSET_SYNCRDY_Pos)
+#define RTC_MODE0_INTENSET_OVF_Pos  7            /**< \brief (RTC_MODE0_INTENSET) Overflow Interrupt Enable */
+#define RTC_MODE0_INTENSET_OVF      (_U_(0x1) << RTC_MODE0_INTENSET_OVF_Pos)
+#define RTC_MODE0_INTENSET_MASK     _U_(0xC1)    /**< \brief (RTC_MODE0_INTENSET) MASK Register */
+
+/* -------- RTC_MODE1_INTENSET : (RTC Offset: 0x07) (R/W  8) MODE1 MODE1 Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CMP0:1;           /*!< bit:      0  Compare 0 Interrupt Enable         */
+    uint8_t  CMP1:1;           /*!< bit:      1  Compare 1 Interrupt Enable         */
+    uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready Interrupt Enable */
+    uint8_t  OVF:1;            /*!< bit:      7  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x Interrupt Enable         */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE1_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_INTENSET_OFFSET   0x07         /**< \brief (RTC_MODE1_INTENSET offset) MODE1 Interrupt Enable Set */
+#define RTC_MODE1_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE1_INTENSET reset_value) MODE1 Interrupt Enable Set */
+
+#define RTC_MODE1_INTENSET_CMP0_Pos 0            /**< \brief (RTC_MODE1_INTENSET) Compare 0 Interrupt Enable */
+#define RTC_MODE1_INTENSET_CMP0     (_U_(1) << RTC_MODE1_INTENSET_CMP0_Pos)
+#define RTC_MODE1_INTENSET_CMP1_Pos 1            /**< \brief (RTC_MODE1_INTENSET) Compare 1 Interrupt Enable */
+#define RTC_MODE1_INTENSET_CMP1     (_U_(1) << RTC_MODE1_INTENSET_CMP1_Pos)
+#define RTC_MODE1_INTENSET_CMP_Pos  0            /**< \brief (RTC_MODE1_INTENSET) Compare x Interrupt Enable */
+#define RTC_MODE1_INTENSET_CMP_Msk  (_U_(0x3) << RTC_MODE1_INTENSET_CMP_Pos)
+#define RTC_MODE1_INTENSET_CMP(value) (RTC_MODE1_INTENSET_CMP_Msk & ((value) << RTC_MODE1_INTENSET_CMP_Pos))
+#define RTC_MODE1_INTENSET_SYNCRDY_Pos 6            /**< \brief (RTC_MODE1_INTENSET) Synchronization Ready Interrupt Enable */
+#define RTC_MODE1_INTENSET_SYNCRDY  (_U_(0x1) << RTC_MODE1_INTENSET_SYNCRDY_Pos)
+#define RTC_MODE1_INTENSET_OVF_Pos  7            /**< \brief (RTC_MODE1_INTENSET) Overflow Interrupt Enable */
+#define RTC_MODE1_INTENSET_OVF      (_U_(0x1) << RTC_MODE1_INTENSET_OVF_Pos)
+#define RTC_MODE1_INTENSET_MASK     _U_(0xC3)    /**< \brief (RTC_MODE1_INTENSET) MASK Register */
+
+/* -------- RTC_MODE2_INTENSET : (RTC Offset: 0x07) (R/W  8) MODE2 MODE2 Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0 Interrupt Enable           */
+    uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready Interrupt Enable */
+    uint8_t  OVF:1;            /*!< bit:      7  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  ALARM:1;          /*!< bit:      0  Alarm x Interrupt Enable           */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE2_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_INTENSET_OFFSET   0x07         /**< \brief (RTC_MODE2_INTENSET offset) MODE2 Interrupt Enable Set */
+#define RTC_MODE2_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE2_INTENSET reset_value) MODE2 Interrupt Enable Set */
+
+#define RTC_MODE2_INTENSET_ALARM0_Pos 0            /**< \brief (RTC_MODE2_INTENSET) Alarm 0 Interrupt Enable */
+#define RTC_MODE2_INTENSET_ALARM0   (_U_(1) << RTC_MODE2_INTENSET_ALARM0_Pos)
+#define RTC_MODE2_INTENSET_ALARM_Pos 0            /**< \brief (RTC_MODE2_INTENSET) Alarm x Interrupt Enable */
+#define RTC_MODE2_INTENSET_ALARM_Msk (_U_(0x1) << RTC_MODE2_INTENSET_ALARM_Pos)
+#define RTC_MODE2_INTENSET_ALARM(value) (RTC_MODE2_INTENSET_ALARM_Msk & ((value) << RTC_MODE2_INTENSET_ALARM_Pos))
+#define RTC_MODE2_INTENSET_SYNCRDY_Pos 6            /**< \brief (RTC_MODE2_INTENSET) Synchronization Ready Interrupt Enable */
+#define RTC_MODE2_INTENSET_SYNCRDY  (_U_(0x1) << RTC_MODE2_INTENSET_SYNCRDY_Pos)
+#define RTC_MODE2_INTENSET_OVF_Pos  7            /**< \brief (RTC_MODE2_INTENSET) Overflow Interrupt Enable */
+#define RTC_MODE2_INTENSET_OVF      (_U_(0x1) << RTC_MODE2_INTENSET_OVF_Pos)
+#define RTC_MODE2_INTENSET_MASK     _U_(0xC1)    /**< \brief (RTC_MODE2_INTENSET) MASK Register */
+
+/* -------- RTC_MODE0_INTFLAG : (RTC Offset: 0x08) (R/W  8) MODE0 MODE0 Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
+    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
+    __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint8_t  CMP:1;            /*!< bit:      0  Compare x                          */
+    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE0_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_INTFLAG_OFFSET    0x08         /**< \brief (RTC_MODE0_INTFLAG offset) MODE0 Interrupt Flag Status and Clear */
+#define RTC_MODE0_INTFLAG_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE0_INTFLAG reset_value) MODE0 Interrupt Flag Status and Clear */
+
+#define RTC_MODE0_INTFLAG_CMP0_Pos  0            /**< \brief (RTC_MODE0_INTFLAG) Compare 0 */
+#define RTC_MODE0_INTFLAG_CMP0      (_U_(1) << RTC_MODE0_INTFLAG_CMP0_Pos)
+#define RTC_MODE0_INTFLAG_CMP_Pos   0            /**< \brief (RTC_MODE0_INTFLAG) Compare x */
+#define RTC_MODE0_INTFLAG_CMP_Msk   (_U_(0x1) << RTC_MODE0_INTFLAG_CMP_Pos)
+#define RTC_MODE0_INTFLAG_CMP(value) (RTC_MODE0_INTFLAG_CMP_Msk & ((value) << RTC_MODE0_INTFLAG_CMP_Pos))
+#define RTC_MODE0_INTFLAG_SYNCRDY_Pos 6            /**< \brief (RTC_MODE0_INTFLAG) Synchronization Ready */
+#define RTC_MODE0_INTFLAG_SYNCRDY   (_U_(0x1) << RTC_MODE0_INTFLAG_SYNCRDY_Pos)
+#define RTC_MODE0_INTFLAG_OVF_Pos   7            /**< \brief (RTC_MODE0_INTFLAG) Overflow */
+#define RTC_MODE0_INTFLAG_OVF       (_U_(0x1) << RTC_MODE0_INTFLAG_OVF_Pos)
+#define RTC_MODE0_INTFLAG_MASK      _U_(0xC1)    /**< \brief (RTC_MODE0_INTFLAG) MASK Register */
+
+/* -------- RTC_MODE1_INTFLAG : (RTC Offset: 0x08) (R/W  8) MODE1 MODE1 Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
+    __I uint8_t  CMP1:1;           /*!< bit:      1  Compare 1                          */
+    __I uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
+    __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x                          */
+    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE1_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_INTFLAG_OFFSET    0x08         /**< \brief (RTC_MODE1_INTFLAG offset) MODE1 Interrupt Flag Status and Clear */
+#define RTC_MODE1_INTFLAG_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE1_INTFLAG reset_value) MODE1 Interrupt Flag Status and Clear */
+
+#define RTC_MODE1_INTFLAG_CMP0_Pos  0            /**< \brief (RTC_MODE1_INTFLAG) Compare 0 */
+#define RTC_MODE1_INTFLAG_CMP0      (_U_(1) << RTC_MODE1_INTFLAG_CMP0_Pos)
+#define RTC_MODE1_INTFLAG_CMP1_Pos  1            /**< \brief (RTC_MODE1_INTFLAG) Compare 1 */
+#define RTC_MODE1_INTFLAG_CMP1      (_U_(1) << RTC_MODE1_INTFLAG_CMP1_Pos)
+#define RTC_MODE1_INTFLAG_CMP_Pos   0            /**< \brief (RTC_MODE1_INTFLAG) Compare x */
+#define RTC_MODE1_INTFLAG_CMP_Msk   (_U_(0x3) << RTC_MODE1_INTFLAG_CMP_Pos)
+#define RTC_MODE1_INTFLAG_CMP(value) (RTC_MODE1_INTFLAG_CMP_Msk & ((value) << RTC_MODE1_INTFLAG_CMP_Pos))
+#define RTC_MODE1_INTFLAG_SYNCRDY_Pos 6            /**< \brief (RTC_MODE1_INTFLAG) Synchronization Ready */
+#define RTC_MODE1_INTFLAG_SYNCRDY   (_U_(0x1) << RTC_MODE1_INTFLAG_SYNCRDY_Pos)
+#define RTC_MODE1_INTFLAG_OVF_Pos   7            /**< \brief (RTC_MODE1_INTFLAG) Overflow */
+#define RTC_MODE1_INTFLAG_OVF       (_U_(0x1) << RTC_MODE1_INTFLAG_OVF_Pos)
+#define RTC_MODE1_INTFLAG_MASK      _U_(0xC3)    /**< \brief (RTC_MODE1_INTFLAG) MASK Register */
+
+/* -------- RTC_MODE2_INTFLAG : (RTC Offset: 0x08) (R/W  8) MODE2 MODE2 Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0                            */
+    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
+    __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint8_t  ALARM:1;          /*!< bit:      0  Alarm x                            */
+    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE2_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_INTFLAG_OFFSET    0x08         /**< \brief (RTC_MODE2_INTFLAG offset) MODE2 Interrupt Flag Status and Clear */
+#define RTC_MODE2_INTFLAG_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE2_INTFLAG reset_value) MODE2 Interrupt Flag Status and Clear */
+
+#define RTC_MODE2_INTFLAG_ALARM0_Pos 0            /**< \brief (RTC_MODE2_INTFLAG) Alarm 0 */
+#define RTC_MODE2_INTFLAG_ALARM0    (_U_(1) << RTC_MODE2_INTFLAG_ALARM0_Pos)
+#define RTC_MODE2_INTFLAG_ALARM_Pos 0            /**< \brief (RTC_MODE2_INTFLAG) Alarm x */
+#define RTC_MODE2_INTFLAG_ALARM_Msk (_U_(0x1) << RTC_MODE2_INTFLAG_ALARM_Pos)
+#define RTC_MODE2_INTFLAG_ALARM(value) (RTC_MODE2_INTFLAG_ALARM_Msk & ((value) << RTC_MODE2_INTFLAG_ALARM_Pos))
+#define RTC_MODE2_INTFLAG_SYNCRDY_Pos 6            /**< \brief (RTC_MODE2_INTFLAG) Synchronization Ready */
+#define RTC_MODE2_INTFLAG_SYNCRDY   (_U_(0x1) << RTC_MODE2_INTFLAG_SYNCRDY_Pos)
+#define RTC_MODE2_INTFLAG_OVF_Pos   7            /**< \brief (RTC_MODE2_INTFLAG) Overflow */
+#define RTC_MODE2_INTFLAG_OVF       (_U_(0x1) << RTC_MODE2_INTFLAG_OVF_Pos)
+#define RTC_MODE2_INTFLAG_MASK      _U_(0xC1)    /**< \brief (RTC_MODE2_INTFLAG) MASK Register */
+
+/* -------- RTC_STATUS : (RTC Offset: 0x0A) (R/W  8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_STATUS_OFFSET           0x0A         /**< \brief (RTC_STATUS offset) Status */
+#define RTC_STATUS_RESETVALUE       _U_(0x00)    /**< \brief (RTC_STATUS reset_value) Status */
+
+#define RTC_STATUS_SYNCBUSY_Pos     7            /**< \brief (RTC_STATUS) Synchronization Busy */
+#define RTC_STATUS_SYNCBUSY         (_U_(0x1) << RTC_STATUS_SYNCBUSY_Pos)
+#define RTC_STATUS_MASK             _U_(0x80)    /**< \brief (RTC_STATUS) MASK Register */
+
+/* -------- RTC_DBGCTRL : (RTC Offset: 0x0B) (R/W  8) Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGRUN:1;         /*!< bit:      0  Run During Debug                   */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_DBGCTRL_OFFSET          0x0B         /**< \brief (RTC_DBGCTRL offset) Debug Control */
+#define RTC_DBGCTRL_RESETVALUE      _U_(0x00)    /**< \brief (RTC_DBGCTRL reset_value) Debug Control */
+
+#define RTC_DBGCTRL_DBGRUN_Pos      0            /**< \brief (RTC_DBGCTRL) Run During Debug */
+#define RTC_DBGCTRL_DBGRUN          (_U_(0x1) << RTC_DBGCTRL_DBGRUN_Pos)
+#define RTC_DBGCTRL_MASK            _U_(0x01)    /**< \brief (RTC_DBGCTRL) MASK Register */
+
+/* -------- RTC_FREQCORR : (RTC Offset: 0x0C) (R/W  8) Frequency Correction -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  VALUE:7;          /*!< bit:  0.. 6  Correction Value                   */
+    uint8_t  SIGN:1;           /*!< bit:      7  Correction Sign                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_FREQCORR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_FREQCORR_OFFSET         0x0C         /**< \brief (RTC_FREQCORR offset) Frequency Correction */
+#define RTC_FREQCORR_RESETVALUE     _U_(0x00)    /**< \brief (RTC_FREQCORR reset_value) Frequency Correction */
+
+#define RTC_FREQCORR_VALUE_Pos      0            /**< \brief (RTC_FREQCORR) Correction Value */
+#define RTC_FREQCORR_VALUE_Msk      (_U_(0x7F) << RTC_FREQCORR_VALUE_Pos)
+#define RTC_FREQCORR_VALUE(value)   (RTC_FREQCORR_VALUE_Msk & ((value) << RTC_FREQCORR_VALUE_Pos))
+#define RTC_FREQCORR_SIGN_Pos       7            /**< \brief (RTC_FREQCORR) Correction Sign */
+#define RTC_FREQCORR_SIGN           (_U_(0x1) << RTC_FREQCORR_SIGN_Pos)
+#define RTC_FREQCORR_MASK           _U_(0xFF)    /**< \brief (RTC_FREQCORR) MASK Register */
+
+/* -------- RTC_MODE0_COUNT : (RTC Offset: 0x10) (R/W 32) MODE0 MODE0 Counter Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t COUNT:32;         /*!< bit:  0..31  Counter Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_COUNT_OFFSET      0x10         /**< \brief (RTC_MODE0_COUNT offset) MODE0 Counter Value */
+#define RTC_MODE0_COUNT_RESETVALUE  _U_(0x00000000) /**< \brief (RTC_MODE0_COUNT reset_value) MODE0 Counter Value */
+
+#define RTC_MODE0_COUNT_COUNT_Pos   0            /**< \brief (RTC_MODE0_COUNT) Counter Value */
+#define RTC_MODE0_COUNT_COUNT_Msk   (_U_(0xFFFFFFFF) << RTC_MODE0_COUNT_COUNT_Pos)
+#define RTC_MODE0_COUNT_COUNT(value) (RTC_MODE0_COUNT_COUNT_Msk & ((value) << RTC_MODE0_COUNT_COUNT_Pos))
+#define RTC_MODE0_COUNT_MASK        _U_(0xFFFFFFFF) /**< \brief (RTC_MODE0_COUNT) MASK Register */
+
+/* -------- RTC_MODE1_COUNT : (RTC Offset: 0x10) (R/W 16) MODE1 MODE1 Counter Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t COUNT:16;         /*!< bit:  0..15  Counter Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_COUNT_OFFSET      0x10         /**< \brief (RTC_MODE1_COUNT offset) MODE1 Counter Value */
+#define RTC_MODE1_COUNT_RESETVALUE  _U_(0x0000)  /**< \brief (RTC_MODE1_COUNT reset_value) MODE1 Counter Value */
+
+#define RTC_MODE1_COUNT_COUNT_Pos   0            /**< \brief (RTC_MODE1_COUNT) Counter Value */
+#define RTC_MODE1_COUNT_COUNT_Msk   (_U_(0xFFFF) << RTC_MODE1_COUNT_COUNT_Pos)
+#define RTC_MODE1_COUNT_COUNT(value) (RTC_MODE1_COUNT_COUNT_Msk & ((value) << RTC_MODE1_COUNT_COUNT_Pos))
+#define RTC_MODE1_COUNT_MASK        _U_(0xFFFF)  /**< \brief (RTC_MODE1_COUNT) MASK Register */
+
+/* -------- RTC_MODE2_CLOCK : (RTC Offset: 0x10) (R/W 32) MODE2 MODE2 Clock Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SECOND:6;         /*!< bit:  0.. 5  Second                             */
+    uint32_t MINUTE:6;         /*!< bit:  6..11  Minute                             */
+    uint32_t HOUR:5;           /*!< bit: 12..16  Hour                               */
+    uint32_t DAY:5;            /*!< bit: 17..21  Day                                */
+    uint32_t MONTH:4;          /*!< bit: 22..25  Month                              */
+    uint32_t YEAR:6;           /*!< bit: 26..31  Year                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_CLOCK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_CLOCK_OFFSET      0x10         /**< \brief (RTC_MODE2_CLOCK offset) MODE2 Clock Value */
+#define RTC_MODE2_CLOCK_RESETVALUE  _U_(0x00000000) /**< \brief (RTC_MODE2_CLOCK reset_value) MODE2 Clock Value */
+
+#define RTC_MODE2_CLOCK_SECOND_Pos  0            /**< \brief (RTC_MODE2_CLOCK) Second */
+#define RTC_MODE2_CLOCK_SECOND_Msk  (_U_(0x3F) << RTC_MODE2_CLOCK_SECOND_Pos)
+#define RTC_MODE2_CLOCK_SECOND(value) (RTC_MODE2_CLOCK_SECOND_Msk & ((value) << RTC_MODE2_CLOCK_SECOND_Pos))
+#define RTC_MODE2_CLOCK_MINUTE_Pos  6            /**< \brief (RTC_MODE2_CLOCK) Minute */
+#define RTC_MODE2_CLOCK_MINUTE_Msk  (_U_(0x3F) << RTC_MODE2_CLOCK_MINUTE_Pos)
+#define RTC_MODE2_CLOCK_MINUTE(value) (RTC_MODE2_CLOCK_MINUTE_Msk & ((value) << RTC_MODE2_CLOCK_MINUTE_Pos))
+#define RTC_MODE2_CLOCK_HOUR_Pos    12           /**< \brief (RTC_MODE2_CLOCK) Hour */
+#define RTC_MODE2_CLOCK_HOUR_Msk    (_U_(0x1F) << RTC_MODE2_CLOCK_HOUR_Pos)
+#define RTC_MODE2_CLOCK_HOUR(value) (RTC_MODE2_CLOCK_HOUR_Msk & ((value) << RTC_MODE2_CLOCK_HOUR_Pos))
+#define   RTC_MODE2_CLOCK_HOUR_AM_Val     _U_(0x0)   /**< \brief (RTC_MODE2_CLOCK) AM when CLKREP in 12-hour */
+#define   RTC_MODE2_CLOCK_HOUR_PM_Val     _U_(0x10)   /**< \brief (RTC_MODE2_CLOCK) Afternoon Hour */
+#define RTC_MODE2_CLOCK_HOUR_AM     (RTC_MODE2_CLOCK_HOUR_AM_Val   << RTC_MODE2_CLOCK_HOUR_Pos)
+#define RTC_MODE2_CLOCK_HOUR_PM     (RTC_MODE2_CLOCK_HOUR_PM_Val   << RTC_MODE2_CLOCK_HOUR_Pos)
+#define RTC_MODE2_CLOCK_DAY_Pos     17           /**< \brief (RTC_MODE2_CLOCK) Day */
+#define RTC_MODE2_CLOCK_DAY_Msk     (_U_(0x1F) << RTC_MODE2_CLOCK_DAY_Pos)
+#define RTC_MODE2_CLOCK_DAY(value)  (RTC_MODE2_CLOCK_DAY_Msk & ((value) << RTC_MODE2_CLOCK_DAY_Pos))
+#define RTC_MODE2_CLOCK_MONTH_Pos   22           /**< \brief (RTC_MODE2_CLOCK) Month */
+#define RTC_MODE2_CLOCK_MONTH_Msk   (_U_(0xF) << RTC_MODE2_CLOCK_MONTH_Pos)
+#define RTC_MODE2_CLOCK_MONTH(value) (RTC_MODE2_CLOCK_MONTH_Msk & ((value) << RTC_MODE2_CLOCK_MONTH_Pos))
+#define RTC_MODE2_CLOCK_YEAR_Pos    26           /**< \brief (RTC_MODE2_CLOCK) Year */
+#define RTC_MODE2_CLOCK_YEAR_Msk    (_U_(0x3F) << RTC_MODE2_CLOCK_YEAR_Pos)
+#define RTC_MODE2_CLOCK_YEAR(value) (RTC_MODE2_CLOCK_YEAR_Msk & ((value) << RTC_MODE2_CLOCK_YEAR_Pos))
+#define RTC_MODE2_CLOCK_MASK        _U_(0xFFFFFFFF) /**< \brief (RTC_MODE2_CLOCK) MASK Register */
+
+/* -------- RTC_MODE1_PER : (RTC Offset: 0x14) (R/W 16) MODE1 MODE1 Counter Period -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PER:16;           /*!< bit:  0..15  Counter Period                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_PER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_PER_OFFSET        0x14         /**< \brief (RTC_MODE1_PER offset) MODE1 Counter Period */
+#define RTC_MODE1_PER_RESETVALUE    _U_(0x0000)  /**< \brief (RTC_MODE1_PER reset_value) MODE1 Counter Period */
+
+#define RTC_MODE1_PER_PER_Pos       0            /**< \brief (RTC_MODE1_PER) Counter Period */
+#define RTC_MODE1_PER_PER_Msk       (_U_(0xFFFF) << RTC_MODE1_PER_PER_Pos)
+#define RTC_MODE1_PER_PER(value)    (RTC_MODE1_PER_PER_Msk & ((value) << RTC_MODE1_PER_PER_Pos))
+#define RTC_MODE1_PER_MASK          _U_(0xFFFF)  /**< \brief (RTC_MODE1_PER) MASK Register */
+
+/* -------- RTC_MODE0_COMP : (RTC Offset: 0x18) (R/W 32) MODE0 MODE0 Compare n Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t COMP:32;          /*!< bit:  0..31  Compare Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_COMP_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_COMP_OFFSET       0x18         /**< \brief (RTC_MODE0_COMP offset) MODE0 Compare n Value */
+#define RTC_MODE0_COMP_RESETVALUE   _U_(0x00000000) /**< \brief (RTC_MODE0_COMP reset_value) MODE0 Compare n Value */
+
+#define RTC_MODE0_COMP_COMP_Pos     0            /**< \brief (RTC_MODE0_COMP) Compare Value */
+#define RTC_MODE0_COMP_COMP_Msk     (_U_(0xFFFFFFFF) << RTC_MODE0_COMP_COMP_Pos)
+#define RTC_MODE0_COMP_COMP(value)  (RTC_MODE0_COMP_COMP_Msk & ((value) << RTC_MODE0_COMP_COMP_Pos))
+#define RTC_MODE0_COMP_MASK         _U_(0xFFFFFFFF) /**< \brief (RTC_MODE0_COMP) MASK Register */
+
+/* -------- RTC_MODE1_COMP : (RTC Offset: 0x18) (R/W 16) MODE1 MODE1 Compare n Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t COMP:16;          /*!< bit:  0..15  Compare Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_COMP_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_COMP_OFFSET       0x18         /**< \brief (RTC_MODE1_COMP offset) MODE1 Compare n Value */
+#define RTC_MODE1_COMP_RESETVALUE   _U_(0x0000)  /**< \brief (RTC_MODE1_COMP reset_value) MODE1 Compare n Value */
+
+#define RTC_MODE1_COMP_COMP_Pos     0            /**< \brief (RTC_MODE1_COMP) Compare Value */
+#define RTC_MODE1_COMP_COMP_Msk     (_U_(0xFFFF) << RTC_MODE1_COMP_COMP_Pos)
+#define RTC_MODE1_COMP_COMP(value)  (RTC_MODE1_COMP_COMP_Msk & ((value) << RTC_MODE1_COMP_COMP_Pos))
+#define RTC_MODE1_COMP_MASK         _U_(0xFFFF)  /**< \brief (RTC_MODE1_COMP) MASK Register */
+
+/* -------- RTC_MODE2_ALARM : (RTC Offset: 0x18) (R/W 32) MODE2 MODE2_ALARM Alarm n Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SECOND:6;         /*!< bit:  0.. 5  Second                             */
+    uint32_t MINUTE:6;         /*!< bit:  6..11  Minute                             */
+    uint32_t HOUR:5;           /*!< bit: 12..16  Hour                               */
+    uint32_t DAY:5;            /*!< bit: 17..21  Day                                */
+    uint32_t MONTH:4;          /*!< bit: 22..25  Month                              */
+    uint32_t YEAR:6;           /*!< bit: 26..31  Year                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_ALARM_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_ALARM_OFFSET      0x18         /**< \brief (RTC_MODE2_ALARM offset) MODE2_ALARM Alarm n Value */
+#define RTC_MODE2_ALARM_RESETVALUE  _U_(0x00000000) /**< \brief (RTC_MODE2_ALARM reset_value) MODE2_ALARM Alarm n Value */
+
+#define RTC_MODE2_ALARM_SECOND_Pos  0            /**< \brief (RTC_MODE2_ALARM) Second */
+#define RTC_MODE2_ALARM_SECOND_Msk  (_U_(0x3F) << RTC_MODE2_ALARM_SECOND_Pos)
+#define RTC_MODE2_ALARM_SECOND(value) (RTC_MODE2_ALARM_SECOND_Msk & ((value) << RTC_MODE2_ALARM_SECOND_Pos))
+#define RTC_MODE2_ALARM_MINUTE_Pos  6            /**< \brief (RTC_MODE2_ALARM) Minute */
+#define RTC_MODE2_ALARM_MINUTE_Msk  (_U_(0x3F) << RTC_MODE2_ALARM_MINUTE_Pos)
+#define RTC_MODE2_ALARM_MINUTE(value) (RTC_MODE2_ALARM_MINUTE_Msk & ((value) << RTC_MODE2_ALARM_MINUTE_Pos))
+#define RTC_MODE2_ALARM_HOUR_Pos    12           /**< \brief (RTC_MODE2_ALARM) Hour */
+#define RTC_MODE2_ALARM_HOUR_Msk    (_U_(0x1F) << RTC_MODE2_ALARM_HOUR_Pos)
+#define RTC_MODE2_ALARM_HOUR(value) (RTC_MODE2_ALARM_HOUR_Msk & ((value) << RTC_MODE2_ALARM_HOUR_Pos))
+#define   RTC_MODE2_ALARM_HOUR_AM_Val     _U_(0x0)   /**< \brief (RTC_MODE2_ALARM) Morning hour */
+#define   RTC_MODE2_ALARM_HOUR_PM_Val     _U_(0x10)   /**< \brief (RTC_MODE2_ALARM) Afternoon hour */
+#define RTC_MODE2_ALARM_HOUR_AM     (RTC_MODE2_ALARM_HOUR_AM_Val   << RTC_MODE2_ALARM_HOUR_Pos)
+#define RTC_MODE2_ALARM_HOUR_PM     (RTC_MODE2_ALARM_HOUR_PM_Val   << RTC_MODE2_ALARM_HOUR_Pos)
+#define RTC_MODE2_ALARM_DAY_Pos     17           /**< \brief (RTC_MODE2_ALARM) Day */
+#define RTC_MODE2_ALARM_DAY_Msk     (_U_(0x1F) << RTC_MODE2_ALARM_DAY_Pos)
+#define RTC_MODE2_ALARM_DAY(value)  (RTC_MODE2_ALARM_DAY_Msk & ((value) << RTC_MODE2_ALARM_DAY_Pos))
+#define RTC_MODE2_ALARM_MONTH_Pos   22           /**< \brief (RTC_MODE2_ALARM) Month */
+#define RTC_MODE2_ALARM_MONTH_Msk   (_U_(0xF) << RTC_MODE2_ALARM_MONTH_Pos)
+#define RTC_MODE2_ALARM_MONTH(value) (RTC_MODE2_ALARM_MONTH_Msk & ((value) << RTC_MODE2_ALARM_MONTH_Pos))
+#define RTC_MODE2_ALARM_YEAR_Pos    26           /**< \brief (RTC_MODE2_ALARM) Year */
+#define RTC_MODE2_ALARM_YEAR_Msk    (_U_(0x3F) << RTC_MODE2_ALARM_YEAR_Pos)
+#define RTC_MODE2_ALARM_YEAR(value) (RTC_MODE2_ALARM_YEAR_Msk & ((value) << RTC_MODE2_ALARM_YEAR_Pos))
+#define RTC_MODE2_ALARM_MASK        _U_(0xFFFFFFFF) /**< \brief (RTC_MODE2_ALARM) MASK Register */
+
+/* -------- RTC_MODE2_MASK : (RTC Offset: 0x1C) (R/W  8) MODE2 MODE2_ALARM Alarm n Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SEL:3;            /*!< bit:  0.. 2  Alarm Mask Selection               */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE2_MASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_MASK_OFFSET       0x1C         /**< \brief (RTC_MODE2_MASK offset) MODE2_ALARM Alarm n Mask */
+#define RTC_MODE2_MASK_RESETVALUE   _U_(0x00)    /**< \brief (RTC_MODE2_MASK reset_value) MODE2_ALARM Alarm n Mask */
+
+#define RTC_MODE2_MASK_SEL_Pos      0            /**< \brief (RTC_MODE2_MASK) Alarm Mask Selection */
+#define RTC_MODE2_MASK_SEL_Msk      (_U_(0x7) << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL(value)   (RTC_MODE2_MASK_SEL_Msk & ((value) << RTC_MODE2_MASK_SEL_Pos))
+#define   RTC_MODE2_MASK_SEL_OFF_Val      _U_(0x0)   /**< \brief (RTC_MODE2_MASK) Alarm Disabled */
+#define   RTC_MODE2_MASK_SEL_SS_Val       _U_(0x1)   /**< \brief (RTC_MODE2_MASK) Match seconds only */
+#define   RTC_MODE2_MASK_SEL_MMSS_Val     _U_(0x2)   /**< \brief (RTC_MODE2_MASK) Match seconds and minutes only */
+#define   RTC_MODE2_MASK_SEL_HHMMSS_Val   _U_(0x3)   /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, and hours only */
+#define   RTC_MODE2_MASK_SEL_DDHHMMSS_Val _U_(0x4)   /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, hours, and days only */
+#define   RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val _U_(0x5)   /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, hours, days, and months only */
+#define   RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val _U_(0x6)   /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, hours, days, months, and years */
+#define RTC_MODE2_MASK_SEL_OFF      (RTC_MODE2_MASK_SEL_OFF_Val    << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_SS       (RTC_MODE2_MASK_SEL_SS_Val     << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_MMSS     (RTC_MODE2_MASK_SEL_MMSS_Val   << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_HHMMSS   (RTC_MODE2_MASK_SEL_HHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_DDHHMMSS (RTC_MODE2_MASK_SEL_DDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_MMDDHHMMSS (RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_YYMMDDHHMMSS (RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_MASK         _U_(0x07)    /**< \brief (RTC_MODE2_MASK) MASK Register */
+
+/** \brief RtcMode2Alarm hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO RTC_MODE2_ALARM_Type      ALARM;       /**< \brief Offset: 0x00 (R/W 32) MODE2_ALARM Alarm n Value */
+  __IO RTC_MODE2_MASK_Type       MASK;        /**< \brief Offset: 0x04 (R/W  8) MODE2_ALARM Alarm n Mask */
+       RoReg8                    Reserved1[0x3];
+} RtcMode2Alarm;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief RTC_MODE0 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* 32-bit Counter with Single 32-bit Compare */
+  __IO RTC_MODE0_CTRL_Type       CTRL;        /**< \brief Offset: 0x00 (R/W 16) MODE0 Control */
+  __IO RTC_READREQ_Type          READREQ;     /**< \brief Offset: 0x02 (R/W 16) Read Request */
+  __IO RTC_MODE0_EVCTRL_Type     EVCTRL;      /**< \brief Offset: 0x04 (R/W 16) MODE0 Event Control */
+  __IO RTC_MODE0_INTENCLR_Type   INTENCLR;    /**< \brief Offset: 0x06 (R/W  8) MODE0 Interrupt Enable Clear */
+  __IO RTC_MODE0_INTENSET_Type   INTENSET;    /**< \brief Offset: 0x07 (R/W  8) MODE0 Interrupt Enable Set */
+  __IO RTC_MODE0_INTFLAG_Type    INTFLAG;     /**< \brief Offset: 0x08 (R/W  8) MODE0 Interrupt Flag Status and Clear */
+       RoReg8                    Reserved1[0x1];
+  __IO RTC_STATUS_Type           STATUS;      /**< \brief Offset: 0x0A (R/W  8) Status */
+  __IO RTC_DBGCTRL_Type          DBGCTRL;     /**< \brief Offset: 0x0B (R/W  8) Debug Control */
+  __IO RTC_FREQCORR_Type         FREQCORR;    /**< \brief Offset: 0x0C (R/W  8) Frequency Correction */
+       RoReg8                    Reserved2[0x3];
+  __IO RTC_MODE0_COUNT_Type      COUNT;       /**< \brief Offset: 0x10 (R/W 32) MODE0 Counter Value */
+       RoReg8                    Reserved3[0x4];
+  __IO RTC_MODE0_COMP_Type       COMP[1];     /**< \brief Offset: 0x18 (R/W 32) MODE0 Compare n Value */
+} RtcMode0;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief RTC_MODE1 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* 16-bit Counter with Two 16-bit Compares */
+  __IO RTC_MODE1_CTRL_Type       CTRL;        /**< \brief Offset: 0x00 (R/W 16) MODE1 Control */
+  __IO RTC_READREQ_Type          READREQ;     /**< \brief Offset: 0x02 (R/W 16) Read Request */
+  __IO RTC_MODE1_EVCTRL_Type     EVCTRL;      /**< \brief Offset: 0x04 (R/W 16) MODE1 Event Control */
+  __IO RTC_MODE1_INTENCLR_Type   INTENCLR;    /**< \brief Offset: 0x06 (R/W  8) MODE1 Interrupt Enable Clear */
+  __IO RTC_MODE1_INTENSET_Type   INTENSET;    /**< \brief Offset: 0x07 (R/W  8) MODE1 Interrupt Enable Set */
+  __IO RTC_MODE1_INTFLAG_Type    INTFLAG;     /**< \brief Offset: 0x08 (R/W  8) MODE1 Interrupt Flag Status and Clear */
+       RoReg8                    Reserved1[0x1];
+  __IO RTC_STATUS_Type           STATUS;      /**< \brief Offset: 0x0A (R/W  8) Status */
+  __IO RTC_DBGCTRL_Type          DBGCTRL;     /**< \brief Offset: 0x0B (R/W  8) Debug Control */
+  __IO RTC_FREQCORR_Type         FREQCORR;    /**< \brief Offset: 0x0C (R/W  8) Frequency Correction */
+       RoReg8                    Reserved2[0x3];
+  __IO RTC_MODE1_COUNT_Type      COUNT;       /**< \brief Offset: 0x10 (R/W 16) MODE1 Counter Value */
+       RoReg8                    Reserved3[0x2];
+  __IO RTC_MODE1_PER_Type        PER;         /**< \brief Offset: 0x14 (R/W 16) MODE1 Counter Period */
+       RoReg8                    Reserved4[0x2];
+  __IO RTC_MODE1_COMP_Type       COMP[2];     /**< \brief Offset: 0x18 (R/W 16) MODE1 Compare n Value */
+} RtcMode1;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief RTC_MODE2 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* Clock/Calendar with Alarm */
+  __IO RTC_MODE2_CTRL_Type       CTRL;        /**< \brief Offset: 0x00 (R/W 16) MODE2 Control */
+  __IO RTC_READREQ_Type          READREQ;     /**< \brief Offset: 0x02 (R/W 16) Read Request */
+  __IO RTC_MODE2_EVCTRL_Type     EVCTRL;      /**< \brief Offset: 0x04 (R/W 16) MODE2 Event Control */
+  __IO RTC_MODE2_INTENCLR_Type   INTENCLR;    /**< \brief Offset: 0x06 (R/W  8) MODE2 Interrupt Enable Clear */
+  __IO RTC_MODE2_INTENSET_Type   INTENSET;    /**< \brief Offset: 0x07 (R/W  8) MODE2 Interrupt Enable Set */
+  __IO RTC_MODE2_INTFLAG_Type    INTFLAG;     /**< \brief Offset: 0x08 (R/W  8) MODE2 Interrupt Flag Status and Clear */
+       RoReg8                    Reserved1[0x1];
+  __IO RTC_STATUS_Type           STATUS;      /**< \brief Offset: 0x0A (R/W  8) Status */
+  __IO RTC_DBGCTRL_Type          DBGCTRL;     /**< \brief Offset: 0x0B (R/W  8) Debug Control */
+  __IO RTC_FREQCORR_Type         FREQCORR;    /**< \brief Offset: 0x0C (R/W  8) Frequency Correction */
+       RoReg8                    Reserved2[0x3];
+  __IO RTC_MODE2_CLOCK_Type      CLOCK;       /**< \brief Offset: 0x10 (R/W 32) MODE2 Clock Value */
+       RoReg8                    Reserved3[0x4];
+       RtcMode2Alarm             Mode2Alarm[1]; /**< \brief Offset: 0x18 RtcMode2Alarm groups [ALARM_NUM] */
+} RtcMode2;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+       RtcMode0                  MODE0;       /**< \brief Offset: 0x00 32-bit Counter with Single 32-bit Compare */
+       RtcMode1                  MODE1;       /**< \brief Offset: 0x00 16-bit Counter with Two 16-bit Compares */
+       RtcMode2                  MODE2;       /**< \brief Offset: 0x00 Clock/Calendar with Alarm */
+} Rtc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_RTC_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/sercom.h
@@ -1,0 +1,1210 @@
+/**
+ * \file
+ *
+ * \brief Component description for SERCOM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SERCOM_COMPONENT_
+#define _SAMD20_SERCOM_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SERCOM */
+/* ========================================================================== */
+/** \addtogroup SAMD20_SERCOM Serial Communication Interface */
+/*@{*/
+
+#define SERCOM_U2201
+#define REV_SERCOM                  0x102
+
+/* -------- SERCOM_I2CM_CTRLA : (SERCOM Offset: 0x00) (R/W 32) I2CM I2CM Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t MODE:3;           /*!< bit:  2.. 4  Operating Mode                     */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      7  Run in Standby                     */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t PINOUT:1;         /*!< bit:     16  Pin Usage                          */
+    uint32_t :3;               /*!< bit: 17..19  Reserved                           */
+    uint32_t SDAHOLD:2;        /*!< bit: 20..21  SDA Hold Time                      */
+    uint32_t :6;               /*!< bit: 22..27  Reserved                           */
+    uint32_t INACTOUT:2;       /*!< bit: 28..29  Inactive Time-out                  */
+    uint32_t LOWTOUT:1;        /*!< bit:     30  SCL Low Time-out                   */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CM_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_CTRLA_OFFSET    0x00         /**< \brief (SERCOM_I2CM_CTRLA offset) I2CM Control A */
+#define SERCOM_I2CM_CTRLA_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CM_CTRLA reset_value) I2CM Control A */
+
+#define SERCOM_I2CM_CTRLA_SWRST_Pos 0            /**< \brief (SERCOM_I2CM_CTRLA) Software Reset */
+#define SERCOM_I2CM_CTRLA_SWRST     (_U_(0x1) << SERCOM_I2CM_CTRLA_SWRST_Pos)
+#define SERCOM_I2CM_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_I2CM_CTRLA) Enable */
+#define SERCOM_I2CM_CTRLA_ENABLE    (_U_(0x1) << SERCOM_I2CM_CTRLA_ENABLE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE_Pos  2            /**< \brief (SERCOM_I2CM_CTRLA) Operating Mode */
+#define SERCOM_I2CM_CTRLA_MODE_Msk  (_U_(0x7) << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE(value) (SERCOM_I2CM_CTRLA_MODE_Msk & ((value) << SERCOM_I2CM_CTRLA_MODE_Pos))
+#define   SERCOM_I2CM_CTRLA_MODE_USART_EXT_CLK_Val _U_(0x0)   /**< \brief (SERCOM_I2CM_CTRLA) USART mode with external clock */
+#define   SERCOM_I2CM_CTRLA_MODE_USART_INT_CLK_Val _U_(0x1)   /**< \brief (SERCOM_I2CM_CTRLA) USART mode with internal clock */
+#define   SERCOM_I2CM_CTRLA_MODE_SPI_SLAVE_Val _U_(0x2)   /**< \brief (SERCOM_I2CM_CTRLA) SPI mode with external clock */
+#define   SERCOM_I2CM_CTRLA_MODE_SPI_MASTER_Val _U_(0x3)   /**< \brief (SERCOM_I2CM_CTRLA) SPI mode with internal clock */
+#define   SERCOM_I2CM_CTRLA_MODE_I2C_SLAVE_Val _U_(0x4)   /**< \brief (SERCOM_I2CM_CTRLA) I2C mode with external clock */
+#define   SERCOM_I2CM_CTRLA_MODE_I2C_MASTER_Val _U_(0x5)   /**< \brief (SERCOM_I2CM_CTRLA) I2C mode with internal clock */
+#define SERCOM_I2CM_CTRLA_MODE_USART_EXT_CLK (SERCOM_I2CM_CTRLA_MODE_USART_EXT_CLK_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE_USART_INT_CLK (SERCOM_I2CM_CTRLA_MODE_USART_INT_CLK_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE_SPI_SLAVE (SERCOM_I2CM_CTRLA_MODE_SPI_SLAVE_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE_SPI_MASTER (SERCOM_I2CM_CTRLA_MODE_SPI_MASTER_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE_I2C_SLAVE (SERCOM_I2CM_CTRLA_MODE_I2C_SLAVE_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE_I2C_MASTER (SERCOM_I2CM_CTRLA_MODE_I2C_MASTER_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_I2CM_CTRLA) Run in Standby */
+#define SERCOM_I2CM_CTRLA_RUNSTDBY  (_U_(0x1) << SERCOM_I2CM_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_I2CM_CTRLA_PINOUT_Pos 16           /**< \brief (SERCOM_I2CM_CTRLA) Pin Usage */
+#define SERCOM_I2CM_CTRLA_PINOUT    (_U_(0x1) << SERCOM_I2CM_CTRLA_PINOUT_Pos)
+#define SERCOM_I2CM_CTRLA_SDAHOLD_Pos 20           /**< \brief (SERCOM_I2CM_CTRLA) SDA Hold Time */
+#define SERCOM_I2CM_CTRLA_SDAHOLD_Msk (_U_(0x3) << SERCOM_I2CM_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CM_CTRLA_SDAHOLD(value) (SERCOM_I2CM_CTRLA_SDAHOLD_Msk & ((value) << SERCOM_I2CM_CTRLA_SDAHOLD_Pos))
+#define SERCOM_I2CM_CTRLA_INACTOUT_Pos 28           /**< \brief (SERCOM_I2CM_CTRLA) Inactive Time-out */
+#define SERCOM_I2CM_CTRLA_INACTOUT_Msk (_U_(0x3) << SERCOM_I2CM_CTRLA_INACTOUT_Pos)
+#define SERCOM_I2CM_CTRLA_INACTOUT(value) (SERCOM_I2CM_CTRLA_INACTOUT_Msk & ((value) << SERCOM_I2CM_CTRLA_INACTOUT_Pos))
+#define SERCOM_I2CM_CTRLA_LOWTOUT_Pos 30           /**< \brief (SERCOM_I2CM_CTRLA) SCL Low Time-out */
+#define SERCOM_I2CM_CTRLA_LOWTOUT   (_U_(0x1) << SERCOM_I2CM_CTRLA_LOWTOUT_Pos)
+#define SERCOM_I2CM_CTRLA_MASK      _U_(0x7031009F) /**< \brief (SERCOM_I2CM_CTRLA) MASK Register */
+
+/* -------- SERCOM_I2CS_CTRLA : (SERCOM Offset: 0x00) (R/W 32) I2CS I2CS Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t MODE:3;           /*!< bit:  2.. 4  Operating Mode                     */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      7  Run in Standby                     */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t PINOUT:1;         /*!< bit:     16  Pin Usage                          */
+    uint32_t :3;               /*!< bit: 17..19  Reserved                           */
+    uint32_t SDAHOLD:2;        /*!< bit: 20..21  SDA Hold Time                      */
+    uint32_t :8;               /*!< bit: 22..29  Reserved                           */
+    uint32_t LOWTOUT:1;        /*!< bit:     30  SCL Low Time-out                   */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CS_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_CTRLA_OFFSET    0x00         /**< \brief (SERCOM_I2CS_CTRLA offset) I2CS Control A */
+#define SERCOM_I2CS_CTRLA_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CS_CTRLA reset_value) I2CS Control A */
+
+#define SERCOM_I2CS_CTRLA_SWRST_Pos 0            /**< \brief (SERCOM_I2CS_CTRLA) Software Reset */
+#define SERCOM_I2CS_CTRLA_SWRST     (_U_(0x1) << SERCOM_I2CS_CTRLA_SWRST_Pos)
+#define SERCOM_I2CS_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_I2CS_CTRLA) Enable */
+#define SERCOM_I2CS_CTRLA_ENABLE    (_U_(0x1) << SERCOM_I2CS_CTRLA_ENABLE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE_Pos  2            /**< \brief (SERCOM_I2CS_CTRLA) Operating Mode */
+#define SERCOM_I2CS_CTRLA_MODE_Msk  (_U_(0x7) << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE(value) (SERCOM_I2CS_CTRLA_MODE_Msk & ((value) << SERCOM_I2CS_CTRLA_MODE_Pos))
+#define   SERCOM_I2CS_CTRLA_MODE_USART_EXT_CLK_Val _U_(0x0)   /**< \brief (SERCOM_I2CS_CTRLA) USART mode with external clock */
+#define   SERCOM_I2CS_CTRLA_MODE_USART_INT_CLK_Val _U_(0x1)   /**< \brief (SERCOM_I2CS_CTRLA) USART mode with internal clock */
+#define   SERCOM_I2CS_CTRLA_MODE_SPI_SLAVE_Val _U_(0x2)   /**< \brief (SERCOM_I2CS_CTRLA) SPI mode with external clock */
+#define   SERCOM_I2CS_CTRLA_MODE_SPI_MASTER_Val _U_(0x3)   /**< \brief (SERCOM_I2CS_CTRLA) SPI mode with internal clock */
+#define   SERCOM_I2CS_CTRLA_MODE_I2C_SLAVE_Val _U_(0x4)   /**< \brief (SERCOM_I2CS_CTRLA) I2C mode with external clock */
+#define   SERCOM_I2CS_CTRLA_MODE_I2C_MASTER_Val _U_(0x5)   /**< \brief (SERCOM_I2CS_CTRLA) I2C mode with internal clock */
+#define SERCOM_I2CS_CTRLA_MODE_USART_EXT_CLK (SERCOM_I2CS_CTRLA_MODE_USART_EXT_CLK_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE_USART_INT_CLK (SERCOM_I2CS_CTRLA_MODE_USART_INT_CLK_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE_SPI_SLAVE (SERCOM_I2CS_CTRLA_MODE_SPI_SLAVE_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE_SPI_MASTER (SERCOM_I2CS_CTRLA_MODE_SPI_MASTER_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE_I2C_SLAVE (SERCOM_I2CS_CTRLA_MODE_I2C_SLAVE_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE_I2C_MASTER (SERCOM_I2CS_CTRLA_MODE_I2C_MASTER_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_I2CS_CTRLA) Run in Standby */
+#define SERCOM_I2CS_CTRLA_RUNSTDBY  (_U_(0x1) << SERCOM_I2CS_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_I2CS_CTRLA_PINOUT_Pos 16           /**< \brief (SERCOM_I2CS_CTRLA) Pin Usage */
+#define SERCOM_I2CS_CTRLA_PINOUT    (_U_(0x1) << SERCOM_I2CS_CTRLA_PINOUT_Pos)
+#define SERCOM_I2CS_CTRLA_SDAHOLD_Pos 20           /**< \brief (SERCOM_I2CS_CTRLA) SDA Hold Time */
+#define SERCOM_I2CS_CTRLA_SDAHOLD_Msk (_U_(0x3) << SERCOM_I2CS_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CS_CTRLA_SDAHOLD(value) (SERCOM_I2CS_CTRLA_SDAHOLD_Msk & ((value) << SERCOM_I2CS_CTRLA_SDAHOLD_Pos))
+#define   SERCOM_I2CS_CTRLA_SDAHOLD_DIS_Val _U_(0x0)   /**< \brief (SERCOM_I2CS_CTRLA) Disabled */
+#define   SERCOM_I2CS_CTRLA_SDAHOLD_75_Val _U_(0x1)   /**< \brief (SERCOM_I2CS_CTRLA) 50-100 ns hold time */
+#define   SERCOM_I2CS_CTRLA_SDAHOLD_450_Val _U_(0x2)   /**< \brief (SERCOM_I2CS_CTRLA) 300-600 ns hold time */
+#define   SERCOM_I2CS_CTRLA_SDAHOLD_600_Val _U_(0x3)   /**< \brief (SERCOM_I2CS_CTRLA) 400-800 ns hold time */
+#define SERCOM_I2CS_CTRLA_SDAHOLD_DIS (SERCOM_I2CS_CTRLA_SDAHOLD_DIS_Val << SERCOM_I2CS_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CS_CTRLA_SDAHOLD_75 (SERCOM_I2CS_CTRLA_SDAHOLD_75_Val << SERCOM_I2CS_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CS_CTRLA_SDAHOLD_450 (SERCOM_I2CS_CTRLA_SDAHOLD_450_Val << SERCOM_I2CS_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CS_CTRLA_SDAHOLD_600 (SERCOM_I2CS_CTRLA_SDAHOLD_600_Val << SERCOM_I2CS_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CS_CTRLA_LOWTOUT_Pos 30           /**< \brief (SERCOM_I2CS_CTRLA) SCL Low Time-out */
+#define SERCOM_I2CS_CTRLA_LOWTOUT   (_U_(0x1) << SERCOM_I2CS_CTRLA_LOWTOUT_Pos)
+#define SERCOM_I2CS_CTRLA_MASK      _U_(0x4031009F) /**< \brief (SERCOM_I2CS_CTRLA) MASK Register */
+
+/* -------- SERCOM_SPI_CTRLA : (SERCOM Offset: 0x00) (R/W 32) SPI SPI Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t MODE:3;           /*!< bit:  2.. 4  Operating Mode                     */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      7  Run In Standby                     */
+    uint32_t IBON:1;           /*!< bit:      8  Immediate Buffer Overflow Notification */
+    uint32_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint32_t DOPO:2;           /*!< bit: 16..17  Data Out Pinout                    */
+    uint32_t :2;               /*!< bit: 18..19  Reserved                           */
+    uint32_t DIPO:2;           /*!< bit: 20..21  Data In Pinout                     */
+    uint32_t :2;               /*!< bit: 22..23  Reserved                           */
+    uint32_t FORM:4;           /*!< bit: 24..27  Frame Format                       */
+    uint32_t CPHA:1;           /*!< bit:     28  Clock Phase                        */
+    uint32_t CPOL:1;           /*!< bit:     29  Clock Polarity                     */
+    uint32_t DORD:1;           /*!< bit:     30  Data Order                         */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_CTRLA_OFFSET     0x00         /**< \brief (SERCOM_SPI_CTRLA offset) SPI Control A */
+#define SERCOM_SPI_CTRLA_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_SPI_CTRLA reset_value) SPI Control A */
+
+#define SERCOM_SPI_CTRLA_SWRST_Pos  0            /**< \brief (SERCOM_SPI_CTRLA) Software Reset */
+#define SERCOM_SPI_CTRLA_SWRST      (_U_(0x1) << SERCOM_SPI_CTRLA_SWRST_Pos)
+#define SERCOM_SPI_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_SPI_CTRLA) Enable */
+#define SERCOM_SPI_CTRLA_ENABLE     (_U_(0x1) << SERCOM_SPI_CTRLA_ENABLE_Pos)
+#define SERCOM_SPI_CTRLA_MODE_Pos   2            /**< \brief (SERCOM_SPI_CTRLA) Operating Mode */
+#define SERCOM_SPI_CTRLA_MODE_Msk   (_U_(0x7) << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_MODE(value) (SERCOM_SPI_CTRLA_MODE_Msk & ((value) << SERCOM_SPI_CTRLA_MODE_Pos))
+#define   SERCOM_SPI_CTRLA_MODE_USART_EXT_CLK_Val _U_(0x0)   /**< \brief (SERCOM_SPI_CTRLA) USART mode with external clock */
+#define   SERCOM_SPI_CTRLA_MODE_USART_INT_CLK_Val _U_(0x1)   /**< \brief (SERCOM_SPI_CTRLA) USART mode with internal clock */
+#define   SERCOM_SPI_CTRLA_MODE_SPI_SLAVE_Val _U_(0x2)   /**< \brief (SERCOM_SPI_CTRLA) SPI mode with external clock */
+#define   SERCOM_SPI_CTRLA_MODE_SPI_MASTER_Val _U_(0x3)   /**< \brief (SERCOM_SPI_CTRLA) SPI mode with internal clock */
+#define   SERCOM_SPI_CTRLA_MODE_I2C_SLAVE_Val _U_(0x4)   /**< \brief (SERCOM_SPI_CTRLA) I2C mode with external clock */
+#define   SERCOM_SPI_CTRLA_MODE_I2C_MASTER_Val _U_(0x5)   /**< \brief (SERCOM_SPI_CTRLA) I2C mode with internal clock */
+#define SERCOM_SPI_CTRLA_MODE_USART_EXT_CLK (SERCOM_SPI_CTRLA_MODE_USART_EXT_CLK_Val << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_MODE_USART_INT_CLK (SERCOM_SPI_CTRLA_MODE_USART_INT_CLK_Val << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_MODE_SPI_SLAVE (SERCOM_SPI_CTRLA_MODE_SPI_SLAVE_Val << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_MODE_SPI_MASTER (SERCOM_SPI_CTRLA_MODE_SPI_MASTER_Val << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_MODE_I2C_SLAVE (SERCOM_SPI_CTRLA_MODE_I2C_SLAVE_Val << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_MODE_I2C_MASTER (SERCOM_SPI_CTRLA_MODE_I2C_MASTER_Val << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_SPI_CTRLA) Run In Standby */
+#define SERCOM_SPI_CTRLA_RUNSTDBY   (_U_(0x1) << SERCOM_SPI_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_SPI_CTRLA_IBON_Pos   8            /**< \brief (SERCOM_SPI_CTRLA) Immediate Buffer Overflow Notification */
+#define SERCOM_SPI_CTRLA_IBON       (_U_(0x1) << SERCOM_SPI_CTRLA_IBON_Pos)
+#define SERCOM_SPI_CTRLA_DOPO_Pos   16           /**< \brief (SERCOM_SPI_CTRLA) Data Out Pinout */
+#define SERCOM_SPI_CTRLA_DOPO_Msk   (_U_(0x3) << SERCOM_SPI_CTRLA_DOPO_Pos)
+#define SERCOM_SPI_CTRLA_DOPO(value) (SERCOM_SPI_CTRLA_DOPO_Msk & ((value) << SERCOM_SPI_CTRLA_DOPO_Pos))
+#define SERCOM_SPI_CTRLA_DIPO_Pos   20           /**< \brief (SERCOM_SPI_CTRLA) Data In Pinout */
+#define SERCOM_SPI_CTRLA_DIPO_Msk   (_U_(0x3) << SERCOM_SPI_CTRLA_DIPO_Pos)
+#define SERCOM_SPI_CTRLA_DIPO(value) (SERCOM_SPI_CTRLA_DIPO_Msk & ((value) << SERCOM_SPI_CTRLA_DIPO_Pos))
+#define SERCOM_SPI_CTRLA_FORM_Pos   24           /**< \brief (SERCOM_SPI_CTRLA) Frame Format */
+#define SERCOM_SPI_CTRLA_FORM_Msk   (_U_(0xF) << SERCOM_SPI_CTRLA_FORM_Pos)
+#define SERCOM_SPI_CTRLA_FORM(value) (SERCOM_SPI_CTRLA_FORM_Msk & ((value) << SERCOM_SPI_CTRLA_FORM_Pos))
+#define   SERCOM_SPI_CTRLA_FORM_SPI_Val   _U_(0x0)   /**< \brief (SERCOM_SPI_CTRLA) SPI frame */
+#define   SERCOM_SPI_CTRLA_FORM_SPI_ADDR_Val _U_(0x2)   /**< \brief (SERCOM_SPI_CTRLA) SPI frame with address */
+#define SERCOM_SPI_CTRLA_FORM_SPI   (SERCOM_SPI_CTRLA_FORM_SPI_Val << SERCOM_SPI_CTRLA_FORM_Pos)
+#define SERCOM_SPI_CTRLA_FORM_SPI_ADDR (SERCOM_SPI_CTRLA_FORM_SPI_ADDR_Val << SERCOM_SPI_CTRLA_FORM_Pos)
+#define SERCOM_SPI_CTRLA_CPHA_Pos   28           /**< \brief (SERCOM_SPI_CTRLA) Clock Phase */
+#define SERCOM_SPI_CTRLA_CPHA       (_U_(0x1) << SERCOM_SPI_CTRLA_CPHA_Pos)
+#define SERCOM_SPI_CTRLA_CPOL_Pos   29           /**< \brief (SERCOM_SPI_CTRLA) Clock Polarity */
+#define SERCOM_SPI_CTRLA_CPOL       (_U_(0x1) << SERCOM_SPI_CTRLA_CPOL_Pos)
+#define SERCOM_SPI_CTRLA_DORD_Pos   30           /**< \brief (SERCOM_SPI_CTRLA) Data Order */
+#define SERCOM_SPI_CTRLA_DORD       (_U_(0x1) << SERCOM_SPI_CTRLA_DORD_Pos)
+#define SERCOM_SPI_CTRLA_MASK       _U_(0x7F33019F) /**< \brief (SERCOM_SPI_CTRLA) MASK Register */
+
+/* -------- SERCOM_USART_CTRLA : (SERCOM Offset: 0x00) (R/W 32) USART USART Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t MODE:3;           /*!< bit:  2.. 4  Operating Mode                     */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      7  Run In Standby                     */
+    uint32_t IBON:1;           /*!< bit:      8  Immediate Buffer Overflow Notification */
+    uint32_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint32_t TXPO:1;           /*!< bit:     16  Transmit Data Pinout               */
+    uint32_t :3;               /*!< bit: 17..19  Reserved                           */
+    uint32_t RXPO:2;           /*!< bit: 20..21  Receive Data Pinout                */
+    uint32_t :2;               /*!< bit: 22..23  Reserved                           */
+    uint32_t FORM:4;           /*!< bit: 24..27  Frame Format                       */
+    uint32_t CMODE:1;          /*!< bit:     28  Communication Mode                 */
+    uint32_t CPOL:1;           /*!< bit:     29  Clock Polarity                     */
+    uint32_t DORD:1;           /*!< bit:     30  Data Order                         */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_CTRLA_OFFSET   0x00         /**< \brief (SERCOM_USART_CTRLA offset) USART Control A */
+#define SERCOM_USART_CTRLA_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_USART_CTRLA reset_value) USART Control A */
+
+#define SERCOM_USART_CTRLA_SWRST_Pos 0            /**< \brief (SERCOM_USART_CTRLA) Software Reset */
+#define SERCOM_USART_CTRLA_SWRST    (_U_(0x1) << SERCOM_USART_CTRLA_SWRST_Pos)
+#define SERCOM_USART_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_USART_CTRLA) Enable */
+#define SERCOM_USART_CTRLA_ENABLE   (_U_(0x1) << SERCOM_USART_CTRLA_ENABLE_Pos)
+#define SERCOM_USART_CTRLA_MODE_Pos 2            /**< \brief (SERCOM_USART_CTRLA) Operating Mode */
+#define SERCOM_USART_CTRLA_MODE_Msk (_U_(0x7) << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_MODE(value) (SERCOM_USART_CTRLA_MODE_Msk & ((value) << SERCOM_USART_CTRLA_MODE_Pos))
+#define   SERCOM_USART_CTRLA_MODE_USART_EXT_CLK_Val _U_(0x0)   /**< \brief (SERCOM_USART_CTRLA) USART mode with external clock */
+#define   SERCOM_USART_CTRLA_MODE_USART_INT_CLK_Val _U_(0x1)   /**< \brief (SERCOM_USART_CTRLA) USART mode with internal clock */
+#define   SERCOM_USART_CTRLA_MODE_SPI_SLAVE_Val _U_(0x2)   /**< \brief (SERCOM_USART_CTRLA) SPI mode with external clock */
+#define   SERCOM_USART_CTRLA_MODE_SPI_MASTER_Val _U_(0x3)   /**< \brief (SERCOM_USART_CTRLA) SPI mode with internal clock */
+#define   SERCOM_USART_CTRLA_MODE_I2C_SLAVE_Val _U_(0x4)   /**< \brief (SERCOM_USART_CTRLA) I2C mode with external clock */
+#define   SERCOM_USART_CTRLA_MODE_I2C_MASTER_Val _U_(0x5)   /**< \brief (SERCOM_USART_CTRLA) I2C mode with internal clock */
+#define SERCOM_USART_CTRLA_MODE_USART_EXT_CLK (SERCOM_USART_CTRLA_MODE_USART_EXT_CLK_Val << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_MODE_USART_INT_CLK (SERCOM_USART_CTRLA_MODE_USART_INT_CLK_Val << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_MODE_SPI_SLAVE (SERCOM_USART_CTRLA_MODE_SPI_SLAVE_Val << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_MODE_SPI_MASTER (SERCOM_USART_CTRLA_MODE_SPI_MASTER_Val << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_MODE_I2C_SLAVE (SERCOM_USART_CTRLA_MODE_I2C_SLAVE_Val << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_MODE_I2C_MASTER (SERCOM_USART_CTRLA_MODE_I2C_MASTER_Val << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_USART_CTRLA) Run In Standby */
+#define SERCOM_USART_CTRLA_RUNSTDBY (_U_(0x1) << SERCOM_USART_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_USART_CTRLA_IBON_Pos 8            /**< \brief (SERCOM_USART_CTRLA) Immediate Buffer Overflow Notification */
+#define SERCOM_USART_CTRLA_IBON     (_U_(0x1) << SERCOM_USART_CTRLA_IBON_Pos)
+#define SERCOM_USART_CTRLA_TXPO_Pos 16           /**< \brief (SERCOM_USART_CTRLA) Transmit Data Pinout */
+#define SERCOM_USART_CTRLA_TXPO     (_U_(0x1) << SERCOM_USART_CTRLA_TXPO_Pos)
+#define   SERCOM_USART_CTRLA_TXPO_PAD0_Val _U_(0x0)   /**< \brief (SERCOM_USART_CTRLA) TXD at PAD0, XCK at PAD1 */
+#define   SERCOM_USART_CTRLA_TXPO_PAD2_Val _U_(0x1)   /**< \brief (SERCOM_USART_CTRLA) TXD at PAD2, XCK at PAD3 */
+#define SERCOM_USART_CTRLA_TXPO_PAD0 (SERCOM_USART_CTRLA_TXPO_PAD0_Val << SERCOM_USART_CTRLA_TXPO_Pos)
+#define SERCOM_USART_CTRLA_TXPO_PAD2 (SERCOM_USART_CTRLA_TXPO_PAD2_Val << SERCOM_USART_CTRLA_TXPO_Pos)
+#define SERCOM_USART_CTRLA_RXPO_Pos 20           /**< \brief (SERCOM_USART_CTRLA) Receive Data Pinout */
+#define SERCOM_USART_CTRLA_RXPO_Msk (_U_(0x3) << SERCOM_USART_CTRLA_RXPO_Pos)
+#define SERCOM_USART_CTRLA_RXPO(value) (SERCOM_USART_CTRLA_RXPO_Msk & ((value) << SERCOM_USART_CTRLA_RXPO_Pos))
+#define   SERCOM_USART_CTRLA_RXPO_PAD0_Val _U_(0x0)   /**< \brief (SERCOM_USART_CTRLA) SERCOM_PAD0 */
+#define   SERCOM_USART_CTRLA_RXPO_PAD1_Val _U_(0x1)   /**< \brief (SERCOM_USART_CTRLA) SERCOM_PAD1 */
+#define   SERCOM_USART_CTRLA_RXPO_PAD2_Val _U_(0x2)   /**< \brief (SERCOM_USART_CTRLA) SERCOM_PAD2 */
+#define   SERCOM_USART_CTRLA_RXPO_PAD3_Val _U_(0x3)   /**< \brief (SERCOM_USART_CTRLA) SERCOM_PAD3 */
+#define SERCOM_USART_CTRLA_RXPO_PAD0 (SERCOM_USART_CTRLA_RXPO_PAD0_Val << SERCOM_USART_CTRLA_RXPO_Pos)
+#define SERCOM_USART_CTRLA_RXPO_PAD1 (SERCOM_USART_CTRLA_RXPO_PAD1_Val << SERCOM_USART_CTRLA_RXPO_Pos)
+#define SERCOM_USART_CTRLA_RXPO_PAD2 (SERCOM_USART_CTRLA_RXPO_PAD2_Val << SERCOM_USART_CTRLA_RXPO_Pos)
+#define SERCOM_USART_CTRLA_RXPO_PAD3 (SERCOM_USART_CTRLA_RXPO_PAD3_Val << SERCOM_USART_CTRLA_RXPO_Pos)
+#define SERCOM_USART_CTRLA_FORM_Pos 24           /**< \brief (SERCOM_USART_CTRLA) Frame Format */
+#define SERCOM_USART_CTRLA_FORM_Msk (_U_(0xF) << SERCOM_USART_CTRLA_FORM_Pos)
+#define SERCOM_USART_CTRLA_FORM(value) (SERCOM_USART_CTRLA_FORM_Msk & ((value) << SERCOM_USART_CTRLA_FORM_Pos))
+#define   SERCOM_USART_CTRLA_FORM_0_Val   _U_(0x0)   /**< \brief (SERCOM_USART_CTRLA) USART frame */
+#define   SERCOM_USART_CTRLA_FORM_1_Val   _U_(0x1)   /**< \brief (SERCOM_USART_CTRLA) USART frame with parity */
+#define SERCOM_USART_CTRLA_FORM_0   (SERCOM_USART_CTRLA_FORM_0_Val << SERCOM_USART_CTRLA_FORM_Pos)
+#define SERCOM_USART_CTRLA_FORM_1   (SERCOM_USART_CTRLA_FORM_1_Val << SERCOM_USART_CTRLA_FORM_Pos)
+#define SERCOM_USART_CTRLA_CMODE_Pos 28           /**< \brief (SERCOM_USART_CTRLA) Communication Mode */
+#define SERCOM_USART_CTRLA_CMODE    (_U_(0x1) << SERCOM_USART_CTRLA_CMODE_Pos)
+#define SERCOM_USART_CTRLA_CPOL_Pos 29           /**< \brief (SERCOM_USART_CTRLA) Clock Polarity */
+#define SERCOM_USART_CTRLA_CPOL     (_U_(0x1) << SERCOM_USART_CTRLA_CPOL_Pos)
+#define SERCOM_USART_CTRLA_DORD_Pos 30           /**< \brief (SERCOM_USART_CTRLA) Data Order */
+#define SERCOM_USART_CTRLA_DORD     (_U_(0x1) << SERCOM_USART_CTRLA_DORD_Pos)
+#define SERCOM_USART_CTRLA_MASK     _U_(0x7F31019F) /**< \brief (SERCOM_USART_CTRLA) MASK Register */
+
+/* -------- SERCOM_I2CM_CTRLB : (SERCOM Offset: 0x04) (R/W 32) I2CM I2CM Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :8;               /*!< bit:  0.. 7  Reserved                           */
+    uint32_t SMEN:1;           /*!< bit:      8  Smart Mode Enable                  */
+    uint32_t QCEN:1;           /*!< bit:      9  Quick Command Enable               */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t CMD:2;            /*!< bit: 16..17  Command                            */
+    uint32_t ACKACT:1;         /*!< bit:     18  Acknowledge Action                 */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CM_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_CTRLB_OFFSET    0x04         /**< \brief (SERCOM_I2CM_CTRLB offset) I2CM Control B */
+#define SERCOM_I2CM_CTRLB_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CM_CTRLB reset_value) I2CM Control B */
+
+#define SERCOM_I2CM_CTRLB_SMEN_Pos  8            /**< \brief (SERCOM_I2CM_CTRLB) Smart Mode Enable */
+#define SERCOM_I2CM_CTRLB_SMEN      (_U_(0x1) << SERCOM_I2CM_CTRLB_SMEN_Pos)
+#define SERCOM_I2CM_CTRLB_QCEN_Pos  9            /**< \brief (SERCOM_I2CM_CTRLB) Quick Command Enable */
+#define SERCOM_I2CM_CTRLB_QCEN      (_U_(0x1) << SERCOM_I2CM_CTRLB_QCEN_Pos)
+#define SERCOM_I2CM_CTRLB_CMD_Pos   16           /**< \brief (SERCOM_I2CM_CTRLB) Command */
+#define SERCOM_I2CM_CTRLB_CMD_Msk   (_U_(0x3) << SERCOM_I2CM_CTRLB_CMD_Pos)
+#define SERCOM_I2CM_CTRLB_CMD(value) (SERCOM_I2CM_CTRLB_CMD_Msk & ((value) << SERCOM_I2CM_CTRLB_CMD_Pos))
+#define SERCOM_I2CM_CTRLB_ACKACT_Pos 18           /**< \brief (SERCOM_I2CM_CTRLB) Acknowledge Action */
+#define SERCOM_I2CM_CTRLB_ACKACT    (_U_(0x1) << SERCOM_I2CM_CTRLB_ACKACT_Pos)
+#define SERCOM_I2CM_CTRLB_MASK      _U_(0x00070300) /**< \brief (SERCOM_I2CM_CTRLB) MASK Register */
+
+/* -------- SERCOM_I2CS_CTRLB : (SERCOM Offset: 0x04) (R/W 32) I2CS I2CS Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :8;               /*!< bit:  0.. 7  Reserved                           */
+    uint32_t SMEN:1;           /*!< bit:      8  Smart Mode Enable                  */
+    uint32_t :5;               /*!< bit:  9..13  Reserved                           */
+    uint32_t AMODE:2;          /*!< bit: 14..15  Address Mode                       */
+    uint32_t CMD:2;            /*!< bit: 16..17  Command                            */
+    uint32_t ACKACT:1;         /*!< bit:     18  Acknowledge Action                 */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CS_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_CTRLB_OFFSET    0x04         /**< \brief (SERCOM_I2CS_CTRLB offset) I2CS Control B */
+#define SERCOM_I2CS_CTRLB_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CS_CTRLB reset_value) I2CS Control B */
+
+#define SERCOM_I2CS_CTRLB_SMEN_Pos  8            /**< \brief (SERCOM_I2CS_CTRLB) Smart Mode Enable */
+#define SERCOM_I2CS_CTRLB_SMEN      (_U_(0x1) << SERCOM_I2CS_CTRLB_SMEN_Pos)
+#define SERCOM_I2CS_CTRLB_AMODE_Pos 14           /**< \brief (SERCOM_I2CS_CTRLB) Address Mode */
+#define SERCOM_I2CS_CTRLB_AMODE_Msk (_U_(0x3) << SERCOM_I2CS_CTRLB_AMODE_Pos)
+#define SERCOM_I2CS_CTRLB_AMODE(value) (SERCOM_I2CS_CTRLB_AMODE_Msk & ((value) << SERCOM_I2CS_CTRLB_AMODE_Pos))
+#define SERCOM_I2CS_CTRLB_CMD_Pos   16           /**< \brief (SERCOM_I2CS_CTRLB) Command */
+#define SERCOM_I2CS_CTRLB_CMD_Msk   (_U_(0x3) << SERCOM_I2CS_CTRLB_CMD_Pos)
+#define SERCOM_I2CS_CTRLB_CMD(value) (SERCOM_I2CS_CTRLB_CMD_Msk & ((value) << SERCOM_I2CS_CTRLB_CMD_Pos))
+#define SERCOM_I2CS_CTRLB_ACKACT_Pos 18           /**< \brief (SERCOM_I2CS_CTRLB) Acknowledge Action */
+#define SERCOM_I2CS_CTRLB_ACKACT    (_U_(0x1) << SERCOM_I2CS_CTRLB_ACKACT_Pos)
+#define SERCOM_I2CS_CTRLB_MASK      _U_(0x0007C100) /**< \brief (SERCOM_I2CS_CTRLB) MASK Register */
+
+/* -------- SERCOM_SPI_CTRLB : (SERCOM Offset: 0x04) (R/W 32) SPI SPI Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CHSIZE:3;         /*!< bit:  0.. 2  Character Size                     */
+    uint32_t :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint32_t PLOADEN:1;        /*!< bit:      6  Slave Data Preload Enable          */
+    uint32_t :7;               /*!< bit:  7..13  Reserved                           */
+    uint32_t AMODE:2;          /*!< bit: 14..15  Address Mode                       */
+    uint32_t :1;               /*!< bit:     16  Reserved                           */
+    uint32_t RXEN:1;           /*!< bit:     17  Receiver Enable                    */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_CTRLB_OFFSET     0x04         /**< \brief (SERCOM_SPI_CTRLB offset) SPI Control B */
+#define SERCOM_SPI_CTRLB_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_SPI_CTRLB reset_value) SPI Control B */
+
+#define SERCOM_SPI_CTRLB_CHSIZE_Pos 0            /**< \brief (SERCOM_SPI_CTRLB) Character Size */
+#define SERCOM_SPI_CTRLB_CHSIZE_Msk (_U_(0x7) << SERCOM_SPI_CTRLB_CHSIZE_Pos)
+#define SERCOM_SPI_CTRLB_CHSIZE(value) (SERCOM_SPI_CTRLB_CHSIZE_Msk & ((value) << SERCOM_SPI_CTRLB_CHSIZE_Pos))
+#define SERCOM_SPI_CTRLB_PLOADEN_Pos 6            /**< \brief (SERCOM_SPI_CTRLB) Slave Data Preload Enable */
+#define SERCOM_SPI_CTRLB_PLOADEN    (_U_(0x1) << SERCOM_SPI_CTRLB_PLOADEN_Pos)
+#define SERCOM_SPI_CTRLB_AMODE_Pos  14           /**< \brief (SERCOM_SPI_CTRLB) Address Mode */
+#define SERCOM_SPI_CTRLB_AMODE_Msk  (_U_(0x3) << SERCOM_SPI_CTRLB_AMODE_Pos)
+#define SERCOM_SPI_CTRLB_AMODE(value) (SERCOM_SPI_CTRLB_AMODE_Msk & ((value) << SERCOM_SPI_CTRLB_AMODE_Pos))
+#define   SERCOM_SPI_CTRLB_AMODE_MASK_Val _U_(0x0)   /**< \brief (SERCOM_SPI_CTRLB) ADDRMASK is used as a mask to the ADDR register. */
+#define   SERCOM_SPI_CTRLB_AMODE_2ADDR_Val _U_(0x1)   /**< \brief (SERCOM_SPI_CTRLB) The slave responds to the 2 unique addresses in ADDR and ADDRMASK. */
+#define   SERCOM_SPI_CTRLB_AMODE_RANGE_Val _U_(0x2)   /**< \brief (SERCOM_SPI_CTRLB) The slave responds to the range of addresses between and including ADDR and ADDRMASK. ADDR is the upper limit. */
+#define SERCOM_SPI_CTRLB_AMODE_MASK (SERCOM_SPI_CTRLB_AMODE_MASK_Val << SERCOM_SPI_CTRLB_AMODE_Pos)
+#define SERCOM_SPI_CTRLB_AMODE_2ADDR (SERCOM_SPI_CTRLB_AMODE_2ADDR_Val << SERCOM_SPI_CTRLB_AMODE_Pos)
+#define SERCOM_SPI_CTRLB_AMODE_RANGE (SERCOM_SPI_CTRLB_AMODE_RANGE_Val << SERCOM_SPI_CTRLB_AMODE_Pos)
+#define SERCOM_SPI_CTRLB_RXEN_Pos   17           /**< \brief (SERCOM_SPI_CTRLB) Receiver Enable */
+#define SERCOM_SPI_CTRLB_RXEN       (_U_(0x1) << SERCOM_SPI_CTRLB_RXEN_Pos)
+#define SERCOM_SPI_CTRLB_MASK       _U_(0x0002C047) /**< \brief (SERCOM_SPI_CTRLB) MASK Register */
+
+/* -------- SERCOM_USART_CTRLB : (SERCOM Offset: 0x04) (R/W 32) USART USART Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CHSIZE:3;         /*!< bit:  0.. 2  Character Size                     */
+    uint32_t :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint32_t SBMODE:1;         /*!< bit:      6  Stop Bit Mode                      */
+    uint32_t :2;               /*!< bit:  7.. 8  Reserved                           */
+    uint32_t SFDE:1;           /*!< bit:      9  Start of Frame Detection Enable    */
+    uint32_t :3;               /*!< bit: 10..12  Reserved                           */
+    uint32_t PMODE:1;          /*!< bit:     13  Parity Mode                        */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t TXEN:1;           /*!< bit:     16  Transmitter Enable                 */
+    uint32_t RXEN:1;           /*!< bit:     17  Receiver Enable                    */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_CTRLB_OFFSET   0x04         /**< \brief (SERCOM_USART_CTRLB offset) USART Control B */
+#define SERCOM_USART_CTRLB_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_USART_CTRLB reset_value) USART Control B */
+
+#define SERCOM_USART_CTRLB_CHSIZE_Pos 0            /**< \brief (SERCOM_USART_CTRLB) Character Size */
+#define SERCOM_USART_CTRLB_CHSIZE_Msk (_U_(0x7) << SERCOM_USART_CTRLB_CHSIZE_Pos)
+#define SERCOM_USART_CTRLB_CHSIZE(value) (SERCOM_USART_CTRLB_CHSIZE_Msk & ((value) << SERCOM_USART_CTRLB_CHSIZE_Pos))
+#define SERCOM_USART_CTRLB_SBMODE_Pos 6            /**< \brief (SERCOM_USART_CTRLB) Stop Bit Mode */
+#define SERCOM_USART_CTRLB_SBMODE   (_U_(0x1) << SERCOM_USART_CTRLB_SBMODE_Pos)
+#define SERCOM_USART_CTRLB_SFDE_Pos 9            /**< \brief (SERCOM_USART_CTRLB) Start of Frame Detection Enable */
+#define SERCOM_USART_CTRLB_SFDE     (_U_(0x1) << SERCOM_USART_CTRLB_SFDE_Pos)
+#define SERCOM_USART_CTRLB_PMODE_Pos 13           /**< \brief (SERCOM_USART_CTRLB) Parity Mode */
+#define SERCOM_USART_CTRLB_PMODE    (_U_(0x1) << SERCOM_USART_CTRLB_PMODE_Pos)
+#define SERCOM_USART_CTRLB_TXEN_Pos 16           /**< \brief (SERCOM_USART_CTRLB) Transmitter Enable */
+#define SERCOM_USART_CTRLB_TXEN     (_U_(0x1) << SERCOM_USART_CTRLB_TXEN_Pos)
+#define SERCOM_USART_CTRLB_RXEN_Pos 17           /**< \brief (SERCOM_USART_CTRLB) Receiver Enable */
+#define SERCOM_USART_CTRLB_RXEN     (_U_(0x1) << SERCOM_USART_CTRLB_RXEN_Pos)
+#define SERCOM_USART_CTRLB_MASK     _U_(0x00032247) /**< \brief (SERCOM_USART_CTRLB) MASK Register */
+
+/* -------- SERCOM_I2CM_DBGCTRL : (SERCOM Offset: 0x08) (R/W  8) I2CM I2CM Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGSTOP:1;        /*!< bit:      0  Debug Stop Mode                    */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_DBGCTRL_OFFSET  0x08         /**< \brief (SERCOM_I2CM_DBGCTRL offset) I2CM Debug Control */
+#define SERCOM_I2CM_DBGCTRL_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CM_DBGCTRL reset_value) I2CM Debug Control */
+
+#define SERCOM_I2CM_DBGCTRL_DBGSTOP_Pos 0            /**< \brief (SERCOM_I2CM_DBGCTRL) Debug Stop Mode */
+#define SERCOM_I2CM_DBGCTRL_DBGSTOP (_U_(0x1) << SERCOM_I2CM_DBGCTRL_DBGSTOP_Pos)
+#define SERCOM_I2CM_DBGCTRL_MASK    _U_(0x01)    /**< \brief (SERCOM_I2CM_DBGCTRL) MASK Register */
+
+/* -------- SERCOM_SPI_DBGCTRL : (SERCOM Offset: 0x08) (R/W  8) SPI SPI Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGSTOP:1;        /*!< bit:      0  Debug Stop Mode                    */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_SPI_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_DBGCTRL_OFFSET   0x08         /**< \brief (SERCOM_SPI_DBGCTRL offset) SPI Debug Control */
+#define SERCOM_SPI_DBGCTRL_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_SPI_DBGCTRL reset_value) SPI Debug Control */
+
+#define SERCOM_SPI_DBGCTRL_DBGSTOP_Pos 0            /**< \brief (SERCOM_SPI_DBGCTRL) Debug Stop Mode */
+#define SERCOM_SPI_DBGCTRL_DBGSTOP  (_U_(0x1) << SERCOM_SPI_DBGCTRL_DBGSTOP_Pos)
+#define SERCOM_SPI_DBGCTRL_MASK     _U_(0x01)    /**< \brief (SERCOM_SPI_DBGCTRL) MASK Register */
+
+/* -------- SERCOM_USART_DBGCTRL : (SERCOM Offset: 0x08) (R/W  8) USART USART Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGSTOP:1;        /*!< bit:      0  Debug Stop Mode                    */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_USART_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_DBGCTRL_OFFSET 0x08         /**< \brief (SERCOM_USART_DBGCTRL offset) USART Debug Control */
+#define SERCOM_USART_DBGCTRL_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_USART_DBGCTRL reset_value) USART Debug Control */
+
+#define SERCOM_USART_DBGCTRL_DBGSTOP_Pos 0            /**< \brief (SERCOM_USART_DBGCTRL) Debug Stop Mode */
+#define SERCOM_USART_DBGCTRL_DBGSTOP (_U_(0x1) << SERCOM_USART_DBGCTRL_DBGSTOP_Pos)
+#define SERCOM_USART_DBGCTRL_MASK   _U_(0x01)    /**< \brief (SERCOM_USART_DBGCTRL) MASK Register */
+
+/* -------- SERCOM_I2CM_BAUD : (SERCOM Offset: 0x0A) (R/W 16) I2CM I2CM Baud Rate -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t BAUD:8;           /*!< bit:  0.. 7  Master Baud Rate                   */
+    uint16_t BAUDLOW:8;        /*!< bit:  8..15  Master Baud Rate Low               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CM_BAUD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_BAUD_OFFSET     0x0A         /**< \brief (SERCOM_I2CM_BAUD offset) I2CM Baud Rate */
+#define SERCOM_I2CM_BAUD_RESETVALUE _U_(0x0000)  /**< \brief (SERCOM_I2CM_BAUD reset_value) I2CM Baud Rate */
+
+#define SERCOM_I2CM_BAUD_BAUD_Pos   0            /**< \brief (SERCOM_I2CM_BAUD) Master Baud Rate */
+#define SERCOM_I2CM_BAUD_BAUD_Msk   (_U_(0xFF) << SERCOM_I2CM_BAUD_BAUD_Pos)
+#define SERCOM_I2CM_BAUD_BAUD(value) (SERCOM_I2CM_BAUD_BAUD_Msk & ((value) << SERCOM_I2CM_BAUD_BAUD_Pos))
+#define SERCOM_I2CM_BAUD_BAUDLOW_Pos 8            /**< \brief (SERCOM_I2CM_BAUD) Master Baud Rate Low */
+#define SERCOM_I2CM_BAUD_BAUDLOW_Msk (_U_(0xFF) << SERCOM_I2CM_BAUD_BAUDLOW_Pos)
+#define SERCOM_I2CM_BAUD_BAUDLOW(value) (SERCOM_I2CM_BAUD_BAUDLOW_Msk & ((value) << SERCOM_I2CM_BAUD_BAUDLOW_Pos))
+#define SERCOM_I2CM_BAUD_MASK       _U_(0xFFFF)  /**< \brief (SERCOM_I2CM_BAUD) MASK Register */
+
+/* -------- SERCOM_SPI_BAUD : (SERCOM Offset: 0x0A) (R/W  8) SPI SPI Baud Rate -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  BAUD:8;           /*!< bit:  0.. 7  Baud Register                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_SPI_BAUD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_BAUD_OFFSET      0x0A         /**< \brief (SERCOM_SPI_BAUD offset) SPI Baud Rate */
+#define SERCOM_SPI_BAUD_RESETVALUE  _U_(0x00)    /**< \brief (SERCOM_SPI_BAUD reset_value) SPI Baud Rate */
+
+#define SERCOM_SPI_BAUD_BAUD_Pos    0            /**< \brief (SERCOM_SPI_BAUD) Baud Register */
+#define SERCOM_SPI_BAUD_BAUD_Msk    (_U_(0xFF) << SERCOM_SPI_BAUD_BAUD_Pos)
+#define SERCOM_SPI_BAUD_BAUD(value) (SERCOM_SPI_BAUD_BAUD_Msk & ((value) << SERCOM_SPI_BAUD_BAUD_Pos))
+#define SERCOM_SPI_BAUD_MASK        _U_(0xFF)    /**< \brief (SERCOM_SPI_BAUD) MASK Register */
+
+/* -------- SERCOM_USART_BAUD : (SERCOM Offset: 0x0A) (R/W 16) USART USART Baud -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t BAUD:16;          /*!< bit:  0..15  Baud Value                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_BAUD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_BAUD_OFFSET    0x0A         /**< \brief (SERCOM_USART_BAUD offset) USART Baud */
+#define SERCOM_USART_BAUD_RESETVALUE _U_(0x0000)  /**< \brief (SERCOM_USART_BAUD reset_value) USART Baud */
+
+#define SERCOM_USART_BAUD_BAUD_Pos  0            /**< \brief (SERCOM_USART_BAUD) Baud Value */
+#define SERCOM_USART_BAUD_BAUD_Msk  (_U_(0xFFFF) << SERCOM_USART_BAUD_BAUD_Pos)
+#define SERCOM_USART_BAUD_BAUD(value) (SERCOM_USART_BAUD_BAUD_Msk & ((value) << SERCOM_USART_BAUD_BAUD_Pos))
+#define SERCOM_USART_BAUD_MASK      _U_(0xFFFF)  /**< \brief (SERCOM_USART_BAUD) MASK Register */
+
+/* -------- SERCOM_I2CM_INTENCLR : (SERCOM Offset: 0x0C) (R/W  8) I2CM I2CM Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  MB:1;             /*!< bit:      0  Master on Bus Interrupt Enable     */
+    uint8_t  SB:1;             /*!< bit:      1  Slave on Bus Interrupt Enable      */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_INTENCLR_OFFSET 0x0C         /**< \brief (SERCOM_I2CM_INTENCLR offset) I2CM Interrupt Enable Clear */
+#define SERCOM_I2CM_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CM_INTENCLR reset_value) I2CM Interrupt Enable Clear */
+
+#define SERCOM_I2CM_INTENCLR_MB_Pos 0            /**< \brief (SERCOM_I2CM_INTENCLR) Master on Bus Interrupt Enable */
+#define SERCOM_I2CM_INTENCLR_MB     (_U_(0x1) << SERCOM_I2CM_INTENCLR_MB_Pos)
+#define SERCOM_I2CM_INTENCLR_SB_Pos 1            /**< \brief (SERCOM_I2CM_INTENCLR) Slave on Bus Interrupt Enable */
+#define SERCOM_I2CM_INTENCLR_SB     (_U_(0x1) << SERCOM_I2CM_INTENCLR_SB_Pos)
+#define SERCOM_I2CM_INTENCLR_MASK   _U_(0x03)    /**< \brief (SERCOM_I2CM_INTENCLR) MASK Register */
+
+/* -------- SERCOM_I2CS_INTENCLR : (SERCOM Offset: 0x0C) (R/W  8) I2CS I2CS Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt Enable     */
+    uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt Enable     */
+    uint8_t  DRDY:1;           /*!< bit:      2  Data Ready Interrupt Enable        */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CS_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_INTENCLR_OFFSET 0x0C         /**< \brief (SERCOM_I2CS_INTENCLR offset) I2CS Interrupt Enable Clear */
+#define SERCOM_I2CS_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CS_INTENCLR reset_value) I2CS Interrupt Enable Clear */
+
+#define SERCOM_I2CS_INTENCLR_PREC_Pos 0            /**< \brief (SERCOM_I2CS_INTENCLR) Stop Received Interrupt Enable */
+#define SERCOM_I2CS_INTENCLR_PREC   (_U_(0x1) << SERCOM_I2CS_INTENCLR_PREC_Pos)
+#define SERCOM_I2CS_INTENCLR_AMATCH_Pos 1            /**< \brief (SERCOM_I2CS_INTENCLR) Address Match Interrupt Enable */
+#define SERCOM_I2CS_INTENCLR_AMATCH (_U_(0x1) << SERCOM_I2CS_INTENCLR_AMATCH_Pos)
+#define SERCOM_I2CS_INTENCLR_DRDY_Pos 2            /**< \brief (SERCOM_I2CS_INTENCLR) Data Ready Interrupt Enable */
+#define SERCOM_I2CS_INTENCLR_DRDY   (_U_(0x1) << SERCOM_I2CS_INTENCLR_DRDY_Pos)
+#define SERCOM_I2CS_INTENCLR_MASK   _U_(0x07)    /**< \brief (SERCOM_I2CS_INTENCLR) MASK Register */
+
+/* -------- SERCOM_SPI_INTENCLR : (SERCOM Offset: 0x0C) (R/W  8) SPI SPI Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty Interrupt Enable */
+    uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt Enable */
+    uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt Enable  */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_SPI_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_INTENCLR_OFFSET  0x0C         /**< \brief (SERCOM_SPI_INTENCLR offset) SPI Interrupt Enable Clear */
+#define SERCOM_SPI_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_SPI_INTENCLR reset_value) SPI Interrupt Enable Clear */
+
+#define SERCOM_SPI_INTENCLR_DRE_Pos 0            /**< \brief (SERCOM_SPI_INTENCLR) Data Register Empty Interrupt Enable */
+#define SERCOM_SPI_INTENCLR_DRE     (_U_(0x1) << SERCOM_SPI_INTENCLR_DRE_Pos)
+#define SERCOM_SPI_INTENCLR_TXC_Pos 1            /**< \brief (SERCOM_SPI_INTENCLR) Transmit Complete Interrupt Enable */
+#define SERCOM_SPI_INTENCLR_TXC     (_U_(0x1) << SERCOM_SPI_INTENCLR_TXC_Pos)
+#define SERCOM_SPI_INTENCLR_RXC_Pos 2            /**< \brief (SERCOM_SPI_INTENCLR) Receive Complete Interrupt Enable */
+#define SERCOM_SPI_INTENCLR_RXC     (_U_(0x1) << SERCOM_SPI_INTENCLR_RXC_Pos)
+#define SERCOM_SPI_INTENCLR_MASK    _U_(0x07)    /**< \brief (SERCOM_SPI_INTENCLR) MASK Register */
+
+/* -------- SERCOM_USART_INTENCLR : (SERCOM Offset: 0x0C) (R/W  8) USART USART Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty Interrupt Enable */
+    uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt Enable */
+    uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt Enable  */
+    uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt Disable    */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_USART_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_INTENCLR_OFFSET 0x0C         /**< \brief (SERCOM_USART_INTENCLR offset) USART Interrupt Enable Clear */
+#define SERCOM_USART_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_USART_INTENCLR reset_value) USART Interrupt Enable Clear */
+
+#define SERCOM_USART_INTENCLR_DRE_Pos 0            /**< \brief (SERCOM_USART_INTENCLR) Data Register Empty Interrupt Enable */
+#define SERCOM_USART_INTENCLR_DRE   (_U_(0x1) << SERCOM_USART_INTENCLR_DRE_Pos)
+#define SERCOM_USART_INTENCLR_TXC_Pos 1            /**< \brief (SERCOM_USART_INTENCLR) Transmit Complete Interrupt Enable */
+#define SERCOM_USART_INTENCLR_TXC   (_U_(0x1) << SERCOM_USART_INTENCLR_TXC_Pos)
+#define SERCOM_USART_INTENCLR_RXC_Pos 2            /**< \brief (SERCOM_USART_INTENCLR) Receive Complete Interrupt Enable */
+#define SERCOM_USART_INTENCLR_RXC   (_U_(0x1) << SERCOM_USART_INTENCLR_RXC_Pos)
+#define SERCOM_USART_INTENCLR_RXS_Pos 3            /**< \brief (SERCOM_USART_INTENCLR) Receive Start Interrupt Disable */
+#define SERCOM_USART_INTENCLR_RXS   (_U_(0x1) << SERCOM_USART_INTENCLR_RXS_Pos)
+#define SERCOM_USART_INTENCLR_MASK  _U_(0x0F)    /**< \brief (SERCOM_USART_INTENCLR) MASK Register */
+
+/* -------- SERCOM_I2CM_INTENSET : (SERCOM Offset: 0x0D) (R/W  8) I2CM I2CM Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  MB:1;             /*!< bit:      0  Master on Bus Interrupt Enable     */
+    uint8_t  SB:1;             /*!< bit:      1  Slave on Bus Interrupt Enable      */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_INTENSET_OFFSET 0x0D         /**< \brief (SERCOM_I2CM_INTENSET offset) I2CM Interrupt Enable Set */
+#define SERCOM_I2CM_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CM_INTENSET reset_value) I2CM Interrupt Enable Set */
+
+#define SERCOM_I2CM_INTENSET_MB_Pos 0            /**< \brief (SERCOM_I2CM_INTENSET) Master on Bus Interrupt Enable */
+#define SERCOM_I2CM_INTENSET_MB     (_U_(0x1) << SERCOM_I2CM_INTENSET_MB_Pos)
+#define SERCOM_I2CM_INTENSET_SB_Pos 1            /**< \brief (SERCOM_I2CM_INTENSET) Slave on Bus Interrupt Enable */
+#define SERCOM_I2CM_INTENSET_SB     (_U_(0x1) << SERCOM_I2CM_INTENSET_SB_Pos)
+#define SERCOM_I2CM_INTENSET_MASK   _U_(0x03)    /**< \brief (SERCOM_I2CM_INTENSET) MASK Register */
+
+/* -------- SERCOM_I2CS_INTENSET : (SERCOM Offset: 0x0D) (R/W  8) I2CS I2CS Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt Enable     */
+    uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt Enable     */
+    uint8_t  DRDY:1;           /*!< bit:      2  Data Ready Interrupt Enable        */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CS_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_INTENSET_OFFSET 0x0D         /**< \brief (SERCOM_I2CS_INTENSET offset) I2CS Interrupt Enable Set */
+#define SERCOM_I2CS_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CS_INTENSET reset_value) I2CS Interrupt Enable Set */
+
+#define SERCOM_I2CS_INTENSET_PREC_Pos 0            /**< \brief (SERCOM_I2CS_INTENSET) Stop Received Interrupt Enable */
+#define SERCOM_I2CS_INTENSET_PREC   (_U_(0x1) << SERCOM_I2CS_INTENSET_PREC_Pos)
+#define SERCOM_I2CS_INTENSET_AMATCH_Pos 1            /**< \brief (SERCOM_I2CS_INTENSET) Address Match Interrupt Enable */
+#define SERCOM_I2CS_INTENSET_AMATCH (_U_(0x1) << SERCOM_I2CS_INTENSET_AMATCH_Pos)
+#define SERCOM_I2CS_INTENSET_DRDY_Pos 2            /**< \brief (SERCOM_I2CS_INTENSET) Data Ready Interrupt Enable */
+#define SERCOM_I2CS_INTENSET_DRDY   (_U_(0x1) << SERCOM_I2CS_INTENSET_DRDY_Pos)
+#define SERCOM_I2CS_INTENSET_MASK   _U_(0x07)    /**< \brief (SERCOM_I2CS_INTENSET) MASK Register */
+
+/* -------- SERCOM_SPI_INTENSET : (SERCOM Offset: 0x0D) (R/W  8) SPI SPI Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty Interrupt Enable */
+    uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt Enable */
+    uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt Enable  */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_SPI_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_INTENSET_OFFSET  0x0D         /**< \brief (SERCOM_SPI_INTENSET offset) SPI Interrupt Enable Set */
+#define SERCOM_SPI_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_SPI_INTENSET reset_value) SPI Interrupt Enable Set */
+
+#define SERCOM_SPI_INTENSET_DRE_Pos 0            /**< \brief (SERCOM_SPI_INTENSET) Data Register Empty Interrupt Enable */
+#define SERCOM_SPI_INTENSET_DRE     (_U_(0x1) << SERCOM_SPI_INTENSET_DRE_Pos)
+#define SERCOM_SPI_INTENSET_TXC_Pos 1            /**< \brief (SERCOM_SPI_INTENSET) Transmit Complete Interrupt Enable */
+#define SERCOM_SPI_INTENSET_TXC     (_U_(0x1) << SERCOM_SPI_INTENSET_TXC_Pos)
+#define SERCOM_SPI_INTENSET_RXC_Pos 2            /**< \brief (SERCOM_SPI_INTENSET) Receive Complete Interrupt Enable */
+#define SERCOM_SPI_INTENSET_RXC     (_U_(0x1) << SERCOM_SPI_INTENSET_RXC_Pos)
+#define SERCOM_SPI_INTENSET_MASK    _U_(0x07)    /**< \brief (SERCOM_SPI_INTENSET) MASK Register */
+
+/* -------- SERCOM_USART_INTENSET : (SERCOM Offset: 0x0D) (R/W  8) USART USART Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty Interrupt Enable */
+    uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt Enable */
+    uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt Enable  */
+    uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt Enable     */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_USART_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_INTENSET_OFFSET 0x0D         /**< \brief (SERCOM_USART_INTENSET offset) USART Interrupt Enable Set */
+#define SERCOM_USART_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_USART_INTENSET reset_value) USART Interrupt Enable Set */
+
+#define SERCOM_USART_INTENSET_DRE_Pos 0            /**< \brief (SERCOM_USART_INTENSET) Data Register Empty Interrupt Enable */
+#define SERCOM_USART_INTENSET_DRE   (_U_(0x1) << SERCOM_USART_INTENSET_DRE_Pos)
+#define SERCOM_USART_INTENSET_TXC_Pos 1            /**< \brief (SERCOM_USART_INTENSET) Transmit Complete Interrupt Enable */
+#define SERCOM_USART_INTENSET_TXC   (_U_(0x1) << SERCOM_USART_INTENSET_TXC_Pos)
+#define SERCOM_USART_INTENSET_RXC_Pos 2            /**< \brief (SERCOM_USART_INTENSET) Receive Complete Interrupt Enable */
+#define SERCOM_USART_INTENSET_RXC   (_U_(0x1) << SERCOM_USART_INTENSET_RXC_Pos)
+#define SERCOM_USART_INTENSET_RXS_Pos 3            /**< \brief (SERCOM_USART_INTENSET) Receive Start Interrupt Enable */
+#define SERCOM_USART_INTENSET_RXS   (_U_(0x1) << SERCOM_USART_INTENSET_RXS_Pos)
+#define SERCOM_USART_INTENSET_MASK  _U_(0x0F)    /**< \brief (SERCOM_USART_INTENSET) MASK Register */
+
+/* -------- SERCOM_I2CM_INTFLAG : (SERCOM Offset: 0x0E) (R/W  8) I2CM I2CM Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  MB:1;             /*!< bit:      0  Master on Bus                      */
+    __I uint8_t  SB:1;             /*!< bit:      1  Slave on Bus                       */
+    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_INTFLAG_OFFSET  0x0E         /**< \brief (SERCOM_I2CM_INTFLAG offset) I2CM Interrupt Flag Status and Clear */
+#define SERCOM_I2CM_INTFLAG_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CM_INTFLAG reset_value) I2CM Interrupt Flag Status and Clear */
+
+#define SERCOM_I2CM_INTFLAG_MB_Pos  0            /**< \brief (SERCOM_I2CM_INTFLAG) Master on Bus */
+#define SERCOM_I2CM_INTFLAG_MB      (_U_(0x1) << SERCOM_I2CM_INTFLAG_MB_Pos)
+#define SERCOM_I2CM_INTFLAG_SB_Pos  1            /**< \brief (SERCOM_I2CM_INTFLAG) Slave on Bus */
+#define SERCOM_I2CM_INTFLAG_SB      (_U_(0x1) << SERCOM_I2CM_INTFLAG_SB_Pos)
+#define SERCOM_I2CM_INTFLAG_MASK    _U_(0x03)    /**< \brief (SERCOM_I2CM_INTFLAG) MASK Register */
+
+/* -------- SERCOM_I2CS_INTFLAG : (SERCOM Offset: 0x0E) (R/W  8) I2CS I2CS Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received                      */
+    __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match                      */
+    __I uint8_t  DRDY:1;           /*!< bit:      2  Data Ready                         */
+    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CS_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_INTFLAG_OFFSET  0x0E         /**< \brief (SERCOM_I2CS_INTFLAG offset) I2CS Interrupt Flag Status and Clear */
+#define SERCOM_I2CS_INTFLAG_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CS_INTFLAG reset_value) I2CS Interrupt Flag Status and Clear */
+
+#define SERCOM_I2CS_INTFLAG_PREC_Pos 0            /**< \brief (SERCOM_I2CS_INTFLAG) Stop Received */
+#define SERCOM_I2CS_INTFLAG_PREC    (_U_(0x1) << SERCOM_I2CS_INTFLAG_PREC_Pos)
+#define SERCOM_I2CS_INTFLAG_AMATCH_Pos 1            /**< \brief (SERCOM_I2CS_INTFLAG) Address Match */
+#define SERCOM_I2CS_INTFLAG_AMATCH  (_U_(0x1) << SERCOM_I2CS_INTFLAG_AMATCH_Pos)
+#define SERCOM_I2CS_INTFLAG_DRDY_Pos 2            /**< \brief (SERCOM_I2CS_INTFLAG) Data Ready */
+#define SERCOM_I2CS_INTFLAG_DRDY    (_U_(0x1) << SERCOM_I2CS_INTFLAG_DRDY_Pos)
+#define SERCOM_I2CS_INTFLAG_MASK    _U_(0x07)    /**< \brief (SERCOM_I2CS_INTFLAG) MASK Register */
+
+/* -------- SERCOM_SPI_INTFLAG : (SERCOM Offset: 0x0E) (R/W  8) SPI SPI Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty                */
+    __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete                  */
+    __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete                   */
+    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_SPI_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_INTFLAG_OFFSET   0x0E         /**< \brief (SERCOM_SPI_INTFLAG offset) SPI Interrupt Flag Status and Clear */
+#define SERCOM_SPI_INTFLAG_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_SPI_INTFLAG reset_value) SPI Interrupt Flag Status and Clear */
+
+#define SERCOM_SPI_INTFLAG_DRE_Pos  0            /**< \brief (SERCOM_SPI_INTFLAG) Data Register Empty */
+#define SERCOM_SPI_INTFLAG_DRE      (_U_(0x1) << SERCOM_SPI_INTFLAG_DRE_Pos)
+#define SERCOM_SPI_INTFLAG_TXC_Pos  1            /**< \brief (SERCOM_SPI_INTFLAG) Transmit Complete */
+#define SERCOM_SPI_INTFLAG_TXC      (_U_(0x1) << SERCOM_SPI_INTFLAG_TXC_Pos)
+#define SERCOM_SPI_INTFLAG_RXC_Pos  2            /**< \brief (SERCOM_SPI_INTFLAG) Receive Complete */
+#define SERCOM_SPI_INTFLAG_RXC      (_U_(0x1) << SERCOM_SPI_INTFLAG_RXC_Pos)
+#define SERCOM_SPI_INTFLAG_MASK     _U_(0x07)    /**< \brief (SERCOM_SPI_INTFLAG) MASK Register */
+
+/* -------- SERCOM_USART_INTFLAG : (SERCOM Offset: 0x0E) (R/W  8) USART USART Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty                */
+    __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete                  */
+    __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete                   */
+    __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
+    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_USART_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_INTFLAG_OFFSET 0x0E         /**< \brief (SERCOM_USART_INTFLAG offset) USART Interrupt Flag Status and Clear */
+#define SERCOM_USART_INTFLAG_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_USART_INTFLAG reset_value) USART Interrupt Flag Status and Clear */
+
+#define SERCOM_USART_INTFLAG_DRE_Pos 0            /**< \brief (SERCOM_USART_INTFLAG) Data Register Empty */
+#define SERCOM_USART_INTFLAG_DRE    (_U_(0x1) << SERCOM_USART_INTFLAG_DRE_Pos)
+#define SERCOM_USART_INTFLAG_TXC_Pos 1            /**< \brief (SERCOM_USART_INTFLAG) Transmit Complete */
+#define SERCOM_USART_INTFLAG_TXC    (_U_(0x1) << SERCOM_USART_INTFLAG_TXC_Pos)
+#define SERCOM_USART_INTFLAG_RXC_Pos 2            /**< \brief (SERCOM_USART_INTFLAG) Receive Complete */
+#define SERCOM_USART_INTFLAG_RXC    (_U_(0x1) << SERCOM_USART_INTFLAG_RXC_Pos)
+#define SERCOM_USART_INTFLAG_RXS_Pos 3            /**< \brief (SERCOM_USART_INTFLAG) Receive Start Interrupt */
+#define SERCOM_USART_INTFLAG_RXS    (_U_(0x1) << SERCOM_USART_INTFLAG_RXS_Pos)
+#define SERCOM_USART_INTFLAG_MASK   _U_(0x0F)    /**< \brief (SERCOM_USART_INTFLAG) MASK Register */
+
+/* -------- SERCOM_I2CM_STATUS : (SERCOM Offset: 0x10) (R/W 16) I2CM I2CM Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t BUSERR:1;         /*!< bit:      0  Bus Error                          */
+    uint16_t ARBLOST:1;        /*!< bit:      1  Arbitration Lost                   */
+    uint16_t RXNACK:1;         /*!< bit:      2  Received Not Acknowledge           */
+    uint16_t :1;               /*!< bit:      3  Reserved                           */
+    uint16_t BUSSTATE:2;       /*!< bit:  4.. 5  Bus State                          */
+    uint16_t LOWTOUT:1;        /*!< bit:      6  SCL Low Time-out                   */
+    uint16_t CLKHOLD:1;        /*!< bit:      7  Clock Hold                         */
+    uint16_t :7;               /*!< bit:  8..14  Reserved                           */
+    uint16_t SYNCBUSY:1;       /*!< bit:     15  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CM_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_STATUS_OFFSET   0x10         /**< \brief (SERCOM_I2CM_STATUS offset) I2CM Status */
+#define SERCOM_I2CM_STATUS_RESETVALUE _U_(0x0000)  /**< \brief (SERCOM_I2CM_STATUS reset_value) I2CM Status */
+
+#define SERCOM_I2CM_STATUS_BUSERR_Pos 0            /**< \brief (SERCOM_I2CM_STATUS) Bus Error */
+#define SERCOM_I2CM_STATUS_BUSERR   (_U_(0x1) << SERCOM_I2CM_STATUS_BUSERR_Pos)
+#define SERCOM_I2CM_STATUS_ARBLOST_Pos 1            /**< \brief (SERCOM_I2CM_STATUS) Arbitration Lost */
+#define SERCOM_I2CM_STATUS_ARBLOST  (_U_(0x1) << SERCOM_I2CM_STATUS_ARBLOST_Pos)
+#define SERCOM_I2CM_STATUS_RXNACK_Pos 2            /**< \brief (SERCOM_I2CM_STATUS) Received Not Acknowledge */
+#define SERCOM_I2CM_STATUS_RXNACK   (_U_(0x1) << SERCOM_I2CM_STATUS_RXNACK_Pos)
+#define SERCOM_I2CM_STATUS_BUSSTATE_Pos 4            /**< \brief (SERCOM_I2CM_STATUS) Bus State */
+#define SERCOM_I2CM_STATUS_BUSSTATE_Msk (_U_(0x3) << SERCOM_I2CM_STATUS_BUSSTATE_Pos)
+#define SERCOM_I2CM_STATUS_BUSSTATE(value) (SERCOM_I2CM_STATUS_BUSSTATE_Msk & ((value) << SERCOM_I2CM_STATUS_BUSSTATE_Pos))
+#define SERCOM_I2CM_STATUS_LOWTOUT_Pos 6            /**< \brief (SERCOM_I2CM_STATUS) SCL Low Time-out */
+#define SERCOM_I2CM_STATUS_LOWTOUT  (_U_(0x1) << SERCOM_I2CM_STATUS_LOWTOUT_Pos)
+#define SERCOM_I2CM_STATUS_CLKHOLD_Pos 7            /**< \brief (SERCOM_I2CM_STATUS) Clock Hold */
+#define SERCOM_I2CM_STATUS_CLKHOLD  (_U_(0x1) << SERCOM_I2CM_STATUS_CLKHOLD_Pos)
+#define SERCOM_I2CM_STATUS_SYNCBUSY_Pos 15           /**< \brief (SERCOM_I2CM_STATUS) Synchronization Busy */
+#define SERCOM_I2CM_STATUS_SYNCBUSY (_U_(0x1) << SERCOM_I2CM_STATUS_SYNCBUSY_Pos)
+#define SERCOM_I2CM_STATUS_MASK     _U_(0x80F7)  /**< \brief (SERCOM_I2CM_STATUS) MASK Register */
+
+/* -------- SERCOM_I2CS_STATUS : (SERCOM Offset: 0x10) (R/W 16) I2CS I2CS Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t BUSERR:1;         /*!< bit:      0  Bus Error                          */
+    uint16_t COLL:1;           /*!< bit:      1  Transmit Collision                 */
+    uint16_t RXNACK:1;         /*!< bit:      2  Received Not Acknowledge           */
+    uint16_t DIR:1;            /*!< bit:      3  Read / Write Direction             */
+    uint16_t SR:1;             /*!< bit:      4  Repeated Start                     */
+    uint16_t :1;               /*!< bit:      5  Reserved                           */
+    uint16_t LOWTOUT:1;        /*!< bit:      6  SCL Low Time-out                   */
+    uint16_t CLKHOLD:1;        /*!< bit:      7  Clock Hold                         */
+    uint16_t :7;               /*!< bit:  8..14  Reserved                           */
+    uint16_t SYNCBUSY:1;       /*!< bit:     15  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CS_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_STATUS_OFFSET   0x10         /**< \brief (SERCOM_I2CS_STATUS offset) I2CS Status */
+#define SERCOM_I2CS_STATUS_RESETVALUE _U_(0x0000)  /**< \brief (SERCOM_I2CS_STATUS reset_value) I2CS Status */
+
+#define SERCOM_I2CS_STATUS_BUSERR_Pos 0            /**< \brief (SERCOM_I2CS_STATUS) Bus Error */
+#define SERCOM_I2CS_STATUS_BUSERR   (_U_(0x1) << SERCOM_I2CS_STATUS_BUSERR_Pos)
+#define SERCOM_I2CS_STATUS_COLL_Pos 1            /**< \brief (SERCOM_I2CS_STATUS) Transmit Collision */
+#define SERCOM_I2CS_STATUS_COLL     (_U_(0x1) << SERCOM_I2CS_STATUS_COLL_Pos)
+#define SERCOM_I2CS_STATUS_RXNACK_Pos 2            /**< \brief (SERCOM_I2CS_STATUS) Received Not Acknowledge */
+#define SERCOM_I2CS_STATUS_RXNACK   (_U_(0x1) << SERCOM_I2CS_STATUS_RXNACK_Pos)
+#define SERCOM_I2CS_STATUS_DIR_Pos  3            /**< \brief (SERCOM_I2CS_STATUS) Read / Write Direction */
+#define SERCOM_I2CS_STATUS_DIR      (_U_(0x1) << SERCOM_I2CS_STATUS_DIR_Pos)
+#define SERCOM_I2CS_STATUS_SR_Pos   4            /**< \brief (SERCOM_I2CS_STATUS) Repeated Start */
+#define SERCOM_I2CS_STATUS_SR       (_U_(0x1) << SERCOM_I2CS_STATUS_SR_Pos)
+#define SERCOM_I2CS_STATUS_LOWTOUT_Pos 6            /**< \brief (SERCOM_I2CS_STATUS) SCL Low Time-out */
+#define SERCOM_I2CS_STATUS_LOWTOUT  (_U_(0x1) << SERCOM_I2CS_STATUS_LOWTOUT_Pos)
+#define SERCOM_I2CS_STATUS_CLKHOLD_Pos 7            /**< \brief (SERCOM_I2CS_STATUS) Clock Hold */
+#define SERCOM_I2CS_STATUS_CLKHOLD  (_U_(0x1) << SERCOM_I2CS_STATUS_CLKHOLD_Pos)
+#define SERCOM_I2CS_STATUS_SYNCBUSY_Pos 15           /**< \brief (SERCOM_I2CS_STATUS) Synchronization Busy */
+#define SERCOM_I2CS_STATUS_SYNCBUSY (_U_(0x1) << SERCOM_I2CS_STATUS_SYNCBUSY_Pos)
+#define SERCOM_I2CS_STATUS_MASK     _U_(0x80DF)  /**< \brief (SERCOM_I2CS_STATUS) MASK Register */
+
+/* -------- SERCOM_SPI_STATUS : (SERCOM Offset: 0x10) (R/W 16) SPI SPI Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t BUFOVF:1;         /*!< bit:      2  Buffer Overflow                    */
+    uint16_t :12;              /*!< bit:  3..14  Reserved                           */
+    uint16_t SYNCBUSY:1;       /*!< bit:     15  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_STATUS_OFFSET    0x10         /**< \brief (SERCOM_SPI_STATUS offset) SPI Status */
+#define SERCOM_SPI_STATUS_RESETVALUE _U_(0x0000)  /**< \brief (SERCOM_SPI_STATUS reset_value) SPI Status */
+
+#define SERCOM_SPI_STATUS_BUFOVF_Pos 2            /**< \brief (SERCOM_SPI_STATUS) Buffer Overflow */
+#define SERCOM_SPI_STATUS_BUFOVF    (_U_(0x1) << SERCOM_SPI_STATUS_BUFOVF_Pos)
+#define SERCOM_SPI_STATUS_SYNCBUSY_Pos 15           /**< \brief (SERCOM_SPI_STATUS) Synchronization Busy */
+#define SERCOM_SPI_STATUS_SYNCBUSY  (_U_(0x1) << SERCOM_SPI_STATUS_SYNCBUSY_Pos)
+#define SERCOM_SPI_STATUS_MASK      _U_(0x8004)  /**< \brief (SERCOM_SPI_STATUS) MASK Register */
+
+/* -------- SERCOM_USART_STATUS : (SERCOM Offset: 0x10) (R/W 16) USART USART Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PERR:1;           /*!< bit:      0  Parity Error                       */
+    uint16_t FERR:1;           /*!< bit:      1  Frame Error                        */
+    uint16_t BUFOVF:1;         /*!< bit:      2  Buffer Overflow                    */
+    uint16_t :12;              /*!< bit:  3..14  Reserved                           */
+    uint16_t SYNCBUSY:1;       /*!< bit:     15  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_STATUS_OFFSET  0x10         /**< \brief (SERCOM_USART_STATUS offset) USART Status */
+#define SERCOM_USART_STATUS_RESETVALUE _U_(0x0000)  /**< \brief (SERCOM_USART_STATUS reset_value) USART Status */
+
+#define SERCOM_USART_STATUS_PERR_Pos 0            /**< \brief (SERCOM_USART_STATUS) Parity Error */
+#define SERCOM_USART_STATUS_PERR    (_U_(0x1) << SERCOM_USART_STATUS_PERR_Pos)
+#define SERCOM_USART_STATUS_FERR_Pos 1            /**< \brief (SERCOM_USART_STATUS) Frame Error */
+#define SERCOM_USART_STATUS_FERR    (_U_(0x1) << SERCOM_USART_STATUS_FERR_Pos)
+#define SERCOM_USART_STATUS_BUFOVF_Pos 2            /**< \brief (SERCOM_USART_STATUS) Buffer Overflow */
+#define SERCOM_USART_STATUS_BUFOVF  (_U_(0x1) << SERCOM_USART_STATUS_BUFOVF_Pos)
+#define SERCOM_USART_STATUS_SYNCBUSY_Pos 15           /**< \brief (SERCOM_USART_STATUS) Synchronization Busy */
+#define SERCOM_USART_STATUS_SYNCBUSY (_U_(0x1) << SERCOM_USART_STATUS_SYNCBUSY_Pos)
+#define SERCOM_USART_STATUS_MASK    _U_(0x8007)  /**< \brief (SERCOM_USART_STATUS) MASK Register */
+
+/* -------- SERCOM_I2CM_ADDR : (SERCOM Offset: 0x14) (R/W  8) I2CM I2CM Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  ADDR:8;           /*!< bit:  0.. 7  Address                            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_ADDR_OFFSET     0x14         /**< \brief (SERCOM_I2CM_ADDR offset) I2CM Address */
+#define SERCOM_I2CM_ADDR_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CM_ADDR reset_value) I2CM Address */
+
+#define SERCOM_I2CM_ADDR_ADDR_Pos   0            /**< \brief (SERCOM_I2CM_ADDR) Address */
+#define SERCOM_I2CM_ADDR_ADDR_Msk   (_U_(0xFF) << SERCOM_I2CM_ADDR_ADDR_Pos)
+#define SERCOM_I2CM_ADDR_ADDR(value) (SERCOM_I2CM_ADDR_ADDR_Msk & ((value) << SERCOM_I2CM_ADDR_ADDR_Pos))
+#define SERCOM_I2CM_ADDR_MASK       _U_(0xFF)    /**< \brief (SERCOM_I2CM_ADDR) MASK Register */
+
+/* -------- SERCOM_I2CS_ADDR : (SERCOM Offset: 0x14) (R/W 32) I2CS I2CS Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t GENCEN:1;         /*!< bit:      0  General Call Address Enable        */
+    uint32_t ADDR:7;           /*!< bit:  1.. 7  Address                            */
+    uint32_t :9;               /*!< bit:  8..16  Reserved                           */
+    uint32_t ADDRMASK:7;       /*!< bit: 17..23  Address Mask                       */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CS_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_ADDR_OFFSET     0x14         /**< \brief (SERCOM_I2CS_ADDR offset) I2CS Address */
+#define SERCOM_I2CS_ADDR_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CS_ADDR reset_value) I2CS Address */
+
+#define SERCOM_I2CS_ADDR_GENCEN_Pos 0            /**< \brief (SERCOM_I2CS_ADDR) General Call Address Enable */
+#define SERCOM_I2CS_ADDR_GENCEN     (_U_(0x1) << SERCOM_I2CS_ADDR_GENCEN_Pos)
+#define SERCOM_I2CS_ADDR_ADDR_Pos   1            /**< \brief (SERCOM_I2CS_ADDR) Address */
+#define SERCOM_I2CS_ADDR_ADDR_Msk   (_U_(0x7F) << SERCOM_I2CS_ADDR_ADDR_Pos)
+#define SERCOM_I2CS_ADDR_ADDR(value) (SERCOM_I2CS_ADDR_ADDR_Msk & ((value) << SERCOM_I2CS_ADDR_ADDR_Pos))
+#define SERCOM_I2CS_ADDR_ADDRMASK_Pos 17           /**< \brief (SERCOM_I2CS_ADDR) Address Mask */
+#define SERCOM_I2CS_ADDR_ADDRMASK_Msk (_U_(0x7F) << SERCOM_I2CS_ADDR_ADDRMASK_Pos)
+#define SERCOM_I2CS_ADDR_ADDRMASK(value) (SERCOM_I2CS_ADDR_ADDRMASK_Msk & ((value) << SERCOM_I2CS_ADDR_ADDRMASK_Pos))
+#define SERCOM_I2CS_ADDR_MASK       _U_(0x00FE00FF) /**< \brief (SERCOM_I2CS_ADDR) MASK Register */
+
+/* -------- SERCOM_SPI_ADDR : (SERCOM Offset: 0x14) (R/W 32) SPI SPI Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ADDR:8;           /*!< bit:  0.. 7  Address                            */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t ADDRMASK:8;       /*!< bit: 16..23  Address Mask                       */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_ADDR_OFFSET      0x14         /**< \brief (SERCOM_SPI_ADDR offset) SPI Address */
+#define SERCOM_SPI_ADDR_RESETVALUE  _U_(0x00000000) /**< \brief (SERCOM_SPI_ADDR reset_value) SPI Address */
+
+#define SERCOM_SPI_ADDR_ADDR_Pos    0            /**< \brief (SERCOM_SPI_ADDR) Address */
+#define SERCOM_SPI_ADDR_ADDR_Msk    (_U_(0xFF) << SERCOM_SPI_ADDR_ADDR_Pos)
+#define SERCOM_SPI_ADDR_ADDR(value) (SERCOM_SPI_ADDR_ADDR_Msk & ((value) << SERCOM_SPI_ADDR_ADDR_Pos))
+#define SERCOM_SPI_ADDR_ADDRMASK_Pos 16           /**< \brief (SERCOM_SPI_ADDR) Address Mask */
+#define SERCOM_SPI_ADDR_ADDRMASK_Msk (_U_(0xFF) << SERCOM_SPI_ADDR_ADDRMASK_Pos)
+#define SERCOM_SPI_ADDR_ADDRMASK(value) (SERCOM_SPI_ADDR_ADDRMASK_Msk & ((value) << SERCOM_SPI_ADDR_ADDRMASK_Pos))
+#define SERCOM_SPI_ADDR_MASK        _U_(0x00FF00FF) /**< \brief (SERCOM_SPI_ADDR) MASK Register */
+
+/* -------- SERCOM_I2CM_DATA : (SERCOM Offset: 0x18) (R/W  8) I2CM I2CM Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DATA:8;           /*!< bit:  0.. 7  Data                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_DATA_OFFSET     0x18         /**< \brief (SERCOM_I2CM_DATA offset) I2CM Data */
+#define SERCOM_I2CM_DATA_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CM_DATA reset_value) I2CM Data */
+
+#define SERCOM_I2CM_DATA_DATA_Pos   0            /**< \brief (SERCOM_I2CM_DATA) Data */
+#define SERCOM_I2CM_DATA_DATA_Msk   (_U_(0xFF) << SERCOM_I2CM_DATA_DATA_Pos)
+#define SERCOM_I2CM_DATA_DATA(value) (SERCOM_I2CM_DATA_DATA_Msk & ((value) << SERCOM_I2CM_DATA_DATA_Pos))
+#define SERCOM_I2CM_DATA_MASK       _U_(0xFF)    /**< \brief (SERCOM_I2CM_DATA) MASK Register */
+
+/* -------- SERCOM_I2CS_DATA : (SERCOM Offset: 0x18) (R/W  8) I2CS I2CS Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DATA:8;           /*!< bit:  0.. 7  Data                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CS_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_DATA_OFFSET     0x18         /**< \brief (SERCOM_I2CS_DATA offset) I2CS Data */
+#define SERCOM_I2CS_DATA_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CS_DATA reset_value) I2CS Data */
+
+#define SERCOM_I2CS_DATA_DATA_Pos   0            /**< \brief (SERCOM_I2CS_DATA) Data */
+#define SERCOM_I2CS_DATA_DATA_Msk   (_U_(0xFF) << SERCOM_I2CS_DATA_DATA_Pos)
+#define SERCOM_I2CS_DATA_DATA(value) (SERCOM_I2CS_DATA_DATA_Msk & ((value) << SERCOM_I2CS_DATA_DATA_Pos))
+#define SERCOM_I2CS_DATA_MASK       _U_(0xFF)    /**< \brief (SERCOM_I2CS_DATA) MASK Register */
+
+/* -------- SERCOM_SPI_DATA : (SERCOM Offset: 0x18) (R/W 16) SPI SPI Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DATA:9;           /*!< bit:  0.. 8  Data                               */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_DATA_OFFSET      0x18         /**< \brief (SERCOM_SPI_DATA offset) SPI Data */
+#define SERCOM_SPI_DATA_RESETVALUE  _U_(0x0000)  /**< \brief (SERCOM_SPI_DATA reset_value) SPI Data */
+
+#define SERCOM_SPI_DATA_DATA_Pos    0            /**< \brief (SERCOM_SPI_DATA) Data */
+#define SERCOM_SPI_DATA_DATA_Msk    (_U_(0x1FF) << SERCOM_SPI_DATA_DATA_Pos)
+#define SERCOM_SPI_DATA_DATA(value) (SERCOM_SPI_DATA_DATA_Msk & ((value) << SERCOM_SPI_DATA_DATA_Pos))
+#define SERCOM_SPI_DATA_MASK        _U_(0x01FF)  /**< \brief (SERCOM_SPI_DATA) MASK Register */
+
+/* -------- SERCOM_USART_DATA : (SERCOM Offset: 0x18) (R/W 16) USART USART Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DATA:9;           /*!< bit:  0.. 8  Data                               */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_DATA_OFFSET    0x18         /**< \brief (SERCOM_USART_DATA offset) USART Data */
+#define SERCOM_USART_DATA_RESETVALUE _U_(0x0000)  /**< \brief (SERCOM_USART_DATA reset_value) USART Data */
+
+#define SERCOM_USART_DATA_DATA_Pos  0            /**< \brief (SERCOM_USART_DATA) Data */
+#define SERCOM_USART_DATA_DATA_Msk  (_U_(0x1FF) << SERCOM_USART_DATA_DATA_Pos)
+#define SERCOM_USART_DATA_DATA(value) (SERCOM_USART_DATA_DATA_Msk & ((value) << SERCOM_USART_DATA_DATA_Pos))
+#define SERCOM_USART_DATA_MASK      _U_(0x01FF)  /**< \brief (SERCOM_USART_DATA) MASK Register */
+
+/** \brief SERCOM_I2CM hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* I2C Master Mode */
+  __IO SERCOM_I2CM_CTRLA_Type    CTRLA;       /**< \brief Offset: 0x00 (R/W 32) I2CM Control A */
+  __IO SERCOM_I2CM_CTRLB_Type    CTRLB;       /**< \brief Offset: 0x04 (R/W 32) I2CM Control B */
+  __IO SERCOM_I2CM_DBGCTRL_Type  DBGCTRL;     /**< \brief Offset: 0x08 (R/W  8) I2CM Debug Control */
+       RoReg8                    Reserved1[0x1];
+  __IO SERCOM_I2CM_BAUD_Type     BAUD;        /**< \brief Offset: 0x0A (R/W 16) I2CM Baud Rate */
+  __IO SERCOM_I2CM_INTENCLR_Type INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) I2CM Interrupt Enable Clear */
+  __IO SERCOM_I2CM_INTENSET_Type INTENSET;    /**< \brief Offset: 0x0D (R/W  8) I2CM Interrupt Enable Set */
+  __IO SERCOM_I2CM_INTFLAG_Type  INTFLAG;     /**< \brief Offset: 0x0E (R/W  8) I2CM Interrupt Flag Status and Clear */
+       RoReg8                    Reserved2[0x1];
+  __IO SERCOM_I2CM_STATUS_Type   STATUS;      /**< \brief Offset: 0x10 (R/W 16) I2CM Status */
+       RoReg8                    Reserved3[0x2];
+  __IO SERCOM_I2CM_ADDR_Type     ADDR;        /**< \brief Offset: 0x14 (R/W  8) I2CM Address */
+       RoReg8                    Reserved4[0x3];
+  __IO SERCOM_I2CM_DATA_Type     DATA;        /**< \brief Offset: 0x18 (R/W  8) I2CM Data */
+} SercomI2cm;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief SERCOM_I2CS hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* I2C Slave Mode */
+  __IO SERCOM_I2CS_CTRLA_Type    CTRLA;       /**< \brief Offset: 0x00 (R/W 32) I2CS Control A */
+  __IO SERCOM_I2CS_CTRLB_Type    CTRLB;       /**< \brief Offset: 0x04 (R/W 32) I2CS Control B */
+       RoReg8                    Reserved1[0x4];
+  __IO SERCOM_I2CS_INTENCLR_Type INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) I2CS Interrupt Enable Clear */
+  __IO SERCOM_I2CS_INTENSET_Type INTENSET;    /**< \brief Offset: 0x0D (R/W  8) I2CS Interrupt Enable Set */
+  __IO SERCOM_I2CS_INTFLAG_Type  INTFLAG;     /**< \brief Offset: 0x0E (R/W  8) I2CS Interrupt Flag Status and Clear */
+       RoReg8                    Reserved2[0x1];
+  __IO SERCOM_I2CS_STATUS_Type   STATUS;      /**< \brief Offset: 0x10 (R/W 16) I2CS Status */
+       RoReg8                    Reserved3[0x2];
+  __IO SERCOM_I2CS_ADDR_Type     ADDR;        /**< \brief Offset: 0x14 (R/W 32) I2CS Address */
+  __IO SERCOM_I2CS_DATA_Type     DATA;        /**< \brief Offset: 0x18 (R/W  8) I2CS Data */
+} SercomI2cs;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief SERCOM_SPI hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* SPI Mode */
+  __IO SERCOM_SPI_CTRLA_Type     CTRLA;       /**< \brief Offset: 0x00 (R/W 32) SPI Control A */
+  __IO SERCOM_SPI_CTRLB_Type     CTRLB;       /**< \brief Offset: 0x04 (R/W 32) SPI Control B */
+  __IO SERCOM_SPI_DBGCTRL_Type   DBGCTRL;     /**< \brief Offset: 0x08 (R/W  8) SPI Debug Control */
+       RoReg8                    Reserved1[0x1];
+  __IO SERCOM_SPI_BAUD_Type      BAUD;        /**< \brief Offset: 0x0A (R/W  8) SPI Baud Rate */
+       RoReg8                    Reserved2[0x1];
+  __IO SERCOM_SPI_INTENCLR_Type  INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) SPI Interrupt Enable Clear */
+  __IO SERCOM_SPI_INTENSET_Type  INTENSET;    /**< \brief Offset: 0x0D (R/W  8) SPI Interrupt Enable Set */
+  __IO SERCOM_SPI_INTFLAG_Type   INTFLAG;     /**< \brief Offset: 0x0E (R/W  8) SPI Interrupt Flag Status and Clear */
+       RoReg8                    Reserved3[0x1];
+  __IO SERCOM_SPI_STATUS_Type    STATUS;      /**< \brief Offset: 0x10 (R/W 16) SPI Status */
+       RoReg8                    Reserved4[0x2];
+  __IO SERCOM_SPI_ADDR_Type      ADDR;        /**< \brief Offset: 0x14 (R/W 32) SPI Address */
+  __IO SERCOM_SPI_DATA_Type      DATA;        /**< \brief Offset: 0x18 (R/W 16) SPI Data */
+} SercomSpi;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief SERCOM_USART hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* USART Mode */
+  __IO SERCOM_USART_CTRLA_Type   CTRLA;       /**< \brief Offset: 0x00 (R/W 32) USART Control A */
+  __IO SERCOM_USART_CTRLB_Type   CTRLB;       /**< \brief Offset: 0x04 (R/W 32) USART Control B */
+  __IO SERCOM_USART_DBGCTRL_Type DBGCTRL;     /**< \brief Offset: 0x08 (R/W  8) USART Debug Control */
+       RoReg8                    Reserved1[0x1];
+  __IO SERCOM_USART_BAUD_Type    BAUD;        /**< \brief Offset: 0x0A (R/W 16) USART Baud */
+  __IO SERCOM_USART_INTENCLR_Type INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) USART Interrupt Enable Clear */
+  __IO SERCOM_USART_INTENSET_Type INTENSET;    /**< \brief Offset: 0x0D (R/W  8) USART Interrupt Enable Set */
+  __IO SERCOM_USART_INTFLAG_Type INTFLAG;     /**< \brief Offset: 0x0E (R/W  8) USART Interrupt Flag Status and Clear */
+       RoReg8                    Reserved2[0x1];
+  __IO SERCOM_USART_STATUS_Type  STATUS;      /**< \brief Offset: 0x10 (R/W 16) USART Status */
+       RoReg8                    Reserved3[0x6];
+  __IO SERCOM_USART_DATA_Type    DATA;        /**< \brief Offset: 0x18 (R/W 16) USART Data */
+} SercomUsart;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+       SercomI2cm                I2CM;        /**< \brief Offset: 0x00 I2C Master Mode */
+       SercomI2cs                I2CS;        /**< \brief Offset: 0x00 I2C Slave Mode */
+       SercomSpi                 SPI;         /**< \brief Offset: 0x00 SPI Mode */
+       SercomUsart               USART;       /**< \brief Offset: 0x00 USART Mode */
+} Sercom;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_SERCOM_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/component/sysctrl.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/sysctrl.h
@@ -1,0 +1,674 @@
+/**
+ * \file
+ *
+ * \brief Component description for SYSCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SYSCTRL_COMPONENT_
+#define _SAMD20_SYSCTRL_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SYSCTRL */
+/* ========================================================================== */
+/** \addtogroup SAMD20_SYSCTRL System Control */
+/*@{*/
+
+#define SYSCTRL_U2100
+#define REV_SYSCTRL                 0x201
+
+/* -------- SYSCTRL_INTENCLR : (SYSCTRL Offset: 0x00) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
+    uint32_t XOSC32KRDY:1;     /*!< bit:      1  XOSC32K Ready                      */
+    uint32_t OSC32KRDY:1;      /*!< bit:      2  OSC32K Ready                       */
+    uint32_t OSC8MRDY:1;       /*!< bit:      3  OSC8M Ready                        */
+    uint32_t DFLLRDY:1;        /*!< bit:      4  DFLL Ready                         */
+    uint32_t DFLLOOB:1;        /*!< bit:      5  DFLL Out Of Bounds                 */
+    uint32_t DFLLLCKF:1;       /*!< bit:      6  DFLL Lock Fine                     */
+    uint32_t DFLLLCKC:1;       /*!< bit:      7  DFLL Lock Coarse                   */
+    uint32_t DFLLRCS:1;        /*!< bit:      8  DFLL Reference Clock Stopped       */
+    uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
+    uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
+    uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_INTENCLR_OFFSET     0x00         /**< \brief (SYSCTRL_INTENCLR offset) Interrupt Enable Clear */
+#define SYSCTRL_INTENCLR_RESETVALUE _U_(0x00000000) /**< \brief (SYSCTRL_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define SYSCTRL_INTENCLR_XOSCRDY_Pos 0            /**< \brief (SYSCTRL_INTENCLR) XOSC Ready */
+#define SYSCTRL_INTENCLR_XOSCRDY    (_U_(0x1) << SYSCTRL_INTENCLR_XOSCRDY_Pos)
+#define SYSCTRL_INTENCLR_XOSC32KRDY_Pos 1            /**< \brief (SYSCTRL_INTENCLR) XOSC32K Ready */
+#define SYSCTRL_INTENCLR_XOSC32KRDY (_U_(0x1) << SYSCTRL_INTENCLR_XOSC32KRDY_Pos)
+#define SYSCTRL_INTENCLR_OSC32KRDY_Pos 2            /**< \brief (SYSCTRL_INTENCLR) OSC32K Ready */
+#define SYSCTRL_INTENCLR_OSC32KRDY  (_U_(0x1) << SYSCTRL_INTENCLR_OSC32KRDY_Pos)
+#define SYSCTRL_INTENCLR_OSC8MRDY_Pos 3            /**< \brief (SYSCTRL_INTENCLR) OSC8M Ready */
+#define SYSCTRL_INTENCLR_OSC8MRDY   (_U_(0x1) << SYSCTRL_INTENCLR_OSC8MRDY_Pos)
+#define SYSCTRL_INTENCLR_DFLLRDY_Pos 4            /**< \brief (SYSCTRL_INTENCLR) DFLL Ready */
+#define SYSCTRL_INTENCLR_DFLLRDY    (_U_(0x1) << SYSCTRL_INTENCLR_DFLLRDY_Pos)
+#define SYSCTRL_INTENCLR_DFLLOOB_Pos 5            /**< \brief (SYSCTRL_INTENCLR) DFLL Out Of Bounds */
+#define SYSCTRL_INTENCLR_DFLLOOB    (_U_(0x1) << SYSCTRL_INTENCLR_DFLLOOB_Pos)
+#define SYSCTRL_INTENCLR_DFLLLCKF_Pos 6            /**< \brief (SYSCTRL_INTENCLR) DFLL Lock Fine */
+#define SYSCTRL_INTENCLR_DFLLLCKF   (_U_(0x1) << SYSCTRL_INTENCLR_DFLLLCKF_Pos)
+#define SYSCTRL_INTENCLR_DFLLLCKC_Pos 7            /**< \brief (SYSCTRL_INTENCLR) DFLL Lock Coarse */
+#define SYSCTRL_INTENCLR_DFLLLCKC   (_U_(0x1) << SYSCTRL_INTENCLR_DFLLLCKC_Pos)
+#define SYSCTRL_INTENCLR_DFLLRCS_Pos 8            /**< \brief (SYSCTRL_INTENCLR) DFLL Reference Clock Stopped */
+#define SYSCTRL_INTENCLR_DFLLRCS    (_U_(0x1) << SYSCTRL_INTENCLR_DFLLRCS_Pos)
+#define SYSCTRL_INTENCLR_BOD33RDY_Pos 9            /**< \brief (SYSCTRL_INTENCLR) BOD33 Ready */
+#define SYSCTRL_INTENCLR_BOD33RDY   (_U_(0x1) << SYSCTRL_INTENCLR_BOD33RDY_Pos)
+#define SYSCTRL_INTENCLR_BOD33DET_Pos 10           /**< \brief (SYSCTRL_INTENCLR) BOD33 Detection */
+#define SYSCTRL_INTENCLR_BOD33DET   (_U_(0x1) << SYSCTRL_INTENCLR_BOD33DET_Pos)
+#define SYSCTRL_INTENCLR_B33SRDY_Pos 11           /**< \brief (SYSCTRL_INTENCLR) BOD33 Synchronization Ready */
+#define SYSCTRL_INTENCLR_B33SRDY    (_U_(0x1) << SYSCTRL_INTENCLR_B33SRDY_Pos)
+#define SYSCTRL_INTENCLR_MASK       _U_(0x00000FFF) /**< \brief (SYSCTRL_INTENCLR) MASK Register */
+
+/* -------- SYSCTRL_INTENSET : (SYSCTRL Offset: 0x04) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
+    uint32_t XOSC32KRDY:1;     /*!< bit:      1  XOSC32K Ready                      */
+    uint32_t OSC32KRDY:1;      /*!< bit:      2  OSC32K Ready                       */
+    uint32_t OSC8MRDY:1;       /*!< bit:      3  OSC8M Ready                        */
+    uint32_t DFLLRDY:1;        /*!< bit:      4  DFLL Ready                         */
+    uint32_t DFLLOOB:1;        /*!< bit:      5  DFLL Out Of Bounds                 */
+    uint32_t DFLLLCKF:1;       /*!< bit:      6  DFLL Lock Fine                     */
+    uint32_t DFLLLCKC:1;       /*!< bit:      7  DFLL Lock Coarse                   */
+    uint32_t DFLLRCS:1;        /*!< bit:      8  DFLL Reference Clock Stopped       */
+    uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
+    uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
+    uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_INTENSET_OFFSET     0x04         /**< \brief (SYSCTRL_INTENSET offset) Interrupt Enable Set */
+#define SYSCTRL_INTENSET_RESETVALUE _U_(0x00000000) /**< \brief (SYSCTRL_INTENSET reset_value) Interrupt Enable Set */
+
+#define SYSCTRL_INTENSET_XOSCRDY_Pos 0            /**< \brief (SYSCTRL_INTENSET) XOSC Ready */
+#define SYSCTRL_INTENSET_XOSCRDY    (_U_(0x1) << SYSCTRL_INTENSET_XOSCRDY_Pos)
+#define SYSCTRL_INTENSET_XOSC32KRDY_Pos 1            /**< \brief (SYSCTRL_INTENSET) XOSC32K Ready */
+#define SYSCTRL_INTENSET_XOSC32KRDY (_U_(0x1) << SYSCTRL_INTENSET_XOSC32KRDY_Pos)
+#define SYSCTRL_INTENSET_OSC32KRDY_Pos 2            /**< \brief (SYSCTRL_INTENSET) OSC32K Ready */
+#define SYSCTRL_INTENSET_OSC32KRDY  (_U_(0x1) << SYSCTRL_INTENSET_OSC32KRDY_Pos)
+#define SYSCTRL_INTENSET_OSC8MRDY_Pos 3            /**< \brief (SYSCTRL_INTENSET) OSC8M Ready */
+#define SYSCTRL_INTENSET_OSC8MRDY   (_U_(0x1) << SYSCTRL_INTENSET_OSC8MRDY_Pos)
+#define SYSCTRL_INTENSET_DFLLRDY_Pos 4            /**< \brief (SYSCTRL_INTENSET) DFLL Ready */
+#define SYSCTRL_INTENSET_DFLLRDY    (_U_(0x1) << SYSCTRL_INTENSET_DFLLRDY_Pos)
+#define SYSCTRL_INTENSET_DFLLOOB_Pos 5            /**< \brief (SYSCTRL_INTENSET) DFLL Out Of Bounds */
+#define SYSCTRL_INTENSET_DFLLOOB    (_U_(0x1) << SYSCTRL_INTENSET_DFLLOOB_Pos)
+#define SYSCTRL_INTENSET_DFLLLCKF_Pos 6            /**< \brief (SYSCTRL_INTENSET) DFLL Lock Fine */
+#define SYSCTRL_INTENSET_DFLLLCKF   (_U_(0x1) << SYSCTRL_INTENSET_DFLLLCKF_Pos)
+#define SYSCTRL_INTENSET_DFLLLCKC_Pos 7            /**< \brief (SYSCTRL_INTENSET) DFLL Lock Coarse */
+#define SYSCTRL_INTENSET_DFLLLCKC   (_U_(0x1) << SYSCTRL_INTENSET_DFLLLCKC_Pos)
+#define SYSCTRL_INTENSET_DFLLRCS_Pos 8            /**< \brief (SYSCTRL_INTENSET) DFLL Reference Clock Stopped */
+#define SYSCTRL_INTENSET_DFLLRCS    (_U_(0x1) << SYSCTRL_INTENSET_DFLLRCS_Pos)
+#define SYSCTRL_INTENSET_BOD33RDY_Pos 9            /**< \brief (SYSCTRL_INTENSET) BOD33 Ready */
+#define SYSCTRL_INTENSET_BOD33RDY   (_U_(0x1) << SYSCTRL_INTENSET_BOD33RDY_Pos)
+#define SYSCTRL_INTENSET_BOD33DET_Pos 10           /**< \brief (SYSCTRL_INTENSET) BOD33 Detection */
+#define SYSCTRL_INTENSET_BOD33DET   (_U_(0x1) << SYSCTRL_INTENSET_BOD33DET_Pos)
+#define SYSCTRL_INTENSET_B33SRDY_Pos 11           /**< \brief (SYSCTRL_INTENSET) BOD33 Synchronization Ready */
+#define SYSCTRL_INTENSET_B33SRDY    (_U_(0x1) << SYSCTRL_INTENSET_B33SRDY_Pos)
+#define SYSCTRL_INTENSET_MASK       _U_(0x00000FFF) /**< \brief (SYSCTRL_INTENSET) MASK Register */
+
+/* -------- SYSCTRL_INTFLAG : (SYSCTRL Offset: 0x08) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
+    __I uint32_t XOSC32KRDY:1;     /*!< bit:      1  XOSC32K Ready                      */
+    __I uint32_t OSC32KRDY:1;      /*!< bit:      2  OSC32K Ready                       */
+    __I uint32_t OSC8MRDY:1;       /*!< bit:      3  OSC8M Ready                        */
+    __I uint32_t DFLLRDY:1;        /*!< bit:      4  DFLL Ready                         */
+    __I uint32_t DFLLOOB:1;        /*!< bit:      5  DFLL Out Of Bounds                 */
+    __I uint32_t DFLLLCKF:1;       /*!< bit:      6  DFLL Lock Fine                     */
+    __I uint32_t DFLLLCKC:1;       /*!< bit:      7  DFLL Lock Coarse                   */
+    __I uint32_t DFLLRCS:1;        /*!< bit:      8  DFLL Reference Clock Stopped       */
+    __I uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
+    __I uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
+    __I uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
+    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_INTFLAG_OFFSET      0x08         /**< \brief (SYSCTRL_INTFLAG offset) Interrupt Flag Status and Clear */
+#define SYSCTRL_INTFLAG_RESETVALUE  _U_(0x00000000) /**< \brief (SYSCTRL_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define SYSCTRL_INTFLAG_XOSCRDY_Pos 0            /**< \brief (SYSCTRL_INTFLAG) XOSC Ready */
+#define SYSCTRL_INTFLAG_XOSCRDY     (_U_(0x1) << SYSCTRL_INTFLAG_XOSCRDY_Pos)
+#define SYSCTRL_INTFLAG_XOSC32KRDY_Pos 1            /**< \brief (SYSCTRL_INTFLAG) XOSC32K Ready */
+#define SYSCTRL_INTFLAG_XOSC32KRDY  (_U_(0x1) << SYSCTRL_INTFLAG_XOSC32KRDY_Pos)
+#define SYSCTRL_INTFLAG_OSC32KRDY_Pos 2            /**< \brief (SYSCTRL_INTFLAG) OSC32K Ready */
+#define SYSCTRL_INTFLAG_OSC32KRDY   (_U_(0x1) << SYSCTRL_INTFLAG_OSC32KRDY_Pos)
+#define SYSCTRL_INTFLAG_OSC8MRDY_Pos 3            /**< \brief (SYSCTRL_INTFLAG) OSC8M Ready */
+#define SYSCTRL_INTFLAG_OSC8MRDY    (_U_(0x1) << SYSCTRL_INTFLAG_OSC8MRDY_Pos)
+#define SYSCTRL_INTFLAG_DFLLRDY_Pos 4            /**< \brief (SYSCTRL_INTFLAG) DFLL Ready */
+#define SYSCTRL_INTFLAG_DFLLRDY     (_U_(0x1) << SYSCTRL_INTFLAG_DFLLRDY_Pos)
+#define SYSCTRL_INTFLAG_DFLLOOB_Pos 5            /**< \brief (SYSCTRL_INTFLAG) DFLL Out Of Bounds */
+#define SYSCTRL_INTFLAG_DFLLOOB     (_U_(0x1) << SYSCTRL_INTFLAG_DFLLOOB_Pos)
+#define SYSCTRL_INTFLAG_DFLLLCKF_Pos 6            /**< \brief (SYSCTRL_INTFLAG) DFLL Lock Fine */
+#define SYSCTRL_INTFLAG_DFLLLCKF    (_U_(0x1) << SYSCTRL_INTFLAG_DFLLLCKF_Pos)
+#define SYSCTRL_INTFLAG_DFLLLCKC_Pos 7            /**< \brief (SYSCTRL_INTFLAG) DFLL Lock Coarse */
+#define SYSCTRL_INTFLAG_DFLLLCKC    (_U_(0x1) << SYSCTRL_INTFLAG_DFLLLCKC_Pos)
+#define SYSCTRL_INTFLAG_DFLLRCS_Pos 8            /**< \brief (SYSCTRL_INTFLAG) DFLL Reference Clock Stopped */
+#define SYSCTRL_INTFLAG_DFLLRCS     (_U_(0x1) << SYSCTRL_INTFLAG_DFLLRCS_Pos)
+#define SYSCTRL_INTFLAG_BOD33RDY_Pos 9            /**< \brief (SYSCTRL_INTFLAG) BOD33 Ready */
+#define SYSCTRL_INTFLAG_BOD33RDY    (_U_(0x1) << SYSCTRL_INTFLAG_BOD33RDY_Pos)
+#define SYSCTRL_INTFLAG_BOD33DET_Pos 10           /**< \brief (SYSCTRL_INTFLAG) BOD33 Detection */
+#define SYSCTRL_INTFLAG_BOD33DET    (_U_(0x1) << SYSCTRL_INTFLAG_BOD33DET_Pos)
+#define SYSCTRL_INTFLAG_B33SRDY_Pos 11           /**< \brief (SYSCTRL_INTFLAG) BOD33 Synchronization Ready */
+#define SYSCTRL_INTFLAG_B33SRDY     (_U_(0x1) << SYSCTRL_INTFLAG_B33SRDY_Pos)
+#define SYSCTRL_INTFLAG_MASK        _U_(0x00000FFF) /**< \brief (SYSCTRL_INTFLAG) MASK Register */
+
+/* -------- SYSCTRL_PCLKSR : (SYSCTRL Offset: 0x0C) (R/  32) Power and Clocks Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
+    uint32_t XOSC32KRDY:1;     /*!< bit:      1  XOSC32K Ready                      */
+    uint32_t OSC32KRDY:1;      /*!< bit:      2  OSC32K Ready                       */
+    uint32_t OSC8MRDY:1;       /*!< bit:      3  OSC8M Ready                        */
+    uint32_t DFLLRDY:1;        /*!< bit:      4  DFLL Ready                         */
+    uint32_t DFLLOOB:1;        /*!< bit:      5  DFLL Out Of Bounds                 */
+    uint32_t DFLLLCKF:1;       /*!< bit:      6  DFLL Lock Fine                     */
+    uint32_t DFLLLCKC:1;       /*!< bit:      7  DFLL Lock Coarse                   */
+    uint32_t DFLLRCS:1;        /*!< bit:      8  DFLL Reference Clock Stopped       */
+    uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
+    uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
+    uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_PCLKSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_PCLKSR_OFFSET       0x0C         /**< \brief (SYSCTRL_PCLKSR offset) Power and Clocks Status */
+#define SYSCTRL_PCLKSR_RESETVALUE   _U_(0x00000000) /**< \brief (SYSCTRL_PCLKSR reset_value) Power and Clocks Status */
+
+#define SYSCTRL_PCLKSR_XOSCRDY_Pos  0            /**< \brief (SYSCTRL_PCLKSR) XOSC Ready */
+#define SYSCTRL_PCLKSR_XOSCRDY      (_U_(0x1) << SYSCTRL_PCLKSR_XOSCRDY_Pos)
+#define SYSCTRL_PCLKSR_XOSC32KRDY_Pos 1            /**< \brief (SYSCTRL_PCLKSR) XOSC32K Ready */
+#define SYSCTRL_PCLKSR_XOSC32KRDY   (_U_(0x1) << SYSCTRL_PCLKSR_XOSC32KRDY_Pos)
+#define SYSCTRL_PCLKSR_OSC32KRDY_Pos 2            /**< \brief (SYSCTRL_PCLKSR) OSC32K Ready */
+#define SYSCTRL_PCLKSR_OSC32KRDY    (_U_(0x1) << SYSCTRL_PCLKSR_OSC32KRDY_Pos)
+#define SYSCTRL_PCLKSR_OSC8MRDY_Pos 3            /**< \brief (SYSCTRL_PCLKSR) OSC8M Ready */
+#define SYSCTRL_PCLKSR_OSC8MRDY     (_U_(0x1) << SYSCTRL_PCLKSR_OSC8MRDY_Pos)
+#define SYSCTRL_PCLKSR_DFLLRDY_Pos  4            /**< \brief (SYSCTRL_PCLKSR) DFLL Ready */
+#define SYSCTRL_PCLKSR_DFLLRDY      (_U_(0x1) << SYSCTRL_PCLKSR_DFLLRDY_Pos)
+#define SYSCTRL_PCLKSR_DFLLOOB_Pos  5            /**< \brief (SYSCTRL_PCLKSR) DFLL Out Of Bounds */
+#define SYSCTRL_PCLKSR_DFLLOOB      (_U_(0x1) << SYSCTRL_PCLKSR_DFLLOOB_Pos)
+#define SYSCTRL_PCLKSR_DFLLLCKF_Pos 6            /**< \brief (SYSCTRL_PCLKSR) DFLL Lock Fine */
+#define SYSCTRL_PCLKSR_DFLLLCKF     (_U_(0x1) << SYSCTRL_PCLKSR_DFLLLCKF_Pos)
+#define SYSCTRL_PCLKSR_DFLLLCKC_Pos 7            /**< \brief (SYSCTRL_PCLKSR) DFLL Lock Coarse */
+#define SYSCTRL_PCLKSR_DFLLLCKC     (_U_(0x1) << SYSCTRL_PCLKSR_DFLLLCKC_Pos)
+#define SYSCTRL_PCLKSR_DFLLRCS_Pos  8            /**< \brief (SYSCTRL_PCLKSR) DFLL Reference Clock Stopped */
+#define SYSCTRL_PCLKSR_DFLLRCS      (_U_(0x1) << SYSCTRL_PCLKSR_DFLLRCS_Pos)
+#define SYSCTRL_PCLKSR_BOD33RDY_Pos 9            /**< \brief (SYSCTRL_PCLKSR) BOD33 Ready */
+#define SYSCTRL_PCLKSR_BOD33RDY     (_U_(0x1) << SYSCTRL_PCLKSR_BOD33RDY_Pos)
+#define SYSCTRL_PCLKSR_BOD33DET_Pos 10           /**< \brief (SYSCTRL_PCLKSR) BOD33 Detection */
+#define SYSCTRL_PCLKSR_BOD33DET     (_U_(0x1) << SYSCTRL_PCLKSR_BOD33DET_Pos)
+#define SYSCTRL_PCLKSR_B33SRDY_Pos  11           /**< \brief (SYSCTRL_PCLKSR) BOD33 Synchronization Ready */
+#define SYSCTRL_PCLKSR_B33SRDY      (_U_(0x1) << SYSCTRL_PCLKSR_B33SRDY_Pos)
+#define SYSCTRL_PCLKSR_MASK         _U_(0x00000FFF) /**< \brief (SYSCTRL_PCLKSR) MASK Register */
+
+/* -------- SYSCTRL_XOSC : (SYSCTRL Offset: 0x10) (R/W 16) XOSC Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :1;               /*!< bit:      0  Reserved                           */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t XTALEN:1;         /*!< bit:      2  Crystal Oscillator Enable          */
+    uint16_t :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint16_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint16_t ONDEMAND:1;       /*!< bit:      7  Enable on Demand                   */
+    uint16_t GAIN:3;           /*!< bit:  8..10  Gain Value                         */
+    uint16_t AMPGC:1;          /*!< bit:     11  Automatic Amplitude Gain Control   */
+    uint16_t STARTUP:4;        /*!< bit: 12..15  Start-Up Time                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_XOSC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_XOSC_OFFSET         0x10         /**< \brief (SYSCTRL_XOSC offset) XOSC Control */
+#define SYSCTRL_XOSC_RESETVALUE     _U_(0x0080)  /**< \brief (SYSCTRL_XOSC reset_value) XOSC Control */
+
+#define SYSCTRL_XOSC_ENABLE_Pos     1            /**< \brief (SYSCTRL_XOSC) Enable */
+#define SYSCTRL_XOSC_ENABLE         (_U_(0x1) << SYSCTRL_XOSC_ENABLE_Pos)
+#define SYSCTRL_XOSC_XTALEN_Pos     2            /**< \brief (SYSCTRL_XOSC) Crystal Oscillator Enable */
+#define SYSCTRL_XOSC_XTALEN         (_U_(0x1) << SYSCTRL_XOSC_XTALEN_Pos)
+#define SYSCTRL_XOSC_RUNSTDBY_Pos   6            /**< \brief (SYSCTRL_XOSC) Run during Standby */
+#define SYSCTRL_XOSC_RUNSTDBY       (_U_(0x1) << SYSCTRL_XOSC_RUNSTDBY_Pos)
+#define SYSCTRL_XOSC_ONDEMAND_Pos   7            /**< \brief (SYSCTRL_XOSC) Enable on Demand */
+#define SYSCTRL_XOSC_ONDEMAND       (_U_(0x1) << SYSCTRL_XOSC_ONDEMAND_Pos)
+#define SYSCTRL_XOSC_GAIN_Pos       8            /**< \brief (SYSCTRL_XOSC) Gain Value */
+#define SYSCTRL_XOSC_GAIN_Msk       (_U_(0x7) << SYSCTRL_XOSC_GAIN_Pos)
+#define SYSCTRL_XOSC_GAIN(value)    (SYSCTRL_XOSC_GAIN_Msk & ((value) << SYSCTRL_XOSC_GAIN_Pos))
+#define SYSCTRL_XOSC_AMPGC_Pos      11           /**< \brief (SYSCTRL_XOSC) Automatic Amplitude Gain Control */
+#define SYSCTRL_XOSC_AMPGC          (_U_(0x1) << SYSCTRL_XOSC_AMPGC_Pos)
+#define SYSCTRL_XOSC_STARTUP_Pos    12           /**< \brief (SYSCTRL_XOSC) Start-Up Time */
+#define SYSCTRL_XOSC_STARTUP_Msk    (_U_(0xF) << SYSCTRL_XOSC_STARTUP_Pos)
+#define SYSCTRL_XOSC_STARTUP(value) (SYSCTRL_XOSC_STARTUP_Msk & ((value) << SYSCTRL_XOSC_STARTUP_Pos))
+#define SYSCTRL_XOSC_MASK           _U_(0xFFC6)  /**< \brief (SYSCTRL_XOSC) MASK Register */
+
+/* -------- SYSCTRL_XOSC32K : (SYSCTRL Offset: 0x14) (R/W 16) XOSC32K Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :1;               /*!< bit:      0  Reserved                           */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t XTALEN:1;         /*!< bit:      2  Crystal Oscillator Enable          */
+    uint16_t EN32K:1;          /*!< bit:      3  32kHz Output Enable                */
+    uint16_t EN1K:1;           /*!< bit:      4  1kHz Output Enable                 */
+    uint16_t AAMPEN:1;         /*!< bit:      5  Automatic Amplitude Control Enable */
+    uint16_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint16_t ONDEMAND:1;       /*!< bit:      7  Enable on Demand                   */
+    uint16_t STARTUP:3;        /*!< bit:  8..10  Start-Up Time                      */
+    uint16_t :1;               /*!< bit:     11  Reserved                           */
+    uint16_t WRTLOCK:1;        /*!< bit:     12  Write Lock                         */
+    uint16_t :3;               /*!< bit: 13..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_XOSC32K_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_XOSC32K_OFFSET      0x14         /**< \brief (SYSCTRL_XOSC32K offset) XOSC32K Control */
+#define SYSCTRL_XOSC32K_RESETVALUE  _U_(0x0080)  /**< \brief (SYSCTRL_XOSC32K reset_value) XOSC32K Control */
+
+#define SYSCTRL_XOSC32K_ENABLE_Pos  1            /**< \brief (SYSCTRL_XOSC32K) Enable */
+#define SYSCTRL_XOSC32K_ENABLE      (_U_(0x1) << SYSCTRL_XOSC32K_ENABLE_Pos)
+#define SYSCTRL_XOSC32K_XTALEN_Pos  2            /**< \brief (SYSCTRL_XOSC32K) Crystal Oscillator Enable */
+#define SYSCTRL_XOSC32K_XTALEN      (_U_(0x1) << SYSCTRL_XOSC32K_XTALEN_Pos)
+#define SYSCTRL_XOSC32K_EN32K_Pos   3            /**< \brief (SYSCTRL_XOSC32K) 32kHz Output Enable */
+#define SYSCTRL_XOSC32K_EN32K       (_U_(0x1) << SYSCTRL_XOSC32K_EN32K_Pos)
+#define SYSCTRL_XOSC32K_EN1K_Pos    4            /**< \brief (SYSCTRL_XOSC32K) 1kHz Output Enable */
+#define SYSCTRL_XOSC32K_EN1K        (_U_(0x1) << SYSCTRL_XOSC32K_EN1K_Pos)
+#define SYSCTRL_XOSC32K_AAMPEN_Pos  5            /**< \brief (SYSCTRL_XOSC32K) Automatic Amplitude Control Enable */
+#define SYSCTRL_XOSC32K_AAMPEN      (_U_(0x1) << SYSCTRL_XOSC32K_AAMPEN_Pos)
+#define SYSCTRL_XOSC32K_RUNSTDBY_Pos 6            /**< \brief (SYSCTRL_XOSC32K) Run during Standby */
+#define SYSCTRL_XOSC32K_RUNSTDBY    (_U_(0x1) << SYSCTRL_XOSC32K_RUNSTDBY_Pos)
+#define SYSCTRL_XOSC32K_ONDEMAND_Pos 7            /**< \brief (SYSCTRL_XOSC32K) Enable on Demand */
+#define SYSCTRL_XOSC32K_ONDEMAND    (_U_(0x1) << SYSCTRL_XOSC32K_ONDEMAND_Pos)
+#define SYSCTRL_XOSC32K_STARTUP_Pos 8            /**< \brief (SYSCTRL_XOSC32K) Start-Up Time */
+#define SYSCTRL_XOSC32K_STARTUP_Msk (_U_(0x7) << SYSCTRL_XOSC32K_STARTUP_Pos)
+#define SYSCTRL_XOSC32K_STARTUP(value) (SYSCTRL_XOSC32K_STARTUP_Msk & ((value) << SYSCTRL_XOSC32K_STARTUP_Pos))
+#define SYSCTRL_XOSC32K_WRTLOCK_Pos 12           /**< \brief (SYSCTRL_XOSC32K) Write Lock */
+#define SYSCTRL_XOSC32K_WRTLOCK     (_U_(0x1) << SYSCTRL_XOSC32K_WRTLOCK_Pos)
+#define SYSCTRL_XOSC32K_MASK        _U_(0x17FE)  /**< \brief (SYSCTRL_XOSC32K) MASK Register */
+
+/* -------- SYSCTRL_OSC32K : (SYSCTRL Offset: 0x18) (R/W 32) OSC32K Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t EN32K:1;          /*!< bit:      2  32kHz Output Enable                */
+    uint32_t EN1K:1;           /*!< bit:      3  1kHz Output Enable                 */
+    uint32_t :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint32_t ONDEMAND:1;       /*!< bit:      7  Enable on Demand                   */
+    uint32_t STARTUP:3;        /*!< bit:  8..10  Start-Up Time                      */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t WRTLOCK:1;        /*!< bit:     12  Write Lock                         */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t CALIB:7;          /*!< bit: 16..22  Calibration Value                  */
+    uint32_t :9;               /*!< bit: 23..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_OSC32K_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_OSC32K_OFFSET       0x18         /**< \brief (SYSCTRL_OSC32K offset) OSC32K Control */
+#define SYSCTRL_OSC32K_RESETVALUE   _U_(0x003F0080) /**< \brief (SYSCTRL_OSC32K reset_value) OSC32K Control */
+
+#define SYSCTRL_OSC32K_ENABLE_Pos   1            /**< \brief (SYSCTRL_OSC32K) Enable */
+#define SYSCTRL_OSC32K_ENABLE       (_U_(0x1) << SYSCTRL_OSC32K_ENABLE_Pos)
+#define SYSCTRL_OSC32K_EN32K_Pos    2            /**< \brief (SYSCTRL_OSC32K) 32kHz Output Enable */
+#define SYSCTRL_OSC32K_EN32K        (_U_(0x1) << SYSCTRL_OSC32K_EN32K_Pos)
+#define SYSCTRL_OSC32K_EN1K_Pos     3            /**< \brief (SYSCTRL_OSC32K) 1kHz Output Enable */
+#define SYSCTRL_OSC32K_EN1K         (_U_(0x1) << SYSCTRL_OSC32K_EN1K_Pos)
+#define SYSCTRL_OSC32K_RUNSTDBY_Pos 6            /**< \brief (SYSCTRL_OSC32K) Run during Standby */
+#define SYSCTRL_OSC32K_RUNSTDBY     (_U_(0x1) << SYSCTRL_OSC32K_RUNSTDBY_Pos)
+#define SYSCTRL_OSC32K_ONDEMAND_Pos 7            /**< \brief (SYSCTRL_OSC32K) Enable on Demand */
+#define SYSCTRL_OSC32K_ONDEMAND     (_U_(0x1) << SYSCTRL_OSC32K_ONDEMAND_Pos)
+#define SYSCTRL_OSC32K_STARTUP_Pos  8            /**< \brief (SYSCTRL_OSC32K) Start-Up Time */
+#define SYSCTRL_OSC32K_STARTUP_Msk  (_U_(0x7) << SYSCTRL_OSC32K_STARTUP_Pos)
+#define SYSCTRL_OSC32K_STARTUP(value) (SYSCTRL_OSC32K_STARTUP_Msk & ((value) << SYSCTRL_OSC32K_STARTUP_Pos))
+#define SYSCTRL_OSC32K_WRTLOCK_Pos  12           /**< \brief (SYSCTRL_OSC32K) Write Lock */
+#define SYSCTRL_OSC32K_WRTLOCK      (_U_(0x1) << SYSCTRL_OSC32K_WRTLOCK_Pos)
+#define SYSCTRL_OSC32K_CALIB_Pos    16           /**< \brief (SYSCTRL_OSC32K) Calibration Value */
+#define SYSCTRL_OSC32K_CALIB_Msk    (_U_(0x7F) << SYSCTRL_OSC32K_CALIB_Pos)
+#define SYSCTRL_OSC32K_CALIB(value) (SYSCTRL_OSC32K_CALIB_Msk & ((value) << SYSCTRL_OSC32K_CALIB_Pos))
+#define SYSCTRL_OSC32K_MASK         _U_(0x007F17CE) /**< \brief (SYSCTRL_OSC32K) MASK Register */
+
+/* -------- SYSCTRL_OSCULP32K : (SYSCTRL Offset: 0x1C) (R/W  8) OSCULP32K Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CALIB:5;          /*!< bit:  0.. 4  Calibration Value                  */
+    uint8_t  :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint8_t  WRTLOCK:1;        /*!< bit:      7  Write Lock                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SYSCTRL_OSCULP32K_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_OSCULP32K_OFFSET    0x1C         /**< \brief (SYSCTRL_OSCULP32K offset) OSCULP32K Control */
+#define SYSCTRL_OSCULP32K_RESETVALUE _U_(0x0F)    /**< \brief (SYSCTRL_OSCULP32K reset_value) OSCULP32K Control */
+
+#define SYSCTRL_OSCULP32K_CALIB_Pos 0            /**< \brief (SYSCTRL_OSCULP32K) Calibration Value */
+#define SYSCTRL_OSCULP32K_CALIB_Msk (_U_(0x1F) << SYSCTRL_OSCULP32K_CALIB_Pos)
+#define SYSCTRL_OSCULP32K_CALIB(value) (SYSCTRL_OSCULP32K_CALIB_Msk & ((value) << SYSCTRL_OSCULP32K_CALIB_Pos))
+#define SYSCTRL_OSCULP32K_WRTLOCK_Pos 7            /**< \brief (SYSCTRL_OSCULP32K) Write Lock */
+#define SYSCTRL_OSCULP32K_WRTLOCK   (_U_(0x1) << SYSCTRL_OSCULP32K_WRTLOCK_Pos)
+#define SYSCTRL_OSCULP32K_MASK      _U_(0x9F)    /**< \brief (SYSCTRL_OSCULP32K) MASK Register */
+
+/* -------- SYSCTRL_OSC8M : (SYSCTRL Offset: 0x20) (R/W 32) OSC8M Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint32_t ONDEMAND:1;       /*!< bit:      7  Enable on Demand                   */
+    uint32_t PRESC:2;          /*!< bit:  8.. 9  Prescaler Select                   */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t CALIB:12;         /*!< bit: 16..27  Calibration Value                  */
+    uint32_t :2;               /*!< bit: 28..29  Reserved                           */
+    uint32_t FRANGE:2;         /*!< bit: 30..31  Frequency Range                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_OSC8M_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_OSC8M_OFFSET        0x20         /**< \brief (SYSCTRL_OSC8M offset) OSC8M Control A */
+#define SYSCTRL_OSC8M_RESETVALUE    _U_(0x87070382) /**< \brief (SYSCTRL_OSC8M reset_value) OSC8M Control A */
+
+#define SYSCTRL_OSC8M_ENABLE_Pos    1            /**< \brief (SYSCTRL_OSC8M) Enable */
+#define SYSCTRL_OSC8M_ENABLE        (_U_(0x1) << SYSCTRL_OSC8M_ENABLE_Pos)
+#define SYSCTRL_OSC8M_RUNSTDBY_Pos  6            /**< \brief (SYSCTRL_OSC8M) Run during Standby */
+#define SYSCTRL_OSC8M_RUNSTDBY      (_U_(0x1) << SYSCTRL_OSC8M_RUNSTDBY_Pos)
+#define SYSCTRL_OSC8M_ONDEMAND_Pos  7            /**< \brief (SYSCTRL_OSC8M) Enable on Demand */
+#define SYSCTRL_OSC8M_ONDEMAND      (_U_(0x1) << SYSCTRL_OSC8M_ONDEMAND_Pos)
+#define SYSCTRL_OSC8M_PRESC_Pos     8            /**< \brief (SYSCTRL_OSC8M) Prescaler Select */
+#define SYSCTRL_OSC8M_PRESC_Msk     (_U_(0x3) << SYSCTRL_OSC8M_PRESC_Pos)
+#define SYSCTRL_OSC8M_PRESC(value)  (SYSCTRL_OSC8M_PRESC_Msk & ((value) << SYSCTRL_OSC8M_PRESC_Pos))
+#define SYSCTRL_OSC8M_CALIB_Pos     16           /**< \brief (SYSCTRL_OSC8M) Calibration Value */
+#define SYSCTRL_OSC8M_CALIB_Msk     (_U_(0xFFF) << SYSCTRL_OSC8M_CALIB_Pos)
+#define SYSCTRL_OSC8M_CALIB(value)  (SYSCTRL_OSC8M_CALIB_Msk & ((value) << SYSCTRL_OSC8M_CALIB_Pos))
+#define SYSCTRL_OSC8M_FRANGE_Pos    30           /**< \brief (SYSCTRL_OSC8M) Frequency Range */
+#define SYSCTRL_OSC8M_FRANGE_Msk    (_U_(0x3) << SYSCTRL_OSC8M_FRANGE_Pos)
+#define SYSCTRL_OSC8M_FRANGE(value) (SYSCTRL_OSC8M_FRANGE_Msk & ((value) << SYSCTRL_OSC8M_FRANGE_Pos))
+#define SYSCTRL_OSC8M_MASK          _U_(0xCFFF03C2) /**< \brief (SYSCTRL_OSC8M) MASK Register */
+
+/* -------- SYSCTRL_DFLLCTRL : (SYSCTRL Offset: 0x24) (R/W 16) DFLL Config -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :1;               /*!< bit:      0  Reserved                           */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t MODE:1;           /*!< bit:      2  Mode Selection                     */
+    uint16_t STABLE:1;         /*!< bit:      3  Stable Frequency                   */
+    uint16_t LLAW:1;           /*!< bit:      4  Lose Lock After Wake               */
+    uint16_t :1;               /*!< bit:      5  Reserved                           */
+    uint16_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint16_t ONDEMAND:1;       /*!< bit:      7  Enable on Demand                   */
+    uint16_t CCDIS:1;          /*!< bit:      8  Chill Cycle Disable                */
+    uint16_t QLDIS:1;          /*!< bit:      9  Quick Lock Disable                 */
+    uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_DFLLCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_DFLLCTRL_OFFSET     0x24         /**< \brief (SYSCTRL_DFLLCTRL offset) DFLL Config */
+#define SYSCTRL_DFLLCTRL_RESETVALUE _U_(0x0080)  /**< \brief (SYSCTRL_DFLLCTRL reset_value) DFLL Config */
+
+#define SYSCTRL_DFLLCTRL_ENABLE_Pos 1            /**< \brief (SYSCTRL_DFLLCTRL) Enable */
+#define SYSCTRL_DFLLCTRL_ENABLE     (_U_(0x1) << SYSCTRL_DFLLCTRL_ENABLE_Pos)
+#define SYSCTRL_DFLLCTRL_MODE_Pos   2            /**< \brief (SYSCTRL_DFLLCTRL) Mode Selection */
+#define SYSCTRL_DFLLCTRL_MODE       (_U_(0x1) << SYSCTRL_DFLLCTRL_MODE_Pos)
+#define SYSCTRL_DFLLCTRL_STABLE_Pos 3            /**< \brief (SYSCTRL_DFLLCTRL) Stable Frequency */
+#define SYSCTRL_DFLLCTRL_STABLE     (_U_(0x1) << SYSCTRL_DFLLCTRL_STABLE_Pos)
+#define SYSCTRL_DFLLCTRL_LLAW_Pos   4            /**< \brief (SYSCTRL_DFLLCTRL) Lose Lock After Wake */
+#define SYSCTRL_DFLLCTRL_LLAW       (_U_(0x1) << SYSCTRL_DFLLCTRL_LLAW_Pos)
+#define SYSCTRL_DFLLCTRL_RUNSTDBY_Pos 6            /**< \brief (SYSCTRL_DFLLCTRL) Run during Standby */
+#define SYSCTRL_DFLLCTRL_RUNSTDBY   (_U_(0x1) << SYSCTRL_DFLLCTRL_RUNSTDBY_Pos)
+#define SYSCTRL_DFLLCTRL_ONDEMAND_Pos 7            /**< \brief (SYSCTRL_DFLLCTRL) Enable on Demand */
+#define SYSCTRL_DFLLCTRL_ONDEMAND   (_U_(0x1) << SYSCTRL_DFLLCTRL_ONDEMAND_Pos)
+#define SYSCTRL_DFLLCTRL_CCDIS_Pos  8            /**< \brief (SYSCTRL_DFLLCTRL) Chill Cycle Disable */
+#define SYSCTRL_DFLLCTRL_CCDIS      (_U_(0x1) << SYSCTRL_DFLLCTRL_CCDIS_Pos)
+#define SYSCTRL_DFLLCTRL_QLDIS_Pos  9            /**< \brief (SYSCTRL_DFLLCTRL) Quick Lock Disable */
+#define SYSCTRL_DFLLCTRL_QLDIS      (_U_(0x1) << SYSCTRL_DFLLCTRL_QLDIS_Pos)
+#define SYSCTRL_DFLLCTRL_MASK       _U_(0x03DE)  /**< \brief (SYSCTRL_DFLLCTRL) MASK Register */
+
+/* -------- SYSCTRL_DFLLVAL : (SYSCTRL Offset: 0x28) (R/W 32) DFLL Calibration Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FINE:10;          /*!< bit:  0.. 9  Fine Calibration Value             */
+    uint32_t COARSE:6;         /*!< bit: 10..15  Coarse Calibration Value           */
+    uint32_t DIFF:16;          /*!< bit: 16..31  Multiplication Ratio Difference    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_DFLLVAL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_DFLLVAL_OFFSET      0x28         /**< \brief (SYSCTRL_DFLLVAL offset) DFLL Calibration Value */
+#define SYSCTRL_DFLLVAL_RESETVALUE  _U_(0x00000000) /**< \brief (SYSCTRL_DFLLVAL reset_value) DFLL Calibration Value */
+
+#define SYSCTRL_DFLLVAL_FINE_Pos    0            /**< \brief (SYSCTRL_DFLLVAL) Fine Calibration Value */
+#define SYSCTRL_DFLLVAL_FINE_Msk    (_U_(0x3FF) << SYSCTRL_DFLLVAL_FINE_Pos)
+#define SYSCTRL_DFLLVAL_FINE(value) (SYSCTRL_DFLLVAL_FINE_Msk & ((value) << SYSCTRL_DFLLVAL_FINE_Pos))
+#define SYSCTRL_DFLLVAL_COARSE_Pos  10           /**< \brief (SYSCTRL_DFLLVAL) Coarse Calibration Value */
+#define SYSCTRL_DFLLVAL_COARSE_Msk  (_U_(0x3F) << SYSCTRL_DFLLVAL_COARSE_Pos)
+#define SYSCTRL_DFLLVAL_COARSE(value) (SYSCTRL_DFLLVAL_COARSE_Msk & ((value) << SYSCTRL_DFLLVAL_COARSE_Pos))
+#define SYSCTRL_DFLLVAL_DIFF_Pos    16           /**< \brief (SYSCTRL_DFLLVAL) Multiplication Ratio Difference */
+#define SYSCTRL_DFLLVAL_DIFF_Msk    (_U_(0xFFFF) << SYSCTRL_DFLLVAL_DIFF_Pos)
+#define SYSCTRL_DFLLVAL_DIFF(value) (SYSCTRL_DFLLVAL_DIFF_Msk & ((value) << SYSCTRL_DFLLVAL_DIFF_Pos))
+#define SYSCTRL_DFLLVAL_MASK        _U_(0xFFFFFFFF) /**< \brief (SYSCTRL_DFLLVAL) MASK Register */
+
+/* -------- SYSCTRL_DFLLMUL : (SYSCTRL Offset: 0x2C) (R/W 32) DFLL Multiplier -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MUL:16;           /*!< bit:  0..15  Multiplication Value               */
+    uint32_t FSTEP:10;         /*!< bit: 16..25  Maximum Fine Step Size             */
+    uint32_t CSTEP:6;          /*!< bit: 26..31  Maximum Coarse Step Size           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_DFLLMUL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_DFLLMUL_OFFSET      0x2C         /**< \brief (SYSCTRL_DFLLMUL offset) DFLL Multiplier */
+#define SYSCTRL_DFLLMUL_RESETVALUE  _U_(0x00000000) /**< \brief (SYSCTRL_DFLLMUL reset_value) DFLL Multiplier */
+
+#define SYSCTRL_DFLLMUL_MUL_Pos     0            /**< \brief (SYSCTRL_DFLLMUL) Multiplication Value */
+#define SYSCTRL_DFLLMUL_MUL_Msk     (_U_(0xFFFF) << SYSCTRL_DFLLMUL_MUL_Pos)
+#define SYSCTRL_DFLLMUL_MUL(value)  (SYSCTRL_DFLLMUL_MUL_Msk & ((value) << SYSCTRL_DFLLMUL_MUL_Pos))
+#define SYSCTRL_DFLLMUL_FSTEP_Pos   16           /**< \brief (SYSCTRL_DFLLMUL) Maximum Fine Step Size */
+#define SYSCTRL_DFLLMUL_FSTEP_Msk   (_U_(0x3FF) << SYSCTRL_DFLLMUL_FSTEP_Pos)
+#define SYSCTRL_DFLLMUL_FSTEP(value) (SYSCTRL_DFLLMUL_FSTEP_Msk & ((value) << SYSCTRL_DFLLMUL_FSTEP_Pos))
+#define SYSCTRL_DFLLMUL_CSTEP_Pos   26           /**< \brief (SYSCTRL_DFLLMUL) Maximum Coarse Step Size */
+#define SYSCTRL_DFLLMUL_CSTEP_Msk   (_U_(0x3F) << SYSCTRL_DFLLMUL_CSTEP_Pos)
+#define SYSCTRL_DFLLMUL_CSTEP(value) (SYSCTRL_DFLLMUL_CSTEP_Msk & ((value) << SYSCTRL_DFLLMUL_CSTEP_Pos))
+#define SYSCTRL_DFLLMUL_MASK        _U_(0xFFFFFFFF) /**< \brief (SYSCTRL_DFLLMUL) MASK Register */
+
+/* -------- SYSCTRL_DFLLSYNC : (SYSCTRL Offset: 0x30) (R/W  8) DFLL Synchronization -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  READREQ:1;        /*!< bit:      7  Read Request Synchronization       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SYSCTRL_DFLLSYNC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_DFLLSYNC_OFFSET     0x30         /**< \brief (SYSCTRL_DFLLSYNC offset) DFLL Synchronization */
+#define SYSCTRL_DFLLSYNC_RESETVALUE _U_(0x00)    /**< \brief (SYSCTRL_DFLLSYNC reset_value) DFLL Synchronization */
+
+#define SYSCTRL_DFLLSYNC_READREQ_Pos 7            /**< \brief (SYSCTRL_DFLLSYNC) Read Request Synchronization */
+#define SYSCTRL_DFLLSYNC_READREQ    (_U_(0x1) << SYSCTRL_DFLLSYNC_READREQ_Pos)
+#define SYSCTRL_DFLLSYNC_MASK       _U_(0x80)    /**< \brief (SYSCTRL_DFLLSYNC) MASK Register */
+
+/* -------- SYSCTRL_BOD33 : (SYSCTRL Offset: 0x34) (R/W 32) 3.3V Brown-Out Detector (BOD33) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t HYST:1;           /*!< bit:      2  Hysteresis Enable                  */
+    uint32_t ACTION:2;         /*!< bit:  3.. 4  Action when Threshold Crossed      */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t MODE:1;           /*!< bit:      8  Operation Modes                    */
+    uint32_t CEN:1;            /*!< bit:      9  Clock Enable                       */
+    uint32_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint32_t PSEL:4;           /*!< bit: 12..15  Prescaler Select                   */
+    uint32_t LEVEL:6;          /*!< bit: 16..21  Threshold Level                    */
+    uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_BOD33_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_BOD33_OFFSET        0x34         /**< \brief (SYSCTRL_BOD33 offset) 3.3V Brown-Out Detector (BOD33) Control */
+#define SYSCTRL_BOD33_RESETVALUE    _U_(0x00000000) /**< \brief (SYSCTRL_BOD33 reset_value) 3.3V Brown-Out Detector (BOD33) Control */
+
+#define SYSCTRL_BOD33_ENABLE_Pos    1            /**< \brief (SYSCTRL_BOD33) Enable */
+#define SYSCTRL_BOD33_ENABLE        (_U_(0x1) << SYSCTRL_BOD33_ENABLE_Pos)
+#define SYSCTRL_BOD33_HYST_Pos      2            /**< \brief (SYSCTRL_BOD33) Hysteresis Enable */
+#define SYSCTRL_BOD33_HYST          (_U_(0x1) << SYSCTRL_BOD33_HYST_Pos)
+#define SYSCTRL_BOD33_ACTION_Pos    3            /**< \brief (SYSCTRL_BOD33) Action when Threshold Crossed */
+#define SYSCTRL_BOD33_ACTION_Msk    (_U_(0x3) << SYSCTRL_BOD33_ACTION_Pos)
+#define SYSCTRL_BOD33_ACTION(value) (SYSCTRL_BOD33_ACTION_Msk & ((value) << SYSCTRL_BOD33_ACTION_Pos))
+#define SYSCTRL_BOD33_RUNSTDBY_Pos  6            /**< \brief (SYSCTRL_BOD33) Run during Standby */
+#define SYSCTRL_BOD33_RUNSTDBY      (_U_(0x1) << SYSCTRL_BOD33_RUNSTDBY_Pos)
+#define SYSCTRL_BOD33_MODE_Pos      8            /**< \brief (SYSCTRL_BOD33) Operation Modes */
+#define SYSCTRL_BOD33_MODE          (_U_(0x1) << SYSCTRL_BOD33_MODE_Pos)
+#define SYSCTRL_BOD33_CEN_Pos       9            /**< \brief (SYSCTRL_BOD33) Clock Enable */
+#define SYSCTRL_BOD33_CEN           (_U_(0x1) << SYSCTRL_BOD33_CEN_Pos)
+#define SYSCTRL_BOD33_PSEL_Pos      12           /**< \brief (SYSCTRL_BOD33) Prescaler Select */
+#define SYSCTRL_BOD33_PSEL_Msk      (_U_(0xF) << SYSCTRL_BOD33_PSEL_Pos)
+#define SYSCTRL_BOD33_PSEL(value)   (SYSCTRL_BOD33_PSEL_Msk & ((value) << SYSCTRL_BOD33_PSEL_Pos))
+#define SYSCTRL_BOD33_LEVEL_Pos     16           /**< \brief (SYSCTRL_BOD33) Threshold Level */
+#define SYSCTRL_BOD33_LEVEL_Msk     (_U_(0x3F) << SYSCTRL_BOD33_LEVEL_Pos)
+#define SYSCTRL_BOD33_LEVEL(value)  (SYSCTRL_BOD33_LEVEL_Msk & ((value) << SYSCTRL_BOD33_LEVEL_Pos))
+#define SYSCTRL_BOD33_MASK          _U_(0x003FF35E) /**< \brief (SYSCTRL_BOD33) MASK Register */
+
+/* -------- SYSCTRL_VREG : (SYSCTRL Offset: 0x3C) (R/W 16) VREG Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :6;               /*!< bit:  0.. 5  Reserved                           */
+    uint16_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint16_t :6;               /*!< bit:  7..12  Reserved                           */
+    uint16_t FORCELDO:1;       /*!< bit:     13  Force LDO Voltage Regulator        */
+    uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_VREG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_VREG_OFFSET         0x3C         /**< \brief (SYSCTRL_VREG offset) VREG Control */
+#define SYSCTRL_VREG_RESETVALUE     _U_(0x0402)  /**< \brief (SYSCTRL_VREG reset_value) VREG Control */
+
+#define SYSCTRL_VREG_RUNSTDBY_Pos   6            /**< \brief (SYSCTRL_VREG) Run during Standby */
+#define SYSCTRL_VREG_RUNSTDBY       (_U_(0x1) << SYSCTRL_VREG_RUNSTDBY_Pos)
+#define SYSCTRL_VREG_FORCELDO_Pos   13           /**< \brief (SYSCTRL_VREG) Force LDO Voltage Regulator */
+#define SYSCTRL_VREG_FORCELDO       (_U_(0x1) << SYSCTRL_VREG_FORCELDO_Pos)
+#define SYSCTRL_VREG_MASK           _U_(0x2040)  /**< \brief (SYSCTRL_VREG) MASK Register */
+
+/* -------- SYSCTRL_VREF : (SYSCTRL Offset: 0x40) (R/W 32) VREF Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t TSEN:1;           /*!< bit:      1  Temperature Sensor Output Enable   */
+    uint32_t BGOUTEN:1;        /*!< bit:      2  Bandgap Output Enable              */
+    uint32_t :13;              /*!< bit:  3..15  Reserved                           */
+    uint32_t CALIB:11;         /*!< bit: 16..26  Voltage Reference Calibration Value */
+    uint32_t :5;               /*!< bit: 27..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_VREF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_VREF_OFFSET         0x40         /**< \brief (SYSCTRL_VREF offset) VREF Control A */
+#define SYSCTRL_VREF_RESETVALUE     _U_(0x00000000) /**< \brief (SYSCTRL_VREF reset_value) VREF Control A */
+
+#define SYSCTRL_VREF_TSEN_Pos       1            /**< \brief (SYSCTRL_VREF) Temperature Sensor Output Enable */
+#define SYSCTRL_VREF_TSEN           (_U_(0x1) << SYSCTRL_VREF_TSEN_Pos)
+#define SYSCTRL_VREF_BGOUTEN_Pos    2            /**< \brief (SYSCTRL_VREF) Bandgap Output Enable */
+#define SYSCTRL_VREF_BGOUTEN        (_U_(0x1) << SYSCTRL_VREF_BGOUTEN_Pos)
+#define SYSCTRL_VREF_CALIB_Pos      16           /**< \brief (SYSCTRL_VREF) Voltage Reference Calibration Value */
+#define SYSCTRL_VREF_CALIB_Msk      (_U_(0x7FF) << SYSCTRL_VREF_CALIB_Pos)
+#define SYSCTRL_VREF_CALIB(value)   (SYSCTRL_VREF_CALIB_Msk & ((value) << SYSCTRL_VREF_CALIB_Pos))
+#define SYSCTRL_VREF_MASK           _U_(0x07FF0006) /**< \brief (SYSCTRL_VREF) MASK Register */
+
+/** \brief SYSCTRL hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO SYSCTRL_INTENCLR_Type     INTENCLR;    /**< \brief Offset: 0x00 (R/W 32) Interrupt Enable Clear */
+  __IO SYSCTRL_INTENSET_Type     INTENSET;    /**< \brief Offset: 0x04 (R/W 32) Interrupt Enable Set */
+  __IO SYSCTRL_INTFLAG_Type      INTFLAG;     /**< \brief Offset: 0x08 (R/W 32) Interrupt Flag Status and Clear */
+  __I  SYSCTRL_PCLKSR_Type       PCLKSR;      /**< \brief Offset: 0x0C (R/  32) Power and Clocks Status */
+  __IO SYSCTRL_XOSC_Type         XOSC;        /**< \brief Offset: 0x10 (R/W 16) XOSC Control */
+       RoReg8                    Reserved1[0x2];
+  __IO SYSCTRL_XOSC32K_Type      XOSC32K;     /**< \brief Offset: 0x14 (R/W 16) XOSC32K Control */
+       RoReg8                    Reserved2[0x2];
+  __IO SYSCTRL_OSC32K_Type       OSC32K;      /**< \brief Offset: 0x18 (R/W 32) OSC32K Control */
+  __IO SYSCTRL_OSCULP32K_Type    OSCULP32K;   /**< \brief Offset: 0x1C (R/W  8) OSCULP32K Control */
+       RoReg8                    Reserved3[0x3];
+  __IO SYSCTRL_OSC8M_Type        OSC8M;       /**< \brief Offset: 0x20 (R/W 32) OSC8M Control A */
+  __IO SYSCTRL_DFLLCTRL_Type     DFLLCTRL;    /**< \brief Offset: 0x24 (R/W 16) DFLL Config */
+       RoReg8                    Reserved4[0x2];
+  __IO SYSCTRL_DFLLVAL_Type      DFLLVAL;     /**< \brief Offset: 0x28 (R/W 32) DFLL Calibration Value */
+  __IO SYSCTRL_DFLLMUL_Type      DFLLMUL;     /**< \brief Offset: 0x2C (R/W 32) DFLL Multiplier */
+  __IO SYSCTRL_DFLLSYNC_Type     DFLLSYNC;    /**< \brief Offset: 0x30 (R/W  8) DFLL Synchronization */
+       RoReg8                    Reserved5[0x3];
+  __IO SYSCTRL_BOD33_Type        BOD33;       /**< \brief Offset: 0x34 (R/W 32) 3.3V Brown-Out Detector (BOD33) Control */
+       RoReg8                    Reserved6[0x4];
+  __IO SYSCTRL_VREG_Type         VREG;        /**< \brief Offset: 0x3C (R/W 16) VREG Control */
+       RoReg8                    Reserved7[0x2];
+  __IO SYSCTRL_VREF_Type         VREF;        /**< \brief Offset: 0x40 (R/W 32) VREF Control A */
+} Sysctrl;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_SYSCTRL_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/component/tc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/tc.h
@@ -1,0 +1,670 @@
+/**
+ * \file
+ *
+ * \brief Component description for TC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC_COMPONENT_
+#define _SAMD20_TC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TC */
+/* ========================================================================== */
+/** \addtogroup SAMD20_TC Basic Timer Counter */
+/*@{*/
+
+#define TC_U2212
+#define REV_TC                      0x112
+
+/* -------- TC_CTRLA : (TC Offset: 0x00) (R/W 16) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t MODE:2;           /*!< bit:  2.. 3  TC Mode                            */
+    uint16_t :1;               /*!< bit:      4  Reserved                           */
+    uint16_t WAVEGEN:2;        /*!< bit:  5.. 6  Waveform Generation Operation      */
+    uint16_t :1;               /*!< bit:      7  Reserved                           */
+    uint16_t PRESCALER:3;      /*!< bit:  8..10  Prescaler                          */
+    uint16_t RUNSTDBY:1;       /*!< bit:     11  Run in Standby                     */
+    uint16_t PRESCSYNC:2;      /*!< bit: 12..13  Prescaler and Counter Synchronization */
+    uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLA_OFFSET             0x00         /**< \brief (TC_CTRLA offset) Control A */
+#define TC_CTRLA_RESETVALUE         _U_(0x0000)  /**< \brief (TC_CTRLA reset_value) Control A */
+
+#define TC_CTRLA_SWRST_Pos          0            /**< \brief (TC_CTRLA) Software Reset */
+#define TC_CTRLA_SWRST              (_U_(0x1) << TC_CTRLA_SWRST_Pos)
+#define TC_CTRLA_ENABLE_Pos         1            /**< \brief (TC_CTRLA) Enable */
+#define TC_CTRLA_ENABLE             (_U_(0x1) << TC_CTRLA_ENABLE_Pos)
+#define TC_CTRLA_MODE_Pos           2            /**< \brief (TC_CTRLA) TC Mode */
+#define TC_CTRLA_MODE_Msk           (_U_(0x3) << TC_CTRLA_MODE_Pos)
+#define TC_CTRLA_MODE(value)        (TC_CTRLA_MODE_Msk & ((value) << TC_CTRLA_MODE_Pos))
+#define   TC_CTRLA_MODE_COUNT16_Val       _U_(0x0)   /**< \brief (TC_CTRLA) Counter in 16-bit mode */
+#define   TC_CTRLA_MODE_COUNT8_Val        _U_(0x1)   /**< \brief (TC_CTRLA) Counter in 8-bit mode */
+#define   TC_CTRLA_MODE_COUNT32_Val       _U_(0x2)   /**< \brief (TC_CTRLA) Counter in 32-bit mode */
+#define TC_CTRLA_MODE_COUNT16       (TC_CTRLA_MODE_COUNT16_Val     << TC_CTRLA_MODE_Pos)
+#define TC_CTRLA_MODE_COUNT8        (TC_CTRLA_MODE_COUNT8_Val      << TC_CTRLA_MODE_Pos)
+#define TC_CTRLA_MODE_COUNT32       (TC_CTRLA_MODE_COUNT32_Val     << TC_CTRLA_MODE_Pos)
+#define TC_CTRLA_WAVEGEN_Pos        5            /**< \brief (TC_CTRLA) Waveform Generation Operation */
+#define TC_CTRLA_WAVEGEN_Msk        (_U_(0x3) << TC_CTRLA_WAVEGEN_Pos)
+#define TC_CTRLA_WAVEGEN(value)     (TC_CTRLA_WAVEGEN_Msk & ((value) << TC_CTRLA_WAVEGEN_Pos))
+#define   TC_CTRLA_WAVEGEN_NFRQ_Val       _U_(0x0)   /**< \brief (TC_CTRLA)  */
+#define   TC_CTRLA_WAVEGEN_MFRQ_Val       _U_(0x1)   /**< \brief (TC_CTRLA)  */
+#define   TC_CTRLA_WAVEGEN_NPWM_Val       _U_(0x2)   /**< \brief (TC_CTRLA)  */
+#define   TC_CTRLA_WAVEGEN_MPWM_Val       _U_(0x3)   /**< \brief (TC_CTRLA)  */
+#define TC_CTRLA_WAVEGEN_NFRQ       (TC_CTRLA_WAVEGEN_NFRQ_Val     << TC_CTRLA_WAVEGEN_Pos)
+#define TC_CTRLA_WAVEGEN_MFRQ       (TC_CTRLA_WAVEGEN_MFRQ_Val     << TC_CTRLA_WAVEGEN_Pos)
+#define TC_CTRLA_WAVEGEN_NPWM       (TC_CTRLA_WAVEGEN_NPWM_Val     << TC_CTRLA_WAVEGEN_Pos)
+#define TC_CTRLA_WAVEGEN_MPWM       (TC_CTRLA_WAVEGEN_MPWM_Val     << TC_CTRLA_WAVEGEN_Pos)
+#define TC_CTRLA_PRESCALER_Pos      8            /**< \brief (TC_CTRLA) Prescaler */
+#define TC_CTRLA_PRESCALER_Msk      (_U_(0x7) << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER(value)   (TC_CTRLA_PRESCALER_Msk & ((value) << TC_CTRLA_PRESCALER_Pos))
+#define   TC_CTRLA_PRESCALER_DIV1_Val     _U_(0x0)   /**< \brief (TC_CTRLA) GCLK_TC */
+#define   TC_CTRLA_PRESCALER_DIV2_Val     _U_(0x1)   /**< \brief (TC_CTRLA) GCLK_TC/2 */
+#define   TC_CTRLA_PRESCALER_DIV4_Val     _U_(0x2)   /**< \brief (TC_CTRLA) GCLK_TC/4 */
+#define   TC_CTRLA_PRESCALER_DIV8_Val     _U_(0x3)   /**< \brief (TC_CTRLA) GCLK_TC/8 */
+#define   TC_CTRLA_PRESCALER_DIV16_Val    _U_(0x4)   /**< \brief (TC_CTRLA) GCLK_TC/16 */
+#define   TC_CTRLA_PRESCALER_DIV64_Val    _U_(0x5)   /**< \brief (TC_CTRLA) GCLK_TC/64 */
+#define   TC_CTRLA_PRESCALER_DIV256_Val   _U_(0x6)   /**< \brief (TC_CTRLA) GCLK_TC/256 */
+#define   TC_CTRLA_PRESCALER_DIV1024_Val  _U_(0x7)   /**< \brief (TC_CTRLA) GCLK_TC/1024 */
+#define TC_CTRLA_PRESCALER_DIV1     (TC_CTRLA_PRESCALER_DIV1_Val   << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER_DIV2     (TC_CTRLA_PRESCALER_DIV2_Val   << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER_DIV4     (TC_CTRLA_PRESCALER_DIV4_Val   << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER_DIV8     (TC_CTRLA_PRESCALER_DIV8_Val   << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER_DIV16    (TC_CTRLA_PRESCALER_DIV16_Val  << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER_DIV64    (TC_CTRLA_PRESCALER_DIV64_Val  << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER_DIV256   (TC_CTRLA_PRESCALER_DIV256_Val << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER_DIV1024  (TC_CTRLA_PRESCALER_DIV1024_Val << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_RUNSTDBY_Pos       11           /**< \brief (TC_CTRLA) Run in Standby */
+#define TC_CTRLA_RUNSTDBY           (_U_(0x1) << TC_CTRLA_RUNSTDBY_Pos)
+#define TC_CTRLA_PRESCSYNC_Pos      12           /**< \brief (TC_CTRLA) Prescaler and Counter Synchronization */
+#define TC_CTRLA_PRESCSYNC_Msk      (_U_(0x3) << TC_CTRLA_PRESCSYNC_Pos)
+#define TC_CTRLA_PRESCSYNC(value)   (TC_CTRLA_PRESCSYNC_Msk & ((value) << TC_CTRLA_PRESCSYNC_Pos))
+#define   TC_CTRLA_PRESCSYNC_GCLK_Val     _U_(0x0)   /**< \brief (TC_CTRLA) Reload or reset Counter on next GCLK */
+#define   TC_CTRLA_PRESCSYNC_PRESC_Val    _U_(0x1)   /**< \brief (TC_CTRLA) Reload or reset Counter on next prescaler clock */
+#define   TC_CTRLA_PRESCSYNC_RESYNC_Val   _U_(0x2)   /**< \brief (TC_CTRLA) Reload or reset Counter on next GCLK. Reset prescaler counter */
+#define TC_CTRLA_PRESCSYNC_GCLK     (TC_CTRLA_PRESCSYNC_GCLK_Val   << TC_CTRLA_PRESCSYNC_Pos)
+#define TC_CTRLA_PRESCSYNC_PRESC    (TC_CTRLA_PRESCSYNC_PRESC_Val  << TC_CTRLA_PRESCSYNC_Pos)
+#define TC_CTRLA_PRESCSYNC_RESYNC   (TC_CTRLA_PRESCSYNC_RESYNC_Val << TC_CTRLA_PRESCSYNC_Pos)
+#define TC_CTRLA_MASK               _U_(0x3F6F)  /**< \brief (TC_CTRLA) MASK Register */
+
+/* -------- TC_READREQ : (TC Offset: 0x02) (R/W 16) Read Request -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t ADDR:5;           /*!< bit:  0.. 4  Address                            */
+    uint16_t :9;               /*!< bit:  5..13  Reserved                           */
+    uint16_t RCONT:1;          /*!< bit:     14  Read Continuously                  */
+    uint16_t RREQ:1;           /*!< bit:     15  Read Request                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TC_READREQ_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_READREQ_OFFSET           0x02         /**< \brief (TC_READREQ offset) Read Request */
+#define TC_READREQ_RESETVALUE       _U_(0x0000)  /**< \brief (TC_READREQ reset_value) Read Request */
+
+#define TC_READREQ_ADDR_Pos         0            /**< \brief (TC_READREQ) Address */
+#define TC_READREQ_ADDR_Msk         (_U_(0x1F) << TC_READREQ_ADDR_Pos)
+#define TC_READREQ_ADDR(value)      (TC_READREQ_ADDR_Msk & ((value) << TC_READREQ_ADDR_Pos))
+#define TC_READREQ_RCONT_Pos        14           /**< \brief (TC_READREQ) Read Continuously */
+#define TC_READREQ_RCONT            (_U_(0x1) << TC_READREQ_RCONT_Pos)
+#define TC_READREQ_RREQ_Pos         15           /**< \brief (TC_READREQ) Read Request */
+#define TC_READREQ_RREQ             (_U_(0x1) << TC_READREQ_RREQ_Pos)
+#define TC_READREQ_MASK             _U_(0xC01F)  /**< \brief (TC_READREQ) MASK Register */
+
+/* -------- TC_CTRLBCLR : (TC Offset: 0x04) (R/W  8) Control B Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DIR:1;            /*!< bit:      0  Counter Direction                  */
+    uint8_t  :1;               /*!< bit:      1  Reserved                           */
+    uint8_t  ONESHOT:1;        /*!< bit:      2  One-Shot                           */
+    uint8_t  :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint8_t  CMD:2;            /*!< bit:  6.. 7  Command                            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_CTRLBCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLBCLR_OFFSET          0x04         /**< \brief (TC_CTRLBCLR offset) Control B Clear */
+#define TC_CTRLBCLR_RESETVALUE      _U_(0x02)    /**< \brief (TC_CTRLBCLR reset_value) Control B Clear */
+
+#define TC_CTRLBCLR_DIR_Pos         0            /**< \brief (TC_CTRLBCLR) Counter Direction */
+#define TC_CTRLBCLR_DIR             (_U_(0x1) << TC_CTRLBCLR_DIR_Pos)
+#define TC_CTRLBCLR_ONESHOT_Pos     2            /**< \brief (TC_CTRLBCLR) One-Shot */
+#define TC_CTRLBCLR_ONESHOT         (_U_(0x1) << TC_CTRLBCLR_ONESHOT_Pos)
+#define TC_CTRLBCLR_CMD_Pos         6            /**< \brief (TC_CTRLBCLR) Command */
+#define TC_CTRLBCLR_CMD_Msk         (_U_(0x3) << TC_CTRLBCLR_CMD_Pos)
+#define TC_CTRLBCLR_CMD(value)      (TC_CTRLBCLR_CMD_Msk & ((value) << TC_CTRLBCLR_CMD_Pos))
+#define   TC_CTRLBCLR_CMD_NONE_Val        _U_(0x0)   /**< \brief (TC_CTRLBCLR) No action */
+#define   TC_CTRLBCLR_CMD_RETRIGGER_Val   _U_(0x1)   /**< \brief (TC_CTRLBCLR) Force start, restart or retrigger */
+#define   TC_CTRLBCLR_CMD_STOP_Val        _U_(0x2)   /**< \brief (TC_CTRLBCLR) Force stop */
+#define TC_CTRLBCLR_CMD_NONE        (TC_CTRLBCLR_CMD_NONE_Val      << TC_CTRLBCLR_CMD_Pos)
+#define TC_CTRLBCLR_CMD_RETRIGGER   (TC_CTRLBCLR_CMD_RETRIGGER_Val << TC_CTRLBCLR_CMD_Pos)
+#define TC_CTRLBCLR_CMD_STOP        (TC_CTRLBCLR_CMD_STOP_Val      << TC_CTRLBCLR_CMD_Pos)
+#define TC_CTRLBCLR_MASK            _U_(0xC5)    /**< \brief (TC_CTRLBCLR) MASK Register */
+
+/* -------- TC_CTRLBSET : (TC Offset: 0x05) (R/W  8) Control B Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DIR:1;            /*!< bit:      0  Counter Direction                  */
+    uint8_t  :1;               /*!< bit:      1  Reserved                           */
+    uint8_t  ONESHOT:1;        /*!< bit:      2  One-shot                           */
+    uint8_t  :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint8_t  CMD:2;            /*!< bit:  6.. 7  Command                            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_CTRLBSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLBSET_OFFSET          0x05         /**< \brief (TC_CTRLBSET offset) Control B Set */
+#define TC_CTRLBSET_RESETVALUE      _U_(0x00)    /**< \brief (TC_CTRLBSET reset_value) Control B Set */
+
+#define TC_CTRLBSET_DIR_Pos         0            /**< \brief (TC_CTRLBSET) Counter Direction */
+#define TC_CTRLBSET_DIR             (_U_(0x1) << TC_CTRLBSET_DIR_Pos)
+#define TC_CTRLBSET_ONESHOT_Pos     2            /**< \brief (TC_CTRLBSET) One-shot */
+#define TC_CTRLBSET_ONESHOT         (_U_(0x1) << TC_CTRLBSET_ONESHOT_Pos)
+#define TC_CTRLBSET_CMD_Pos         6            /**< \brief (TC_CTRLBSET) Command */
+#define TC_CTRLBSET_CMD_Msk         (_U_(0x3) << TC_CTRLBSET_CMD_Pos)
+#define TC_CTRLBSET_CMD(value)      (TC_CTRLBSET_CMD_Msk & ((value) << TC_CTRLBSET_CMD_Pos))
+#define   TC_CTRLBSET_CMD_NONE_Val        _U_(0x0)   /**< \brief (TC_CTRLBSET) No action */
+#define   TC_CTRLBSET_CMD_RETRIGGER_Val   _U_(0x1)   /**< \brief (TC_CTRLBSET) Force start, restart or retrigger */
+#define   TC_CTRLBSET_CMD_STOP_Val        _U_(0x2)   /**< \brief (TC_CTRLBSET) Force stop */
+#define TC_CTRLBSET_CMD_NONE        (TC_CTRLBSET_CMD_NONE_Val      << TC_CTRLBSET_CMD_Pos)
+#define TC_CTRLBSET_CMD_RETRIGGER   (TC_CTRLBSET_CMD_RETRIGGER_Val << TC_CTRLBSET_CMD_Pos)
+#define TC_CTRLBSET_CMD_STOP        (TC_CTRLBSET_CMD_STOP_Val      << TC_CTRLBSET_CMD_Pos)
+#define TC_CTRLBSET_MASK            _U_(0xC5)    /**< \brief (TC_CTRLBSET) MASK Register */
+
+/* -------- TC_CTRLC : (TC Offset: 0x06) (R/W  8) Control C -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  INVEN0:1;         /*!< bit:      0  Output Waveform 0 Invert Enable    */
+    uint8_t  INVEN1:1;         /*!< bit:      1  Output Waveform 1 Invert Enable    */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  CPTEN0:1;         /*!< bit:      4  Capture Channel 0 Enable           */
+    uint8_t  CPTEN1:1;         /*!< bit:      5  Capture Channel 1 Enable           */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  INVEN:2;          /*!< bit:  0.. 1  Output Waveform x Invert Enable    */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  CPTEN:2;          /*!< bit:  4.. 5  Capture Channel x Enable           */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_CTRLC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLC_OFFSET             0x06         /**< \brief (TC_CTRLC offset) Control C */
+#define TC_CTRLC_RESETVALUE         _U_(0x00)    /**< \brief (TC_CTRLC reset_value) Control C */
+
+#define TC_CTRLC_INVEN0_Pos         0            /**< \brief (TC_CTRLC) Output Waveform 0 Invert Enable */
+#define TC_CTRLC_INVEN0             (_U_(1) << TC_CTRLC_INVEN0_Pos)
+#define TC_CTRLC_INVEN1_Pos         1            /**< \brief (TC_CTRLC) Output Waveform 1 Invert Enable */
+#define TC_CTRLC_INVEN1             (_U_(1) << TC_CTRLC_INVEN1_Pos)
+#define TC_CTRLC_INVEN_Pos          0            /**< \brief (TC_CTRLC) Output Waveform x Invert Enable */
+#define TC_CTRLC_INVEN_Msk          (_U_(0x3) << TC_CTRLC_INVEN_Pos)
+#define TC_CTRLC_INVEN(value)       (TC_CTRLC_INVEN_Msk & ((value) << TC_CTRLC_INVEN_Pos))
+#define TC_CTRLC_CPTEN0_Pos         4            /**< \brief (TC_CTRLC) Capture Channel 0 Enable */
+#define TC_CTRLC_CPTEN0             (_U_(1) << TC_CTRLC_CPTEN0_Pos)
+#define TC_CTRLC_CPTEN1_Pos         5            /**< \brief (TC_CTRLC) Capture Channel 1 Enable */
+#define TC_CTRLC_CPTEN1             (_U_(1) << TC_CTRLC_CPTEN1_Pos)
+#define TC_CTRLC_CPTEN_Pos          4            /**< \brief (TC_CTRLC) Capture Channel x Enable */
+#define TC_CTRLC_CPTEN_Msk          (_U_(0x3) << TC_CTRLC_CPTEN_Pos)
+#define TC_CTRLC_CPTEN(value)       (TC_CTRLC_CPTEN_Msk & ((value) << TC_CTRLC_CPTEN_Pos))
+#define TC_CTRLC_MASK               _U_(0x33)    /**< \brief (TC_CTRLC) MASK Register */
+
+/* -------- TC_DBGCTRL : (TC Offset: 0x08) (R/W  8) Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGRUN:1;         /*!< bit:      0  Debug Run Mode                     */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_DBGCTRL_OFFSET           0x08         /**< \brief (TC_DBGCTRL offset) Debug Control */
+#define TC_DBGCTRL_RESETVALUE       _U_(0x00)    /**< \brief (TC_DBGCTRL reset_value) Debug Control */
+
+#define TC_DBGCTRL_DBGRUN_Pos       0            /**< \brief (TC_DBGCTRL) Debug Run Mode */
+#define TC_DBGCTRL_DBGRUN           (_U_(0x1) << TC_DBGCTRL_DBGRUN_Pos)
+#define TC_DBGCTRL_MASK             _U_(0x01)    /**< \brief (TC_DBGCTRL) MASK Register */
+
+/* -------- TC_EVCTRL : (TC Offset: 0x0A) (R/W 16) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t EVACT:3;          /*!< bit:  0.. 2  Event Action                       */
+    uint16_t :1;               /*!< bit:      3  Reserved                           */
+    uint16_t TCINV:1;          /*!< bit:      4  TC Inverted Event Input            */
+    uint16_t TCEI:1;           /*!< bit:      5  TC Event Input                     */
+    uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t OVFEO:1;          /*!< bit:      8  Overflow/Underflow Event Output Enable */
+    uint16_t :3;               /*!< bit:  9..11  Reserved                           */
+    uint16_t MCEO0:1;          /*!< bit:     12  Match or Capture Channel 0 Event Output Enable */
+    uint16_t MCEO1:1;          /*!< bit:     13  Match or Capture Channel 1 Event Output Enable */
+    uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t :12;              /*!< bit:  0..11  Reserved                           */
+    uint16_t MCEO:2;           /*!< bit: 12..13  Match or Capture Channel x Event Output Enable */
+    uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_EVCTRL_OFFSET            0x0A         /**< \brief (TC_EVCTRL offset) Event Control */
+#define TC_EVCTRL_RESETVALUE        _U_(0x0000)  /**< \brief (TC_EVCTRL reset_value) Event Control */
+
+#define TC_EVCTRL_EVACT_Pos         0            /**< \brief (TC_EVCTRL) Event Action */
+#define TC_EVCTRL_EVACT_Msk         (_U_(0x7) << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT(value)      (TC_EVCTRL_EVACT_Msk & ((value) << TC_EVCTRL_EVACT_Pos))
+#define   TC_EVCTRL_EVACT_OFF_Val         _U_(0x0)   /**< \brief (TC_EVCTRL) Event action disabled */
+#define   TC_EVCTRL_EVACT_RETRIGGER_Val   _U_(0x1)   /**< \brief (TC_EVCTRL) Start, restart or retrigger TC on event */
+#define   TC_EVCTRL_EVACT_COUNT_Val       _U_(0x2)   /**< \brief (TC_EVCTRL) Count on event */
+#define   TC_EVCTRL_EVACT_START_Val       _U_(0x3)   /**< \brief (TC_EVCTRL) Start TC on event */
+#define   TC_EVCTRL_EVACT_PPW_Val         _U_(0x5)   /**< \brief (TC_EVCTRL) Period captured into CC0 Pulse Width in CC1 */
+#define   TC_EVCTRL_EVACT_PWP_Val         _U_(0x6)   /**< \brief (TC_EVCTRL) Period captured into CC1 Pulse Width on CC0 */
+#define TC_EVCTRL_EVACT_OFF         (TC_EVCTRL_EVACT_OFF_Val       << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_RETRIGGER   (TC_EVCTRL_EVACT_RETRIGGER_Val << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_COUNT       (TC_EVCTRL_EVACT_COUNT_Val     << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_START       (TC_EVCTRL_EVACT_START_Val     << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_PPW         (TC_EVCTRL_EVACT_PPW_Val       << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_PWP         (TC_EVCTRL_EVACT_PWP_Val       << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_TCINV_Pos         4            /**< \brief (TC_EVCTRL) TC Inverted Event Input */
+#define TC_EVCTRL_TCINV             (_U_(0x1) << TC_EVCTRL_TCINV_Pos)
+#define TC_EVCTRL_TCEI_Pos          5            /**< \brief (TC_EVCTRL) TC Event Input */
+#define TC_EVCTRL_TCEI              (_U_(0x1) << TC_EVCTRL_TCEI_Pos)
+#define TC_EVCTRL_OVFEO_Pos         8            /**< \brief (TC_EVCTRL) Overflow/Underflow Event Output Enable */
+#define TC_EVCTRL_OVFEO             (_U_(0x1) << TC_EVCTRL_OVFEO_Pos)
+#define TC_EVCTRL_MCEO0_Pos         12           /**< \brief (TC_EVCTRL) Match or Capture Channel 0 Event Output Enable */
+#define TC_EVCTRL_MCEO0             (_U_(1) << TC_EVCTRL_MCEO0_Pos)
+#define TC_EVCTRL_MCEO1_Pos         13           /**< \brief (TC_EVCTRL) Match or Capture Channel 1 Event Output Enable */
+#define TC_EVCTRL_MCEO1             (_U_(1) << TC_EVCTRL_MCEO1_Pos)
+#define TC_EVCTRL_MCEO_Pos          12           /**< \brief (TC_EVCTRL) Match or Capture Channel x Event Output Enable */
+#define TC_EVCTRL_MCEO_Msk          (_U_(0x3) << TC_EVCTRL_MCEO_Pos)
+#define TC_EVCTRL_MCEO(value)       (TC_EVCTRL_MCEO_Msk & ((value) << TC_EVCTRL_MCEO_Pos))
+#define TC_EVCTRL_MASK              _U_(0x3137)  /**< \brief (TC_EVCTRL) MASK Register */
+
+/* -------- TC_INTENCLR : (TC Offset: 0x0C) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  OVF:1;            /*!< bit:      0  Overflow Interrupt Enable          */
+    uint8_t  ERR:1;            /*!< bit:      1  Error Interrupt Enable             */
+    uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready Interrupt Enable */
+    uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0 Interrupt Enable */
+    uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1 Interrupt Enable */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x Interrupt Enable */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_INTENCLR_OFFSET          0x0C         /**< \brief (TC_INTENCLR offset) Interrupt Enable Clear */
+#define TC_INTENCLR_RESETVALUE      _U_(0x00)    /**< \brief (TC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define TC_INTENCLR_OVF_Pos         0            /**< \brief (TC_INTENCLR) Overflow Interrupt Enable */
+#define TC_INTENCLR_OVF             (_U_(0x1) << TC_INTENCLR_OVF_Pos)
+#define TC_INTENCLR_ERR_Pos         1            /**< \brief (TC_INTENCLR) Error Interrupt Enable */
+#define TC_INTENCLR_ERR             (_U_(0x1) << TC_INTENCLR_ERR_Pos)
+#define TC_INTENCLR_SYNCRDY_Pos     3            /**< \brief (TC_INTENCLR) Synchronization Ready Interrupt Enable */
+#define TC_INTENCLR_SYNCRDY         (_U_(0x1) << TC_INTENCLR_SYNCRDY_Pos)
+#define TC_INTENCLR_MC0_Pos         4            /**< \brief (TC_INTENCLR) Match or Capture Channel 0 Interrupt Enable */
+#define TC_INTENCLR_MC0             (_U_(1) << TC_INTENCLR_MC0_Pos)
+#define TC_INTENCLR_MC1_Pos         5            /**< \brief (TC_INTENCLR) Match or Capture Channel 1 Interrupt Enable */
+#define TC_INTENCLR_MC1             (_U_(1) << TC_INTENCLR_MC1_Pos)
+#define TC_INTENCLR_MC_Pos          4            /**< \brief (TC_INTENCLR) Match or Capture Channel x Interrupt Enable */
+#define TC_INTENCLR_MC_Msk          (_U_(0x3) << TC_INTENCLR_MC_Pos)
+#define TC_INTENCLR_MC(value)       (TC_INTENCLR_MC_Msk & ((value) << TC_INTENCLR_MC_Pos))
+#define TC_INTENCLR_MASK            _U_(0x3B)    /**< \brief (TC_INTENCLR) MASK Register */
+
+/* -------- TC_INTENSET : (TC Offset: 0x0D) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  OVF:1;            /*!< bit:      0  Overflow Interrupt Enable          */
+    uint8_t  ERR:1;            /*!< bit:      1  Error Interrupt Enable             */
+    uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready Interrupt Enable */
+    uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0 Interrupt Enable */
+    uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1 Interrupt Enable */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x Interrupt Enable */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_INTENSET_OFFSET          0x0D         /**< \brief (TC_INTENSET offset) Interrupt Enable Set */
+#define TC_INTENSET_RESETVALUE      _U_(0x00)    /**< \brief (TC_INTENSET reset_value) Interrupt Enable Set */
+
+#define TC_INTENSET_OVF_Pos         0            /**< \brief (TC_INTENSET) Overflow Interrupt Enable */
+#define TC_INTENSET_OVF             (_U_(0x1) << TC_INTENSET_OVF_Pos)
+#define TC_INTENSET_ERR_Pos         1            /**< \brief (TC_INTENSET) Error Interrupt Enable */
+#define TC_INTENSET_ERR             (_U_(0x1) << TC_INTENSET_ERR_Pos)
+#define TC_INTENSET_SYNCRDY_Pos     3            /**< \brief (TC_INTENSET) Synchronization Ready Interrupt Enable */
+#define TC_INTENSET_SYNCRDY         (_U_(0x1) << TC_INTENSET_SYNCRDY_Pos)
+#define TC_INTENSET_MC0_Pos         4            /**< \brief (TC_INTENSET) Match or Capture Channel 0 Interrupt Enable */
+#define TC_INTENSET_MC0             (_U_(1) << TC_INTENSET_MC0_Pos)
+#define TC_INTENSET_MC1_Pos         5            /**< \brief (TC_INTENSET) Match or Capture Channel 1 Interrupt Enable */
+#define TC_INTENSET_MC1             (_U_(1) << TC_INTENSET_MC1_Pos)
+#define TC_INTENSET_MC_Pos          4            /**< \brief (TC_INTENSET) Match or Capture Channel x Interrupt Enable */
+#define TC_INTENSET_MC_Msk          (_U_(0x3) << TC_INTENSET_MC_Pos)
+#define TC_INTENSET_MC(value)       (TC_INTENSET_MC_Msk & ((value) << TC_INTENSET_MC_Pos))
+#define TC_INTENSET_MASK            _U_(0x3B)    /**< \brief (TC_INTENSET) MASK Register */
+
+/* -------- TC_INTFLAG : (TC Offset: 0x0E) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  OVF:1;            /*!< bit:      0  Overflow                           */
+    __I uint8_t  ERR:1;            /*!< bit:      1  Error                              */
+    __I uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
+    __I uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0         */
+    __I uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1         */
+    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x         */
+    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_INTFLAG_OFFSET           0x0E         /**< \brief (TC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define TC_INTFLAG_RESETVALUE       _U_(0x00)    /**< \brief (TC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define TC_INTFLAG_OVF_Pos          0            /**< \brief (TC_INTFLAG) Overflow */
+#define TC_INTFLAG_OVF              (_U_(0x1) << TC_INTFLAG_OVF_Pos)
+#define TC_INTFLAG_ERR_Pos          1            /**< \brief (TC_INTFLAG) Error */
+#define TC_INTFLAG_ERR              (_U_(0x1) << TC_INTFLAG_ERR_Pos)
+#define TC_INTFLAG_SYNCRDY_Pos      3            /**< \brief (TC_INTFLAG) Synchronization Ready */
+#define TC_INTFLAG_SYNCRDY          (_U_(0x1) << TC_INTFLAG_SYNCRDY_Pos)
+#define TC_INTFLAG_MC0_Pos          4            /**< \brief (TC_INTFLAG) Match or Capture Channel 0 */
+#define TC_INTFLAG_MC0              (_U_(1) << TC_INTFLAG_MC0_Pos)
+#define TC_INTFLAG_MC1_Pos          5            /**< \brief (TC_INTFLAG) Match or Capture Channel 1 */
+#define TC_INTFLAG_MC1              (_U_(1) << TC_INTFLAG_MC1_Pos)
+#define TC_INTFLAG_MC_Pos           4            /**< \brief (TC_INTFLAG) Match or Capture Channel x */
+#define TC_INTFLAG_MC_Msk           (_U_(0x3) << TC_INTFLAG_MC_Pos)
+#define TC_INTFLAG_MC(value)        (TC_INTFLAG_MC_Msk & ((value) << TC_INTFLAG_MC_Pos))
+#define TC_INTFLAG_MASK             _U_(0x3B)    /**< \brief (TC_INTFLAG) MASK Register */
+
+/* -------- TC_STATUS : (TC Offset: 0x0F) (R/   8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :3;               /*!< bit:  0.. 2  Reserved                           */
+    uint8_t  STOP:1;           /*!< bit:      3  Stop                               */
+    uint8_t  SLAVE:1;          /*!< bit:      4  Slave                              */
+    uint8_t  :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_STATUS_OFFSET            0x0F         /**< \brief (TC_STATUS offset) Status */
+#define TC_STATUS_RESETVALUE        _U_(0x08)    /**< \brief (TC_STATUS reset_value) Status */
+
+#define TC_STATUS_STOP_Pos          3            /**< \brief (TC_STATUS) Stop */
+#define TC_STATUS_STOP              (_U_(0x1) << TC_STATUS_STOP_Pos)
+#define TC_STATUS_SLAVE_Pos         4            /**< \brief (TC_STATUS) Slave */
+#define TC_STATUS_SLAVE             (_U_(0x1) << TC_STATUS_SLAVE_Pos)
+#define TC_STATUS_SYNCBUSY_Pos      7            /**< \brief (TC_STATUS) Synchronization Busy */
+#define TC_STATUS_SYNCBUSY          (_U_(0x1) << TC_STATUS_SYNCBUSY_Pos)
+#define TC_STATUS_MASK              _U_(0x98)    /**< \brief (TC_STATUS) MASK Register */
+
+/* -------- TC_COUNT16_COUNT : (TC Offset: 0x10) (R/W 16) COUNT16 COUNT16 Counter Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t COUNT:16;         /*!< bit:  0..15  Counter Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TC_COUNT16_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_COUNT_OFFSET     0x10         /**< \brief (TC_COUNT16_COUNT offset) COUNT16 Counter Value */
+#define TC_COUNT16_COUNT_RESETVALUE _U_(0x0000)  /**< \brief (TC_COUNT16_COUNT reset_value) COUNT16 Counter Value */
+
+#define TC_COUNT16_COUNT_COUNT_Pos  0            /**< \brief (TC_COUNT16_COUNT) Counter Value */
+#define TC_COUNT16_COUNT_COUNT_Msk  (_U_(0xFFFF) << TC_COUNT16_COUNT_COUNT_Pos)
+#define TC_COUNT16_COUNT_COUNT(value) (TC_COUNT16_COUNT_COUNT_Msk & ((value) << TC_COUNT16_COUNT_COUNT_Pos))
+#define TC_COUNT16_COUNT_MASK       _U_(0xFFFF)  /**< \brief (TC_COUNT16_COUNT) MASK Register */
+
+/* -------- TC_COUNT32_COUNT : (TC Offset: 0x10) (R/W 32) COUNT32 COUNT32 Counter Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t COUNT:32;         /*!< bit:  0..31  Counter Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_COUNT32_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_COUNT_OFFSET     0x10         /**< \brief (TC_COUNT32_COUNT offset) COUNT32 Counter Value */
+#define TC_COUNT32_COUNT_RESETVALUE _U_(0x00000000) /**< \brief (TC_COUNT32_COUNT reset_value) COUNT32 Counter Value */
+
+#define TC_COUNT32_COUNT_COUNT_Pos  0            /**< \brief (TC_COUNT32_COUNT) Counter Value */
+#define TC_COUNT32_COUNT_COUNT_Msk  (_U_(0xFFFFFFFF) << TC_COUNT32_COUNT_COUNT_Pos)
+#define TC_COUNT32_COUNT_COUNT(value) (TC_COUNT32_COUNT_COUNT_Msk & ((value) << TC_COUNT32_COUNT_COUNT_Pos))
+#define TC_COUNT32_COUNT_MASK       _U_(0xFFFFFFFF) /**< \brief (TC_COUNT32_COUNT) MASK Register */
+
+/* -------- TC_COUNT8_COUNT : (TC Offset: 0x10) (R/W  8) COUNT8 COUNT8 Counter Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  COUNT:8;          /*!< bit:  0.. 7  Counter Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_COUNT8_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_COUNT_OFFSET      0x10         /**< \brief (TC_COUNT8_COUNT offset) COUNT8 Counter Value */
+#define TC_COUNT8_COUNT_RESETVALUE  _U_(0x00)    /**< \brief (TC_COUNT8_COUNT reset_value) COUNT8 Counter Value */
+
+#define TC_COUNT8_COUNT_COUNT_Pos   0            /**< \brief (TC_COUNT8_COUNT) Counter Value */
+#define TC_COUNT8_COUNT_COUNT_Msk   (_U_(0xFF) << TC_COUNT8_COUNT_COUNT_Pos)
+#define TC_COUNT8_COUNT_COUNT(value) (TC_COUNT8_COUNT_COUNT_Msk & ((value) << TC_COUNT8_COUNT_COUNT_Pos))
+#define TC_COUNT8_COUNT_MASK        _U_(0xFF)    /**< \brief (TC_COUNT8_COUNT) MASK Register */
+
+/* -------- TC_COUNT8_PER : (TC Offset: 0x14) (R/W  8) COUNT8 COUNT8 Period Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PER:8;            /*!< bit:  0.. 7  Period Value                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_COUNT8_PER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_PER_OFFSET        0x14         /**< \brief (TC_COUNT8_PER offset) COUNT8 Period Value */
+#define TC_COUNT8_PER_RESETVALUE    _U_(0xFF)    /**< \brief (TC_COUNT8_PER reset_value) COUNT8 Period Value */
+
+#define TC_COUNT8_PER_PER_Pos       0            /**< \brief (TC_COUNT8_PER) Period Value */
+#define TC_COUNT8_PER_PER_Msk       (_U_(0xFF) << TC_COUNT8_PER_PER_Pos)
+#define TC_COUNT8_PER_PER(value)    (TC_COUNT8_PER_PER_Msk & ((value) << TC_COUNT8_PER_PER_Pos))
+#define TC_COUNT8_PER_MASK          _U_(0xFF)    /**< \brief (TC_COUNT8_PER) MASK Register */
+
+/* -------- TC_COUNT16_CC : (TC Offset: 0x18) (R/W 16) COUNT16 COUNT16 Compare/Capture -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t CC:16;            /*!< bit:  0..15  Compare/Capture Value              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TC_COUNT16_CC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_CC_OFFSET        0x18         /**< \brief (TC_COUNT16_CC offset) COUNT16 Compare/Capture */
+#define TC_COUNT16_CC_RESETVALUE    _U_(0x0000)  /**< \brief (TC_COUNT16_CC reset_value) COUNT16 Compare/Capture */
+
+#define TC_COUNT16_CC_CC_Pos        0            /**< \brief (TC_COUNT16_CC) Compare/Capture Value */
+#define TC_COUNT16_CC_CC_Msk        (_U_(0xFFFF) << TC_COUNT16_CC_CC_Pos)
+#define TC_COUNT16_CC_CC(value)     (TC_COUNT16_CC_CC_Msk & ((value) << TC_COUNT16_CC_CC_Pos))
+#define TC_COUNT16_CC_MASK          _U_(0xFFFF)  /**< \brief (TC_COUNT16_CC) MASK Register */
+
+/* -------- TC_COUNT32_CC : (TC Offset: 0x18) (R/W 32) COUNT32 COUNT32 Compare/Capture -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CC:32;            /*!< bit:  0..31  Compare/Capture Value              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_COUNT32_CC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_CC_OFFSET        0x18         /**< \brief (TC_COUNT32_CC offset) COUNT32 Compare/Capture */
+#define TC_COUNT32_CC_RESETVALUE    _U_(0x00000000) /**< \brief (TC_COUNT32_CC reset_value) COUNT32 Compare/Capture */
+
+#define TC_COUNT32_CC_CC_Pos        0            /**< \brief (TC_COUNT32_CC) Compare/Capture Value */
+#define TC_COUNT32_CC_CC_Msk        (_U_(0xFFFFFFFF) << TC_COUNT32_CC_CC_Pos)
+#define TC_COUNT32_CC_CC(value)     (TC_COUNT32_CC_CC_Msk & ((value) << TC_COUNT32_CC_CC_Pos))
+#define TC_COUNT32_CC_MASK          _U_(0xFFFFFFFF) /**< \brief (TC_COUNT32_CC) MASK Register */
+
+/* -------- TC_COUNT8_CC : (TC Offset: 0x18) (R/W  8) COUNT8 COUNT8 Compare/Capture -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CC:8;             /*!< bit:  0.. 7  Compare/Capture Value              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_COUNT8_CC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_CC_OFFSET         0x18         /**< \brief (TC_COUNT8_CC offset) COUNT8 Compare/Capture */
+#define TC_COUNT8_CC_RESETVALUE     _U_(0x00)    /**< \brief (TC_COUNT8_CC reset_value) COUNT8 Compare/Capture */
+
+#define TC_COUNT8_CC_CC_Pos         0            /**< \brief (TC_COUNT8_CC) Compare/Capture Value */
+#define TC_COUNT8_CC_CC_Msk         (_U_(0xFF) << TC_COUNT8_CC_CC_Pos)
+#define TC_COUNT8_CC_CC(value)      (TC_COUNT8_CC_CC_Msk & ((value) << TC_COUNT8_CC_CC_Pos))
+#define TC_COUNT8_CC_MASK           _U_(0xFF)    /**< \brief (TC_COUNT8_CC) MASK Register */
+
+/** \brief TC_COUNT8 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* 8-bit Counter Mode */
+  __IO TC_CTRLA_Type             CTRLA;       /**< \brief Offset: 0x00 (R/W 16) Control A */
+  __IO TC_READREQ_Type           READREQ;     /**< \brief Offset: 0x02 (R/W 16) Read Request */
+  __IO TC_CTRLBCLR_Type          CTRLBCLR;    /**< \brief Offset: 0x04 (R/W  8) Control B Clear */
+  __IO TC_CTRLBSET_Type          CTRLBSET;    /**< \brief Offset: 0x05 (R/W  8) Control B Set */
+  __IO TC_CTRLC_Type             CTRLC;       /**< \brief Offset: 0x06 (R/W  8) Control C */
+       RoReg8                    Reserved1[0x1];
+  __IO TC_DBGCTRL_Type           DBGCTRL;     /**< \brief Offset: 0x08 (R/W  8) Debug Control */
+       RoReg8                    Reserved2[0x1];
+  __IO TC_EVCTRL_Type            EVCTRL;      /**< \brief Offset: 0x0A (R/W 16) Event Control */
+  __IO TC_INTENCLR_Type          INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) Interrupt Enable Clear */
+  __IO TC_INTENSET_Type          INTENSET;    /**< \brief Offset: 0x0D (R/W  8) Interrupt Enable Set */
+  __IO TC_INTFLAG_Type           INTFLAG;     /**< \brief Offset: 0x0E (R/W  8) Interrupt Flag Status and Clear */
+  __I  TC_STATUS_Type            STATUS;      /**< \brief Offset: 0x0F (R/   8) Status */
+  __IO TC_COUNT8_COUNT_Type      COUNT;       /**< \brief Offset: 0x10 (R/W  8) COUNT8 Counter Value */
+       RoReg8                    Reserved3[0x3];
+  __IO TC_COUNT8_PER_Type        PER;         /**< \brief Offset: 0x14 (R/W  8) COUNT8 Period Value */
+       RoReg8                    Reserved4[0x3];
+  __IO TC_COUNT8_CC_Type         CC[2];       /**< \brief Offset: 0x18 (R/W  8) COUNT8 Compare/Capture */
+} TcCount8;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief TC_COUNT16 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* 16-bit Counter Mode */
+  __IO TC_CTRLA_Type             CTRLA;       /**< \brief Offset: 0x00 (R/W 16) Control A */
+  __IO TC_READREQ_Type           READREQ;     /**< \brief Offset: 0x02 (R/W 16) Read Request */
+  __IO TC_CTRLBCLR_Type          CTRLBCLR;    /**< \brief Offset: 0x04 (R/W  8) Control B Clear */
+  __IO TC_CTRLBSET_Type          CTRLBSET;    /**< \brief Offset: 0x05 (R/W  8) Control B Set */
+  __IO TC_CTRLC_Type             CTRLC;       /**< \brief Offset: 0x06 (R/W  8) Control C */
+       RoReg8                    Reserved1[0x1];
+  __IO TC_DBGCTRL_Type           DBGCTRL;     /**< \brief Offset: 0x08 (R/W  8) Debug Control */
+       RoReg8                    Reserved2[0x1];
+  __IO TC_EVCTRL_Type            EVCTRL;      /**< \brief Offset: 0x0A (R/W 16) Event Control */
+  __IO TC_INTENCLR_Type          INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) Interrupt Enable Clear */
+  __IO TC_INTENSET_Type          INTENSET;    /**< \brief Offset: 0x0D (R/W  8) Interrupt Enable Set */
+  __IO TC_INTFLAG_Type           INTFLAG;     /**< \brief Offset: 0x0E (R/W  8) Interrupt Flag Status and Clear */
+  __I  TC_STATUS_Type            STATUS;      /**< \brief Offset: 0x0F (R/   8) Status */
+  __IO TC_COUNT16_COUNT_Type     COUNT;       /**< \brief Offset: 0x10 (R/W 16) COUNT16 Counter Value */
+       RoReg8                    Reserved3[0x6];
+  __IO TC_COUNT16_CC_Type        CC[2];       /**< \brief Offset: 0x18 (R/W 16) COUNT16 Compare/Capture */
+} TcCount16;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief TC_COUNT32 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* 32-bit Counter Mode */
+  __IO TC_CTRLA_Type             CTRLA;       /**< \brief Offset: 0x00 (R/W 16) Control A */
+  __IO TC_READREQ_Type           READREQ;     /**< \brief Offset: 0x02 (R/W 16) Read Request */
+  __IO TC_CTRLBCLR_Type          CTRLBCLR;    /**< \brief Offset: 0x04 (R/W  8) Control B Clear */
+  __IO TC_CTRLBSET_Type          CTRLBSET;    /**< \brief Offset: 0x05 (R/W  8) Control B Set */
+  __IO TC_CTRLC_Type             CTRLC;       /**< \brief Offset: 0x06 (R/W  8) Control C */
+       RoReg8                    Reserved1[0x1];
+  __IO TC_DBGCTRL_Type           DBGCTRL;     /**< \brief Offset: 0x08 (R/W  8) Debug Control */
+       RoReg8                    Reserved2[0x1];
+  __IO TC_EVCTRL_Type            EVCTRL;      /**< \brief Offset: 0x0A (R/W 16) Event Control */
+  __IO TC_INTENCLR_Type          INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) Interrupt Enable Clear */
+  __IO TC_INTENSET_Type          INTENSET;    /**< \brief Offset: 0x0D (R/W  8) Interrupt Enable Set */
+  __IO TC_INTFLAG_Type           INTFLAG;     /**< \brief Offset: 0x0E (R/W  8) Interrupt Flag Status and Clear */
+  __I  TC_STATUS_Type            STATUS;      /**< \brief Offset: 0x0F (R/   8) Status */
+  __IO TC_COUNT32_COUNT_Type     COUNT;       /**< \brief Offset: 0x10 (R/W 32) COUNT32 Counter Value */
+       RoReg8                    Reserved3[0x4];
+  __IO TC_COUNT32_CC_Type        CC[2];       /**< \brief Offset: 0x18 (R/W 32) COUNT32 Compare/Capture */
+} TcCount32;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+       TcCount8                  COUNT8;      /**< \brief Offset: 0x00 8-bit Counter Mode */
+       TcCount16                 COUNT16;     /**< \brief Offset: 0x00 16-bit Counter Mode */
+       TcCount32                 COUNT32;     /**< \brief Offset: 0x00 32-bit Counter Mode */
+} Tc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_TC_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/component/wdt.h
@@ -1,0 +1,289 @@
+/**
+ * \file
+ *
+ * \brief Component description for WDT
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_WDT_COMPONENT_
+#define _SAMD20_WDT_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR WDT */
+/* ========================================================================== */
+/** \addtogroup SAMD20_WDT Watchdog Timer */
+/*@{*/
+
+#define WDT_U2203
+#define REV_WDT                     0x200
+
+/* -------- WDT_CTRL : (WDT Offset: 0x0) (R/W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :1;               /*!< bit:      0  Reserved                           */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  WEN:1;            /*!< bit:      2  Watchdog Timer Window Mode Enable  */
+    uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  ALWAYSON:1;       /*!< bit:      7  Always-On                          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CTRL_OFFSET             0x0          /**< \brief (WDT_CTRL offset) Control */
+#define WDT_CTRL_RESETVALUE         _U_(0x00)    /**< \brief (WDT_CTRL reset_value) Control */
+
+#define WDT_CTRL_ENABLE_Pos         1            /**< \brief (WDT_CTRL) Enable */
+#define WDT_CTRL_ENABLE             (_U_(0x1) << WDT_CTRL_ENABLE_Pos)
+#define WDT_CTRL_WEN_Pos            2            /**< \brief (WDT_CTRL) Watchdog Timer Window Mode Enable */
+#define WDT_CTRL_WEN                (_U_(0x1) << WDT_CTRL_WEN_Pos)
+#define WDT_CTRL_ALWAYSON_Pos       7            /**< \brief (WDT_CTRL) Always-On */
+#define WDT_CTRL_ALWAYSON           (_U_(0x1) << WDT_CTRL_ALWAYSON_Pos)
+#define WDT_CTRL_MASK               _U_(0x86)    /**< \brief (WDT_CTRL) MASK Register */
+
+/* -------- WDT_CONFIG : (WDT Offset: 0x1) (R/W  8) Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PER:4;            /*!< bit:  0.. 3  Time-Out Period                    */
+    uint8_t  WINDOW:4;         /*!< bit:  4.. 7  Window Mode Time-Out Period        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_CONFIG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CONFIG_OFFSET           0x1          /**< \brief (WDT_CONFIG offset) Configuration */
+#define WDT_CONFIG_RESETVALUE       _U_(0xBB)    /**< \brief (WDT_CONFIG reset_value) Configuration */
+
+#define WDT_CONFIG_PER_Pos          0            /**< \brief (WDT_CONFIG) Time-Out Period */
+#define WDT_CONFIG_PER_Msk          (_U_(0xF) << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER(value)       (WDT_CONFIG_PER_Msk & ((value) << WDT_CONFIG_PER_Pos))
+#define   WDT_CONFIG_PER_8_Val            _U_(0x0)   /**< \brief (WDT_CONFIG) 8 clock cycles */
+#define   WDT_CONFIG_PER_16_Val           _U_(0x1)   /**< \brief (WDT_CONFIG) 16 clock cycles */
+#define   WDT_CONFIG_PER_32_Val           _U_(0x2)   /**< \brief (WDT_CONFIG) 32 clock cycles */
+#define   WDT_CONFIG_PER_64_Val           _U_(0x3)   /**< \brief (WDT_CONFIG) 64 clock cycles */
+#define   WDT_CONFIG_PER_128_Val          _U_(0x4)   /**< \brief (WDT_CONFIG) 128 clock cycles */
+#define   WDT_CONFIG_PER_256_Val          _U_(0x5)   /**< \brief (WDT_CONFIG) 256 clock cycles */
+#define   WDT_CONFIG_PER_512_Val          _U_(0x6)   /**< \brief (WDT_CONFIG) 512 clock cycles */
+#define   WDT_CONFIG_PER_1K_Val           _U_(0x7)   /**< \brief (WDT_CONFIG) 1024 clock cycles */
+#define   WDT_CONFIG_PER_2K_Val           _U_(0x8)   /**< \brief (WDT_CONFIG) 2048 clock cycles */
+#define   WDT_CONFIG_PER_4K_Val           _U_(0x9)   /**< \brief (WDT_CONFIG) 4096 clock cycles */
+#define   WDT_CONFIG_PER_8K_Val           _U_(0xA)   /**< \brief (WDT_CONFIG) 8192 clock cycles */
+#define   WDT_CONFIG_PER_16K_Val          _U_(0xB)   /**< \brief (WDT_CONFIG) 16384 clock cycles */
+#define WDT_CONFIG_PER_8            (WDT_CONFIG_PER_8_Val          << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_16           (WDT_CONFIG_PER_16_Val         << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_32           (WDT_CONFIG_PER_32_Val         << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_64           (WDT_CONFIG_PER_64_Val         << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_128          (WDT_CONFIG_PER_128_Val        << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_256          (WDT_CONFIG_PER_256_Val        << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_512          (WDT_CONFIG_PER_512_Val        << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_1K           (WDT_CONFIG_PER_1K_Val         << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_2K           (WDT_CONFIG_PER_2K_Val         << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_4K           (WDT_CONFIG_PER_4K_Val         << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_8K           (WDT_CONFIG_PER_8K_Val         << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_16K          (WDT_CONFIG_PER_16K_Val        << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_WINDOW_Pos       4            /**< \brief (WDT_CONFIG) Window Mode Time-Out Period */
+#define WDT_CONFIG_WINDOW_Msk       (_U_(0xF) << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW(value)    (WDT_CONFIG_WINDOW_Msk & ((value) << WDT_CONFIG_WINDOW_Pos))
+#define   WDT_CONFIG_WINDOW_8_Val         _U_(0x0)   /**< \brief (WDT_CONFIG) 8 clock cycles */
+#define   WDT_CONFIG_WINDOW_16_Val        _U_(0x1)   /**< \brief (WDT_CONFIG) 16 clock cycles */
+#define   WDT_CONFIG_WINDOW_32_Val        _U_(0x2)   /**< \brief (WDT_CONFIG) 32 clock cycles */
+#define   WDT_CONFIG_WINDOW_64_Val        _U_(0x3)   /**< \brief (WDT_CONFIG) 64 clock cycles */
+#define   WDT_CONFIG_WINDOW_128_Val       _U_(0x4)   /**< \brief (WDT_CONFIG) 128 clock cycles */
+#define   WDT_CONFIG_WINDOW_256_Val       _U_(0x5)   /**< \brief (WDT_CONFIG) 256 clock cycles */
+#define   WDT_CONFIG_WINDOW_512_Val       _U_(0x6)   /**< \brief (WDT_CONFIG) 512 clock cycles */
+#define   WDT_CONFIG_WINDOW_1K_Val        _U_(0x7)   /**< \brief (WDT_CONFIG) 1024 clock cycles */
+#define   WDT_CONFIG_WINDOW_2K_Val        _U_(0x8)   /**< \brief (WDT_CONFIG) 2048 clock cycles */
+#define   WDT_CONFIG_WINDOW_4K_Val        _U_(0x9)   /**< \brief (WDT_CONFIG) 4096 clock cycles */
+#define   WDT_CONFIG_WINDOW_8K_Val        _U_(0xA)   /**< \brief (WDT_CONFIG) 8192 clock cycles */
+#define   WDT_CONFIG_WINDOW_16K_Val       _U_(0xB)   /**< \brief (WDT_CONFIG) 16384 clock cycles */
+#define WDT_CONFIG_WINDOW_8         (WDT_CONFIG_WINDOW_8_Val       << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_16        (WDT_CONFIG_WINDOW_16_Val      << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_32        (WDT_CONFIG_WINDOW_32_Val      << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_64        (WDT_CONFIG_WINDOW_64_Val      << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_128       (WDT_CONFIG_WINDOW_128_Val     << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_256       (WDT_CONFIG_WINDOW_256_Val     << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_512       (WDT_CONFIG_WINDOW_512_Val     << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_1K        (WDT_CONFIG_WINDOW_1K_Val      << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_2K        (WDT_CONFIG_WINDOW_2K_Val      << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_4K        (WDT_CONFIG_WINDOW_4K_Val      << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_8K        (WDT_CONFIG_WINDOW_8K_Val      << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_16K       (WDT_CONFIG_WINDOW_16K_Val     << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_MASK             _U_(0xFF)    /**< \brief (WDT_CONFIG) MASK Register */
+
+/* -------- WDT_EWCTRL : (WDT Offset: 0x2) (R/W  8) Early Warning Interrupt Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  EWOFFSET:4;       /*!< bit:  0.. 3  Early Warning Interrupt Time Offset */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_EWCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_EWCTRL_OFFSET           0x2          /**< \brief (WDT_EWCTRL offset) Early Warning Interrupt Control */
+#define WDT_EWCTRL_RESETVALUE       _U_(0x0B)    /**< \brief (WDT_EWCTRL reset_value) Early Warning Interrupt Control */
+
+#define WDT_EWCTRL_EWOFFSET_Pos     0            /**< \brief (WDT_EWCTRL) Early Warning Interrupt Time Offset */
+#define WDT_EWCTRL_EWOFFSET_Msk     (_U_(0xF) << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET(value)  (WDT_EWCTRL_EWOFFSET_Msk & ((value) << WDT_EWCTRL_EWOFFSET_Pos))
+#define   WDT_EWCTRL_EWOFFSET_8_Val       _U_(0x0)   /**< \brief (WDT_EWCTRL) 8 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_16_Val      _U_(0x1)   /**< \brief (WDT_EWCTRL) 16 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_32_Val      _U_(0x2)   /**< \brief (WDT_EWCTRL) 32 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_64_Val      _U_(0x3)   /**< \brief (WDT_EWCTRL) 64 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_128_Val     _U_(0x4)   /**< \brief (WDT_EWCTRL) 128 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_256_Val     _U_(0x5)   /**< \brief (WDT_EWCTRL) 256 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_512_Val     _U_(0x6)   /**< \brief (WDT_EWCTRL) 512 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_1K_Val      _U_(0x7)   /**< \brief (WDT_EWCTRL) 1024 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_2K_Val      _U_(0x8)   /**< \brief (WDT_EWCTRL) 2048 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_4K_Val      _U_(0x9)   /**< \brief (WDT_EWCTRL) 4096 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_8K_Val      _U_(0xA)   /**< \brief (WDT_EWCTRL) 8192 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_16K_Val     _U_(0xB)   /**< \brief (WDT_EWCTRL) 16384 clock cycles */
+#define WDT_EWCTRL_EWOFFSET_8       (WDT_EWCTRL_EWOFFSET_8_Val     << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_16      (WDT_EWCTRL_EWOFFSET_16_Val    << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_32      (WDT_EWCTRL_EWOFFSET_32_Val    << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_64      (WDT_EWCTRL_EWOFFSET_64_Val    << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_128     (WDT_EWCTRL_EWOFFSET_128_Val   << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_256     (WDT_EWCTRL_EWOFFSET_256_Val   << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_512     (WDT_EWCTRL_EWOFFSET_512_Val   << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_1K      (WDT_EWCTRL_EWOFFSET_1K_Val    << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_2K      (WDT_EWCTRL_EWOFFSET_2K_Val    << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_4K      (WDT_EWCTRL_EWOFFSET_4K_Val    << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_8K      (WDT_EWCTRL_EWOFFSET_8K_Val    << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_16K     (WDT_EWCTRL_EWOFFSET_16K_Val   << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_MASK             _U_(0x0F)    /**< \brief (WDT_EWCTRL) MASK Register */
+
+/* -------- WDT_INTENCLR : (WDT Offset: 0x4) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  EW:1;             /*!< bit:      0  Early Warning Interrupt Enable     */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_INTENCLR_OFFSET         0x4          /**< \brief (WDT_INTENCLR offset) Interrupt Enable Clear */
+#define WDT_INTENCLR_RESETVALUE     _U_(0x00)    /**< \brief (WDT_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define WDT_INTENCLR_EW_Pos         0            /**< \brief (WDT_INTENCLR) Early Warning Interrupt Enable */
+#define WDT_INTENCLR_EW             (_U_(0x1) << WDT_INTENCLR_EW_Pos)
+#define WDT_INTENCLR_MASK           _U_(0x01)    /**< \brief (WDT_INTENCLR) MASK Register */
+
+/* -------- WDT_INTENSET : (WDT Offset: 0x5) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  EW:1;             /*!< bit:      0  Early Warning Interrupt Enable     */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_INTENSET_OFFSET         0x5          /**< \brief (WDT_INTENSET offset) Interrupt Enable Set */
+#define WDT_INTENSET_RESETVALUE     _U_(0x00)    /**< \brief (WDT_INTENSET reset_value) Interrupt Enable Set */
+
+#define WDT_INTENSET_EW_Pos         0            /**< \brief (WDT_INTENSET) Early Warning Interrupt Enable */
+#define WDT_INTENSET_EW             (_U_(0x1) << WDT_INTENSET_EW_Pos)
+#define WDT_INTENSET_MASK           _U_(0x01)    /**< \brief (WDT_INTENSET) MASK Register */
+
+/* -------- WDT_INTFLAG : (WDT Offset: 0x6) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
+    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_INTFLAG_OFFSET          0x6          /**< \brief (WDT_INTFLAG offset) Interrupt Flag Status and Clear */
+#define WDT_INTFLAG_RESETVALUE      _U_(0x00)    /**< \brief (WDT_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define WDT_INTFLAG_EW_Pos          0            /**< \brief (WDT_INTFLAG) Early Warning */
+#define WDT_INTFLAG_EW              (_U_(0x1) << WDT_INTFLAG_EW_Pos)
+#define WDT_INTFLAG_MASK            _U_(0x01)    /**< \brief (WDT_INTFLAG) MASK Register */
+
+/* -------- WDT_STATUS : (WDT Offset: 0x7) (R/   8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_STATUS_OFFSET           0x7          /**< \brief (WDT_STATUS offset) Status */
+#define WDT_STATUS_RESETVALUE       _U_(0x00)    /**< \brief (WDT_STATUS reset_value) Status */
+
+#define WDT_STATUS_SYNCBUSY_Pos     7            /**< \brief (WDT_STATUS) Synchronization Busy */
+#define WDT_STATUS_SYNCBUSY         (_U_(0x1) << WDT_STATUS_SYNCBUSY_Pos)
+#define WDT_STATUS_MASK             _U_(0x80)    /**< \brief (WDT_STATUS) MASK Register */
+
+/* -------- WDT_CLEAR : (WDT Offset: 0x8) ( /W  8) Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CLEAR:8;          /*!< bit:  0.. 7  Watchdog Clear                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_CLEAR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CLEAR_OFFSET            0x8          /**< \brief (WDT_CLEAR offset) Clear */
+#define WDT_CLEAR_RESETVALUE        _U_(0x00)    /**< \brief (WDT_CLEAR reset_value) Clear */
+
+#define WDT_CLEAR_CLEAR_Pos         0            /**< \brief (WDT_CLEAR) Watchdog Clear */
+#define WDT_CLEAR_CLEAR_Msk         (_U_(0xFF) << WDT_CLEAR_CLEAR_Pos)
+#define WDT_CLEAR_CLEAR(value)      (WDT_CLEAR_CLEAR_Msk & ((value) << WDT_CLEAR_CLEAR_Pos))
+#define   WDT_CLEAR_CLEAR_KEY_Val         _U_(0xA5)   /**< \brief (WDT_CLEAR) Clear Key */
+#define WDT_CLEAR_CLEAR_KEY         (WDT_CLEAR_CLEAR_KEY_Val       << WDT_CLEAR_CLEAR_Pos)
+#define WDT_CLEAR_MASK              _U_(0xFF)    /**< \brief (WDT_CLEAR) MASK Register */
+
+/** \brief WDT hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO WDT_CTRL_Type             CTRL;        /**< \brief Offset: 0x0 (R/W  8) Control */
+  __IO WDT_CONFIG_Type           CONFIG;      /**< \brief Offset: 0x1 (R/W  8) Configuration */
+  __IO WDT_EWCTRL_Type           EWCTRL;      /**< \brief Offset: 0x2 (R/W  8) Early Warning Interrupt Control */
+       RoReg8                    Reserved1[0x1];
+  __IO WDT_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x4 (R/W  8) Interrupt Enable Clear */
+  __IO WDT_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x5 (R/W  8) Interrupt Enable Set */
+  __IO WDT_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x6 (R/W  8) Interrupt Flag Status and Clear */
+  __I  WDT_STATUS_Type           STATUS;      /**< \brief Offset: 0x7 (R/   8) Status */
+  __O  WDT_CLEAR_Type            CLEAR;       /**< \brief Offset: 0x8 ( /W  8) Clear */
+} Wdt;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_WDT_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/ac.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/ac.h
@@ -1,0 +1,73 @@
+/**
+ * \file
+ *
+ * \brief Instance description for AC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_AC_INSTANCE_
+#define _SAMD20_AC_INSTANCE_
+
+/* ========== Register definition for AC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_AC_CTRLA               (0x42004400) /**< \brief (AC) Control A */
+#define REG_AC_CTRLB               (0x42004401) /**< \brief (AC) Control B */
+#define REG_AC_EVCTRL              (0x42004402) /**< \brief (AC) Event Control */
+#define REG_AC_INTENCLR            (0x42004404) /**< \brief (AC) Interrupt Enable Clear */
+#define REG_AC_INTENSET            (0x42004405) /**< \brief (AC) Interrupt Enable Set */
+#define REG_AC_INTFLAG             (0x42004406) /**< \brief (AC) Interrupt Flag Status and Clear */
+#define REG_AC_STATUSA             (0x42004408) /**< \brief (AC) Status A */
+#define REG_AC_STATUSB             (0x42004409) /**< \brief (AC) Status B */
+#define REG_AC_STATUSC             (0x4200440A) /**< \brief (AC) Status C */
+#define REG_AC_WINCTRL             (0x4200440C) /**< \brief (AC) Window Control */
+#define REG_AC_COMPCTRL0           (0x42004410) /**< \brief (AC) Comparator Control 0 */
+#define REG_AC_COMPCTRL1           (0x42004414) /**< \brief (AC) Comparator Control 1 */
+#define REG_AC_SCALER0             (0x42004420) /**< \brief (AC) Scaler 0 */
+#define REG_AC_SCALER1             (0x42004421) /**< \brief (AC) Scaler 1 */
+#else
+#define REG_AC_CTRLA               (*(RwReg8 *)0x42004400UL) /**< \brief (AC) Control A */
+#define REG_AC_CTRLB               (*(WoReg8 *)0x42004401UL) /**< \brief (AC) Control B */
+#define REG_AC_EVCTRL              (*(RwReg16*)0x42004402UL) /**< \brief (AC) Event Control */
+#define REG_AC_INTENCLR            (*(RwReg8 *)0x42004404UL) /**< \brief (AC) Interrupt Enable Clear */
+#define REG_AC_INTENSET            (*(RwReg8 *)0x42004405UL) /**< \brief (AC) Interrupt Enable Set */
+#define REG_AC_INTFLAG             (*(RwReg8 *)0x42004406UL) /**< \brief (AC) Interrupt Flag Status and Clear */
+#define REG_AC_STATUSA             (*(RoReg8 *)0x42004408UL) /**< \brief (AC) Status A */
+#define REG_AC_STATUSB             (*(RoReg8 *)0x42004409UL) /**< \brief (AC) Status B */
+#define REG_AC_STATUSC             (*(RoReg8 *)0x4200440AUL) /**< \brief (AC) Status C */
+#define REG_AC_WINCTRL             (*(RwReg8 *)0x4200440CUL) /**< \brief (AC) Window Control */
+#define REG_AC_COMPCTRL0           (*(RwReg  *)0x42004410UL) /**< \brief (AC) Comparator Control 0 */
+#define REG_AC_COMPCTRL1           (*(RwReg  *)0x42004414UL) /**< \brief (AC) Comparator Control 1 */
+#define REG_AC_SCALER0             (*(RwReg8 *)0x42004420UL) /**< \brief (AC) Scaler 0 */
+#define REG_AC_SCALER1             (*(RwReg8 *)0x42004421UL) /**< \brief (AC) Scaler 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for AC peripheral ========== */
+#define AC_CMP_NUM                  2        // Number of comparators
+#define AC_GCLK_ID_ANA              25       // Index of Generic Clock for analog
+#define AC_GCLK_ID_DIG              24       // Index of Generic Clock for digital
+#define AC_NUM_CMP                  2       
+#define AC_PAIRS                    1        // Number of pairs of comparators
+
+#endif /* _SAMD20_AC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/adc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/adc.h
@@ -1,0 +1,84 @@
+/**
+ * \file
+ *
+ * \brief Instance description for ADC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_ADC_INSTANCE_
+#define _SAMD20_ADC_INSTANCE_
+
+/* ========== Register definition for ADC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_ADC_CTRLA              (0x42004000) /**< \brief (ADC) Control A */
+#define REG_ADC_REFCTRL            (0x42004001) /**< \brief (ADC) Reference Control */
+#define REG_ADC_AVGCTRL            (0x42004002) /**< \brief (ADC) Average Control */
+#define REG_ADC_SAMPCTRL           (0x42004003) /**< \brief (ADC) Sampling Time Control */
+#define REG_ADC_CTRLB              (0x42004004) /**< \brief (ADC) Control B */
+#define REG_ADC_WINCTRL            (0x42004008) /**< \brief (ADC) Window Monitor Control */
+#define REG_ADC_SWTRIG             (0x4200400C) /**< \brief (ADC) Software Trigger */
+#define REG_ADC_INPUTCTRL          (0x42004010) /**< \brief (ADC) Inputs Control */
+#define REG_ADC_EVCTRL             (0x42004014) /**< \brief (ADC) Event Control */
+#define REG_ADC_INTENCLR           (0x42004016) /**< \brief (ADC) Interrupt Enable Clear */
+#define REG_ADC_INTENSET           (0x42004017) /**< \brief (ADC) Interrupt Enable Set */
+#define REG_ADC_INTFLAG            (0x42004018) /**< \brief (ADC) Interrupt Flag Status and Clear */
+#define REG_ADC_STATUS             (0x42004019) /**< \brief (ADC) Status */
+#define REG_ADC_RESULT             (0x4200401A) /**< \brief (ADC) Result */
+#define REG_ADC_WINLT              (0x4200401C) /**< \brief (ADC) Window Monitor Lower Threshold */
+#define REG_ADC_WINUT              (0x42004020) /**< \brief (ADC) Window Monitor Upper Threshold */
+#define REG_ADC_GAINCORR           (0x42004024) /**< \brief (ADC) Gain Correction */
+#define REG_ADC_OFFSETCORR         (0x42004026) /**< \brief (ADC) Offset Correction */
+#define REG_ADC_CALIB              (0x42004028) /**< \brief (ADC) Calibration */
+#define REG_ADC_DBGCTRL            (0x4200402A) /**< \brief (ADC) Debug Control */
+#else
+#define REG_ADC_CTRLA              (*(RwReg8 *)0x42004000UL) /**< \brief (ADC) Control A */
+#define REG_ADC_REFCTRL            (*(RwReg8 *)0x42004001UL) /**< \brief (ADC) Reference Control */
+#define REG_ADC_AVGCTRL            (*(RwReg8 *)0x42004002UL) /**< \brief (ADC) Average Control */
+#define REG_ADC_SAMPCTRL           (*(RwReg8 *)0x42004003UL) /**< \brief (ADC) Sampling Time Control */
+#define REG_ADC_CTRLB              (*(RwReg16*)0x42004004UL) /**< \brief (ADC) Control B */
+#define REG_ADC_WINCTRL            (*(RwReg8 *)0x42004008UL) /**< \brief (ADC) Window Monitor Control */
+#define REG_ADC_SWTRIG             (*(RwReg8 *)0x4200400CUL) /**< \brief (ADC) Software Trigger */
+#define REG_ADC_INPUTCTRL          (*(RwReg  *)0x42004010UL) /**< \brief (ADC) Inputs Control */
+#define REG_ADC_EVCTRL             (*(RwReg8 *)0x42004014UL) /**< \brief (ADC) Event Control */
+#define REG_ADC_INTENCLR           (*(RwReg8 *)0x42004016UL) /**< \brief (ADC) Interrupt Enable Clear */
+#define REG_ADC_INTENSET           (*(RwReg8 *)0x42004017UL) /**< \brief (ADC) Interrupt Enable Set */
+#define REG_ADC_INTFLAG            (*(RwReg8 *)0x42004018UL) /**< \brief (ADC) Interrupt Flag Status and Clear */
+#define REG_ADC_STATUS             (*(RoReg8 *)0x42004019UL) /**< \brief (ADC) Status */
+#define REG_ADC_RESULT             (*(RoReg16*)0x4200401AUL) /**< \brief (ADC) Result */
+#define REG_ADC_WINLT              (*(RwReg16*)0x4200401CUL) /**< \brief (ADC) Window Monitor Lower Threshold */
+#define REG_ADC_WINUT              (*(RwReg16*)0x42004020UL) /**< \brief (ADC) Window Monitor Upper Threshold */
+#define REG_ADC_GAINCORR           (*(RwReg16*)0x42004024UL) /**< \brief (ADC) Gain Correction */
+#define REG_ADC_OFFSETCORR         (*(RwReg16*)0x42004026UL) /**< \brief (ADC) Offset Correction */
+#define REG_ADC_CALIB              (*(RwReg16*)0x42004028UL) /**< \brief (ADC) Calibration */
+#define REG_ADC_DBGCTRL            (*(RwReg8 *)0x4200402AUL) /**< \brief (ADC) Debug Control */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for ADC peripheral ========== */
+#define ADC_EXTCHANNEL_MSB          19       // Number of external channels
+#define ADC_GCLK_ID                 23       // Index of Generic Clock
+#define ADC_RESULT_BITS             16       // Size of RESULT.RESULT bitfield
+#define ADC_RESULT_MSB              15       // Size of Result
+
+#endif /* _SAMD20_ADC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/dac.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/dac.h
@@ -1,0 +1,59 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DAC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_DAC_INSTANCE_
+#define _SAMD20_DAC_INSTANCE_
+
+/* ========== Register definition for DAC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_DAC_CTRLA              (0x42004800) /**< \brief (DAC) Control A */
+#define REG_DAC_CTRLB              (0x42004801) /**< \brief (DAC) Control B */
+#define REG_DAC_EVCTRL             (0x42004802) /**< \brief (DAC) Event Control */
+#define REG_DAC_INTENCLR           (0x42004804) /**< \brief (DAC) Interrupt Enable Clear */
+#define REG_DAC_INTENSET           (0x42004805) /**< \brief (DAC) Interrupt Enable Set */
+#define REG_DAC_INTFLAG            (0x42004806) /**< \brief (DAC) Interrupt Flag Status and Clear */
+#define REG_DAC_STATUS             (0x42004807) /**< \brief (DAC) Status */
+#define REG_DAC_DATA               (0x42004808) /**< \brief (DAC) Data */
+#define REG_DAC_DATABUF            (0x4200480C) /**< \brief (DAC) Data Buffer */
+#else
+#define REG_DAC_CTRLA              (*(RwReg8 *)0x42004800UL) /**< \brief (DAC) Control A */
+#define REG_DAC_CTRLB              (*(RwReg8 *)0x42004801UL) /**< \brief (DAC) Control B */
+#define REG_DAC_EVCTRL             (*(RwReg8 *)0x42004802UL) /**< \brief (DAC) Event Control */
+#define REG_DAC_INTENCLR           (*(RwReg8 *)0x42004804UL) /**< \brief (DAC) Interrupt Enable Clear */
+#define REG_DAC_INTENSET           (*(RwReg8 *)0x42004805UL) /**< \brief (DAC) Interrupt Enable Set */
+#define REG_DAC_INTFLAG            (*(RwReg8 *)0x42004806UL) /**< \brief (DAC) Interrupt Flag Status and Clear */
+#define REG_DAC_STATUS             (*(RoReg8 *)0x42004807UL) /**< \brief (DAC) Status */
+#define REG_DAC_DATA               (*(RwReg16*)0x42004808UL) /**< \brief (DAC) Data */
+#define REG_DAC_DATABUF            (*(RwReg16*)0x4200480CUL) /**< \brief (DAC) Data Buffer */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for DAC peripheral ========== */
+#define DAC_GCLK_ID                 26      
+
+#endif /* _SAMD20_DAC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/dsu.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/dsu.h
@@ -1,0 +1,95 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DSU
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_DSU_INSTANCE_
+#define _SAMD20_DSU_INSTANCE_
+
+/* ========== Register definition for DSU peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_DSU_CTRL               (0x41002000) /**< \brief (DSU) Control */
+#define REG_DSU_STATUSA            (0x41002001) /**< \brief (DSU) Status A */
+#define REG_DSU_STATUSB            (0x41002002) /**< \brief (DSU) Status B */
+#define REG_DSU_ADDR               (0x41002004) /**< \brief (DSU) Address */
+#define REG_DSU_LENGTH             (0x41002008) /**< \brief (DSU) Length */
+#define REG_DSU_DATA               (0x4100200C) /**< \brief (DSU) Data */
+#define REG_DSU_DCC0               (0x41002010) /**< \brief (DSU) Debug Communication Channel 0 */
+#define REG_DSU_DCC1               (0x41002014) /**< \brief (DSU) Debug Communication Channel 1 */
+#define REG_DSU_DID                (0x41002018) /**< \brief (DSU) Device Identification */
+#define REG_DSU_DCFG0              (0x410020F0) /**< \brief (DSU) Device Configuration 0 */
+#define REG_DSU_DCFG1              (0x410020F4) /**< \brief (DSU) Device Configuration 1 */
+#define REG_DSU_ENTRY0             (0x41003000) /**< \brief (DSU) CoreSight ROM Table Entry 0 */
+#define REG_DSU_ENTRY1             (0x41003004) /**< \brief (DSU) CoreSight ROM Table Entry 1 */
+#define REG_DSU_END                (0x41003008) /**< \brief (DSU) CoreSight ROM Table End */
+#define REG_DSU_MEMTYPE            (0x41003FCC) /**< \brief (DSU) CoreSight ROM Table Memory Type */
+#define REG_DSU_PID4               (0x41003FD0) /**< \brief (DSU) Peripheral Identification 4 */
+#define REG_DSU_PID5               (0x41003FD4) /**< \brief (DSU) Peripheral Identification 5 */
+#define REG_DSU_PID6               (0x41003FD8) /**< \brief (DSU) Peripheral Identification 6 */
+#define REG_DSU_PID7               (0x41003FDC) /**< \brief (DSU) Peripheral Identification 7 */
+#define REG_DSU_PID0               (0x41003FE0) /**< \brief (DSU) Peripheral Identification 0 */
+#define REG_DSU_PID1               (0x41003FE4) /**< \brief (DSU) Peripheral Identification 1 */
+#define REG_DSU_PID2               (0x41003FE8) /**< \brief (DSU) Peripheral Identification 2 */
+#define REG_DSU_PID3               (0x41003FEC) /**< \brief (DSU) Peripheral Identification 3 */
+#define REG_DSU_CID0               (0x41003FF0) /**< \brief (DSU) Component Identification 0 */
+#define REG_DSU_CID1               (0x41003FF4) /**< \brief (DSU) Component Identification 1 */
+#define REG_DSU_CID2               (0x41003FF8) /**< \brief (DSU) Component Identification 2 */
+#define REG_DSU_CID3               (0x41003FFC) /**< \brief (DSU) Component Identification 3 */
+#else
+#define REG_DSU_CTRL               (*(WoReg8 *)0x41002000UL) /**< \brief (DSU) Control */
+#define REG_DSU_STATUSA            (*(RwReg8 *)0x41002001UL) /**< \brief (DSU) Status A */
+#define REG_DSU_STATUSB            (*(RoReg8 *)0x41002002UL) /**< \brief (DSU) Status B */
+#define REG_DSU_ADDR               (*(RwReg  *)0x41002004UL) /**< \brief (DSU) Address */
+#define REG_DSU_LENGTH             (*(RwReg  *)0x41002008UL) /**< \brief (DSU) Length */
+#define REG_DSU_DATA               (*(RwReg  *)0x4100200CUL) /**< \brief (DSU) Data */
+#define REG_DSU_DCC0               (*(RwReg  *)0x41002010UL) /**< \brief (DSU) Debug Communication Channel 0 */
+#define REG_DSU_DCC1               (*(RwReg  *)0x41002014UL) /**< \brief (DSU) Debug Communication Channel 1 */
+#define REG_DSU_DID                (*(RoReg  *)0x41002018UL) /**< \brief (DSU) Device Identification */
+#define REG_DSU_DCFG0              (*(RwReg  *)0x410020F0UL) /**< \brief (DSU) Device Configuration 0 */
+#define REG_DSU_DCFG1              (*(RwReg  *)0x410020F4UL) /**< \brief (DSU) Device Configuration 1 */
+#define REG_DSU_ENTRY0             (*(RoReg  *)0x41003000UL) /**< \brief (DSU) CoreSight ROM Table Entry 0 */
+#define REG_DSU_ENTRY1             (*(RoReg  *)0x41003004UL) /**< \brief (DSU) CoreSight ROM Table Entry 1 */
+#define REG_DSU_END                (*(RoReg  *)0x41003008UL) /**< \brief (DSU) CoreSight ROM Table End */
+#define REG_DSU_MEMTYPE            (*(RoReg  *)0x41003FCCUL) /**< \brief (DSU) CoreSight ROM Table Memory Type */
+#define REG_DSU_PID4               (*(RoReg  *)0x41003FD0UL) /**< \brief (DSU) Peripheral Identification 4 */
+#define REG_DSU_PID5               (*(RoReg  *)0x41003FD4UL) /**< \brief (DSU) Peripheral Identification 5 */
+#define REG_DSU_PID6               (*(RoReg  *)0x41003FD8UL) /**< \brief (DSU) Peripheral Identification 6 */
+#define REG_DSU_PID7               (*(RoReg  *)0x41003FDCUL) /**< \brief (DSU) Peripheral Identification 7 */
+#define REG_DSU_PID0               (*(RoReg  *)0x41003FE0UL) /**< \brief (DSU) Peripheral Identification 0 */
+#define REG_DSU_PID1               (*(RoReg  *)0x41003FE4UL) /**< \brief (DSU) Peripheral Identification 1 */
+#define REG_DSU_PID2               (*(RoReg  *)0x41003FE8UL) /**< \brief (DSU) Peripheral Identification 2 */
+#define REG_DSU_PID3               (*(RoReg  *)0x41003FECUL) /**< \brief (DSU) Peripheral Identification 3 */
+#define REG_DSU_CID0               (*(RoReg  *)0x41003FF0UL) /**< \brief (DSU) Component Identification 0 */
+#define REG_DSU_CID1               (*(RoReg  *)0x41003FF4UL) /**< \brief (DSU) Component Identification 1 */
+#define REG_DSU_CID2               (*(RoReg  *)0x41003FF8UL) /**< \brief (DSU) Component Identification 2 */
+#define REG_DSU_CID3               (*(RoReg  *)0x41003FFCUL) /**< \brief (DSU) Component Identification 3 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for DSU peripheral ========== */
+#define DSU_CLK_HSB_ID              3       
+
+#endif /* _SAMD20_DSU_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/eic.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/eic.h
@@ -1,0 +1,67 @@
+/**
+ * \file
+ *
+ * \brief Instance description for EIC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_EIC_INSTANCE_
+#define _SAMD20_EIC_INSTANCE_
+
+/* ========== Register definition for EIC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_EIC_CTRL               (0x40001800) /**< \brief (EIC) Control */
+#define REG_EIC_STATUS             (0x40001801) /**< \brief (EIC) Status */
+#define REG_EIC_NMICTRL            (0x40001802) /**< \brief (EIC) Non-Maskable Interrupt Control */
+#define REG_EIC_NMIFLAG            (0x40001803) /**< \brief (EIC) Non-Maskable Interrupt Flag Status and Clear */
+#define REG_EIC_EVCTRL             (0x40001804) /**< \brief (EIC) Event Control */
+#define REG_EIC_INTENCLR           (0x40001808) /**< \brief (EIC) Interrupt Enable Clear */
+#define REG_EIC_INTENSET           (0x4000180C) /**< \brief (EIC) Interrupt Enable Set */
+#define REG_EIC_INTFLAG            (0x40001810) /**< \brief (EIC) Interrupt Flag Status and Clear */
+#define REG_EIC_WAKEUP             (0x40001814) /**< \brief (EIC) Wake-Up Enable */
+#define REG_EIC_CONFIG0            (0x40001818) /**< \brief (EIC) Configuration 0 */
+#define REG_EIC_CONFIG1            (0x4000181C) /**< \brief (EIC) Configuration 1 */
+#else
+#define REG_EIC_CTRL               (*(RwReg8 *)0x40001800UL) /**< \brief (EIC) Control */
+#define REG_EIC_STATUS             (*(RoReg8 *)0x40001801UL) /**< \brief (EIC) Status */
+#define REG_EIC_NMICTRL            (*(RwReg8 *)0x40001802UL) /**< \brief (EIC) Non-Maskable Interrupt Control */
+#define REG_EIC_NMIFLAG            (*(RwReg8 *)0x40001803UL) /**< \brief (EIC) Non-Maskable Interrupt Flag Status and Clear */
+#define REG_EIC_EVCTRL             (*(RwReg  *)0x40001804UL) /**< \brief (EIC) Event Control */
+#define REG_EIC_INTENCLR           (*(RwReg  *)0x40001808UL) /**< \brief (EIC) Interrupt Enable Clear */
+#define REG_EIC_INTENSET           (*(RwReg  *)0x4000180CUL) /**< \brief (EIC) Interrupt Enable Set */
+#define REG_EIC_INTFLAG            (*(RwReg  *)0x40001810UL) /**< \brief (EIC) Interrupt Flag Status and Clear */
+#define REG_EIC_WAKEUP             (*(RwReg  *)0x40001814UL) /**< \brief (EIC) Wake-Up Enable */
+#define REG_EIC_CONFIG0            (*(RwReg  *)0x40001818UL) /**< \brief (EIC) Configuration 0 */
+#define REG_EIC_CONFIG1            (*(RwReg  *)0x4000181CUL) /**< \brief (EIC) Configuration 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for EIC peripheral ========== */
+#define EIC_CONFIG_NUM              2        // Number of CONFIG registers
+#define EIC_EXTINT_NUM              16       // Number of External Interrupts
+#define EIC_GCLK_ID                 3        // Index of Generic Clock
+#define EIC_NUMBER_OF_CONFIG_REGS   2        // Number of CONFIG registers (obsolete)
+#define EIC_NUMBER_OF_INTERRUPTS    16       // Number of External Interrupts (obsolete)
+
+#endif /* _SAMD20_EIC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/evsys.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/evsys.h
@@ -1,0 +1,148 @@
+/**
+ * \file
+ *
+ * \brief Instance description for EVSYS
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_EVSYS_INSTANCE_
+#define _SAMD20_EVSYS_INSTANCE_
+
+/* ========== Register definition for EVSYS peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_EVSYS_CTRL             (0x42000400) /**< \brief (EVSYS) Control */
+#define REG_EVSYS_CHANNEL          (0x42000404) /**< \brief (EVSYS) Channel */
+#define REG_EVSYS_USER             (0x42000408) /**< \brief (EVSYS) User Multiplexer */
+#define REG_EVSYS_CHSTATUS         (0x4200040C) /**< \brief (EVSYS) Channel Status */
+#define REG_EVSYS_INTENCLR         (0x42000410) /**< \brief (EVSYS) Interrupt Enable Clear */
+#define REG_EVSYS_INTENSET         (0x42000414) /**< \brief (EVSYS) Interrupt Enable Set */
+#define REG_EVSYS_INTFLAG          (0x42000418) /**< \brief (EVSYS) Interrupt Flag Status and Clear */
+#else
+#define REG_EVSYS_CTRL             (*(WoReg8 *)0x42000400UL) /**< \brief (EVSYS) Control */
+#define REG_EVSYS_CHANNEL          (*(RwReg  *)0x42000404UL) /**< \brief (EVSYS) Channel */
+#define REG_EVSYS_USER             (*(RwReg16*)0x42000408UL) /**< \brief (EVSYS) User Multiplexer */
+#define REG_EVSYS_CHSTATUS         (*(RoReg  *)0x4200040CUL) /**< \brief (EVSYS) Channel Status */
+#define REG_EVSYS_INTENCLR         (*(RwReg  *)0x42000410UL) /**< \brief (EVSYS) Interrupt Enable Clear */
+#define REG_EVSYS_INTENSET         (*(RwReg  *)0x42000414UL) /**< \brief (EVSYS) Interrupt Enable Set */
+#define REG_EVSYS_INTFLAG          (*(RwReg  *)0x42000418UL) /**< \brief (EVSYS) Interrupt Flag Status and Clear */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for EVSYS peripheral ========== */
+#define EVSYS_CHANNELS              8        // Number of Channels
+#define EVSYS_CHANNELS_BITS         3        // Number of bits to select Channel
+#define EVSYS_CHANNELS_MSB          7        // Number of Channels - 1
+#define EVSYS_EXTEVT_NUM                     // Number of External Event Generators
+#define EVSYS_EXT_EVT_MSB           0        // Number of External Event Generators - 1
+#define EVSYS_GCLK_ID_0             4
+#define EVSYS_GCLK_ID_1             5
+#define EVSYS_GCLK_ID_2             6
+#define EVSYS_GCLK_ID_3             7
+#define EVSYS_GCLK_ID_4             8
+#define EVSYS_GCLK_ID_5             9
+#define EVSYS_GCLK_ID_6             10
+#define EVSYS_GCLK_ID_7             11
+#define EVSYS_GCLK_ID_LSB           4
+#define EVSYS_GCLK_ID_MSB           11
+#define EVSYS_GCLK_ID_SIZE          8
+#define EVSYS_GENERATORS            59       // Total Number of Event Generators
+#define EVSYS_GENERATORS_BITS       6        // Number of bits to select Event Generator
+#define EVSYS_USERS                 14       // Total Number of Event Users
+#define EVSYS_USERS_BITS            4        // Number of bits to select Event User
+
+// GENERATORS
+#define EVSYS_ID_GEN_RTC_CMP_0      1
+#define EVSYS_ID_GEN_RTC_CMP_1      2
+#define EVSYS_ID_GEN_RTC_OVF        3
+#define EVSYS_ID_GEN_RTC_PER_0      4
+#define EVSYS_ID_GEN_RTC_PER_1      5
+#define EVSYS_ID_GEN_RTC_PER_2      6
+#define EVSYS_ID_GEN_RTC_PER_3      7
+#define EVSYS_ID_GEN_RTC_PER_4      8
+#define EVSYS_ID_GEN_RTC_PER_5      9
+#define EVSYS_ID_GEN_RTC_PER_6      10
+#define EVSYS_ID_GEN_RTC_PER_7      11
+#define EVSYS_ID_GEN_EIC_EXTINT_0   12
+#define EVSYS_ID_GEN_EIC_EXTINT_1   13
+#define EVSYS_ID_GEN_EIC_EXTINT_2   14
+#define EVSYS_ID_GEN_EIC_EXTINT_3   15
+#define EVSYS_ID_GEN_EIC_EXTINT_4   16
+#define EVSYS_ID_GEN_EIC_EXTINT_5   17
+#define EVSYS_ID_GEN_EIC_EXTINT_6   18
+#define EVSYS_ID_GEN_EIC_EXTINT_7   19
+#define EVSYS_ID_GEN_EIC_EXTINT_8   20
+#define EVSYS_ID_GEN_EIC_EXTINT_9   21
+#define EVSYS_ID_GEN_EIC_EXTINT_10  22
+#define EVSYS_ID_GEN_EIC_EXTINT_11  23
+#define EVSYS_ID_GEN_EIC_EXTINT_12  24
+#define EVSYS_ID_GEN_EIC_EXTINT_13  25
+#define EVSYS_ID_GEN_EIC_EXTINT_14  26
+#define EVSYS_ID_GEN_EIC_EXTINT_15  27
+#define EVSYS_ID_GEN_TC0_OVF        28
+#define EVSYS_ID_GEN_TC0_MCX_0      29
+#define EVSYS_ID_GEN_TC0_MCX_1      30
+#define EVSYS_ID_GEN_TC1_OVF        31
+#define EVSYS_ID_GEN_TC1_MCX_0      32
+#define EVSYS_ID_GEN_TC1_MCX_1      33
+#define EVSYS_ID_GEN_TC2_OVF        34
+#define EVSYS_ID_GEN_TC2_MCX_0      35
+#define EVSYS_ID_GEN_TC2_MCX_1      36
+#define EVSYS_ID_GEN_TC3_OVF        37
+#define EVSYS_ID_GEN_TC3_MCX_0      38
+#define EVSYS_ID_GEN_TC3_MCX_1      39
+#define EVSYS_ID_GEN_TC4_OVF        40
+#define EVSYS_ID_GEN_TC4_MCX_0      41
+#define EVSYS_ID_GEN_TC4_MCX_1      42
+#define EVSYS_ID_GEN_TC5_OVF        43
+#define EVSYS_ID_GEN_TC5_MCX_0      44
+#define EVSYS_ID_GEN_TC5_MCX_1      45
+#define EVSYS_ID_GEN_TC6_OVF        46
+#define EVSYS_ID_GEN_TC6_MCX_0      47
+#define EVSYS_ID_GEN_TC6_MCX_1      48
+#define EVSYS_ID_GEN_TC7_OVF        49
+#define EVSYS_ID_GEN_TC7_MCX_0      50
+#define EVSYS_ID_GEN_TC7_MCX_1      51
+#define EVSYS_ID_GEN_ADC_RESRDY     52
+#define EVSYS_ID_GEN_ADC_WINMON     53
+#define EVSYS_ID_GEN_AC_COMP_0      54
+#define EVSYS_ID_GEN_AC_COMP_1      55
+#define EVSYS_ID_GEN_AC_WIN_0       56
+#define EVSYS_ID_GEN_DAC_EMPTY      57
+
+// USERS
+#define EVSYS_ID_USER_TC0_EVU       0
+#define EVSYS_ID_USER_TC1_EVU       1
+#define EVSYS_ID_USER_TC2_EVU       2
+#define EVSYS_ID_USER_TC3_EVU       3
+#define EVSYS_ID_USER_TC4_EVU       4
+#define EVSYS_ID_USER_TC5_EVU       5
+#define EVSYS_ID_USER_TC6_EVU       6
+#define EVSYS_ID_USER_TC7_EVU       7
+#define EVSYS_ID_USER_ADC_START     8
+#define EVSYS_ID_USER_ADC_SYNC      9
+#define EVSYS_ID_USER_AC_SOC_0      10
+#define EVSYS_ID_USER_AC_SOC_1      11
+#define EVSYS_ID_USER_DAC_START     12
+
+#endif /* _SAMD20_EVSYS_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/gclk.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/gclk.h
@@ -1,0 +1,64 @@
+/**
+ * \file
+ *
+ * \brief Instance description for GCLK
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_GCLK_INSTANCE_
+#define _SAMD20_GCLK_INSTANCE_
+
+/* ========== Register definition for GCLK peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_GCLK_CTRL              (0x40000C00) /**< \brief (GCLK) Control */
+#define REG_GCLK_STATUS            (0x40000C01) /**< \brief (GCLK) Status */
+#define REG_GCLK_CLKCTRL           (0x40000C02) /**< \brief (GCLK) Generic Clock Control */
+#define REG_GCLK_GENCTRL           (0x40000C04) /**< \brief (GCLK) Generic Clock Generator Control */
+#define REG_GCLK_GENDIV            (0x40000C08) /**< \brief (GCLK) Generic Clock Generator Division */
+#else
+#define REG_GCLK_CTRL              (*(RwReg8 *)0x40000C00UL) /**< \brief (GCLK) Control */
+#define REG_GCLK_STATUS            (*(RoReg8 *)0x40000C01UL) /**< \brief (GCLK) Status */
+#define REG_GCLK_CLKCTRL           (*(RwReg16*)0x40000C02UL) /**< \brief (GCLK) Generic Clock Control */
+#define REG_GCLK_GENCTRL           (*(RwReg  *)0x40000C04UL) /**< \brief (GCLK) Generic Clock Generator Control */
+#define REG_GCLK_GENDIV            (*(RwReg  *)0x40000C08UL) /**< \brief (GCLK) Generic Clock Generator Division */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for GCLK peripheral ========== */
+#define GCLK_GENDIV_BITS            16      
+#define GCLK_GEN_NUM                8        // Number of Generic Clock Generators
+#define GCLK_GEN_NUM_MSB            7        // Number of Generic Clock Generators - 1
+#define GCLK_GEN_SOURCE_NUM_MSB     7        // Number of Generic Clock Sources - 1
+#define GCLK_NUM                    28       // Number of Generic Clock Users
+#define GCLK_SOURCE_DFLL48M         7       
+#define GCLK_SOURCE_GCLKGEN1        2       
+#define GCLK_SOURCE_GCLKIN          1       
+#define GCLK_SOURCE_NUM             8        // Number of Generic Clock Sources
+#define GCLK_SOURCE_OSCULP32K       3       
+#define GCLK_SOURCE_OSC8M           6       
+#define GCLK_SOURCE_OSC32K          4       
+#define GCLK_SOURCE_XOSC            0       
+#define GCLK_SOURCE_XOSC32K         5       
+
+#endif /* _SAMD20_GCLK_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/nvmctrl.h
@@ -1,0 +1,77 @@
+/**
+ * \file
+ *
+ * \brief Instance description for NVMCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_NVMCTRL_INSTANCE_
+#define _SAMD20_NVMCTRL_INSTANCE_
+
+/* ========== Register definition for NVMCTRL peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_NVMCTRL_CTRLA          (0x41004000) /**< \brief (NVMCTRL) Control A */
+#define REG_NVMCTRL_CTRLB          (0x41004004) /**< \brief (NVMCTRL) Control B */
+#define REG_NVMCTRL_PARAM          (0x41004008) /**< \brief (NVMCTRL) NVM Parameter */
+#define REG_NVMCTRL_INTENCLR       (0x4100400C) /**< \brief (NVMCTRL) Interrupt Enable Clear */
+#define REG_NVMCTRL_INTENSET       (0x41004010) /**< \brief (NVMCTRL) Interrupt Enable Set */
+#define REG_NVMCTRL_INTFLAG        (0x41004014) /**< \brief (NVMCTRL) Interrupt Flag Status and Clear */
+#define REG_NVMCTRL_STATUS         (0x41004018) /**< \brief (NVMCTRL) Status */
+#define REG_NVMCTRL_ADDR           (0x4100401C) /**< \brief (NVMCTRL) Address */
+#define REG_NVMCTRL_LOCK           (0x41004020) /**< \brief (NVMCTRL) Lock Section */
+#else
+#define REG_NVMCTRL_CTRLA          (*(RwReg16*)0x41004000UL) /**< \brief (NVMCTRL) Control A */
+#define REG_NVMCTRL_CTRLB          (*(RwReg  *)0x41004004UL) /**< \brief (NVMCTRL) Control B */
+#define REG_NVMCTRL_PARAM          (*(RwReg  *)0x41004008UL) /**< \brief (NVMCTRL) NVM Parameter */
+#define REG_NVMCTRL_INTENCLR       (*(RwReg8 *)0x4100400CUL) /**< \brief (NVMCTRL) Interrupt Enable Clear */
+#define REG_NVMCTRL_INTENSET       (*(RwReg8 *)0x41004010UL) /**< \brief (NVMCTRL) Interrupt Enable Set */
+#define REG_NVMCTRL_INTFLAG        (*(RwReg8 *)0x41004014UL) /**< \brief (NVMCTRL) Interrupt Flag Status and Clear */
+#define REG_NVMCTRL_STATUS         (*(RwReg16*)0x41004018UL) /**< \brief (NVMCTRL) Status */
+#define REG_NVMCTRL_ADDR           (*(RwReg  *)0x4100401CUL) /**< \brief (NVMCTRL) Address */
+#define REG_NVMCTRL_LOCK           (*(RwReg16*)0x41004020UL) /**< \brief (NVMCTRL) Lock Section */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for NVMCTRL peripheral ========== */
+#define NVMCTRL_AUX0_ADDRESS        0x00804000
+#define NVMCTRL_AUX1_ADDRESS        0x00806000
+#define NVMCTRL_AUX2_ADDRESS        0x00808000
+#define NVMCTRL_AUX3_ADDRESS        0x0080A000
+#define NVMCTRL_CLK_AHB_ID          4        // Index of AHB Clock in PM.AHBMASK register
+#define NVMCTRL_FACTORY_WORD_IMPLEMENTED_MASK 0xC0000007FFFFFFFF
+#define NVMCTRL_FLASH_SIZE          262144  
+#define NVMCTRL_LOCKBIT_ADDRESS     0x00802000
+#define NVMCTRL_PAGE_HW             32      
+#define NVMCTRL_PAGE_SIZE           64      
+#define NVMCTRL_PAGE_W              16      
+#define NVMCTRL_PMSB                3       
+#define NVMCTRL_PSZ_BITS            6       
+#define NVMCTRL_ROW_PAGES           4       
+#define NVMCTRL_ROW_SIZE            256     
+#define NVMCTRL_TEMP_LOG_ADDRESS    0x00806030
+#define NVMCTRL_USER_PAGE_ADDRESS   0x00800000
+#define NVMCTRL_USER_PAGE_OFFSET    0x00800000
+#define NVMCTRL_USER_WORD_IMPLEMENTED_MASK 0xC01FFFFFFFFFFFFF
+
+#endif /* _SAMD20_NVMCTRL_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/pac0.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/pac0.h
@@ -1,0 +1,45 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PAC0
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PAC0_INSTANCE_
+#define _SAMD20_PAC0_INSTANCE_
+
+/* ========== Register definition for PAC0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PAC0_WPCLR             (0x40000000) /**< \brief (PAC0) Write Protection Clear */
+#define REG_PAC0_WPSET             (0x40000004) /**< \brief (PAC0) Write Protection Set */
+#else
+#define REG_PAC0_WPCLR             (*(RwReg  *)0x40000000UL) /**< \brief (PAC0) Write Protection Clear */
+#define REG_PAC0_WPSET             (*(RwReg  *)0x40000004UL) /**< \brief (PAC0) Write Protection Set */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PAC0 peripheral ========== */
+#define PAC0_WPROT_DEFAULT_VAL      0x00000000 // PAC protection mask at reset
+
+#endif /* _SAMD20_PAC0_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/pac1.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/pac1.h
@@ -1,0 +1,45 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PAC1
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PAC1_INSTANCE_
+#define _SAMD20_PAC1_INSTANCE_
+
+/* ========== Register definition for PAC1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PAC1_WPCLR             (0x41000000) /**< \brief (PAC1) Write Protection Clear */
+#define REG_PAC1_WPSET             (0x41000004) /**< \brief (PAC1) Write Protection Set */
+#else
+#define REG_PAC1_WPCLR             (*(RwReg  *)0x41000000UL) /**< \brief (PAC1) Write Protection Clear */
+#define REG_PAC1_WPSET             (*(RwReg  *)0x41000004UL) /**< \brief (PAC1) Write Protection Set */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PAC1 peripheral ========== */
+#define PAC1_WPROT_DEFAULT_VAL      0x00000002 // PAC protection mask at reset
+
+#endif /* _SAMD20_PAC1_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/pac2.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/pac2.h
@@ -1,0 +1,45 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PAC2
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PAC2_INSTANCE_
+#define _SAMD20_PAC2_INSTANCE_
+
+/* ========== Register definition for PAC2 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PAC2_WPCLR             (0x42000000) /**< \brief (PAC2) Write Protection Clear */
+#define REG_PAC2_WPSET             (0x42000004) /**< \brief (PAC2) Write Protection Set */
+#else
+#define REG_PAC2_WPCLR             (*(RwReg  *)0x42000000UL) /**< \brief (PAC2) Write Protection Clear */
+#define REG_PAC2_WPSET             (*(RwReg  *)0x42000004UL) /**< \brief (PAC2) Write Protection Set */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PAC2 peripheral ========== */
+#define PAC2_WPROT_DEFAULT_VAL      0x00100000 // PAC protection mask at reset
+
+#endif /* _SAMD20_PAC2_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/pm.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/pm.h
@@ -1,0 +1,74 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PM
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PM_INSTANCE_
+#define _SAMD20_PM_INSTANCE_
+
+/* ========== Register definition for PM peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PM_CTRL                (0x40000400) /**< \brief (PM) Control */
+#define REG_PM_SLEEP               (0x40000401) /**< \brief (PM) Sleep Mode */
+#define REG_PM_CPUSEL              (0x40000408) /**< \brief (PM) CPU Clock Select */
+#define REG_PM_APBASEL             (0x40000409) /**< \brief (PM) APBA Clock Select */
+#define REG_PM_APBBSEL             (0x4000040A) /**< \brief (PM) APBB Clock Select */
+#define REG_PM_APBCSEL             (0x4000040B) /**< \brief (PM) APBC Clock Select */
+#define REG_PM_AHBMASK             (0x40000414) /**< \brief (PM) AHB Mask */
+#define REG_PM_APBAMASK            (0x40000418) /**< \brief (PM) APBA Mask */
+#define REG_PM_APBBMASK            (0x4000041C) /**< \brief (PM) APBB Mask */
+#define REG_PM_APBCMASK            (0x40000420) /**< \brief (PM) APBC Mask */
+#define REG_PM_INTENCLR            (0x40000434) /**< \brief (PM) Interrupt Enable Clear */
+#define REG_PM_INTENSET            (0x40000435) /**< \brief (PM) Interrupt Enable Set */
+#define REG_PM_INTFLAG             (0x40000436) /**< \brief (PM) Interrupt Flag Status and Clear */
+#define REG_PM_RCAUSE              (0x40000438) /**< \brief (PM) Reset Cause */
+#else
+#define REG_PM_CTRL                (*(RwReg8 *)0x40000400UL) /**< \brief (PM) Control */
+#define REG_PM_SLEEP               (*(RwReg8 *)0x40000401UL) /**< \brief (PM) Sleep Mode */
+#define REG_PM_CPUSEL              (*(RwReg8 *)0x40000408UL) /**< \brief (PM) CPU Clock Select */
+#define REG_PM_APBASEL             (*(RwReg8 *)0x40000409UL) /**< \brief (PM) APBA Clock Select */
+#define REG_PM_APBBSEL             (*(RwReg8 *)0x4000040AUL) /**< \brief (PM) APBB Clock Select */
+#define REG_PM_APBCSEL             (*(RwReg8 *)0x4000040BUL) /**< \brief (PM) APBC Clock Select */
+#define REG_PM_AHBMASK             (*(RwReg  *)0x40000414UL) /**< \brief (PM) AHB Mask */
+#define REG_PM_APBAMASK            (*(RwReg  *)0x40000418UL) /**< \brief (PM) APBA Mask */
+#define REG_PM_APBBMASK            (*(RwReg  *)0x4000041CUL) /**< \brief (PM) APBB Mask */
+#define REG_PM_APBCMASK            (*(RwReg  *)0x40000420UL) /**< \brief (PM) APBC Mask */
+#define REG_PM_INTENCLR            (*(RwReg8 *)0x40000434UL) /**< \brief (PM) Interrupt Enable Clear */
+#define REG_PM_INTENSET            (*(RwReg8 *)0x40000435UL) /**< \brief (PM) Interrupt Enable Set */
+#define REG_PM_INTFLAG             (*(RwReg8 *)0x40000436UL) /**< \brief (PM) Interrupt Flag Status and Clear */
+#define REG_PM_RCAUSE              (*(RoReg8 *)0x40000438UL) /**< \brief (PM) Reset Cause */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PM peripheral ========== */
+#define PM_CTRL_MCSEL_DFLL48M       3       
+#define PM_CTRL_MCSEL_GCLK          0       
+#define PM_CTRL_MCSEL_OSC8M         1       
+#define PM_CTRL_MCSEL_XOSC          2       
+#define PM_PM_CLK_APB_NUM           2       
+#define PM_SYSTEM_CLOCK             1000000  // System Clock Frequency at Reset
+
+#endif /* _SAMD20_PM_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/port.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/port.h
@@ -1,0 +1,122 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PORT
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PORT_INSTANCE_
+#define _SAMD20_PORT_INSTANCE_
+
+/* ========== Register definition for PORT peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PORT_DIR0              (0x41004400) /**< \brief (PORT) Data Direction 0 */
+#define REG_PORT_DIRCLR0           (0x41004404) /**< \brief (PORT) Data Direction Clear 0 */
+#define REG_PORT_DIRSET0           (0x41004408) /**< \brief (PORT) Data Direction Set 0 */
+#define REG_PORT_DIRTGL0           (0x4100440C) /**< \brief (PORT) Data Direction Toggle 0 */
+#define REG_PORT_OUT0              (0x41004410) /**< \brief (PORT) Data Output Value 0 */
+#define REG_PORT_OUTCLR0           (0x41004414) /**< \brief (PORT) Data Output Value Clear 0 */
+#define REG_PORT_OUTSET0           (0x41004418) /**< \brief (PORT) Data Output Value Set 0 */
+#define REG_PORT_OUTTGL0           (0x4100441C) /**< \brief (PORT) Data Output Value Toggle 0 */
+#define REG_PORT_IN0               (0x41004420) /**< \brief (PORT) Data Input Value 0 */
+#define REG_PORT_CTRL0             (0x41004424) /**< \brief (PORT) Control 0 */
+#define REG_PORT_WRCONFIG0         (0x41004428) /**< \brief (PORT) Write Configuration 0 */
+#define REG_PORT_PMUX0             (0x41004430) /**< \brief (PORT) Peripheral Multiplexing 0 */
+#define REG_PORT_PINCFG0           (0x41004440) /**< \brief (PORT) Pin Configuration 0 */
+#define REG_PORT_DIR1              (0x41004480) /**< \brief (PORT) Data Direction 1 */
+#define REG_PORT_DIRCLR1           (0x41004484) /**< \brief (PORT) Data Direction Clear 1 */
+#define REG_PORT_DIRSET1           (0x41004488) /**< \brief (PORT) Data Direction Set 1 */
+#define REG_PORT_DIRTGL1           (0x4100448C) /**< \brief (PORT) Data Direction Toggle 1 */
+#define REG_PORT_OUT1              (0x41004490) /**< \brief (PORT) Data Output Value 1 */
+#define REG_PORT_OUTCLR1           (0x41004494) /**< \brief (PORT) Data Output Value Clear 1 */
+#define REG_PORT_OUTSET1           (0x41004498) /**< \brief (PORT) Data Output Value Set 1 */
+#define REG_PORT_OUTTGL1           (0x4100449C) /**< \brief (PORT) Data Output Value Toggle 1 */
+#define REG_PORT_IN1               (0x410044A0) /**< \brief (PORT) Data Input Value 1 */
+#define REG_PORT_CTRL1             (0x410044A4) /**< \brief (PORT) Control 1 */
+#define REG_PORT_WRCONFIG1         (0x410044A8) /**< \brief (PORT) Write Configuration 1 */
+#define REG_PORT_PMUX1             (0x410044B0) /**< \brief (PORT) Peripheral Multiplexing 1 */
+#define REG_PORT_PINCFG1           (0x410044C0) /**< \brief (PORT) Pin Configuration 1 */
+#else
+#define REG_PORT_DIR0              (*(RwReg  *)0x41004400UL) /**< \brief (PORT) Data Direction 0 */
+#define REG_PORT_DIRCLR0           (*(RwReg  *)0x41004404UL) /**< \brief (PORT) Data Direction Clear 0 */
+#define REG_PORT_DIRSET0           (*(RwReg  *)0x41004408UL) /**< \brief (PORT) Data Direction Set 0 */
+#define REG_PORT_DIRTGL0           (*(RwReg  *)0x4100440CUL) /**< \brief (PORT) Data Direction Toggle 0 */
+#define REG_PORT_OUT0              (*(RwReg  *)0x41004410UL) /**< \brief (PORT) Data Output Value 0 */
+#define REG_PORT_OUTCLR0           (*(RwReg  *)0x41004414UL) /**< \brief (PORT) Data Output Value Clear 0 */
+#define REG_PORT_OUTSET0           (*(RwReg  *)0x41004418UL) /**< \brief (PORT) Data Output Value Set 0 */
+#define REG_PORT_OUTTGL0           (*(RwReg  *)0x4100441CUL) /**< \brief (PORT) Data Output Value Toggle 0 */
+#define REG_PORT_IN0               (*(RoReg  *)0x41004420UL) /**< \brief (PORT) Data Input Value 0 */
+#define REG_PORT_CTRL0             (*(RwReg  *)0x41004424UL) /**< \brief (PORT) Control 0 */
+#define REG_PORT_WRCONFIG0         (*(WoReg  *)0x41004428UL) /**< \brief (PORT) Write Configuration 0 */
+#define REG_PORT_PMUX0             (*(RwReg8 *)0x41004430UL) /**< \brief (PORT) Peripheral Multiplexing 0 */
+#define REG_PORT_PINCFG0           (*(RwReg8 *)0x41004440UL) /**< \brief (PORT) Pin Configuration 0 */
+#define REG_PORT_DIR1              (*(RwReg  *)0x41004480UL) /**< \brief (PORT) Data Direction 1 */
+#define REG_PORT_DIRCLR1           (*(RwReg  *)0x41004484UL) /**< \brief (PORT) Data Direction Clear 1 */
+#define REG_PORT_DIRSET1           (*(RwReg  *)0x41004488UL) /**< \brief (PORT) Data Direction Set 1 */
+#define REG_PORT_DIRTGL1           (*(RwReg  *)0x4100448CUL) /**< \brief (PORT) Data Direction Toggle 1 */
+#define REG_PORT_OUT1              (*(RwReg  *)0x41004490UL) /**< \brief (PORT) Data Output Value 1 */
+#define REG_PORT_OUTCLR1           (*(RwReg  *)0x41004494UL) /**< \brief (PORT) Data Output Value Clear 1 */
+#define REG_PORT_OUTSET1           (*(RwReg  *)0x41004498UL) /**< \brief (PORT) Data Output Value Set 1 */
+#define REG_PORT_OUTTGL1           (*(RwReg  *)0x4100449CUL) /**< \brief (PORT) Data Output Value Toggle 1 */
+#define REG_PORT_IN1               (*(RoReg  *)0x410044A0UL) /**< \brief (PORT) Data Input Value 1 */
+#define REG_PORT_CTRL1             (*(RwReg  *)0x410044A4UL) /**< \brief (PORT) Control 1 */
+#define REG_PORT_WRCONFIG1         (*(WoReg  *)0x410044A8UL) /**< \brief (PORT) Write Configuration 1 */
+#define REG_PORT_PMUX1             (*(RwReg8 *)0x410044B0UL) /**< \brief (PORT) Peripheral Multiplexing 1 */
+#define REG_PORT_PINCFG1           (*(RwReg8 *)0x410044C0UL) /**< \brief (PORT) Pin Configuration 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PORT peripheral ========== */
+#define PORT_BITS                   64       // Number of PORT pins
+#define PORT_DIR_DEFAULT_VAL        { 0x00000000, 0x00000000 } // Default value for DIR of all pins
+#define PORT_DIR_IMPLEMENTED        { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for DIR of all pins
+#define PORT_DRVSTR                 1        // DRVSTR supported
+#define PORT_DRVSTR_DEFAULT_VAL     { 0xDBFFFFFF, 0xC0C3FFFF } // Default value for DRVSTR of all pins
+#define PORT_DRVSTR_IMPLEMENTED     { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for DRVSTR of all pins
+#define PORT_EVENT_IMPLEMENTED      { 0x00000000, 0x00000000 }
+#define PORT_INEN_DEFAULT_VAL       { 0x00000000, 0x00000000 } // Default value for INEN of all pins
+#define PORT_INEN_IMPLEMENTED       { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for INEN of all pins
+#define PORT_ODRAIN                 0        // ODRAIN supported
+#define PORT_ODRAIN_DEFAULT_VAL     { 0x00000000, 0x00000000 } // Default value for ODRAIN of all pins
+#define PORT_ODRAIN_IMPLEMENTED     { 0x00000000, 0x00000000 } // Implementation mask for ODRAIN of all pins
+#define PORT_OUT_DEFAULT_VAL        { 0x00000000, 0x00000000 } // Default value for OUT of all pins
+#define PORT_OUT_IMPLEMENTED        { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for OUT of all pins
+#define PORT_PIN_IMPLEMENTED        { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for all PORT pins
+#define PORT_PMUXBIT0_DEFAULT_VAL   { 0x00000000, 0x00000000 } // Default value for PMUX[0] of all pins
+#define PORT_PMUXBIT0_IMPLEMENTED   { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for PMUX[0] of all pins
+#define PORT_PMUXBIT1_DEFAULT_VAL   { 0x40000000, 0x00000000 } // Default value for PMUX[1] of all pins
+#define PORT_PMUXBIT1_IMPLEMENTED   { 0xDBFFFFF3, 0xC0C3FF0F } // Implementation mask for PMUX[1] of all pins
+#define PORT_PMUXBIT2_DEFAULT_VAL   { 0x40000000, 0x00000000 } // Default value for PMUX[2] of all pins
+#define PORT_PMUXBIT2_IMPLEMENTED   { 0xDBFFFFF3, 0xC0C3FF0F } // Implementation mask for PMUX[2] of all pins
+#define PORT_PMUXBIT3_DEFAULT_VAL   { 0x00000000, 0x00000000 } // Default value for PMUX[3] of all pins
+#define PORT_PMUXBIT3_IMPLEMENTED   { 0x00000000, 0x00000000 } // Implementation mask for PMUX[3] of all pins
+#define PORT_PMUXEN_DEFAULT_VAL     { 0x64000000, 0x3F3C0000 } // Default value for PMUXEN of all pins
+#define PORT_PMUXEN_IMPLEMENTED     { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for PMUXEN of all pins
+#define PORT_PULLEN_DEFAULT_VAL     { 0x00000000, 0x00000000 } // Default value for PULLEN of all pins
+#define PORT_PULLEN_IMPLEMENTED     { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for PULLEN of all pins
+#define PORT_SLEWLIM                0        // SLEWLIM supported
+#define PORT_SLEWLIM_DEFAULT_VAL    { 0x00000000, 0x00000000 } // Default value for SLEWLIM of all pins
+#define PORT_SLEWLIM_IMPLEMENTED    { 0x00000000, 0x00000000 } // Implementation mask for SLEWLIM of all pins
+
+#endif /* _SAMD20_PORT_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/ptc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/ptc.h
@@ -1,0 +1,36 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PTC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PTC_INSTANCE_
+#define _SAMD20_PTC_INSTANCE_
+
+/* ========== Instance parameters for PTC peripheral ========== */
+#define PTC_GCLK_ID                 27       // Index of Generic Clock
+
+#endif /* _SAMD20_PTC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/rtc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/rtc.h
@@ -1,0 +1,103 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RTC
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_RTC_INSTANCE_
+#define _SAMD20_RTC_INSTANCE_
+
+/* ========== Register definition for RTC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_RTC_READREQ            (0x40001402) /**< \brief (RTC) Read Request */
+#define REG_RTC_STATUS             (0x4000140A) /**< \brief (RTC) Status */
+#define REG_RTC_DBGCTRL            (0x4000140B) /**< \brief (RTC) Debug Control */
+#define REG_RTC_FREQCORR           (0x4000140C) /**< \brief (RTC) Frequency Correction */
+#define REG_RTC_MODE0_CTRL         (0x40001400) /**< \brief (RTC) MODE0 Control */
+#define REG_RTC_MODE0_EVCTRL       (0x40001404) /**< \brief (RTC) MODE0 Event Control */
+#define REG_RTC_MODE0_INTENCLR     (0x40001406) /**< \brief (RTC) MODE0 Interrupt Enable Clear */
+#define REG_RTC_MODE0_INTENSET     (0x40001407) /**< \brief (RTC) MODE0 Interrupt Enable Set */
+#define REG_RTC_MODE0_INTFLAG      (0x40001408) /**< \brief (RTC) MODE0 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE0_COUNT        (0x40001410) /**< \brief (RTC) MODE0 Counter Value */
+#define REG_RTC_MODE0_COMP0        (0x40001418) /**< \brief (RTC) MODE0 Compare 0 Value */
+#define REG_RTC_MODE1_CTRL         (0x40001400) /**< \brief (RTC) MODE1 Control */
+#define REG_RTC_MODE1_EVCTRL       (0x40001404) /**< \brief (RTC) MODE1 Event Control */
+#define REG_RTC_MODE1_INTENCLR     (0x40001406) /**< \brief (RTC) MODE1 Interrupt Enable Clear */
+#define REG_RTC_MODE1_INTENSET     (0x40001407) /**< \brief (RTC) MODE1 Interrupt Enable Set */
+#define REG_RTC_MODE1_INTFLAG      (0x40001408) /**< \brief (RTC) MODE1 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE1_COUNT        (0x40001410) /**< \brief (RTC) MODE1 Counter Value */
+#define REG_RTC_MODE1_PER          (0x40001414) /**< \brief (RTC) MODE1 Counter Period */
+#define REG_RTC_MODE1_COMP0        (0x40001418) /**< \brief (RTC) MODE1 Compare 0 Value */
+#define REG_RTC_MODE1_COMP1        (0x4000141A) /**< \brief (RTC) MODE1 Compare 1 Value */
+#define REG_RTC_MODE2_CTRL         (0x40001400) /**< \brief (RTC) MODE2 Control */
+#define REG_RTC_MODE2_EVCTRL       (0x40001404) /**< \brief (RTC) MODE2 Event Control */
+#define REG_RTC_MODE2_INTENCLR     (0x40001406) /**< \brief (RTC) MODE2 Interrupt Enable Clear */
+#define REG_RTC_MODE2_INTENSET     (0x40001407) /**< \brief (RTC) MODE2 Interrupt Enable Set */
+#define REG_RTC_MODE2_INTFLAG      (0x40001408) /**< \brief (RTC) MODE2 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE2_CLOCK        (0x40001410) /**< \brief (RTC) MODE2 Clock Value */
+#define REG_RTC_MODE2_ALARM_ALARM0 (0x40001418) /**< \brief (RTC) MODE2_ALARM Alarm 0 Value */
+#define REG_RTC_MODE2_ALARM_MASK0  (0x4000141C) /**< \brief (RTC) MODE2_ALARM Alarm 0 Mask */
+#else
+#define REG_RTC_READREQ            (*(RwReg16*)0x40001402UL) /**< \brief (RTC) Read Request */
+#define REG_RTC_STATUS             (*(RwReg8 *)0x4000140AUL) /**< \brief (RTC) Status */
+#define REG_RTC_DBGCTRL            (*(RwReg8 *)0x4000140BUL) /**< \brief (RTC) Debug Control */
+#define REG_RTC_FREQCORR           (*(RwReg8 *)0x4000140CUL) /**< \brief (RTC) Frequency Correction */
+#define REG_RTC_MODE0_CTRL         (*(RwReg16*)0x40001400UL) /**< \brief (RTC) MODE0 Control */
+#define REG_RTC_MODE0_EVCTRL       (*(RwReg16*)0x40001404UL) /**< \brief (RTC) MODE0 Event Control */
+#define REG_RTC_MODE0_INTENCLR     (*(RwReg8 *)0x40001406UL) /**< \brief (RTC) MODE0 Interrupt Enable Clear */
+#define REG_RTC_MODE0_INTENSET     (*(RwReg8 *)0x40001407UL) /**< \brief (RTC) MODE0 Interrupt Enable Set */
+#define REG_RTC_MODE0_INTFLAG      (*(RwReg8 *)0x40001408UL) /**< \brief (RTC) MODE0 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE0_COUNT        (*(RwReg  *)0x40001410UL) /**< \brief (RTC) MODE0 Counter Value */
+#define REG_RTC_MODE0_COMP0        (*(RwReg  *)0x40001418UL) /**< \brief (RTC) MODE0 Compare 0 Value */
+#define REG_RTC_MODE1_CTRL         (*(RwReg16*)0x40001400UL) /**< \brief (RTC) MODE1 Control */
+#define REG_RTC_MODE1_EVCTRL       (*(RwReg16*)0x40001404UL) /**< \brief (RTC) MODE1 Event Control */
+#define REG_RTC_MODE1_INTENCLR     (*(RwReg8 *)0x40001406UL) /**< \brief (RTC) MODE1 Interrupt Enable Clear */
+#define REG_RTC_MODE1_INTENSET     (*(RwReg8 *)0x40001407UL) /**< \brief (RTC) MODE1 Interrupt Enable Set */
+#define REG_RTC_MODE1_INTFLAG      (*(RwReg8 *)0x40001408UL) /**< \brief (RTC) MODE1 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE1_COUNT        (*(RwReg16*)0x40001410UL) /**< \brief (RTC) MODE1 Counter Value */
+#define REG_RTC_MODE1_PER          (*(RwReg16*)0x40001414UL) /**< \brief (RTC) MODE1 Counter Period */
+#define REG_RTC_MODE1_COMP0        (*(RwReg16*)0x40001418UL) /**< \brief (RTC) MODE1 Compare 0 Value */
+#define REG_RTC_MODE1_COMP1        (*(RwReg16*)0x4000141AUL) /**< \brief (RTC) MODE1 Compare 1 Value */
+#define REG_RTC_MODE2_CTRL         (*(RwReg16*)0x40001400UL) /**< \brief (RTC) MODE2 Control */
+#define REG_RTC_MODE2_EVCTRL       (*(RwReg16*)0x40001404UL) /**< \brief (RTC) MODE2 Event Control */
+#define REG_RTC_MODE2_INTENCLR     (*(RwReg8 *)0x40001406UL) /**< \brief (RTC) MODE2 Interrupt Enable Clear */
+#define REG_RTC_MODE2_INTENSET     (*(RwReg8 *)0x40001407UL) /**< \brief (RTC) MODE2 Interrupt Enable Set */
+#define REG_RTC_MODE2_INTFLAG      (*(RwReg8 *)0x40001408UL) /**< \brief (RTC) MODE2 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE2_CLOCK        (*(RwReg  *)0x40001410UL) /**< \brief (RTC) MODE2 Clock Value */
+#define REG_RTC_MODE2_ALARM_ALARM0 (*(RwReg  *)0x40001418UL) /**< \brief (RTC) MODE2_ALARM Alarm 0 Value */
+#define REG_RTC_MODE2_ALARM_MASK0  (*(RwReg8 *)0x4000141CUL) /**< \brief (RTC) MODE2_ALARM Alarm 0 Mask */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for RTC peripheral ========== */
+#define RTC_ALARM_NUM               1        // Number of Alarms
+#define RTC_COMP16_NUM              2        // Number of 16-bit Comparators
+#define RTC_COMP32_NUM              1        // Number of 32-bit Comparators
+#define RTC_GCLK_ID                 2        // Index of Generic Clock
+#define RTC_NUM_OF_ALARMS           1        // Number of Alarms (obsolete)
+#define RTC_NUM_OF_COMP16           2        // Number of 16-bit Comparators (obsolete)
+#define RTC_NUM_OF_COMP32           1        // Number of 32-bit Comparators (obsolete)
+
+#endif /* _SAMD20_RTC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/sercom0.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/sercom0.h
@@ -1,0 +1,118 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM0
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SERCOM0_INSTANCE_
+#define _SAMD20_SERCOM0_INSTANCE_
+
+/* ========== Register definition for SERCOM0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM0_I2CM_CTRLA     (0x42000800) /**< \brief (SERCOM0) I2CM Control A */
+#define REG_SERCOM0_I2CM_CTRLB     (0x42000804) /**< \brief (SERCOM0) I2CM Control B */
+#define REG_SERCOM0_I2CM_DBGCTRL   (0x42000808) /**< \brief (SERCOM0) I2CM Debug Control */
+#define REG_SERCOM0_I2CM_BAUD      (0x4200080A) /**< \brief (SERCOM0) I2CM Baud Rate */
+#define REG_SERCOM0_I2CM_INTENCLR  (0x4200080C) /**< \brief (SERCOM0) I2CM Interrupt Enable Clear */
+#define REG_SERCOM0_I2CM_INTENSET  (0x4200080D) /**< \brief (SERCOM0) I2CM Interrupt Enable Set */
+#define REG_SERCOM0_I2CM_INTFLAG   (0x4200080E) /**< \brief (SERCOM0) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CM_STATUS    (0x42000810) /**< \brief (SERCOM0) I2CM Status */
+#define REG_SERCOM0_I2CM_ADDR      (0x42000814) /**< \brief (SERCOM0) I2CM Address */
+#define REG_SERCOM0_I2CM_DATA      (0x42000818) /**< \brief (SERCOM0) I2CM Data */
+#define REG_SERCOM0_I2CS_CTRLA     (0x42000800) /**< \brief (SERCOM0) I2CS Control A */
+#define REG_SERCOM0_I2CS_CTRLB     (0x42000804) /**< \brief (SERCOM0) I2CS Control B */
+#define REG_SERCOM0_I2CS_INTENCLR  (0x4200080C) /**< \brief (SERCOM0) I2CS Interrupt Enable Clear */
+#define REG_SERCOM0_I2CS_INTENSET  (0x4200080D) /**< \brief (SERCOM0) I2CS Interrupt Enable Set */
+#define REG_SERCOM0_I2CS_INTFLAG   (0x4200080E) /**< \brief (SERCOM0) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CS_STATUS    (0x42000810) /**< \brief (SERCOM0) I2CS Status */
+#define REG_SERCOM0_I2CS_ADDR      (0x42000814) /**< \brief (SERCOM0) I2CS Address */
+#define REG_SERCOM0_I2CS_DATA      (0x42000818) /**< \brief (SERCOM0) I2CS Data */
+#define REG_SERCOM0_SPI_CTRLA      (0x42000800) /**< \brief (SERCOM0) SPI Control A */
+#define REG_SERCOM0_SPI_CTRLB      (0x42000804) /**< \brief (SERCOM0) SPI Control B */
+#define REG_SERCOM0_SPI_DBGCTRL    (0x42000808) /**< \brief (SERCOM0) SPI Debug Control */
+#define REG_SERCOM0_SPI_BAUD       (0x4200080A) /**< \brief (SERCOM0) SPI Baud Rate */
+#define REG_SERCOM0_SPI_INTENCLR   (0x4200080C) /**< \brief (SERCOM0) SPI Interrupt Enable Clear */
+#define REG_SERCOM0_SPI_INTENSET   (0x4200080D) /**< \brief (SERCOM0) SPI Interrupt Enable Set */
+#define REG_SERCOM0_SPI_INTFLAG    (0x4200080E) /**< \brief (SERCOM0) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM0_SPI_STATUS     (0x42000810) /**< \brief (SERCOM0) SPI Status */
+#define REG_SERCOM0_SPI_ADDR       (0x42000814) /**< \brief (SERCOM0) SPI Address */
+#define REG_SERCOM0_SPI_DATA       (0x42000818) /**< \brief (SERCOM0) SPI Data */
+#define REG_SERCOM0_USART_CTRLA    (0x42000800) /**< \brief (SERCOM0) USART Control A */
+#define REG_SERCOM0_USART_CTRLB    (0x42000804) /**< \brief (SERCOM0) USART Control B */
+#define REG_SERCOM0_USART_DBGCTRL  (0x42000808) /**< \brief (SERCOM0) USART Debug Control */
+#define REG_SERCOM0_USART_BAUD     (0x4200080A) /**< \brief (SERCOM0) USART Baud */
+#define REG_SERCOM0_USART_INTENCLR (0x4200080C) /**< \brief (SERCOM0) USART Interrupt Enable Clear */
+#define REG_SERCOM0_USART_INTENSET (0x4200080D) /**< \brief (SERCOM0) USART Interrupt Enable Set */
+#define REG_SERCOM0_USART_INTFLAG  (0x4200080E) /**< \brief (SERCOM0) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM0_USART_STATUS   (0x42000810) /**< \brief (SERCOM0) USART Status */
+#define REG_SERCOM0_USART_DATA     (0x42000818) /**< \brief (SERCOM0) USART Data */
+#else
+#define REG_SERCOM0_I2CM_CTRLA     (*(RwReg  *)0x42000800UL) /**< \brief (SERCOM0) I2CM Control A */
+#define REG_SERCOM0_I2CM_CTRLB     (*(RwReg  *)0x42000804UL) /**< \brief (SERCOM0) I2CM Control B */
+#define REG_SERCOM0_I2CM_DBGCTRL   (*(RwReg8 *)0x42000808UL) /**< \brief (SERCOM0) I2CM Debug Control */
+#define REG_SERCOM0_I2CM_BAUD      (*(RwReg16*)0x4200080AUL) /**< \brief (SERCOM0) I2CM Baud Rate */
+#define REG_SERCOM0_I2CM_INTENCLR  (*(RwReg8 *)0x4200080CUL) /**< \brief (SERCOM0) I2CM Interrupt Enable Clear */
+#define REG_SERCOM0_I2CM_INTENSET  (*(RwReg8 *)0x4200080DUL) /**< \brief (SERCOM0) I2CM Interrupt Enable Set */
+#define REG_SERCOM0_I2CM_INTFLAG   (*(RwReg8 *)0x4200080EUL) /**< \brief (SERCOM0) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CM_STATUS    (*(RwReg16*)0x42000810UL) /**< \brief (SERCOM0) I2CM Status */
+#define REG_SERCOM0_I2CM_ADDR      (*(RwReg8 *)0x42000814UL) /**< \brief (SERCOM0) I2CM Address */
+#define REG_SERCOM0_I2CM_DATA      (*(RwReg8 *)0x42000818UL) /**< \brief (SERCOM0) I2CM Data */
+#define REG_SERCOM0_I2CS_CTRLA     (*(RwReg  *)0x42000800UL) /**< \brief (SERCOM0) I2CS Control A */
+#define REG_SERCOM0_I2CS_CTRLB     (*(RwReg  *)0x42000804UL) /**< \brief (SERCOM0) I2CS Control B */
+#define REG_SERCOM0_I2CS_INTENCLR  (*(RwReg8 *)0x4200080CUL) /**< \brief (SERCOM0) I2CS Interrupt Enable Clear */
+#define REG_SERCOM0_I2CS_INTENSET  (*(RwReg8 *)0x4200080DUL) /**< \brief (SERCOM0) I2CS Interrupt Enable Set */
+#define REG_SERCOM0_I2CS_INTFLAG   (*(RwReg8 *)0x4200080EUL) /**< \brief (SERCOM0) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CS_STATUS    (*(RwReg16*)0x42000810UL) /**< \brief (SERCOM0) I2CS Status */
+#define REG_SERCOM0_I2CS_ADDR      (*(RwReg  *)0x42000814UL) /**< \brief (SERCOM0) I2CS Address */
+#define REG_SERCOM0_I2CS_DATA      (*(RwReg8 *)0x42000818UL) /**< \brief (SERCOM0) I2CS Data */
+#define REG_SERCOM0_SPI_CTRLA      (*(RwReg  *)0x42000800UL) /**< \brief (SERCOM0) SPI Control A */
+#define REG_SERCOM0_SPI_CTRLB      (*(RwReg  *)0x42000804UL) /**< \brief (SERCOM0) SPI Control B */
+#define REG_SERCOM0_SPI_DBGCTRL    (*(RwReg8 *)0x42000808UL) /**< \brief (SERCOM0) SPI Debug Control */
+#define REG_SERCOM0_SPI_BAUD       (*(RwReg8 *)0x4200080AUL) /**< \brief (SERCOM0) SPI Baud Rate */
+#define REG_SERCOM0_SPI_INTENCLR   (*(RwReg8 *)0x4200080CUL) /**< \brief (SERCOM0) SPI Interrupt Enable Clear */
+#define REG_SERCOM0_SPI_INTENSET   (*(RwReg8 *)0x4200080DUL) /**< \brief (SERCOM0) SPI Interrupt Enable Set */
+#define REG_SERCOM0_SPI_INTFLAG    (*(RwReg8 *)0x4200080EUL) /**< \brief (SERCOM0) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM0_SPI_STATUS     (*(RwReg16*)0x42000810UL) /**< \brief (SERCOM0) SPI Status */
+#define REG_SERCOM0_SPI_ADDR       (*(RwReg  *)0x42000814UL) /**< \brief (SERCOM0) SPI Address */
+#define REG_SERCOM0_SPI_DATA       (*(RwReg16*)0x42000818UL) /**< \brief (SERCOM0) SPI Data */
+#define REG_SERCOM0_USART_CTRLA    (*(RwReg  *)0x42000800UL) /**< \brief (SERCOM0) USART Control A */
+#define REG_SERCOM0_USART_CTRLB    (*(RwReg  *)0x42000804UL) /**< \brief (SERCOM0) USART Control B */
+#define REG_SERCOM0_USART_DBGCTRL  (*(RwReg8 *)0x42000808UL) /**< \brief (SERCOM0) USART Debug Control */
+#define REG_SERCOM0_USART_BAUD     (*(RwReg16*)0x4200080AUL) /**< \brief (SERCOM0) USART Baud */
+#define REG_SERCOM0_USART_INTENCLR (*(RwReg8 *)0x4200080CUL) /**< \brief (SERCOM0) USART Interrupt Enable Clear */
+#define REG_SERCOM0_USART_INTENSET (*(RwReg8 *)0x4200080DUL) /**< \brief (SERCOM0) USART Interrupt Enable Set */
+#define REG_SERCOM0_USART_INTFLAG  (*(RwReg8 *)0x4200080EUL) /**< \brief (SERCOM0) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM0_USART_STATUS   (*(RwReg16*)0x42000810UL) /**< \brief (SERCOM0) USART Status */
+#define REG_SERCOM0_USART_DATA     (*(RwReg16*)0x42000818UL) /**< \brief (SERCOM0) USART Data */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM0 peripheral ========== */
+#define SERCOM0_GCLK_ID_CORE        13      
+#define SERCOM0_GCLK_ID_SLOW        12      
+#define SERCOM0_INT_MSB             3       
+#define SERCOM0_PMSB                3       
+
+#endif /* _SAMD20_SERCOM0_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/sercom1.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/sercom1.h
@@ -1,0 +1,118 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM1
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SERCOM1_INSTANCE_
+#define _SAMD20_SERCOM1_INSTANCE_
+
+/* ========== Register definition for SERCOM1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM1_I2CM_CTRLA     (0x42000C00) /**< \brief (SERCOM1) I2CM Control A */
+#define REG_SERCOM1_I2CM_CTRLB     (0x42000C04) /**< \brief (SERCOM1) I2CM Control B */
+#define REG_SERCOM1_I2CM_DBGCTRL   (0x42000C08) /**< \brief (SERCOM1) I2CM Debug Control */
+#define REG_SERCOM1_I2CM_BAUD      (0x42000C0A) /**< \brief (SERCOM1) I2CM Baud Rate */
+#define REG_SERCOM1_I2CM_INTENCLR  (0x42000C0C) /**< \brief (SERCOM1) I2CM Interrupt Enable Clear */
+#define REG_SERCOM1_I2CM_INTENSET  (0x42000C0D) /**< \brief (SERCOM1) I2CM Interrupt Enable Set */
+#define REG_SERCOM1_I2CM_INTFLAG   (0x42000C0E) /**< \brief (SERCOM1) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CM_STATUS    (0x42000C10) /**< \brief (SERCOM1) I2CM Status */
+#define REG_SERCOM1_I2CM_ADDR      (0x42000C14) /**< \brief (SERCOM1) I2CM Address */
+#define REG_SERCOM1_I2CM_DATA      (0x42000C18) /**< \brief (SERCOM1) I2CM Data */
+#define REG_SERCOM1_I2CS_CTRLA     (0x42000C00) /**< \brief (SERCOM1) I2CS Control A */
+#define REG_SERCOM1_I2CS_CTRLB     (0x42000C04) /**< \brief (SERCOM1) I2CS Control B */
+#define REG_SERCOM1_I2CS_INTENCLR  (0x42000C0C) /**< \brief (SERCOM1) I2CS Interrupt Enable Clear */
+#define REG_SERCOM1_I2CS_INTENSET  (0x42000C0D) /**< \brief (SERCOM1) I2CS Interrupt Enable Set */
+#define REG_SERCOM1_I2CS_INTFLAG   (0x42000C0E) /**< \brief (SERCOM1) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CS_STATUS    (0x42000C10) /**< \brief (SERCOM1) I2CS Status */
+#define REG_SERCOM1_I2CS_ADDR      (0x42000C14) /**< \brief (SERCOM1) I2CS Address */
+#define REG_SERCOM1_I2CS_DATA      (0x42000C18) /**< \brief (SERCOM1) I2CS Data */
+#define REG_SERCOM1_SPI_CTRLA      (0x42000C00) /**< \brief (SERCOM1) SPI Control A */
+#define REG_SERCOM1_SPI_CTRLB      (0x42000C04) /**< \brief (SERCOM1) SPI Control B */
+#define REG_SERCOM1_SPI_DBGCTRL    (0x42000C08) /**< \brief (SERCOM1) SPI Debug Control */
+#define REG_SERCOM1_SPI_BAUD       (0x42000C0A) /**< \brief (SERCOM1) SPI Baud Rate */
+#define REG_SERCOM1_SPI_INTENCLR   (0x42000C0C) /**< \brief (SERCOM1) SPI Interrupt Enable Clear */
+#define REG_SERCOM1_SPI_INTENSET   (0x42000C0D) /**< \brief (SERCOM1) SPI Interrupt Enable Set */
+#define REG_SERCOM1_SPI_INTFLAG    (0x42000C0E) /**< \brief (SERCOM1) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM1_SPI_STATUS     (0x42000C10) /**< \brief (SERCOM1) SPI Status */
+#define REG_SERCOM1_SPI_ADDR       (0x42000C14) /**< \brief (SERCOM1) SPI Address */
+#define REG_SERCOM1_SPI_DATA       (0x42000C18) /**< \brief (SERCOM1) SPI Data */
+#define REG_SERCOM1_USART_CTRLA    (0x42000C00) /**< \brief (SERCOM1) USART Control A */
+#define REG_SERCOM1_USART_CTRLB    (0x42000C04) /**< \brief (SERCOM1) USART Control B */
+#define REG_SERCOM1_USART_DBGCTRL  (0x42000C08) /**< \brief (SERCOM1) USART Debug Control */
+#define REG_SERCOM1_USART_BAUD     (0x42000C0A) /**< \brief (SERCOM1) USART Baud */
+#define REG_SERCOM1_USART_INTENCLR (0x42000C0C) /**< \brief (SERCOM1) USART Interrupt Enable Clear */
+#define REG_SERCOM1_USART_INTENSET (0x42000C0D) /**< \brief (SERCOM1) USART Interrupt Enable Set */
+#define REG_SERCOM1_USART_INTFLAG  (0x42000C0E) /**< \brief (SERCOM1) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM1_USART_STATUS   (0x42000C10) /**< \brief (SERCOM1) USART Status */
+#define REG_SERCOM1_USART_DATA     (0x42000C18) /**< \brief (SERCOM1) USART Data */
+#else
+#define REG_SERCOM1_I2CM_CTRLA     (*(RwReg  *)0x42000C00UL) /**< \brief (SERCOM1) I2CM Control A */
+#define REG_SERCOM1_I2CM_CTRLB     (*(RwReg  *)0x42000C04UL) /**< \brief (SERCOM1) I2CM Control B */
+#define REG_SERCOM1_I2CM_DBGCTRL   (*(RwReg8 *)0x42000C08UL) /**< \brief (SERCOM1) I2CM Debug Control */
+#define REG_SERCOM1_I2CM_BAUD      (*(RwReg16*)0x42000C0AUL) /**< \brief (SERCOM1) I2CM Baud Rate */
+#define REG_SERCOM1_I2CM_INTENCLR  (*(RwReg8 *)0x42000C0CUL) /**< \brief (SERCOM1) I2CM Interrupt Enable Clear */
+#define REG_SERCOM1_I2CM_INTENSET  (*(RwReg8 *)0x42000C0DUL) /**< \brief (SERCOM1) I2CM Interrupt Enable Set */
+#define REG_SERCOM1_I2CM_INTFLAG   (*(RwReg8 *)0x42000C0EUL) /**< \brief (SERCOM1) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CM_STATUS    (*(RwReg16*)0x42000C10UL) /**< \brief (SERCOM1) I2CM Status */
+#define REG_SERCOM1_I2CM_ADDR      (*(RwReg8 *)0x42000C14UL) /**< \brief (SERCOM1) I2CM Address */
+#define REG_SERCOM1_I2CM_DATA      (*(RwReg8 *)0x42000C18UL) /**< \brief (SERCOM1) I2CM Data */
+#define REG_SERCOM1_I2CS_CTRLA     (*(RwReg  *)0x42000C00UL) /**< \brief (SERCOM1) I2CS Control A */
+#define REG_SERCOM1_I2CS_CTRLB     (*(RwReg  *)0x42000C04UL) /**< \brief (SERCOM1) I2CS Control B */
+#define REG_SERCOM1_I2CS_INTENCLR  (*(RwReg8 *)0x42000C0CUL) /**< \brief (SERCOM1) I2CS Interrupt Enable Clear */
+#define REG_SERCOM1_I2CS_INTENSET  (*(RwReg8 *)0x42000C0DUL) /**< \brief (SERCOM1) I2CS Interrupt Enable Set */
+#define REG_SERCOM1_I2CS_INTFLAG   (*(RwReg8 *)0x42000C0EUL) /**< \brief (SERCOM1) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CS_STATUS    (*(RwReg16*)0x42000C10UL) /**< \brief (SERCOM1) I2CS Status */
+#define REG_SERCOM1_I2CS_ADDR      (*(RwReg  *)0x42000C14UL) /**< \brief (SERCOM1) I2CS Address */
+#define REG_SERCOM1_I2CS_DATA      (*(RwReg8 *)0x42000C18UL) /**< \brief (SERCOM1) I2CS Data */
+#define REG_SERCOM1_SPI_CTRLA      (*(RwReg  *)0x42000C00UL) /**< \brief (SERCOM1) SPI Control A */
+#define REG_SERCOM1_SPI_CTRLB      (*(RwReg  *)0x42000C04UL) /**< \brief (SERCOM1) SPI Control B */
+#define REG_SERCOM1_SPI_DBGCTRL    (*(RwReg8 *)0x42000C08UL) /**< \brief (SERCOM1) SPI Debug Control */
+#define REG_SERCOM1_SPI_BAUD       (*(RwReg8 *)0x42000C0AUL) /**< \brief (SERCOM1) SPI Baud Rate */
+#define REG_SERCOM1_SPI_INTENCLR   (*(RwReg8 *)0x42000C0CUL) /**< \brief (SERCOM1) SPI Interrupt Enable Clear */
+#define REG_SERCOM1_SPI_INTENSET   (*(RwReg8 *)0x42000C0DUL) /**< \brief (SERCOM1) SPI Interrupt Enable Set */
+#define REG_SERCOM1_SPI_INTFLAG    (*(RwReg8 *)0x42000C0EUL) /**< \brief (SERCOM1) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM1_SPI_STATUS     (*(RwReg16*)0x42000C10UL) /**< \brief (SERCOM1) SPI Status */
+#define REG_SERCOM1_SPI_ADDR       (*(RwReg  *)0x42000C14UL) /**< \brief (SERCOM1) SPI Address */
+#define REG_SERCOM1_SPI_DATA       (*(RwReg16*)0x42000C18UL) /**< \brief (SERCOM1) SPI Data */
+#define REG_SERCOM1_USART_CTRLA    (*(RwReg  *)0x42000C00UL) /**< \brief (SERCOM1) USART Control A */
+#define REG_SERCOM1_USART_CTRLB    (*(RwReg  *)0x42000C04UL) /**< \brief (SERCOM1) USART Control B */
+#define REG_SERCOM1_USART_DBGCTRL  (*(RwReg8 *)0x42000C08UL) /**< \brief (SERCOM1) USART Debug Control */
+#define REG_SERCOM1_USART_BAUD     (*(RwReg16*)0x42000C0AUL) /**< \brief (SERCOM1) USART Baud */
+#define REG_SERCOM1_USART_INTENCLR (*(RwReg8 *)0x42000C0CUL) /**< \brief (SERCOM1) USART Interrupt Enable Clear */
+#define REG_SERCOM1_USART_INTENSET (*(RwReg8 *)0x42000C0DUL) /**< \brief (SERCOM1) USART Interrupt Enable Set */
+#define REG_SERCOM1_USART_INTFLAG  (*(RwReg8 *)0x42000C0EUL) /**< \brief (SERCOM1) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM1_USART_STATUS   (*(RwReg16*)0x42000C10UL) /**< \brief (SERCOM1) USART Status */
+#define REG_SERCOM1_USART_DATA     (*(RwReg16*)0x42000C18UL) /**< \brief (SERCOM1) USART Data */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM1 peripheral ========== */
+#define SERCOM1_GCLK_ID_CORE        14      
+#define SERCOM1_GCLK_ID_SLOW        12      
+#define SERCOM1_INT_MSB             3       
+#define SERCOM1_PMSB                3       
+
+#endif /* _SAMD20_SERCOM1_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/sercom2.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/sercom2.h
@@ -1,0 +1,118 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM2
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SERCOM2_INSTANCE_
+#define _SAMD20_SERCOM2_INSTANCE_
+
+/* ========== Register definition for SERCOM2 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM2_I2CM_CTRLA     (0x42001000) /**< \brief (SERCOM2) I2CM Control A */
+#define REG_SERCOM2_I2CM_CTRLB     (0x42001004) /**< \brief (SERCOM2) I2CM Control B */
+#define REG_SERCOM2_I2CM_DBGCTRL   (0x42001008) /**< \brief (SERCOM2) I2CM Debug Control */
+#define REG_SERCOM2_I2CM_BAUD      (0x4200100A) /**< \brief (SERCOM2) I2CM Baud Rate */
+#define REG_SERCOM2_I2CM_INTENCLR  (0x4200100C) /**< \brief (SERCOM2) I2CM Interrupt Enable Clear */
+#define REG_SERCOM2_I2CM_INTENSET  (0x4200100D) /**< \brief (SERCOM2) I2CM Interrupt Enable Set */
+#define REG_SERCOM2_I2CM_INTFLAG   (0x4200100E) /**< \brief (SERCOM2) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CM_STATUS    (0x42001010) /**< \brief (SERCOM2) I2CM Status */
+#define REG_SERCOM2_I2CM_ADDR      (0x42001014) /**< \brief (SERCOM2) I2CM Address */
+#define REG_SERCOM2_I2CM_DATA      (0x42001018) /**< \brief (SERCOM2) I2CM Data */
+#define REG_SERCOM2_I2CS_CTRLA     (0x42001000) /**< \brief (SERCOM2) I2CS Control A */
+#define REG_SERCOM2_I2CS_CTRLB     (0x42001004) /**< \brief (SERCOM2) I2CS Control B */
+#define REG_SERCOM2_I2CS_INTENCLR  (0x4200100C) /**< \brief (SERCOM2) I2CS Interrupt Enable Clear */
+#define REG_SERCOM2_I2CS_INTENSET  (0x4200100D) /**< \brief (SERCOM2) I2CS Interrupt Enable Set */
+#define REG_SERCOM2_I2CS_INTFLAG   (0x4200100E) /**< \brief (SERCOM2) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CS_STATUS    (0x42001010) /**< \brief (SERCOM2) I2CS Status */
+#define REG_SERCOM2_I2CS_ADDR      (0x42001014) /**< \brief (SERCOM2) I2CS Address */
+#define REG_SERCOM2_I2CS_DATA      (0x42001018) /**< \brief (SERCOM2) I2CS Data */
+#define REG_SERCOM2_SPI_CTRLA      (0x42001000) /**< \brief (SERCOM2) SPI Control A */
+#define REG_SERCOM2_SPI_CTRLB      (0x42001004) /**< \brief (SERCOM2) SPI Control B */
+#define REG_SERCOM2_SPI_DBGCTRL    (0x42001008) /**< \brief (SERCOM2) SPI Debug Control */
+#define REG_SERCOM2_SPI_BAUD       (0x4200100A) /**< \brief (SERCOM2) SPI Baud Rate */
+#define REG_SERCOM2_SPI_INTENCLR   (0x4200100C) /**< \brief (SERCOM2) SPI Interrupt Enable Clear */
+#define REG_SERCOM2_SPI_INTENSET   (0x4200100D) /**< \brief (SERCOM2) SPI Interrupt Enable Set */
+#define REG_SERCOM2_SPI_INTFLAG    (0x4200100E) /**< \brief (SERCOM2) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM2_SPI_STATUS     (0x42001010) /**< \brief (SERCOM2) SPI Status */
+#define REG_SERCOM2_SPI_ADDR       (0x42001014) /**< \brief (SERCOM2) SPI Address */
+#define REG_SERCOM2_SPI_DATA       (0x42001018) /**< \brief (SERCOM2) SPI Data */
+#define REG_SERCOM2_USART_CTRLA    (0x42001000) /**< \brief (SERCOM2) USART Control A */
+#define REG_SERCOM2_USART_CTRLB    (0x42001004) /**< \brief (SERCOM2) USART Control B */
+#define REG_SERCOM2_USART_DBGCTRL  (0x42001008) /**< \brief (SERCOM2) USART Debug Control */
+#define REG_SERCOM2_USART_BAUD     (0x4200100A) /**< \brief (SERCOM2) USART Baud */
+#define REG_SERCOM2_USART_INTENCLR (0x4200100C) /**< \brief (SERCOM2) USART Interrupt Enable Clear */
+#define REG_SERCOM2_USART_INTENSET (0x4200100D) /**< \brief (SERCOM2) USART Interrupt Enable Set */
+#define REG_SERCOM2_USART_INTFLAG  (0x4200100E) /**< \brief (SERCOM2) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM2_USART_STATUS   (0x42001010) /**< \brief (SERCOM2) USART Status */
+#define REG_SERCOM2_USART_DATA     (0x42001018) /**< \brief (SERCOM2) USART Data */
+#else
+#define REG_SERCOM2_I2CM_CTRLA     (*(RwReg  *)0x42001000UL) /**< \brief (SERCOM2) I2CM Control A */
+#define REG_SERCOM2_I2CM_CTRLB     (*(RwReg  *)0x42001004UL) /**< \brief (SERCOM2) I2CM Control B */
+#define REG_SERCOM2_I2CM_DBGCTRL   (*(RwReg8 *)0x42001008UL) /**< \brief (SERCOM2) I2CM Debug Control */
+#define REG_SERCOM2_I2CM_BAUD      (*(RwReg16*)0x4200100AUL) /**< \brief (SERCOM2) I2CM Baud Rate */
+#define REG_SERCOM2_I2CM_INTENCLR  (*(RwReg8 *)0x4200100CUL) /**< \brief (SERCOM2) I2CM Interrupt Enable Clear */
+#define REG_SERCOM2_I2CM_INTENSET  (*(RwReg8 *)0x4200100DUL) /**< \brief (SERCOM2) I2CM Interrupt Enable Set */
+#define REG_SERCOM2_I2CM_INTFLAG   (*(RwReg8 *)0x4200100EUL) /**< \brief (SERCOM2) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CM_STATUS    (*(RwReg16*)0x42001010UL) /**< \brief (SERCOM2) I2CM Status */
+#define REG_SERCOM2_I2CM_ADDR      (*(RwReg8 *)0x42001014UL) /**< \brief (SERCOM2) I2CM Address */
+#define REG_SERCOM2_I2CM_DATA      (*(RwReg8 *)0x42001018UL) /**< \brief (SERCOM2) I2CM Data */
+#define REG_SERCOM2_I2CS_CTRLA     (*(RwReg  *)0x42001000UL) /**< \brief (SERCOM2) I2CS Control A */
+#define REG_SERCOM2_I2CS_CTRLB     (*(RwReg  *)0x42001004UL) /**< \brief (SERCOM2) I2CS Control B */
+#define REG_SERCOM2_I2CS_INTENCLR  (*(RwReg8 *)0x4200100CUL) /**< \brief (SERCOM2) I2CS Interrupt Enable Clear */
+#define REG_SERCOM2_I2CS_INTENSET  (*(RwReg8 *)0x4200100DUL) /**< \brief (SERCOM2) I2CS Interrupt Enable Set */
+#define REG_SERCOM2_I2CS_INTFLAG   (*(RwReg8 *)0x4200100EUL) /**< \brief (SERCOM2) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CS_STATUS    (*(RwReg16*)0x42001010UL) /**< \brief (SERCOM2) I2CS Status */
+#define REG_SERCOM2_I2CS_ADDR      (*(RwReg  *)0x42001014UL) /**< \brief (SERCOM2) I2CS Address */
+#define REG_SERCOM2_I2CS_DATA      (*(RwReg8 *)0x42001018UL) /**< \brief (SERCOM2) I2CS Data */
+#define REG_SERCOM2_SPI_CTRLA      (*(RwReg  *)0x42001000UL) /**< \brief (SERCOM2) SPI Control A */
+#define REG_SERCOM2_SPI_CTRLB      (*(RwReg  *)0x42001004UL) /**< \brief (SERCOM2) SPI Control B */
+#define REG_SERCOM2_SPI_DBGCTRL    (*(RwReg8 *)0x42001008UL) /**< \brief (SERCOM2) SPI Debug Control */
+#define REG_SERCOM2_SPI_BAUD       (*(RwReg8 *)0x4200100AUL) /**< \brief (SERCOM2) SPI Baud Rate */
+#define REG_SERCOM2_SPI_INTENCLR   (*(RwReg8 *)0x4200100CUL) /**< \brief (SERCOM2) SPI Interrupt Enable Clear */
+#define REG_SERCOM2_SPI_INTENSET   (*(RwReg8 *)0x4200100DUL) /**< \brief (SERCOM2) SPI Interrupt Enable Set */
+#define REG_SERCOM2_SPI_INTFLAG    (*(RwReg8 *)0x4200100EUL) /**< \brief (SERCOM2) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM2_SPI_STATUS     (*(RwReg16*)0x42001010UL) /**< \brief (SERCOM2) SPI Status */
+#define REG_SERCOM2_SPI_ADDR       (*(RwReg  *)0x42001014UL) /**< \brief (SERCOM2) SPI Address */
+#define REG_SERCOM2_SPI_DATA       (*(RwReg16*)0x42001018UL) /**< \brief (SERCOM2) SPI Data */
+#define REG_SERCOM2_USART_CTRLA    (*(RwReg  *)0x42001000UL) /**< \brief (SERCOM2) USART Control A */
+#define REG_SERCOM2_USART_CTRLB    (*(RwReg  *)0x42001004UL) /**< \brief (SERCOM2) USART Control B */
+#define REG_SERCOM2_USART_DBGCTRL  (*(RwReg8 *)0x42001008UL) /**< \brief (SERCOM2) USART Debug Control */
+#define REG_SERCOM2_USART_BAUD     (*(RwReg16*)0x4200100AUL) /**< \brief (SERCOM2) USART Baud */
+#define REG_SERCOM2_USART_INTENCLR (*(RwReg8 *)0x4200100CUL) /**< \brief (SERCOM2) USART Interrupt Enable Clear */
+#define REG_SERCOM2_USART_INTENSET (*(RwReg8 *)0x4200100DUL) /**< \brief (SERCOM2) USART Interrupt Enable Set */
+#define REG_SERCOM2_USART_INTFLAG  (*(RwReg8 *)0x4200100EUL) /**< \brief (SERCOM2) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM2_USART_STATUS   (*(RwReg16*)0x42001010UL) /**< \brief (SERCOM2) USART Status */
+#define REG_SERCOM2_USART_DATA     (*(RwReg16*)0x42001018UL) /**< \brief (SERCOM2) USART Data */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM2 peripheral ========== */
+#define SERCOM2_GCLK_ID_CORE        15      
+#define SERCOM2_GCLK_ID_SLOW        12      
+#define SERCOM2_INT_MSB             3       
+#define SERCOM2_PMSB                3       
+
+#endif /* _SAMD20_SERCOM2_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/sercom3.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/sercom3.h
@@ -1,0 +1,118 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM3
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SERCOM3_INSTANCE_
+#define _SAMD20_SERCOM3_INSTANCE_
+
+/* ========== Register definition for SERCOM3 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM3_I2CM_CTRLA     (0x42001400) /**< \brief (SERCOM3) I2CM Control A */
+#define REG_SERCOM3_I2CM_CTRLB     (0x42001404) /**< \brief (SERCOM3) I2CM Control B */
+#define REG_SERCOM3_I2CM_DBGCTRL   (0x42001408) /**< \brief (SERCOM3) I2CM Debug Control */
+#define REG_SERCOM3_I2CM_BAUD      (0x4200140A) /**< \brief (SERCOM3) I2CM Baud Rate */
+#define REG_SERCOM3_I2CM_INTENCLR  (0x4200140C) /**< \brief (SERCOM3) I2CM Interrupt Enable Clear */
+#define REG_SERCOM3_I2CM_INTENSET  (0x4200140D) /**< \brief (SERCOM3) I2CM Interrupt Enable Set */
+#define REG_SERCOM3_I2CM_INTFLAG   (0x4200140E) /**< \brief (SERCOM3) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CM_STATUS    (0x42001410) /**< \brief (SERCOM3) I2CM Status */
+#define REG_SERCOM3_I2CM_ADDR      (0x42001414) /**< \brief (SERCOM3) I2CM Address */
+#define REG_SERCOM3_I2CM_DATA      (0x42001418) /**< \brief (SERCOM3) I2CM Data */
+#define REG_SERCOM3_I2CS_CTRLA     (0x42001400) /**< \brief (SERCOM3) I2CS Control A */
+#define REG_SERCOM3_I2CS_CTRLB     (0x42001404) /**< \brief (SERCOM3) I2CS Control B */
+#define REG_SERCOM3_I2CS_INTENCLR  (0x4200140C) /**< \brief (SERCOM3) I2CS Interrupt Enable Clear */
+#define REG_SERCOM3_I2CS_INTENSET  (0x4200140D) /**< \brief (SERCOM3) I2CS Interrupt Enable Set */
+#define REG_SERCOM3_I2CS_INTFLAG   (0x4200140E) /**< \brief (SERCOM3) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CS_STATUS    (0x42001410) /**< \brief (SERCOM3) I2CS Status */
+#define REG_SERCOM3_I2CS_ADDR      (0x42001414) /**< \brief (SERCOM3) I2CS Address */
+#define REG_SERCOM3_I2CS_DATA      (0x42001418) /**< \brief (SERCOM3) I2CS Data */
+#define REG_SERCOM3_SPI_CTRLA      (0x42001400) /**< \brief (SERCOM3) SPI Control A */
+#define REG_SERCOM3_SPI_CTRLB      (0x42001404) /**< \brief (SERCOM3) SPI Control B */
+#define REG_SERCOM3_SPI_DBGCTRL    (0x42001408) /**< \brief (SERCOM3) SPI Debug Control */
+#define REG_SERCOM3_SPI_BAUD       (0x4200140A) /**< \brief (SERCOM3) SPI Baud Rate */
+#define REG_SERCOM3_SPI_INTENCLR   (0x4200140C) /**< \brief (SERCOM3) SPI Interrupt Enable Clear */
+#define REG_SERCOM3_SPI_INTENSET   (0x4200140D) /**< \brief (SERCOM3) SPI Interrupt Enable Set */
+#define REG_SERCOM3_SPI_INTFLAG    (0x4200140E) /**< \brief (SERCOM3) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM3_SPI_STATUS     (0x42001410) /**< \brief (SERCOM3) SPI Status */
+#define REG_SERCOM3_SPI_ADDR       (0x42001414) /**< \brief (SERCOM3) SPI Address */
+#define REG_SERCOM3_SPI_DATA       (0x42001418) /**< \brief (SERCOM3) SPI Data */
+#define REG_SERCOM3_USART_CTRLA    (0x42001400) /**< \brief (SERCOM3) USART Control A */
+#define REG_SERCOM3_USART_CTRLB    (0x42001404) /**< \brief (SERCOM3) USART Control B */
+#define REG_SERCOM3_USART_DBGCTRL  (0x42001408) /**< \brief (SERCOM3) USART Debug Control */
+#define REG_SERCOM3_USART_BAUD     (0x4200140A) /**< \brief (SERCOM3) USART Baud */
+#define REG_SERCOM3_USART_INTENCLR (0x4200140C) /**< \brief (SERCOM3) USART Interrupt Enable Clear */
+#define REG_SERCOM3_USART_INTENSET (0x4200140D) /**< \brief (SERCOM3) USART Interrupt Enable Set */
+#define REG_SERCOM3_USART_INTFLAG  (0x4200140E) /**< \brief (SERCOM3) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM3_USART_STATUS   (0x42001410) /**< \brief (SERCOM3) USART Status */
+#define REG_SERCOM3_USART_DATA     (0x42001418) /**< \brief (SERCOM3) USART Data */
+#else
+#define REG_SERCOM3_I2CM_CTRLA     (*(RwReg  *)0x42001400UL) /**< \brief (SERCOM3) I2CM Control A */
+#define REG_SERCOM3_I2CM_CTRLB     (*(RwReg  *)0x42001404UL) /**< \brief (SERCOM3) I2CM Control B */
+#define REG_SERCOM3_I2CM_DBGCTRL   (*(RwReg8 *)0x42001408UL) /**< \brief (SERCOM3) I2CM Debug Control */
+#define REG_SERCOM3_I2CM_BAUD      (*(RwReg16*)0x4200140AUL) /**< \brief (SERCOM3) I2CM Baud Rate */
+#define REG_SERCOM3_I2CM_INTENCLR  (*(RwReg8 *)0x4200140CUL) /**< \brief (SERCOM3) I2CM Interrupt Enable Clear */
+#define REG_SERCOM3_I2CM_INTENSET  (*(RwReg8 *)0x4200140DUL) /**< \brief (SERCOM3) I2CM Interrupt Enable Set */
+#define REG_SERCOM3_I2CM_INTFLAG   (*(RwReg8 *)0x4200140EUL) /**< \brief (SERCOM3) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CM_STATUS    (*(RwReg16*)0x42001410UL) /**< \brief (SERCOM3) I2CM Status */
+#define REG_SERCOM3_I2CM_ADDR      (*(RwReg8 *)0x42001414UL) /**< \brief (SERCOM3) I2CM Address */
+#define REG_SERCOM3_I2CM_DATA      (*(RwReg8 *)0x42001418UL) /**< \brief (SERCOM3) I2CM Data */
+#define REG_SERCOM3_I2CS_CTRLA     (*(RwReg  *)0x42001400UL) /**< \brief (SERCOM3) I2CS Control A */
+#define REG_SERCOM3_I2CS_CTRLB     (*(RwReg  *)0x42001404UL) /**< \brief (SERCOM3) I2CS Control B */
+#define REG_SERCOM3_I2CS_INTENCLR  (*(RwReg8 *)0x4200140CUL) /**< \brief (SERCOM3) I2CS Interrupt Enable Clear */
+#define REG_SERCOM3_I2CS_INTENSET  (*(RwReg8 *)0x4200140DUL) /**< \brief (SERCOM3) I2CS Interrupt Enable Set */
+#define REG_SERCOM3_I2CS_INTFLAG   (*(RwReg8 *)0x4200140EUL) /**< \brief (SERCOM3) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CS_STATUS    (*(RwReg16*)0x42001410UL) /**< \brief (SERCOM3) I2CS Status */
+#define REG_SERCOM3_I2CS_ADDR      (*(RwReg  *)0x42001414UL) /**< \brief (SERCOM3) I2CS Address */
+#define REG_SERCOM3_I2CS_DATA      (*(RwReg8 *)0x42001418UL) /**< \brief (SERCOM3) I2CS Data */
+#define REG_SERCOM3_SPI_CTRLA      (*(RwReg  *)0x42001400UL) /**< \brief (SERCOM3) SPI Control A */
+#define REG_SERCOM3_SPI_CTRLB      (*(RwReg  *)0x42001404UL) /**< \brief (SERCOM3) SPI Control B */
+#define REG_SERCOM3_SPI_DBGCTRL    (*(RwReg8 *)0x42001408UL) /**< \brief (SERCOM3) SPI Debug Control */
+#define REG_SERCOM3_SPI_BAUD       (*(RwReg8 *)0x4200140AUL) /**< \brief (SERCOM3) SPI Baud Rate */
+#define REG_SERCOM3_SPI_INTENCLR   (*(RwReg8 *)0x4200140CUL) /**< \brief (SERCOM3) SPI Interrupt Enable Clear */
+#define REG_SERCOM3_SPI_INTENSET   (*(RwReg8 *)0x4200140DUL) /**< \brief (SERCOM3) SPI Interrupt Enable Set */
+#define REG_SERCOM3_SPI_INTFLAG    (*(RwReg8 *)0x4200140EUL) /**< \brief (SERCOM3) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM3_SPI_STATUS     (*(RwReg16*)0x42001410UL) /**< \brief (SERCOM3) SPI Status */
+#define REG_SERCOM3_SPI_ADDR       (*(RwReg  *)0x42001414UL) /**< \brief (SERCOM3) SPI Address */
+#define REG_SERCOM3_SPI_DATA       (*(RwReg16*)0x42001418UL) /**< \brief (SERCOM3) SPI Data */
+#define REG_SERCOM3_USART_CTRLA    (*(RwReg  *)0x42001400UL) /**< \brief (SERCOM3) USART Control A */
+#define REG_SERCOM3_USART_CTRLB    (*(RwReg  *)0x42001404UL) /**< \brief (SERCOM3) USART Control B */
+#define REG_SERCOM3_USART_DBGCTRL  (*(RwReg8 *)0x42001408UL) /**< \brief (SERCOM3) USART Debug Control */
+#define REG_SERCOM3_USART_BAUD     (*(RwReg16*)0x4200140AUL) /**< \brief (SERCOM3) USART Baud */
+#define REG_SERCOM3_USART_INTENCLR (*(RwReg8 *)0x4200140CUL) /**< \brief (SERCOM3) USART Interrupt Enable Clear */
+#define REG_SERCOM3_USART_INTENSET (*(RwReg8 *)0x4200140DUL) /**< \brief (SERCOM3) USART Interrupt Enable Set */
+#define REG_SERCOM3_USART_INTFLAG  (*(RwReg8 *)0x4200140EUL) /**< \brief (SERCOM3) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM3_USART_STATUS   (*(RwReg16*)0x42001410UL) /**< \brief (SERCOM3) USART Status */
+#define REG_SERCOM3_USART_DATA     (*(RwReg16*)0x42001418UL) /**< \brief (SERCOM3) USART Data */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM3 peripheral ========== */
+#define SERCOM3_GCLK_ID_CORE        16      
+#define SERCOM3_GCLK_ID_SLOW        12      
+#define SERCOM3_INT_MSB             3       
+#define SERCOM3_PMSB                3       
+
+#endif /* _SAMD20_SERCOM3_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/sercom4.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/sercom4.h
@@ -1,0 +1,118 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM4
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SERCOM4_INSTANCE_
+#define _SAMD20_SERCOM4_INSTANCE_
+
+/* ========== Register definition for SERCOM4 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM4_I2CM_CTRLA     (0x42001800) /**< \brief (SERCOM4) I2CM Control A */
+#define REG_SERCOM4_I2CM_CTRLB     (0x42001804) /**< \brief (SERCOM4) I2CM Control B */
+#define REG_SERCOM4_I2CM_DBGCTRL   (0x42001808) /**< \brief (SERCOM4) I2CM Debug Control */
+#define REG_SERCOM4_I2CM_BAUD      (0x4200180A) /**< \brief (SERCOM4) I2CM Baud Rate */
+#define REG_SERCOM4_I2CM_INTENCLR  (0x4200180C) /**< \brief (SERCOM4) I2CM Interrupt Enable Clear */
+#define REG_SERCOM4_I2CM_INTENSET  (0x4200180D) /**< \brief (SERCOM4) I2CM Interrupt Enable Set */
+#define REG_SERCOM4_I2CM_INTFLAG   (0x4200180E) /**< \brief (SERCOM4) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CM_STATUS    (0x42001810) /**< \brief (SERCOM4) I2CM Status */
+#define REG_SERCOM4_I2CM_ADDR      (0x42001814) /**< \brief (SERCOM4) I2CM Address */
+#define REG_SERCOM4_I2CM_DATA      (0x42001818) /**< \brief (SERCOM4) I2CM Data */
+#define REG_SERCOM4_I2CS_CTRLA     (0x42001800) /**< \brief (SERCOM4) I2CS Control A */
+#define REG_SERCOM4_I2CS_CTRLB     (0x42001804) /**< \brief (SERCOM4) I2CS Control B */
+#define REG_SERCOM4_I2CS_INTENCLR  (0x4200180C) /**< \brief (SERCOM4) I2CS Interrupt Enable Clear */
+#define REG_SERCOM4_I2CS_INTENSET  (0x4200180D) /**< \brief (SERCOM4) I2CS Interrupt Enable Set */
+#define REG_SERCOM4_I2CS_INTFLAG   (0x4200180E) /**< \brief (SERCOM4) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CS_STATUS    (0x42001810) /**< \brief (SERCOM4) I2CS Status */
+#define REG_SERCOM4_I2CS_ADDR      (0x42001814) /**< \brief (SERCOM4) I2CS Address */
+#define REG_SERCOM4_I2CS_DATA      (0x42001818) /**< \brief (SERCOM4) I2CS Data */
+#define REG_SERCOM4_SPI_CTRLA      (0x42001800) /**< \brief (SERCOM4) SPI Control A */
+#define REG_SERCOM4_SPI_CTRLB      (0x42001804) /**< \brief (SERCOM4) SPI Control B */
+#define REG_SERCOM4_SPI_DBGCTRL    (0x42001808) /**< \brief (SERCOM4) SPI Debug Control */
+#define REG_SERCOM4_SPI_BAUD       (0x4200180A) /**< \brief (SERCOM4) SPI Baud Rate */
+#define REG_SERCOM4_SPI_INTENCLR   (0x4200180C) /**< \brief (SERCOM4) SPI Interrupt Enable Clear */
+#define REG_SERCOM4_SPI_INTENSET   (0x4200180D) /**< \brief (SERCOM4) SPI Interrupt Enable Set */
+#define REG_SERCOM4_SPI_INTFLAG    (0x4200180E) /**< \brief (SERCOM4) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM4_SPI_STATUS     (0x42001810) /**< \brief (SERCOM4) SPI Status */
+#define REG_SERCOM4_SPI_ADDR       (0x42001814) /**< \brief (SERCOM4) SPI Address */
+#define REG_SERCOM4_SPI_DATA       (0x42001818) /**< \brief (SERCOM4) SPI Data */
+#define REG_SERCOM4_USART_CTRLA    (0x42001800) /**< \brief (SERCOM4) USART Control A */
+#define REG_SERCOM4_USART_CTRLB    (0x42001804) /**< \brief (SERCOM4) USART Control B */
+#define REG_SERCOM4_USART_DBGCTRL  (0x42001808) /**< \brief (SERCOM4) USART Debug Control */
+#define REG_SERCOM4_USART_BAUD     (0x4200180A) /**< \brief (SERCOM4) USART Baud */
+#define REG_SERCOM4_USART_INTENCLR (0x4200180C) /**< \brief (SERCOM4) USART Interrupt Enable Clear */
+#define REG_SERCOM4_USART_INTENSET (0x4200180D) /**< \brief (SERCOM4) USART Interrupt Enable Set */
+#define REG_SERCOM4_USART_INTFLAG  (0x4200180E) /**< \brief (SERCOM4) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM4_USART_STATUS   (0x42001810) /**< \brief (SERCOM4) USART Status */
+#define REG_SERCOM4_USART_DATA     (0x42001818) /**< \brief (SERCOM4) USART Data */
+#else
+#define REG_SERCOM4_I2CM_CTRLA     (*(RwReg  *)0x42001800UL) /**< \brief (SERCOM4) I2CM Control A */
+#define REG_SERCOM4_I2CM_CTRLB     (*(RwReg  *)0x42001804UL) /**< \brief (SERCOM4) I2CM Control B */
+#define REG_SERCOM4_I2CM_DBGCTRL   (*(RwReg8 *)0x42001808UL) /**< \brief (SERCOM4) I2CM Debug Control */
+#define REG_SERCOM4_I2CM_BAUD      (*(RwReg16*)0x4200180AUL) /**< \brief (SERCOM4) I2CM Baud Rate */
+#define REG_SERCOM4_I2CM_INTENCLR  (*(RwReg8 *)0x4200180CUL) /**< \brief (SERCOM4) I2CM Interrupt Enable Clear */
+#define REG_SERCOM4_I2CM_INTENSET  (*(RwReg8 *)0x4200180DUL) /**< \brief (SERCOM4) I2CM Interrupt Enable Set */
+#define REG_SERCOM4_I2CM_INTFLAG   (*(RwReg8 *)0x4200180EUL) /**< \brief (SERCOM4) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CM_STATUS    (*(RwReg16*)0x42001810UL) /**< \brief (SERCOM4) I2CM Status */
+#define REG_SERCOM4_I2CM_ADDR      (*(RwReg8 *)0x42001814UL) /**< \brief (SERCOM4) I2CM Address */
+#define REG_SERCOM4_I2CM_DATA      (*(RwReg8 *)0x42001818UL) /**< \brief (SERCOM4) I2CM Data */
+#define REG_SERCOM4_I2CS_CTRLA     (*(RwReg  *)0x42001800UL) /**< \brief (SERCOM4) I2CS Control A */
+#define REG_SERCOM4_I2CS_CTRLB     (*(RwReg  *)0x42001804UL) /**< \brief (SERCOM4) I2CS Control B */
+#define REG_SERCOM4_I2CS_INTENCLR  (*(RwReg8 *)0x4200180CUL) /**< \brief (SERCOM4) I2CS Interrupt Enable Clear */
+#define REG_SERCOM4_I2CS_INTENSET  (*(RwReg8 *)0x4200180DUL) /**< \brief (SERCOM4) I2CS Interrupt Enable Set */
+#define REG_SERCOM4_I2CS_INTFLAG   (*(RwReg8 *)0x4200180EUL) /**< \brief (SERCOM4) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CS_STATUS    (*(RwReg16*)0x42001810UL) /**< \brief (SERCOM4) I2CS Status */
+#define REG_SERCOM4_I2CS_ADDR      (*(RwReg  *)0x42001814UL) /**< \brief (SERCOM4) I2CS Address */
+#define REG_SERCOM4_I2CS_DATA      (*(RwReg8 *)0x42001818UL) /**< \brief (SERCOM4) I2CS Data */
+#define REG_SERCOM4_SPI_CTRLA      (*(RwReg  *)0x42001800UL) /**< \brief (SERCOM4) SPI Control A */
+#define REG_SERCOM4_SPI_CTRLB      (*(RwReg  *)0x42001804UL) /**< \brief (SERCOM4) SPI Control B */
+#define REG_SERCOM4_SPI_DBGCTRL    (*(RwReg8 *)0x42001808UL) /**< \brief (SERCOM4) SPI Debug Control */
+#define REG_SERCOM4_SPI_BAUD       (*(RwReg8 *)0x4200180AUL) /**< \brief (SERCOM4) SPI Baud Rate */
+#define REG_SERCOM4_SPI_INTENCLR   (*(RwReg8 *)0x4200180CUL) /**< \brief (SERCOM4) SPI Interrupt Enable Clear */
+#define REG_SERCOM4_SPI_INTENSET   (*(RwReg8 *)0x4200180DUL) /**< \brief (SERCOM4) SPI Interrupt Enable Set */
+#define REG_SERCOM4_SPI_INTFLAG    (*(RwReg8 *)0x4200180EUL) /**< \brief (SERCOM4) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM4_SPI_STATUS     (*(RwReg16*)0x42001810UL) /**< \brief (SERCOM4) SPI Status */
+#define REG_SERCOM4_SPI_ADDR       (*(RwReg  *)0x42001814UL) /**< \brief (SERCOM4) SPI Address */
+#define REG_SERCOM4_SPI_DATA       (*(RwReg16*)0x42001818UL) /**< \brief (SERCOM4) SPI Data */
+#define REG_SERCOM4_USART_CTRLA    (*(RwReg  *)0x42001800UL) /**< \brief (SERCOM4) USART Control A */
+#define REG_SERCOM4_USART_CTRLB    (*(RwReg  *)0x42001804UL) /**< \brief (SERCOM4) USART Control B */
+#define REG_SERCOM4_USART_DBGCTRL  (*(RwReg8 *)0x42001808UL) /**< \brief (SERCOM4) USART Debug Control */
+#define REG_SERCOM4_USART_BAUD     (*(RwReg16*)0x4200180AUL) /**< \brief (SERCOM4) USART Baud */
+#define REG_SERCOM4_USART_INTENCLR (*(RwReg8 *)0x4200180CUL) /**< \brief (SERCOM4) USART Interrupt Enable Clear */
+#define REG_SERCOM4_USART_INTENSET (*(RwReg8 *)0x4200180DUL) /**< \brief (SERCOM4) USART Interrupt Enable Set */
+#define REG_SERCOM4_USART_INTFLAG  (*(RwReg8 *)0x4200180EUL) /**< \brief (SERCOM4) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM4_USART_STATUS   (*(RwReg16*)0x42001810UL) /**< \brief (SERCOM4) USART Status */
+#define REG_SERCOM4_USART_DATA     (*(RwReg16*)0x42001818UL) /**< \brief (SERCOM4) USART Data */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM4 peripheral ========== */
+#define SERCOM4_GCLK_ID_CORE        17      
+#define SERCOM4_GCLK_ID_SLOW        12      
+#define SERCOM4_INT_MSB             3       
+#define SERCOM4_PMSB                3       
+
+#endif /* _SAMD20_SERCOM4_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/sercom5.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/sercom5.h
@@ -1,0 +1,118 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM5
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SERCOM5_INSTANCE_
+#define _SAMD20_SERCOM5_INSTANCE_
+
+/* ========== Register definition for SERCOM5 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM5_I2CM_CTRLA     (0x42001C00) /**< \brief (SERCOM5) I2CM Control A */
+#define REG_SERCOM5_I2CM_CTRLB     (0x42001C04) /**< \brief (SERCOM5) I2CM Control B */
+#define REG_SERCOM5_I2CM_DBGCTRL   (0x42001C08) /**< \brief (SERCOM5) I2CM Debug Control */
+#define REG_SERCOM5_I2CM_BAUD      (0x42001C0A) /**< \brief (SERCOM5) I2CM Baud Rate */
+#define REG_SERCOM5_I2CM_INTENCLR  (0x42001C0C) /**< \brief (SERCOM5) I2CM Interrupt Enable Clear */
+#define REG_SERCOM5_I2CM_INTENSET  (0x42001C0D) /**< \brief (SERCOM5) I2CM Interrupt Enable Set */
+#define REG_SERCOM5_I2CM_INTFLAG   (0x42001C0E) /**< \brief (SERCOM5) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CM_STATUS    (0x42001C10) /**< \brief (SERCOM5) I2CM Status */
+#define REG_SERCOM5_I2CM_ADDR      (0x42001C14) /**< \brief (SERCOM5) I2CM Address */
+#define REG_SERCOM5_I2CM_DATA      (0x42001C18) /**< \brief (SERCOM5) I2CM Data */
+#define REG_SERCOM5_I2CS_CTRLA     (0x42001C00) /**< \brief (SERCOM5) I2CS Control A */
+#define REG_SERCOM5_I2CS_CTRLB     (0x42001C04) /**< \brief (SERCOM5) I2CS Control B */
+#define REG_SERCOM5_I2CS_INTENCLR  (0x42001C0C) /**< \brief (SERCOM5) I2CS Interrupt Enable Clear */
+#define REG_SERCOM5_I2CS_INTENSET  (0x42001C0D) /**< \brief (SERCOM5) I2CS Interrupt Enable Set */
+#define REG_SERCOM5_I2CS_INTFLAG   (0x42001C0E) /**< \brief (SERCOM5) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CS_STATUS    (0x42001C10) /**< \brief (SERCOM5) I2CS Status */
+#define REG_SERCOM5_I2CS_ADDR      (0x42001C14) /**< \brief (SERCOM5) I2CS Address */
+#define REG_SERCOM5_I2CS_DATA      (0x42001C18) /**< \brief (SERCOM5) I2CS Data */
+#define REG_SERCOM5_SPI_CTRLA      (0x42001C00) /**< \brief (SERCOM5) SPI Control A */
+#define REG_SERCOM5_SPI_CTRLB      (0x42001C04) /**< \brief (SERCOM5) SPI Control B */
+#define REG_SERCOM5_SPI_DBGCTRL    (0x42001C08) /**< \brief (SERCOM5) SPI Debug Control */
+#define REG_SERCOM5_SPI_BAUD       (0x42001C0A) /**< \brief (SERCOM5) SPI Baud Rate */
+#define REG_SERCOM5_SPI_INTENCLR   (0x42001C0C) /**< \brief (SERCOM5) SPI Interrupt Enable Clear */
+#define REG_SERCOM5_SPI_INTENSET   (0x42001C0D) /**< \brief (SERCOM5) SPI Interrupt Enable Set */
+#define REG_SERCOM5_SPI_INTFLAG    (0x42001C0E) /**< \brief (SERCOM5) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM5_SPI_STATUS     (0x42001C10) /**< \brief (SERCOM5) SPI Status */
+#define REG_SERCOM5_SPI_ADDR       (0x42001C14) /**< \brief (SERCOM5) SPI Address */
+#define REG_SERCOM5_SPI_DATA       (0x42001C18) /**< \brief (SERCOM5) SPI Data */
+#define REG_SERCOM5_USART_CTRLA    (0x42001C00) /**< \brief (SERCOM5) USART Control A */
+#define REG_SERCOM5_USART_CTRLB    (0x42001C04) /**< \brief (SERCOM5) USART Control B */
+#define REG_SERCOM5_USART_DBGCTRL  (0x42001C08) /**< \brief (SERCOM5) USART Debug Control */
+#define REG_SERCOM5_USART_BAUD     (0x42001C0A) /**< \brief (SERCOM5) USART Baud */
+#define REG_SERCOM5_USART_INTENCLR (0x42001C0C) /**< \brief (SERCOM5) USART Interrupt Enable Clear */
+#define REG_SERCOM5_USART_INTENSET (0x42001C0D) /**< \brief (SERCOM5) USART Interrupt Enable Set */
+#define REG_SERCOM5_USART_INTFLAG  (0x42001C0E) /**< \brief (SERCOM5) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM5_USART_STATUS   (0x42001C10) /**< \brief (SERCOM5) USART Status */
+#define REG_SERCOM5_USART_DATA     (0x42001C18) /**< \brief (SERCOM5) USART Data */
+#else
+#define REG_SERCOM5_I2CM_CTRLA     (*(RwReg  *)0x42001C00UL) /**< \brief (SERCOM5) I2CM Control A */
+#define REG_SERCOM5_I2CM_CTRLB     (*(RwReg  *)0x42001C04UL) /**< \brief (SERCOM5) I2CM Control B */
+#define REG_SERCOM5_I2CM_DBGCTRL   (*(RwReg8 *)0x42001C08UL) /**< \brief (SERCOM5) I2CM Debug Control */
+#define REG_SERCOM5_I2CM_BAUD      (*(RwReg16*)0x42001C0AUL) /**< \brief (SERCOM5) I2CM Baud Rate */
+#define REG_SERCOM5_I2CM_INTENCLR  (*(RwReg8 *)0x42001C0CUL) /**< \brief (SERCOM5) I2CM Interrupt Enable Clear */
+#define REG_SERCOM5_I2CM_INTENSET  (*(RwReg8 *)0x42001C0DUL) /**< \brief (SERCOM5) I2CM Interrupt Enable Set */
+#define REG_SERCOM5_I2CM_INTFLAG   (*(RwReg8 *)0x42001C0EUL) /**< \brief (SERCOM5) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CM_STATUS    (*(RwReg16*)0x42001C10UL) /**< \brief (SERCOM5) I2CM Status */
+#define REG_SERCOM5_I2CM_ADDR      (*(RwReg8 *)0x42001C14UL) /**< \brief (SERCOM5) I2CM Address */
+#define REG_SERCOM5_I2CM_DATA      (*(RwReg8 *)0x42001C18UL) /**< \brief (SERCOM5) I2CM Data */
+#define REG_SERCOM5_I2CS_CTRLA     (*(RwReg  *)0x42001C00UL) /**< \brief (SERCOM5) I2CS Control A */
+#define REG_SERCOM5_I2CS_CTRLB     (*(RwReg  *)0x42001C04UL) /**< \brief (SERCOM5) I2CS Control B */
+#define REG_SERCOM5_I2CS_INTENCLR  (*(RwReg8 *)0x42001C0CUL) /**< \brief (SERCOM5) I2CS Interrupt Enable Clear */
+#define REG_SERCOM5_I2CS_INTENSET  (*(RwReg8 *)0x42001C0DUL) /**< \brief (SERCOM5) I2CS Interrupt Enable Set */
+#define REG_SERCOM5_I2CS_INTFLAG   (*(RwReg8 *)0x42001C0EUL) /**< \brief (SERCOM5) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CS_STATUS    (*(RwReg16*)0x42001C10UL) /**< \brief (SERCOM5) I2CS Status */
+#define REG_SERCOM5_I2CS_ADDR      (*(RwReg  *)0x42001C14UL) /**< \brief (SERCOM5) I2CS Address */
+#define REG_SERCOM5_I2CS_DATA      (*(RwReg8 *)0x42001C18UL) /**< \brief (SERCOM5) I2CS Data */
+#define REG_SERCOM5_SPI_CTRLA      (*(RwReg  *)0x42001C00UL) /**< \brief (SERCOM5) SPI Control A */
+#define REG_SERCOM5_SPI_CTRLB      (*(RwReg  *)0x42001C04UL) /**< \brief (SERCOM5) SPI Control B */
+#define REG_SERCOM5_SPI_DBGCTRL    (*(RwReg8 *)0x42001C08UL) /**< \brief (SERCOM5) SPI Debug Control */
+#define REG_SERCOM5_SPI_BAUD       (*(RwReg8 *)0x42001C0AUL) /**< \brief (SERCOM5) SPI Baud Rate */
+#define REG_SERCOM5_SPI_INTENCLR   (*(RwReg8 *)0x42001C0CUL) /**< \brief (SERCOM5) SPI Interrupt Enable Clear */
+#define REG_SERCOM5_SPI_INTENSET   (*(RwReg8 *)0x42001C0DUL) /**< \brief (SERCOM5) SPI Interrupt Enable Set */
+#define REG_SERCOM5_SPI_INTFLAG    (*(RwReg8 *)0x42001C0EUL) /**< \brief (SERCOM5) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM5_SPI_STATUS     (*(RwReg16*)0x42001C10UL) /**< \brief (SERCOM5) SPI Status */
+#define REG_SERCOM5_SPI_ADDR       (*(RwReg  *)0x42001C14UL) /**< \brief (SERCOM5) SPI Address */
+#define REG_SERCOM5_SPI_DATA       (*(RwReg16*)0x42001C18UL) /**< \brief (SERCOM5) SPI Data */
+#define REG_SERCOM5_USART_CTRLA    (*(RwReg  *)0x42001C00UL) /**< \brief (SERCOM5) USART Control A */
+#define REG_SERCOM5_USART_CTRLB    (*(RwReg  *)0x42001C04UL) /**< \brief (SERCOM5) USART Control B */
+#define REG_SERCOM5_USART_DBGCTRL  (*(RwReg8 *)0x42001C08UL) /**< \brief (SERCOM5) USART Debug Control */
+#define REG_SERCOM5_USART_BAUD     (*(RwReg16*)0x42001C0AUL) /**< \brief (SERCOM5) USART Baud */
+#define REG_SERCOM5_USART_INTENCLR (*(RwReg8 *)0x42001C0CUL) /**< \brief (SERCOM5) USART Interrupt Enable Clear */
+#define REG_SERCOM5_USART_INTENSET (*(RwReg8 *)0x42001C0DUL) /**< \brief (SERCOM5) USART Interrupt Enable Set */
+#define REG_SERCOM5_USART_INTFLAG  (*(RwReg8 *)0x42001C0EUL) /**< \brief (SERCOM5) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM5_USART_STATUS   (*(RwReg16*)0x42001C10UL) /**< \brief (SERCOM5) USART Status */
+#define REG_SERCOM5_USART_DATA     (*(RwReg16*)0x42001C18UL) /**< \brief (SERCOM5) USART Data */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM5 peripheral ========== */
+#define SERCOM5_GCLK_ID_CORE        18      
+#define SERCOM5_GCLK_ID_SLOW        12      
+#define SERCOM5_INT_MSB             3       
+#define SERCOM5_PMSB                3       
+
+#endif /* _SAMD20_SERCOM5_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/sysctrl.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/sysctrl.h
@@ -1,0 +1,96 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SYSCTRL
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SYSCTRL_INSTANCE_
+#define _SAMD20_SYSCTRL_INSTANCE_
+
+/* ========== Register definition for SYSCTRL peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SYSCTRL_INTENCLR       (0x40000800) /**< \brief (SYSCTRL) Interrupt Enable Clear */
+#define REG_SYSCTRL_INTENSET       (0x40000804) /**< \brief (SYSCTRL) Interrupt Enable Set */
+#define REG_SYSCTRL_INTFLAG        (0x40000808) /**< \brief (SYSCTRL) Interrupt Flag Status and Clear */
+#define REG_SYSCTRL_PCLKSR         (0x4000080C) /**< \brief (SYSCTRL) Power and Clocks Status */
+#define REG_SYSCTRL_XOSC           (0x40000810) /**< \brief (SYSCTRL) XOSC Control */
+#define REG_SYSCTRL_XOSC32K        (0x40000814) /**< \brief (SYSCTRL) XOSC32K Control */
+#define REG_SYSCTRL_OSC32K         (0x40000818) /**< \brief (SYSCTRL) OSC32K Control */
+#define REG_SYSCTRL_OSCULP32K      (0x4000081C) /**< \brief (SYSCTRL) OSCULP32K Control */
+#define REG_SYSCTRL_OSC8M          (0x40000820) /**< \brief (SYSCTRL) OSC8M Control A */
+#define REG_SYSCTRL_DFLLCTRL       (0x40000824) /**< \brief (SYSCTRL) DFLL Config */
+#define REG_SYSCTRL_DFLLVAL        (0x40000828) /**< \brief (SYSCTRL) DFLL Calibration Value */
+#define REG_SYSCTRL_DFLLMUL        (0x4000082C) /**< \brief (SYSCTRL) DFLL Multiplier */
+#define REG_SYSCTRL_DFLLSYNC       (0x40000830) /**< \brief (SYSCTRL) DFLL Synchronization */
+#define REG_SYSCTRL_BOD33          (0x40000834) /**< \brief (SYSCTRL) 3.3V Brown-Out Detector (BOD33) Control */
+#define REG_SYSCTRL_VREG           (0x4000083C) /**< \brief (SYSCTRL) VREG Control */
+#define REG_SYSCTRL_VREF           (0x40000840) /**< \brief (SYSCTRL) VREF Control A */
+#else
+#define REG_SYSCTRL_INTENCLR       (*(RwReg  *)0x40000800UL) /**< \brief (SYSCTRL) Interrupt Enable Clear */
+#define REG_SYSCTRL_INTENSET       (*(RwReg  *)0x40000804UL) /**< \brief (SYSCTRL) Interrupt Enable Set */
+#define REG_SYSCTRL_INTFLAG        (*(RwReg  *)0x40000808UL) /**< \brief (SYSCTRL) Interrupt Flag Status and Clear */
+#define REG_SYSCTRL_PCLKSR         (*(RoReg  *)0x4000080CUL) /**< \brief (SYSCTRL) Power and Clocks Status */
+#define REG_SYSCTRL_XOSC           (*(RwReg16*)0x40000810UL) /**< \brief (SYSCTRL) XOSC Control */
+#define REG_SYSCTRL_XOSC32K        (*(RwReg16*)0x40000814UL) /**< \brief (SYSCTRL) XOSC32K Control */
+#define REG_SYSCTRL_OSC32K         (*(RwReg  *)0x40000818UL) /**< \brief (SYSCTRL) OSC32K Control */
+#define REG_SYSCTRL_OSCULP32K      (*(RwReg8 *)0x4000081CUL) /**< \brief (SYSCTRL) OSCULP32K Control */
+#define REG_SYSCTRL_OSC8M          (*(RwReg  *)0x40000820UL) /**< \brief (SYSCTRL) OSC8M Control A */
+#define REG_SYSCTRL_DFLLCTRL       (*(RwReg16*)0x40000824UL) /**< \brief (SYSCTRL) DFLL Config */
+#define REG_SYSCTRL_DFLLVAL        (*(RwReg  *)0x40000828UL) /**< \brief (SYSCTRL) DFLL Calibration Value */
+#define REG_SYSCTRL_DFLLMUL        (*(RwReg  *)0x4000082CUL) /**< \brief (SYSCTRL) DFLL Multiplier */
+#define REG_SYSCTRL_DFLLSYNC       (*(RwReg8 *)0x40000830UL) /**< \brief (SYSCTRL) DFLL Synchronization */
+#define REG_SYSCTRL_BOD33          (*(RwReg  *)0x40000834UL) /**< \brief (SYSCTRL) 3.3V Brown-Out Detector (BOD33) Control */
+#define REG_SYSCTRL_VREG           (*(RwReg16*)0x4000083CUL) /**< \brief (SYSCTRL) VREG Control */
+#define REG_SYSCTRL_VREF           (*(RwReg  *)0x40000840UL) /**< \brief (SYSCTRL) VREF Control A */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SYSCTRL peripheral ========== */
+#define SYSCTRL_BGAP_CALIB_MSB      11      
+#define SYSCTRL_BOD33_CALIB_MSB     5       
+#define SYSCTRL_DFLL48M_COARSE_MSB  4       
+#define SYSCTRL_DFLL48M_FINE_MSB    7       
+#define SYSCTRL_GCLK_ID_DFLL48      0       
+#define SYSCTRL_OSC32K_COARSE_CALIB_MSB 6       
+#define SYSCTRL_POR33_ENTEST_MSB    1       
+#define SYSCTRL_ULPVREF_DIVLEV_MSB  3       
+#define SYSCTRL_ULPVREG_FORCEGAIN_MSB 1       
+#define SYSCTRL_ULPVREG_RAMREFSEL_MSB 2       
+#define SYSCTRL_VREF_CONTROL_MSB    48      
+#define SYSCTRL_VREF_STATUS_MSB     7       
+#define SYSCTRL_VREG_LEVEL_MSB      2       
+#define SYSCTRL_BOD12_VERSION       0x111   
+#define SYSCTRL_BOD33_VERSION       0x111   
+#define SYSCTRL_DFLL48M_VERSION     0x211   
+#define SYSCTRL_GCLK_VERSION        0x210   
+#define SYSCTRL_OSCULP32K_VERSION   0x111   
+#define SYSCTRL_OSC8M_VERSION       0x120   
+#define SYSCTRL_OSC32K_VERSION      0x1101  
+#define SYSCTRL_VREF_VERSION        0x200   
+#define SYSCTRL_VREG_VERSION        0x201   
+#define SYSCTRL_XOSC_VERSION        0x1101  
+#define SYSCTRL_XOSC32K_VERSION     0x1101  
+
+#endif /* _SAMD20_SYSCTRL_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/tc0.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/tc0.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC0
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC0_INSTANCE_
+#define _SAMD20_TC0_INSTANCE_
+
+/* ========== Register definition for TC0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC0_CTRLA              (0x42002000) /**< \brief (TC0) Control A */
+#define REG_TC0_READREQ            (0x42002002) /**< \brief (TC0) Read Request */
+#define REG_TC0_CTRLBCLR           (0x42002004) /**< \brief (TC0) Control B Clear */
+#define REG_TC0_CTRLBSET           (0x42002005) /**< \brief (TC0) Control B Set */
+#define REG_TC0_CTRLC              (0x42002006) /**< \brief (TC0) Control C */
+#define REG_TC0_DBGCTRL            (0x42002008) /**< \brief (TC0) Debug Control */
+#define REG_TC0_EVCTRL             (0x4200200A) /**< \brief (TC0) Event Control */
+#define REG_TC0_INTENCLR           (0x4200200C) /**< \brief (TC0) Interrupt Enable Clear */
+#define REG_TC0_INTENSET           (0x4200200D) /**< \brief (TC0) Interrupt Enable Set */
+#define REG_TC0_INTFLAG            (0x4200200E) /**< \brief (TC0) Interrupt Flag Status and Clear */
+#define REG_TC0_STATUS             (0x4200200F) /**< \brief (TC0) Status */
+#define REG_TC0_COUNT16_COUNT      (0x42002010) /**< \brief (TC0) COUNT16 Counter Value */
+#define REG_TC0_COUNT16_CC0        (0x42002018) /**< \brief (TC0) COUNT16 Compare/Capture 0 */
+#define REG_TC0_COUNT16_CC1        (0x4200201A) /**< \brief (TC0) COUNT16 Compare/Capture 1 */
+#define REG_TC0_COUNT32_COUNT      (0x42002010) /**< \brief (TC0) COUNT32 Counter Value */
+#define REG_TC0_COUNT32_CC0        (0x42002018) /**< \brief (TC0) COUNT32 Compare/Capture 0 */
+#define REG_TC0_COUNT32_CC1        (0x4200201C) /**< \brief (TC0) COUNT32 Compare/Capture 1 */
+#define REG_TC0_COUNT8_COUNT       (0x42002010) /**< \brief (TC0) COUNT8 Counter Value */
+#define REG_TC0_COUNT8_PER         (0x42002014) /**< \brief (TC0) COUNT8 Period Value */
+#define REG_TC0_COUNT8_CC0         (0x42002018) /**< \brief (TC0) COUNT8 Compare/Capture 0 */
+#define REG_TC0_COUNT8_CC1         (0x42002019) /**< \brief (TC0) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC0_CTRLA              (*(RwReg16*)0x42002000UL) /**< \brief (TC0) Control A */
+#define REG_TC0_READREQ            (*(RwReg16*)0x42002002UL) /**< \brief (TC0) Read Request */
+#define REG_TC0_CTRLBCLR           (*(RwReg8 *)0x42002004UL) /**< \brief (TC0) Control B Clear */
+#define REG_TC0_CTRLBSET           (*(RwReg8 *)0x42002005UL) /**< \brief (TC0) Control B Set */
+#define REG_TC0_CTRLC              (*(RwReg8 *)0x42002006UL) /**< \brief (TC0) Control C */
+#define REG_TC0_DBGCTRL            (*(RwReg8 *)0x42002008UL) /**< \brief (TC0) Debug Control */
+#define REG_TC0_EVCTRL             (*(RwReg16*)0x4200200AUL) /**< \brief (TC0) Event Control */
+#define REG_TC0_INTENCLR           (*(RwReg8 *)0x4200200CUL) /**< \brief (TC0) Interrupt Enable Clear */
+#define REG_TC0_INTENSET           (*(RwReg8 *)0x4200200DUL) /**< \brief (TC0) Interrupt Enable Set */
+#define REG_TC0_INTFLAG            (*(RwReg8 *)0x4200200EUL) /**< \brief (TC0) Interrupt Flag Status and Clear */
+#define REG_TC0_STATUS             (*(RoReg8 *)0x4200200FUL) /**< \brief (TC0) Status */
+#define REG_TC0_COUNT16_COUNT      (*(RwReg16*)0x42002010UL) /**< \brief (TC0) COUNT16 Counter Value */
+#define REG_TC0_COUNT16_CC0        (*(RwReg16*)0x42002018UL) /**< \brief (TC0) COUNT16 Compare/Capture 0 */
+#define REG_TC0_COUNT16_CC1        (*(RwReg16*)0x4200201AUL) /**< \brief (TC0) COUNT16 Compare/Capture 1 */
+#define REG_TC0_COUNT32_COUNT      (*(RwReg  *)0x42002010UL) /**< \brief (TC0) COUNT32 Counter Value */
+#define REG_TC0_COUNT32_CC0        (*(RwReg  *)0x42002018UL) /**< \brief (TC0) COUNT32 Compare/Capture 0 */
+#define REG_TC0_COUNT32_CC1        (*(RwReg  *)0x4200201CUL) /**< \brief (TC0) COUNT32 Compare/Capture 1 */
+#define REG_TC0_COUNT8_COUNT       (*(RwReg8 *)0x42002010UL) /**< \brief (TC0) COUNT8 Counter Value */
+#define REG_TC0_COUNT8_PER         (*(RwReg8 *)0x42002014UL) /**< \brief (TC0) COUNT8 Period Value */
+#define REG_TC0_COUNT8_CC0         (*(RwReg8 *)0x42002018UL) /**< \brief (TC0) COUNT8 Compare/Capture 0 */
+#define REG_TC0_COUNT8_CC1         (*(RwReg8 *)0x42002019UL) /**< \brief (TC0) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC0 peripheral ========== */
+#define TC0_CC8_NUM                 2       
+#define TC0_CC16_NUM                2       
+#define TC0_CC32_NUM                2       
+#define TC0_DITHERING_EXT           0       
+#define TC0_GCLK_ID                 19      
+#define TC0_MASTER                  1       
+#define TC0_OW_NUM                  2       
+#define TC0_PERIOD_EXT              0       
+#define TC0_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC0_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/tc1.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/tc1.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC1
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC1_INSTANCE_
+#define _SAMD20_TC1_INSTANCE_
+
+/* ========== Register definition for TC1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC1_CTRLA              (0x42002400) /**< \brief (TC1) Control A */
+#define REG_TC1_READREQ            (0x42002402) /**< \brief (TC1) Read Request */
+#define REG_TC1_CTRLBCLR           (0x42002404) /**< \brief (TC1) Control B Clear */
+#define REG_TC1_CTRLBSET           (0x42002405) /**< \brief (TC1) Control B Set */
+#define REG_TC1_CTRLC              (0x42002406) /**< \brief (TC1) Control C */
+#define REG_TC1_DBGCTRL            (0x42002408) /**< \brief (TC1) Debug Control */
+#define REG_TC1_EVCTRL             (0x4200240A) /**< \brief (TC1) Event Control */
+#define REG_TC1_INTENCLR           (0x4200240C) /**< \brief (TC1) Interrupt Enable Clear */
+#define REG_TC1_INTENSET           (0x4200240D) /**< \brief (TC1) Interrupt Enable Set */
+#define REG_TC1_INTFLAG            (0x4200240E) /**< \brief (TC1) Interrupt Flag Status and Clear */
+#define REG_TC1_STATUS             (0x4200240F) /**< \brief (TC1) Status */
+#define REG_TC1_COUNT16_COUNT      (0x42002410) /**< \brief (TC1) COUNT16 Counter Value */
+#define REG_TC1_COUNT16_CC0        (0x42002418) /**< \brief (TC1) COUNT16 Compare/Capture 0 */
+#define REG_TC1_COUNT16_CC1        (0x4200241A) /**< \brief (TC1) COUNT16 Compare/Capture 1 */
+#define REG_TC1_COUNT32_COUNT      (0x42002410) /**< \brief (TC1) COUNT32 Counter Value */
+#define REG_TC1_COUNT32_CC0        (0x42002418) /**< \brief (TC1) COUNT32 Compare/Capture 0 */
+#define REG_TC1_COUNT32_CC1        (0x4200241C) /**< \brief (TC1) COUNT32 Compare/Capture 1 */
+#define REG_TC1_COUNT8_COUNT       (0x42002410) /**< \brief (TC1) COUNT8 Counter Value */
+#define REG_TC1_COUNT8_PER         (0x42002414) /**< \brief (TC1) COUNT8 Period Value */
+#define REG_TC1_COUNT8_CC0         (0x42002418) /**< \brief (TC1) COUNT8 Compare/Capture 0 */
+#define REG_TC1_COUNT8_CC1         (0x42002419) /**< \brief (TC1) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC1_CTRLA              (*(RwReg16*)0x42002400UL) /**< \brief (TC1) Control A */
+#define REG_TC1_READREQ            (*(RwReg16*)0x42002402UL) /**< \brief (TC1) Read Request */
+#define REG_TC1_CTRLBCLR           (*(RwReg8 *)0x42002404UL) /**< \brief (TC1) Control B Clear */
+#define REG_TC1_CTRLBSET           (*(RwReg8 *)0x42002405UL) /**< \brief (TC1) Control B Set */
+#define REG_TC1_CTRLC              (*(RwReg8 *)0x42002406UL) /**< \brief (TC1) Control C */
+#define REG_TC1_DBGCTRL            (*(RwReg8 *)0x42002408UL) /**< \brief (TC1) Debug Control */
+#define REG_TC1_EVCTRL             (*(RwReg16*)0x4200240AUL) /**< \brief (TC1) Event Control */
+#define REG_TC1_INTENCLR           (*(RwReg8 *)0x4200240CUL) /**< \brief (TC1) Interrupt Enable Clear */
+#define REG_TC1_INTENSET           (*(RwReg8 *)0x4200240DUL) /**< \brief (TC1) Interrupt Enable Set */
+#define REG_TC1_INTFLAG            (*(RwReg8 *)0x4200240EUL) /**< \brief (TC1) Interrupt Flag Status and Clear */
+#define REG_TC1_STATUS             (*(RoReg8 *)0x4200240FUL) /**< \brief (TC1) Status */
+#define REG_TC1_COUNT16_COUNT      (*(RwReg16*)0x42002410UL) /**< \brief (TC1) COUNT16 Counter Value */
+#define REG_TC1_COUNT16_CC0        (*(RwReg16*)0x42002418UL) /**< \brief (TC1) COUNT16 Compare/Capture 0 */
+#define REG_TC1_COUNT16_CC1        (*(RwReg16*)0x4200241AUL) /**< \brief (TC1) COUNT16 Compare/Capture 1 */
+#define REG_TC1_COUNT32_COUNT      (*(RwReg  *)0x42002410UL) /**< \brief (TC1) COUNT32 Counter Value */
+#define REG_TC1_COUNT32_CC0        (*(RwReg  *)0x42002418UL) /**< \brief (TC1) COUNT32 Compare/Capture 0 */
+#define REG_TC1_COUNT32_CC1        (*(RwReg  *)0x4200241CUL) /**< \brief (TC1) COUNT32 Compare/Capture 1 */
+#define REG_TC1_COUNT8_COUNT       (*(RwReg8 *)0x42002410UL) /**< \brief (TC1) COUNT8 Counter Value */
+#define REG_TC1_COUNT8_PER         (*(RwReg8 *)0x42002414UL) /**< \brief (TC1) COUNT8 Period Value */
+#define REG_TC1_COUNT8_CC0         (*(RwReg8 *)0x42002418UL) /**< \brief (TC1) COUNT8 Compare/Capture 0 */
+#define REG_TC1_COUNT8_CC1         (*(RwReg8 *)0x42002419UL) /**< \brief (TC1) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC1 peripheral ========== */
+#define TC1_CC8_NUM                 2       
+#define TC1_CC16_NUM                2       
+#define TC1_CC32_NUM                2       
+#define TC1_DITHERING_EXT           0       
+#define TC1_GCLK_ID                 19      
+#define TC1_MASTER                  0       
+#define TC1_OW_NUM                  2       
+#define TC1_PERIOD_EXT              0       
+#define TC1_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC1_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/tc2.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/tc2.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC2
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC2_INSTANCE_
+#define _SAMD20_TC2_INSTANCE_
+
+/* ========== Register definition for TC2 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC2_CTRLA              (0x42002800) /**< \brief (TC2) Control A */
+#define REG_TC2_READREQ            (0x42002802) /**< \brief (TC2) Read Request */
+#define REG_TC2_CTRLBCLR           (0x42002804) /**< \brief (TC2) Control B Clear */
+#define REG_TC2_CTRLBSET           (0x42002805) /**< \brief (TC2) Control B Set */
+#define REG_TC2_CTRLC              (0x42002806) /**< \brief (TC2) Control C */
+#define REG_TC2_DBGCTRL            (0x42002808) /**< \brief (TC2) Debug Control */
+#define REG_TC2_EVCTRL             (0x4200280A) /**< \brief (TC2) Event Control */
+#define REG_TC2_INTENCLR           (0x4200280C) /**< \brief (TC2) Interrupt Enable Clear */
+#define REG_TC2_INTENSET           (0x4200280D) /**< \brief (TC2) Interrupt Enable Set */
+#define REG_TC2_INTFLAG            (0x4200280E) /**< \brief (TC2) Interrupt Flag Status and Clear */
+#define REG_TC2_STATUS             (0x4200280F) /**< \brief (TC2) Status */
+#define REG_TC2_COUNT16_COUNT      (0x42002810) /**< \brief (TC2) COUNT16 Counter Value */
+#define REG_TC2_COUNT16_CC0        (0x42002818) /**< \brief (TC2) COUNT16 Compare/Capture 0 */
+#define REG_TC2_COUNT16_CC1        (0x4200281A) /**< \brief (TC2) COUNT16 Compare/Capture 1 */
+#define REG_TC2_COUNT32_COUNT      (0x42002810) /**< \brief (TC2) COUNT32 Counter Value */
+#define REG_TC2_COUNT32_CC0        (0x42002818) /**< \brief (TC2) COUNT32 Compare/Capture 0 */
+#define REG_TC2_COUNT32_CC1        (0x4200281C) /**< \brief (TC2) COUNT32 Compare/Capture 1 */
+#define REG_TC2_COUNT8_COUNT       (0x42002810) /**< \brief (TC2) COUNT8 Counter Value */
+#define REG_TC2_COUNT8_PER         (0x42002814) /**< \brief (TC2) COUNT8 Period Value */
+#define REG_TC2_COUNT8_CC0         (0x42002818) /**< \brief (TC2) COUNT8 Compare/Capture 0 */
+#define REG_TC2_COUNT8_CC1         (0x42002819) /**< \brief (TC2) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC2_CTRLA              (*(RwReg16*)0x42002800UL) /**< \brief (TC2) Control A */
+#define REG_TC2_READREQ            (*(RwReg16*)0x42002802UL) /**< \brief (TC2) Read Request */
+#define REG_TC2_CTRLBCLR           (*(RwReg8 *)0x42002804UL) /**< \brief (TC2) Control B Clear */
+#define REG_TC2_CTRLBSET           (*(RwReg8 *)0x42002805UL) /**< \brief (TC2) Control B Set */
+#define REG_TC2_CTRLC              (*(RwReg8 *)0x42002806UL) /**< \brief (TC2) Control C */
+#define REG_TC2_DBGCTRL            (*(RwReg8 *)0x42002808UL) /**< \brief (TC2) Debug Control */
+#define REG_TC2_EVCTRL             (*(RwReg16*)0x4200280AUL) /**< \brief (TC2) Event Control */
+#define REG_TC2_INTENCLR           (*(RwReg8 *)0x4200280CUL) /**< \brief (TC2) Interrupt Enable Clear */
+#define REG_TC2_INTENSET           (*(RwReg8 *)0x4200280DUL) /**< \brief (TC2) Interrupt Enable Set */
+#define REG_TC2_INTFLAG            (*(RwReg8 *)0x4200280EUL) /**< \brief (TC2) Interrupt Flag Status and Clear */
+#define REG_TC2_STATUS             (*(RoReg8 *)0x4200280FUL) /**< \brief (TC2) Status */
+#define REG_TC2_COUNT16_COUNT      (*(RwReg16*)0x42002810UL) /**< \brief (TC2) COUNT16 Counter Value */
+#define REG_TC2_COUNT16_CC0        (*(RwReg16*)0x42002818UL) /**< \brief (TC2) COUNT16 Compare/Capture 0 */
+#define REG_TC2_COUNT16_CC1        (*(RwReg16*)0x4200281AUL) /**< \brief (TC2) COUNT16 Compare/Capture 1 */
+#define REG_TC2_COUNT32_COUNT      (*(RwReg  *)0x42002810UL) /**< \brief (TC2) COUNT32 Counter Value */
+#define REG_TC2_COUNT32_CC0        (*(RwReg  *)0x42002818UL) /**< \brief (TC2) COUNT32 Compare/Capture 0 */
+#define REG_TC2_COUNT32_CC1        (*(RwReg  *)0x4200281CUL) /**< \brief (TC2) COUNT32 Compare/Capture 1 */
+#define REG_TC2_COUNT8_COUNT       (*(RwReg8 *)0x42002810UL) /**< \brief (TC2) COUNT8 Counter Value */
+#define REG_TC2_COUNT8_PER         (*(RwReg8 *)0x42002814UL) /**< \brief (TC2) COUNT8 Period Value */
+#define REG_TC2_COUNT8_CC0         (*(RwReg8 *)0x42002818UL) /**< \brief (TC2) COUNT8 Compare/Capture 0 */
+#define REG_TC2_COUNT8_CC1         (*(RwReg8 *)0x42002819UL) /**< \brief (TC2) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC2 peripheral ========== */
+#define TC2_CC8_NUM                 2       
+#define TC2_CC16_NUM                2       
+#define TC2_CC32_NUM                2       
+#define TC2_DITHERING_EXT           0       
+#define TC2_GCLK_ID                 20      
+#define TC2_MASTER                  1       
+#define TC2_OW_NUM                  2       
+#define TC2_PERIOD_EXT              0       
+#define TC2_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC2_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/tc3.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/tc3.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC3
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC3_INSTANCE_
+#define _SAMD20_TC3_INSTANCE_
+
+/* ========== Register definition for TC3 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC3_CTRLA              (0x42002C00) /**< \brief (TC3) Control A */
+#define REG_TC3_READREQ            (0x42002C02) /**< \brief (TC3) Read Request */
+#define REG_TC3_CTRLBCLR           (0x42002C04) /**< \brief (TC3) Control B Clear */
+#define REG_TC3_CTRLBSET           (0x42002C05) /**< \brief (TC3) Control B Set */
+#define REG_TC3_CTRLC              (0x42002C06) /**< \brief (TC3) Control C */
+#define REG_TC3_DBGCTRL            (0x42002C08) /**< \brief (TC3) Debug Control */
+#define REG_TC3_EVCTRL             (0x42002C0A) /**< \brief (TC3) Event Control */
+#define REG_TC3_INTENCLR           (0x42002C0C) /**< \brief (TC3) Interrupt Enable Clear */
+#define REG_TC3_INTENSET           (0x42002C0D) /**< \brief (TC3) Interrupt Enable Set */
+#define REG_TC3_INTFLAG            (0x42002C0E) /**< \brief (TC3) Interrupt Flag Status and Clear */
+#define REG_TC3_STATUS             (0x42002C0F) /**< \brief (TC3) Status */
+#define REG_TC3_COUNT16_COUNT      (0x42002C10) /**< \brief (TC3) COUNT16 Counter Value */
+#define REG_TC3_COUNT16_CC0        (0x42002C18) /**< \brief (TC3) COUNT16 Compare/Capture 0 */
+#define REG_TC3_COUNT16_CC1        (0x42002C1A) /**< \brief (TC3) COUNT16 Compare/Capture 1 */
+#define REG_TC3_COUNT32_COUNT      (0x42002C10) /**< \brief (TC3) COUNT32 Counter Value */
+#define REG_TC3_COUNT32_CC0        (0x42002C18) /**< \brief (TC3) COUNT32 Compare/Capture 0 */
+#define REG_TC3_COUNT32_CC1        (0x42002C1C) /**< \brief (TC3) COUNT32 Compare/Capture 1 */
+#define REG_TC3_COUNT8_COUNT       (0x42002C10) /**< \brief (TC3) COUNT8 Counter Value */
+#define REG_TC3_COUNT8_PER         (0x42002C14) /**< \brief (TC3) COUNT8 Period Value */
+#define REG_TC3_COUNT8_CC0         (0x42002C18) /**< \brief (TC3) COUNT8 Compare/Capture 0 */
+#define REG_TC3_COUNT8_CC1         (0x42002C19) /**< \brief (TC3) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC3_CTRLA              (*(RwReg16*)0x42002C00UL) /**< \brief (TC3) Control A */
+#define REG_TC3_READREQ            (*(RwReg16*)0x42002C02UL) /**< \brief (TC3) Read Request */
+#define REG_TC3_CTRLBCLR           (*(RwReg8 *)0x42002C04UL) /**< \brief (TC3) Control B Clear */
+#define REG_TC3_CTRLBSET           (*(RwReg8 *)0x42002C05UL) /**< \brief (TC3) Control B Set */
+#define REG_TC3_CTRLC              (*(RwReg8 *)0x42002C06UL) /**< \brief (TC3) Control C */
+#define REG_TC3_DBGCTRL            (*(RwReg8 *)0x42002C08UL) /**< \brief (TC3) Debug Control */
+#define REG_TC3_EVCTRL             (*(RwReg16*)0x42002C0AUL) /**< \brief (TC3) Event Control */
+#define REG_TC3_INTENCLR           (*(RwReg8 *)0x42002C0CUL) /**< \brief (TC3) Interrupt Enable Clear */
+#define REG_TC3_INTENSET           (*(RwReg8 *)0x42002C0DUL) /**< \brief (TC3) Interrupt Enable Set */
+#define REG_TC3_INTFLAG            (*(RwReg8 *)0x42002C0EUL) /**< \brief (TC3) Interrupt Flag Status and Clear */
+#define REG_TC3_STATUS             (*(RoReg8 *)0x42002C0FUL) /**< \brief (TC3) Status */
+#define REG_TC3_COUNT16_COUNT      (*(RwReg16*)0x42002C10UL) /**< \brief (TC3) COUNT16 Counter Value */
+#define REG_TC3_COUNT16_CC0        (*(RwReg16*)0x42002C18UL) /**< \brief (TC3) COUNT16 Compare/Capture 0 */
+#define REG_TC3_COUNT16_CC1        (*(RwReg16*)0x42002C1AUL) /**< \brief (TC3) COUNT16 Compare/Capture 1 */
+#define REG_TC3_COUNT32_COUNT      (*(RwReg  *)0x42002C10UL) /**< \brief (TC3) COUNT32 Counter Value */
+#define REG_TC3_COUNT32_CC0        (*(RwReg  *)0x42002C18UL) /**< \brief (TC3) COUNT32 Compare/Capture 0 */
+#define REG_TC3_COUNT32_CC1        (*(RwReg  *)0x42002C1CUL) /**< \brief (TC3) COUNT32 Compare/Capture 1 */
+#define REG_TC3_COUNT8_COUNT       (*(RwReg8 *)0x42002C10UL) /**< \brief (TC3) COUNT8 Counter Value */
+#define REG_TC3_COUNT8_PER         (*(RwReg8 *)0x42002C14UL) /**< \brief (TC3) COUNT8 Period Value */
+#define REG_TC3_COUNT8_CC0         (*(RwReg8 *)0x42002C18UL) /**< \brief (TC3) COUNT8 Compare/Capture 0 */
+#define REG_TC3_COUNT8_CC1         (*(RwReg8 *)0x42002C19UL) /**< \brief (TC3) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC3 peripheral ========== */
+#define TC3_CC8_NUM                 2       
+#define TC3_CC16_NUM                2       
+#define TC3_CC32_NUM                2       
+#define TC3_DITHERING_EXT           0       
+#define TC3_GCLK_ID                 20      
+#define TC3_MASTER                  0       
+#define TC3_OW_NUM                  2       
+#define TC3_PERIOD_EXT              0       
+#define TC3_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC3_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/tc4.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/tc4.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC4
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC4_INSTANCE_
+#define _SAMD20_TC4_INSTANCE_
+
+/* ========== Register definition for TC4 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC4_CTRLA              (0x42003000) /**< \brief (TC4) Control A */
+#define REG_TC4_READREQ            (0x42003002) /**< \brief (TC4) Read Request */
+#define REG_TC4_CTRLBCLR           (0x42003004) /**< \brief (TC4) Control B Clear */
+#define REG_TC4_CTRLBSET           (0x42003005) /**< \brief (TC4) Control B Set */
+#define REG_TC4_CTRLC              (0x42003006) /**< \brief (TC4) Control C */
+#define REG_TC4_DBGCTRL            (0x42003008) /**< \brief (TC4) Debug Control */
+#define REG_TC4_EVCTRL             (0x4200300A) /**< \brief (TC4) Event Control */
+#define REG_TC4_INTENCLR           (0x4200300C) /**< \brief (TC4) Interrupt Enable Clear */
+#define REG_TC4_INTENSET           (0x4200300D) /**< \brief (TC4) Interrupt Enable Set */
+#define REG_TC4_INTFLAG            (0x4200300E) /**< \brief (TC4) Interrupt Flag Status and Clear */
+#define REG_TC4_STATUS             (0x4200300F) /**< \brief (TC4) Status */
+#define REG_TC4_COUNT16_COUNT      (0x42003010) /**< \brief (TC4) COUNT16 Counter Value */
+#define REG_TC4_COUNT16_CC0        (0x42003018) /**< \brief (TC4) COUNT16 Compare/Capture 0 */
+#define REG_TC4_COUNT16_CC1        (0x4200301A) /**< \brief (TC4) COUNT16 Compare/Capture 1 */
+#define REG_TC4_COUNT32_COUNT      (0x42003010) /**< \brief (TC4) COUNT32 Counter Value */
+#define REG_TC4_COUNT32_CC0        (0x42003018) /**< \brief (TC4) COUNT32 Compare/Capture 0 */
+#define REG_TC4_COUNT32_CC1        (0x4200301C) /**< \brief (TC4) COUNT32 Compare/Capture 1 */
+#define REG_TC4_COUNT8_COUNT       (0x42003010) /**< \brief (TC4) COUNT8 Counter Value */
+#define REG_TC4_COUNT8_PER         (0x42003014) /**< \brief (TC4) COUNT8 Period Value */
+#define REG_TC4_COUNT8_CC0         (0x42003018) /**< \brief (TC4) COUNT8 Compare/Capture 0 */
+#define REG_TC4_COUNT8_CC1         (0x42003019) /**< \brief (TC4) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC4_CTRLA              (*(RwReg16*)0x42003000UL) /**< \brief (TC4) Control A */
+#define REG_TC4_READREQ            (*(RwReg16*)0x42003002UL) /**< \brief (TC4) Read Request */
+#define REG_TC4_CTRLBCLR           (*(RwReg8 *)0x42003004UL) /**< \brief (TC4) Control B Clear */
+#define REG_TC4_CTRLBSET           (*(RwReg8 *)0x42003005UL) /**< \brief (TC4) Control B Set */
+#define REG_TC4_CTRLC              (*(RwReg8 *)0x42003006UL) /**< \brief (TC4) Control C */
+#define REG_TC4_DBGCTRL            (*(RwReg8 *)0x42003008UL) /**< \brief (TC4) Debug Control */
+#define REG_TC4_EVCTRL             (*(RwReg16*)0x4200300AUL) /**< \brief (TC4) Event Control */
+#define REG_TC4_INTENCLR           (*(RwReg8 *)0x4200300CUL) /**< \brief (TC4) Interrupt Enable Clear */
+#define REG_TC4_INTENSET           (*(RwReg8 *)0x4200300DUL) /**< \brief (TC4) Interrupt Enable Set */
+#define REG_TC4_INTFLAG            (*(RwReg8 *)0x4200300EUL) /**< \brief (TC4) Interrupt Flag Status and Clear */
+#define REG_TC4_STATUS             (*(RoReg8 *)0x4200300FUL) /**< \brief (TC4) Status */
+#define REG_TC4_COUNT16_COUNT      (*(RwReg16*)0x42003010UL) /**< \brief (TC4) COUNT16 Counter Value */
+#define REG_TC4_COUNT16_CC0        (*(RwReg16*)0x42003018UL) /**< \brief (TC4) COUNT16 Compare/Capture 0 */
+#define REG_TC4_COUNT16_CC1        (*(RwReg16*)0x4200301AUL) /**< \brief (TC4) COUNT16 Compare/Capture 1 */
+#define REG_TC4_COUNT32_COUNT      (*(RwReg  *)0x42003010UL) /**< \brief (TC4) COUNT32 Counter Value */
+#define REG_TC4_COUNT32_CC0        (*(RwReg  *)0x42003018UL) /**< \brief (TC4) COUNT32 Compare/Capture 0 */
+#define REG_TC4_COUNT32_CC1        (*(RwReg  *)0x4200301CUL) /**< \brief (TC4) COUNT32 Compare/Capture 1 */
+#define REG_TC4_COUNT8_COUNT       (*(RwReg8 *)0x42003010UL) /**< \brief (TC4) COUNT8 Counter Value */
+#define REG_TC4_COUNT8_PER         (*(RwReg8 *)0x42003014UL) /**< \brief (TC4) COUNT8 Period Value */
+#define REG_TC4_COUNT8_CC0         (*(RwReg8 *)0x42003018UL) /**< \brief (TC4) COUNT8 Compare/Capture 0 */
+#define REG_TC4_COUNT8_CC1         (*(RwReg8 *)0x42003019UL) /**< \brief (TC4) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC4 peripheral ========== */
+#define TC4_CC8_NUM                 2       
+#define TC4_CC16_NUM                2       
+#define TC4_CC32_NUM                2       
+#define TC4_DITHERING_EXT           0       
+#define TC4_GCLK_ID                 21      
+#define TC4_MASTER                  1       
+#define TC4_OW_NUM                  2       
+#define TC4_PERIOD_EXT              0       
+#define TC4_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC4_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/tc5.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/tc5.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC5
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC5_INSTANCE_
+#define _SAMD20_TC5_INSTANCE_
+
+/* ========== Register definition for TC5 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC5_CTRLA              (0x42003400) /**< \brief (TC5) Control A */
+#define REG_TC5_READREQ            (0x42003402) /**< \brief (TC5) Read Request */
+#define REG_TC5_CTRLBCLR           (0x42003404) /**< \brief (TC5) Control B Clear */
+#define REG_TC5_CTRLBSET           (0x42003405) /**< \brief (TC5) Control B Set */
+#define REG_TC5_CTRLC              (0x42003406) /**< \brief (TC5) Control C */
+#define REG_TC5_DBGCTRL            (0x42003408) /**< \brief (TC5) Debug Control */
+#define REG_TC5_EVCTRL             (0x4200340A) /**< \brief (TC5) Event Control */
+#define REG_TC5_INTENCLR           (0x4200340C) /**< \brief (TC5) Interrupt Enable Clear */
+#define REG_TC5_INTENSET           (0x4200340D) /**< \brief (TC5) Interrupt Enable Set */
+#define REG_TC5_INTFLAG            (0x4200340E) /**< \brief (TC5) Interrupt Flag Status and Clear */
+#define REG_TC5_STATUS             (0x4200340F) /**< \brief (TC5) Status */
+#define REG_TC5_COUNT16_COUNT      (0x42003410) /**< \brief (TC5) COUNT16 Counter Value */
+#define REG_TC5_COUNT16_CC0        (0x42003418) /**< \brief (TC5) COUNT16 Compare/Capture 0 */
+#define REG_TC5_COUNT16_CC1        (0x4200341A) /**< \brief (TC5) COUNT16 Compare/Capture 1 */
+#define REG_TC5_COUNT32_COUNT      (0x42003410) /**< \brief (TC5) COUNT32 Counter Value */
+#define REG_TC5_COUNT32_CC0        (0x42003418) /**< \brief (TC5) COUNT32 Compare/Capture 0 */
+#define REG_TC5_COUNT32_CC1        (0x4200341C) /**< \brief (TC5) COUNT32 Compare/Capture 1 */
+#define REG_TC5_COUNT8_COUNT       (0x42003410) /**< \brief (TC5) COUNT8 Counter Value */
+#define REG_TC5_COUNT8_PER         (0x42003414) /**< \brief (TC5) COUNT8 Period Value */
+#define REG_TC5_COUNT8_CC0         (0x42003418) /**< \brief (TC5) COUNT8 Compare/Capture 0 */
+#define REG_TC5_COUNT8_CC1         (0x42003419) /**< \brief (TC5) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC5_CTRLA              (*(RwReg16*)0x42003400UL) /**< \brief (TC5) Control A */
+#define REG_TC5_READREQ            (*(RwReg16*)0x42003402UL) /**< \brief (TC5) Read Request */
+#define REG_TC5_CTRLBCLR           (*(RwReg8 *)0x42003404UL) /**< \brief (TC5) Control B Clear */
+#define REG_TC5_CTRLBSET           (*(RwReg8 *)0x42003405UL) /**< \brief (TC5) Control B Set */
+#define REG_TC5_CTRLC              (*(RwReg8 *)0x42003406UL) /**< \brief (TC5) Control C */
+#define REG_TC5_DBGCTRL            (*(RwReg8 *)0x42003408UL) /**< \brief (TC5) Debug Control */
+#define REG_TC5_EVCTRL             (*(RwReg16*)0x4200340AUL) /**< \brief (TC5) Event Control */
+#define REG_TC5_INTENCLR           (*(RwReg8 *)0x4200340CUL) /**< \brief (TC5) Interrupt Enable Clear */
+#define REG_TC5_INTENSET           (*(RwReg8 *)0x4200340DUL) /**< \brief (TC5) Interrupt Enable Set */
+#define REG_TC5_INTFLAG            (*(RwReg8 *)0x4200340EUL) /**< \brief (TC5) Interrupt Flag Status and Clear */
+#define REG_TC5_STATUS             (*(RoReg8 *)0x4200340FUL) /**< \brief (TC5) Status */
+#define REG_TC5_COUNT16_COUNT      (*(RwReg16*)0x42003410UL) /**< \brief (TC5) COUNT16 Counter Value */
+#define REG_TC5_COUNT16_CC0        (*(RwReg16*)0x42003418UL) /**< \brief (TC5) COUNT16 Compare/Capture 0 */
+#define REG_TC5_COUNT16_CC1        (*(RwReg16*)0x4200341AUL) /**< \brief (TC5) COUNT16 Compare/Capture 1 */
+#define REG_TC5_COUNT32_COUNT      (*(RwReg  *)0x42003410UL) /**< \brief (TC5) COUNT32 Counter Value */
+#define REG_TC5_COUNT32_CC0        (*(RwReg  *)0x42003418UL) /**< \brief (TC5) COUNT32 Compare/Capture 0 */
+#define REG_TC5_COUNT32_CC1        (*(RwReg  *)0x4200341CUL) /**< \brief (TC5) COUNT32 Compare/Capture 1 */
+#define REG_TC5_COUNT8_COUNT       (*(RwReg8 *)0x42003410UL) /**< \brief (TC5) COUNT8 Counter Value */
+#define REG_TC5_COUNT8_PER         (*(RwReg8 *)0x42003414UL) /**< \brief (TC5) COUNT8 Period Value */
+#define REG_TC5_COUNT8_CC0         (*(RwReg8 *)0x42003418UL) /**< \brief (TC5) COUNT8 Compare/Capture 0 */
+#define REG_TC5_COUNT8_CC1         (*(RwReg8 *)0x42003419UL) /**< \brief (TC5) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC5 peripheral ========== */
+#define TC5_CC8_NUM                 2       
+#define TC5_CC16_NUM                2       
+#define TC5_CC32_NUM                2       
+#define TC5_DITHERING_EXT           0       
+#define TC5_GCLK_ID                 21      
+#define TC5_MASTER                  0       
+#define TC5_OW_NUM                  2       
+#define TC5_PERIOD_EXT              0       
+#define TC5_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC5_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/tc6.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/tc6.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC6
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC6_INSTANCE_
+#define _SAMD20_TC6_INSTANCE_
+
+/* ========== Register definition for TC6 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC6_CTRLA              (0x42003800) /**< \brief (TC6) Control A */
+#define REG_TC6_READREQ            (0x42003802) /**< \brief (TC6) Read Request */
+#define REG_TC6_CTRLBCLR           (0x42003804) /**< \brief (TC6) Control B Clear */
+#define REG_TC6_CTRLBSET           (0x42003805) /**< \brief (TC6) Control B Set */
+#define REG_TC6_CTRLC              (0x42003806) /**< \brief (TC6) Control C */
+#define REG_TC6_DBGCTRL            (0x42003808) /**< \brief (TC6) Debug Control */
+#define REG_TC6_EVCTRL             (0x4200380A) /**< \brief (TC6) Event Control */
+#define REG_TC6_INTENCLR           (0x4200380C) /**< \brief (TC6) Interrupt Enable Clear */
+#define REG_TC6_INTENSET           (0x4200380D) /**< \brief (TC6) Interrupt Enable Set */
+#define REG_TC6_INTFLAG            (0x4200380E) /**< \brief (TC6) Interrupt Flag Status and Clear */
+#define REG_TC6_STATUS             (0x4200380F) /**< \brief (TC6) Status */
+#define REG_TC6_COUNT16_COUNT      (0x42003810) /**< \brief (TC6) COUNT16 Counter Value */
+#define REG_TC6_COUNT16_CC0        (0x42003818) /**< \brief (TC6) COUNT16 Compare/Capture 0 */
+#define REG_TC6_COUNT16_CC1        (0x4200381A) /**< \brief (TC6) COUNT16 Compare/Capture 1 */
+#define REG_TC6_COUNT32_COUNT      (0x42003810) /**< \brief (TC6) COUNT32 Counter Value */
+#define REG_TC6_COUNT32_CC0        (0x42003818) /**< \brief (TC6) COUNT32 Compare/Capture 0 */
+#define REG_TC6_COUNT32_CC1        (0x4200381C) /**< \brief (TC6) COUNT32 Compare/Capture 1 */
+#define REG_TC6_COUNT8_COUNT       (0x42003810) /**< \brief (TC6) COUNT8 Counter Value */
+#define REG_TC6_COUNT8_PER         (0x42003814) /**< \brief (TC6) COUNT8 Period Value */
+#define REG_TC6_COUNT8_CC0         (0x42003818) /**< \brief (TC6) COUNT8 Compare/Capture 0 */
+#define REG_TC6_COUNT8_CC1         (0x42003819) /**< \brief (TC6) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC6_CTRLA              (*(RwReg16*)0x42003800UL) /**< \brief (TC6) Control A */
+#define REG_TC6_READREQ            (*(RwReg16*)0x42003802UL) /**< \brief (TC6) Read Request */
+#define REG_TC6_CTRLBCLR           (*(RwReg8 *)0x42003804UL) /**< \brief (TC6) Control B Clear */
+#define REG_TC6_CTRLBSET           (*(RwReg8 *)0x42003805UL) /**< \brief (TC6) Control B Set */
+#define REG_TC6_CTRLC              (*(RwReg8 *)0x42003806UL) /**< \brief (TC6) Control C */
+#define REG_TC6_DBGCTRL            (*(RwReg8 *)0x42003808UL) /**< \brief (TC6) Debug Control */
+#define REG_TC6_EVCTRL             (*(RwReg16*)0x4200380AUL) /**< \brief (TC6) Event Control */
+#define REG_TC6_INTENCLR           (*(RwReg8 *)0x4200380CUL) /**< \brief (TC6) Interrupt Enable Clear */
+#define REG_TC6_INTENSET           (*(RwReg8 *)0x4200380DUL) /**< \brief (TC6) Interrupt Enable Set */
+#define REG_TC6_INTFLAG            (*(RwReg8 *)0x4200380EUL) /**< \brief (TC6) Interrupt Flag Status and Clear */
+#define REG_TC6_STATUS             (*(RoReg8 *)0x4200380FUL) /**< \brief (TC6) Status */
+#define REG_TC6_COUNT16_COUNT      (*(RwReg16*)0x42003810UL) /**< \brief (TC6) COUNT16 Counter Value */
+#define REG_TC6_COUNT16_CC0        (*(RwReg16*)0x42003818UL) /**< \brief (TC6) COUNT16 Compare/Capture 0 */
+#define REG_TC6_COUNT16_CC1        (*(RwReg16*)0x4200381AUL) /**< \brief (TC6) COUNT16 Compare/Capture 1 */
+#define REG_TC6_COUNT32_COUNT      (*(RwReg  *)0x42003810UL) /**< \brief (TC6) COUNT32 Counter Value */
+#define REG_TC6_COUNT32_CC0        (*(RwReg  *)0x42003818UL) /**< \brief (TC6) COUNT32 Compare/Capture 0 */
+#define REG_TC6_COUNT32_CC1        (*(RwReg  *)0x4200381CUL) /**< \brief (TC6) COUNT32 Compare/Capture 1 */
+#define REG_TC6_COUNT8_COUNT       (*(RwReg8 *)0x42003810UL) /**< \brief (TC6) COUNT8 Counter Value */
+#define REG_TC6_COUNT8_PER         (*(RwReg8 *)0x42003814UL) /**< \brief (TC6) COUNT8 Period Value */
+#define REG_TC6_COUNT8_CC0         (*(RwReg8 *)0x42003818UL) /**< \brief (TC6) COUNT8 Compare/Capture 0 */
+#define REG_TC6_COUNT8_CC1         (*(RwReg8 *)0x42003819UL) /**< \brief (TC6) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC6 peripheral ========== */
+#define TC6_CC8_NUM                 2       
+#define TC6_CC16_NUM                2       
+#define TC6_CC32_NUM                2       
+#define TC6_DITHERING_EXT           0       
+#define TC6_GCLK_ID                 22      
+#define TC6_MASTER                  1       
+#define TC6_OW_NUM                  2       
+#define TC6_PERIOD_EXT              0       
+#define TC6_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC6_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/tc7.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/tc7.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC7
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC7_INSTANCE_
+#define _SAMD20_TC7_INSTANCE_
+
+/* ========== Register definition for TC7 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC7_CTRLA              (0x42003C00) /**< \brief (TC7) Control A */
+#define REG_TC7_READREQ            (0x42003C02) /**< \brief (TC7) Read Request */
+#define REG_TC7_CTRLBCLR           (0x42003C04) /**< \brief (TC7) Control B Clear */
+#define REG_TC7_CTRLBSET           (0x42003C05) /**< \brief (TC7) Control B Set */
+#define REG_TC7_CTRLC              (0x42003C06) /**< \brief (TC7) Control C */
+#define REG_TC7_DBGCTRL            (0x42003C08) /**< \brief (TC7) Debug Control */
+#define REG_TC7_EVCTRL             (0x42003C0A) /**< \brief (TC7) Event Control */
+#define REG_TC7_INTENCLR           (0x42003C0C) /**< \brief (TC7) Interrupt Enable Clear */
+#define REG_TC7_INTENSET           (0x42003C0D) /**< \brief (TC7) Interrupt Enable Set */
+#define REG_TC7_INTFLAG            (0x42003C0E) /**< \brief (TC7) Interrupt Flag Status and Clear */
+#define REG_TC7_STATUS             (0x42003C0F) /**< \brief (TC7) Status */
+#define REG_TC7_COUNT16_COUNT      (0x42003C10) /**< \brief (TC7) COUNT16 Counter Value */
+#define REG_TC7_COUNT16_CC0        (0x42003C18) /**< \brief (TC7) COUNT16 Compare/Capture 0 */
+#define REG_TC7_COUNT16_CC1        (0x42003C1A) /**< \brief (TC7) COUNT16 Compare/Capture 1 */
+#define REG_TC7_COUNT32_COUNT      (0x42003C10) /**< \brief (TC7) COUNT32 Counter Value */
+#define REG_TC7_COUNT32_CC0        (0x42003C18) /**< \brief (TC7) COUNT32 Compare/Capture 0 */
+#define REG_TC7_COUNT32_CC1        (0x42003C1C) /**< \brief (TC7) COUNT32 Compare/Capture 1 */
+#define REG_TC7_COUNT8_COUNT       (0x42003C10) /**< \brief (TC7) COUNT8 Counter Value */
+#define REG_TC7_COUNT8_PER         (0x42003C14) /**< \brief (TC7) COUNT8 Period Value */
+#define REG_TC7_COUNT8_CC0         (0x42003C18) /**< \brief (TC7) COUNT8 Compare/Capture 0 */
+#define REG_TC7_COUNT8_CC1         (0x42003C19) /**< \brief (TC7) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC7_CTRLA              (*(RwReg16*)0x42003C00UL) /**< \brief (TC7) Control A */
+#define REG_TC7_READREQ            (*(RwReg16*)0x42003C02UL) /**< \brief (TC7) Read Request */
+#define REG_TC7_CTRLBCLR           (*(RwReg8 *)0x42003C04UL) /**< \brief (TC7) Control B Clear */
+#define REG_TC7_CTRLBSET           (*(RwReg8 *)0x42003C05UL) /**< \brief (TC7) Control B Set */
+#define REG_TC7_CTRLC              (*(RwReg8 *)0x42003C06UL) /**< \brief (TC7) Control C */
+#define REG_TC7_DBGCTRL            (*(RwReg8 *)0x42003C08UL) /**< \brief (TC7) Debug Control */
+#define REG_TC7_EVCTRL             (*(RwReg16*)0x42003C0AUL) /**< \brief (TC7) Event Control */
+#define REG_TC7_INTENCLR           (*(RwReg8 *)0x42003C0CUL) /**< \brief (TC7) Interrupt Enable Clear */
+#define REG_TC7_INTENSET           (*(RwReg8 *)0x42003C0DUL) /**< \brief (TC7) Interrupt Enable Set */
+#define REG_TC7_INTFLAG            (*(RwReg8 *)0x42003C0EUL) /**< \brief (TC7) Interrupt Flag Status and Clear */
+#define REG_TC7_STATUS             (*(RoReg8 *)0x42003C0FUL) /**< \brief (TC7) Status */
+#define REG_TC7_COUNT16_COUNT      (*(RwReg16*)0x42003C10UL) /**< \brief (TC7) COUNT16 Counter Value */
+#define REG_TC7_COUNT16_CC0        (*(RwReg16*)0x42003C18UL) /**< \brief (TC7) COUNT16 Compare/Capture 0 */
+#define REG_TC7_COUNT16_CC1        (*(RwReg16*)0x42003C1AUL) /**< \brief (TC7) COUNT16 Compare/Capture 1 */
+#define REG_TC7_COUNT32_COUNT      (*(RwReg  *)0x42003C10UL) /**< \brief (TC7) COUNT32 Counter Value */
+#define REG_TC7_COUNT32_CC0        (*(RwReg  *)0x42003C18UL) /**< \brief (TC7) COUNT32 Compare/Capture 0 */
+#define REG_TC7_COUNT32_CC1        (*(RwReg  *)0x42003C1CUL) /**< \brief (TC7) COUNT32 Compare/Capture 1 */
+#define REG_TC7_COUNT8_COUNT       (*(RwReg8 *)0x42003C10UL) /**< \brief (TC7) COUNT8 Counter Value */
+#define REG_TC7_COUNT8_PER         (*(RwReg8 *)0x42003C14UL) /**< \brief (TC7) COUNT8 Period Value */
+#define REG_TC7_COUNT8_CC0         (*(RwReg8 *)0x42003C18UL) /**< \brief (TC7) COUNT8 Compare/Capture 0 */
+#define REG_TC7_COUNT8_CC1         (*(RwReg8 *)0x42003C19UL) /**< \brief (TC7) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC7 peripheral ========== */
+#define TC7_CC8_NUM                 2       
+#define TC7_CC16_NUM                2       
+#define TC7_CC32_NUM                2       
+#define TC7_DITHERING_EXT           0       
+#define TC7_GCLK_ID                 22      
+#define TC7_MASTER                  0       
+#define TC7_OW_NUM                  2       
+#define TC7_PERIOD_EXT              0       
+#define TC7_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC7_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/instance/wdt.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/instance/wdt.h
@@ -1,0 +1,57 @@
+/**
+ * \file
+ *
+ * \brief Instance description for WDT
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_WDT_INSTANCE_
+#define _SAMD20_WDT_INSTANCE_
+
+/* ========== Register definition for WDT peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_WDT_CTRL               (0x40001000) /**< \brief (WDT) Control */
+#define REG_WDT_CONFIG             (0x40001001) /**< \brief (WDT) Configuration */
+#define REG_WDT_EWCTRL             (0x40001002) /**< \brief (WDT) Early Warning Interrupt Control */
+#define REG_WDT_INTENCLR           (0x40001004) /**< \brief (WDT) Interrupt Enable Clear */
+#define REG_WDT_INTENSET           (0x40001005) /**< \brief (WDT) Interrupt Enable Set */
+#define REG_WDT_INTFLAG            (0x40001006) /**< \brief (WDT) Interrupt Flag Status and Clear */
+#define REG_WDT_STATUS             (0x40001007) /**< \brief (WDT) Status */
+#define REG_WDT_CLEAR              (0x40001008) /**< \brief (WDT) Clear */
+#else
+#define REG_WDT_CTRL               (*(RwReg8 *)0x40001000UL) /**< \brief (WDT) Control */
+#define REG_WDT_CONFIG             (*(RwReg8 *)0x40001001UL) /**< \brief (WDT) Configuration */
+#define REG_WDT_EWCTRL             (*(RwReg8 *)0x40001002UL) /**< \brief (WDT) Early Warning Interrupt Control */
+#define REG_WDT_INTENCLR           (*(RwReg8 *)0x40001004UL) /**< \brief (WDT) Interrupt Enable Clear */
+#define REG_WDT_INTENSET           (*(RwReg8 *)0x40001005UL) /**< \brief (WDT) Interrupt Enable Set */
+#define REG_WDT_INTFLAG            (*(RwReg8 *)0x40001006UL) /**< \brief (WDT) Interrupt Flag Status and Clear */
+#define REG_WDT_STATUS             (*(RoReg8 *)0x40001007UL) /**< \brief (WDT) Status */
+#define REG_WDT_CLEAR              (*(WoReg8 *)0x40001008UL) /**< \brief (WDT) Clear */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for WDT peripheral ========== */
+#define WDT_GCLK_ID                 1        // Index of Generic Clock
+
+#endif /* _SAMD20_WDT_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20e14.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20e14.h
@@ -1,0 +1,558 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20E14
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E14_PIO_
+#define _SAMD20E14_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20E14_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20e15.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20e15.h
@@ -1,0 +1,558 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20E15
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E15_PIO_
+#define _SAMD20E15_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20E15_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20e16.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20e16.h
@@ -1,0 +1,558 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20E16
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E16_PIO_
+#define _SAMD20E16_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20E16_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20e17.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20e17.h
@@ -1,0 +1,558 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20E17
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E17_PIO_
+#define _SAMD20E17_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20E17_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20e18.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20e18.h
@@ -1,0 +1,558 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20E18
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E18_PIO_
+#define _SAMD20E18_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20E18_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20g14.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20g14.h
@@ -1,0 +1,804 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20G14
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G14_PIO_
+#define _SAMD20G14_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20G14_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20g15.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20g15.h
@@ -1,0 +1,804 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20G15
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G15_PIO_
+#define _SAMD20G15_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20G15_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20g16.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20g16.h
@@ -1,0 +1,804 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20G16
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G16_PIO_
+#define _SAMD20G16_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20G16_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20g17.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20g17.h
@@ -1,0 +1,804 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20G17
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G17_PIO_
+#define _SAMD20G17_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20G17_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20g17u.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20g17u.h
@@ -1,0 +1,747 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20G17U
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G17U_PIO_
+#define _SAMD20G17U_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB04                           36  /**< \brief Pin Number for PB04 */
+#define PORT_PB04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PB04 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PB04A_EIC_EXTINT4          _L_(36) /**< \brief EIC signal: EXTINT4 on PB04 mux A */
+#define MUX_PB04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PB04A_EIC_EXTINT4   ((PIN_PB04A_EIC_EXTINT4 << 16) | MUX_PB04A_EIC_EXTINT4)
+#define PORT_PB04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PB04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PB04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PB04B_ADC_AIN12            _L_(36) /**< \brief ADC signal: AIN12 on PB04 mux B */
+#define MUX_PB04B_ADC_AIN12             _L_(1)
+#define PINMUX_PB04B_ADC_AIN12     ((PIN_PB04B_ADC_AIN12 << 16) | MUX_PB04B_ADC_AIN12)
+#define PORT_PB04B_ADC_AIN12   (_UL_(1) <<  4)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20G17U_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20g18.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20g18.h
@@ -1,0 +1,804 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20G18
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G18_PIO_
+#define _SAMD20G18_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20G18_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20g18u.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20g18u.h
@@ -1,0 +1,747 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20G18U
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G18U_PIO_
+#define _SAMD20G18U_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB04                           36  /**< \brief Pin Number for PB04 */
+#define PORT_PB04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PB04 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PB04A_EIC_EXTINT4          _L_(36) /**< \brief EIC signal: EXTINT4 on PB04 mux A */
+#define MUX_PB04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PB04A_EIC_EXTINT4   ((PIN_PB04A_EIC_EXTINT4 << 16) | MUX_PB04A_EIC_EXTINT4)
+#define PORT_PB04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PB04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PB04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PB04B_ADC_AIN12            _L_(36) /**< \brief ADC signal: AIN12 on PB04 mux B */
+#define MUX_PB04B_ADC_AIN12             _L_(1)
+#define PINMUX_PB04B_ADC_AIN12     ((PIN_PB04B_ADC_AIN12 << 16) | MUX_PB04B_ADC_AIN12)
+#define PORT_PB04B_ADC_AIN12   (_UL_(1) <<  4)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20G18U_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20j14.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20j14.h
@@ -1,0 +1,1056 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20J14
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J14_PIO_
+#define _SAMD20J14_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB00                           32  /**< \brief Pin Number for PB00 */
+#define PORT_PB00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PB00 */
+#define PIN_PB01                           33  /**< \brief Pin Number for PB01 */
+#define PORT_PB01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PB01 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB04                           36  /**< \brief Pin Number for PB04 */
+#define PORT_PB04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PB04 */
+#define PIN_PB05                           37  /**< \brief Pin Number for PB05 */
+#define PORT_PB05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PB05 */
+#define PIN_PB06                           38  /**< \brief Pin Number for PB06 */
+#define PORT_PB06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PB06 */
+#define PIN_PB07                           39  /**< \brief Pin Number for PB07 */
+#define PORT_PB07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PB07 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB12                           44  /**< \brief Pin Number for PB12 */
+#define PORT_PB12              (_UL_(1) << 12) /**< \brief PORT Mask  for PB12 */
+#define PIN_PB13                           45  /**< \brief Pin Number for PB13 */
+#define PORT_PB13              (_UL_(1) << 13) /**< \brief PORT Mask  for PB13 */
+#define PIN_PB14                           46  /**< \brief Pin Number for PB14 */
+#define PORT_PB14              (_UL_(1) << 14) /**< \brief PORT Mask  for PB14 */
+#define PIN_PB15                           47  /**< \brief Pin Number for PB15 */
+#define PORT_PB15              (_UL_(1) << 15) /**< \brief PORT Mask  for PB15 */
+#define PIN_PB16                           48  /**< \brief Pin Number for PB16 */
+#define PORT_PB16              (_UL_(1) << 16) /**< \brief PORT Mask  for PB16 */
+#define PIN_PB17                           49  /**< \brief Pin Number for PB17 */
+#define PORT_PB17              (_UL_(1) << 17) /**< \brief PORT Mask  for PB17 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+#define PIN_PB30                           62  /**< \brief Pin Number for PB30 */
+#define PORT_PB30              (_UL_(1) << 30) /**< \brief PORT Mask  for PB30 */
+#define PIN_PB31                           63  /**< \brief Pin Number for PB31 */
+#define PORT_PB31              (_UL_(1) << 31) /**< \brief PORT Mask  for PB31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB14H_GCLK_IO0             _L_(46) /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0              _L_(7)
+#define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
+#define PORT_PB14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB15H_GCLK_IO1             _L_(47) /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1              _L_(7)
+#define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
+#define PORT_PB15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB16H_GCLK_IO2             _L_(48) /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2              _L_(7)
+#define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
+#define PORT_PB16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PB17H_GCLK_IO3             _L_(49) /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3              _L_(7)
+#define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
+#define PORT_PB17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PB12H_GCLK_IO6             _L_(44) /**< \brief GCLK signal: IO6 on PB12 mux H */
+#define MUX_PB12H_GCLK_IO6              _L_(7)
+#define PINMUX_PB12H_GCLK_IO6      ((PIN_PB12H_GCLK_IO6 << 16) | MUX_PB12H_GCLK_IO6)
+#define PORT_PB12H_GCLK_IO6    (_UL_(1) << 12)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+#define PIN_PB13H_GCLK_IO7             _L_(45) /**< \brief GCLK signal: IO7 on PB13 mux H */
+#define MUX_PB13H_GCLK_IO7              _L_(7)
+#define PINMUX_PB13H_GCLK_IO7      ((PIN_PB13H_GCLK_IO7 << 16) | MUX_PB13H_GCLK_IO7)
+#define PORT_PB13H_GCLK_IO7    (_UL_(1) << 13)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PB00A_EIC_EXTINT0          _L_(32) /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
+#define PORT_PB00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PB00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB00 External Interrupt Line */
+#define PIN_PB16A_EIC_EXTINT0          _L_(48) /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
+#define PORT_PB16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PB16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PB01A_EIC_EXTINT1          _L_(33) /**< \brief EIC signal: EXTINT1 on PB01 mux A */
+#define MUX_PB01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB01A_EIC_EXTINT1   ((PIN_PB01A_EIC_EXTINT1 << 16) | MUX_PB01A_EIC_EXTINT1)
+#define PORT_PB01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PB01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PB17A_EIC_EXTINT1          _L_(49) /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
+#define PORT_PB17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PB17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PB04A_EIC_EXTINT4          _L_(36) /**< \brief EIC signal: EXTINT4 on PB04 mux A */
+#define MUX_PB04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PB04A_EIC_EXTINT4   ((PIN_PB04A_EIC_EXTINT4 << 16) | MUX_PB04A_EIC_EXTINT4)
+#define PORT_PB04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PB04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PB04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PB05A_EIC_EXTINT5          _L_(37) /**< \brief EIC signal: EXTINT5 on PB05 mux A */
+#define MUX_PB05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PB05A_EIC_EXTINT5   ((PIN_PB05A_EIC_EXTINT5 << 16) | MUX_PB05A_EIC_EXTINT5)
+#define PORT_PB05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PB05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PB05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB06A_EIC_EXTINT6          _L_(38) /**< \brief EIC signal: EXTINT6 on PB06 mux A */
+#define MUX_PB06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB06A_EIC_EXTINT6   ((PIN_PB06A_EIC_EXTINT6 << 16) | MUX_PB06A_EIC_EXTINT6)
+#define PORT_PB06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PB06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB06 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB07A_EIC_EXTINT7          _L_(39) /**< \brief EIC signal: EXTINT7 on PB07 mux A */
+#define MUX_PB07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB07A_EIC_EXTINT7   ((PIN_PB07A_EIC_EXTINT7 << 16) | MUX_PB07A_EIC_EXTINT7)
+#define PORT_PB07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PB07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB07 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PB12A_EIC_EXTINT12         _L_(44) /**< \brief EIC signal: EXTINT12 on PB12 mux A */
+#define MUX_PB12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PB12A_EIC_EXTINT12  ((PIN_PB12A_EIC_EXTINT12 << 16) | MUX_PB12A_EIC_EXTINT12)
+#define PORT_PB12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PB12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PB12 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PB13A_EIC_EXTINT13         _L_(45) /**< \brief EIC signal: EXTINT13 on PB13 mux A */
+#define MUX_PB13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PB13A_EIC_EXTINT13  ((PIN_PB13A_EIC_EXTINT13 << 16) | MUX_PB13A_EIC_EXTINT13)
+#define PORT_PB13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PB13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PB13 External Interrupt Line */
+#define PIN_PB14A_EIC_EXTINT14         _L_(46) /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
+#define PORT_PB14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PB14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB14 External Interrupt Line */
+#define PIN_PB30A_EIC_EXTINT14         _L_(62) /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
+#define PORT_PB30A_EIC_EXTINT14  (_UL_(1) << 30)
+#define PIN_PB30A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB30 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PB15A_EIC_EXTINT15         _L_(47) /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
+#define PORT_PB15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PB15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB15 External Interrupt Line */
+#define PIN_PB31A_EIC_EXTINT15         _L_(63) /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
+#define PORT_PB31A_EIC_EXTINT15  (_UL_(1) << 31)
+#define PIN_PB31A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB31 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PB12C_SERCOM4_PAD0         _L_(44) /**< \brief SERCOM4 signal: PAD0 on PB12 mux C */
+#define MUX_PB12C_SERCOM4_PAD0          _L_(2)
+#define PINMUX_PB12C_SERCOM4_PAD0  ((PIN_PB12C_SERCOM4_PAD0 << 16) | MUX_PB12C_SERCOM4_PAD0)
+#define PORT_PB12C_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PB13C_SERCOM4_PAD1         _L_(45) /**< \brief SERCOM4 signal: PAD1 on PB13 mux C */
+#define MUX_PB13C_SERCOM4_PAD1          _L_(2)
+#define PINMUX_PB13C_SERCOM4_PAD1  ((PIN_PB13C_SERCOM4_PAD1 << 16) | MUX_PB13C_SERCOM4_PAD1)
+#define PORT_PB13C_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PB14C_SERCOM4_PAD2         _L_(46) /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2          _L_(2)
+#define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
+#define PORT_PB14C_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+#define PIN_PB15C_SERCOM4_PAD3         _L_(47) /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3          _L_(2)
+#define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
+#define PORT_PB15C_SERCOM4_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PB30D_SERCOM5_PAD0         _L_(62) /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
+#define PORT_PB30D_SERCOM5_PAD0  (_UL_(1) << 30)
+#define PIN_PB16C_SERCOM5_PAD0         _L_(48) /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0          _L_(2)
+#define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
+#define PORT_PB16C_SERCOM5_PAD0  (_UL_(1) << 16)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PB31D_SERCOM5_PAD1         _L_(63) /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
+#define PORT_PB31D_SERCOM5_PAD1  (_UL_(1) << 31)
+#define PIN_PB17C_SERCOM5_PAD1         _L_(49) /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1          _L_(2)
+#define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
+#define PORT_PB17C_SERCOM5_PAD1  (_UL_(1) << 17)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB00D_SERCOM5_PAD2         _L_(32) /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
+#define PORT_PB00D_SERCOM5_PAD2  (_UL_(1) <<  0)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB01D_SERCOM5_PAD3         _L_(33) /**< \brief SERCOM5 signal: PAD3 on PB01 mux D */
+#define MUX_PB01D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB01D_SERCOM5_PAD3  ((PIN_PB01D_SERCOM5_PAD3 << 16) | MUX_PB01D_SERCOM5_PAD3)
+#define PORT_PB01D_SERCOM5_PAD3  (_UL_(1) <<  1)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PB30F_TC0_WO0              _L_(62) /**< \brief TC0 signal: WO0 on PB30 mux F */
+#define MUX_PB30F_TC0_WO0               _L_(5)
+#define PINMUX_PB30F_TC0_WO0       ((PIN_PB30F_TC0_WO0 << 16) | MUX_PB30F_TC0_WO0)
+#define PORT_PB30F_TC0_WO0     (_UL_(1) << 30)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PB31F_TC0_WO1              _L_(63) /**< \brief TC0 signal: WO1 on PB31 mux F */
+#define MUX_PB31F_TC0_WO1               _L_(5)
+#define PINMUX_PB31F_TC0_WO1       ((PIN_PB31F_TC0_WO1 << 16) | MUX_PB31F_TC0_WO1)
+#define PORT_PB31F_TC0_WO1     (_UL_(1) << 31)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PB12E_TC4_WO0              _L_(44) /**< \brief TC4 signal: WO0 on PB12 mux E */
+#define MUX_PB12E_TC4_WO0               _L_(4)
+#define PINMUX_PB12E_TC4_WO0       ((PIN_PB12E_TC4_WO0 << 16) | MUX_PB12E_TC4_WO0)
+#define PORT_PB12E_TC4_WO0     (_UL_(1) << 12)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+#define PIN_PB13E_TC4_WO1              _L_(45) /**< \brief TC4 signal: WO1 on PB13 mux E */
+#define MUX_PB13E_TC4_WO1               _L_(4)
+#define PINMUX_PB13E_TC4_WO1       ((PIN_PB13E_TC4_WO1 << 16) | MUX_PB13E_TC4_WO1)
+#define PORT_PB13E_TC4_WO1     (_UL_(1) << 13)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PB14E_TC5_WO0              _L_(46) /**< \brief TC5 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC5_WO0               _L_(4)
+#define PINMUX_PB14E_TC5_WO0       ((PIN_PB14E_TC5_WO0 << 16) | MUX_PB14E_TC5_WO0)
+#define PORT_PB14E_TC5_WO0     (_UL_(1) << 14)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+#define PIN_PB15E_TC5_WO1              _L_(47) /**< \brief TC5 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC5_WO1               _L_(4)
+#define PINMUX_PB15E_TC5_WO1       ((PIN_PB15E_TC5_WO1 << 16) | MUX_PB15E_TC5_WO1)
+#define PORT_PB15E_TC5_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC6 peripheral ========== */
+#define PIN_PB02F_TC6_WO0              _L_(34) /**< \brief TC6 signal: WO0 on PB02 mux F */
+#define MUX_PB02F_TC6_WO0               _L_(5)
+#define PINMUX_PB02F_TC6_WO0       ((PIN_PB02F_TC6_WO0 << 16) | MUX_PB02F_TC6_WO0)
+#define PORT_PB02F_TC6_WO0     (_UL_(1) <<  2)
+#define PIN_PB16E_TC6_WO0              _L_(48) /**< \brief TC6 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC6_WO0               _L_(4)
+#define PINMUX_PB16E_TC6_WO0       ((PIN_PB16E_TC6_WO0 << 16) | MUX_PB16E_TC6_WO0)
+#define PORT_PB16E_TC6_WO0     (_UL_(1) << 16)
+#define PIN_PB03F_TC6_WO1              _L_(35) /**< \brief TC6 signal: WO1 on PB03 mux F */
+#define MUX_PB03F_TC6_WO1               _L_(5)
+#define PINMUX_PB03F_TC6_WO1       ((PIN_PB03F_TC6_WO1 << 16) | MUX_PB03F_TC6_WO1)
+#define PORT_PB03F_TC6_WO1     (_UL_(1) <<  3)
+#define PIN_PB17E_TC6_WO1              _L_(49) /**< \brief TC6 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC6_WO1               _L_(4)
+#define PINMUX_PB17E_TC6_WO1       ((PIN_PB17E_TC6_WO1 << 16) | MUX_PB17E_TC6_WO1)
+#define PORT_PB17E_TC6_WO1     (_UL_(1) << 17)
+/* ========== PORT definition for TC7 peripheral ========== */
+#define PIN_PB00F_TC7_WO0              _L_(32) /**< \brief TC7 signal: WO0 on PB00 mux F */
+#define MUX_PB00F_TC7_WO0               _L_(5)
+#define PINMUX_PB00F_TC7_WO0       ((PIN_PB00F_TC7_WO0 << 16) | MUX_PB00F_TC7_WO0)
+#define PORT_PB00F_TC7_WO0     (_UL_(1) <<  0)
+#define PIN_PB22F_TC7_WO0              _L_(54) /**< \brief TC7 signal: WO0 on PB22 mux F */
+#define MUX_PB22F_TC7_WO0               _L_(5)
+#define PINMUX_PB22F_TC7_WO0       ((PIN_PB22F_TC7_WO0 << 16) | MUX_PB22F_TC7_WO0)
+#define PORT_PB22F_TC7_WO0     (_UL_(1) << 22)
+#define PIN_PA20E_TC7_WO0              _L_(20) /**< \brief TC7 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC7_WO0               _L_(4)
+#define PINMUX_PA20E_TC7_WO0       ((PIN_PA20E_TC7_WO0 << 16) | MUX_PA20E_TC7_WO0)
+#define PORT_PA20E_TC7_WO0     (_UL_(1) << 20)
+#define PIN_PB01F_TC7_WO1              _L_(33) /**< \brief TC7 signal: WO1 on PB01 mux F */
+#define MUX_PB01F_TC7_WO1               _L_(5)
+#define PINMUX_PB01F_TC7_WO1       ((PIN_PB01F_TC7_WO1 << 16) | MUX_PB01F_TC7_WO1)
+#define PORT_PB01F_TC7_WO1     (_UL_(1) <<  1)
+#define PIN_PB23F_TC7_WO1              _L_(55) /**< \brief TC7 signal: WO1 on PB23 mux F */
+#define MUX_PB23F_TC7_WO1               _L_(5)
+#define PINMUX_PB23F_TC7_WO1       ((PIN_PB23F_TC7_WO1 << 16) | MUX_PB23F_TC7_WO1)
+#define PORT_PB23F_TC7_WO1     (_UL_(1) << 23)
+#define PIN_PA21E_TC7_WO1              _L_(21) /**< \brief TC7 signal: WO1 on PA21 mux E */
+#define MUX_PA21E_TC7_WO1               _L_(4)
+#define PINMUX_PA21E_TC7_WO1       ((PIN_PA21E_TC7_WO1 << 16) | MUX_PA21E_TC7_WO1)
+#define PORT_PA21E_TC7_WO1     (_UL_(1) << 21)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB00B_ADC_AIN8             _L_(32) /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8              _L_(1)
+#define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
+#define PORT_PB00B_ADC_AIN8    (_UL_(1) <<  0)
+#define PIN_PB01B_ADC_AIN9             _L_(33) /**< \brief ADC signal: AIN9 on PB01 mux B */
+#define MUX_PB01B_ADC_AIN9              _L_(1)
+#define PINMUX_PB01B_ADC_AIN9      ((PIN_PB01B_ADC_AIN9 << 16) | MUX_PB01B_ADC_AIN9)
+#define PORT_PB01B_ADC_AIN9    (_UL_(1) <<  1)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PB04B_ADC_AIN12            _L_(36) /**< \brief ADC signal: AIN12 on PB04 mux B */
+#define MUX_PB04B_ADC_AIN12             _L_(1)
+#define PINMUX_PB04B_ADC_AIN12     ((PIN_PB04B_ADC_AIN12 << 16) | MUX_PB04B_ADC_AIN12)
+#define PORT_PB04B_ADC_AIN12   (_UL_(1) <<  4)
+#define PIN_PB05B_ADC_AIN13            _L_(37) /**< \brief ADC signal: AIN13 on PB05 mux B */
+#define MUX_PB05B_ADC_AIN13             _L_(1)
+#define PINMUX_PB05B_ADC_AIN13     ((PIN_PB05B_ADC_AIN13 << 16) | MUX_PB05B_ADC_AIN13)
+#define PORT_PB05B_ADC_AIN13   (_UL_(1) <<  5)
+#define PIN_PB06B_ADC_AIN14            _L_(38) /**< \brief ADC signal: AIN14 on PB06 mux B */
+#define MUX_PB06B_ADC_AIN14             _L_(1)
+#define PINMUX_PB06B_ADC_AIN14     ((PIN_PB06B_ADC_AIN14 << 16) | MUX_PB06B_ADC_AIN14)
+#define PORT_PB06B_ADC_AIN14   (_UL_(1) <<  6)
+#define PIN_PB07B_ADC_AIN15            _L_(39) /**< \brief ADC signal: AIN15 on PB07 mux B */
+#define MUX_PB07B_ADC_AIN15             _L_(1)
+#define PINMUX_PB07B_ADC_AIN15     ((PIN_PB07B_ADC_AIN15 << 16) | MUX_PB07B_ADC_AIN15)
+#define PORT_PB07B_ADC_AIN15   (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20J14_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20j15.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20j15.h
@@ -1,0 +1,1056 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20J15
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J15_PIO_
+#define _SAMD20J15_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB00                           32  /**< \brief Pin Number for PB00 */
+#define PORT_PB00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PB00 */
+#define PIN_PB01                           33  /**< \brief Pin Number for PB01 */
+#define PORT_PB01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PB01 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB04                           36  /**< \brief Pin Number for PB04 */
+#define PORT_PB04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PB04 */
+#define PIN_PB05                           37  /**< \brief Pin Number for PB05 */
+#define PORT_PB05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PB05 */
+#define PIN_PB06                           38  /**< \brief Pin Number for PB06 */
+#define PORT_PB06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PB06 */
+#define PIN_PB07                           39  /**< \brief Pin Number for PB07 */
+#define PORT_PB07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PB07 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB12                           44  /**< \brief Pin Number for PB12 */
+#define PORT_PB12              (_UL_(1) << 12) /**< \brief PORT Mask  for PB12 */
+#define PIN_PB13                           45  /**< \brief Pin Number for PB13 */
+#define PORT_PB13              (_UL_(1) << 13) /**< \brief PORT Mask  for PB13 */
+#define PIN_PB14                           46  /**< \brief Pin Number for PB14 */
+#define PORT_PB14              (_UL_(1) << 14) /**< \brief PORT Mask  for PB14 */
+#define PIN_PB15                           47  /**< \brief Pin Number for PB15 */
+#define PORT_PB15              (_UL_(1) << 15) /**< \brief PORT Mask  for PB15 */
+#define PIN_PB16                           48  /**< \brief Pin Number for PB16 */
+#define PORT_PB16              (_UL_(1) << 16) /**< \brief PORT Mask  for PB16 */
+#define PIN_PB17                           49  /**< \brief Pin Number for PB17 */
+#define PORT_PB17              (_UL_(1) << 17) /**< \brief PORT Mask  for PB17 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+#define PIN_PB30                           62  /**< \brief Pin Number for PB30 */
+#define PORT_PB30              (_UL_(1) << 30) /**< \brief PORT Mask  for PB30 */
+#define PIN_PB31                           63  /**< \brief Pin Number for PB31 */
+#define PORT_PB31              (_UL_(1) << 31) /**< \brief PORT Mask  for PB31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB14H_GCLK_IO0             _L_(46) /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0              _L_(7)
+#define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
+#define PORT_PB14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB15H_GCLK_IO1             _L_(47) /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1              _L_(7)
+#define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
+#define PORT_PB15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB16H_GCLK_IO2             _L_(48) /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2              _L_(7)
+#define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
+#define PORT_PB16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PB17H_GCLK_IO3             _L_(49) /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3              _L_(7)
+#define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
+#define PORT_PB17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PB12H_GCLK_IO6             _L_(44) /**< \brief GCLK signal: IO6 on PB12 mux H */
+#define MUX_PB12H_GCLK_IO6              _L_(7)
+#define PINMUX_PB12H_GCLK_IO6      ((PIN_PB12H_GCLK_IO6 << 16) | MUX_PB12H_GCLK_IO6)
+#define PORT_PB12H_GCLK_IO6    (_UL_(1) << 12)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+#define PIN_PB13H_GCLK_IO7             _L_(45) /**< \brief GCLK signal: IO7 on PB13 mux H */
+#define MUX_PB13H_GCLK_IO7              _L_(7)
+#define PINMUX_PB13H_GCLK_IO7      ((PIN_PB13H_GCLK_IO7 << 16) | MUX_PB13H_GCLK_IO7)
+#define PORT_PB13H_GCLK_IO7    (_UL_(1) << 13)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PB00A_EIC_EXTINT0          _L_(32) /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
+#define PORT_PB00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PB00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB00 External Interrupt Line */
+#define PIN_PB16A_EIC_EXTINT0          _L_(48) /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
+#define PORT_PB16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PB16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PB01A_EIC_EXTINT1          _L_(33) /**< \brief EIC signal: EXTINT1 on PB01 mux A */
+#define MUX_PB01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB01A_EIC_EXTINT1   ((PIN_PB01A_EIC_EXTINT1 << 16) | MUX_PB01A_EIC_EXTINT1)
+#define PORT_PB01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PB01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PB17A_EIC_EXTINT1          _L_(49) /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
+#define PORT_PB17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PB17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PB04A_EIC_EXTINT4          _L_(36) /**< \brief EIC signal: EXTINT4 on PB04 mux A */
+#define MUX_PB04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PB04A_EIC_EXTINT4   ((PIN_PB04A_EIC_EXTINT4 << 16) | MUX_PB04A_EIC_EXTINT4)
+#define PORT_PB04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PB04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PB04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PB05A_EIC_EXTINT5          _L_(37) /**< \brief EIC signal: EXTINT5 on PB05 mux A */
+#define MUX_PB05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PB05A_EIC_EXTINT5   ((PIN_PB05A_EIC_EXTINT5 << 16) | MUX_PB05A_EIC_EXTINT5)
+#define PORT_PB05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PB05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PB05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB06A_EIC_EXTINT6          _L_(38) /**< \brief EIC signal: EXTINT6 on PB06 mux A */
+#define MUX_PB06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB06A_EIC_EXTINT6   ((PIN_PB06A_EIC_EXTINT6 << 16) | MUX_PB06A_EIC_EXTINT6)
+#define PORT_PB06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PB06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB06 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB07A_EIC_EXTINT7          _L_(39) /**< \brief EIC signal: EXTINT7 on PB07 mux A */
+#define MUX_PB07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB07A_EIC_EXTINT7   ((PIN_PB07A_EIC_EXTINT7 << 16) | MUX_PB07A_EIC_EXTINT7)
+#define PORT_PB07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PB07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB07 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PB12A_EIC_EXTINT12         _L_(44) /**< \brief EIC signal: EXTINT12 on PB12 mux A */
+#define MUX_PB12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PB12A_EIC_EXTINT12  ((PIN_PB12A_EIC_EXTINT12 << 16) | MUX_PB12A_EIC_EXTINT12)
+#define PORT_PB12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PB12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PB12 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PB13A_EIC_EXTINT13         _L_(45) /**< \brief EIC signal: EXTINT13 on PB13 mux A */
+#define MUX_PB13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PB13A_EIC_EXTINT13  ((PIN_PB13A_EIC_EXTINT13 << 16) | MUX_PB13A_EIC_EXTINT13)
+#define PORT_PB13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PB13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PB13 External Interrupt Line */
+#define PIN_PB14A_EIC_EXTINT14         _L_(46) /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
+#define PORT_PB14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PB14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB14 External Interrupt Line */
+#define PIN_PB30A_EIC_EXTINT14         _L_(62) /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
+#define PORT_PB30A_EIC_EXTINT14  (_UL_(1) << 30)
+#define PIN_PB30A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB30 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PB15A_EIC_EXTINT15         _L_(47) /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
+#define PORT_PB15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PB15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB15 External Interrupt Line */
+#define PIN_PB31A_EIC_EXTINT15         _L_(63) /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
+#define PORT_PB31A_EIC_EXTINT15  (_UL_(1) << 31)
+#define PIN_PB31A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB31 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PB12C_SERCOM4_PAD0         _L_(44) /**< \brief SERCOM4 signal: PAD0 on PB12 mux C */
+#define MUX_PB12C_SERCOM4_PAD0          _L_(2)
+#define PINMUX_PB12C_SERCOM4_PAD0  ((PIN_PB12C_SERCOM4_PAD0 << 16) | MUX_PB12C_SERCOM4_PAD0)
+#define PORT_PB12C_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PB13C_SERCOM4_PAD1         _L_(45) /**< \brief SERCOM4 signal: PAD1 on PB13 mux C */
+#define MUX_PB13C_SERCOM4_PAD1          _L_(2)
+#define PINMUX_PB13C_SERCOM4_PAD1  ((PIN_PB13C_SERCOM4_PAD1 << 16) | MUX_PB13C_SERCOM4_PAD1)
+#define PORT_PB13C_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PB14C_SERCOM4_PAD2         _L_(46) /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2          _L_(2)
+#define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
+#define PORT_PB14C_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+#define PIN_PB15C_SERCOM4_PAD3         _L_(47) /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3          _L_(2)
+#define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
+#define PORT_PB15C_SERCOM4_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PB30D_SERCOM5_PAD0         _L_(62) /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
+#define PORT_PB30D_SERCOM5_PAD0  (_UL_(1) << 30)
+#define PIN_PB16C_SERCOM5_PAD0         _L_(48) /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0          _L_(2)
+#define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
+#define PORT_PB16C_SERCOM5_PAD0  (_UL_(1) << 16)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PB31D_SERCOM5_PAD1         _L_(63) /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
+#define PORT_PB31D_SERCOM5_PAD1  (_UL_(1) << 31)
+#define PIN_PB17C_SERCOM5_PAD1         _L_(49) /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1          _L_(2)
+#define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
+#define PORT_PB17C_SERCOM5_PAD1  (_UL_(1) << 17)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB00D_SERCOM5_PAD2         _L_(32) /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
+#define PORT_PB00D_SERCOM5_PAD2  (_UL_(1) <<  0)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB01D_SERCOM5_PAD3         _L_(33) /**< \brief SERCOM5 signal: PAD3 on PB01 mux D */
+#define MUX_PB01D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB01D_SERCOM5_PAD3  ((PIN_PB01D_SERCOM5_PAD3 << 16) | MUX_PB01D_SERCOM5_PAD3)
+#define PORT_PB01D_SERCOM5_PAD3  (_UL_(1) <<  1)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PB30F_TC0_WO0              _L_(62) /**< \brief TC0 signal: WO0 on PB30 mux F */
+#define MUX_PB30F_TC0_WO0               _L_(5)
+#define PINMUX_PB30F_TC0_WO0       ((PIN_PB30F_TC0_WO0 << 16) | MUX_PB30F_TC0_WO0)
+#define PORT_PB30F_TC0_WO0     (_UL_(1) << 30)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PB31F_TC0_WO1              _L_(63) /**< \brief TC0 signal: WO1 on PB31 mux F */
+#define MUX_PB31F_TC0_WO1               _L_(5)
+#define PINMUX_PB31F_TC0_WO1       ((PIN_PB31F_TC0_WO1 << 16) | MUX_PB31F_TC0_WO1)
+#define PORT_PB31F_TC0_WO1     (_UL_(1) << 31)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PB12E_TC4_WO0              _L_(44) /**< \brief TC4 signal: WO0 on PB12 mux E */
+#define MUX_PB12E_TC4_WO0               _L_(4)
+#define PINMUX_PB12E_TC4_WO0       ((PIN_PB12E_TC4_WO0 << 16) | MUX_PB12E_TC4_WO0)
+#define PORT_PB12E_TC4_WO0     (_UL_(1) << 12)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+#define PIN_PB13E_TC4_WO1              _L_(45) /**< \brief TC4 signal: WO1 on PB13 mux E */
+#define MUX_PB13E_TC4_WO1               _L_(4)
+#define PINMUX_PB13E_TC4_WO1       ((PIN_PB13E_TC4_WO1 << 16) | MUX_PB13E_TC4_WO1)
+#define PORT_PB13E_TC4_WO1     (_UL_(1) << 13)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PB14E_TC5_WO0              _L_(46) /**< \brief TC5 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC5_WO0               _L_(4)
+#define PINMUX_PB14E_TC5_WO0       ((PIN_PB14E_TC5_WO0 << 16) | MUX_PB14E_TC5_WO0)
+#define PORT_PB14E_TC5_WO0     (_UL_(1) << 14)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+#define PIN_PB15E_TC5_WO1              _L_(47) /**< \brief TC5 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC5_WO1               _L_(4)
+#define PINMUX_PB15E_TC5_WO1       ((PIN_PB15E_TC5_WO1 << 16) | MUX_PB15E_TC5_WO1)
+#define PORT_PB15E_TC5_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC6 peripheral ========== */
+#define PIN_PB02F_TC6_WO0              _L_(34) /**< \brief TC6 signal: WO0 on PB02 mux F */
+#define MUX_PB02F_TC6_WO0               _L_(5)
+#define PINMUX_PB02F_TC6_WO0       ((PIN_PB02F_TC6_WO0 << 16) | MUX_PB02F_TC6_WO0)
+#define PORT_PB02F_TC6_WO0     (_UL_(1) <<  2)
+#define PIN_PB16E_TC6_WO0              _L_(48) /**< \brief TC6 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC6_WO0               _L_(4)
+#define PINMUX_PB16E_TC6_WO0       ((PIN_PB16E_TC6_WO0 << 16) | MUX_PB16E_TC6_WO0)
+#define PORT_PB16E_TC6_WO0     (_UL_(1) << 16)
+#define PIN_PB03F_TC6_WO1              _L_(35) /**< \brief TC6 signal: WO1 on PB03 mux F */
+#define MUX_PB03F_TC6_WO1               _L_(5)
+#define PINMUX_PB03F_TC6_WO1       ((PIN_PB03F_TC6_WO1 << 16) | MUX_PB03F_TC6_WO1)
+#define PORT_PB03F_TC6_WO1     (_UL_(1) <<  3)
+#define PIN_PB17E_TC6_WO1              _L_(49) /**< \brief TC6 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC6_WO1               _L_(4)
+#define PINMUX_PB17E_TC6_WO1       ((PIN_PB17E_TC6_WO1 << 16) | MUX_PB17E_TC6_WO1)
+#define PORT_PB17E_TC6_WO1     (_UL_(1) << 17)
+/* ========== PORT definition for TC7 peripheral ========== */
+#define PIN_PB00F_TC7_WO0              _L_(32) /**< \brief TC7 signal: WO0 on PB00 mux F */
+#define MUX_PB00F_TC7_WO0               _L_(5)
+#define PINMUX_PB00F_TC7_WO0       ((PIN_PB00F_TC7_WO0 << 16) | MUX_PB00F_TC7_WO0)
+#define PORT_PB00F_TC7_WO0     (_UL_(1) <<  0)
+#define PIN_PB22F_TC7_WO0              _L_(54) /**< \brief TC7 signal: WO0 on PB22 mux F */
+#define MUX_PB22F_TC7_WO0               _L_(5)
+#define PINMUX_PB22F_TC7_WO0       ((PIN_PB22F_TC7_WO0 << 16) | MUX_PB22F_TC7_WO0)
+#define PORT_PB22F_TC7_WO0     (_UL_(1) << 22)
+#define PIN_PA20E_TC7_WO0              _L_(20) /**< \brief TC7 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC7_WO0               _L_(4)
+#define PINMUX_PA20E_TC7_WO0       ((PIN_PA20E_TC7_WO0 << 16) | MUX_PA20E_TC7_WO0)
+#define PORT_PA20E_TC7_WO0     (_UL_(1) << 20)
+#define PIN_PB01F_TC7_WO1              _L_(33) /**< \brief TC7 signal: WO1 on PB01 mux F */
+#define MUX_PB01F_TC7_WO1               _L_(5)
+#define PINMUX_PB01F_TC7_WO1       ((PIN_PB01F_TC7_WO1 << 16) | MUX_PB01F_TC7_WO1)
+#define PORT_PB01F_TC7_WO1     (_UL_(1) <<  1)
+#define PIN_PB23F_TC7_WO1              _L_(55) /**< \brief TC7 signal: WO1 on PB23 mux F */
+#define MUX_PB23F_TC7_WO1               _L_(5)
+#define PINMUX_PB23F_TC7_WO1       ((PIN_PB23F_TC7_WO1 << 16) | MUX_PB23F_TC7_WO1)
+#define PORT_PB23F_TC7_WO1     (_UL_(1) << 23)
+#define PIN_PA21E_TC7_WO1              _L_(21) /**< \brief TC7 signal: WO1 on PA21 mux E */
+#define MUX_PA21E_TC7_WO1               _L_(4)
+#define PINMUX_PA21E_TC7_WO1       ((PIN_PA21E_TC7_WO1 << 16) | MUX_PA21E_TC7_WO1)
+#define PORT_PA21E_TC7_WO1     (_UL_(1) << 21)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB00B_ADC_AIN8             _L_(32) /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8              _L_(1)
+#define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
+#define PORT_PB00B_ADC_AIN8    (_UL_(1) <<  0)
+#define PIN_PB01B_ADC_AIN9             _L_(33) /**< \brief ADC signal: AIN9 on PB01 mux B */
+#define MUX_PB01B_ADC_AIN9              _L_(1)
+#define PINMUX_PB01B_ADC_AIN9      ((PIN_PB01B_ADC_AIN9 << 16) | MUX_PB01B_ADC_AIN9)
+#define PORT_PB01B_ADC_AIN9    (_UL_(1) <<  1)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PB04B_ADC_AIN12            _L_(36) /**< \brief ADC signal: AIN12 on PB04 mux B */
+#define MUX_PB04B_ADC_AIN12             _L_(1)
+#define PINMUX_PB04B_ADC_AIN12     ((PIN_PB04B_ADC_AIN12 << 16) | MUX_PB04B_ADC_AIN12)
+#define PORT_PB04B_ADC_AIN12   (_UL_(1) <<  4)
+#define PIN_PB05B_ADC_AIN13            _L_(37) /**< \brief ADC signal: AIN13 on PB05 mux B */
+#define MUX_PB05B_ADC_AIN13             _L_(1)
+#define PINMUX_PB05B_ADC_AIN13     ((PIN_PB05B_ADC_AIN13 << 16) | MUX_PB05B_ADC_AIN13)
+#define PORT_PB05B_ADC_AIN13   (_UL_(1) <<  5)
+#define PIN_PB06B_ADC_AIN14            _L_(38) /**< \brief ADC signal: AIN14 on PB06 mux B */
+#define MUX_PB06B_ADC_AIN14             _L_(1)
+#define PINMUX_PB06B_ADC_AIN14     ((PIN_PB06B_ADC_AIN14 << 16) | MUX_PB06B_ADC_AIN14)
+#define PORT_PB06B_ADC_AIN14   (_UL_(1) <<  6)
+#define PIN_PB07B_ADC_AIN15            _L_(39) /**< \brief ADC signal: AIN15 on PB07 mux B */
+#define MUX_PB07B_ADC_AIN15             _L_(1)
+#define PINMUX_PB07B_ADC_AIN15     ((PIN_PB07B_ADC_AIN15 << 16) | MUX_PB07B_ADC_AIN15)
+#define PORT_PB07B_ADC_AIN15   (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20J15_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20j16.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20j16.h
@@ -1,0 +1,1056 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20J16
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J16_PIO_
+#define _SAMD20J16_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB00                           32  /**< \brief Pin Number for PB00 */
+#define PORT_PB00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PB00 */
+#define PIN_PB01                           33  /**< \brief Pin Number for PB01 */
+#define PORT_PB01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PB01 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB04                           36  /**< \brief Pin Number for PB04 */
+#define PORT_PB04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PB04 */
+#define PIN_PB05                           37  /**< \brief Pin Number for PB05 */
+#define PORT_PB05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PB05 */
+#define PIN_PB06                           38  /**< \brief Pin Number for PB06 */
+#define PORT_PB06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PB06 */
+#define PIN_PB07                           39  /**< \brief Pin Number for PB07 */
+#define PORT_PB07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PB07 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB12                           44  /**< \brief Pin Number for PB12 */
+#define PORT_PB12              (_UL_(1) << 12) /**< \brief PORT Mask  for PB12 */
+#define PIN_PB13                           45  /**< \brief Pin Number for PB13 */
+#define PORT_PB13              (_UL_(1) << 13) /**< \brief PORT Mask  for PB13 */
+#define PIN_PB14                           46  /**< \brief Pin Number for PB14 */
+#define PORT_PB14              (_UL_(1) << 14) /**< \brief PORT Mask  for PB14 */
+#define PIN_PB15                           47  /**< \brief Pin Number for PB15 */
+#define PORT_PB15              (_UL_(1) << 15) /**< \brief PORT Mask  for PB15 */
+#define PIN_PB16                           48  /**< \brief Pin Number for PB16 */
+#define PORT_PB16              (_UL_(1) << 16) /**< \brief PORT Mask  for PB16 */
+#define PIN_PB17                           49  /**< \brief Pin Number for PB17 */
+#define PORT_PB17              (_UL_(1) << 17) /**< \brief PORT Mask  for PB17 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+#define PIN_PB30                           62  /**< \brief Pin Number for PB30 */
+#define PORT_PB30              (_UL_(1) << 30) /**< \brief PORT Mask  for PB30 */
+#define PIN_PB31                           63  /**< \brief Pin Number for PB31 */
+#define PORT_PB31              (_UL_(1) << 31) /**< \brief PORT Mask  for PB31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB14H_GCLK_IO0             _L_(46) /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0              _L_(7)
+#define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
+#define PORT_PB14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB15H_GCLK_IO1             _L_(47) /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1              _L_(7)
+#define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
+#define PORT_PB15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB16H_GCLK_IO2             _L_(48) /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2              _L_(7)
+#define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
+#define PORT_PB16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PB17H_GCLK_IO3             _L_(49) /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3              _L_(7)
+#define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
+#define PORT_PB17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PB12H_GCLK_IO6             _L_(44) /**< \brief GCLK signal: IO6 on PB12 mux H */
+#define MUX_PB12H_GCLK_IO6              _L_(7)
+#define PINMUX_PB12H_GCLK_IO6      ((PIN_PB12H_GCLK_IO6 << 16) | MUX_PB12H_GCLK_IO6)
+#define PORT_PB12H_GCLK_IO6    (_UL_(1) << 12)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+#define PIN_PB13H_GCLK_IO7             _L_(45) /**< \brief GCLK signal: IO7 on PB13 mux H */
+#define MUX_PB13H_GCLK_IO7              _L_(7)
+#define PINMUX_PB13H_GCLK_IO7      ((PIN_PB13H_GCLK_IO7 << 16) | MUX_PB13H_GCLK_IO7)
+#define PORT_PB13H_GCLK_IO7    (_UL_(1) << 13)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PB00A_EIC_EXTINT0          _L_(32) /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
+#define PORT_PB00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PB00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB00 External Interrupt Line */
+#define PIN_PB16A_EIC_EXTINT0          _L_(48) /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
+#define PORT_PB16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PB16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PB01A_EIC_EXTINT1          _L_(33) /**< \brief EIC signal: EXTINT1 on PB01 mux A */
+#define MUX_PB01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB01A_EIC_EXTINT1   ((PIN_PB01A_EIC_EXTINT1 << 16) | MUX_PB01A_EIC_EXTINT1)
+#define PORT_PB01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PB01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PB17A_EIC_EXTINT1          _L_(49) /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
+#define PORT_PB17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PB17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PB04A_EIC_EXTINT4          _L_(36) /**< \brief EIC signal: EXTINT4 on PB04 mux A */
+#define MUX_PB04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PB04A_EIC_EXTINT4   ((PIN_PB04A_EIC_EXTINT4 << 16) | MUX_PB04A_EIC_EXTINT4)
+#define PORT_PB04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PB04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PB04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PB05A_EIC_EXTINT5          _L_(37) /**< \brief EIC signal: EXTINT5 on PB05 mux A */
+#define MUX_PB05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PB05A_EIC_EXTINT5   ((PIN_PB05A_EIC_EXTINT5 << 16) | MUX_PB05A_EIC_EXTINT5)
+#define PORT_PB05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PB05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PB05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB06A_EIC_EXTINT6          _L_(38) /**< \brief EIC signal: EXTINT6 on PB06 mux A */
+#define MUX_PB06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB06A_EIC_EXTINT6   ((PIN_PB06A_EIC_EXTINT6 << 16) | MUX_PB06A_EIC_EXTINT6)
+#define PORT_PB06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PB06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB06 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB07A_EIC_EXTINT7          _L_(39) /**< \brief EIC signal: EXTINT7 on PB07 mux A */
+#define MUX_PB07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB07A_EIC_EXTINT7   ((PIN_PB07A_EIC_EXTINT7 << 16) | MUX_PB07A_EIC_EXTINT7)
+#define PORT_PB07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PB07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB07 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PB12A_EIC_EXTINT12         _L_(44) /**< \brief EIC signal: EXTINT12 on PB12 mux A */
+#define MUX_PB12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PB12A_EIC_EXTINT12  ((PIN_PB12A_EIC_EXTINT12 << 16) | MUX_PB12A_EIC_EXTINT12)
+#define PORT_PB12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PB12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PB12 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PB13A_EIC_EXTINT13         _L_(45) /**< \brief EIC signal: EXTINT13 on PB13 mux A */
+#define MUX_PB13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PB13A_EIC_EXTINT13  ((PIN_PB13A_EIC_EXTINT13 << 16) | MUX_PB13A_EIC_EXTINT13)
+#define PORT_PB13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PB13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PB13 External Interrupt Line */
+#define PIN_PB14A_EIC_EXTINT14         _L_(46) /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
+#define PORT_PB14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PB14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB14 External Interrupt Line */
+#define PIN_PB30A_EIC_EXTINT14         _L_(62) /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
+#define PORT_PB30A_EIC_EXTINT14  (_UL_(1) << 30)
+#define PIN_PB30A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB30 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PB15A_EIC_EXTINT15         _L_(47) /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
+#define PORT_PB15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PB15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB15 External Interrupt Line */
+#define PIN_PB31A_EIC_EXTINT15         _L_(63) /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
+#define PORT_PB31A_EIC_EXTINT15  (_UL_(1) << 31)
+#define PIN_PB31A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB31 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PB12C_SERCOM4_PAD0         _L_(44) /**< \brief SERCOM4 signal: PAD0 on PB12 mux C */
+#define MUX_PB12C_SERCOM4_PAD0          _L_(2)
+#define PINMUX_PB12C_SERCOM4_PAD0  ((PIN_PB12C_SERCOM4_PAD0 << 16) | MUX_PB12C_SERCOM4_PAD0)
+#define PORT_PB12C_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PB13C_SERCOM4_PAD1         _L_(45) /**< \brief SERCOM4 signal: PAD1 on PB13 mux C */
+#define MUX_PB13C_SERCOM4_PAD1          _L_(2)
+#define PINMUX_PB13C_SERCOM4_PAD1  ((PIN_PB13C_SERCOM4_PAD1 << 16) | MUX_PB13C_SERCOM4_PAD1)
+#define PORT_PB13C_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PB14C_SERCOM4_PAD2         _L_(46) /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2          _L_(2)
+#define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
+#define PORT_PB14C_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+#define PIN_PB15C_SERCOM4_PAD3         _L_(47) /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3          _L_(2)
+#define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
+#define PORT_PB15C_SERCOM4_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PB30D_SERCOM5_PAD0         _L_(62) /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
+#define PORT_PB30D_SERCOM5_PAD0  (_UL_(1) << 30)
+#define PIN_PB16C_SERCOM5_PAD0         _L_(48) /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0          _L_(2)
+#define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
+#define PORT_PB16C_SERCOM5_PAD0  (_UL_(1) << 16)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PB31D_SERCOM5_PAD1         _L_(63) /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
+#define PORT_PB31D_SERCOM5_PAD1  (_UL_(1) << 31)
+#define PIN_PB17C_SERCOM5_PAD1         _L_(49) /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1          _L_(2)
+#define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
+#define PORT_PB17C_SERCOM5_PAD1  (_UL_(1) << 17)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB00D_SERCOM5_PAD2         _L_(32) /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
+#define PORT_PB00D_SERCOM5_PAD2  (_UL_(1) <<  0)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB01D_SERCOM5_PAD3         _L_(33) /**< \brief SERCOM5 signal: PAD3 on PB01 mux D */
+#define MUX_PB01D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB01D_SERCOM5_PAD3  ((PIN_PB01D_SERCOM5_PAD3 << 16) | MUX_PB01D_SERCOM5_PAD3)
+#define PORT_PB01D_SERCOM5_PAD3  (_UL_(1) <<  1)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PB30F_TC0_WO0              _L_(62) /**< \brief TC0 signal: WO0 on PB30 mux F */
+#define MUX_PB30F_TC0_WO0               _L_(5)
+#define PINMUX_PB30F_TC0_WO0       ((PIN_PB30F_TC0_WO0 << 16) | MUX_PB30F_TC0_WO0)
+#define PORT_PB30F_TC0_WO0     (_UL_(1) << 30)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PB31F_TC0_WO1              _L_(63) /**< \brief TC0 signal: WO1 on PB31 mux F */
+#define MUX_PB31F_TC0_WO1               _L_(5)
+#define PINMUX_PB31F_TC0_WO1       ((PIN_PB31F_TC0_WO1 << 16) | MUX_PB31F_TC0_WO1)
+#define PORT_PB31F_TC0_WO1     (_UL_(1) << 31)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PB12E_TC4_WO0              _L_(44) /**< \brief TC4 signal: WO0 on PB12 mux E */
+#define MUX_PB12E_TC4_WO0               _L_(4)
+#define PINMUX_PB12E_TC4_WO0       ((PIN_PB12E_TC4_WO0 << 16) | MUX_PB12E_TC4_WO0)
+#define PORT_PB12E_TC4_WO0     (_UL_(1) << 12)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+#define PIN_PB13E_TC4_WO1              _L_(45) /**< \brief TC4 signal: WO1 on PB13 mux E */
+#define MUX_PB13E_TC4_WO1               _L_(4)
+#define PINMUX_PB13E_TC4_WO1       ((PIN_PB13E_TC4_WO1 << 16) | MUX_PB13E_TC4_WO1)
+#define PORT_PB13E_TC4_WO1     (_UL_(1) << 13)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PB14E_TC5_WO0              _L_(46) /**< \brief TC5 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC5_WO0               _L_(4)
+#define PINMUX_PB14E_TC5_WO0       ((PIN_PB14E_TC5_WO0 << 16) | MUX_PB14E_TC5_WO0)
+#define PORT_PB14E_TC5_WO0     (_UL_(1) << 14)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+#define PIN_PB15E_TC5_WO1              _L_(47) /**< \brief TC5 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC5_WO1               _L_(4)
+#define PINMUX_PB15E_TC5_WO1       ((PIN_PB15E_TC5_WO1 << 16) | MUX_PB15E_TC5_WO1)
+#define PORT_PB15E_TC5_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC6 peripheral ========== */
+#define PIN_PB02F_TC6_WO0              _L_(34) /**< \brief TC6 signal: WO0 on PB02 mux F */
+#define MUX_PB02F_TC6_WO0               _L_(5)
+#define PINMUX_PB02F_TC6_WO0       ((PIN_PB02F_TC6_WO0 << 16) | MUX_PB02F_TC6_WO0)
+#define PORT_PB02F_TC6_WO0     (_UL_(1) <<  2)
+#define PIN_PB16E_TC6_WO0              _L_(48) /**< \brief TC6 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC6_WO0               _L_(4)
+#define PINMUX_PB16E_TC6_WO0       ((PIN_PB16E_TC6_WO0 << 16) | MUX_PB16E_TC6_WO0)
+#define PORT_PB16E_TC6_WO0     (_UL_(1) << 16)
+#define PIN_PB03F_TC6_WO1              _L_(35) /**< \brief TC6 signal: WO1 on PB03 mux F */
+#define MUX_PB03F_TC6_WO1               _L_(5)
+#define PINMUX_PB03F_TC6_WO1       ((PIN_PB03F_TC6_WO1 << 16) | MUX_PB03F_TC6_WO1)
+#define PORT_PB03F_TC6_WO1     (_UL_(1) <<  3)
+#define PIN_PB17E_TC6_WO1              _L_(49) /**< \brief TC6 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC6_WO1               _L_(4)
+#define PINMUX_PB17E_TC6_WO1       ((PIN_PB17E_TC6_WO1 << 16) | MUX_PB17E_TC6_WO1)
+#define PORT_PB17E_TC6_WO1     (_UL_(1) << 17)
+/* ========== PORT definition for TC7 peripheral ========== */
+#define PIN_PB00F_TC7_WO0              _L_(32) /**< \brief TC7 signal: WO0 on PB00 mux F */
+#define MUX_PB00F_TC7_WO0               _L_(5)
+#define PINMUX_PB00F_TC7_WO0       ((PIN_PB00F_TC7_WO0 << 16) | MUX_PB00F_TC7_WO0)
+#define PORT_PB00F_TC7_WO0     (_UL_(1) <<  0)
+#define PIN_PB22F_TC7_WO0              _L_(54) /**< \brief TC7 signal: WO0 on PB22 mux F */
+#define MUX_PB22F_TC7_WO0               _L_(5)
+#define PINMUX_PB22F_TC7_WO0       ((PIN_PB22F_TC7_WO0 << 16) | MUX_PB22F_TC7_WO0)
+#define PORT_PB22F_TC7_WO0     (_UL_(1) << 22)
+#define PIN_PA20E_TC7_WO0              _L_(20) /**< \brief TC7 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC7_WO0               _L_(4)
+#define PINMUX_PA20E_TC7_WO0       ((PIN_PA20E_TC7_WO0 << 16) | MUX_PA20E_TC7_WO0)
+#define PORT_PA20E_TC7_WO0     (_UL_(1) << 20)
+#define PIN_PB01F_TC7_WO1              _L_(33) /**< \brief TC7 signal: WO1 on PB01 mux F */
+#define MUX_PB01F_TC7_WO1               _L_(5)
+#define PINMUX_PB01F_TC7_WO1       ((PIN_PB01F_TC7_WO1 << 16) | MUX_PB01F_TC7_WO1)
+#define PORT_PB01F_TC7_WO1     (_UL_(1) <<  1)
+#define PIN_PB23F_TC7_WO1              _L_(55) /**< \brief TC7 signal: WO1 on PB23 mux F */
+#define MUX_PB23F_TC7_WO1               _L_(5)
+#define PINMUX_PB23F_TC7_WO1       ((PIN_PB23F_TC7_WO1 << 16) | MUX_PB23F_TC7_WO1)
+#define PORT_PB23F_TC7_WO1     (_UL_(1) << 23)
+#define PIN_PA21E_TC7_WO1              _L_(21) /**< \brief TC7 signal: WO1 on PA21 mux E */
+#define MUX_PA21E_TC7_WO1               _L_(4)
+#define PINMUX_PA21E_TC7_WO1       ((PIN_PA21E_TC7_WO1 << 16) | MUX_PA21E_TC7_WO1)
+#define PORT_PA21E_TC7_WO1     (_UL_(1) << 21)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB00B_ADC_AIN8             _L_(32) /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8              _L_(1)
+#define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
+#define PORT_PB00B_ADC_AIN8    (_UL_(1) <<  0)
+#define PIN_PB01B_ADC_AIN9             _L_(33) /**< \brief ADC signal: AIN9 on PB01 mux B */
+#define MUX_PB01B_ADC_AIN9              _L_(1)
+#define PINMUX_PB01B_ADC_AIN9      ((PIN_PB01B_ADC_AIN9 << 16) | MUX_PB01B_ADC_AIN9)
+#define PORT_PB01B_ADC_AIN9    (_UL_(1) <<  1)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PB04B_ADC_AIN12            _L_(36) /**< \brief ADC signal: AIN12 on PB04 mux B */
+#define MUX_PB04B_ADC_AIN12             _L_(1)
+#define PINMUX_PB04B_ADC_AIN12     ((PIN_PB04B_ADC_AIN12 << 16) | MUX_PB04B_ADC_AIN12)
+#define PORT_PB04B_ADC_AIN12   (_UL_(1) <<  4)
+#define PIN_PB05B_ADC_AIN13            _L_(37) /**< \brief ADC signal: AIN13 on PB05 mux B */
+#define MUX_PB05B_ADC_AIN13             _L_(1)
+#define PINMUX_PB05B_ADC_AIN13     ((PIN_PB05B_ADC_AIN13 << 16) | MUX_PB05B_ADC_AIN13)
+#define PORT_PB05B_ADC_AIN13   (_UL_(1) <<  5)
+#define PIN_PB06B_ADC_AIN14            _L_(38) /**< \brief ADC signal: AIN14 on PB06 mux B */
+#define MUX_PB06B_ADC_AIN14             _L_(1)
+#define PINMUX_PB06B_ADC_AIN14     ((PIN_PB06B_ADC_AIN14 << 16) | MUX_PB06B_ADC_AIN14)
+#define PORT_PB06B_ADC_AIN14   (_UL_(1) <<  6)
+#define PIN_PB07B_ADC_AIN15            _L_(39) /**< \brief ADC signal: AIN15 on PB07 mux B */
+#define MUX_PB07B_ADC_AIN15             _L_(1)
+#define PINMUX_PB07B_ADC_AIN15     ((PIN_PB07B_ADC_AIN15 << 16) | MUX_PB07B_ADC_AIN15)
+#define PORT_PB07B_ADC_AIN15   (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20J16_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20j17.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20j17.h
@@ -1,0 +1,1056 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20J17
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J17_PIO_
+#define _SAMD20J17_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB00                           32  /**< \brief Pin Number for PB00 */
+#define PORT_PB00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PB00 */
+#define PIN_PB01                           33  /**< \brief Pin Number for PB01 */
+#define PORT_PB01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PB01 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB04                           36  /**< \brief Pin Number for PB04 */
+#define PORT_PB04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PB04 */
+#define PIN_PB05                           37  /**< \brief Pin Number for PB05 */
+#define PORT_PB05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PB05 */
+#define PIN_PB06                           38  /**< \brief Pin Number for PB06 */
+#define PORT_PB06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PB06 */
+#define PIN_PB07                           39  /**< \brief Pin Number for PB07 */
+#define PORT_PB07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PB07 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB12                           44  /**< \brief Pin Number for PB12 */
+#define PORT_PB12              (_UL_(1) << 12) /**< \brief PORT Mask  for PB12 */
+#define PIN_PB13                           45  /**< \brief Pin Number for PB13 */
+#define PORT_PB13              (_UL_(1) << 13) /**< \brief PORT Mask  for PB13 */
+#define PIN_PB14                           46  /**< \brief Pin Number for PB14 */
+#define PORT_PB14              (_UL_(1) << 14) /**< \brief PORT Mask  for PB14 */
+#define PIN_PB15                           47  /**< \brief Pin Number for PB15 */
+#define PORT_PB15              (_UL_(1) << 15) /**< \brief PORT Mask  for PB15 */
+#define PIN_PB16                           48  /**< \brief Pin Number for PB16 */
+#define PORT_PB16              (_UL_(1) << 16) /**< \brief PORT Mask  for PB16 */
+#define PIN_PB17                           49  /**< \brief Pin Number for PB17 */
+#define PORT_PB17              (_UL_(1) << 17) /**< \brief PORT Mask  for PB17 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+#define PIN_PB30                           62  /**< \brief Pin Number for PB30 */
+#define PORT_PB30              (_UL_(1) << 30) /**< \brief PORT Mask  for PB30 */
+#define PIN_PB31                           63  /**< \brief Pin Number for PB31 */
+#define PORT_PB31              (_UL_(1) << 31) /**< \brief PORT Mask  for PB31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB14H_GCLK_IO0             _L_(46) /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0              _L_(7)
+#define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
+#define PORT_PB14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB15H_GCLK_IO1             _L_(47) /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1              _L_(7)
+#define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
+#define PORT_PB15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB16H_GCLK_IO2             _L_(48) /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2              _L_(7)
+#define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
+#define PORT_PB16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PB17H_GCLK_IO3             _L_(49) /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3              _L_(7)
+#define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
+#define PORT_PB17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PB12H_GCLK_IO6             _L_(44) /**< \brief GCLK signal: IO6 on PB12 mux H */
+#define MUX_PB12H_GCLK_IO6              _L_(7)
+#define PINMUX_PB12H_GCLK_IO6      ((PIN_PB12H_GCLK_IO6 << 16) | MUX_PB12H_GCLK_IO6)
+#define PORT_PB12H_GCLK_IO6    (_UL_(1) << 12)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+#define PIN_PB13H_GCLK_IO7             _L_(45) /**< \brief GCLK signal: IO7 on PB13 mux H */
+#define MUX_PB13H_GCLK_IO7              _L_(7)
+#define PINMUX_PB13H_GCLK_IO7      ((PIN_PB13H_GCLK_IO7 << 16) | MUX_PB13H_GCLK_IO7)
+#define PORT_PB13H_GCLK_IO7    (_UL_(1) << 13)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PB00A_EIC_EXTINT0          _L_(32) /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
+#define PORT_PB00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PB00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB00 External Interrupt Line */
+#define PIN_PB16A_EIC_EXTINT0          _L_(48) /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
+#define PORT_PB16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PB16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PB01A_EIC_EXTINT1          _L_(33) /**< \brief EIC signal: EXTINT1 on PB01 mux A */
+#define MUX_PB01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB01A_EIC_EXTINT1   ((PIN_PB01A_EIC_EXTINT1 << 16) | MUX_PB01A_EIC_EXTINT1)
+#define PORT_PB01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PB01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PB17A_EIC_EXTINT1          _L_(49) /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
+#define PORT_PB17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PB17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PB04A_EIC_EXTINT4          _L_(36) /**< \brief EIC signal: EXTINT4 on PB04 mux A */
+#define MUX_PB04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PB04A_EIC_EXTINT4   ((PIN_PB04A_EIC_EXTINT4 << 16) | MUX_PB04A_EIC_EXTINT4)
+#define PORT_PB04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PB04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PB04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PB05A_EIC_EXTINT5          _L_(37) /**< \brief EIC signal: EXTINT5 on PB05 mux A */
+#define MUX_PB05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PB05A_EIC_EXTINT5   ((PIN_PB05A_EIC_EXTINT5 << 16) | MUX_PB05A_EIC_EXTINT5)
+#define PORT_PB05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PB05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PB05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB06A_EIC_EXTINT6          _L_(38) /**< \brief EIC signal: EXTINT6 on PB06 mux A */
+#define MUX_PB06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB06A_EIC_EXTINT6   ((PIN_PB06A_EIC_EXTINT6 << 16) | MUX_PB06A_EIC_EXTINT6)
+#define PORT_PB06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PB06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB06 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB07A_EIC_EXTINT7          _L_(39) /**< \brief EIC signal: EXTINT7 on PB07 mux A */
+#define MUX_PB07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB07A_EIC_EXTINT7   ((PIN_PB07A_EIC_EXTINT7 << 16) | MUX_PB07A_EIC_EXTINT7)
+#define PORT_PB07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PB07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB07 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PB12A_EIC_EXTINT12         _L_(44) /**< \brief EIC signal: EXTINT12 on PB12 mux A */
+#define MUX_PB12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PB12A_EIC_EXTINT12  ((PIN_PB12A_EIC_EXTINT12 << 16) | MUX_PB12A_EIC_EXTINT12)
+#define PORT_PB12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PB12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PB12 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PB13A_EIC_EXTINT13         _L_(45) /**< \brief EIC signal: EXTINT13 on PB13 mux A */
+#define MUX_PB13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PB13A_EIC_EXTINT13  ((PIN_PB13A_EIC_EXTINT13 << 16) | MUX_PB13A_EIC_EXTINT13)
+#define PORT_PB13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PB13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PB13 External Interrupt Line */
+#define PIN_PB14A_EIC_EXTINT14         _L_(46) /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
+#define PORT_PB14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PB14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB14 External Interrupt Line */
+#define PIN_PB30A_EIC_EXTINT14         _L_(62) /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
+#define PORT_PB30A_EIC_EXTINT14  (_UL_(1) << 30)
+#define PIN_PB30A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB30 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PB15A_EIC_EXTINT15         _L_(47) /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
+#define PORT_PB15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PB15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB15 External Interrupt Line */
+#define PIN_PB31A_EIC_EXTINT15         _L_(63) /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
+#define PORT_PB31A_EIC_EXTINT15  (_UL_(1) << 31)
+#define PIN_PB31A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB31 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PB12C_SERCOM4_PAD0         _L_(44) /**< \brief SERCOM4 signal: PAD0 on PB12 mux C */
+#define MUX_PB12C_SERCOM4_PAD0          _L_(2)
+#define PINMUX_PB12C_SERCOM4_PAD0  ((PIN_PB12C_SERCOM4_PAD0 << 16) | MUX_PB12C_SERCOM4_PAD0)
+#define PORT_PB12C_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PB13C_SERCOM4_PAD1         _L_(45) /**< \brief SERCOM4 signal: PAD1 on PB13 mux C */
+#define MUX_PB13C_SERCOM4_PAD1          _L_(2)
+#define PINMUX_PB13C_SERCOM4_PAD1  ((PIN_PB13C_SERCOM4_PAD1 << 16) | MUX_PB13C_SERCOM4_PAD1)
+#define PORT_PB13C_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PB14C_SERCOM4_PAD2         _L_(46) /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2          _L_(2)
+#define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
+#define PORT_PB14C_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+#define PIN_PB15C_SERCOM4_PAD3         _L_(47) /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3          _L_(2)
+#define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
+#define PORT_PB15C_SERCOM4_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PB30D_SERCOM5_PAD0         _L_(62) /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
+#define PORT_PB30D_SERCOM5_PAD0  (_UL_(1) << 30)
+#define PIN_PB16C_SERCOM5_PAD0         _L_(48) /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0          _L_(2)
+#define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
+#define PORT_PB16C_SERCOM5_PAD0  (_UL_(1) << 16)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PB31D_SERCOM5_PAD1         _L_(63) /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
+#define PORT_PB31D_SERCOM5_PAD1  (_UL_(1) << 31)
+#define PIN_PB17C_SERCOM5_PAD1         _L_(49) /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1          _L_(2)
+#define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
+#define PORT_PB17C_SERCOM5_PAD1  (_UL_(1) << 17)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB00D_SERCOM5_PAD2         _L_(32) /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
+#define PORT_PB00D_SERCOM5_PAD2  (_UL_(1) <<  0)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB01D_SERCOM5_PAD3         _L_(33) /**< \brief SERCOM5 signal: PAD3 on PB01 mux D */
+#define MUX_PB01D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB01D_SERCOM5_PAD3  ((PIN_PB01D_SERCOM5_PAD3 << 16) | MUX_PB01D_SERCOM5_PAD3)
+#define PORT_PB01D_SERCOM5_PAD3  (_UL_(1) <<  1)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PB30F_TC0_WO0              _L_(62) /**< \brief TC0 signal: WO0 on PB30 mux F */
+#define MUX_PB30F_TC0_WO0               _L_(5)
+#define PINMUX_PB30F_TC0_WO0       ((PIN_PB30F_TC0_WO0 << 16) | MUX_PB30F_TC0_WO0)
+#define PORT_PB30F_TC0_WO0     (_UL_(1) << 30)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PB31F_TC0_WO1              _L_(63) /**< \brief TC0 signal: WO1 on PB31 mux F */
+#define MUX_PB31F_TC0_WO1               _L_(5)
+#define PINMUX_PB31F_TC0_WO1       ((PIN_PB31F_TC0_WO1 << 16) | MUX_PB31F_TC0_WO1)
+#define PORT_PB31F_TC0_WO1     (_UL_(1) << 31)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PB12E_TC4_WO0              _L_(44) /**< \brief TC4 signal: WO0 on PB12 mux E */
+#define MUX_PB12E_TC4_WO0               _L_(4)
+#define PINMUX_PB12E_TC4_WO0       ((PIN_PB12E_TC4_WO0 << 16) | MUX_PB12E_TC4_WO0)
+#define PORT_PB12E_TC4_WO0     (_UL_(1) << 12)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+#define PIN_PB13E_TC4_WO1              _L_(45) /**< \brief TC4 signal: WO1 on PB13 mux E */
+#define MUX_PB13E_TC4_WO1               _L_(4)
+#define PINMUX_PB13E_TC4_WO1       ((PIN_PB13E_TC4_WO1 << 16) | MUX_PB13E_TC4_WO1)
+#define PORT_PB13E_TC4_WO1     (_UL_(1) << 13)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PB14E_TC5_WO0              _L_(46) /**< \brief TC5 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC5_WO0               _L_(4)
+#define PINMUX_PB14E_TC5_WO0       ((PIN_PB14E_TC5_WO0 << 16) | MUX_PB14E_TC5_WO0)
+#define PORT_PB14E_TC5_WO0     (_UL_(1) << 14)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+#define PIN_PB15E_TC5_WO1              _L_(47) /**< \brief TC5 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC5_WO1               _L_(4)
+#define PINMUX_PB15E_TC5_WO1       ((PIN_PB15E_TC5_WO1 << 16) | MUX_PB15E_TC5_WO1)
+#define PORT_PB15E_TC5_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC6 peripheral ========== */
+#define PIN_PB02F_TC6_WO0              _L_(34) /**< \brief TC6 signal: WO0 on PB02 mux F */
+#define MUX_PB02F_TC6_WO0               _L_(5)
+#define PINMUX_PB02F_TC6_WO0       ((PIN_PB02F_TC6_WO0 << 16) | MUX_PB02F_TC6_WO0)
+#define PORT_PB02F_TC6_WO0     (_UL_(1) <<  2)
+#define PIN_PB16E_TC6_WO0              _L_(48) /**< \brief TC6 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC6_WO0               _L_(4)
+#define PINMUX_PB16E_TC6_WO0       ((PIN_PB16E_TC6_WO0 << 16) | MUX_PB16E_TC6_WO0)
+#define PORT_PB16E_TC6_WO0     (_UL_(1) << 16)
+#define PIN_PB03F_TC6_WO1              _L_(35) /**< \brief TC6 signal: WO1 on PB03 mux F */
+#define MUX_PB03F_TC6_WO1               _L_(5)
+#define PINMUX_PB03F_TC6_WO1       ((PIN_PB03F_TC6_WO1 << 16) | MUX_PB03F_TC6_WO1)
+#define PORT_PB03F_TC6_WO1     (_UL_(1) <<  3)
+#define PIN_PB17E_TC6_WO1              _L_(49) /**< \brief TC6 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC6_WO1               _L_(4)
+#define PINMUX_PB17E_TC6_WO1       ((PIN_PB17E_TC6_WO1 << 16) | MUX_PB17E_TC6_WO1)
+#define PORT_PB17E_TC6_WO1     (_UL_(1) << 17)
+/* ========== PORT definition for TC7 peripheral ========== */
+#define PIN_PB00F_TC7_WO0              _L_(32) /**< \brief TC7 signal: WO0 on PB00 mux F */
+#define MUX_PB00F_TC7_WO0               _L_(5)
+#define PINMUX_PB00F_TC7_WO0       ((PIN_PB00F_TC7_WO0 << 16) | MUX_PB00F_TC7_WO0)
+#define PORT_PB00F_TC7_WO0     (_UL_(1) <<  0)
+#define PIN_PB22F_TC7_WO0              _L_(54) /**< \brief TC7 signal: WO0 on PB22 mux F */
+#define MUX_PB22F_TC7_WO0               _L_(5)
+#define PINMUX_PB22F_TC7_WO0       ((PIN_PB22F_TC7_WO0 << 16) | MUX_PB22F_TC7_WO0)
+#define PORT_PB22F_TC7_WO0     (_UL_(1) << 22)
+#define PIN_PA20E_TC7_WO0              _L_(20) /**< \brief TC7 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC7_WO0               _L_(4)
+#define PINMUX_PA20E_TC7_WO0       ((PIN_PA20E_TC7_WO0 << 16) | MUX_PA20E_TC7_WO0)
+#define PORT_PA20E_TC7_WO0     (_UL_(1) << 20)
+#define PIN_PB01F_TC7_WO1              _L_(33) /**< \brief TC7 signal: WO1 on PB01 mux F */
+#define MUX_PB01F_TC7_WO1               _L_(5)
+#define PINMUX_PB01F_TC7_WO1       ((PIN_PB01F_TC7_WO1 << 16) | MUX_PB01F_TC7_WO1)
+#define PORT_PB01F_TC7_WO1     (_UL_(1) <<  1)
+#define PIN_PB23F_TC7_WO1              _L_(55) /**< \brief TC7 signal: WO1 on PB23 mux F */
+#define MUX_PB23F_TC7_WO1               _L_(5)
+#define PINMUX_PB23F_TC7_WO1       ((PIN_PB23F_TC7_WO1 << 16) | MUX_PB23F_TC7_WO1)
+#define PORT_PB23F_TC7_WO1     (_UL_(1) << 23)
+#define PIN_PA21E_TC7_WO1              _L_(21) /**< \brief TC7 signal: WO1 on PA21 mux E */
+#define MUX_PA21E_TC7_WO1               _L_(4)
+#define PINMUX_PA21E_TC7_WO1       ((PIN_PA21E_TC7_WO1 << 16) | MUX_PA21E_TC7_WO1)
+#define PORT_PA21E_TC7_WO1     (_UL_(1) << 21)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB00B_ADC_AIN8             _L_(32) /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8              _L_(1)
+#define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
+#define PORT_PB00B_ADC_AIN8    (_UL_(1) <<  0)
+#define PIN_PB01B_ADC_AIN9             _L_(33) /**< \brief ADC signal: AIN9 on PB01 mux B */
+#define MUX_PB01B_ADC_AIN9              _L_(1)
+#define PINMUX_PB01B_ADC_AIN9      ((PIN_PB01B_ADC_AIN9 << 16) | MUX_PB01B_ADC_AIN9)
+#define PORT_PB01B_ADC_AIN9    (_UL_(1) <<  1)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PB04B_ADC_AIN12            _L_(36) /**< \brief ADC signal: AIN12 on PB04 mux B */
+#define MUX_PB04B_ADC_AIN12             _L_(1)
+#define PINMUX_PB04B_ADC_AIN12     ((PIN_PB04B_ADC_AIN12 << 16) | MUX_PB04B_ADC_AIN12)
+#define PORT_PB04B_ADC_AIN12   (_UL_(1) <<  4)
+#define PIN_PB05B_ADC_AIN13            _L_(37) /**< \brief ADC signal: AIN13 on PB05 mux B */
+#define MUX_PB05B_ADC_AIN13             _L_(1)
+#define PINMUX_PB05B_ADC_AIN13     ((PIN_PB05B_ADC_AIN13 << 16) | MUX_PB05B_ADC_AIN13)
+#define PORT_PB05B_ADC_AIN13   (_UL_(1) <<  5)
+#define PIN_PB06B_ADC_AIN14            _L_(38) /**< \brief ADC signal: AIN14 on PB06 mux B */
+#define MUX_PB06B_ADC_AIN14             _L_(1)
+#define PINMUX_PB06B_ADC_AIN14     ((PIN_PB06B_ADC_AIN14 << 16) | MUX_PB06B_ADC_AIN14)
+#define PORT_PB06B_ADC_AIN14   (_UL_(1) <<  6)
+#define PIN_PB07B_ADC_AIN15            _L_(39) /**< \brief ADC signal: AIN15 on PB07 mux B */
+#define MUX_PB07B_ADC_AIN15             _L_(1)
+#define PINMUX_PB07B_ADC_AIN15     ((PIN_PB07B_ADC_AIN15 << 16) | MUX_PB07B_ADC_AIN15)
+#define PORT_PB07B_ADC_AIN15   (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20J17_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/pio/samd20j18.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/pio/samd20j18.h
@@ -1,0 +1,1056 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20J18
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J18_PIO_
+#define _SAMD20J18_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB00                           32  /**< \brief Pin Number for PB00 */
+#define PORT_PB00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PB00 */
+#define PIN_PB01                           33  /**< \brief Pin Number for PB01 */
+#define PORT_PB01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PB01 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB04                           36  /**< \brief Pin Number for PB04 */
+#define PORT_PB04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PB04 */
+#define PIN_PB05                           37  /**< \brief Pin Number for PB05 */
+#define PORT_PB05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PB05 */
+#define PIN_PB06                           38  /**< \brief Pin Number for PB06 */
+#define PORT_PB06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PB06 */
+#define PIN_PB07                           39  /**< \brief Pin Number for PB07 */
+#define PORT_PB07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PB07 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB12                           44  /**< \brief Pin Number for PB12 */
+#define PORT_PB12              (_UL_(1) << 12) /**< \brief PORT Mask  for PB12 */
+#define PIN_PB13                           45  /**< \brief Pin Number for PB13 */
+#define PORT_PB13              (_UL_(1) << 13) /**< \brief PORT Mask  for PB13 */
+#define PIN_PB14                           46  /**< \brief Pin Number for PB14 */
+#define PORT_PB14              (_UL_(1) << 14) /**< \brief PORT Mask  for PB14 */
+#define PIN_PB15                           47  /**< \brief Pin Number for PB15 */
+#define PORT_PB15              (_UL_(1) << 15) /**< \brief PORT Mask  for PB15 */
+#define PIN_PB16                           48  /**< \brief Pin Number for PB16 */
+#define PORT_PB16              (_UL_(1) << 16) /**< \brief PORT Mask  for PB16 */
+#define PIN_PB17                           49  /**< \brief Pin Number for PB17 */
+#define PORT_PB17              (_UL_(1) << 17) /**< \brief PORT Mask  for PB17 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+#define PIN_PB30                           62  /**< \brief Pin Number for PB30 */
+#define PORT_PB30              (_UL_(1) << 30) /**< \brief PORT Mask  for PB30 */
+#define PIN_PB31                           63  /**< \brief Pin Number for PB31 */
+#define PORT_PB31              (_UL_(1) << 31) /**< \brief PORT Mask  for PB31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB14H_GCLK_IO0             _L_(46) /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0              _L_(7)
+#define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
+#define PORT_PB14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB15H_GCLK_IO1             _L_(47) /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1              _L_(7)
+#define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
+#define PORT_PB15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB16H_GCLK_IO2             _L_(48) /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2              _L_(7)
+#define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
+#define PORT_PB16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PB17H_GCLK_IO3             _L_(49) /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3              _L_(7)
+#define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
+#define PORT_PB17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PB12H_GCLK_IO6             _L_(44) /**< \brief GCLK signal: IO6 on PB12 mux H */
+#define MUX_PB12H_GCLK_IO6              _L_(7)
+#define PINMUX_PB12H_GCLK_IO6      ((PIN_PB12H_GCLK_IO6 << 16) | MUX_PB12H_GCLK_IO6)
+#define PORT_PB12H_GCLK_IO6    (_UL_(1) << 12)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+#define PIN_PB13H_GCLK_IO7             _L_(45) /**< \brief GCLK signal: IO7 on PB13 mux H */
+#define MUX_PB13H_GCLK_IO7              _L_(7)
+#define PINMUX_PB13H_GCLK_IO7      ((PIN_PB13H_GCLK_IO7 << 16) | MUX_PB13H_GCLK_IO7)
+#define PORT_PB13H_GCLK_IO7    (_UL_(1) << 13)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PB00A_EIC_EXTINT0          _L_(32) /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
+#define PORT_PB00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PB00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB00 External Interrupt Line */
+#define PIN_PB16A_EIC_EXTINT0          _L_(48) /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
+#define PORT_PB16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PB16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PB01A_EIC_EXTINT1          _L_(33) /**< \brief EIC signal: EXTINT1 on PB01 mux A */
+#define MUX_PB01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB01A_EIC_EXTINT1   ((PIN_PB01A_EIC_EXTINT1 << 16) | MUX_PB01A_EIC_EXTINT1)
+#define PORT_PB01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PB01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PB17A_EIC_EXTINT1          _L_(49) /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
+#define PORT_PB17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PB17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PB04A_EIC_EXTINT4          _L_(36) /**< \brief EIC signal: EXTINT4 on PB04 mux A */
+#define MUX_PB04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PB04A_EIC_EXTINT4   ((PIN_PB04A_EIC_EXTINT4 << 16) | MUX_PB04A_EIC_EXTINT4)
+#define PORT_PB04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PB04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PB04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PB05A_EIC_EXTINT5          _L_(37) /**< \brief EIC signal: EXTINT5 on PB05 mux A */
+#define MUX_PB05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PB05A_EIC_EXTINT5   ((PIN_PB05A_EIC_EXTINT5 << 16) | MUX_PB05A_EIC_EXTINT5)
+#define PORT_PB05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PB05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PB05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB06A_EIC_EXTINT6          _L_(38) /**< \brief EIC signal: EXTINT6 on PB06 mux A */
+#define MUX_PB06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB06A_EIC_EXTINT6   ((PIN_PB06A_EIC_EXTINT6 << 16) | MUX_PB06A_EIC_EXTINT6)
+#define PORT_PB06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PB06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB06 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB07A_EIC_EXTINT7          _L_(39) /**< \brief EIC signal: EXTINT7 on PB07 mux A */
+#define MUX_PB07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB07A_EIC_EXTINT7   ((PIN_PB07A_EIC_EXTINT7 << 16) | MUX_PB07A_EIC_EXTINT7)
+#define PORT_PB07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PB07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB07 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PB12A_EIC_EXTINT12         _L_(44) /**< \brief EIC signal: EXTINT12 on PB12 mux A */
+#define MUX_PB12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PB12A_EIC_EXTINT12  ((PIN_PB12A_EIC_EXTINT12 << 16) | MUX_PB12A_EIC_EXTINT12)
+#define PORT_PB12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PB12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PB12 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PB13A_EIC_EXTINT13         _L_(45) /**< \brief EIC signal: EXTINT13 on PB13 mux A */
+#define MUX_PB13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PB13A_EIC_EXTINT13  ((PIN_PB13A_EIC_EXTINT13 << 16) | MUX_PB13A_EIC_EXTINT13)
+#define PORT_PB13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PB13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PB13 External Interrupt Line */
+#define PIN_PB14A_EIC_EXTINT14         _L_(46) /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
+#define PORT_PB14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PB14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB14 External Interrupt Line */
+#define PIN_PB30A_EIC_EXTINT14         _L_(62) /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
+#define PORT_PB30A_EIC_EXTINT14  (_UL_(1) << 30)
+#define PIN_PB30A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB30 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PB15A_EIC_EXTINT15         _L_(47) /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
+#define PORT_PB15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PB15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB15 External Interrupt Line */
+#define PIN_PB31A_EIC_EXTINT15         _L_(63) /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
+#define PORT_PB31A_EIC_EXTINT15  (_UL_(1) << 31)
+#define PIN_PB31A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB31 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PB12C_SERCOM4_PAD0         _L_(44) /**< \brief SERCOM4 signal: PAD0 on PB12 mux C */
+#define MUX_PB12C_SERCOM4_PAD0          _L_(2)
+#define PINMUX_PB12C_SERCOM4_PAD0  ((PIN_PB12C_SERCOM4_PAD0 << 16) | MUX_PB12C_SERCOM4_PAD0)
+#define PORT_PB12C_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PB13C_SERCOM4_PAD1         _L_(45) /**< \brief SERCOM4 signal: PAD1 on PB13 mux C */
+#define MUX_PB13C_SERCOM4_PAD1          _L_(2)
+#define PINMUX_PB13C_SERCOM4_PAD1  ((PIN_PB13C_SERCOM4_PAD1 << 16) | MUX_PB13C_SERCOM4_PAD1)
+#define PORT_PB13C_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PB14C_SERCOM4_PAD2         _L_(46) /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2          _L_(2)
+#define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
+#define PORT_PB14C_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+#define PIN_PB15C_SERCOM4_PAD3         _L_(47) /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3          _L_(2)
+#define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
+#define PORT_PB15C_SERCOM4_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PB30D_SERCOM5_PAD0         _L_(62) /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
+#define PORT_PB30D_SERCOM5_PAD0  (_UL_(1) << 30)
+#define PIN_PB16C_SERCOM5_PAD0         _L_(48) /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0          _L_(2)
+#define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
+#define PORT_PB16C_SERCOM5_PAD0  (_UL_(1) << 16)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PB31D_SERCOM5_PAD1         _L_(63) /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
+#define PORT_PB31D_SERCOM5_PAD1  (_UL_(1) << 31)
+#define PIN_PB17C_SERCOM5_PAD1         _L_(49) /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1          _L_(2)
+#define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
+#define PORT_PB17C_SERCOM5_PAD1  (_UL_(1) << 17)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB00D_SERCOM5_PAD2         _L_(32) /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
+#define PORT_PB00D_SERCOM5_PAD2  (_UL_(1) <<  0)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB01D_SERCOM5_PAD3         _L_(33) /**< \brief SERCOM5 signal: PAD3 on PB01 mux D */
+#define MUX_PB01D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB01D_SERCOM5_PAD3  ((PIN_PB01D_SERCOM5_PAD3 << 16) | MUX_PB01D_SERCOM5_PAD3)
+#define PORT_PB01D_SERCOM5_PAD3  (_UL_(1) <<  1)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PB30F_TC0_WO0              _L_(62) /**< \brief TC0 signal: WO0 on PB30 mux F */
+#define MUX_PB30F_TC0_WO0               _L_(5)
+#define PINMUX_PB30F_TC0_WO0       ((PIN_PB30F_TC0_WO0 << 16) | MUX_PB30F_TC0_WO0)
+#define PORT_PB30F_TC0_WO0     (_UL_(1) << 30)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PB31F_TC0_WO1              _L_(63) /**< \brief TC0 signal: WO1 on PB31 mux F */
+#define MUX_PB31F_TC0_WO1               _L_(5)
+#define PINMUX_PB31F_TC0_WO1       ((PIN_PB31F_TC0_WO1 << 16) | MUX_PB31F_TC0_WO1)
+#define PORT_PB31F_TC0_WO1     (_UL_(1) << 31)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PB12E_TC4_WO0              _L_(44) /**< \brief TC4 signal: WO0 on PB12 mux E */
+#define MUX_PB12E_TC4_WO0               _L_(4)
+#define PINMUX_PB12E_TC4_WO0       ((PIN_PB12E_TC4_WO0 << 16) | MUX_PB12E_TC4_WO0)
+#define PORT_PB12E_TC4_WO0     (_UL_(1) << 12)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+#define PIN_PB13E_TC4_WO1              _L_(45) /**< \brief TC4 signal: WO1 on PB13 mux E */
+#define MUX_PB13E_TC4_WO1               _L_(4)
+#define PINMUX_PB13E_TC4_WO1       ((PIN_PB13E_TC4_WO1 << 16) | MUX_PB13E_TC4_WO1)
+#define PORT_PB13E_TC4_WO1     (_UL_(1) << 13)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PB14E_TC5_WO0              _L_(46) /**< \brief TC5 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC5_WO0               _L_(4)
+#define PINMUX_PB14E_TC5_WO0       ((PIN_PB14E_TC5_WO0 << 16) | MUX_PB14E_TC5_WO0)
+#define PORT_PB14E_TC5_WO0     (_UL_(1) << 14)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+#define PIN_PB15E_TC5_WO1              _L_(47) /**< \brief TC5 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC5_WO1               _L_(4)
+#define PINMUX_PB15E_TC5_WO1       ((PIN_PB15E_TC5_WO1 << 16) | MUX_PB15E_TC5_WO1)
+#define PORT_PB15E_TC5_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC6 peripheral ========== */
+#define PIN_PB02F_TC6_WO0              _L_(34) /**< \brief TC6 signal: WO0 on PB02 mux F */
+#define MUX_PB02F_TC6_WO0               _L_(5)
+#define PINMUX_PB02F_TC6_WO0       ((PIN_PB02F_TC6_WO0 << 16) | MUX_PB02F_TC6_WO0)
+#define PORT_PB02F_TC6_WO0     (_UL_(1) <<  2)
+#define PIN_PB16E_TC6_WO0              _L_(48) /**< \brief TC6 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC6_WO0               _L_(4)
+#define PINMUX_PB16E_TC6_WO0       ((PIN_PB16E_TC6_WO0 << 16) | MUX_PB16E_TC6_WO0)
+#define PORT_PB16E_TC6_WO0     (_UL_(1) << 16)
+#define PIN_PB03F_TC6_WO1              _L_(35) /**< \brief TC6 signal: WO1 on PB03 mux F */
+#define MUX_PB03F_TC6_WO1               _L_(5)
+#define PINMUX_PB03F_TC6_WO1       ((PIN_PB03F_TC6_WO1 << 16) | MUX_PB03F_TC6_WO1)
+#define PORT_PB03F_TC6_WO1     (_UL_(1) <<  3)
+#define PIN_PB17E_TC6_WO1              _L_(49) /**< \brief TC6 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC6_WO1               _L_(4)
+#define PINMUX_PB17E_TC6_WO1       ((PIN_PB17E_TC6_WO1 << 16) | MUX_PB17E_TC6_WO1)
+#define PORT_PB17E_TC6_WO1     (_UL_(1) << 17)
+/* ========== PORT definition for TC7 peripheral ========== */
+#define PIN_PB00F_TC7_WO0              _L_(32) /**< \brief TC7 signal: WO0 on PB00 mux F */
+#define MUX_PB00F_TC7_WO0               _L_(5)
+#define PINMUX_PB00F_TC7_WO0       ((PIN_PB00F_TC7_WO0 << 16) | MUX_PB00F_TC7_WO0)
+#define PORT_PB00F_TC7_WO0     (_UL_(1) <<  0)
+#define PIN_PB22F_TC7_WO0              _L_(54) /**< \brief TC7 signal: WO0 on PB22 mux F */
+#define MUX_PB22F_TC7_WO0               _L_(5)
+#define PINMUX_PB22F_TC7_WO0       ((PIN_PB22F_TC7_WO0 << 16) | MUX_PB22F_TC7_WO0)
+#define PORT_PB22F_TC7_WO0     (_UL_(1) << 22)
+#define PIN_PA20E_TC7_WO0              _L_(20) /**< \brief TC7 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC7_WO0               _L_(4)
+#define PINMUX_PA20E_TC7_WO0       ((PIN_PA20E_TC7_WO0 << 16) | MUX_PA20E_TC7_WO0)
+#define PORT_PA20E_TC7_WO0     (_UL_(1) << 20)
+#define PIN_PB01F_TC7_WO1              _L_(33) /**< \brief TC7 signal: WO1 on PB01 mux F */
+#define MUX_PB01F_TC7_WO1               _L_(5)
+#define PINMUX_PB01F_TC7_WO1       ((PIN_PB01F_TC7_WO1 << 16) | MUX_PB01F_TC7_WO1)
+#define PORT_PB01F_TC7_WO1     (_UL_(1) <<  1)
+#define PIN_PB23F_TC7_WO1              _L_(55) /**< \brief TC7 signal: WO1 on PB23 mux F */
+#define MUX_PB23F_TC7_WO1               _L_(5)
+#define PINMUX_PB23F_TC7_WO1       ((PIN_PB23F_TC7_WO1 << 16) | MUX_PB23F_TC7_WO1)
+#define PORT_PB23F_TC7_WO1     (_UL_(1) << 23)
+#define PIN_PA21E_TC7_WO1              _L_(21) /**< \brief TC7 signal: WO1 on PA21 mux E */
+#define MUX_PA21E_TC7_WO1               _L_(4)
+#define PINMUX_PA21E_TC7_WO1       ((PIN_PA21E_TC7_WO1 << 16) | MUX_PA21E_TC7_WO1)
+#define PORT_PA21E_TC7_WO1     (_UL_(1) << 21)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB00B_ADC_AIN8             _L_(32) /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8              _L_(1)
+#define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
+#define PORT_PB00B_ADC_AIN8    (_UL_(1) <<  0)
+#define PIN_PB01B_ADC_AIN9             _L_(33) /**< \brief ADC signal: AIN9 on PB01 mux B */
+#define MUX_PB01B_ADC_AIN9              _L_(1)
+#define PINMUX_PB01B_ADC_AIN9      ((PIN_PB01B_ADC_AIN9 << 16) | MUX_PB01B_ADC_AIN9)
+#define PORT_PB01B_ADC_AIN9    (_UL_(1) <<  1)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PB04B_ADC_AIN12            _L_(36) /**< \brief ADC signal: AIN12 on PB04 mux B */
+#define MUX_PB04B_ADC_AIN12             _L_(1)
+#define PINMUX_PB04B_ADC_AIN12     ((PIN_PB04B_ADC_AIN12 << 16) | MUX_PB04B_ADC_AIN12)
+#define PORT_PB04B_ADC_AIN12   (_UL_(1) <<  4)
+#define PIN_PB05B_ADC_AIN13            _L_(37) /**< \brief ADC signal: AIN13 on PB05 mux B */
+#define MUX_PB05B_ADC_AIN13             _L_(1)
+#define PINMUX_PB05B_ADC_AIN13     ((PIN_PB05B_ADC_AIN13 << 16) | MUX_PB05B_ADC_AIN13)
+#define PORT_PB05B_ADC_AIN13   (_UL_(1) <<  5)
+#define PIN_PB06B_ADC_AIN14            _L_(38) /**< \brief ADC signal: AIN14 on PB06 mux B */
+#define MUX_PB06B_ADC_AIN14             _L_(1)
+#define PINMUX_PB06B_ADC_AIN14     ((PIN_PB06B_ADC_AIN14 << 16) | MUX_PB06B_ADC_AIN14)
+#define PORT_PB06B_ADC_AIN14   (_UL_(1) <<  6)
+#define PIN_PB07B_ADC_AIN15            _L_(39) /**< \brief ADC signal: AIN15 on PB07 mux B */
+#define MUX_PB07B_ADC_AIN15             _L_(1)
+#define PINMUX_PB07B_ADC_AIN15     ((PIN_PB07B_ADC_AIN15 << 16) | MUX_PB07B_ADC_AIN15)
+#define PORT_PB07B_ADC_AIN15   (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20J18_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/sam.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/sam.h
@@ -1,0 +1,72 @@
+/**
+ * \file
+ *
+ * \brief Top level header file
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+#ifndef _SAM_
+#define _SAM_
+
+#if   defined(__SAMD20G17__) || defined(__ATSAMD20G17__)
+  #include "samd20g17.h"
+#elif defined(__SAMD20J15__) || defined(__ATSAMD20J15__)
+  #include "samd20j15.h"
+#elif defined(__SAMD20E14__) || defined(__ATSAMD20E14__)
+  #include "samd20e14.h"
+#elif defined(__SAMD20G14__) || defined(__ATSAMD20G14__)
+  #include "samd20g14.h"
+#elif defined(__SAMD20G18__) || defined(__ATSAMD20G18__)
+  #include "samd20g18.h"
+#elif defined(__SAMD20J17__) || defined(__ATSAMD20J17__)
+  #include "samd20j17.h"
+#elif defined(__SAMD20E17__) || defined(__ATSAMD20E17__)
+  #include "samd20e17.h"
+#elif defined(__SAMD20G15__) || defined(__ATSAMD20G15__)
+  #include "samd20g15.h"
+#elif defined(__SAMD20E15__) || defined(__ATSAMD20E15__)
+  #include "samd20e15.h"
+#elif defined(__SAMD20E16__) || defined(__ATSAMD20E16__)
+  #include "samd20e16.h"
+#elif defined(__SAMD20E18__) || defined(__ATSAMD20E18__)
+  #include "samd20e18.h"
+#elif defined(__SAMD20J14__) || defined(__ATSAMD20J14__)
+  #include "samd20j14.h"
+#elif defined(__SAMD20G18U__) || defined(__ATSAMD20G18U__)
+  #include "samd20g18u.h"
+#elif defined(__SAMD20G16__) || defined(__ATSAMD20G16__)
+  #include "samd20g16.h"
+#elif defined(__SAMD20J18__) || defined(__ATSAMD20J18__)
+  #include "samd20j18.h"
+#elif defined(__SAMD20G17U__) || defined(__ATSAMD20G17U__)
+  #include "samd20g17u.h"
+#elif defined(__SAMD20J16__) || defined(__ATSAMD20J16__)
+  #include "samd20j16.h"
+#else
+  #error Library does not support the specified device
+#endif
+
+#endif /* _SAM_ */
+

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20.h
@@ -1,0 +1,78 @@
+/**
+ * \file
+ *
+ * \brief Top header file for SAMD20
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_
+#define _SAMD20_
+
+/**
+ * \defgroup SAMD20_definitions SAMD20 Device Definitions
+ * \brief SAMD20 CMSIS Definitions.
+ */
+
+#if   defined(__SAMD20E1F__) || defined(__ATSAMD20E1F__)
+  #include "samd20e1f.h"
+#elif defined(__SAMD20E14__) || defined(__ATSAMD20E14__)
+  #include "samd20e14.h"
+#elif defined(__SAMD20E15__) || defined(__ATSAMD20E15__)
+  #include "samd20e15.h"
+#elif defined(__SAMD20E16__) || defined(__ATSAMD20E16__)
+  #include "samd20e16.h"
+#elif defined(__SAMD20E17__) || defined(__ATSAMD20E17__)
+  #include "samd20e17.h"
+#elif defined(__SAMD20E18__) || defined(__ATSAMD20E18__)
+  #include "samd20e18.h"
+#elif defined(__SAMD20G14__) || defined(__ATSAMD20G14__)
+  #include "samd20g14.h"
+#elif defined(__SAMD20G15__) || defined(__ATSAMD20G15__)
+  #include "samd20g15.h"
+#elif defined(__SAMD20G16__) || defined(__ATSAMD20G16__)
+  #include "samd20g16.h"
+#elif defined(__SAMD20G17__) || defined(__ATSAMD20G17__)
+  #include "samd20g17.h"
+#elif defined(__SAMD20G17U__) || defined(__ATSAMD20G17U__)
+  #include "samd20g17u.h"
+#elif defined(__SAMD20G18__) || defined(__ATSAMD20G18__)
+  #include "samd20g18.h"
+#elif defined(__SAMD20G18U__) || defined(__ATSAMD20G18U__)
+  #include "samd20g18u.h"
+#elif defined(__SAMD20J14__) || defined(__ATSAMD20J14__)
+  #include "samd20j14.h"
+#elif defined(__SAMD20J15__) || defined(__ATSAMD20J15__)
+  #include "samd20j15.h"
+#elif defined(__SAMD20J16__) || defined(__ATSAMD20J16__)
+  #include "samd20j16.h"
+#elif defined(__SAMD20J17__) || defined(__ATSAMD20J17__)
+  #include "samd20j17.h"
+#elif defined(__SAMD20J18__) || defined(__ATSAMD20J18__)
+  #include "samd20j18.h"
+#else
+  #error Library does not support the specified device.
+#endif
+
+#endif /* _SAMD20_ */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20e14.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20e14.h
@@ -1,0 +1,504 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20E14
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E14_
+#define _SAMD20E14_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20E14_definitions SAMD20E14 definitions
+ * This file defines all structures and symbols for SAMD20E14:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20E14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E14_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20E14-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20E14 Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20E14 System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20E14 Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20E14 Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20E14 External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20E14 Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20E14 Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20E14 Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20E14 Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20E14 Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20E14 Serial Communication Interface 3 (SERCOM3) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20E14 Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20E14 Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20E14 Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20E14 Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20E14 Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20E14 Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20E14 Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20E14 Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20E14 Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20E14 Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pvReserved11;
+  void* pvReserved12;
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20E14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E14_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20E14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E14_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20E14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E14_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20E14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E14_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM_INST_NUM   4                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20E14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E14_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20e14.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20E14 */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00004000) /* 16 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     256
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x1000140E)
+#define PORT_GROUPS           1
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20E14 */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20E14_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20e15.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20e15.h
@@ -1,0 +1,504 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20E15
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E15_
+#define _SAMD20E15_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20E15_definitions SAMD20E15 definitions
+ * This file defines all structures and symbols for SAMD20E15:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20E15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20E15-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20E15 Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20E15 System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20E15 Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20E15 Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20E15 External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20E15 Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20E15 Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20E15 Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20E15 Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20E15 Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20E15 Serial Communication Interface 3 (SERCOM3) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20E15 Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20E15 Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20E15 Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20E15 Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20E15 Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20E15 Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20E15 Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20E15 Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20E15 Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20E15 Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pvReserved11;
+  void* pvReserved12;
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20E15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20E15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20E15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20E15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM_INST_NUM   4                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20E15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20e15.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20E15 */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00008000) /* 32 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     512
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00001000) /* 4 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x1000140D)
+#define PORT_GROUPS           1
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20E15 */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20E15_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20e16.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20e16.h
@@ -1,0 +1,504 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20E16
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E16_
+#define _SAMD20E16_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20E16_definitions SAMD20E16 definitions
+ * This file defines all structures and symbols for SAMD20E16:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20E16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20E16-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20E16 Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20E16 System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20E16 Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20E16 Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20E16 External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20E16 Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20E16 Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20E16 Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20E16 Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20E16 Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20E16 Serial Communication Interface 3 (SERCOM3) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20E16 Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20E16 Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20E16 Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20E16 Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20E16 Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20E16 Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20E16 Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20E16 Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20E16 Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20E16 Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pvReserved11;
+  void* pvReserved12;
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20E16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20E16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20E16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20E16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM_INST_NUM   4                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20E16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20e16.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20E16 */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00010000) /* 64 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     1024
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00002000) /* 8 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x1000140C)
+#define PORT_GROUPS           1
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20E16 */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20E16_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20e17.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20e17.h
@@ -1,0 +1,504 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20E17
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E17_
+#define _SAMD20E17_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20E17_definitions SAMD20E17 definitions
+ * This file defines all structures and symbols for SAMD20E17:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20E17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E17_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20E17-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20E17 Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20E17 System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20E17 Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20E17 Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20E17 External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20E17 Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20E17 Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20E17 Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20E17 Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20E17 Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20E17 Serial Communication Interface 3 (SERCOM3) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20E17 Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20E17 Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20E17 Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20E17 Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20E17 Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20E17 Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20E17 Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20E17 Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20E17 Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20E17 Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pvReserved11;
+  void* pvReserved12;
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20E17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E17_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20E17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E17_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20E17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E17_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20E17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E17_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM_INST_NUM   4                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20E17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E17_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20e17.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20E17 */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00020000) /* 128 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     2048
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00004000) /* 16 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x1000140B)
+#define PORT_GROUPS           1
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20E17 */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20E17_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20e18.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20e18.h
@@ -1,0 +1,504 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20E18
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E18_
+#define _SAMD20E18_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20E18_definitions SAMD20E18 definitions
+ * This file defines all structures and symbols for SAMD20E18:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20E18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E18_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20E18-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20E18 Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20E18 System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20E18 Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20E18 Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20E18 External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20E18 Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20E18 Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20E18 Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20E18 Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20E18 Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20E18 Serial Communication Interface 3 (SERCOM3) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20E18 Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20E18 Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20E18 Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20E18 Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20E18 Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20E18 Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20E18 Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20E18 Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20E18 Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20E18 Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pvReserved11;
+  void* pvReserved12;
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20E18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E18_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20E18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E18_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20E18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E18_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20E18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E18_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM_INST_NUM   4                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20E18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20E18_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20e18.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20E18 */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00040000) /* 256 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     4096
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x1000140A)
+#define PORT_GROUPS           1
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20E18 */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20E18_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20g14.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20g14.h
@@ -1,0 +1,516 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20G14
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G14_
+#define _SAMD20G14_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20G14_definitions SAMD20G14 definitions
+ * This file defines all structures and symbols for SAMD20G14:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20G14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G14_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20G14-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20G14 Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20G14 System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20G14 Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20G14 Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20G14 External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20G14 Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20G14 Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20G14 Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20G14 Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20G14 Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20G14 Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20G14 Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20G14 Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20G14 Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20G14 Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20G14 Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20G14 Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20G14 Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20G14 Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20G14 Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20G14 Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20G14 Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20G14 Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20G14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G14_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20G14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G14_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20G14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G14_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20G14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G14_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20G14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G14_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20g14.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20G14 */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00004000) /* 16 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     256
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001409)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20G14 */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20G14_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20g15.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20g15.h
@@ -1,0 +1,516 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20G15
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G15_
+#define _SAMD20G15_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20G15_definitions SAMD20G15 definitions
+ * This file defines all structures and symbols for SAMD20G15:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20G15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G15_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20G15-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20G15 Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20G15 System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20G15 Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20G15 Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20G15 External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20G15 Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20G15 Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20G15 Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20G15 Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20G15 Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20G15 Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20G15 Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20G15 Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20G15 Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20G15 Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20G15 Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20G15 Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20G15 Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20G15 Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20G15 Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20G15 Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20G15 Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20G15 Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20G15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G15_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20G15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G15_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20G15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G15_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20G15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G15_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20G15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G15_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20g15.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20G15 */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00008000) /* 32 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     512
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00001000) /* 4 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001408)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20G15 */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20G15_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20g16.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20g16.h
@@ -1,0 +1,516 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20G16
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G16_
+#define _SAMD20G16_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20G16_definitions SAMD20G16 definitions
+ * This file defines all structures and symbols for SAMD20G16:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20G16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G16_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20G16-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20G16 Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20G16 System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20G16 Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20G16 Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20G16 External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20G16 Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20G16 Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20G16 Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20G16 Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20G16 Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20G16 Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20G16 Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20G16 Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20G16 Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20G16 Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20G16 Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20G16 Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20G16 Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20G16 Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20G16 Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20G16 Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20G16 Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20G16 Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20G16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G16_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20G16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G16_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20G16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G16_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20G16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G16_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20G16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G16_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20g16.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20G16 */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00010000) /* 64 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     1024
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00002000) /* 8 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001407)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20G16 */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20G16_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20g17.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20g17.h
@@ -1,0 +1,516 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20G17
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G17_
+#define _SAMD20G17_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20G17_definitions SAMD20G17 definitions
+ * This file defines all structures and symbols for SAMD20G17:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20G17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G17_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20G17-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20G17 Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20G17 System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20G17 Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20G17 Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20G17 External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20G17 Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20G17 Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20G17 Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20G17 Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20G17 Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20G17 Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20G17 Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20G17 Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20G17 Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20G17 Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20G17 Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20G17 Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20G17 Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20G17 Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20G17 Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20G17 Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20G17 Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20G17 Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20G17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G17_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20G17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G17_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20G17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G17_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20G17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G17_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20G17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G17_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20g17.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20G17 */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00020000) /* 128 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     2048
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00004000) /* 16 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001406)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20G17 */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20G17_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20g17u.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20g17u.h
@@ -1,0 +1,516 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20G17U
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G17U_
+#define _SAMD20G17U_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20G17U_definitions SAMD20G17U definitions
+ * This file defines all structures and symbols for SAMD20G17U:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20G17U */
+/* ************************************************************************** */
+/** \defgroup SAMD20G17U_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20G17U-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20G17U Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20G17U System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20G17U Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20G17U Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20G17U External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20G17U Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20G17U Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20G17U Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20G17U Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20G17U Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20G17U Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20G17U Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20G17U Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20G17U Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20G17U Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20G17U Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20G17U Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20G17U Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20G17U Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20G17U Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20G17U Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20G17U Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20G17U Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20G17U */
+/* ************************************************************************** */
+/** \defgroup SAMD20G17U_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20G17U */
+/* ************************************************************************** */
+/** \defgroup SAMD20G17U_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20G17U */
+/* ************************************************************************** */
+/** \defgroup SAMD20G17U_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20G17U */
+/* ************************************************************************** */
+/** \defgroup SAMD20G17U_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20G17U */
+/* ************************************************************************** */
+/** \defgroup SAMD20G17U_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20g17u.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20G17U */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00020000) /* 128 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     2048
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00004000) /* 16 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001411)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20G17U */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20G17U_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20g18.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20g18.h
@@ -1,0 +1,516 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20G18
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G18_
+#define _SAMD20G18_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20G18_definitions SAMD20G18 definitions
+ * This file defines all structures and symbols for SAMD20G18:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20G18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G18_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20G18-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20G18 Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20G18 System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20G18 Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20G18 Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20G18 External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20G18 Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20G18 Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20G18 Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20G18 Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20G18 Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20G18 Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20G18 Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20G18 Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20G18 Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20G18 Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20G18 Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20G18 Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20G18 Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20G18 Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20G18 Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20G18 Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20G18 Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20G18 Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20G18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G18_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20G18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G18_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20G18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G18_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20G18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G18_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20G18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20G18_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20g18.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20G18 */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00040000) /* 256 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     4096
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001405)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20G18 */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20G18_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20g18u.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20g18u.h
@@ -1,0 +1,516 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20G18U
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G18U_
+#define _SAMD20G18U_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20G18U_definitions SAMD20G18U definitions
+ * This file defines all structures and symbols for SAMD20G18U:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20G18U */
+/* ************************************************************************** */
+/** \defgroup SAMD20G18U_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20G18U-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20G18U Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20G18U System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20G18U Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20G18U Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20G18U External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20G18U Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20G18U Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20G18U Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20G18U Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20G18U Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20G18U Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20G18U Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20G18U Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20G18U Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20G18U Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20G18U Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20G18U Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20G18U Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20G18U Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20G18U Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20G18U Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20G18U Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20G18U Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20G18U */
+/* ************************************************************************** */
+/** \defgroup SAMD20G18U_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20G18U */
+/* ************************************************************************** */
+/** \defgroup SAMD20G18U_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20G18U */
+/* ************************************************************************** */
+/** \defgroup SAMD20G18U_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20G18U */
+/* ************************************************************************** */
+/** \defgroup SAMD20G18U_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20G18U */
+/* ************************************************************************** */
+/** \defgroup SAMD20G18U_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20g18u.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20G18U */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00040000) /* 256 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     4096
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001410)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20G18U */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20G18U_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20j14.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20j14.h
@@ -1,0 +1,528 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20J14
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J14_
+#define _SAMD20J14_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20J14_definitions SAMD20J14 definitions
+ * This file defines all structures and symbols for SAMD20J14:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20J14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J14_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20J14-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20J14 Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20J14 System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20J14 Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20J14 Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20J14 External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20J14 Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20J14 Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20J14 Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20J14 Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20J14 Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20J14 Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20J14 Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20J14 Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20J14 Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20J14 Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20J14 Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20J14 Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20J14 Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20J14 Basic Timer Counter 5 (TC5) */
+  TC6_IRQn                 = 19, /**< 19 SAMD20J14 Basic Timer Counter 6 (TC6) */
+  TC7_IRQn                 = 20, /**< 20 SAMD20J14 Basic Timer Counter 7 (TC7) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20J14 Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20J14 Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20J14 Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20J14 Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pfnTC6_Handler;                   /* 19 Basic Timer Counter 6 */
+  void* pfnTC7_Handler;                   /* 20 Basic Timer Counter 7 */
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void TC6_Handler                 ( void );
+void TC7_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20J14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J14_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20J14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J14_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/tc6.h"
+#include "instance/tc7.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20J14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J14_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_TC6           78 /**< \brief Basic Timer Counter 6 (TC6) */
+#define ID_TC7           79 /**< \brief Basic Timer Counter 7 (TC7) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20J14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J14_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define TC6                           (0x42003800) /**< \brief (TC6) APB Base Address */
+#define TC7                           (0x42003C00) /**< \brief (TC7) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC6               ((Tc       *)0x42003800UL) /**< \brief (TC6) APB Base Address */
+#define TC7               ((Tc       *)0x42003C00UL) /**< \brief (TC7) APB Base Address */
+#define TC_INST_NUM       8                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5, TC6, TC7 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20J14 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J14_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20j14.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20J14 */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00004000) /* 16 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     256
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001404)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20J14 */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20J14_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20j15.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20j15.h
@@ -1,0 +1,528 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20J15
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J15_
+#define _SAMD20J15_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20J15_definitions SAMD20J15 definitions
+ * This file defines all structures and symbols for SAMD20J15:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20J15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J15_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20J15-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20J15 Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20J15 System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20J15 Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20J15 Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20J15 External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20J15 Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20J15 Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20J15 Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20J15 Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20J15 Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20J15 Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20J15 Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20J15 Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20J15 Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20J15 Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20J15 Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20J15 Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20J15 Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20J15 Basic Timer Counter 5 (TC5) */
+  TC6_IRQn                 = 19, /**< 19 SAMD20J15 Basic Timer Counter 6 (TC6) */
+  TC7_IRQn                 = 20, /**< 20 SAMD20J15 Basic Timer Counter 7 (TC7) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20J15 Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20J15 Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20J15 Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20J15 Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pfnTC6_Handler;                   /* 19 Basic Timer Counter 6 */
+  void* pfnTC7_Handler;                   /* 20 Basic Timer Counter 7 */
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void TC6_Handler                 ( void );
+void TC7_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20J15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J15_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20J15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J15_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/tc6.h"
+#include "instance/tc7.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20J15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J15_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_TC6           78 /**< \brief Basic Timer Counter 6 (TC6) */
+#define ID_TC7           79 /**< \brief Basic Timer Counter 7 (TC7) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20J15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J15_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define TC6                           (0x42003800) /**< \brief (TC6) APB Base Address */
+#define TC7                           (0x42003C00) /**< \brief (TC7) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC6               ((Tc       *)0x42003800UL) /**< \brief (TC6) APB Base Address */
+#define TC7               ((Tc       *)0x42003C00UL) /**< \brief (TC7) APB Base Address */
+#define TC_INST_NUM       8                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5, TC6, TC7 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20J15 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J15_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20j15.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20J15 */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00008000) /* 32 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     512
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00001000) /* 4 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001403)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20J15 */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20J15_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20j16.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20j16.h
@@ -1,0 +1,528 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20J16
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J16_
+#define _SAMD20J16_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20J16_definitions SAMD20J16 definitions
+ * This file defines all structures and symbols for SAMD20J16:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20J16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J16_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20J16-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20J16 Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20J16 System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20J16 Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20J16 Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20J16 External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20J16 Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20J16 Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20J16 Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20J16 Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20J16 Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20J16 Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20J16 Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20J16 Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20J16 Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20J16 Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20J16 Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20J16 Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20J16 Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20J16 Basic Timer Counter 5 (TC5) */
+  TC6_IRQn                 = 19, /**< 19 SAMD20J16 Basic Timer Counter 6 (TC6) */
+  TC7_IRQn                 = 20, /**< 20 SAMD20J16 Basic Timer Counter 7 (TC7) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20J16 Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20J16 Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20J16 Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20J16 Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pfnTC6_Handler;                   /* 19 Basic Timer Counter 6 */
+  void* pfnTC7_Handler;                   /* 20 Basic Timer Counter 7 */
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void TC6_Handler                 ( void );
+void TC7_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20J16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J16_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20J16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J16_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/tc6.h"
+#include "instance/tc7.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20J16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J16_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_TC6           78 /**< \brief Basic Timer Counter 6 (TC6) */
+#define ID_TC7           79 /**< \brief Basic Timer Counter 7 (TC7) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20J16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J16_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define TC6                           (0x42003800) /**< \brief (TC6) APB Base Address */
+#define TC7                           (0x42003C00) /**< \brief (TC7) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC6               ((Tc       *)0x42003800UL) /**< \brief (TC6) APB Base Address */
+#define TC7               ((Tc       *)0x42003C00UL) /**< \brief (TC7) APB Base Address */
+#define TC_INST_NUM       8                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5, TC6, TC7 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20J16 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J16_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20j16.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20J16 */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00010000) /* 64 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     1024
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00002000) /* 8 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001402)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20J16 */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20J16_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20j17.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20j17.h
@@ -1,0 +1,528 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20J17
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J17_
+#define _SAMD20J17_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20J17_definitions SAMD20J17 definitions
+ * This file defines all structures and symbols for SAMD20J17:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20J17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J17_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20J17-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20J17 Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20J17 System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20J17 Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20J17 Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20J17 External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20J17 Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20J17 Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20J17 Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20J17 Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20J17 Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20J17 Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20J17 Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20J17 Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20J17 Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20J17 Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20J17 Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20J17 Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20J17 Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20J17 Basic Timer Counter 5 (TC5) */
+  TC6_IRQn                 = 19, /**< 19 SAMD20J17 Basic Timer Counter 6 (TC6) */
+  TC7_IRQn                 = 20, /**< 20 SAMD20J17 Basic Timer Counter 7 (TC7) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20J17 Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20J17 Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20J17 Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20J17 Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pfnTC6_Handler;                   /* 19 Basic Timer Counter 6 */
+  void* pfnTC7_Handler;                   /* 20 Basic Timer Counter 7 */
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void TC6_Handler                 ( void );
+void TC7_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20J17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J17_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20J17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J17_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/tc6.h"
+#include "instance/tc7.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20J17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J17_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_TC6           78 /**< \brief Basic Timer Counter 6 (TC6) */
+#define ID_TC7           79 /**< \brief Basic Timer Counter 7 (TC7) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20J17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J17_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define TC6                           (0x42003800) /**< \brief (TC6) APB Base Address */
+#define TC7                           (0x42003C00) /**< \brief (TC7) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC6               ((Tc       *)0x42003800UL) /**< \brief (TC6) APB Base Address */
+#define TC7               ((Tc       *)0x42003C00UL) /**< \brief (TC7) APB Base Address */
+#define TC_INST_NUM       8                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5, TC6, TC7 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20J17 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J17_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20j17.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20J17 */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00020000) /* 128 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     2048
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00004000) /* 16 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001401)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20J17 */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20J17_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/samd20j18.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/samd20j18.h
@@ -1,0 +1,528 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20J18
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J18_
+#define _SAMD20J18_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20J18_definitions SAMD20J18 definitions
+ * This file defines all structures and symbols for SAMD20J18:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20J18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J18_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20J18-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20J18 Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20J18 System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20J18 Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20J18 Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20J18 External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20J18 Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20J18 Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20J18 Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20J18 Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20J18 Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20J18 Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20J18 Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20J18 Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20J18 Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20J18 Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20J18 Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20J18 Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20J18 Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20J18 Basic Timer Counter 5 (TC5) */
+  TC6_IRQn                 = 19, /**< 19 SAMD20J18 Basic Timer Counter 6 (TC6) */
+  TC7_IRQn                 = 20, /**< 20 SAMD20J18 Basic Timer Counter 7 (TC7) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20J18 Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20J18 Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20J18 Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20J18 Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pfnTC6_Handler;                   /* 19 Basic Timer Counter 6 */
+  void* pfnTC7_Handler;                   /* 20 Basic Timer Counter 7 */
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void TC6_Handler                 ( void );
+void TC7_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20J18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J18_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20J18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J18_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/tc6.h"
+#include "instance/tc7.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20J18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J18_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_TC6           78 /**< \brief Basic Timer Counter 6 (TC6) */
+#define ID_TC7           79 /**< \brief Basic Timer Counter 7 (TC7) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20J18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J18_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define TC6                           (0x42003800) /**< \brief (TC6) APB Base Address */
+#define TC7                           (0x42003C00) /**< \brief (TC7) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC6               ((Tc       *)0x42003800UL) /**< \brief (TC6) APB Base Address */
+#define TC7               ((Tc       *)0x42003C00UL) /**< \brief (TC7) APB Base Address */
+#define TC_INST_NUM       8                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5, TC6, TC7 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20J18 */
+/* ************************************************************************** */
+/** \defgroup SAMD20J18_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20j18.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20J18 */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00040000) /* 256 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     4096
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00008000) /* 32 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001400)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20J18 */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20J18_H */

--- a/cpu/sam0_common/include/vendor/samd20/include/system_samd20.h
+++ b/cpu/sam0_common/include/vendor/samd20/include/system_samd20.h
@@ -1,0 +1,48 @@
+/**
+ * \file
+ *
+ * \brief Low-level initialization functions called upon chip startup
+ *
+ * Copyright (c) 2018 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SYSTEM_SAMD20_H_INCLUDED_
+#define _SYSTEM_SAMD20_H_INCLUDED_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+extern uint32_t SystemCoreClock;   /*!< System Clock Frequency (Core Clock)  */
+
+void SystemInit(void);
+void SystemCoreClockUpdate(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSTEM_SAMD20_H_INCLUDED */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component-version.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component-version.h
@@ -1,0 +1,64 @@
+/**
+ * \file
+ *
+ * \brief Component version header file
+ *
+ * Copyright (c) 2020 Atmel Corporation, a wholly owned subsidiary of Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+#ifndef _COMPONENT_VERSION_H_INCLUDED
+#define _COMPONENT_VERSION_H_INCLUDED
+
+#define COMPONENT_VERSION_MAJOR 1
+#define COMPONENT_VERSION_MINOR 3
+
+//
+// The COMPONENT_VERSION define is composed of the major and the minor version number.
+//
+// The last four digits of the COMPONENT_VERSION is the minor version with leading zeros.
+// The rest of the COMPONENT_VERSION is the major version.
+//
+#define COMPONENT_VERSION 10003
+
+//
+// The build number does not refer to the component, but to the build number
+// of the device pack that provides the component.
+//
+#define BUILD_NUMBER 165
+
+//
+// The COMPONENT_VERSION_STRING is a string (enclosed in ") that can be used for logging or embedding.
+//
+#define COMPONENT_VERSION_STRING "1.3"
+
+//
+// The COMPONENT_DATE_STRING contains a timestamp of when the pack was generated.
+//
+// The COMPONENT_DATE_STRING is written out using the following strftime pattern.
+//
+//     "%Y-%m-%d %H:%M:%S"
+//
+//
+#define COMPONENT_DATE_STRING "2020-01-20 13:50:49"
+
+#endif/* #ifndef _COMPONENT_VERSION_H_INCLUDED */
+

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/ac.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/ac.h
@@ -1,0 +1,545 @@
+/**
+ * \file
+ *
+ * \brief Component description for AC
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_AC_COMPONENT_
+#define _SAMD20_AC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR AC */
+/* ========================================================================== */
+/** \addtogroup SAMD20_AC Analog Comparators */
+/*@{*/
+
+#define AC_U2205
+#define REV_AC                      0x111
+
+/* -------- AC_CTRLA : (AC Offset: 0x00) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  RUNSTDBY:1;       /*!< bit:      2  Run in Standby                     */
+    uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  LPMUX:1;          /*!< bit:      7  Low-Power Mux                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_CTRLA_OFFSET             0x00         /**< \brief (AC_CTRLA offset) Control A */
+#define AC_CTRLA_RESETVALUE         _U_(0x00)    /**< \brief (AC_CTRLA reset_value) Control A */
+
+#define AC_CTRLA_SWRST_Pos          0            /**< \brief (AC_CTRLA) Software Reset */
+#define AC_CTRLA_SWRST              (_U_(0x1) << AC_CTRLA_SWRST_Pos)
+#define AC_CTRLA_ENABLE_Pos         1            /**< \brief (AC_CTRLA) Enable */
+#define AC_CTRLA_ENABLE             (_U_(0x1) << AC_CTRLA_ENABLE_Pos)
+#define AC_CTRLA_RUNSTDBY_Pos       2            /**< \brief (AC_CTRLA) Run in Standby */
+#define AC_CTRLA_RUNSTDBY_Msk       (_U_(0x1) << AC_CTRLA_RUNSTDBY_Pos)
+#define AC_CTRLA_RUNSTDBY(value)    (AC_CTRLA_RUNSTDBY_Msk & ((value) << AC_CTRLA_RUNSTDBY_Pos))
+#define AC_CTRLA_LPMUX_Pos          7            /**< \brief (AC_CTRLA) Low-Power Mux */
+#define AC_CTRLA_LPMUX              (_U_(0x1) << AC_CTRLA_LPMUX_Pos)
+#define AC_CTRLA_MASK               _U_(0x87)    /**< \brief (AC_CTRLA) MASK Register */
+
+/* -------- AC_CTRLB : (AC Offset: 0x01) ( /W  8) Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  START0:1;         /*!< bit:      0  Comparator 0 Start Comparison      */
+    uint8_t  START1:1;         /*!< bit:      1  Comparator 1 Start Comparison      */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  START:2;          /*!< bit:  0.. 1  Comparator x Start Comparison      */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_CTRLB_OFFSET             0x01         /**< \brief (AC_CTRLB offset) Control B */
+#define AC_CTRLB_RESETVALUE         _U_(0x00)    /**< \brief (AC_CTRLB reset_value) Control B */
+
+#define AC_CTRLB_START0_Pos         0            /**< \brief (AC_CTRLB) Comparator 0 Start Comparison */
+#define AC_CTRLB_START0             (_U_(1) << AC_CTRLB_START0_Pos)
+#define AC_CTRLB_START1_Pos         1            /**< \brief (AC_CTRLB) Comparator 1 Start Comparison */
+#define AC_CTRLB_START1             (_U_(1) << AC_CTRLB_START1_Pos)
+#define AC_CTRLB_START_Pos          0            /**< \brief (AC_CTRLB) Comparator x Start Comparison */
+#define AC_CTRLB_START_Msk          (_U_(0x3) << AC_CTRLB_START_Pos)
+#define AC_CTRLB_START(value)       (AC_CTRLB_START_Msk & ((value) << AC_CTRLB_START_Pos))
+#define AC_CTRLB_MASK               _U_(0x03)    /**< \brief (AC_CTRLB) MASK Register */
+
+/* -------- AC_EVCTRL : (AC Offset: 0x02) (R/W 16) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t COMPEO0:1;        /*!< bit:      0  Comparator 0 Event Output Enable   */
+    uint16_t COMPEO1:1;        /*!< bit:      1  Comparator 1 Event Output Enable   */
+    uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t WINEO0:1;         /*!< bit:      4  Window 0 Event Output Enable       */
+    uint16_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint16_t COMPEI0:1;        /*!< bit:      8  Comparator 0 Event Input           */
+    uint16_t COMPEI1:1;        /*!< bit:      9  Comparator 1 Event Input           */
+    uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t COMPEO:2;         /*!< bit:  0.. 1  Comparator x Event Output Enable   */
+    uint16_t :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint16_t WINEO:1;          /*!< bit:      4  Window x Event Output Enable       */
+    uint16_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint16_t COMPEI:2;         /*!< bit:  8.. 9  Comparator x Event Input           */
+    uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} AC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_EVCTRL_OFFSET            0x02         /**< \brief (AC_EVCTRL offset) Event Control */
+#define AC_EVCTRL_RESETVALUE        _U_(0x0000)  /**< \brief (AC_EVCTRL reset_value) Event Control */
+
+#define AC_EVCTRL_COMPEO0_Pos       0            /**< \brief (AC_EVCTRL) Comparator 0 Event Output Enable */
+#define AC_EVCTRL_COMPEO0           (_U_(1) << AC_EVCTRL_COMPEO0_Pos)
+#define AC_EVCTRL_COMPEO1_Pos       1            /**< \brief (AC_EVCTRL) Comparator 1 Event Output Enable */
+#define AC_EVCTRL_COMPEO1           (_U_(1) << AC_EVCTRL_COMPEO1_Pos)
+#define AC_EVCTRL_COMPEO_Pos        0            /**< \brief (AC_EVCTRL) Comparator x Event Output Enable */
+#define AC_EVCTRL_COMPEO_Msk        (_U_(0x3) << AC_EVCTRL_COMPEO_Pos)
+#define AC_EVCTRL_COMPEO(value)     (AC_EVCTRL_COMPEO_Msk & ((value) << AC_EVCTRL_COMPEO_Pos))
+#define AC_EVCTRL_WINEO0_Pos        4            /**< \brief (AC_EVCTRL) Window 0 Event Output Enable */
+#define AC_EVCTRL_WINEO0            (_U_(1) << AC_EVCTRL_WINEO0_Pos)
+#define AC_EVCTRL_WINEO_Pos         4            /**< \brief (AC_EVCTRL) Window x Event Output Enable */
+#define AC_EVCTRL_WINEO_Msk         (_U_(0x1) << AC_EVCTRL_WINEO_Pos)
+#define AC_EVCTRL_WINEO(value)      (AC_EVCTRL_WINEO_Msk & ((value) << AC_EVCTRL_WINEO_Pos))
+#define AC_EVCTRL_COMPEI0_Pos       8            /**< \brief (AC_EVCTRL) Comparator 0 Event Input */
+#define AC_EVCTRL_COMPEI0           (_U_(1) << AC_EVCTRL_COMPEI0_Pos)
+#define AC_EVCTRL_COMPEI1_Pos       9            /**< \brief (AC_EVCTRL) Comparator 1 Event Input */
+#define AC_EVCTRL_COMPEI1           (_U_(1) << AC_EVCTRL_COMPEI1_Pos)
+#define AC_EVCTRL_COMPEI_Pos        8            /**< \brief (AC_EVCTRL) Comparator x Event Input */
+#define AC_EVCTRL_COMPEI_Msk        (_U_(0x3) << AC_EVCTRL_COMPEI_Pos)
+#define AC_EVCTRL_COMPEI(value)     (AC_EVCTRL_COMPEI_Msk & ((value) << AC_EVCTRL_COMPEI_Pos))
+#define AC_EVCTRL_MASK              _U_(0x0313)  /**< \brief (AC_EVCTRL) MASK Register */
+
+/* -------- AC_INTENCLR : (AC Offset: 0x04) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0 Interrupt Enable      */
+    uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1 Interrupt Enable      */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WIN0:1;           /*!< bit:      4  Window 0 Interrupt Enable          */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x Interrupt Enable      */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WIN:1;            /*!< bit:      4  Window x Interrupt Enable          */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_INTENCLR_OFFSET          0x04         /**< \brief (AC_INTENCLR offset) Interrupt Enable Clear */
+#define AC_INTENCLR_RESETVALUE      _U_(0x00)    /**< \brief (AC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define AC_INTENCLR_COMP0_Pos       0            /**< \brief (AC_INTENCLR) Comparator 0 Interrupt Enable */
+#define AC_INTENCLR_COMP0           (_U_(1) << AC_INTENCLR_COMP0_Pos)
+#define AC_INTENCLR_COMP1_Pos       1            /**< \brief (AC_INTENCLR) Comparator 1 Interrupt Enable */
+#define AC_INTENCLR_COMP1           (_U_(1) << AC_INTENCLR_COMP1_Pos)
+#define AC_INTENCLR_COMP_Pos        0            /**< \brief (AC_INTENCLR) Comparator x Interrupt Enable */
+#define AC_INTENCLR_COMP_Msk        (_U_(0x3) << AC_INTENCLR_COMP_Pos)
+#define AC_INTENCLR_COMP(value)     (AC_INTENCLR_COMP_Msk & ((value) << AC_INTENCLR_COMP_Pos))
+#define AC_INTENCLR_WIN0_Pos        4            /**< \brief (AC_INTENCLR) Window 0 Interrupt Enable */
+#define AC_INTENCLR_WIN0            (_U_(1) << AC_INTENCLR_WIN0_Pos)
+#define AC_INTENCLR_WIN_Pos         4            /**< \brief (AC_INTENCLR) Window x Interrupt Enable */
+#define AC_INTENCLR_WIN_Msk         (_U_(0x1) << AC_INTENCLR_WIN_Pos)
+#define AC_INTENCLR_WIN(value)      (AC_INTENCLR_WIN_Msk & ((value) << AC_INTENCLR_WIN_Pos))
+#define AC_INTENCLR_MASK            _U_(0x13)    /**< \brief (AC_INTENCLR) MASK Register */
+
+/* -------- AC_INTENSET : (AC Offset: 0x05) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0 Interrupt Enable      */
+    uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1 Interrupt Enable      */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WIN0:1;           /*!< bit:      4  Window 0 Interrupt Enable          */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x Interrupt Enable      */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WIN:1;            /*!< bit:      4  Window x Interrupt Enable          */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_INTENSET_OFFSET          0x05         /**< \brief (AC_INTENSET offset) Interrupt Enable Set */
+#define AC_INTENSET_RESETVALUE      _U_(0x00)    /**< \brief (AC_INTENSET reset_value) Interrupt Enable Set */
+
+#define AC_INTENSET_COMP0_Pos       0            /**< \brief (AC_INTENSET) Comparator 0 Interrupt Enable */
+#define AC_INTENSET_COMP0           (_U_(1) << AC_INTENSET_COMP0_Pos)
+#define AC_INTENSET_COMP1_Pos       1            /**< \brief (AC_INTENSET) Comparator 1 Interrupt Enable */
+#define AC_INTENSET_COMP1           (_U_(1) << AC_INTENSET_COMP1_Pos)
+#define AC_INTENSET_COMP_Pos        0            /**< \brief (AC_INTENSET) Comparator x Interrupt Enable */
+#define AC_INTENSET_COMP_Msk        (_U_(0x3) << AC_INTENSET_COMP_Pos)
+#define AC_INTENSET_COMP(value)     (AC_INTENSET_COMP_Msk & ((value) << AC_INTENSET_COMP_Pos))
+#define AC_INTENSET_WIN0_Pos        4            /**< \brief (AC_INTENSET) Window 0 Interrupt Enable */
+#define AC_INTENSET_WIN0            (_U_(1) << AC_INTENSET_WIN0_Pos)
+#define AC_INTENSET_WIN_Pos         4            /**< \brief (AC_INTENSET) Window x Interrupt Enable */
+#define AC_INTENSET_WIN_Msk         (_U_(0x1) << AC_INTENSET_WIN_Pos)
+#define AC_INTENSET_WIN(value)      (AC_INTENSET_WIN_Msk & ((value) << AC_INTENSET_WIN_Pos))
+#define AC_INTENSET_MASK            _U_(0x13)    /**< \brief (AC_INTENSET) MASK Register */
+
+/* -------- AC_INTFLAG : (AC Offset: 0x06) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  COMP0:1;          /*!< bit:      0  Comparator 0                       */
+    __I uint8_t  COMP1:1;          /*!< bit:      1  Comparator 1                       */
+    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  WIN0:1;           /*!< bit:      4  Window 0                           */
+    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint8_t  COMP:2;           /*!< bit:  0.. 1  Comparator x                       */
+    __I uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    __I uint8_t  WIN:1;            /*!< bit:      4  Window x                           */
+    __I uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_INTFLAG_OFFSET           0x06         /**< \brief (AC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define AC_INTFLAG_RESETVALUE       _U_(0x00)    /**< \brief (AC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define AC_INTFLAG_COMP0_Pos        0            /**< \brief (AC_INTFLAG) Comparator 0 */
+#define AC_INTFLAG_COMP0            (_U_(1) << AC_INTFLAG_COMP0_Pos)
+#define AC_INTFLAG_COMP1_Pos        1            /**< \brief (AC_INTFLAG) Comparator 1 */
+#define AC_INTFLAG_COMP1            (_U_(1) << AC_INTFLAG_COMP1_Pos)
+#define AC_INTFLAG_COMP_Pos         0            /**< \brief (AC_INTFLAG) Comparator x */
+#define AC_INTFLAG_COMP_Msk         (_U_(0x3) << AC_INTFLAG_COMP_Pos)
+#define AC_INTFLAG_COMP(value)      (AC_INTFLAG_COMP_Msk & ((value) << AC_INTFLAG_COMP_Pos))
+#define AC_INTFLAG_WIN0_Pos         4            /**< \brief (AC_INTFLAG) Window 0 */
+#define AC_INTFLAG_WIN0             (_U_(1) << AC_INTFLAG_WIN0_Pos)
+#define AC_INTFLAG_WIN_Pos          4            /**< \brief (AC_INTFLAG) Window x */
+#define AC_INTFLAG_WIN_Msk          (_U_(0x1) << AC_INTFLAG_WIN_Pos)
+#define AC_INTFLAG_WIN(value)       (AC_INTFLAG_WIN_Msk & ((value) << AC_INTFLAG_WIN_Pos))
+#define AC_INTFLAG_MASK             _U_(0x13)    /**< \brief (AC_INTFLAG) MASK Register */
+
+/* -------- AC_STATUSA : (AC Offset: 0x08) (R/   8) Status A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  STATE0:1;         /*!< bit:      0  Comparator 0 Current State         */
+    uint8_t  STATE1:1;         /*!< bit:      1  Comparator 1 Current State         */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WSTATE0:2;        /*!< bit:  4.. 5  Window 0 Current State             */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  STATE:2;          /*!< bit:  0.. 1  Comparator x Current State         */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_STATUSA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_STATUSA_OFFSET           0x08         /**< \brief (AC_STATUSA offset) Status A */
+#define AC_STATUSA_RESETVALUE       _U_(0x00)    /**< \brief (AC_STATUSA reset_value) Status A */
+
+#define AC_STATUSA_STATE0_Pos       0            /**< \brief (AC_STATUSA) Comparator 0 Current State */
+#define AC_STATUSA_STATE0           (_U_(1) << AC_STATUSA_STATE0_Pos)
+#define AC_STATUSA_STATE1_Pos       1            /**< \brief (AC_STATUSA) Comparator 1 Current State */
+#define AC_STATUSA_STATE1           (_U_(1) << AC_STATUSA_STATE1_Pos)
+#define AC_STATUSA_STATE_Pos        0            /**< \brief (AC_STATUSA) Comparator x Current State */
+#define AC_STATUSA_STATE_Msk        (_U_(0x3) << AC_STATUSA_STATE_Pos)
+#define AC_STATUSA_STATE(value)     (AC_STATUSA_STATE_Msk & ((value) << AC_STATUSA_STATE_Pos))
+#define AC_STATUSA_WSTATE0_Pos      4            /**< \brief (AC_STATUSA) Window 0 Current State */
+#define AC_STATUSA_WSTATE0_Msk      (_U_(0x3) << AC_STATUSA_WSTATE0_Pos)
+#define AC_STATUSA_WSTATE0(value)   (AC_STATUSA_WSTATE0_Msk & ((value) << AC_STATUSA_WSTATE0_Pos))
+#define   AC_STATUSA_WSTATE0_ABOVE_Val    _U_(0x0)   /**< \brief (AC_STATUSA) Signal is above window */
+#define   AC_STATUSA_WSTATE0_INSIDE_Val   _U_(0x1)   /**< \brief (AC_STATUSA) Signal is inside window */
+#define   AC_STATUSA_WSTATE0_BELOW_Val    _U_(0x2)   /**< \brief (AC_STATUSA) Signal is below window */
+#define AC_STATUSA_WSTATE0_ABOVE    (AC_STATUSA_WSTATE0_ABOVE_Val  << AC_STATUSA_WSTATE0_Pos)
+#define AC_STATUSA_WSTATE0_INSIDE   (AC_STATUSA_WSTATE0_INSIDE_Val << AC_STATUSA_WSTATE0_Pos)
+#define AC_STATUSA_WSTATE0_BELOW    (AC_STATUSA_WSTATE0_BELOW_Val  << AC_STATUSA_WSTATE0_Pos)
+#define AC_STATUSA_MASK             _U_(0x33)    /**< \brief (AC_STATUSA) MASK Register */
+
+/* -------- AC_STATUSB : (AC Offset: 0x09) (R/   8) Status B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  READY0:1;         /*!< bit:      0  Comparator 0 Ready                 */
+    uint8_t  READY1:1;         /*!< bit:      1  Comparator 1 Ready                 */
+    uint8_t  :5;               /*!< bit:  2.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  READY:2;          /*!< bit:  0.. 1  Comparator x Ready                 */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_STATUSB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_STATUSB_OFFSET           0x09         /**< \brief (AC_STATUSB offset) Status B */
+#define AC_STATUSB_RESETVALUE       _U_(0x00)    /**< \brief (AC_STATUSB reset_value) Status B */
+
+#define AC_STATUSB_READY0_Pos       0            /**< \brief (AC_STATUSB) Comparator 0 Ready */
+#define AC_STATUSB_READY0           (_U_(1) << AC_STATUSB_READY0_Pos)
+#define AC_STATUSB_READY1_Pos       1            /**< \brief (AC_STATUSB) Comparator 1 Ready */
+#define AC_STATUSB_READY1           (_U_(1) << AC_STATUSB_READY1_Pos)
+#define AC_STATUSB_READY_Pos        0            /**< \brief (AC_STATUSB) Comparator x Ready */
+#define AC_STATUSB_READY_Msk        (_U_(0x3) << AC_STATUSB_READY_Pos)
+#define AC_STATUSB_READY(value)     (AC_STATUSB_READY_Msk & ((value) << AC_STATUSB_READY_Pos))
+#define AC_STATUSB_SYNCBUSY_Pos     7            /**< \brief (AC_STATUSB) Synchronization Busy */
+#define AC_STATUSB_SYNCBUSY         (_U_(0x1) << AC_STATUSB_SYNCBUSY_Pos)
+#define AC_STATUSB_MASK             _U_(0x83)    /**< \brief (AC_STATUSB) MASK Register */
+
+/* -------- AC_STATUSC : (AC Offset: 0x0A) (R/   8) Status C -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  STATE0:1;         /*!< bit:      0  Comparator 0 Current State         */
+    uint8_t  STATE1:1;         /*!< bit:      1  Comparator 1 Current State         */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  WSTATE0:2;        /*!< bit:  4.. 5  Window 0 Current State             */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  STATE:2;          /*!< bit:  0.. 1  Comparator x Current State         */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_STATUSC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_STATUSC_OFFSET           0x0A         /**< \brief (AC_STATUSC offset) Status C */
+#define AC_STATUSC_RESETVALUE       _U_(0x00)    /**< \brief (AC_STATUSC reset_value) Status C */
+
+#define AC_STATUSC_STATE0_Pos       0            /**< \brief (AC_STATUSC) Comparator 0 Current State */
+#define AC_STATUSC_STATE0           (_U_(1) << AC_STATUSC_STATE0_Pos)
+#define AC_STATUSC_STATE1_Pos       1            /**< \brief (AC_STATUSC) Comparator 1 Current State */
+#define AC_STATUSC_STATE1           (_U_(1) << AC_STATUSC_STATE1_Pos)
+#define AC_STATUSC_STATE_Pos        0            /**< \brief (AC_STATUSC) Comparator x Current State */
+#define AC_STATUSC_STATE_Msk        (_U_(0x3) << AC_STATUSC_STATE_Pos)
+#define AC_STATUSC_STATE(value)     (AC_STATUSC_STATE_Msk & ((value) << AC_STATUSC_STATE_Pos))
+#define AC_STATUSC_WSTATE0_Pos      4            /**< \brief (AC_STATUSC) Window 0 Current State */
+#define AC_STATUSC_WSTATE0_Msk      (_U_(0x3) << AC_STATUSC_WSTATE0_Pos)
+#define AC_STATUSC_WSTATE0(value)   (AC_STATUSC_WSTATE0_Msk & ((value) << AC_STATUSC_WSTATE0_Pos))
+#define   AC_STATUSC_WSTATE0_ABOVE_Val    _U_(0x0)   /**< \brief (AC_STATUSC) Signal is above window */
+#define   AC_STATUSC_WSTATE0_INSIDE_Val   _U_(0x1)   /**< \brief (AC_STATUSC) Signal is inside window */
+#define   AC_STATUSC_WSTATE0_BELOW_Val    _U_(0x2)   /**< \brief (AC_STATUSC) Signal is below window */
+#define AC_STATUSC_WSTATE0_ABOVE    (AC_STATUSC_WSTATE0_ABOVE_Val  << AC_STATUSC_WSTATE0_Pos)
+#define AC_STATUSC_WSTATE0_INSIDE   (AC_STATUSC_WSTATE0_INSIDE_Val << AC_STATUSC_WSTATE0_Pos)
+#define AC_STATUSC_WSTATE0_BELOW    (AC_STATUSC_WSTATE0_BELOW_Val  << AC_STATUSC_WSTATE0_Pos)
+#define AC_STATUSC_MASK             _U_(0x33)    /**< \brief (AC_STATUSC) MASK Register */
+
+/* -------- AC_WINCTRL : (AC Offset: 0x0C) (R/W  8) Window Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  WEN0:1;           /*!< bit:      0  Window 0 Mode Enable               */
+    uint8_t  WINTSEL0:2;       /*!< bit:  1.. 2  Window 0 Interrupt Selection       */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_WINCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_WINCTRL_OFFSET           0x0C         /**< \brief (AC_WINCTRL offset) Window Control */
+#define AC_WINCTRL_RESETVALUE       _U_(0x00)    /**< \brief (AC_WINCTRL reset_value) Window Control */
+
+#define AC_WINCTRL_WEN0_Pos         0            /**< \brief (AC_WINCTRL) Window 0 Mode Enable */
+#define AC_WINCTRL_WEN0             (_U_(0x1) << AC_WINCTRL_WEN0_Pos)
+#define AC_WINCTRL_WINTSEL0_Pos     1            /**< \brief (AC_WINCTRL) Window 0 Interrupt Selection */
+#define AC_WINCTRL_WINTSEL0_Msk     (_U_(0x3) << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_WINTSEL0(value)  (AC_WINCTRL_WINTSEL0_Msk & ((value) << AC_WINCTRL_WINTSEL0_Pos))
+#define   AC_WINCTRL_WINTSEL0_ABOVE_Val   _U_(0x0)   /**< \brief (AC_WINCTRL) Interrupt on signal above window */
+#define   AC_WINCTRL_WINTSEL0_INSIDE_Val  _U_(0x1)   /**< \brief (AC_WINCTRL) Interrupt on signal inside window */
+#define   AC_WINCTRL_WINTSEL0_BELOW_Val   _U_(0x2)   /**< \brief (AC_WINCTRL) Interrupt on signal below window */
+#define   AC_WINCTRL_WINTSEL0_OUTSIDE_Val _U_(0x3)   /**< \brief (AC_WINCTRL) Interrupt on signal outside window */
+#define AC_WINCTRL_WINTSEL0_ABOVE   (AC_WINCTRL_WINTSEL0_ABOVE_Val << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_WINTSEL0_INSIDE  (AC_WINCTRL_WINTSEL0_INSIDE_Val << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_WINTSEL0_BELOW   (AC_WINCTRL_WINTSEL0_BELOW_Val << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_WINTSEL0_OUTSIDE (AC_WINCTRL_WINTSEL0_OUTSIDE_Val << AC_WINCTRL_WINTSEL0_Pos)
+#define AC_WINCTRL_MASK             _U_(0x07)    /**< \brief (AC_WINCTRL) MASK Register */
+
+/* -------- AC_COMPCTRL : (AC Offset: 0x10) (R/W 32) Comparator Control n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ENABLE:1;         /*!< bit:      0  Enable                             */
+    uint32_t SINGLE:1;         /*!< bit:      1  Single-Shot Mode                   */
+    uint32_t SPEED:2;          /*!< bit:  2.. 3  Speed Selection                    */
+    uint32_t :1;               /*!< bit:      4  Reserved                           */
+    uint32_t INTSEL:2;         /*!< bit:  5.. 6  Interrupt Selection                */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t MUXNEG:3;         /*!< bit:  8..10  Negative Input Mux Selection       */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t MUXPOS:2;         /*!< bit: 12..13  Positive Input Mux Selection       */
+    uint32_t :1;               /*!< bit:     14  Reserved                           */
+    uint32_t SWAP:1;           /*!< bit:     15  Swap Inputs and Invert             */
+    uint32_t OUT:2;            /*!< bit: 16..17  Output                             */
+    uint32_t :1;               /*!< bit:     18  Reserved                           */
+    uint32_t HYST:1;           /*!< bit:     19  Hysteresis Enable                  */
+    uint32_t :4;               /*!< bit: 20..23  Reserved                           */
+    uint32_t FLEN:3;           /*!< bit: 24..26  Filter Length                      */
+    uint32_t :5;               /*!< bit: 27..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} AC_COMPCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_COMPCTRL_OFFSET          0x10         /**< \brief (AC_COMPCTRL offset) Comparator Control n */
+#define AC_COMPCTRL_RESETVALUE      _U_(0x00000000) /**< \brief (AC_COMPCTRL reset_value) Comparator Control n */
+
+#define AC_COMPCTRL_ENABLE_Pos      0            /**< \brief (AC_COMPCTRL) Enable */
+#define AC_COMPCTRL_ENABLE          (_U_(0x1) << AC_COMPCTRL_ENABLE_Pos)
+#define AC_COMPCTRL_SINGLE_Pos      1            /**< \brief (AC_COMPCTRL) Single-Shot Mode */
+#define AC_COMPCTRL_SINGLE          (_U_(0x1) << AC_COMPCTRL_SINGLE_Pos)
+#define AC_COMPCTRL_SPEED_Pos       2            /**< \brief (AC_COMPCTRL) Speed Selection */
+#define AC_COMPCTRL_SPEED_Msk       (_U_(0x3) << AC_COMPCTRL_SPEED_Pos)
+#define AC_COMPCTRL_SPEED(value)    (AC_COMPCTRL_SPEED_Msk & ((value) << AC_COMPCTRL_SPEED_Pos))
+#define   AC_COMPCTRL_SPEED_LOW_Val       _U_(0x0)   /**< \brief (AC_COMPCTRL) Low speed */
+#define   AC_COMPCTRL_SPEED_HIGH_Val      _U_(0x1)   /**< \brief (AC_COMPCTRL) High speed */
+#define AC_COMPCTRL_SPEED_LOW       (AC_COMPCTRL_SPEED_LOW_Val     << AC_COMPCTRL_SPEED_Pos)
+#define AC_COMPCTRL_SPEED_HIGH      (AC_COMPCTRL_SPEED_HIGH_Val    << AC_COMPCTRL_SPEED_Pos)
+#define AC_COMPCTRL_INTSEL_Pos      5            /**< \brief (AC_COMPCTRL) Interrupt Selection */
+#define AC_COMPCTRL_INTSEL_Msk      (_U_(0x3) << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_INTSEL(value)   (AC_COMPCTRL_INTSEL_Msk & ((value) << AC_COMPCTRL_INTSEL_Pos))
+#define   AC_COMPCTRL_INTSEL_TOGGLE_Val   _U_(0x0)   /**< \brief (AC_COMPCTRL) Interrupt on comparator output toggle */
+#define   AC_COMPCTRL_INTSEL_RISING_Val   _U_(0x1)   /**< \brief (AC_COMPCTRL) Interrupt on comparator output rising */
+#define   AC_COMPCTRL_INTSEL_FALLING_Val  _U_(0x2)   /**< \brief (AC_COMPCTRL) Interrupt on comparator output falling */
+#define   AC_COMPCTRL_INTSEL_EOC_Val      _U_(0x3)   /**< \brief (AC_COMPCTRL) Interrupt on end of comparison (single-shot mode only) */
+#define AC_COMPCTRL_INTSEL_TOGGLE   (AC_COMPCTRL_INTSEL_TOGGLE_Val << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_INTSEL_RISING   (AC_COMPCTRL_INTSEL_RISING_Val << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_INTSEL_FALLING  (AC_COMPCTRL_INTSEL_FALLING_Val << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_INTSEL_EOC      (AC_COMPCTRL_INTSEL_EOC_Val    << AC_COMPCTRL_INTSEL_Pos)
+#define AC_COMPCTRL_MUXNEG_Pos      8            /**< \brief (AC_COMPCTRL) Negative Input Mux Selection */
+#define AC_COMPCTRL_MUXNEG_Msk      (_U_(0x7) << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG(value)   (AC_COMPCTRL_MUXNEG_Msk & ((value) << AC_COMPCTRL_MUXNEG_Pos))
+#define   AC_COMPCTRL_MUXNEG_PIN0_Val     _U_(0x0)   /**< \brief (AC_COMPCTRL) I/O pin 0 */
+#define   AC_COMPCTRL_MUXNEG_PIN1_Val     _U_(0x1)   /**< \brief (AC_COMPCTRL) I/O pin 1 */
+#define   AC_COMPCTRL_MUXNEG_PIN2_Val     _U_(0x2)   /**< \brief (AC_COMPCTRL) I/O pin 2 */
+#define   AC_COMPCTRL_MUXNEG_PIN3_Val     _U_(0x3)   /**< \brief (AC_COMPCTRL) I/O pin 3 */
+#define   AC_COMPCTRL_MUXNEG_GND_Val      _U_(0x4)   /**< \brief (AC_COMPCTRL) Ground */
+#define   AC_COMPCTRL_MUXNEG_VSCALE_Val   _U_(0x5)   /**< \brief (AC_COMPCTRL) VDD scaler */
+#define   AC_COMPCTRL_MUXNEG_BANDGAP_Val  _U_(0x6)   /**< \brief (AC_COMPCTRL) Internal bandgap voltage */
+#define   AC_COMPCTRL_MUXNEG_DAC_Val      _U_(0x7)   /**< \brief (AC_COMPCTRL) DAC output */
+#define AC_COMPCTRL_MUXNEG_PIN0     (AC_COMPCTRL_MUXNEG_PIN0_Val   << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_PIN1     (AC_COMPCTRL_MUXNEG_PIN1_Val   << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_PIN2     (AC_COMPCTRL_MUXNEG_PIN2_Val   << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_PIN3     (AC_COMPCTRL_MUXNEG_PIN3_Val   << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_GND      (AC_COMPCTRL_MUXNEG_GND_Val    << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_VSCALE   (AC_COMPCTRL_MUXNEG_VSCALE_Val << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_BANDGAP  (AC_COMPCTRL_MUXNEG_BANDGAP_Val << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXNEG_DAC      (AC_COMPCTRL_MUXNEG_DAC_Val    << AC_COMPCTRL_MUXNEG_Pos)
+#define AC_COMPCTRL_MUXPOS_Pos      12           /**< \brief (AC_COMPCTRL) Positive Input Mux Selection */
+#define AC_COMPCTRL_MUXPOS_Msk      (_U_(0x3) << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_MUXPOS(value)   (AC_COMPCTRL_MUXPOS_Msk & ((value) << AC_COMPCTRL_MUXPOS_Pos))
+#define   AC_COMPCTRL_MUXPOS_PIN0_Val     _U_(0x0)   /**< \brief (AC_COMPCTRL) I/O pin 0 */
+#define   AC_COMPCTRL_MUXPOS_PIN1_Val     _U_(0x1)   /**< \brief (AC_COMPCTRL) I/O pin 1 */
+#define   AC_COMPCTRL_MUXPOS_PIN2_Val     _U_(0x2)   /**< \brief (AC_COMPCTRL) I/O pin 2 */
+#define   AC_COMPCTRL_MUXPOS_PIN3_Val     _U_(0x3)   /**< \brief (AC_COMPCTRL) I/O pin 3 */
+#define AC_COMPCTRL_MUXPOS_PIN0     (AC_COMPCTRL_MUXPOS_PIN0_Val   << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_MUXPOS_PIN1     (AC_COMPCTRL_MUXPOS_PIN1_Val   << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_MUXPOS_PIN2     (AC_COMPCTRL_MUXPOS_PIN2_Val   << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_MUXPOS_PIN3     (AC_COMPCTRL_MUXPOS_PIN3_Val   << AC_COMPCTRL_MUXPOS_Pos)
+#define AC_COMPCTRL_SWAP_Pos        15           /**< \brief (AC_COMPCTRL) Swap Inputs and Invert */
+#define AC_COMPCTRL_SWAP            (_U_(0x1) << AC_COMPCTRL_SWAP_Pos)
+#define AC_COMPCTRL_OUT_Pos         16           /**< \brief (AC_COMPCTRL) Output */
+#define AC_COMPCTRL_OUT_Msk         (_U_(0x3) << AC_COMPCTRL_OUT_Pos)
+#define AC_COMPCTRL_OUT(value)      (AC_COMPCTRL_OUT_Msk & ((value) << AC_COMPCTRL_OUT_Pos))
+#define   AC_COMPCTRL_OUT_OFF_Val         _U_(0x0)   /**< \brief (AC_COMPCTRL) The output of COMPn is not routed to the COMPn I/O port */
+#define   AC_COMPCTRL_OUT_ASYNC_Val       _U_(0x1)   /**< \brief (AC_COMPCTRL) The asynchronous output of COMPn is routed to the COMPn I/O port */
+#define   AC_COMPCTRL_OUT_SYNC_Val        _U_(0x2)   /**< \brief (AC_COMPCTRL) The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port */
+#define AC_COMPCTRL_OUT_OFF         (AC_COMPCTRL_OUT_OFF_Val       << AC_COMPCTRL_OUT_Pos)
+#define AC_COMPCTRL_OUT_ASYNC       (AC_COMPCTRL_OUT_ASYNC_Val     << AC_COMPCTRL_OUT_Pos)
+#define AC_COMPCTRL_OUT_SYNC        (AC_COMPCTRL_OUT_SYNC_Val      << AC_COMPCTRL_OUT_Pos)
+#define AC_COMPCTRL_HYST_Pos        19           /**< \brief (AC_COMPCTRL) Hysteresis Enable */
+#define AC_COMPCTRL_HYST            (_U_(0x1) << AC_COMPCTRL_HYST_Pos)
+#define AC_COMPCTRL_FLEN_Pos        24           /**< \brief (AC_COMPCTRL) Filter Length */
+#define AC_COMPCTRL_FLEN_Msk        (_U_(0x7) << AC_COMPCTRL_FLEN_Pos)
+#define AC_COMPCTRL_FLEN(value)     (AC_COMPCTRL_FLEN_Msk & ((value) << AC_COMPCTRL_FLEN_Pos))
+#define   AC_COMPCTRL_FLEN_OFF_Val        _U_(0x0)   /**< \brief (AC_COMPCTRL) No filtering */
+#define   AC_COMPCTRL_FLEN_MAJ3_Val       _U_(0x1)   /**< \brief (AC_COMPCTRL) 3-bit majority function (2 of 3) */
+#define   AC_COMPCTRL_FLEN_MAJ5_Val       _U_(0x2)   /**< \brief (AC_COMPCTRL) 5-bit majority function (3 of 5) */
+#define AC_COMPCTRL_FLEN_OFF        (AC_COMPCTRL_FLEN_OFF_Val      << AC_COMPCTRL_FLEN_Pos)
+#define AC_COMPCTRL_FLEN_MAJ3       (AC_COMPCTRL_FLEN_MAJ3_Val     << AC_COMPCTRL_FLEN_Pos)
+#define AC_COMPCTRL_FLEN_MAJ5       (AC_COMPCTRL_FLEN_MAJ5_Val     << AC_COMPCTRL_FLEN_Pos)
+#define AC_COMPCTRL_MASK            _U_(0x070BB76F) /**< \brief (AC_COMPCTRL) MASK Register */
+
+/* -------- AC_SCALER : (AC Offset: 0x20) (R/W  8) Scaler n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  VALUE:6;          /*!< bit:  0.. 5  Scaler Value                       */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} AC_SCALER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define AC_SCALER_OFFSET            0x20         /**< \brief (AC_SCALER offset) Scaler n */
+#define AC_SCALER_RESETVALUE        _U_(0x00)    /**< \brief (AC_SCALER reset_value) Scaler n */
+
+#define AC_SCALER_VALUE_Pos         0            /**< \brief (AC_SCALER) Scaler Value */
+#define AC_SCALER_VALUE_Msk         (_U_(0x3F) << AC_SCALER_VALUE_Pos)
+#define AC_SCALER_VALUE(value)      (AC_SCALER_VALUE_Msk & ((value) << AC_SCALER_VALUE_Pos))
+#define AC_SCALER_MASK              _U_(0x3F)    /**< \brief (AC_SCALER) MASK Register */
+
+/** \brief AC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO AC_CTRLA_Type             CTRLA;       /**< \brief Offset: 0x00 (R/W  8) Control A */
+  __O  AC_CTRLB_Type             CTRLB;       /**< \brief Offset: 0x01 ( /W  8) Control B */
+  __IO AC_EVCTRL_Type            EVCTRL;      /**< \brief Offset: 0x02 (R/W 16) Event Control */
+  __IO AC_INTENCLR_Type          INTENCLR;    /**< \brief Offset: 0x04 (R/W  8) Interrupt Enable Clear */
+  __IO AC_INTENSET_Type          INTENSET;    /**< \brief Offset: 0x05 (R/W  8) Interrupt Enable Set */
+  __IO AC_INTFLAG_Type           INTFLAG;     /**< \brief Offset: 0x06 (R/W  8) Interrupt Flag Status and Clear */
+       RoReg8                    Reserved1[0x1];
+  __I  AC_STATUSA_Type           STATUSA;     /**< \brief Offset: 0x08 (R/   8) Status A */
+  __I  AC_STATUSB_Type           STATUSB;     /**< \brief Offset: 0x09 (R/   8) Status B */
+  __I  AC_STATUSC_Type           STATUSC;     /**< \brief Offset: 0x0A (R/   8) Status C */
+       RoReg8                    Reserved2[0x1];
+  __IO AC_WINCTRL_Type           WINCTRL;     /**< \brief Offset: 0x0C (R/W  8) Window Control */
+       RoReg8                    Reserved3[0x3];
+  __IO AC_COMPCTRL_Type          COMPCTRL[2]; /**< \brief Offset: 0x10 (R/W 32) Comparator Control n */
+       RoReg8                    Reserved4[0x8];
+  __IO AC_SCALER_Type            SCALER[2];   /**< \brief Offset: 0x20 (R/W  8) Scaler n */
+} Ac;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_AC_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/adc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/adc.h
@@ -1,0 +1,685 @@
+/**
+ * \file
+ *
+ * \brief Component description for ADC
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_ADC_COMPONENT_
+#define _SAMD20_ADC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR ADC */
+/* ========================================================================== */
+/** \addtogroup SAMD20_ADC Analog Digital Converter */
+/*@{*/
+
+#define ADC_U2204
+#define REV_ADC                     0x111
+
+/* -------- ADC_CTRLA : (ADC Offset: 0x00) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  RUNSTDBY:1;       /*!< bit:      2  Run in Standby                     */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CTRLA_OFFSET            0x00         /**< \brief (ADC_CTRLA offset) Control A */
+#define ADC_CTRLA_RESETVALUE        _U_(0x00)    /**< \brief (ADC_CTRLA reset_value) Control A */
+
+#define ADC_CTRLA_SWRST_Pos         0            /**< \brief (ADC_CTRLA) Software Reset */
+#define ADC_CTRLA_SWRST             (_U_(0x1) << ADC_CTRLA_SWRST_Pos)
+#define ADC_CTRLA_ENABLE_Pos        1            /**< \brief (ADC_CTRLA) Enable */
+#define ADC_CTRLA_ENABLE            (_U_(0x1) << ADC_CTRLA_ENABLE_Pos)
+#define ADC_CTRLA_RUNSTDBY_Pos      2            /**< \brief (ADC_CTRLA) Run in Standby */
+#define ADC_CTRLA_RUNSTDBY          (_U_(0x1) << ADC_CTRLA_RUNSTDBY_Pos)
+#define ADC_CTRLA_MASK              _U_(0x07)    /**< \brief (ADC_CTRLA) MASK Register */
+
+/* -------- ADC_REFCTRL : (ADC Offset: 0x01) (R/W  8) Reference Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  REFSEL:4;         /*!< bit:  0.. 3  Reference Selection                */
+    uint8_t  :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint8_t  REFCOMP:1;        /*!< bit:      7  Reference Buffer Offset Compensation Enable */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_REFCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_REFCTRL_OFFSET          0x01         /**< \brief (ADC_REFCTRL offset) Reference Control */
+#define ADC_REFCTRL_RESETVALUE      _U_(0x00)    /**< \brief (ADC_REFCTRL reset_value) Reference Control */
+
+#define ADC_REFCTRL_REFSEL_Pos      0            /**< \brief (ADC_REFCTRL) Reference Selection */
+#define ADC_REFCTRL_REFSEL_Msk      (_U_(0xF) << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL(value)   (ADC_REFCTRL_REFSEL_Msk & ((value) << ADC_REFCTRL_REFSEL_Pos))
+#define   ADC_REFCTRL_REFSEL_INT1V_Val    _U_(0x0)   /**< \brief (ADC_REFCTRL) 1.0V voltage reference */
+#define   ADC_REFCTRL_REFSEL_INTVCC0_Val  _U_(0x1)   /**< \brief (ADC_REFCTRL) 1/1.48 VDDANA */
+#define   ADC_REFCTRL_REFSEL_INTVCC1_Val  _U_(0x2)   /**< \brief (ADC_REFCTRL) 1/2 VDDANA (only for VDDANA > 2.0V) */
+#define   ADC_REFCTRL_REFSEL_AREFA_Val    _U_(0x3)   /**< \brief (ADC_REFCTRL) External reference A */
+#define   ADC_REFCTRL_REFSEL_AREFB_Val    _U_(0x4)   /**< \brief (ADC_REFCTRL) External reference B */
+#define ADC_REFCTRL_REFSEL_INT1V    (ADC_REFCTRL_REFSEL_INT1V_Val  << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL_INTVCC0  (ADC_REFCTRL_REFSEL_INTVCC0_Val << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL_INTVCC1  (ADC_REFCTRL_REFSEL_INTVCC1_Val << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL_AREFA    (ADC_REFCTRL_REFSEL_AREFA_Val  << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFSEL_AREFB    (ADC_REFCTRL_REFSEL_AREFB_Val  << ADC_REFCTRL_REFSEL_Pos)
+#define ADC_REFCTRL_REFCOMP_Pos     7            /**< \brief (ADC_REFCTRL) Reference Buffer Offset Compensation Enable */
+#define ADC_REFCTRL_REFCOMP         (_U_(0x1) << ADC_REFCTRL_REFCOMP_Pos)
+#define ADC_REFCTRL_MASK            _U_(0x8F)    /**< \brief (ADC_REFCTRL) MASK Register */
+
+/* -------- ADC_AVGCTRL : (ADC Offset: 0x02) (R/W  8) Average Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SAMPLENUM:4;      /*!< bit:  0.. 3  Number of Samples to be Collected  */
+    uint8_t  ADJRES:3;         /*!< bit:  4.. 6  Adjusting Result / Division Coefficient */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_AVGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_AVGCTRL_OFFSET          0x02         /**< \brief (ADC_AVGCTRL offset) Average Control */
+#define ADC_AVGCTRL_RESETVALUE      _U_(0x00)    /**< \brief (ADC_AVGCTRL reset_value) Average Control */
+
+#define ADC_AVGCTRL_SAMPLENUM_Pos   0            /**< \brief (ADC_AVGCTRL) Number of Samples to be Collected */
+#define ADC_AVGCTRL_SAMPLENUM_Msk   (_U_(0xF) << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM(value) (ADC_AVGCTRL_SAMPLENUM_Msk & ((value) << ADC_AVGCTRL_SAMPLENUM_Pos))
+#define   ADC_AVGCTRL_SAMPLENUM_1_Val     _U_(0x0)   /**< \brief (ADC_AVGCTRL) 1 sample */
+#define   ADC_AVGCTRL_SAMPLENUM_2_Val     _U_(0x1)   /**< \brief (ADC_AVGCTRL) 2 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_4_Val     _U_(0x2)   /**< \brief (ADC_AVGCTRL) 4 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_8_Val     _U_(0x3)   /**< \brief (ADC_AVGCTRL) 8 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_16_Val    _U_(0x4)   /**< \brief (ADC_AVGCTRL) 16 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_32_Val    _U_(0x5)   /**< \brief (ADC_AVGCTRL) 32 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_64_Val    _U_(0x6)   /**< \brief (ADC_AVGCTRL) 64 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_128_Val   _U_(0x7)   /**< \brief (ADC_AVGCTRL) 128 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_256_Val   _U_(0x8)   /**< \brief (ADC_AVGCTRL) 256 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_512_Val   _U_(0x9)   /**< \brief (ADC_AVGCTRL) 512 samples */
+#define   ADC_AVGCTRL_SAMPLENUM_1024_Val  _U_(0xA)   /**< \brief (ADC_AVGCTRL) 1024 samples */
+#define ADC_AVGCTRL_SAMPLENUM_1     (ADC_AVGCTRL_SAMPLENUM_1_Val   << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_2     (ADC_AVGCTRL_SAMPLENUM_2_Val   << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_4     (ADC_AVGCTRL_SAMPLENUM_4_Val   << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_8     (ADC_AVGCTRL_SAMPLENUM_8_Val   << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_16    (ADC_AVGCTRL_SAMPLENUM_16_Val  << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_32    (ADC_AVGCTRL_SAMPLENUM_32_Val  << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_64    (ADC_AVGCTRL_SAMPLENUM_64_Val  << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_128   (ADC_AVGCTRL_SAMPLENUM_128_Val << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_256   (ADC_AVGCTRL_SAMPLENUM_256_Val << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_512   (ADC_AVGCTRL_SAMPLENUM_512_Val << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_SAMPLENUM_1024  (ADC_AVGCTRL_SAMPLENUM_1024_Val << ADC_AVGCTRL_SAMPLENUM_Pos)
+#define ADC_AVGCTRL_ADJRES_Pos      4            /**< \brief (ADC_AVGCTRL) Adjusting Result / Division Coefficient */
+#define ADC_AVGCTRL_ADJRES_Msk      (_U_(0x7) << ADC_AVGCTRL_ADJRES_Pos)
+#define ADC_AVGCTRL_ADJRES(value)   (ADC_AVGCTRL_ADJRES_Msk & ((value) << ADC_AVGCTRL_ADJRES_Pos))
+#define ADC_AVGCTRL_MASK            _U_(0x7F)    /**< \brief (ADC_AVGCTRL) MASK Register */
+
+/* -------- ADC_SAMPCTRL : (ADC Offset: 0x03) (R/W  8) Sampling Time Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SAMPLEN:6;        /*!< bit:  0.. 5  Sampling Time Length               */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_SAMPCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SAMPCTRL_OFFSET         0x03         /**< \brief (ADC_SAMPCTRL offset) Sampling Time Control */
+#define ADC_SAMPCTRL_RESETVALUE     _U_(0x00)    /**< \brief (ADC_SAMPCTRL reset_value) Sampling Time Control */
+
+#define ADC_SAMPCTRL_SAMPLEN_Pos    0            /**< \brief (ADC_SAMPCTRL) Sampling Time Length */
+#define ADC_SAMPCTRL_SAMPLEN_Msk    (_U_(0x3F) << ADC_SAMPCTRL_SAMPLEN_Pos)
+#define ADC_SAMPCTRL_SAMPLEN(value) (ADC_SAMPCTRL_SAMPLEN_Msk & ((value) << ADC_SAMPCTRL_SAMPLEN_Pos))
+#define ADC_SAMPCTRL_MASK           _U_(0x3F)    /**< \brief (ADC_SAMPCTRL) MASK Register */
+
+/* -------- ADC_CTRLB : (ADC Offset: 0x04) (R/W 16) Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DIFFMODE:1;       /*!< bit:      0  Differential Mode                  */
+    uint16_t LEFTADJ:1;        /*!< bit:      1  Left Adjusted Result               */
+    uint16_t FREERUN:1;        /*!< bit:      2  Free Running Mode                  */
+    uint16_t CORREN:1;         /*!< bit:      3  Digital Correction Logic Enabled   */
+    uint16_t RESSEL:2;         /*!< bit:  4.. 5  Conversion Result Resolution       */
+    uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t PRESCALER:3;      /*!< bit:  8..10  Prescaler Configuration            */
+    uint16_t :5;               /*!< bit: 11..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CTRLB_OFFSET            0x04         /**< \brief (ADC_CTRLB offset) Control B */
+#define ADC_CTRLB_RESETVALUE        _U_(0x0000)  /**< \brief (ADC_CTRLB reset_value) Control B */
+
+#define ADC_CTRLB_DIFFMODE_Pos      0            /**< \brief (ADC_CTRLB) Differential Mode */
+#define ADC_CTRLB_DIFFMODE          (_U_(0x1) << ADC_CTRLB_DIFFMODE_Pos)
+#define ADC_CTRLB_LEFTADJ_Pos       1            /**< \brief (ADC_CTRLB) Left Adjusted Result */
+#define ADC_CTRLB_LEFTADJ           (_U_(0x1) << ADC_CTRLB_LEFTADJ_Pos)
+#define ADC_CTRLB_FREERUN_Pos       2            /**< \brief (ADC_CTRLB) Free Running Mode */
+#define ADC_CTRLB_FREERUN           (_U_(0x1) << ADC_CTRLB_FREERUN_Pos)
+#define ADC_CTRLB_CORREN_Pos        3            /**< \brief (ADC_CTRLB) Digital Correction Logic Enabled */
+#define ADC_CTRLB_CORREN            (_U_(0x1) << ADC_CTRLB_CORREN_Pos)
+#define ADC_CTRLB_RESSEL_Pos        4            /**< \brief (ADC_CTRLB) Conversion Result Resolution */
+#define ADC_CTRLB_RESSEL_Msk        (_U_(0x3) << ADC_CTRLB_RESSEL_Pos)
+#define ADC_CTRLB_RESSEL(value)     (ADC_CTRLB_RESSEL_Msk & ((value) << ADC_CTRLB_RESSEL_Pos))
+#define   ADC_CTRLB_RESSEL_12BIT_Val      _U_(0x0)   /**< \brief (ADC_CTRLB) 12-bit result */
+#define   ADC_CTRLB_RESSEL_16BIT_Val      _U_(0x1)   /**< \brief (ADC_CTRLB) 16-bit averaging mode */
+#define   ADC_CTRLB_RESSEL_10BIT_Val      _U_(0x2)   /**< \brief (ADC_CTRLB) 10-bit result */
+#define   ADC_CTRLB_RESSEL_8BIT_Val       _U_(0x3)   /**< \brief (ADC_CTRLB) 8-bit result */
+#define ADC_CTRLB_RESSEL_12BIT      (ADC_CTRLB_RESSEL_12BIT_Val    << ADC_CTRLB_RESSEL_Pos)
+#define ADC_CTRLB_RESSEL_16BIT      (ADC_CTRLB_RESSEL_16BIT_Val    << ADC_CTRLB_RESSEL_Pos)
+#define ADC_CTRLB_RESSEL_10BIT      (ADC_CTRLB_RESSEL_10BIT_Val    << ADC_CTRLB_RESSEL_Pos)
+#define ADC_CTRLB_RESSEL_8BIT       (ADC_CTRLB_RESSEL_8BIT_Val     << ADC_CTRLB_RESSEL_Pos)
+#define ADC_CTRLB_PRESCALER_Pos     8            /**< \brief (ADC_CTRLB) Prescaler Configuration */
+#define ADC_CTRLB_PRESCALER_Msk     (_U_(0x7) << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER(value)  (ADC_CTRLB_PRESCALER_Msk & ((value) << ADC_CTRLB_PRESCALER_Pos))
+#define   ADC_CTRLB_PRESCALER_DIV4_Val    _U_(0x0)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 4 */
+#define   ADC_CTRLB_PRESCALER_DIV8_Val    _U_(0x1)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 8 */
+#define   ADC_CTRLB_PRESCALER_DIV16_Val   _U_(0x2)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 16 */
+#define   ADC_CTRLB_PRESCALER_DIV32_Val   _U_(0x3)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 32 */
+#define   ADC_CTRLB_PRESCALER_DIV64_Val   _U_(0x4)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 64 */
+#define   ADC_CTRLB_PRESCALER_DIV128_Val  _U_(0x5)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 128 */
+#define   ADC_CTRLB_PRESCALER_DIV256_Val  _U_(0x6)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 256 */
+#define   ADC_CTRLB_PRESCALER_DIV512_Val  _U_(0x7)   /**< \brief (ADC_CTRLB) Peripheral clock divided by 512 */
+#define ADC_CTRLB_PRESCALER_DIV4    (ADC_CTRLB_PRESCALER_DIV4_Val  << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV8    (ADC_CTRLB_PRESCALER_DIV8_Val  << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV16   (ADC_CTRLB_PRESCALER_DIV16_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV32   (ADC_CTRLB_PRESCALER_DIV32_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV64   (ADC_CTRLB_PRESCALER_DIV64_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV128  (ADC_CTRLB_PRESCALER_DIV128_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV256  (ADC_CTRLB_PRESCALER_DIV256_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_PRESCALER_DIV512  (ADC_CTRLB_PRESCALER_DIV512_Val << ADC_CTRLB_PRESCALER_Pos)
+#define ADC_CTRLB_MASK              _U_(0x073F)  /**< \brief (ADC_CTRLB) MASK Register */
+
+/* -------- ADC_WINCTRL : (ADC Offset: 0x08) (R/W  8) Window Monitor Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  WINMODE:3;        /*!< bit:  0.. 2  Window Monitor Mode                */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_WINCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_WINCTRL_OFFSET          0x08         /**< \brief (ADC_WINCTRL offset) Window Monitor Control */
+#define ADC_WINCTRL_RESETVALUE      _U_(0x00)    /**< \brief (ADC_WINCTRL reset_value) Window Monitor Control */
+
+#define ADC_WINCTRL_WINMODE_Pos     0            /**< \brief (ADC_WINCTRL) Window Monitor Mode */
+#define ADC_WINCTRL_WINMODE_Msk     (_U_(0x7) << ADC_WINCTRL_WINMODE_Pos)
+#define ADC_WINCTRL_WINMODE(value)  (ADC_WINCTRL_WINMODE_Msk & ((value) << ADC_WINCTRL_WINMODE_Pos))
+#define   ADC_WINCTRL_WINMODE_DISABLE_Val _U_(0x0)   /**< \brief (ADC_WINCTRL) No window mode (default) */
+#define   ADC_WINCTRL_WINMODE_MODE1_Val   _U_(0x1)   /**< \brief (ADC_WINCTRL) Mode 1: RESULT > WINLT */
+#define   ADC_WINCTRL_WINMODE_MODE2_Val   _U_(0x2)   /**< \brief (ADC_WINCTRL) Mode 2: RESULT < WINUT */
+#define   ADC_WINCTRL_WINMODE_MODE3_Val   _U_(0x3)   /**< \brief (ADC_WINCTRL) Mode 3: WINLT < RESULT < WINUT */
+#define   ADC_WINCTRL_WINMODE_MODE4_Val   _U_(0x4)   /**< \brief (ADC_WINCTRL) Mode 4: !(WINLT < RESULT < WINUT) */
+#define ADC_WINCTRL_WINMODE_DISABLE (ADC_WINCTRL_WINMODE_DISABLE_Val << ADC_WINCTRL_WINMODE_Pos)
+#define ADC_WINCTRL_WINMODE_MODE1   (ADC_WINCTRL_WINMODE_MODE1_Val << ADC_WINCTRL_WINMODE_Pos)
+#define ADC_WINCTRL_WINMODE_MODE2   (ADC_WINCTRL_WINMODE_MODE2_Val << ADC_WINCTRL_WINMODE_Pos)
+#define ADC_WINCTRL_WINMODE_MODE3   (ADC_WINCTRL_WINMODE_MODE3_Val << ADC_WINCTRL_WINMODE_Pos)
+#define ADC_WINCTRL_WINMODE_MODE4   (ADC_WINCTRL_WINMODE_MODE4_Val << ADC_WINCTRL_WINMODE_Pos)
+#define ADC_WINCTRL_MASK            _U_(0x07)    /**< \brief (ADC_WINCTRL) MASK Register */
+
+/* -------- ADC_SWTRIG : (ADC Offset: 0x0C) (R/W  8) Software Trigger -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  FLUSH:1;          /*!< bit:      0  ADC Conversion Flush               */
+    uint8_t  START:1;          /*!< bit:      1  ADC Start Conversion               */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_SWTRIG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_SWTRIG_OFFSET           0x0C         /**< \brief (ADC_SWTRIG offset) Software Trigger */
+#define ADC_SWTRIG_RESETVALUE       _U_(0x00)    /**< \brief (ADC_SWTRIG reset_value) Software Trigger */
+
+#define ADC_SWTRIG_FLUSH_Pos        0            /**< \brief (ADC_SWTRIG) ADC Conversion Flush */
+#define ADC_SWTRIG_FLUSH            (_U_(0x1) << ADC_SWTRIG_FLUSH_Pos)
+#define ADC_SWTRIG_START_Pos        1            /**< \brief (ADC_SWTRIG) ADC Start Conversion */
+#define ADC_SWTRIG_START            (_U_(0x1) << ADC_SWTRIG_START_Pos)
+#define ADC_SWTRIG_MASK             _U_(0x03)    /**< \brief (ADC_SWTRIG) MASK Register */
+
+/* -------- ADC_INPUTCTRL : (ADC Offset: 0x10) (R/W 32) Inputs Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MUXPOS:5;         /*!< bit:  0.. 4  Positive MUX Input Selection       */
+    uint32_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint32_t MUXNEG:5;         /*!< bit:  8..12  Negative MUX Input Selection       */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t INPUTSCAN:4;      /*!< bit: 16..19  Number of Input Channels Included in Scan */
+    uint32_t INPUTOFFSET:4;    /*!< bit: 20..23  Positive MUX Setting Offset        */
+    uint32_t GAIN:4;           /*!< bit: 24..27  Gain Factor Selection              */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} ADC_INPUTCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INPUTCTRL_OFFSET        0x10         /**< \brief (ADC_INPUTCTRL offset) Inputs Control */
+#define ADC_INPUTCTRL_RESETVALUE    _U_(0x00000000) /**< \brief (ADC_INPUTCTRL reset_value) Inputs Control */
+
+#define ADC_INPUTCTRL_MUXPOS_Pos    0            /**< \brief (ADC_INPUTCTRL) Positive MUX Input Selection */
+#define ADC_INPUTCTRL_MUXPOS_Msk    (_U_(0x1F) << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS(value) (ADC_INPUTCTRL_MUXPOS_Msk & ((value) << ADC_INPUTCTRL_MUXPOS_Pos))
+#define   ADC_INPUTCTRL_MUXPOS_PIN0_Val   _U_(0x0)   /**< \brief (ADC_INPUTCTRL) ADC AIN0 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN1_Val   _U_(0x1)   /**< \brief (ADC_INPUTCTRL) ADC AIN1 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN2_Val   _U_(0x2)   /**< \brief (ADC_INPUTCTRL) ADC AIN2 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN3_Val   _U_(0x3)   /**< \brief (ADC_INPUTCTRL) ADC AIN3 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN4_Val   _U_(0x4)   /**< \brief (ADC_INPUTCTRL) ADC AIN4 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN5_Val   _U_(0x5)   /**< \brief (ADC_INPUTCTRL) ADC AIN5 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN6_Val   _U_(0x6)   /**< \brief (ADC_INPUTCTRL) ADC AIN6 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN7_Val   _U_(0x7)   /**< \brief (ADC_INPUTCTRL) ADC AIN7 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN8_Val   _U_(0x8)   /**< \brief (ADC_INPUTCTRL) ADC AIN8 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN9_Val   _U_(0x9)   /**< \brief (ADC_INPUTCTRL) ADC AIN9 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN10_Val  _U_(0xA)   /**< \brief (ADC_INPUTCTRL) ADC AIN10 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN11_Val  _U_(0xB)   /**< \brief (ADC_INPUTCTRL) ADC AIN11 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN12_Val  _U_(0xC)   /**< \brief (ADC_INPUTCTRL) ADC AIN12 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN13_Val  _U_(0xD)   /**< \brief (ADC_INPUTCTRL) ADC AIN13 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN14_Val  _U_(0xE)   /**< \brief (ADC_INPUTCTRL) ADC AIN14 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN15_Val  _U_(0xF)   /**< \brief (ADC_INPUTCTRL) ADC AIN15 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN16_Val  _U_(0x10)   /**< \brief (ADC_INPUTCTRL) ADC AIN16 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN17_Val  _U_(0x11)   /**< \brief (ADC_INPUTCTRL) ADC AIN17 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN18_Val  _U_(0x12)   /**< \brief (ADC_INPUTCTRL) ADC AIN18 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_PIN19_Val  _U_(0x13)   /**< \brief (ADC_INPUTCTRL) ADC AIN19 Pin */
+#define   ADC_INPUTCTRL_MUXPOS_TEMP_Val   _U_(0x18)   /**< \brief (ADC_INPUTCTRL) Temperature Reference */
+#define   ADC_INPUTCTRL_MUXPOS_BANDGAP_Val _U_(0x19)   /**< \brief (ADC_INPUTCTRL) Bandgap Voltage */
+#define   ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC_Val _U_(0x1A)   /**< \brief (ADC_INPUTCTRL) 1/4  Scaled Core Supply */
+#define   ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val _U_(0x1B)   /**< \brief (ADC_INPUTCTRL) 1/4  Scaled I/O Supply */
+#define   ADC_INPUTCTRL_MUXPOS_DAC_Val    _U_(0x1C)   /**< \brief (ADC_INPUTCTRL) DAC Output */
+#define ADC_INPUTCTRL_MUXPOS_PIN0   (ADC_INPUTCTRL_MUXPOS_PIN0_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN1   (ADC_INPUTCTRL_MUXPOS_PIN1_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN2   (ADC_INPUTCTRL_MUXPOS_PIN2_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN3   (ADC_INPUTCTRL_MUXPOS_PIN3_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN4   (ADC_INPUTCTRL_MUXPOS_PIN4_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN5   (ADC_INPUTCTRL_MUXPOS_PIN5_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN6   (ADC_INPUTCTRL_MUXPOS_PIN6_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN7   (ADC_INPUTCTRL_MUXPOS_PIN7_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN8   (ADC_INPUTCTRL_MUXPOS_PIN8_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN9   (ADC_INPUTCTRL_MUXPOS_PIN9_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN10  (ADC_INPUTCTRL_MUXPOS_PIN10_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN11  (ADC_INPUTCTRL_MUXPOS_PIN11_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN12  (ADC_INPUTCTRL_MUXPOS_PIN12_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN13  (ADC_INPUTCTRL_MUXPOS_PIN13_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN14  (ADC_INPUTCTRL_MUXPOS_PIN14_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN15  (ADC_INPUTCTRL_MUXPOS_PIN15_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN16  (ADC_INPUTCTRL_MUXPOS_PIN16_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN17  (ADC_INPUTCTRL_MUXPOS_PIN17_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN18  (ADC_INPUTCTRL_MUXPOS_PIN18_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_PIN19  (ADC_INPUTCTRL_MUXPOS_PIN19_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_TEMP   (ADC_INPUTCTRL_MUXPOS_TEMP_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_BANDGAP (ADC_INPUTCTRL_MUXPOS_BANDGAP_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC (ADC_INPUTCTRL_MUXPOS_SCALEDCOREVCC_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC (ADC_INPUTCTRL_MUXPOS_SCALEDIOVCC_Val << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXPOS_DAC    (ADC_INPUTCTRL_MUXPOS_DAC_Val  << ADC_INPUTCTRL_MUXPOS_Pos)
+#define ADC_INPUTCTRL_MUXNEG_Pos    8            /**< \brief (ADC_INPUTCTRL) Negative MUX Input Selection */
+#define ADC_INPUTCTRL_MUXNEG_Msk    (_U_(0x1F) << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG(value) (ADC_INPUTCTRL_MUXNEG_Msk & ((value) << ADC_INPUTCTRL_MUXNEG_Pos))
+#define   ADC_INPUTCTRL_MUXNEG_PIN0_Val   _U_(0x0)   /**< \brief (ADC_INPUTCTRL) ADC AIN0 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN1_Val   _U_(0x1)   /**< \brief (ADC_INPUTCTRL) ADC AIN1 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN2_Val   _U_(0x2)   /**< \brief (ADC_INPUTCTRL) ADC AIN2 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN3_Val   _U_(0x3)   /**< \brief (ADC_INPUTCTRL) ADC AIN3 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN4_Val   _U_(0x4)   /**< \brief (ADC_INPUTCTRL) ADC AIN4 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN5_Val   _U_(0x5)   /**< \brief (ADC_INPUTCTRL) ADC AIN5 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN6_Val   _U_(0x6)   /**< \brief (ADC_INPUTCTRL) ADC AIN6 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_PIN7_Val   _U_(0x7)   /**< \brief (ADC_INPUTCTRL) ADC AIN7 Pin */
+#define   ADC_INPUTCTRL_MUXNEG_GND_Val    _U_(0x18)   /**< \brief (ADC_INPUTCTRL) Internal ground */
+#define   ADC_INPUTCTRL_MUXNEG_IOGND_Val  _U_(0x19)   /**< \brief (ADC_INPUTCTRL) IO ground */
+#define ADC_INPUTCTRL_MUXNEG_PIN0   (ADC_INPUTCTRL_MUXNEG_PIN0_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_PIN1   (ADC_INPUTCTRL_MUXNEG_PIN1_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_PIN2   (ADC_INPUTCTRL_MUXNEG_PIN2_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_PIN3   (ADC_INPUTCTRL_MUXNEG_PIN3_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_PIN4   (ADC_INPUTCTRL_MUXNEG_PIN4_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_PIN5   (ADC_INPUTCTRL_MUXNEG_PIN5_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_PIN6   (ADC_INPUTCTRL_MUXNEG_PIN6_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_PIN7   (ADC_INPUTCTRL_MUXNEG_PIN7_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_GND    (ADC_INPUTCTRL_MUXNEG_GND_Val  << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_MUXNEG_IOGND  (ADC_INPUTCTRL_MUXNEG_IOGND_Val << ADC_INPUTCTRL_MUXNEG_Pos)
+#define ADC_INPUTCTRL_INPUTSCAN_Pos 16           /**< \brief (ADC_INPUTCTRL) Number of Input Channels Included in Scan */
+#define ADC_INPUTCTRL_INPUTSCAN_Msk (_U_(0xF) << ADC_INPUTCTRL_INPUTSCAN_Pos)
+#define ADC_INPUTCTRL_INPUTSCAN(value) (ADC_INPUTCTRL_INPUTSCAN_Msk & ((value) << ADC_INPUTCTRL_INPUTSCAN_Pos))
+#define ADC_INPUTCTRL_INPUTOFFSET_Pos 20           /**< \brief (ADC_INPUTCTRL) Positive MUX Setting Offset */
+#define ADC_INPUTCTRL_INPUTOFFSET_Msk (_U_(0xF) << ADC_INPUTCTRL_INPUTOFFSET_Pos)
+#define ADC_INPUTCTRL_INPUTOFFSET(value) (ADC_INPUTCTRL_INPUTOFFSET_Msk & ((value) << ADC_INPUTCTRL_INPUTOFFSET_Pos))
+#define ADC_INPUTCTRL_GAIN_Pos      24           /**< \brief (ADC_INPUTCTRL) Gain Factor Selection */
+#define ADC_INPUTCTRL_GAIN_Msk      (_U_(0xF) << ADC_INPUTCTRL_GAIN_Pos)
+#define ADC_INPUTCTRL_GAIN(value)   (ADC_INPUTCTRL_GAIN_Msk & ((value) << ADC_INPUTCTRL_GAIN_Pos))
+#define   ADC_INPUTCTRL_GAIN_1X_Val       _U_(0x0)   /**< \brief (ADC_INPUTCTRL) 1x */
+#define   ADC_INPUTCTRL_GAIN_2X_Val       _U_(0x1)   /**< \brief (ADC_INPUTCTRL) 2x */
+#define   ADC_INPUTCTRL_GAIN_4X_Val       _U_(0x2)   /**< \brief (ADC_INPUTCTRL) 4x */
+#define   ADC_INPUTCTRL_GAIN_8X_Val       _U_(0x3)   /**< \brief (ADC_INPUTCTRL) 8x */
+#define   ADC_INPUTCTRL_GAIN_16X_Val      _U_(0x4)   /**< \brief (ADC_INPUTCTRL) 16x */
+#define   ADC_INPUTCTRL_GAIN_DIV2_Val     _U_(0xF)   /**< \brief (ADC_INPUTCTRL) 1/2x */
+#define ADC_INPUTCTRL_GAIN_1X       (ADC_INPUTCTRL_GAIN_1X_Val     << ADC_INPUTCTRL_GAIN_Pos)
+#define ADC_INPUTCTRL_GAIN_2X       (ADC_INPUTCTRL_GAIN_2X_Val     << ADC_INPUTCTRL_GAIN_Pos)
+#define ADC_INPUTCTRL_GAIN_4X       (ADC_INPUTCTRL_GAIN_4X_Val     << ADC_INPUTCTRL_GAIN_Pos)
+#define ADC_INPUTCTRL_GAIN_8X       (ADC_INPUTCTRL_GAIN_8X_Val     << ADC_INPUTCTRL_GAIN_Pos)
+#define ADC_INPUTCTRL_GAIN_16X      (ADC_INPUTCTRL_GAIN_16X_Val    << ADC_INPUTCTRL_GAIN_Pos)
+#define ADC_INPUTCTRL_GAIN_DIV2     (ADC_INPUTCTRL_GAIN_DIV2_Val   << ADC_INPUTCTRL_GAIN_Pos)
+#define ADC_INPUTCTRL_MASK          _U_(0x0FFF1F1F) /**< \brief (ADC_INPUTCTRL) MASK Register */
+
+/* -------- ADC_EVCTRL : (ADC Offset: 0x14) (R/W  8) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  STARTEI:1;        /*!< bit:      0  Start Conversion Event In          */
+    uint8_t  SYNCEI:1;         /*!< bit:      1  Synchronization Event In           */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  RESRDYEO:1;       /*!< bit:      4  Result Ready Event Out             */
+    uint8_t  WINMONEO:1;       /*!< bit:      5  Window Monitor Event Out           */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_EVCTRL_OFFSET           0x14         /**< \brief (ADC_EVCTRL offset) Event Control */
+#define ADC_EVCTRL_RESETVALUE       _U_(0x00)    /**< \brief (ADC_EVCTRL reset_value) Event Control */
+
+#define ADC_EVCTRL_STARTEI_Pos      0            /**< \brief (ADC_EVCTRL) Start Conversion Event In */
+#define ADC_EVCTRL_STARTEI          (_U_(0x1) << ADC_EVCTRL_STARTEI_Pos)
+#define ADC_EVCTRL_SYNCEI_Pos       1            /**< \brief (ADC_EVCTRL) Synchronization Event In */
+#define ADC_EVCTRL_SYNCEI           (_U_(0x1) << ADC_EVCTRL_SYNCEI_Pos)
+#define ADC_EVCTRL_RESRDYEO_Pos     4            /**< \brief (ADC_EVCTRL) Result Ready Event Out */
+#define ADC_EVCTRL_RESRDYEO         (_U_(0x1) << ADC_EVCTRL_RESRDYEO_Pos)
+#define ADC_EVCTRL_WINMONEO_Pos     5            /**< \brief (ADC_EVCTRL) Window Monitor Event Out */
+#define ADC_EVCTRL_WINMONEO         (_U_(0x1) << ADC_EVCTRL_WINMONEO_Pos)
+#define ADC_EVCTRL_MASK             _U_(0x33)    /**< \brief (ADC_EVCTRL) MASK Register */
+
+/* -------- ADC_INTENCLR : (ADC Offset: 0x16) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Enable      */
+    uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Enable           */
+    uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Enable    */
+    uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready Interrupt Enable */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INTENCLR_OFFSET         0x16         /**< \brief (ADC_INTENCLR offset) Interrupt Enable Clear */
+#define ADC_INTENCLR_RESETVALUE     _U_(0x00)    /**< \brief (ADC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define ADC_INTENCLR_RESRDY_Pos     0            /**< \brief (ADC_INTENCLR) Result Ready Interrupt Enable */
+#define ADC_INTENCLR_RESRDY         (_U_(0x1) << ADC_INTENCLR_RESRDY_Pos)
+#define ADC_INTENCLR_OVERRUN_Pos    1            /**< \brief (ADC_INTENCLR) Overrun Interrupt Enable */
+#define ADC_INTENCLR_OVERRUN        (_U_(0x1) << ADC_INTENCLR_OVERRUN_Pos)
+#define ADC_INTENCLR_WINMON_Pos     2            /**< \brief (ADC_INTENCLR) Window Monitor Interrupt Enable */
+#define ADC_INTENCLR_WINMON         (_U_(0x1) << ADC_INTENCLR_WINMON_Pos)
+#define ADC_INTENCLR_SYNCRDY_Pos    3            /**< \brief (ADC_INTENCLR) Synchronization Ready Interrupt Enable */
+#define ADC_INTENCLR_SYNCRDY        (_U_(0x1) << ADC_INTENCLR_SYNCRDY_Pos)
+#define ADC_INTENCLR_MASK           _U_(0x0F)    /**< \brief (ADC_INTENCLR) MASK Register */
+
+/* -------- ADC_INTENSET : (ADC Offset: 0x17) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready Interrupt Enable      */
+    uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun Interrupt Enable           */
+    uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor Interrupt Enable    */
+    uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready Interrupt Enable */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INTENSET_OFFSET         0x17         /**< \brief (ADC_INTENSET offset) Interrupt Enable Set */
+#define ADC_INTENSET_RESETVALUE     _U_(0x00)    /**< \brief (ADC_INTENSET reset_value) Interrupt Enable Set */
+
+#define ADC_INTENSET_RESRDY_Pos     0            /**< \brief (ADC_INTENSET) Result Ready Interrupt Enable */
+#define ADC_INTENSET_RESRDY         (_U_(0x1) << ADC_INTENSET_RESRDY_Pos)
+#define ADC_INTENSET_OVERRUN_Pos    1            /**< \brief (ADC_INTENSET) Overrun Interrupt Enable */
+#define ADC_INTENSET_OVERRUN        (_U_(0x1) << ADC_INTENSET_OVERRUN_Pos)
+#define ADC_INTENSET_WINMON_Pos     2            /**< \brief (ADC_INTENSET) Window Monitor Interrupt Enable */
+#define ADC_INTENSET_WINMON         (_U_(0x1) << ADC_INTENSET_WINMON_Pos)
+#define ADC_INTENSET_SYNCRDY_Pos    3            /**< \brief (ADC_INTENSET) Synchronization Ready Interrupt Enable */
+#define ADC_INTENSET_SYNCRDY        (_U_(0x1) << ADC_INTENSET_SYNCRDY_Pos)
+#define ADC_INTENSET_MASK           _U_(0x0F)    /**< \brief (ADC_INTENSET) MASK Register */
+
+/* -------- ADC_INTFLAG : (ADC Offset: 0x18) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  RESRDY:1;         /*!< bit:      0  Result Ready                       */
+    __I uint8_t  OVERRUN:1;        /*!< bit:      1  Overrun                            */
+    __I uint8_t  WINMON:1;         /*!< bit:      2  Window Monitor                     */
+    __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
+    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_INTFLAG_OFFSET          0x18         /**< \brief (ADC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define ADC_INTFLAG_RESETVALUE      _U_(0x00)    /**< \brief (ADC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define ADC_INTFLAG_RESRDY_Pos      0            /**< \brief (ADC_INTFLAG) Result Ready */
+#define ADC_INTFLAG_RESRDY          (_U_(0x1) << ADC_INTFLAG_RESRDY_Pos)
+#define ADC_INTFLAG_OVERRUN_Pos     1            /**< \brief (ADC_INTFLAG) Overrun */
+#define ADC_INTFLAG_OVERRUN         (_U_(0x1) << ADC_INTFLAG_OVERRUN_Pos)
+#define ADC_INTFLAG_WINMON_Pos      2            /**< \brief (ADC_INTFLAG) Window Monitor */
+#define ADC_INTFLAG_WINMON          (_U_(0x1) << ADC_INTFLAG_WINMON_Pos)
+#define ADC_INTFLAG_SYNCRDY_Pos     3            /**< \brief (ADC_INTFLAG) Synchronization Ready */
+#define ADC_INTFLAG_SYNCRDY         (_U_(0x1) << ADC_INTFLAG_SYNCRDY_Pos)
+#define ADC_INTFLAG_MASK            _U_(0x0F)    /**< \brief (ADC_INTFLAG) MASK Register */
+
+/* -------- ADC_STATUS : (ADC Offset: 0x19) (R/   8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_STATUS_OFFSET           0x19         /**< \brief (ADC_STATUS offset) Status */
+#define ADC_STATUS_RESETVALUE       _U_(0x00)    /**< \brief (ADC_STATUS reset_value) Status */
+
+#define ADC_STATUS_SYNCBUSY_Pos     7            /**< \brief (ADC_STATUS) Synchronization Busy */
+#define ADC_STATUS_SYNCBUSY         (_U_(0x1) << ADC_STATUS_SYNCBUSY_Pos)
+#define ADC_STATUS_MASK             _U_(0x80)    /**< \brief (ADC_STATUS) MASK Register */
+
+/* -------- ADC_RESULT : (ADC Offset: 0x1A) (R/  16) Result -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t RESULT:16;        /*!< bit:  0..15  Result Conversion Value            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_RESULT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_RESULT_OFFSET           0x1A         /**< \brief (ADC_RESULT offset) Result */
+#define ADC_RESULT_RESETVALUE       _U_(0x0000)  /**< \brief (ADC_RESULT reset_value) Result */
+
+#define ADC_RESULT_RESULT_Pos       0            /**< \brief (ADC_RESULT) Result Conversion Value */
+#define ADC_RESULT_RESULT_Msk       (_U_(0xFFFF) << ADC_RESULT_RESULT_Pos)
+#define ADC_RESULT_RESULT(value)    (ADC_RESULT_RESULT_Msk & ((value) << ADC_RESULT_RESULT_Pos))
+#define ADC_RESULT_MASK             _U_(0xFFFF)  /**< \brief (ADC_RESULT) MASK Register */
+
+/* -------- ADC_WINLT : (ADC Offset: 0x1C) (R/W 16) Window Monitor Lower Threshold -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t WINLT:16;         /*!< bit:  0..15  Window Lower Threshold             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_WINLT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_WINLT_OFFSET            0x1C         /**< \brief (ADC_WINLT offset) Window Monitor Lower Threshold */
+#define ADC_WINLT_RESETVALUE        _U_(0x0000)  /**< \brief (ADC_WINLT reset_value) Window Monitor Lower Threshold */
+
+#define ADC_WINLT_WINLT_Pos         0            /**< \brief (ADC_WINLT) Window Lower Threshold */
+#define ADC_WINLT_WINLT_Msk         (_U_(0xFFFF) << ADC_WINLT_WINLT_Pos)
+#define ADC_WINLT_WINLT(value)      (ADC_WINLT_WINLT_Msk & ((value) << ADC_WINLT_WINLT_Pos))
+#define ADC_WINLT_MASK              _U_(0xFFFF)  /**< \brief (ADC_WINLT) MASK Register */
+
+/* -------- ADC_WINUT : (ADC Offset: 0x20) (R/W 16) Window Monitor Upper Threshold -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t WINUT:16;         /*!< bit:  0..15  Window Upper Threshold             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_WINUT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_WINUT_OFFSET            0x20         /**< \brief (ADC_WINUT offset) Window Monitor Upper Threshold */
+#define ADC_WINUT_RESETVALUE        _U_(0x0000)  /**< \brief (ADC_WINUT reset_value) Window Monitor Upper Threshold */
+
+#define ADC_WINUT_WINUT_Pos         0            /**< \brief (ADC_WINUT) Window Upper Threshold */
+#define ADC_WINUT_WINUT_Msk         (_U_(0xFFFF) << ADC_WINUT_WINUT_Pos)
+#define ADC_WINUT_WINUT(value)      (ADC_WINUT_WINUT_Msk & ((value) << ADC_WINUT_WINUT_Pos))
+#define ADC_WINUT_MASK              _U_(0xFFFF)  /**< \brief (ADC_WINUT) MASK Register */
+
+/* -------- ADC_GAINCORR : (ADC Offset: 0x24) (R/W 16) Gain Correction -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t GAINCORR:12;      /*!< bit:  0..11  Gain Correction Value              */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_GAINCORR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_GAINCORR_OFFSET         0x24         /**< \brief (ADC_GAINCORR offset) Gain Correction */
+#define ADC_GAINCORR_RESETVALUE     _U_(0x0000)  /**< \brief (ADC_GAINCORR reset_value) Gain Correction */
+
+#define ADC_GAINCORR_GAINCORR_Pos   0            /**< \brief (ADC_GAINCORR) Gain Correction Value */
+#define ADC_GAINCORR_GAINCORR_Msk   (_U_(0xFFF) << ADC_GAINCORR_GAINCORR_Pos)
+#define ADC_GAINCORR_GAINCORR(value) (ADC_GAINCORR_GAINCORR_Msk & ((value) << ADC_GAINCORR_GAINCORR_Pos))
+#define ADC_GAINCORR_MASK           _U_(0x0FFF)  /**< \brief (ADC_GAINCORR) MASK Register */
+
+/* -------- ADC_OFFSETCORR : (ADC Offset: 0x26) (R/W 16) Offset Correction -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t OFFSETCORR:12;    /*!< bit:  0..11  Offset Correction Value            */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_OFFSETCORR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_OFFSETCORR_OFFSET       0x26         /**< \brief (ADC_OFFSETCORR offset) Offset Correction */
+#define ADC_OFFSETCORR_RESETVALUE   _U_(0x0000)  /**< \brief (ADC_OFFSETCORR reset_value) Offset Correction */
+
+#define ADC_OFFSETCORR_OFFSETCORR_Pos 0            /**< \brief (ADC_OFFSETCORR) Offset Correction Value */
+#define ADC_OFFSETCORR_OFFSETCORR_Msk (_U_(0xFFF) << ADC_OFFSETCORR_OFFSETCORR_Pos)
+#define ADC_OFFSETCORR_OFFSETCORR(value) (ADC_OFFSETCORR_OFFSETCORR_Msk & ((value) << ADC_OFFSETCORR_OFFSETCORR_Pos))
+#define ADC_OFFSETCORR_MASK         _U_(0x0FFF)  /**< \brief (ADC_OFFSETCORR) MASK Register */
+
+/* -------- ADC_CALIB : (ADC Offset: 0x28) (R/W 16) Calibration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t LINEARITY_CAL:8;  /*!< bit:  0.. 7  Linearity Calibration Value        */
+    uint16_t BIAS_CAL:3;       /*!< bit:  8..10  Bias Calibration Value             */
+    uint16_t :5;               /*!< bit: 11..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} ADC_CALIB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_CALIB_OFFSET            0x28         /**< \brief (ADC_CALIB offset) Calibration */
+#define ADC_CALIB_RESETVALUE        _U_(0x0000)  /**< \brief (ADC_CALIB reset_value) Calibration */
+
+#define ADC_CALIB_LINEARITY_CAL_Pos 0            /**< \brief (ADC_CALIB) Linearity Calibration Value */
+#define ADC_CALIB_LINEARITY_CAL_Msk (_U_(0xFF) << ADC_CALIB_LINEARITY_CAL_Pos)
+#define ADC_CALIB_LINEARITY_CAL(value) (ADC_CALIB_LINEARITY_CAL_Msk & ((value) << ADC_CALIB_LINEARITY_CAL_Pos))
+#define ADC_CALIB_BIAS_CAL_Pos      8            /**< \brief (ADC_CALIB) Bias Calibration Value */
+#define ADC_CALIB_BIAS_CAL_Msk      (_U_(0x7) << ADC_CALIB_BIAS_CAL_Pos)
+#define ADC_CALIB_BIAS_CAL(value)   (ADC_CALIB_BIAS_CAL_Msk & ((value) << ADC_CALIB_BIAS_CAL_Pos))
+#define ADC_CALIB_MASK              _U_(0x07FF)  /**< \brief (ADC_CALIB) MASK Register */
+
+/* -------- ADC_DBGCTRL : (ADC Offset: 0x2A) (R/W  8) Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGRUN:1;         /*!< bit:      0  Debug Run                          */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} ADC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define ADC_DBGCTRL_OFFSET          0x2A         /**< \brief (ADC_DBGCTRL offset) Debug Control */
+#define ADC_DBGCTRL_RESETVALUE      _U_(0x00)    /**< \brief (ADC_DBGCTRL reset_value) Debug Control */
+
+#define ADC_DBGCTRL_DBGRUN_Pos      0            /**< \brief (ADC_DBGCTRL) Debug Run */
+#define ADC_DBGCTRL_DBGRUN          (_U_(0x1) << ADC_DBGCTRL_DBGRUN_Pos)
+#define ADC_DBGCTRL_MASK            _U_(0x01)    /**< \brief (ADC_DBGCTRL) MASK Register */
+
+/** \brief ADC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO ADC_CTRLA_Type            CTRLA;       /**< \brief Offset: 0x00 (R/W  8) Control A */
+  __IO ADC_REFCTRL_Type          REFCTRL;     /**< \brief Offset: 0x01 (R/W  8) Reference Control */
+  __IO ADC_AVGCTRL_Type          AVGCTRL;     /**< \brief Offset: 0x02 (R/W  8) Average Control */
+  __IO ADC_SAMPCTRL_Type         SAMPCTRL;    /**< \brief Offset: 0x03 (R/W  8) Sampling Time Control */
+  __IO ADC_CTRLB_Type            CTRLB;       /**< \brief Offset: 0x04 (R/W 16) Control B */
+       RoReg8                    Reserved1[0x2];
+  __IO ADC_WINCTRL_Type          WINCTRL;     /**< \brief Offset: 0x08 (R/W  8) Window Monitor Control */
+       RoReg8                    Reserved2[0x3];
+  __IO ADC_SWTRIG_Type           SWTRIG;      /**< \brief Offset: 0x0C (R/W  8) Software Trigger */
+       RoReg8                    Reserved3[0x3];
+  __IO ADC_INPUTCTRL_Type        INPUTCTRL;   /**< \brief Offset: 0x10 (R/W 32) Inputs Control */
+  __IO ADC_EVCTRL_Type           EVCTRL;      /**< \brief Offset: 0x14 (R/W  8) Event Control */
+       RoReg8                    Reserved4[0x1];
+  __IO ADC_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x16 (R/W  8) Interrupt Enable Clear */
+  __IO ADC_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x17 (R/W  8) Interrupt Enable Set */
+  __IO ADC_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x18 (R/W  8) Interrupt Flag Status and Clear */
+  __I  ADC_STATUS_Type           STATUS;      /**< \brief Offset: 0x19 (R/   8) Status */
+  __I  ADC_RESULT_Type           RESULT;      /**< \brief Offset: 0x1A (R/  16) Result */
+  __IO ADC_WINLT_Type            WINLT;       /**< \brief Offset: 0x1C (R/W 16) Window Monitor Lower Threshold */
+       RoReg8                    Reserved5[0x2];
+  __IO ADC_WINUT_Type            WINUT;       /**< \brief Offset: 0x20 (R/W 16) Window Monitor Upper Threshold */
+       RoReg8                    Reserved6[0x2];
+  __IO ADC_GAINCORR_Type         GAINCORR;    /**< \brief Offset: 0x24 (R/W 16) Gain Correction */
+  __IO ADC_OFFSETCORR_Type       OFFSETCORR;  /**< \brief Offset: 0x26 (R/W 16) Offset Correction */
+  __IO ADC_CALIB_Type            CALIB;       /**< \brief Offset: 0x28 (R/W 16) Calibration */
+  __IO ADC_DBGCTRL_Type          DBGCTRL;     /**< \brief Offset: 0x2A (R/W  8) Debug Control */
+} Adc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_ADC_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/dac.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/dac.h
@@ -1,0 +1,269 @@
+/**
+ * \file
+ *
+ * \brief Component description for DAC
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_DAC_COMPONENT_
+#define _SAMD20_DAC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DAC */
+/* ========================================================================== */
+/** \addtogroup SAMD20_DAC Digital Analog Converter */
+/*@{*/
+
+#define DAC_U2214
+#define REV_DAC                     0x101
+
+/* -------- DAC_CTRLA : (DAC Offset: 0x0) (R/W  8) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  RUNSTDBY:1;       /*!< bit:      2  Run in Standby                     */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_CTRLA_OFFSET            0x0          /**< \brief (DAC_CTRLA offset) Control A */
+#define DAC_CTRLA_RESETVALUE        _U_(0x00)    /**< \brief (DAC_CTRLA reset_value) Control A */
+
+#define DAC_CTRLA_SWRST_Pos         0            /**< \brief (DAC_CTRLA) Software Reset */
+#define DAC_CTRLA_SWRST             (_U_(0x1) << DAC_CTRLA_SWRST_Pos)
+#define DAC_CTRLA_ENABLE_Pos        1            /**< \brief (DAC_CTRLA) Enable */
+#define DAC_CTRLA_ENABLE            (_U_(0x1) << DAC_CTRLA_ENABLE_Pos)
+#define DAC_CTRLA_RUNSTDBY_Pos      2            /**< \brief (DAC_CTRLA) Run in Standby */
+#define DAC_CTRLA_RUNSTDBY          (_U_(0x1) << DAC_CTRLA_RUNSTDBY_Pos)
+#define DAC_CTRLA_MASK              _U_(0x07)    /**< \brief (DAC_CTRLA) MASK Register */
+
+/* -------- DAC_CTRLB : (DAC Offset: 0x1) (R/W  8) Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  EOEN:1;           /*!< bit:      0  External Output Enable             */
+    uint8_t  IOEN:1;           /*!< bit:      1  Internal Output Enable             */
+    uint8_t  LEFTADJ:1;        /*!< bit:      2  Left Adjusted Data                 */
+    uint8_t  VPD:1;            /*!< bit:      3  Voltage Pump Disable               */
+    uint8_t  :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint8_t  REFSEL:2;         /*!< bit:  6.. 7  Reference Selection                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_CTRLB_OFFSET            0x1          /**< \brief (DAC_CTRLB offset) Control B */
+#define DAC_CTRLB_RESETVALUE        _U_(0x00)    /**< \brief (DAC_CTRLB reset_value) Control B */
+
+#define DAC_CTRLB_EOEN_Pos          0            /**< \brief (DAC_CTRLB) External Output Enable */
+#define DAC_CTRLB_EOEN              (_U_(0x1) << DAC_CTRLB_EOEN_Pos)
+#define DAC_CTRLB_IOEN_Pos          1            /**< \brief (DAC_CTRLB) Internal Output Enable */
+#define DAC_CTRLB_IOEN              (_U_(0x1) << DAC_CTRLB_IOEN_Pos)
+#define DAC_CTRLB_LEFTADJ_Pos       2            /**< \brief (DAC_CTRLB) Left Adjusted Data */
+#define DAC_CTRLB_LEFTADJ           (_U_(0x1) << DAC_CTRLB_LEFTADJ_Pos)
+#define DAC_CTRLB_VPD_Pos           3            /**< \brief (DAC_CTRLB) Voltage Pump Disable */
+#define DAC_CTRLB_VPD               (_U_(0x1) << DAC_CTRLB_VPD_Pos)
+#define DAC_CTRLB_REFSEL_Pos        6            /**< \brief (DAC_CTRLB) Reference Selection */
+#define DAC_CTRLB_REFSEL_Msk        (_U_(0x3) << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_REFSEL(value)     (DAC_CTRLB_REFSEL_Msk & ((value) << DAC_CTRLB_REFSEL_Pos))
+#define   DAC_CTRLB_REFSEL_INT1V_Val      _U_(0x0)   /**< \brief (DAC_CTRLB) Internal 1.0V reference */
+#define   DAC_CTRLB_REFSEL_AVCC_Val       _U_(0x1)   /**< \brief (DAC_CTRLB) AVCC */
+#define   DAC_CTRLB_REFSEL_VREFP_Val      _U_(0x2)   /**< \brief (DAC_CTRLB) External reference */
+#define DAC_CTRLB_REFSEL_INT1V      (DAC_CTRLB_REFSEL_INT1V_Val    << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_REFSEL_AVCC       (DAC_CTRLB_REFSEL_AVCC_Val     << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_REFSEL_VREFP      (DAC_CTRLB_REFSEL_VREFP_Val    << DAC_CTRLB_REFSEL_Pos)
+#define DAC_CTRLB_MASK              _U_(0xCF)    /**< \brief (DAC_CTRLB) MASK Register */
+
+/* -------- DAC_EVCTRL : (DAC Offset: 0x2) (R/W  8) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  STARTEI:1;        /*!< bit:      0  Start Conversion Event Input       */
+    uint8_t  EMPTYEO:1;        /*!< bit:      1  Data Buffer Empty Event Output     */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_EVCTRL_OFFSET           0x2          /**< \brief (DAC_EVCTRL offset) Event Control */
+#define DAC_EVCTRL_RESETVALUE       _U_(0x00)    /**< \brief (DAC_EVCTRL reset_value) Event Control */
+
+#define DAC_EVCTRL_STARTEI_Pos      0            /**< \brief (DAC_EVCTRL) Start Conversion Event Input */
+#define DAC_EVCTRL_STARTEI          (_U_(0x1) << DAC_EVCTRL_STARTEI_Pos)
+#define DAC_EVCTRL_EMPTYEO_Pos      1            /**< \brief (DAC_EVCTRL) Data Buffer Empty Event Output */
+#define DAC_EVCTRL_EMPTYEO          (_U_(0x1) << DAC_EVCTRL_EMPTYEO_Pos)
+#define DAC_EVCTRL_MASK             _U_(0x03)    /**< \brief (DAC_EVCTRL) MASK Register */
+
+/* -------- DAC_INTENCLR : (DAC Offset: 0x4) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
+    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready Interrupt Enable */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTENCLR_OFFSET         0x4          /**< \brief (DAC_INTENCLR offset) Interrupt Enable Clear */
+#define DAC_INTENCLR_RESETVALUE     _U_(0x00)    /**< \brief (DAC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define DAC_INTENCLR_UNDERRUN_Pos   0            /**< \brief (DAC_INTENCLR) Underrun Interrupt Enable */
+#define DAC_INTENCLR_UNDERRUN       (_U_(0x1) << DAC_INTENCLR_UNDERRUN_Pos)
+#define DAC_INTENCLR_EMPTY_Pos      1            /**< \brief (DAC_INTENCLR) Data Buffer Empty Interrupt Enable */
+#define DAC_INTENCLR_EMPTY          (_U_(0x1) << DAC_INTENCLR_EMPTY_Pos)
+#define DAC_INTENCLR_SYNCRDY_Pos    2            /**< \brief (DAC_INTENCLR) Synchronization Ready Interrupt Enable */
+#define DAC_INTENCLR_SYNCRDY        (_U_(0x1) << DAC_INTENCLR_SYNCRDY_Pos)
+#define DAC_INTENCLR_MASK           _U_(0x07)    /**< \brief (DAC_INTENCLR) MASK Register */
+
+/* -------- DAC_INTENSET : (DAC Offset: 0x5) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun Interrupt Enable          */
+    uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty Interrupt Enable */
+    uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready Interrupt Enable */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTENSET_OFFSET         0x5          /**< \brief (DAC_INTENSET offset) Interrupt Enable Set */
+#define DAC_INTENSET_RESETVALUE     _U_(0x00)    /**< \brief (DAC_INTENSET reset_value) Interrupt Enable Set */
+
+#define DAC_INTENSET_UNDERRUN_Pos   0            /**< \brief (DAC_INTENSET) Underrun Interrupt Enable */
+#define DAC_INTENSET_UNDERRUN       (_U_(0x1) << DAC_INTENSET_UNDERRUN_Pos)
+#define DAC_INTENSET_EMPTY_Pos      1            /**< \brief (DAC_INTENSET) Data Buffer Empty Interrupt Enable */
+#define DAC_INTENSET_EMPTY          (_U_(0x1) << DAC_INTENSET_EMPTY_Pos)
+#define DAC_INTENSET_SYNCRDY_Pos    2            /**< \brief (DAC_INTENSET) Synchronization Ready Interrupt Enable */
+#define DAC_INTENSET_SYNCRDY        (_U_(0x1) << DAC_INTENSET_SYNCRDY_Pos)
+#define DAC_INTENSET_MASK           _U_(0x07)    /**< \brief (DAC_INTENSET) MASK Register */
+
+/* -------- DAC_INTFLAG : (DAC Offset: 0x6) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  UNDERRUN:1;       /*!< bit:      0  Underrun                           */
+    __I uint8_t  EMPTY:1;          /*!< bit:      1  Data Buffer Empty                  */
+    __I uint8_t  SYNCRDY:1;        /*!< bit:      2  Synchronization Ready              */
+    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_INTFLAG_OFFSET          0x6          /**< \brief (DAC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define DAC_INTFLAG_RESETVALUE      _U_(0x00)    /**< \brief (DAC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define DAC_INTFLAG_UNDERRUN_Pos    0            /**< \brief (DAC_INTFLAG) Underrun */
+#define DAC_INTFLAG_UNDERRUN        (_U_(0x1) << DAC_INTFLAG_UNDERRUN_Pos)
+#define DAC_INTFLAG_EMPTY_Pos       1            /**< \brief (DAC_INTFLAG) Data Buffer Empty */
+#define DAC_INTFLAG_EMPTY           (_U_(0x1) << DAC_INTFLAG_EMPTY_Pos)
+#define DAC_INTFLAG_SYNCRDY_Pos     2            /**< \brief (DAC_INTFLAG) Synchronization Ready */
+#define DAC_INTFLAG_SYNCRDY         (_U_(0x1) << DAC_INTFLAG_SYNCRDY_Pos)
+#define DAC_INTFLAG_MASK            _U_(0x07)    /**< \brief (DAC_INTFLAG) MASK Register */
+
+/* -------- DAC_STATUS : (DAC Offset: 0x7) (R/   8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy Status        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DAC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_STATUS_OFFSET           0x7          /**< \brief (DAC_STATUS offset) Status */
+#define DAC_STATUS_RESETVALUE       _U_(0x00)    /**< \brief (DAC_STATUS reset_value) Status */
+
+#define DAC_STATUS_SYNCBUSY_Pos     7            /**< \brief (DAC_STATUS) Synchronization Busy Status */
+#define DAC_STATUS_SYNCBUSY         (_U_(0x1) << DAC_STATUS_SYNCBUSY_Pos)
+#define DAC_STATUS_MASK             _U_(0x80)    /**< \brief (DAC_STATUS) MASK Register */
+
+/* -------- DAC_DATA : (DAC Offset: 0x8) (R/W 16) Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DATA:16;          /*!< bit:  0..15  Data to be converted               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} DAC_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DATA_OFFSET             0x8          /**< \brief (DAC_DATA offset) Data */
+#define DAC_DATA_RESETVALUE         _U_(0x0000)  /**< \brief (DAC_DATA reset_value) Data */
+
+#define DAC_DATA_DATA_Pos           0            /**< \brief (DAC_DATA) Data to be converted */
+#define DAC_DATA_DATA_Msk           (_U_(0xFFFF) << DAC_DATA_DATA_Pos)
+#define DAC_DATA_DATA(value)        (DAC_DATA_DATA_Msk & ((value) << DAC_DATA_DATA_Pos))
+#define DAC_DATA_MASK               _U_(0xFFFF)  /**< \brief (DAC_DATA) MASK Register */
+
+/* -------- DAC_DATABUF : (DAC Offset: 0xC) (R/W 16) Data Buffer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DATABUF:16;       /*!< bit:  0..15  Data Buffer                        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} DAC_DATABUF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DAC_DATABUF_OFFSET          0xC          /**< \brief (DAC_DATABUF offset) Data Buffer */
+#define DAC_DATABUF_RESETVALUE      _U_(0x0000)  /**< \brief (DAC_DATABUF reset_value) Data Buffer */
+
+#define DAC_DATABUF_DATABUF_Pos     0            /**< \brief (DAC_DATABUF) Data Buffer */
+#define DAC_DATABUF_DATABUF_Msk     (_U_(0xFFFF) << DAC_DATABUF_DATABUF_Pos)
+#define DAC_DATABUF_DATABUF(value)  (DAC_DATABUF_DATABUF_Msk & ((value) << DAC_DATABUF_DATABUF_Pos))
+#define DAC_DATABUF_MASK            _U_(0xFFFF)  /**< \brief (DAC_DATABUF) MASK Register */
+
+/** \brief DAC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO DAC_CTRLA_Type            CTRLA;       /**< \brief Offset: 0x0 (R/W  8) Control A */
+  __IO DAC_CTRLB_Type            CTRLB;       /**< \brief Offset: 0x1 (R/W  8) Control B */
+  __IO DAC_EVCTRL_Type           EVCTRL;      /**< \brief Offset: 0x2 (R/W  8) Event Control */
+       RoReg8                    Reserved1[0x1];
+  __IO DAC_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x4 (R/W  8) Interrupt Enable Clear */
+  __IO DAC_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x5 (R/W  8) Interrupt Enable Set */
+  __IO DAC_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x6 (R/W  8) Interrupt Flag Status and Clear */
+  __I  DAC_STATUS_Type           STATUS;      /**< \brief Offset: 0x7 (R/   8) Status */
+  __IO DAC_DATA_Type             DATA;        /**< \brief Offset: 0x8 (R/W 16) Data */
+       RoReg8                    Reserved2[0x2];
+  __IO DAC_DATABUF_Type          DATABUF;     /**< \brief Offset: 0xC (R/W 16) Data Buffer */
+} Dac;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_DAC_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/dsu.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/dsu.h
@@ -1,0 +1,629 @@
+/**
+ * \file
+ *
+ * \brief Component description for DSU
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_DSU_COMPONENT_
+#define _SAMD20_DSU_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR DSU */
+/* ========================================================================== */
+/** \addtogroup SAMD20_DSU Device Service Unit */
+/*@{*/
+
+#define DSU_U2209
+#define REV_DSU                     0x103
+
+/* -------- DSU_CTRL : (DSU Offset: 0x0000) ( /W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  :1;               /*!< bit:      1  Reserved                           */
+    uint8_t  CRC:1;            /*!< bit:      2  32-bit Cyclic Redundancy Code      */
+    uint8_t  MBIST:1;          /*!< bit:      3  Memory built-in self-test          */
+    uint8_t  CE:1;             /*!< bit:      4  Chip-Erase                         */
+    uint8_t  :1;               /*!< bit:      5  Reserved                           */
+    uint8_t  ARR:1;            /*!< bit:      6  Auxiliary Row Read                 */
+    uint8_t  SMSA:1;           /*!< bit:      7  Start Memory Stream Access         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DSU_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CTRL_OFFSET             0x0000       /**< \brief (DSU_CTRL offset) Control */
+#define DSU_CTRL_RESETVALUE         _U_(0x00)    /**< \brief (DSU_CTRL reset_value) Control */
+
+#define DSU_CTRL_SWRST_Pos          0            /**< \brief (DSU_CTRL) Software Reset */
+#define DSU_CTRL_SWRST              (_U_(0x1) << DSU_CTRL_SWRST_Pos)
+#define DSU_CTRL_CRC_Pos            2            /**< \brief (DSU_CTRL) 32-bit Cyclic Redundancy Code */
+#define DSU_CTRL_CRC                (_U_(0x1) << DSU_CTRL_CRC_Pos)
+#define DSU_CTRL_MBIST_Pos          3            /**< \brief (DSU_CTRL) Memory built-in self-test */
+#define DSU_CTRL_MBIST              (_U_(0x1) << DSU_CTRL_MBIST_Pos)
+#define DSU_CTRL_CE_Pos             4            /**< \brief (DSU_CTRL) Chip-Erase */
+#define DSU_CTRL_CE                 (_U_(0x1) << DSU_CTRL_CE_Pos)
+#define DSU_CTRL_ARR_Pos            6            /**< \brief (DSU_CTRL) Auxiliary Row Read */
+#define DSU_CTRL_ARR                (_U_(0x1) << DSU_CTRL_ARR_Pos)
+#define DSU_CTRL_SMSA_Pos           7            /**< \brief (DSU_CTRL) Start Memory Stream Access */
+#define DSU_CTRL_SMSA               (_U_(0x1) << DSU_CTRL_SMSA_Pos)
+#define DSU_CTRL_MASK               _U_(0xDD)    /**< \brief (DSU_CTRL) MASK Register */
+
+/* -------- DSU_STATUSA : (DSU Offset: 0x0001) (R/W  8) Status A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DONE:1;           /*!< bit:      0  Done                               */
+    uint8_t  CRSTEXT:1;        /*!< bit:      1  CPU Reset Phase Extension          */
+    uint8_t  BERR:1;           /*!< bit:      2  Bus Error                          */
+    uint8_t  FAIL:1;           /*!< bit:      3  Failure                            */
+    uint8_t  PERR:1;           /*!< bit:      4  Protection Error                   */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DSU_STATUSA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_STATUSA_OFFSET          0x0001       /**< \brief (DSU_STATUSA offset) Status A */
+#define DSU_STATUSA_RESETVALUE      _U_(0x00)    /**< \brief (DSU_STATUSA reset_value) Status A */
+
+#define DSU_STATUSA_DONE_Pos        0            /**< \brief (DSU_STATUSA) Done */
+#define DSU_STATUSA_DONE            (_U_(0x1) << DSU_STATUSA_DONE_Pos)
+#define DSU_STATUSA_CRSTEXT_Pos     1            /**< \brief (DSU_STATUSA) CPU Reset Phase Extension */
+#define DSU_STATUSA_CRSTEXT         (_U_(0x1) << DSU_STATUSA_CRSTEXT_Pos)
+#define DSU_STATUSA_BERR_Pos        2            /**< \brief (DSU_STATUSA) Bus Error */
+#define DSU_STATUSA_BERR            (_U_(0x1) << DSU_STATUSA_BERR_Pos)
+#define DSU_STATUSA_FAIL_Pos        3            /**< \brief (DSU_STATUSA) Failure */
+#define DSU_STATUSA_FAIL            (_U_(0x1) << DSU_STATUSA_FAIL_Pos)
+#define DSU_STATUSA_PERR_Pos        4            /**< \brief (DSU_STATUSA) Protection Error */
+#define DSU_STATUSA_PERR            (_U_(0x1) << DSU_STATUSA_PERR_Pos)
+#define DSU_STATUSA_MASK            _U_(0x1F)    /**< \brief (DSU_STATUSA) MASK Register */
+
+/* -------- DSU_STATUSB : (DSU Offset: 0x0002) (R/   8) Status B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PROT:1;           /*!< bit:      0  Protected                          */
+    uint8_t  DBGPRES:1;        /*!< bit:      1  Debugger Present                   */
+    uint8_t  DCCD0:1;          /*!< bit:      2  Debug Communication Channel 0 Dirty */
+    uint8_t  DCCD1:1;          /*!< bit:      3  Debug Communication Channel 1 Dirty */
+    uint8_t  HPE:1;            /*!< bit:      4  Hot-Plugging Enable                */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint8_t  DCCD:2;           /*!< bit:  2.. 3  Debug Communication Channel x Dirty */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} DSU_STATUSB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_STATUSB_OFFSET          0x0002       /**< \brief (DSU_STATUSB offset) Status B */
+#define DSU_STATUSB_RESETVALUE      _U_(0x00)    /**< \brief (DSU_STATUSB reset_value) Status B */
+
+#define DSU_STATUSB_PROT_Pos        0            /**< \brief (DSU_STATUSB) Protected */
+#define DSU_STATUSB_PROT            (_U_(0x1) << DSU_STATUSB_PROT_Pos)
+#define DSU_STATUSB_DBGPRES_Pos     1            /**< \brief (DSU_STATUSB) Debugger Present */
+#define DSU_STATUSB_DBGPRES         (_U_(0x1) << DSU_STATUSB_DBGPRES_Pos)
+#define DSU_STATUSB_DCCD0_Pos       2            /**< \brief (DSU_STATUSB) Debug Communication Channel 0 Dirty */
+#define DSU_STATUSB_DCCD0           (_U_(1) << DSU_STATUSB_DCCD0_Pos)
+#define DSU_STATUSB_DCCD1_Pos       3            /**< \brief (DSU_STATUSB) Debug Communication Channel 1 Dirty */
+#define DSU_STATUSB_DCCD1           (_U_(1) << DSU_STATUSB_DCCD1_Pos)
+#define DSU_STATUSB_DCCD_Pos        2            /**< \brief (DSU_STATUSB) Debug Communication Channel x Dirty */
+#define DSU_STATUSB_DCCD_Msk        (_U_(0x3) << DSU_STATUSB_DCCD_Pos)
+#define DSU_STATUSB_DCCD(value)     (DSU_STATUSB_DCCD_Msk & ((value) << DSU_STATUSB_DCCD_Pos))
+#define DSU_STATUSB_HPE_Pos         4            /**< \brief (DSU_STATUSB) Hot-Plugging Enable */
+#define DSU_STATUSB_HPE             (_U_(0x1) << DSU_STATUSB_HPE_Pos)
+#define DSU_STATUSB_MASK            _U_(0x1F)    /**< \brief (DSU_STATUSB) MASK Register */
+
+/* -------- DSU_ADDR : (DSU Offset: 0x0004) (R/W 32) Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t AMOD:2;           /*!< bit:  0.. 1  Access Mode                        */
+    uint32_t ADDR:30;          /*!< bit:  2..31  Address                            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_ADDR_OFFSET             0x0004       /**< \brief (DSU_ADDR offset) Address */
+#define DSU_ADDR_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_ADDR reset_value) Address */
+
+#define DSU_ADDR_AMOD_Pos           0            /**< \brief (DSU_ADDR) Access Mode */
+#define DSU_ADDR_AMOD_Msk           (_U_(0x3) << DSU_ADDR_AMOD_Pos)
+#define DSU_ADDR_AMOD(value)        (DSU_ADDR_AMOD_Msk & ((value) << DSU_ADDR_AMOD_Pos))
+#define DSU_ADDR_ADDR_Pos           2            /**< \brief (DSU_ADDR) Address */
+#define DSU_ADDR_ADDR_Msk           (_U_(0x3FFFFFFF) << DSU_ADDR_ADDR_Pos)
+#define DSU_ADDR_ADDR(value)        (DSU_ADDR_ADDR_Msk & ((value) << DSU_ADDR_ADDR_Pos))
+#define DSU_ADDR_MASK               _U_(0xFFFFFFFF) /**< \brief (DSU_ADDR) MASK Register */
+
+/* -------- DSU_LENGTH : (DSU Offset: 0x0008) (R/W 32) Length -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint32_t LENGTH:30;        /*!< bit:  2..31  Length                             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_LENGTH_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_LENGTH_OFFSET           0x0008       /**< \brief (DSU_LENGTH offset) Length */
+#define DSU_LENGTH_RESETVALUE       _U_(0x00000000) /**< \brief (DSU_LENGTH reset_value) Length */
+
+#define DSU_LENGTH_LENGTH_Pos       2            /**< \brief (DSU_LENGTH) Length */
+#define DSU_LENGTH_LENGTH_Msk       (_U_(0x3FFFFFFF) << DSU_LENGTH_LENGTH_Pos)
+#define DSU_LENGTH_LENGTH(value)    (DSU_LENGTH_LENGTH_Msk & ((value) << DSU_LENGTH_LENGTH_Pos))
+#define DSU_LENGTH_MASK             _U_(0xFFFFFFFC) /**< \brief (DSU_LENGTH) MASK Register */
+
+/* -------- DSU_DATA : (DSU Offset: 0x000C) (R/W 32) Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Data                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DATA_OFFSET             0x000C       /**< \brief (DSU_DATA offset) Data */
+#define DSU_DATA_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_DATA reset_value) Data */
+
+#define DSU_DATA_DATA_Pos           0            /**< \brief (DSU_DATA) Data */
+#define DSU_DATA_DATA_Msk           (_U_(0xFFFFFFFF) << DSU_DATA_DATA_Pos)
+#define DSU_DATA_DATA(value)        (DSU_DATA_DATA_Msk & ((value) << DSU_DATA_DATA_Pos))
+#define DSU_DATA_MASK               _U_(0xFFFFFFFF) /**< \brief (DSU_DATA) MASK Register */
+
+/* -------- DSU_DCC : (DSU Offset: 0x0010) (R/W 32) Debug Communication Channel n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DATA:32;          /*!< bit:  0..31  Data                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_DCC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DCC_OFFSET              0x0010       /**< \brief (DSU_DCC offset) Debug Communication Channel n */
+#define DSU_DCC_RESETVALUE          _U_(0x00000000) /**< \brief (DSU_DCC reset_value) Debug Communication Channel n */
+
+#define DSU_DCC_DATA_Pos            0            /**< \brief (DSU_DCC) Data */
+#define DSU_DCC_DATA_Msk            (_U_(0xFFFFFFFF) << DSU_DCC_DATA_Pos)
+#define DSU_DCC_DATA(value)         (DSU_DCC_DATA_Msk & ((value) << DSU_DCC_DATA_Pos))
+#define DSU_DCC_MASK                _U_(0xFFFFFFFF) /**< \brief (DSU_DCC) MASK Register */
+
+/* -------- DSU_DID : (DSU Offset: 0x0018) (R/  32) Device Identification -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DEVSEL:8;         /*!< bit:  0.. 7  Device Select                      */
+    uint32_t REVISION:4;       /*!< bit:  8..11  Revision Number                    */
+    uint32_t DIE:4;            /*!< bit: 12..15  Die Number                         */
+    uint32_t SERIES:6;         /*!< bit: 16..21  Series                             */
+    uint32_t :1;               /*!< bit:     22  Reserved                           */
+    uint32_t FAMILY:5;         /*!< bit: 23..27  Family                             */
+    uint32_t PROCESSOR:4;      /*!< bit: 28..31  Processor                          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_DID_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DID_OFFSET              0x0018       /**< \brief (DSU_DID offset) Device Identification */
+
+#define DSU_DID_DEVSEL_Pos          0            /**< \brief (DSU_DID) Device Select */
+#define DSU_DID_DEVSEL_Msk          (_U_(0xFF) << DSU_DID_DEVSEL_Pos)
+#define DSU_DID_DEVSEL(value)       (DSU_DID_DEVSEL_Msk & ((value) << DSU_DID_DEVSEL_Pos))
+#define DSU_DID_REVISION_Pos        8            /**< \brief (DSU_DID) Revision Number */
+#define DSU_DID_REVISION_Msk        (_U_(0xF) << DSU_DID_REVISION_Pos)
+#define DSU_DID_REVISION(value)     (DSU_DID_REVISION_Msk & ((value) << DSU_DID_REVISION_Pos))
+#define DSU_DID_DIE_Pos             12           /**< \brief (DSU_DID) Die Number */
+#define DSU_DID_DIE_Msk             (_U_(0xF) << DSU_DID_DIE_Pos)
+#define DSU_DID_DIE(value)          (DSU_DID_DIE_Msk & ((value) << DSU_DID_DIE_Pos))
+#define DSU_DID_SERIES_Pos          16           /**< \brief (DSU_DID) Series */
+#define DSU_DID_SERIES_Msk          (_U_(0x3F) << DSU_DID_SERIES_Pos)
+#define DSU_DID_SERIES(value)       (DSU_DID_SERIES_Msk & ((value) << DSU_DID_SERIES_Pos))
+#define   DSU_DID_SERIES_0_Val            _U_(0x0)   /**< \brief (DSU_DID) Cortex-M0+ processor, basic feature set */
+#define   DSU_DID_SERIES_1_Val            _U_(0x1)   /**< \brief (DSU_DID) Cortex-M0+ processor, USB */
+#define DSU_DID_SERIES_0            (DSU_DID_SERIES_0_Val          << DSU_DID_SERIES_Pos)
+#define DSU_DID_SERIES_1            (DSU_DID_SERIES_1_Val          << DSU_DID_SERIES_Pos)
+#define DSU_DID_FAMILY_Pos          23           /**< \brief (DSU_DID) Family */
+#define DSU_DID_FAMILY_Msk          (_U_(0x1F) << DSU_DID_FAMILY_Pos)
+#define DSU_DID_FAMILY(value)       (DSU_DID_FAMILY_Msk & ((value) << DSU_DID_FAMILY_Pos))
+#define   DSU_DID_FAMILY_0_Val            _U_(0x0)   /**< \brief (DSU_DID) General purpose microcontroller */
+#define   DSU_DID_FAMILY_1_Val            _U_(0x1)   /**< \brief (DSU_DID) PicoPower */
+#define DSU_DID_FAMILY_0            (DSU_DID_FAMILY_0_Val          << DSU_DID_FAMILY_Pos)
+#define DSU_DID_FAMILY_1            (DSU_DID_FAMILY_1_Val          << DSU_DID_FAMILY_Pos)
+#define DSU_DID_PROCESSOR_Pos       28           /**< \brief (DSU_DID) Processor */
+#define DSU_DID_PROCESSOR_Msk       (_U_(0xF) << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_PROCESSOR(value)    (DSU_DID_PROCESSOR_Msk & ((value) << DSU_DID_PROCESSOR_Pos))
+#define   DSU_DID_PROCESSOR_0_Val         _U_(0x0)   /**< \brief (DSU_DID) Cortex-M0 */
+#define   DSU_DID_PROCESSOR_1_Val         _U_(0x1)   /**< \brief (DSU_DID) Cortex-M0+ */
+#define   DSU_DID_PROCESSOR_2_Val         _U_(0x2)   /**< \brief (DSU_DID) Cortex-M3 */
+#define   DSU_DID_PROCESSOR_3_Val         _U_(0x3)   /**< \brief (DSU_DID) Cortex-M4 */
+#define DSU_DID_PROCESSOR_0         (DSU_DID_PROCESSOR_0_Val       << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_PROCESSOR_1         (DSU_DID_PROCESSOR_1_Val       << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_PROCESSOR_2         (DSU_DID_PROCESSOR_2_Val       << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_PROCESSOR_3         (DSU_DID_PROCESSOR_3_Val       << DSU_DID_PROCESSOR_Pos)
+#define DSU_DID_MASK                _U_(0xFFBFFFFF) /**< \brief (DSU_DID) MASK Register */
+
+/* -------- DSU_DCFG : (DSU Offset: 0x00F0) (R/W 32) Device Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DCFG:32;          /*!< bit:  0..31  Device Configuration               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_DCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_DCFG_OFFSET             0x00F0       /**< \brief (DSU_DCFG offset) Device Configuration */
+#define DSU_DCFG_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_DCFG reset_value) Device Configuration */
+
+#define DSU_DCFG_DCFG_Pos           0            /**< \brief (DSU_DCFG) Device Configuration */
+#define DSU_DCFG_DCFG_Msk           (_U_(0xFFFFFFFF) << DSU_DCFG_DCFG_Pos)
+#define DSU_DCFG_DCFG(value)        (DSU_DCFG_DCFG_Msk & ((value) << DSU_DCFG_DCFG_Pos))
+#define DSU_DCFG_MASK               _U_(0xFFFFFFFF) /**< \brief (DSU_DCFG) MASK Register */
+
+/* -------- DSU_ENTRY0 : (DSU Offset: 0x1000) (R/  32) Coresight ROM Table Entry 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EPRES:1;          /*!< bit:      0  Entry Present                      */
+    uint32_t FMT:1;            /*!< bit:      1  Format                             */
+    uint32_t :10;              /*!< bit:  2..11  Reserved                           */
+    uint32_t ADDOFF:20;        /*!< bit: 12..31  Address Offset                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_ENTRY0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_ENTRY0_OFFSET           0x1000       /**< \brief (DSU_ENTRY0 offset) Coresight ROM Table Entry 0 */
+#define DSU_ENTRY0_RESETVALUE       _U_(0x9F9FC002) /**< \brief (DSU_ENTRY0 reset_value) Coresight ROM Table Entry 0 */
+
+#define DSU_ENTRY0_EPRES_Pos        0            /**< \brief (DSU_ENTRY0) Entry Present */
+#define DSU_ENTRY0_EPRES            (_U_(0x1) << DSU_ENTRY0_EPRES_Pos)
+#define DSU_ENTRY0_FMT_Pos          1            /**< \brief (DSU_ENTRY0) Format */
+#define DSU_ENTRY0_FMT              (_U_(0x1) << DSU_ENTRY0_FMT_Pos)
+#define DSU_ENTRY0_ADDOFF_Pos       12           /**< \brief (DSU_ENTRY0) Address Offset */
+#define DSU_ENTRY0_ADDOFF_Msk       (_U_(0xFFFFF) << DSU_ENTRY0_ADDOFF_Pos)
+#define DSU_ENTRY0_ADDOFF(value)    (DSU_ENTRY0_ADDOFF_Msk & ((value) << DSU_ENTRY0_ADDOFF_Pos))
+#define DSU_ENTRY0_MASK             _U_(0xFFFFF003) /**< \brief (DSU_ENTRY0) MASK Register */
+
+/* -------- DSU_ENTRY1 : (DSU Offset: 0x1004) (R/  32) Coresight ROM Table Entry 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_ENTRY1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_ENTRY1_OFFSET           0x1004       /**< \brief (DSU_ENTRY1 offset) Coresight ROM Table Entry 1 */
+#define DSU_ENTRY1_RESETVALUE       _U_(0x00000000) /**< \brief (DSU_ENTRY1 reset_value) Coresight ROM Table Entry 1 */
+#define DSU_ENTRY1_MASK             _U_(0xFFFFFFFF) /**< \brief (DSU_ENTRY1) MASK Register */
+
+/* -------- DSU_END : (DSU Offset: 0x1008) (R/  32) Coresight ROM Table End -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t END:32;           /*!< bit:  0..31  End Marker                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_END_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_END_OFFSET              0x1008       /**< \brief (DSU_END offset) Coresight ROM Table End */
+#define DSU_END_RESETVALUE          _U_(0x00000000) /**< \brief (DSU_END reset_value) Coresight ROM Table End */
+
+#define DSU_END_END_Pos             0            /**< \brief (DSU_END) End Marker */
+#define DSU_END_END_Msk             (_U_(0xFFFFFFFF) << DSU_END_END_Pos)
+#define DSU_END_END(value)          (DSU_END_END_Msk & ((value) << DSU_END_END_Pos))
+#define DSU_END_MASK                _U_(0xFFFFFFFF) /**< \brief (DSU_END) MASK Register */
+
+/* -------- DSU_MEMTYPE : (DSU Offset: 0x1FCC) (R/  32) Coresight ROM Table Memory Type -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SMEMP:1;          /*!< bit:      0  System Memory Present              */
+    uint32_t :31;              /*!< bit:  1..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_MEMTYPE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_MEMTYPE_OFFSET          0x1FCC       /**< \brief (DSU_MEMTYPE offset) Coresight ROM Table Memory Type */
+#define DSU_MEMTYPE_RESETVALUE      _U_(0x00000000) /**< \brief (DSU_MEMTYPE reset_value) Coresight ROM Table Memory Type */
+
+#define DSU_MEMTYPE_SMEMP_Pos       0            /**< \brief (DSU_MEMTYPE) System Memory Present */
+#define DSU_MEMTYPE_SMEMP           (_U_(0x1) << DSU_MEMTYPE_SMEMP_Pos)
+#define DSU_MEMTYPE_MASK            _U_(0x00000001) /**< \brief (DSU_MEMTYPE) MASK Register */
+
+/* -------- DSU_PID4 : (DSU Offset: 0x1FD0) (R/  32) Peripheral Identification 4 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t JEPCC:4;          /*!< bit:  0.. 3  JEP-106 Continuation Code          */
+    uint32_t FKBC:4;           /*!< bit:  4.. 7  4KB count                          */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID4_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID4_OFFSET             0x1FD0       /**< \brief (DSU_PID4 offset) Peripheral Identification 4 */
+#define DSU_PID4_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_PID4 reset_value) Peripheral Identification 4 */
+
+#define DSU_PID4_JEPCC_Pos          0            /**< \brief (DSU_PID4) JEP-106 Continuation Code */
+#define DSU_PID4_JEPCC_Msk          (_U_(0xF) << DSU_PID4_JEPCC_Pos)
+#define DSU_PID4_JEPCC(value)       (DSU_PID4_JEPCC_Msk & ((value) << DSU_PID4_JEPCC_Pos))
+#define DSU_PID4_FKBC_Pos           4            /**< \brief (DSU_PID4) 4KB count */
+#define DSU_PID4_FKBC_Msk           (_U_(0xF) << DSU_PID4_FKBC_Pos)
+#define DSU_PID4_FKBC(value)        (DSU_PID4_FKBC_Msk & ((value) << DSU_PID4_FKBC_Pos))
+#define DSU_PID4_MASK               _U_(0x000000FF) /**< \brief (DSU_PID4) MASK Register */
+
+/* -------- DSU_PID5 : (DSU Offset: 0x1FD4) (R/  32) Peripheral Identification 5 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID5_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID5_OFFSET             0x1FD4       /**< \brief (DSU_PID5 offset) Peripheral Identification 5 */
+#define DSU_PID5_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_PID5 reset_value) Peripheral Identification 5 */
+#define DSU_PID5_MASK               _U_(0x00000000) /**< \brief (DSU_PID5) MASK Register */
+
+/* -------- DSU_PID6 : (DSU Offset: 0x1FD8) (R/  32) Peripheral Identification 6 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID6_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID6_OFFSET             0x1FD8       /**< \brief (DSU_PID6 offset) Peripheral Identification 6 */
+#define DSU_PID6_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_PID6 reset_value) Peripheral Identification 6 */
+#define DSU_PID6_MASK               _U_(0x00000000) /**< \brief (DSU_PID6) MASK Register */
+
+/* -------- DSU_PID7 : (DSU Offset: 0x1FDC) (R/  32) Peripheral Identification 7 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID7_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID7_OFFSET             0x1FDC       /**< \brief (DSU_PID7 offset) Peripheral Identification 7 */
+#define DSU_PID7_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_PID7 reset_value) Peripheral Identification 7 */
+#define DSU_PID7_MASK               _U_(0x00000000) /**< \brief (DSU_PID7) MASK Register */
+
+/* -------- DSU_PID0 : (DSU Offset: 0x1FE0) (R/  32) Peripheral Identification 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PARTNBL:8;        /*!< bit:  0.. 7  Part Number Low                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID0_OFFSET             0x1FE0       /**< \brief (DSU_PID0 offset) Peripheral Identification 0 */
+#define DSU_PID0_RESETVALUE         _U_(0x000000D0) /**< \brief (DSU_PID0 reset_value) Peripheral Identification 0 */
+
+#define DSU_PID0_PARTNBL_Pos        0            /**< \brief (DSU_PID0) Part Number Low */
+#define DSU_PID0_PARTNBL_Msk        (_U_(0xFF) << DSU_PID0_PARTNBL_Pos)
+#define DSU_PID0_PARTNBL(value)     (DSU_PID0_PARTNBL_Msk & ((value) << DSU_PID0_PARTNBL_Pos))
+#define DSU_PID0_MASK               _U_(0x000000FF) /**< \brief (DSU_PID0) MASK Register */
+
+/* -------- DSU_PID1 : (DSU Offset: 0x1FE4) (R/  32) Peripheral Identification 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PARTNBH:4;        /*!< bit:  0.. 3  Part Number High                   */
+    uint32_t JEPIDCL:4;        /*!< bit:  4.. 7  Low part of the JEP-106 Identity Code */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID1_OFFSET             0x1FE4       /**< \brief (DSU_PID1 offset) Peripheral Identification 1 */
+#define DSU_PID1_RESETVALUE         _U_(0x000000FC) /**< \brief (DSU_PID1 reset_value) Peripheral Identification 1 */
+
+#define DSU_PID1_PARTNBH_Pos        0            /**< \brief (DSU_PID1) Part Number High */
+#define DSU_PID1_PARTNBH_Msk        (_U_(0xF) << DSU_PID1_PARTNBH_Pos)
+#define DSU_PID1_PARTNBH(value)     (DSU_PID1_PARTNBH_Msk & ((value) << DSU_PID1_PARTNBH_Pos))
+#define DSU_PID1_JEPIDCL_Pos        4            /**< \brief (DSU_PID1) Low part of the JEP-106 Identity Code */
+#define DSU_PID1_JEPIDCL_Msk        (_U_(0xF) << DSU_PID1_JEPIDCL_Pos)
+#define DSU_PID1_JEPIDCL(value)     (DSU_PID1_JEPIDCL_Msk & ((value) << DSU_PID1_JEPIDCL_Pos))
+#define DSU_PID1_MASK               _U_(0x000000FF) /**< \brief (DSU_PID1) MASK Register */
+
+/* -------- DSU_PID2 : (DSU Offset: 0x1FE8) (R/  32) Peripheral Identification 2 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t JEPIDCH:3;        /*!< bit:  0.. 2  JEP-106 Identity Code High         */
+    uint32_t JEPU:1;           /*!< bit:      3  JEP-106 Identity Code is used      */
+    uint32_t REVISION:4;       /*!< bit:  4.. 7  Revision Number                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID2_OFFSET             0x1FE8       /**< \brief (DSU_PID2 offset) Peripheral Identification 2 */
+#define DSU_PID2_RESETVALUE         _U_(0x00000009) /**< \brief (DSU_PID2 reset_value) Peripheral Identification 2 */
+
+#define DSU_PID2_JEPIDCH_Pos        0            /**< \brief (DSU_PID2) JEP-106 Identity Code High */
+#define DSU_PID2_JEPIDCH_Msk        (_U_(0x7) << DSU_PID2_JEPIDCH_Pos)
+#define DSU_PID2_JEPIDCH(value)     (DSU_PID2_JEPIDCH_Msk & ((value) << DSU_PID2_JEPIDCH_Pos))
+#define DSU_PID2_JEPU_Pos           3            /**< \brief (DSU_PID2) JEP-106 Identity Code is used */
+#define DSU_PID2_JEPU               (_U_(0x1) << DSU_PID2_JEPU_Pos)
+#define DSU_PID2_REVISION_Pos       4            /**< \brief (DSU_PID2) Revision Number */
+#define DSU_PID2_REVISION_Msk       (_U_(0xF) << DSU_PID2_REVISION_Pos)
+#define DSU_PID2_REVISION(value)    (DSU_PID2_REVISION_Msk & ((value) << DSU_PID2_REVISION_Pos))
+#define DSU_PID2_MASK               _U_(0x000000FF) /**< \brief (DSU_PID2) MASK Register */
+
+/* -------- DSU_PID3 : (DSU Offset: 0x1FEC) (R/  32) Peripheral Identification 3 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CUSMOD:4;         /*!< bit:  0.. 3  ARM CUSMOD                         */
+    uint32_t REVAND:4;         /*!< bit:  4.. 7  Revision Number                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_PID3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_PID3_OFFSET             0x1FEC       /**< \brief (DSU_PID3 offset) Peripheral Identification 3 */
+#define DSU_PID3_RESETVALUE         _U_(0x00000000) /**< \brief (DSU_PID3 reset_value) Peripheral Identification 3 */
+
+#define DSU_PID3_CUSMOD_Pos         0            /**< \brief (DSU_PID3) ARM CUSMOD */
+#define DSU_PID3_CUSMOD_Msk         (_U_(0xF) << DSU_PID3_CUSMOD_Pos)
+#define DSU_PID3_CUSMOD(value)      (DSU_PID3_CUSMOD_Msk & ((value) << DSU_PID3_CUSMOD_Pos))
+#define DSU_PID3_REVAND_Pos         4            /**< \brief (DSU_PID3) Revision Number */
+#define DSU_PID3_REVAND_Msk         (_U_(0xF) << DSU_PID3_REVAND_Pos)
+#define DSU_PID3_REVAND(value)      (DSU_PID3_REVAND_Msk & ((value) << DSU_PID3_REVAND_Pos))
+#define DSU_PID3_MASK               _U_(0x000000FF) /**< \brief (DSU_PID3) MASK Register */
+
+/* -------- DSU_CID0 : (DSU Offset: 0x1FF0) (R/  32) Component Identification 0 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PREAMBLEB0:8;     /*!< bit:  0.. 7  Preamble Byte 0                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_CID0_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID0_OFFSET             0x1FF0       /**< \brief (DSU_CID0 offset) Component Identification 0 */
+#define DSU_CID0_RESETVALUE         _U_(0x0000000D) /**< \brief (DSU_CID0 reset_value) Component Identification 0 */
+
+#define DSU_CID0_PREAMBLEB0_Pos     0            /**< \brief (DSU_CID0) Preamble Byte 0 */
+#define DSU_CID0_PREAMBLEB0_Msk     (_U_(0xFF) << DSU_CID0_PREAMBLEB0_Pos)
+#define DSU_CID0_PREAMBLEB0(value)  (DSU_CID0_PREAMBLEB0_Msk & ((value) << DSU_CID0_PREAMBLEB0_Pos))
+#define DSU_CID0_MASK               _U_(0x000000FF) /**< \brief (DSU_CID0) MASK Register */
+
+/* -------- DSU_CID1 : (DSU Offset: 0x1FF4) (R/  32) Component Identification 1 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PREAMBLE:4;       /*!< bit:  0.. 3  Preamble                           */
+    uint32_t CCLASS:4;         /*!< bit:  4.. 7  Component Class                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_CID1_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID1_OFFSET             0x1FF4       /**< \brief (DSU_CID1 offset) Component Identification 1 */
+#define DSU_CID1_RESETVALUE         _U_(0x00000010) /**< \brief (DSU_CID1 reset_value) Component Identification 1 */
+
+#define DSU_CID1_PREAMBLE_Pos       0            /**< \brief (DSU_CID1) Preamble */
+#define DSU_CID1_PREAMBLE_Msk       (_U_(0xF) << DSU_CID1_PREAMBLE_Pos)
+#define DSU_CID1_PREAMBLE(value)    (DSU_CID1_PREAMBLE_Msk & ((value) << DSU_CID1_PREAMBLE_Pos))
+#define DSU_CID1_CCLASS_Pos         4            /**< \brief (DSU_CID1) Component Class */
+#define DSU_CID1_CCLASS_Msk         (_U_(0xF) << DSU_CID1_CCLASS_Pos)
+#define DSU_CID1_CCLASS(value)      (DSU_CID1_CCLASS_Msk & ((value) << DSU_CID1_CCLASS_Pos))
+#define DSU_CID1_MASK               _U_(0x000000FF) /**< \brief (DSU_CID1) MASK Register */
+
+/* -------- DSU_CID2 : (DSU Offset: 0x1FF8) (R/  32) Component Identification 2 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PREAMBLEB2:8;     /*!< bit:  0.. 7  Preamble Byte 2                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_CID2_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID2_OFFSET             0x1FF8       /**< \brief (DSU_CID2 offset) Component Identification 2 */
+#define DSU_CID2_RESETVALUE         _U_(0x00000005) /**< \brief (DSU_CID2 reset_value) Component Identification 2 */
+
+#define DSU_CID2_PREAMBLEB2_Pos     0            /**< \brief (DSU_CID2) Preamble Byte 2 */
+#define DSU_CID2_PREAMBLEB2_Msk     (_U_(0xFF) << DSU_CID2_PREAMBLEB2_Pos)
+#define DSU_CID2_PREAMBLEB2(value)  (DSU_CID2_PREAMBLEB2_Msk & ((value) << DSU_CID2_PREAMBLEB2_Pos))
+#define DSU_CID2_MASK               _U_(0x000000FF) /**< \brief (DSU_CID2) MASK Register */
+
+/* -------- DSU_CID3 : (DSU Offset: 0x1FFC) (R/  32) Component Identification 3 -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PREAMBLEB3:8;     /*!< bit:  0.. 7  Preamble Byte 3                    */
+    uint32_t :24;              /*!< bit:  8..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} DSU_CID3_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define DSU_CID3_OFFSET             0x1FFC       /**< \brief (DSU_CID3 offset) Component Identification 3 */
+#define DSU_CID3_RESETVALUE         _U_(0x000000B1) /**< \brief (DSU_CID3 reset_value) Component Identification 3 */
+
+#define DSU_CID3_PREAMBLEB3_Pos     0            /**< \brief (DSU_CID3) Preamble Byte 3 */
+#define DSU_CID3_PREAMBLEB3_Msk     (_U_(0xFF) << DSU_CID3_PREAMBLEB3_Pos)
+#define DSU_CID3_PREAMBLEB3(value)  (DSU_CID3_PREAMBLEB3_Msk & ((value) << DSU_CID3_PREAMBLEB3_Pos))
+#define DSU_CID3_MASK               _U_(0x000000FF) /**< \brief (DSU_CID3) MASK Register */
+
+/** \brief DSU hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __O  DSU_CTRL_Type             CTRL;        /**< \brief Offset: 0x0000 ( /W  8) Control */
+  __IO DSU_STATUSA_Type          STATUSA;     /**< \brief Offset: 0x0001 (R/W  8) Status A */
+  __I  DSU_STATUSB_Type          STATUSB;     /**< \brief Offset: 0x0002 (R/   8) Status B */
+       RoReg8                    Reserved1[0x1];
+  __IO DSU_ADDR_Type             ADDR;        /**< \brief Offset: 0x0004 (R/W 32) Address */
+  __IO DSU_LENGTH_Type           LENGTH;      /**< \brief Offset: 0x0008 (R/W 32) Length */
+  __IO DSU_DATA_Type             DATA;        /**< \brief Offset: 0x000C (R/W 32) Data */
+  __IO DSU_DCC_Type              DCC[2];      /**< \brief Offset: 0x0010 (R/W 32) Debug Communication Channel n */
+  __I  DSU_DID_Type              DID;         /**< \brief Offset: 0x0018 (R/  32) Device Identification */
+       RoReg8                    Reserved2[0xD4];
+  __IO DSU_DCFG_Type             DCFG[2];     /**< \brief Offset: 0x00F0 (R/W 32) Device Configuration */
+       RoReg8                    Reserved3[0xF08];
+  __I  DSU_ENTRY0_Type           ENTRY0;      /**< \brief Offset: 0x1000 (R/  32) Coresight ROM Table Entry 0 */
+  __I  DSU_ENTRY1_Type           ENTRY1;      /**< \brief Offset: 0x1004 (R/  32) Coresight ROM Table Entry 1 */
+  __I  DSU_END_Type              END;         /**< \brief Offset: 0x1008 (R/  32) Coresight ROM Table End */
+       RoReg8                    Reserved4[0xFC0];
+  __I  DSU_MEMTYPE_Type          MEMTYPE;     /**< \brief Offset: 0x1FCC (R/  32) Coresight ROM Table Memory Type */
+  __I  DSU_PID4_Type             PID4;        /**< \brief Offset: 0x1FD0 (R/  32) Peripheral Identification 4 */
+  __I  DSU_PID5_Type             PID5;        /**< \brief Offset: 0x1FD4 (R/  32) Peripheral Identification 5 */
+  __I  DSU_PID6_Type             PID6;        /**< \brief Offset: 0x1FD8 (R/  32) Peripheral Identification 6 */
+  __I  DSU_PID7_Type             PID7;        /**< \brief Offset: 0x1FDC (R/  32) Peripheral Identification 7 */
+  __I  DSU_PID0_Type             PID0;        /**< \brief Offset: 0x1FE0 (R/  32) Peripheral Identification 0 */
+  __I  DSU_PID1_Type             PID1;        /**< \brief Offset: 0x1FE4 (R/  32) Peripheral Identification 1 */
+  __I  DSU_PID2_Type             PID2;        /**< \brief Offset: 0x1FE8 (R/  32) Peripheral Identification 2 */
+  __I  DSU_PID3_Type             PID3;        /**< \brief Offset: 0x1FEC (R/  32) Peripheral Identification 3 */
+  __I  DSU_CID0_Type             CID0;        /**< \brief Offset: 0x1FF0 (R/  32) Component Identification 0 */
+  __I  DSU_CID1_Type             CID1;        /**< \brief Offset: 0x1FF4 (R/  32) Component Identification 1 */
+  __I  DSU_CID2_Type             CID2;        /**< \brief Offset: 0x1FF8 (R/  32) Component Identification 2 */
+  __I  DSU_CID3_Type             CID3;        /**< \brief Offset: 0x1FFC (R/  32) Component Identification 3 */
+} Dsu;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_DSU_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/eic.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/eic.h
@@ -1,0 +1,667 @@
+/**
+ * \file
+ *
+ * \brief Component description for EIC
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_EIC_COMPONENT_
+#define _SAMD20_EIC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR EIC */
+/* ========================================================================== */
+/** \addtogroup SAMD20_EIC External Interrupt Controller */
+/*@{*/
+
+#define EIC_U2217
+#define REV_EIC                     0x101
+
+/* -------- EIC_CTRL : (EIC Offset: 0x00) (R/W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} EIC_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_CTRL_OFFSET             0x00         /**< \brief (EIC_CTRL offset) Control */
+#define EIC_CTRL_RESETVALUE         _U_(0x00)    /**< \brief (EIC_CTRL reset_value) Control */
+
+#define EIC_CTRL_SWRST_Pos          0            /**< \brief (EIC_CTRL) Software Reset */
+#define EIC_CTRL_SWRST              (_U_(0x1) << EIC_CTRL_SWRST_Pos)
+#define EIC_CTRL_ENABLE_Pos         1            /**< \brief (EIC_CTRL) Enable */
+#define EIC_CTRL_ENABLE             (_U_(0x1) << EIC_CTRL_ENABLE_Pos)
+#define EIC_CTRL_MASK               _U_(0x03)    /**< \brief (EIC_CTRL) MASK Register */
+
+/* -------- EIC_STATUS : (EIC Offset: 0x01) (R/   8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} EIC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_STATUS_OFFSET           0x01         /**< \brief (EIC_STATUS offset) Status */
+#define EIC_STATUS_RESETVALUE       _U_(0x00)    /**< \brief (EIC_STATUS reset_value) Status */
+
+#define EIC_STATUS_SYNCBUSY_Pos     7            /**< \brief (EIC_STATUS) Synchronization Busy */
+#define EIC_STATUS_SYNCBUSY         (_U_(0x1) << EIC_STATUS_SYNCBUSY_Pos)
+#define EIC_STATUS_MASK             _U_(0x80)    /**< \brief (EIC_STATUS) MASK Register */
+
+/* -------- EIC_NMICTRL : (EIC Offset: 0x02) (R/W  8) Non-Maskable Interrupt Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  NMISENSE:3;       /*!< bit:  0.. 2  Non-Maskable Interrupt Sense       */
+    uint8_t  NMIFILTEN:1;      /*!< bit:      3  Non-Maskable Interrupt Filter Enable */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} EIC_NMICTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_NMICTRL_OFFSET          0x02         /**< \brief (EIC_NMICTRL offset) Non-Maskable Interrupt Control */
+#define EIC_NMICTRL_RESETVALUE      _U_(0x00)    /**< \brief (EIC_NMICTRL reset_value) Non-Maskable Interrupt Control */
+
+#define EIC_NMICTRL_NMISENSE_Pos    0            /**< \brief (EIC_NMICTRL) Non-Maskable Interrupt Sense */
+#define EIC_NMICTRL_NMISENSE_Msk    (_U_(0x7) << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE(value) (EIC_NMICTRL_NMISENSE_Msk & ((value) << EIC_NMICTRL_NMISENSE_Pos))
+#define   EIC_NMICTRL_NMISENSE_NONE_Val   _U_(0x0)   /**< \brief (EIC_NMICTRL) No detection */
+#define   EIC_NMICTRL_NMISENSE_RISE_Val   _U_(0x1)   /**< \brief (EIC_NMICTRL) Rising-edge detection */
+#define   EIC_NMICTRL_NMISENSE_FALL_Val   _U_(0x2)   /**< \brief (EIC_NMICTRL) Falling-edge detection */
+#define   EIC_NMICTRL_NMISENSE_BOTH_Val   _U_(0x3)   /**< \brief (EIC_NMICTRL) Both-edges detection */
+#define   EIC_NMICTRL_NMISENSE_HIGH_Val   _U_(0x4)   /**< \brief (EIC_NMICTRL) High-level detection */
+#define   EIC_NMICTRL_NMISENSE_LOW_Val    _U_(0x5)   /**< \brief (EIC_NMICTRL) Low-level detection */
+#define EIC_NMICTRL_NMISENSE_NONE   (EIC_NMICTRL_NMISENSE_NONE_Val << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_RISE   (EIC_NMICTRL_NMISENSE_RISE_Val << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_FALL   (EIC_NMICTRL_NMISENSE_FALL_Val << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_BOTH   (EIC_NMICTRL_NMISENSE_BOTH_Val << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_HIGH   (EIC_NMICTRL_NMISENSE_HIGH_Val << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMISENSE_LOW    (EIC_NMICTRL_NMISENSE_LOW_Val  << EIC_NMICTRL_NMISENSE_Pos)
+#define EIC_NMICTRL_NMIFILTEN_Pos   3            /**< \brief (EIC_NMICTRL) Non-Maskable Interrupt Filter Enable */
+#define EIC_NMICTRL_NMIFILTEN       (_U_(0x1) << EIC_NMICTRL_NMIFILTEN_Pos)
+#define EIC_NMICTRL_MASK            _U_(0x0F)    /**< \brief (EIC_NMICTRL) MASK Register */
+
+/* -------- EIC_NMIFLAG : (EIC Offset: 0x03) (R/W  8) Non-Maskable Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  NMI:1;            /*!< bit:      0  Non-Maskable Interrupt             */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} EIC_NMIFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_NMIFLAG_OFFSET          0x03         /**< \brief (EIC_NMIFLAG offset) Non-Maskable Interrupt Flag Status and Clear */
+#define EIC_NMIFLAG_RESETVALUE      _U_(0x00)    /**< \brief (EIC_NMIFLAG reset_value) Non-Maskable Interrupt Flag Status and Clear */
+
+#define EIC_NMIFLAG_NMI_Pos         0            /**< \brief (EIC_NMIFLAG) Non-Maskable Interrupt */
+#define EIC_NMIFLAG_NMI             (_U_(0x1) << EIC_NMIFLAG_NMI_Pos)
+#define EIC_NMIFLAG_MASK            _U_(0x01)    /**< \brief (EIC_NMIFLAG) MASK Register */
+
+/* -------- EIC_EVCTRL : (EIC Offset: 0x04) (R/W 32) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EXTINTEO0:1;      /*!< bit:      0  External Interrupt 0 Event Output Enable */
+    uint32_t EXTINTEO1:1;      /*!< bit:      1  External Interrupt 1 Event Output Enable */
+    uint32_t EXTINTEO2:1;      /*!< bit:      2  External Interrupt 2 Event Output Enable */
+    uint32_t EXTINTEO3:1;      /*!< bit:      3  External Interrupt 3 Event Output Enable */
+    uint32_t EXTINTEO4:1;      /*!< bit:      4  External Interrupt 4 Event Output Enable */
+    uint32_t EXTINTEO5:1;      /*!< bit:      5  External Interrupt 5 Event Output Enable */
+    uint32_t EXTINTEO6:1;      /*!< bit:      6  External Interrupt 6 Event Output Enable */
+    uint32_t EXTINTEO7:1;      /*!< bit:      7  External Interrupt 7 Event Output Enable */
+    uint32_t EXTINTEO8:1;      /*!< bit:      8  External Interrupt 8 Event Output Enable */
+    uint32_t EXTINTEO9:1;      /*!< bit:      9  External Interrupt 9 Event Output Enable */
+    uint32_t EXTINTEO10:1;     /*!< bit:     10  External Interrupt 10 Event Output Enable */
+    uint32_t EXTINTEO11:1;     /*!< bit:     11  External Interrupt 11 Event Output Enable */
+    uint32_t EXTINTEO12:1;     /*!< bit:     12  External Interrupt 12 Event Output Enable */
+    uint32_t EXTINTEO13:1;     /*!< bit:     13  External Interrupt 13 Event Output Enable */
+    uint32_t EXTINTEO14:1;     /*!< bit:     14  External Interrupt 14 Event Output Enable */
+    uint32_t EXTINTEO15:1;     /*!< bit:     15  External Interrupt 15 Event Output Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t EXTINTEO:16;      /*!< bit:  0..15  External Interrupt x Event Output Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_EVCTRL_OFFSET           0x04         /**< \brief (EIC_EVCTRL offset) Event Control */
+#define EIC_EVCTRL_RESETVALUE       _U_(0x00000000) /**< \brief (EIC_EVCTRL reset_value) Event Control */
+
+#define EIC_EVCTRL_EXTINTEO0_Pos    0            /**< \brief (EIC_EVCTRL) External Interrupt 0 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO0        (_U_(1) << EIC_EVCTRL_EXTINTEO0_Pos)
+#define EIC_EVCTRL_EXTINTEO1_Pos    1            /**< \brief (EIC_EVCTRL) External Interrupt 1 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO1        (_U_(1) << EIC_EVCTRL_EXTINTEO1_Pos)
+#define EIC_EVCTRL_EXTINTEO2_Pos    2            /**< \brief (EIC_EVCTRL) External Interrupt 2 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO2        (_U_(1) << EIC_EVCTRL_EXTINTEO2_Pos)
+#define EIC_EVCTRL_EXTINTEO3_Pos    3            /**< \brief (EIC_EVCTRL) External Interrupt 3 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO3        (_U_(1) << EIC_EVCTRL_EXTINTEO3_Pos)
+#define EIC_EVCTRL_EXTINTEO4_Pos    4            /**< \brief (EIC_EVCTRL) External Interrupt 4 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO4        (_U_(1) << EIC_EVCTRL_EXTINTEO4_Pos)
+#define EIC_EVCTRL_EXTINTEO5_Pos    5            /**< \brief (EIC_EVCTRL) External Interrupt 5 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO5        (_U_(1) << EIC_EVCTRL_EXTINTEO5_Pos)
+#define EIC_EVCTRL_EXTINTEO6_Pos    6            /**< \brief (EIC_EVCTRL) External Interrupt 6 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO6        (_U_(1) << EIC_EVCTRL_EXTINTEO6_Pos)
+#define EIC_EVCTRL_EXTINTEO7_Pos    7            /**< \brief (EIC_EVCTRL) External Interrupt 7 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO7        (_U_(1) << EIC_EVCTRL_EXTINTEO7_Pos)
+#define EIC_EVCTRL_EXTINTEO8_Pos    8            /**< \brief (EIC_EVCTRL) External Interrupt 8 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO8        (_U_(1) << EIC_EVCTRL_EXTINTEO8_Pos)
+#define EIC_EVCTRL_EXTINTEO9_Pos    9            /**< \brief (EIC_EVCTRL) External Interrupt 9 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO9        (_U_(1) << EIC_EVCTRL_EXTINTEO9_Pos)
+#define EIC_EVCTRL_EXTINTEO10_Pos   10           /**< \brief (EIC_EVCTRL) External Interrupt 10 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO10       (_U_(1) << EIC_EVCTRL_EXTINTEO10_Pos)
+#define EIC_EVCTRL_EXTINTEO11_Pos   11           /**< \brief (EIC_EVCTRL) External Interrupt 11 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO11       (_U_(1) << EIC_EVCTRL_EXTINTEO11_Pos)
+#define EIC_EVCTRL_EXTINTEO12_Pos   12           /**< \brief (EIC_EVCTRL) External Interrupt 12 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO12       (_U_(1) << EIC_EVCTRL_EXTINTEO12_Pos)
+#define EIC_EVCTRL_EXTINTEO13_Pos   13           /**< \brief (EIC_EVCTRL) External Interrupt 13 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO13       (_U_(1) << EIC_EVCTRL_EXTINTEO13_Pos)
+#define EIC_EVCTRL_EXTINTEO14_Pos   14           /**< \brief (EIC_EVCTRL) External Interrupt 14 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO14       (_U_(1) << EIC_EVCTRL_EXTINTEO14_Pos)
+#define EIC_EVCTRL_EXTINTEO15_Pos   15           /**< \brief (EIC_EVCTRL) External Interrupt 15 Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO15       (_U_(1) << EIC_EVCTRL_EXTINTEO15_Pos)
+#define EIC_EVCTRL_EXTINTEO_Pos     0            /**< \brief (EIC_EVCTRL) External Interrupt x Event Output Enable */
+#define EIC_EVCTRL_EXTINTEO_Msk     (_U_(0xFFFF) << EIC_EVCTRL_EXTINTEO_Pos)
+#define EIC_EVCTRL_EXTINTEO(value)  (EIC_EVCTRL_EXTINTEO_Msk & ((value) << EIC_EVCTRL_EXTINTEO_Pos))
+#define EIC_EVCTRL_MASK             _U_(0x0000FFFF) /**< \brief (EIC_EVCTRL) MASK Register */
+
+/* -------- EIC_INTENCLR : (EIC Offset: 0x08) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EXTINT0:1;        /*!< bit:      0  External Interrupt 0 Enable        */
+    uint32_t EXTINT1:1;        /*!< bit:      1  External Interrupt 1 Enable        */
+    uint32_t EXTINT2:1;        /*!< bit:      2  External Interrupt 2 Enable        */
+    uint32_t EXTINT3:1;        /*!< bit:      3  External Interrupt 3 Enable        */
+    uint32_t EXTINT4:1;        /*!< bit:      4  External Interrupt 4 Enable        */
+    uint32_t EXTINT5:1;        /*!< bit:      5  External Interrupt 5 Enable        */
+    uint32_t EXTINT6:1;        /*!< bit:      6  External Interrupt 6 Enable        */
+    uint32_t EXTINT7:1;        /*!< bit:      7  External Interrupt 7 Enable        */
+    uint32_t EXTINT8:1;        /*!< bit:      8  External Interrupt 8 Enable        */
+    uint32_t EXTINT9:1;        /*!< bit:      9  External Interrupt 9 Enable        */
+    uint32_t EXTINT10:1;       /*!< bit:     10  External Interrupt 10 Enable       */
+    uint32_t EXTINT11:1;       /*!< bit:     11  External Interrupt 11 Enable       */
+    uint32_t EXTINT12:1;       /*!< bit:     12  External Interrupt 12 Enable       */
+    uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13 Enable       */
+    uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14 Enable       */
+    uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15 Enable       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x Enable        */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_INTENCLR_OFFSET         0x08         /**< \brief (EIC_INTENCLR offset) Interrupt Enable Clear */
+#define EIC_INTENCLR_RESETVALUE     _U_(0x00000000) /**< \brief (EIC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define EIC_INTENCLR_EXTINT0_Pos    0            /**< \brief (EIC_INTENCLR) External Interrupt 0 Enable */
+#define EIC_INTENCLR_EXTINT0        (_U_(1) << EIC_INTENCLR_EXTINT0_Pos)
+#define EIC_INTENCLR_EXTINT1_Pos    1            /**< \brief (EIC_INTENCLR) External Interrupt 1 Enable */
+#define EIC_INTENCLR_EXTINT1        (_U_(1) << EIC_INTENCLR_EXTINT1_Pos)
+#define EIC_INTENCLR_EXTINT2_Pos    2            /**< \brief (EIC_INTENCLR) External Interrupt 2 Enable */
+#define EIC_INTENCLR_EXTINT2        (_U_(1) << EIC_INTENCLR_EXTINT2_Pos)
+#define EIC_INTENCLR_EXTINT3_Pos    3            /**< \brief (EIC_INTENCLR) External Interrupt 3 Enable */
+#define EIC_INTENCLR_EXTINT3        (_U_(1) << EIC_INTENCLR_EXTINT3_Pos)
+#define EIC_INTENCLR_EXTINT4_Pos    4            /**< \brief (EIC_INTENCLR) External Interrupt 4 Enable */
+#define EIC_INTENCLR_EXTINT4        (_U_(1) << EIC_INTENCLR_EXTINT4_Pos)
+#define EIC_INTENCLR_EXTINT5_Pos    5            /**< \brief (EIC_INTENCLR) External Interrupt 5 Enable */
+#define EIC_INTENCLR_EXTINT5        (_U_(1) << EIC_INTENCLR_EXTINT5_Pos)
+#define EIC_INTENCLR_EXTINT6_Pos    6            /**< \brief (EIC_INTENCLR) External Interrupt 6 Enable */
+#define EIC_INTENCLR_EXTINT6        (_U_(1) << EIC_INTENCLR_EXTINT6_Pos)
+#define EIC_INTENCLR_EXTINT7_Pos    7            /**< \brief (EIC_INTENCLR) External Interrupt 7 Enable */
+#define EIC_INTENCLR_EXTINT7        (_U_(1) << EIC_INTENCLR_EXTINT7_Pos)
+#define EIC_INTENCLR_EXTINT8_Pos    8            /**< \brief (EIC_INTENCLR) External Interrupt 8 Enable */
+#define EIC_INTENCLR_EXTINT8        (_U_(1) << EIC_INTENCLR_EXTINT8_Pos)
+#define EIC_INTENCLR_EXTINT9_Pos    9            /**< \brief (EIC_INTENCLR) External Interrupt 9 Enable */
+#define EIC_INTENCLR_EXTINT9        (_U_(1) << EIC_INTENCLR_EXTINT9_Pos)
+#define EIC_INTENCLR_EXTINT10_Pos   10           /**< \brief (EIC_INTENCLR) External Interrupt 10 Enable */
+#define EIC_INTENCLR_EXTINT10       (_U_(1) << EIC_INTENCLR_EXTINT10_Pos)
+#define EIC_INTENCLR_EXTINT11_Pos   11           /**< \brief (EIC_INTENCLR) External Interrupt 11 Enable */
+#define EIC_INTENCLR_EXTINT11       (_U_(1) << EIC_INTENCLR_EXTINT11_Pos)
+#define EIC_INTENCLR_EXTINT12_Pos   12           /**< \brief (EIC_INTENCLR) External Interrupt 12 Enable */
+#define EIC_INTENCLR_EXTINT12       (_U_(1) << EIC_INTENCLR_EXTINT12_Pos)
+#define EIC_INTENCLR_EXTINT13_Pos   13           /**< \brief (EIC_INTENCLR) External Interrupt 13 Enable */
+#define EIC_INTENCLR_EXTINT13       (_U_(1) << EIC_INTENCLR_EXTINT13_Pos)
+#define EIC_INTENCLR_EXTINT14_Pos   14           /**< \brief (EIC_INTENCLR) External Interrupt 14 Enable */
+#define EIC_INTENCLR_EXTINT14       (_U_(1) << EIC_INTENCLR_EXTINT14_Pos)
+#define EIC_INTENCLR_EXTINT15_Pos   15           /**< \brief (EIC_INTENCLR) External Interrupt 15 Enable */
+#define EIC_INTENCLR_EXTINT15       (_U_(1) << EIC_INTENCLR_EXTINT15_Pos)
+#define EIC_INTENCLR_EXTINT_Pos     0            /**< \brief (EIC_INTENCLR) External Interrupt x Enable */
+#define EIC_INTENCLR_EXTINT_Msk     (_U_(0xFFFF) << EIC_INTENCLR_EXTINT_Pos)
+#define EIC_INTENCLR_EXTINT(value)  (EIC_INTENCLR_EXTINT_Msk & ((value) << EIC_INTENCLR_EXTINT_Pos))
+#define EIC_INTENCLR_MASK           _U_(0x0000FFFF) /**< \brief (EIC_INTENCLR) MASK Register */
+
+/* -------- EIC_INTENSET : (EIC Offset: 0x0C) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t EXTINT0:1;        /*!< bit:      0  External Interrupt 0 Enable        */
+    uint32_t EXTINT1:1;        /*!< bit:      1  External Interrupt 1 Enable        */
+    uint32_t EXTINT2:1;        /*!< bit:      2  External Interrupt 2 Enable        */
+    uint32_t EXTINT3:1;        /*!< bit:      3  External Interrupt 3 Enable        */
+    uint32_t EXTINT4:1;        /*!< bit:      4  External Interrupt 4 Enable        */
+    uint32_t EXTINT5:1;        /*!< bit:      5  External Interrupt 5 Enable        */
+    uint32_t EXTINT6:1;        /*!< bit:      6  External Interrupt 6 Enable        */
+    uint32_t EXTINT7:1;        /*!< bit:      7  External Interrupt 7 Enable        */
+    uint32_t EXTINT8:1;        /*!< bit:      8  External Interrupt 8 Enable        */
+    uint32_t EXTINT9:1;        /*!< bit:      9  External Interrupt 9 Enable        */
+    uint32_t EXTINT10:1;       /*!< bit:     10  External Interrupt 10 Enable       */
+    uint32_t EXTINT11:1;       /*!< bit:     11  External Interrupt 11 Enable       */
+    uint32_t EXTINT12:1;       /*!< bit:     12  External Interrupt 12 Enable       */
+    uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13 Enable       */
+    uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14 Enable       */
+    uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15 Enable       */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x Enable        */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_INTENSET_OFFSET         0x0C         /**< \brief (EIC_INTENSET offset) Interrupt Enable Set */
+#define EIC_INTENSET_RESETVALUE     _U_(0x00000000) /**< \brief (EIC_INTENSET reset_value) Interrupt Enable Set */
+
+#define EIC_INTENSET_EXTINT0_Pos    0            /**< \brief (EIC_INTENSET) External Interrupt 0 Enable */
+#define EIC_INTENSET_EXTINT0        (_U_(1) << EIC_INTENSET_EXTINT0_Pos)
+#define EIC_INTENSET_EXTINT1_Pos    1            /**< \brief (EIC_INTENSET) External Interrupt 1 Enable */
+#define EIC_INTENSET_EXTINT1        (_U_(1) << EIC_INTENSET_EXTINT1_Pos)
+#define EIC_INTENSET_EXTINT2_Pos    2            /**< \brief (EIC_INTENSET) External Interrupt 2 Enable */
+#define EIC_INTENSET_EXTINT2        (_U_(1) << EIC_INTENSET_EXTINT2_Pos)
+#define EIC_INTENSET_EXTINT3_Pos    3            /**< \brief (EIC_INTENSET) External Interrupt 3 Enable */
+#define EIC_INTENSET_EXTINT3        (_U_(1) << EIC_INTENSET_EXTINT3_Pos)
+#define EIC_INTENSET_EXTINT4_Pos    4            /**< \brief (EIC_INTENSET) External Interrupt 4 Enable */
+#define EIC_INTENSET_EXTINT4        (_U_(1) << EIC_INTENSET_EXTINT4_Pos)
+#define EIC_INTENSET_EXTINT5_Pos    5            /**< \brief (EIC_INTENSET) External Interrupt 5 Enable */
+#define EIC_INTENSET_EXTINT5        (_U_(1) << EIC_INTENSET_EXTINT5_Pos)
+#define EIC_INTENSET_EXTINT6_Pos    6            /**< \brief (EIC_INTENSET) External Interrupt 6 Enable */
+#define EIC_INTENSET_EXTINT6        (_U_(1) << EIC_INTENSET_EXTINT6_Pos)
+#define EIC_INTENSET_EXTINT7_Pos    7            /**< \brief (EIC_INTENSET) External Interrupt 7 Enable */
+#define EIC_INTENSET_EXTINT7        (_U_(1) << EIC_INTENSET_EXTINT7_Pos)
+#define EIC_INTENSET_EXTINT8_Pos    8            /**< \brief (EIC_INTENSET) External Interrupt 8 Enable */
+#define EIC_INTENSET_EXTINT8        (_U_(1) << EIC_INTENSET_EXTINT8_Pos)
+#define EIC_INTENSET_EXTINT9_Pos    9            /**< \brief (EIC_INTENSET) External Interrupt 9 Enable */
+#define EIC_INTENSET_EXTINT9        (_U_(1) << EIC_INTENSET_EXTINT9_Pos)
+#define EIC_INTENSET_EXTINT10_Pos   10           /**< \brief (EIC_INTENSET) External Interrupt 10 Enable */
+#define EIC_INTENSET_EXTINT10       (_U_(1) << EIC_INTENSET_EXTINT10_Pos)
+#define EIC_INTENSET_EXTINT11_Pos   11           /**< \brief (EIC_INTENSET) External Interrupt 11 Enable */
+#define EIC_INTENSET_EXTINT11       (_U_(1) << EIC_INTENSET_EXTINT11_Pos)
+#define EIC_INTENSET_EXTINT12_Pos   12           /**< \brief (EIC_INTENSET) External Interrupt 12 Enable */
+#define EIC_INTENSET_EXTINT12       (_U_(1) << EIC_INTENSET_EXTINT12_Pos)
+#define EIC_INTENSET_EXTINT13_Pos   13           /**< \brief (EIC_INTENSET) External Interrupt 13 Enable */
+#define EIC_INTENSET_EXTINT13       (_U_(1) << EIC_INTENSET_EXTINT13_Pos)
+#define EIC_INTENSET_EXTINT14_Pos   14           /**< \brief (EIC_INTENSET) External Interrupt 14 Enable */
+#define EIC_INTENSET_EXTINT14       (_U_(1) << EIC_INTENSET_EXTINT14_Pos)
+#define EIC_INTENSET_EXTINT15_Pos   15           /**< \brief (EIC_INTENSET) External Interrupt 15 Enable */
+#define EIC_INTENSET_EXTINT15       (_U_(1) << EIC_INTENSET_EXTINT15_Pos)
+#define EIC_INTENSET_EXTINT_Pos     0            /**< \brief (EIC_INTENSET) External Interrupt x Enable */
+#define EIC_INTENSET_EXTINT_Msk     (_U_(0xFFFF) << EIC_INTENSET_EXTINT_Pos)
+#define EIC_INTENSET_EXTINT(value)  (EIC_INTENSET_EXTINT_Msk & ((value) << EIC_INTENSET_EXTINT_Pos))
+#define EIC_INTENSET_MASK           _U_(0x0000FFFF) /**< \brief (EIC_INTENSET) MASK Register */
+
+/* -------- EIC_INTFLAG : (EIC Offset: 0x10) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t EXTINT0:1;        /*!< bit:      0  External Interrupt 0               */
+    __I uint32_t EXTINT1:1;        /*!< bit:      1  External Interrupt 1               */
+    __I uint32_t EXTINT2:1;        /*!< bit:      2  External Interrupt 2               */
+    __I uint32_t EXTINT3:1;        /*!< bit:      3  External Interrupt 3               */
+    __I uint32_t EXTINT4:1;        /*!< bit:      4  External Interrupt 4               */
+    __I uint32_t EXTINT5:1;        /*!< bit:      5  External Interrupt 5               */
+    __I uint32_t EXTINT6:1;        /*!< bit:      6  External Interrupt 6               */
+    __I uint32_t EXTINT7:1;        /*!< bit:      7  External Interrupt 7               */
+    __I uint32_t EXTINT8:1;        /*!< bit:      8  External Interrupt 8               */
+    __I uint32_t EXTINT9:1;        /*!< bit:      9  External Interrupt 9               */
+    __I uint32_t EXTINT10:1;       /*!< bit:     10  External Interrupt 10              */
+    __I uint32_t EXTINT11:1;       /*!< bit:     11  External Interrupt 11              */
+    __I uint32_t EXTINT12:1;       /*!< bit:     12  External Interrupt 12              */
+    __I uint32_t EXTINT13:1;       /*!< bit:     13  External Interrupt 13              */
+    __I uint32_t EXTINT14:1;       /*!< bit:     14  External Interrupt 14              */
+    __I uint32_t EXTINT15:1;       /*!< bit:     15  External Interrupt 15              */
+    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint32_t EXTINT:16;        /*!< bit:  0..15  External Interrupt x               */
+    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_INTFLAG_OFFSET          0x10         /**< \brief (EIC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define EIC_INTFLAG_RESETVALUE      _U_(0x00000000) /**< \brief (EIC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define EIC_INTFLAG_EXTINT0_Pos     0            /**< \brief (EIC_INTFLAG) External Interrupt 0 */
+#define EIC_INTFLAG_EXTINT0         (_U_(1) << EIC_INTFLAG_EXTINT0_Pos)
+#define EIC_INTFLAG_EXTINT1_Pos     1            /**< \brief (EIC_INTFLAG) External Interrupt 1 */
+#define EIC_INTFLAG_EXTINT1         (_U_(1) << EIC_INTFLAG_EXTINT1_Pos)
+#define EIC_INTFLAG_EXTINT2_Pos     2            /**< \brief (EIC_INTFLAG) External Interrupt 2 */
+#define EIC_INTFLAG_EXTINT2         (_U_(1) << EIC_INTFLAG_EXTINT2_Pos)
+#define EIC_INTFLAG_EXTINT3_Pos     3            /**< \brief (EIC_INTFLAG) External Interrupt 3 */
+#define EIC_INTFLAG_EXTINT3         (_U_(1) << EIC_INTFLAG_EXTINT3_Pos)
+#define EIC_INTFLAG_EXTINT4_Pos     4            /**< \brief (EIC_INTFLAG) External Interrupt 4 */
+#define EIC_INTFLAG_EXTINT4         (_U_(1) << EIC_INTFLAG_EXTINT4_Pos)
+#define EIC_INTFLAG_EXTINT5_Pos     5            /**< \brief (EIC_INTFLAG) External Interrupt 5 */
+#define EIC_INTFLAG_EXTINT5         (_U_(1) << EIC_INTFLAG_EXTINT5_Pos)
+#define EIC_INTFLAG_EXTINT6_Pos     6            /**< \brief (EIC_INTFLAG) External Interrupt 6 */
+#define EIC_INTFLAG_EXTINT6         (_U_(1) << EIC_INTFLAG_EXTINT6_Pos)
+#define EIC_INTFLAG_EXTINT7_Pos     7            /**< \brief (EIC_INTFLAG) External Interrupt 7 */
+#define EIC_INTFLAG_EXTINT7         (_U_(1) << EIC_INTFLAG_EXTINT7_Pos)
+#define EIC_INTFLAG_EXTINT8_Pos     8            /**< \brief (EIC_INTFLAG) External Interrupt 8 */
+#define EIC_INTFLAG_EXTINT8         (_U_(1) << EIC_INTFLAG_EXTINT8_Pos)
+#define EIC_INTFLAG_EXTINT9_Pos     9            /**< \brief (EIC_INTFLAG) External Interrupt 9 */
+#define EIC_INTFLAG_EXTINT9         (_U_(1) << EIC_INTFLAG_EXTINT9_Pos)
+#define EIC_INTFLAG_EXTINT10_Pos    10           /**< \brief (EIC_INTFLAG) External Interrupt 10 */
+#define EIC_INTFLAG_EXTINT10        (_U_(1) << EIC_INTFLAG_EXTINT10_Pos)
+#define EIC_INTFLAG_EXTINT11_Pos    11           /**< \brief (EIC_INTFLAG) External Interrupt 11 */
+#define EIC_INTFLAG_EXTINT11        (_U_(1) << EIC_INTFLAG_EXTINT11_Pos)
+#define EIC_INTFLAG_EXTINT12_Pos    12           /**< \brief (EIC_INTFLAG) External Interrupt 12 */
+#define EIC_INTFLAG_EXTINT12        (_U_(1) << EIC_INTFLAG_EXTINT12_Pos)
+#define EIC_INTFLAG_EXTINT13_Pos    13           /**< \brief (EIC_INTFLAG) External Interrupt 13 */
+#define EIC_INTFLAG_EXTINT13        (_U_(1) << EIC_INTFLAG_EXTINT13_Pos)
+#define EIC_INTFLAG_EXTINT14_Pos    14           /**< \brief (EIC_INTFLAG) External Interrupt 14 */
+#define EIC_INTFLAG_EXTINT14        (_U_(1) << EIC_INTFLAG_EXTINT14_Pos)
+#define EIC_INTFLAG_EXTINT15_Pos    15           /**< \brief (EIC_INTFLAG) External Interrupt 15 */
+#define EIC_INTFLAG_EXTINT15        (_U_(1) << EIC_INTFLAG_EXTINT15_Pos)
+#define EIC_INTFLAG_EXTINT_Pos      0            /**< \brief (EIC_INTFLAG) External Interrupt x */
+#define EIC_INTFLAG_EXTINT_Msk      (_U_(0xFFFF) << EIC_INTFLAG_EXTINT_Pos)
+#define EIC_INTFLAG_EXTINT(value)   (EIC_INTFLAG_EXTINT_Msk & ((value) << EIC_INTFLAG_EXTINT_Pos))
+#define EIC_INTFLAG_MASK            _U_(0x0000FFFF) /**< \brief (EIC_INTFLAG) MASK Register */
+
+/* -------- EIC_WAKEUP : (EIC Offset: 0x14) (R/W 32) Wake-Up Enable -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t WAKEUPEN0:1;      /*!< bit:      0  External Interrupt 0 Wake-up Enable */
+    uint32_t WAKEUPEN1:1;      /*!< bit:      1  External Interrupt 1 Wake-up Enable */
+    uint32_t WAKEUPEN2:1;      /*!< bit:      2  External Interrupt 2 Wake-up Enable */
+    uint32_t WAKEUPEN3:1;      /*!< bit:      3  External Interrupt 3 Wake-up Enable */
+    uint32_t WAKEUPEN4:1;      /*!< bit:      4  External Interrupt 4 Wake-up Enable */
+    uint32_t WAKEUPEN5:1;      /*!< bit:      5  External Interrupt 5 Wake-up Enable */
+    uint32_t WAKEUPEN6:1;      /*!< bit:      6  External Interrupt 6 Wake-up Enable */
+    uint32_t WAKEUPEN7:1;      /*!< bit:      7  External Interrupt 7 Wake-up Enable */
+    uint32_t WAKEUPEN8:1;      /*!< bit:      8  External Interrupt 8 Wake-up Enable */
+    uint32_t WAKEUPEN9:1;      /*!< bit:      9  External Interrupt 9 Wake-up Enable */
+    uint32_t WAKEUPEN10:1;     /*!< bit:     10  External Interrupt 10 Wake-up Enable */
+    uint32_t WAKEUPEN11:1;     /*!< bit:     11  External Interrupt 11 Wake-up Enable */
+    uint32_t WAKEUPEN12:1;     /*!< bit:     12  External Interrupt 12 Wake-up Enable */
+    uint32_t WAKEUPEN13:1;     /*!< bit:     13  External Interrupt 13 Wake-up Enable */
+    uint32_t WAKEUPEN14:1;     /*!< bit:     14  External Interrupt 14 Wake-up Enable */
+    uint32_t WAKEUPEN15:1;     /*!< bit:     15  External Interrupt 15 Wake-up Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t WAKEUPEN:16;      /*!< bit:  0..15  External Interrupt x Wake-up Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_WAKEUP_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_WAKEUP_OFFSET           0x14         /**< \brief (EIC_WAKEUP offset) Wake-Up Enable */
+#define EIC_WAKEUP_RESETVALUE       _U_(0x00000000) /**< \brief (EIC_WAKEUP reset_value) Wake-Up Enable */
+
+#define EIC_WAKEUP_WAKEUPEN0_Pos    0            /**< \brief (EIC_WAKEUP) External Interrupt 0 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN0        (_U_(1) << EIC_WAKEUP_WAKEUPEN0_Pos)
+#define EIC_WAKEUP_WAKEUPEN1_Pos    1            /**< \brief (EIC_WAKEUP) External Interrupt 1 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN1        (_U_(1) << EIC_WAKEUP_WAKEUPEN1_Pos)
+#define EIC_WAKEUP_WAKEUPEN2_Pos    2            /**< \brief (EIC_WAKEUP) External Interrupt 2 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN2        (_U_(1) << EIC_WAKEUP_WAKEUPEN2_Pos)
+#define EIC_WAKEUP_WAKEUPEN3_Pos    3            /**< \brief (EIC_WAKEUP) External Interrupt 3 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN3        (_U_(1) << EIC_WAKEUP_WAKEUPEN3_Pos)
+#define EIC_WAKEUP_WAKEUPEN4_Pos    4            /**< \brief (EIC_WAKEUP) External Interrupt 4 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN4        (_U_(1) << EIC_WAKEUP_WAKEUPEN4_Pos)
+#define EIC_WAKEUP_WAKEUPEN5_Pos    5            /**< \brief (EIC_WAKEUP) External Interrupt 5 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN5        (_U_(1) << EIC_WAKEUP_WAKEUPEN5_Pos)
+#define EIC_WAKEUP_WAKEUPEN6_Pos    6            /**< \brief (EIC_WAKEUP) External Interrupt 6 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN6        (_U_(1) << EIC_WAKEUP_WAKEUPEN6_Pos)
+#define EIC_WAKEUP_WAKEUPEN7_Pos    7            /**< \brief (EIC_WAKEUP) External Interrupt 7 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN7        (_U_(1) << EIC_WAKEUP_WAKEUPEN7_Pos)
+#define EIC_WAKEUP_WAKEUPEN8_Pos    8            /**< \brief (EIC_WAKEUP) External Interrupt 8 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN8        (_U_(1) << EIC_WAKEUP_WAKEUPEN8_Pos)
+#define EIC_WAKEUP_WAKEUPEN9_Pos    9            /**< \brief (EIC_WAKEUP) External Interrupt 9 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN9        (_U_(1) << EIC_WAKEUP_WAKEUPEN9_Pos)
+#define EIC_WAKEUP_WAKEUPEN10_Pos   10           /**< \brief (EIC_WAKEUP) External Interrupt 10 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN10       (_U_(1) << EIC_WAKEUP_WAKEUPEN10_Pos)
+#define EIC_WAKEUP_WAKEUPEN11_Pos   11           /**< \brief (EIC_WAKEUP) External Interrupt 11 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN11       (_U_(1) << EIC_WAKEUP_WAKEUPEN11_Pos)
+#define EIC_WAKEUP_WAKEUPEN12_Pos   12           /**< \brief (EIC_WAKEUP) External Interrupt 12 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN12       (_U_(1) << EIC_WAKEUP_WAKEUPEN12_Pos)
+#define EIC_WAKEUP_WAKEUPEN13_Pos   13           /**< \brief (EIC_WAKEUP) External Interrupt 13 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN13       (_U_(1) << EIC_WAKEUP_WAKEUPEN13_Pos)
+#define EIC_WAKEUP_WAKEUPEN14_Pos   14           /**< \brief (EIC_WAKEUP) External Interrupt 14 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN14       (_U_(1) << EIC_WAKEUP_WAKEUPEN14_Pos)
+#define EIC_WAKEUP_WAKEUPEN15_Pos   15           /**< \brief (EIC_WAKEUP) External Interrupt 15 Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN15       (_U_(1) << EIC_WAKEUP_WAKEUPEN15_Pos)
+#define EIC_WAKEUP_WAKEUPEN_Pos     0            /**< \brief (EIC_WAKEUP) External Interrupt x Wake-up Enable */
+#define EIC_WAKEUP_WAKEUPEN_Msk     (_U_(0xFFFF) << EIC_WAKEUP_WAKEUPEN_Pos)
+#define EIC_WAKEUP_WAKEUPEN(value)  (EIC_WAKEUP_WAKEUPEN_Msk & ((value) << EIC_WAKEUP_WAKEUPEN_Pos))
+#define EIC_WAKEUP_MASK             _U_(0x0000FFFF) /**< \brief (EIC_WAKEUP) MASK Register */
+
+/* -------- EIC_CONFIG : (EIC Offset: 0x18) (R/W 32) Configuration n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SENSE0:3;         /*!< bit:  0.. 2  Input Sense 0 Configuration        */
+    uint32_t FILTEN0:1;        /*!< bit:      3  Filter 0 Enable                    */
+    uint32_t SENSE1:3;         /*!< bit:  4.. 6  Input Sense 1 Configuration        */
+    uint32_t FILTEN1:1;        /*!< bit:      7  Filter 1 Enable                    */
+    uint32_t SENSE2:3;         /*!< bit:  8..10  Input Sense 2 Configuration        */
+    uint32_t FILTEN2:1;        /*!< bit:     11  Filter 2 Enable                    */
+    uint32_t SENSE3:3;         /*!< bit: 12..14  Input Sense 3 Configuration        */
+    uint32_t FILTEN3:1;        /*!< bit:     15  Filter 3 Enable                    */
+    uint32_t SENSE4:3;         /*!< bit: 16..18  Input Sense 4 Configuration        */
+    uint32_t FILTEN4:1;        /*!< bit:     19  Filter 4 Enable                    */
+    uint32_t SENSE5:3;         /*!< bit: 20..22  Input Sense 5 Configuration        */
+    uint32_t FILTEN5:1;        /*!< bit:     23  Filter 5 Enable                    */
+    uint32_t SENSE6:3;         /*!< bit: 24..26  Input Sense 6 Configuration        */
+    uint32_t FILTEN6:1;        /*!< bit:     27  Filter 6 Enable                    */
+    uint32_t SENSE7:3;         /*!< bit: 28..30  Input Sense 7 Configuration        */
+    uint32_t FILTEN7:1;        /*!< bit:     31  Filter 7 Enable                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EIC_CONFIG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EIC_CONFIG_OFFSET           0x18         /**< \brief (EIC_CONFIG offset) Configuration n */
+#define EIC_CONFIG_RESETVALUE       _U_(0x00000000) /**< \brief (EIC_CONFIG reset_value) Configuration n */
+
+#define EIC_CONFIG_SENSE0_Pos       0            /**< \brief (EIC_CONFIG) Input Sense 0 Configuration */
+#define EIC_CONFIG_SENSE0_Msk       (_U_(0x7) << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0(value)    (EIC_CONFIG_SENSE0_Msk & ((value) << EIC_CONFIG_SENSE0_Pos))
+#define   EIC_CONFIG_SENSE0_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE0_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising-edge detection */
+#define   EIC_CONFIG_SENSE0_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling-edge detection */
+#define   EIC_CONFIG_SENSE0_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both-edges detection */
+#define   EIC_CONFIG_SENSE0_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High-level detection */
+#define   EIC_CONFIG_SENSE0_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low-level detection */
+#define EIC_CONFIG_SENSE0_NONE      (EIC_CONFIG_SENSE0_NONE_Val    << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_RISE      (EIC_CONFIG_SENSE0_RISE_Val    << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_FALL      (EIC_CONFIG_SENSE0_FALL_Val    << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_BOTH      (EIC_CONFIG_SENSE0_BOTH_Val    << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_HIGH      (EIC_CONFIG_SENSE0_HIGH_Val    << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_SENSE0_LOW       (EIC_CONFIG_SENSE0_LOW_Val     << EIC_CONFIG_SENSE0_Pos)
+#define EIC_CONFIG_FILTEN0_Pos      3            /**< \brief (EIC_CONFIG) Filter 0 Enable */
+#define EIC_CONFIG_FILTEN0          (_U_(0x1) << EIC_CONFIG_FILTEN0_Pos)
+#define EIC_CONFIG_SENSE1_Pos       4            /**< \brief (EIC_CONFIG) Input Sense 1 Configuration */
+#define EIC_CONFIG_SENSE1_Msk       (_U_(0x7) << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1(value)    (EIC_CONFIG_SENSE1_Msk & ((value) << EIC_CONFIG_SENSE1_Pos))
+#define   EIC_CONFIG_SENSE1_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE1_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE1_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE1_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE1_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE1_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE1_NONE      (EIC_CONFIG_SENSE1_NONE_Val    << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_RISE      (EIC_CONFIG_SENSE1_RISE_Val    << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_FALL      (EIC_CONFIG_SENSE1_FALL_Val    << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_BOTH      (EIC_CONFIG_SENSE1_BOTH_Val    << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_HIGH      (EIC_CONFIG_SENSE1_HIGH_Val    << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_SENSE1_LOW       (EIC_CONFIG_SENSE1_LOW_Val     << EIC_CONFIG_SENSE1_Pos)
+#define EIC_CONFIG_FILTEN1_Pos      7            /**< \brief (EIC_CONFIG) Filter 1 Enable */
+#define EIC_CONFIG_FILTEN1          (_U_(0x1) << EIC_CONFIG_FILTEN1_Pos)
+#define EIC_CONFIG_SENSE2_Pos       8            /**< \brief (EIC_CONFIG) Input Sense 2 Configuration */
+#define EIC_CONFIG_SENSE2_Msk       (_U_(0x7) << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2(value)    (EIC_CONFIG_SENSE2_Msk & ((value) << EIC_CONFIG_SENSE2_Pos))
+#define   EIC_CONFIG_SENSE2_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE2_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE2_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE2_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE2_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE2_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE2_NONE      (EIC_CONFIG_SENSE2_NONE_Val    << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_RISE      (EIC_CONFIG_SENSE2_RISE_Val    << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_FALL      (EIC_CONFIG_SENSE2_FALL_Val    << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_BOTH      (EIC_CONFIG_SENSE2_BOTH_Val    << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_HIGH      (EIC_CONFIG_SENSE2_HIGH_Val    << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_SENSE2_LOW       (EIC_CONFIG_SENSE2_LOW_Val     << EIC_CONFIG_SENSE2_Pos)
+#define EIC_CONFIG_FILTEN2_Pos      11           /**< \brief (EIC_CONFIG) Filter 2 Enable */
+#define EIC_CONFIG_FILTEN2          (_U_(0x1) << EIC_CONFIG_FILTEN2_Pos)
+#define EIC_CONFIG_SENSE3_Pos       12           /**< \brief (EIC_CONFIG) Input Sense 3 Configuration */
+#define EIC_CONFIG_SENSE3_Msk       (_U_(0x7) << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3(value)    (EIC_CONFIG_SENSE3_Msk & ((value) << EIC_CONFIG_SENSE3_Pos))
+#define   EIC_CONFIG_SENSE3_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE3_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE3_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE3_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE3_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE3_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE3_NONE      (EIC_CONFIG_SENSE3_NONE_Val    << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_RISE      (EIC_CONFIG_SENSE3_RISE_Val    << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_FALL      (EIC_CONFIG_SENSE3_FALL_Val    << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_BOTH      (EIC_CONFIG_SENSE3_BOTH_Val    << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_HIGH      (EIC_CONFIG_SENSE3_HIGH_Val    << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_SENSE3_LOW       (EIC_CONFIG_SENSE3_LOW_Val     << EIC_CONFIG_SENSE3_Pos)
+#define EIC_CONFIG_FILTEN3_Pos      15           /**< \brief (EIC_CONFIG) Filter 3 Enable */
+#define EIC_CONFIG_FILTEN3          (_U_(0x1) << EIC_CONFIG_FILTEN3_Pos)
+#define EIC_CONFIG_SENSE4_Pos       16           /**< \brief (EIC_CONFIG) Input Sense 4 Configuration */
+#define EIC_CONFIG_SENSE4_Msk       (_U_(0x7) << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4(value)    (EIC_CONFIG_SENSE4_Msk & ((value) << EIC_CONFIG_SENSE4_Pos))
+#define   EIC_CONFIG_SENSE4_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE4_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE4_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE4_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE4_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE4_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE4_NONE      (EIC_CONFIG_SENSE4_NONE_Val    << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_RISE      (EIC_CONFIG_SENSE4_RISE_Val    << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_FALL      (EIC_CONFIG_SENSE4_FALL_Val    << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_BOTH      (EIC_CONFIG_SENSE4_BOTH_Val    << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_HIGH      (EIC_CONFIG_SENSE4_HIGH_Val    << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_SENSE4_LOW       (EIC_CONFIG_SENSE4_LOW_Val     << EIC_CONFIG_SENSE4_Pos)
+#define EIC_CONFIG_FILTEN4_Pos      19           /**< \brief (EIC_CONFIG) Filter 4 Enable */
+#define EIC_CONFIG_FILTEN4          (_U_(0x1) << EIC_CONFIG_FILTEN4_Pos)
+#define EIC_CONFIG_SENSE5_Pos       20           /**< \brief (EIC_CONFIG) Input Sense 5 Configuration */
+#define EIC_CONFIG_SENSE5_Msk       (_U_(0x7) << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5(value)    (EIC_CONFIG_SENSE5_Msk & ((value) << EIC_CONFIG_SENSE5_Pos))
+#define   EIC_CONFIG_SENSE5_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE5_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE5_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE5_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE5_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE5_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE5_NONE      (EIC_CONFIG_SENSE5_NONE_Val    << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_RISE      (EIC_CONFIG_SENSE5_RISE_Val    << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_FALL      (EIC_CONFIG_SENSE5_FALL_Val    << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_BOTH      (EIC_CONFIG_SENSE5_BOTH_Val    << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_HIGH      (EIC_CONFIG_SENSE5_HIGH_Val    << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_SENSE5_LOW       (EIC_CONFIG_SENSE5_LOW_Val     << EIC_CONFIG_SENSE5_Pos)
+#define EIC_CONFIG_FILTEN5_Pos      23           /**< \brief (EIC_CONFIG) Filter 5 Enable */
+#define EIC_CONFIG_FILTEN5          (_U_(0x1) << EIC_CONFIG_FILTEN5_Pos)
+#define EIC_CONFIG_SENSE6_Pos       24           /**< \brief (EIC_CONFIG) Input Sense 6 Configuration */
+#define EIC_CONFIG_SENSE6_Msk       (_U_(0x7) << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6(value)    (EIC_CONFIG_SENSE6_Msk & ((value) << EIC_CONFIG_SENSE6_Pos))
+#define   EIC_CONFIG_SENSE6_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE6_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE6_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE6_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE6_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE6_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE6_NONE      (EIC_CONFIG_SENSE6_NONE_Val    << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_RISE      (EIC_CONFIG_SENSE6_RISE_Val    << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_FALL      (EIC_CONFIG_SENSE6_FALL_Val    << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_BOTH      (EIC_CONFIG_SENSE6_BOTH_Val    << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_HIGH      (EIC_CONFIG_SENSE6_HIGH_Val    << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_SENSE6_LOW       (EIC_CONFIG_SENSE6_LOW_Val     << EIC_CONFIG_SENSE6_Pos)
+#define EIC_CONFIG_FILTEN6_Pos      27           /**< \brief (EIC_CONFIG) Filter 6 Enable */
+#define EIC_CONFIG_FILTEN6          (_U_(0x1) << EIC_CONFIG_FILTEN6_Pos)
+#define EIC_CONFIG_SENSE7_Pos       28           /**< \brief (EIC_CONFIG) Input Sense 7 Configuration */
+#define EIC_CONFIG_SENSE7_Msk       (_U_(0x7) << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7(value)    (EIC_CONFIG_SENSE7_Msk & ((value) << EIC_CONFIG_SENSE7_Pos))
+#define   EIC_CONFIG_SENSE7_NONE_Val      _U_(0x0)   /**< \brief (EIC_CONFIG) No detection */
+#define   EIC_CONFIG_SENSE7_RISE_Val      _U_(0x1)   /**< \brief (EIC_CONFIG) Rising edge detection */
+#define   EIC_CONFIG_SENSE7_FALL_Val      _U_(0x2)   /**< \brief (EIC_CONFIG) Falling edge detection */
+#define   EIC_CONFIG_SENSE7_BOTH_Val      _U_(0x3)   /**< \brief (EIC_CONFIG) Both edges detection */
+#define   EIC_CONFIG_SENSE7_HIGH_Val      _U_(0x4)   /**< \brief (EIC_CONFIG) High level detection */
+#define   EIC_CONFIG_SENSE7_LOW_Val       _U_(0x5)   /**< \brief (EIC_CONFIG) Low level detection */
+#define EIC_CONFIG_SENSE7_NONE      (EIC_CONFIG_SENSE7_NONE_Val    << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_RISE      (EIC_CONFIG_SENSE7_RISE_Val    << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_FALL      (EIC_CONFIG_SENSE7_FALL_Val    << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_BOTH      (EIC_CONFIG_SENSE7_BOTH_Val    << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_HIGH      (EIC_CONFIG_SENSE7_HIGH_Val    << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_SENSE7_LOW       (EIC_CONFIG_SENSE7_LOW_Val     << EIC_CONFIG_SENSE7_Pos)
+#define EIC_CONFIG_FILTEN7_Pos      31           /**< \brief (EIC_CONFIG) Filter 7 Enable */
+#define EIC_CONFIG_FILTEN7          (_U_(0x1) << EIC_CONFIG_FILTEN7_Pos)
+#define EIC_CONFIG_MASK             _U_(0xFFFFFFFF) /**< \brief (EIC_CONFIG) MASK Register */
+
+/** \brief EIC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO EIC_CTRL_Type             CTRL;        /**< \brief Offset: 0x00 (R/W  8) Control */
+  __I  EIC_STATUS_Type           STATUS;      /**< \brief Offset: 0x01 (R/   8) Status */
+  __IO EIC_NMICTRL_Type          NMICTRL;     /**< \brief Offset: 0x02 (R/W  8) Non-Maskable Interrupt Control */
+  __IO EIC_NMIFLAG_Type          NMIFLAG;     /**< \brief Offset: 0x03 (R/W  8) Non-Maskable Interrupt Flag Status and Clear */
+  __IO EIC_EVCTRL_Type           EVCTRL;      /**< \brief Offset: 0x04 (R/W 32) Event Control */
+  __IO EIC_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x08 (R/W 32) Interrupt Enable Clear */
+  __IO EIC_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x0C (R/W 32) Interrupt Enable Set */
+  __IO EIC_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x10 (R/W 32) Interrupt Flag Status and Clear */
+  __IO EIC_WAKEUP_Type           WAKEUP;      /**< \brief Offset: 0x14 (R/W 32) Wake-Up Enable */
+  __IO EIC_CONFIG_Type           CONFIG[2];   /**< \brief Offset: 0x18 (R/W 32) Configuration n */
+} Eic;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_EIC_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/evsys.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/evsys.h
@@ -1,0 +1,454 @@
+/**
+ * \file
+ *
+ * \brief Component description for EVSYS
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_EVSYS_COMPONENT_
+#define _SAMD20_EVSYS_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR EVSYS */
+/* ========================================================================== */
+/** \addtogroup SAMD20_EVSYS Event System Interface */
+/*@{*/
+
+#define EVSYS_U2208
+#define REV_EVSYS                   0x101
+
+/* -------- EVSYS_CTRL : (EVSYS Offset: 0x00) ( /W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  :3;               /*!< bit:  1.. 3  Reserved                           */
+    uint8_t  GCLKREQ:1;        /*!< bit:      4  Generic Clock Requests             */
+    uint8_t  :3;               /*!< bit:  5.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} EVSYS_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CTRL_OFFSET           0x00         /**< \brief (EVSYS_CTRL offset) Control */
+#define EVSYS_CTRL_RESETVALUE       _U_(0x00)    /**< \brief (EVSYS_CTRL reset_value) Control */
+
+#define EVSYS_CTRL_SWRST_Pos        0            /**< \brief (EVSYS_CTRL) Software Reset */
+#define EVSYS_CTRL_SWRST            (_U_(0x1) << EVSYS_CTRL_SWRST_Pos)
+#define EVSYS_CTRL_GCLKREQ_Pos      4            /**< \brief (EVSYS_CTRL) Generic Clock Requests */
+#define EVSYS_CTRL_GCLKREQ          (_U_(0x1) << EVSYS_CTRL_GCLKREQ_Pos)
+#define EVSYS_CTRL_MASK             _U_(0x11)    /**< \brief (EVSYS_CTRL) MASK Register */
+
+/* -------- EVSYS_CHANNEL : (EVSYS Offset: 0x04) (R/W 32) Channel -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CHANNEL:3;        /*!< bit:  0.. 2  Channel Selection                  */
+    uint32_t :5;               /*!< bit:  3.. 7  Reserved                           */
+    uint32_t SWEVT:1;          /*!< bit:      8  Software Event                     */
+    uint32_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint32_t EVGEN:6;          /*!< bit: 16..21  Event Generator Selection          */
+    uint32_t :2;               /*!< bit: 22..23  Reserved                           */
+    uint32_t PATH:2;           /*!< bit: 24..25  Path Selection                     */
+    uint32_t EDGSEL:2;         /*!< bit: 26..27  Edge Detection Selection           */
+    uint32_t :4;               /*!< bit: 28..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_CHANNEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHANNEL_OFFSET        0x04         /**< \brief (EVSYS_CHANNEL offset) Channel */
+#define EVSYS_CHANNEL_RESETVALUE    _U_(0x00000000) /**< \brief (EVSYS_CHANNEL reset_value) Channel */
+
+#define EVSYS_CHANNEL_CHANNEL_Pos   0            /**< \brief (EVSYS_CHANNEL) Channel Selection */
+#define EVSYS_CHANNEL_CHANNEL_Msk   (_U_(0x7) << EVSYS_CHANNEL_CHANNEL_Pos)
+#define EVSYS_CHANNEL_CHANNEL(value) (EVSYS_CHANNEL_CHANNEL_Msk & ((value) << EVSYS_CHANNEL_CHANNEL_Pos))
+#define EVSYS_CHANNEL_SWEVT_Pos     8            /**< \brief (EVSYS_CHANNEL) Software Event */
+#define EVSYS_CHANNEL_SWEVT         (_U_(0x1) << EVSYS_CHANNEL_SWEVT_Pos)
+#define EVSYS_CHANNEL_EVGEN_Pos     16           /**< \brief (EVSYS_CHANNEL) Event Generator Selection */
+#define EVSYS_CHANNEL_EVGEN_Msk     (_U_(0x3F) << EVSYS_CHANNEL_EVGEN_Pos)
+#define EVSYS_CHANNEL_EVGEN(value)  (EVSYS_CHANNEL_EVGEN_Msk & ((value) << EVSYS_CHANNEL_EVGEN_Pos))
+#define EVSYS_CHANNEL_PATH_Pos      24           /**< \brief (EVSYS_CHANNEL) Path Selection */
+#define EVSYS_CHANNEL_PATH_Msk      (_U_(0x3) << EVSYS_CHANNEL_PATH_Pos)
+#define EVSYS_CHANNEL_PATH(value)   (EVSYS_CHANNEL_PATH_Msk & ((value) << EVSYS_CHANNEL_PATH_Pos))
+#define   EVSYS_CHANNEL_PATH_SYNCHRONOUS_Val _U_(0x0)   /**< \brief (EVSYS_CHANNEL) Synchronous path */
+#define   EVSYS_CHANNEL_PATH_RESYNCHRONIZED_Val _U_(0x1)   /**< \brief (EVSYS_CHANNEL) Resynchronized path */
+#define   EVSYS_CHANNEL_PATH_ASYNCHRONOUS_Val _U_(0x2)   /**< \brief (EVSYS_CHANNEL) Asynchronous path */
+#define EVSYS_CHANNEL_PATH_SYNCHRONOUS (EVSYS_CHANNEL_PATH_SYNCHRONOUS_Val << EVSYS_CHANNEL_PATH_Pos)
+#define EVSYS_CHANNEL_PATH_RESYNCHRONIZED (EVSYS_CHANNEL_PATH_RESYNCHRONIZED_Val << EVSYS_CHANNEL_PATH_Pos)
+#define EVSYS_CHANNEL_PATH_ASYNCHRONOUS (EVSYS_CHANNEL_PATH_ASYNCHRONOUS_Val << EVSYS_CHANNEL_PATH_Pos)
+#define EVSYS_CHANNEL_EDGSEL_Pos    26           /**< \brief (EVSYS_CHANNEL) Edge Detection Selection */
+#define EVSYS_CHANNEL_EDGSEL_Msk    (_U_(0x3) << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_EDGSEL(value) (EVSYS_CHANNEL_EDGSEL_Msk & ((value) << EVSYS_CHANNEL_EDGSEL_Pos))
+#define   EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT_Val _U_(0x0)   /**< \brief (EVSYS_CHANNEL) No event output when using the resynchronized or synchronous path */
+#define   EVSYS_CHANNEL_EDGSEL_RISING_EDGE_Val _U_(0x1)   /**< \brief (EVSYS_CHANNEL) Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path */
+#define   EVSYS_CHANNEL_EDGSEL_FALLING_EDGE_Val _U_(0x2)   /**< \brief (EVSYS_CHANNEL) Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path */
+#define   EVSYS_CHANNEL_EDGSEL_BOTH_EDGES_Val _U_(0x3)   /**< \brief (EVSYS_CHANNEL) Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path */
+#define EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT (EVSYS_CHANNEL_EDGSEL_NO_EVT_OUTPUT_Val << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_EDGSEL_RISING_EDGE (EVSYS_CHANNEL_EDGSEL_RISING_EDGE_Val << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_EDGSEL_FALLING_EDGE (EVSYS_CHANNEL_EDGSEL_FALLING_EDGE_Val << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_EDGSEL_BOTH_EDGES (EVSYS_CHANNEL_EDGSEL_BOTH_EDGES_Val << EVSYS_CHANNEL_EDGSEL_Pos)
+#define EVSYS_CHANNEL_MASK          _U_(0x0F3F0107) /**< \brief (EVSYS_CHANNEL) MASK Register */
+
+/* -------- EVSYS_USER : (EVSYS Offset: 0x08) (R/W 16) User Multiplexer -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t USER:4;           /*!< bit:  0.. 3  User Multiplexer Selection         */
+    uint16_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint16_t CHANNEL:4;        /*!< bit:  8..11  Channel Event Selection            */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} EVSYS_USER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_USER_OFFSET           0x08         /**< \brief (EVSYS_USER offset) User Multiplexer */
+#define EVSYS_USER_RESETVALUE       _U_(0x0000)  /**< \brief (EVSYS_USER reset_value) User Multiplexer */
+
+#define EVSYS_USER_USER_Pos         0            /**< \brief (EVSYS_USER) User Multiplexer Selection */
+#define EVSYS_USER_USER_Msk         (_U_(0xF) << EVSYS_USER_USER_Pos)
+#define EVSYS_USER_USER(value)      (EVSYS_USER_USER_Msk & ((value) << EVSYS_USER_USER_Pos))
+#define EVSYS_USER_CHANNEL_Pos      8            /**< \brief (EVSYS_USER) Channel Event Selection */
+#define EVSYS_USER_CHANNEL_Msk      (_U_(0xF) << EVSYS_USER_CHANNEL_Pos)
+#define EVSYS_USER_CHANNEL(value)   (EVSYS_USER_CHANNEL_Msk & ((value) << EVSYS_USER_CHANNEL_Pos))
+#define   EVSYS_USER_CHANNEL_0_Val        _U_(0x0)   /**< \brief (EVSYS_USER) No Channel Output Selected */
+#define EVSYS_USER_CHANNEL_0        (EVSYS_USER_CHANNEL_0_Val      << EVSYS_USER_CHANNEL_Pos)
+#define EVSYS_USER_MASK             _U_(0x0F0F)  /**< \brief (EVSYS_USER) MASK Register */
+
+/* -------- EVSYS_CHSTATUS : (EVSYS Offset: 0x0C) (R/  32) Channel Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t USRRDY0:1;        /*!< bit:      0  Channel 0 User Ready               */
+    uint32_t USRRDY1:1;        /*!< bit:      1  Channel 1 User Ready               */
+    uint32_t USRRDY2:1;        /*!< bit:      2  Channel 2 User Ready               */
+    uint32_t USRRDY3:1;        /*!< bit:      3  Channel 3 User Ready               */
+    uint32_t USRRDY4:1;        /*!< bit:      4  Channel 4 User Ready               */
+    uint32_t USRRDY5:1;        /*!< bit:      5  Channel 5 User Ready               */
+    uint32_t USRRDY6:1;        /*!< bit:      6  Channel 6 User Ready               */
+    uint32_t USRRDY7:1;        /*!< bit:      7  Channel 7 User Ready               */
+    uint32_t CHBUSY0:1;        /*!< bit:      8  Channel 0 Busy                     */
+    uint32_t CHBUSY1:1;        /*!< bit:      9  Channel 1 Busy                     */
+    uint32_t CHBUSY2:1;        /*!< bit:     10  Channel 2 Busy                     */
+    uint32_t CHBUSY3:1;        /*!< bit:     11  Channel 3 Busy                     */
+    uint32_t CHBUSY4:1;        /*!< bit:     12  Channel 4 Busy                     */
+    uint32_t CHBUSY5:1;        /*!< bit:     13  Channel 5 Busy                     */
+    uint32_t CHBUSY6:1;        /*!< bit:     14  Channel 6 Busy                     */
+    uint32_t CHBUSY7:1;        /*!< bit:     15  Channel 7 Busy                     */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t USRRDY:8;         /*!< bit:  0.. 7  Channel x User Ready               */
+    uint32_t CHBUSY:8;         /*!< bit:  8..15  Channel x Busy                     */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_CHSTATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_CHSTATUS_OFFSET       0x0C         /**< \brief (EVSYS_CHSTATUS offset) Channel Status */
+#define EVSYS_CHSTATUS_RESETVALUE   _U_(0x000F00FF) /**< \brief (EVSYS_CHSTATUS reset_value) Channel Status */
+
+#define EVSYS_CHSTATUS_USRRDY0_Pos  0            /**< \brief (EVSYS_CHSTATUS) Channel 0 User Ready */
+#define EVSYS_CHSTATUS_USRRDY0      (_U_(1) << EVSYS_CHSTATUS_USRRDY0_Pos)
+#define EVSYS_CHSTATUS_USRRDY1_Pos  1            /**< \brief (EVSYS_CHSTATUS) Channel 1 User Ready */
+#define EVSYS_CHSTATUS_USRRDY1      (_U_(1) << EVSYS_CHSTATUS_USRRDY1_Pos)
+#define EVSYS_CHSTATUS_USRRDY2_Pos  2            /**< \brief (EVSYS_CHSTATUS) Channel 2 User Ready */
+#define EVSYS_CHSTATUS_USRRDY2      (_U_(1) << EVSYS_CHSTATUS_USRRDY2_Pos)
+#define EVSYS_CHSTATUS_USRRDY3_Pos  3            /**< \brief (EVSYS_CHSTATUS) Channel 3 User Ready */
+#define EVSYS_CHSTATUS_USRRDY3      (_U_(1) << EVSYS_CHSTATUS_USRRDY3_Pos)
+#define EVSYS_CHSTATUS_USRRDY4_Pos  4            /**< \brief (EVSYS_CHSTATUS) Channel 4 User Ready */
+#define EVSYS_CHSTATUS_USRRDY4      (_U_(1) << EVSYS_CHSTATUS_USRRDY4_Pos)
+#define EVSYS_CHSTATUS_USRRDY5_Pos  5            /**< \brief (EVSYS_CHSTATUS) Channel 5 User Ready */
+#define EVSYS_CHSTATUS_USRRDY5      (_U_(1) << EVSYS_CHSTATUS_USRRDY5_Pos)
+#define EVSYS_CHSTATUS_USRRDY6_Pos  6            /**< \brief (EVSYS_CHSTATUS) Channel 6 User Ready */
+#define EVSYS_CHSTATUS_USRRDY6      (_U_(1) << EVSYS_CHSTATUS_USRRDY6_Pos)
+#define EVSYS_CHSTATUS_USRRDY7_Pos  7            /**< \brief (EVSYS_CHSTATUS) Channel 7 User Ready */
+#define EVSYS_CHSTATUS_USRRDY7      (_U_(1) << EVSYS_CHSTATUS_USRRDY7_Pos)
+#define EVSYS_CHSTATUS_USRRDY_Pos   0            /**< \brief (EVSYS_CHSTATUS) Channel x User Ready */
+#define EVSYS_CHSTATUS_USRRDY_Msk   (_U_(0xFF) << EVSYS_CHSTATUS_USRRDY_Pos)
+#define EVSYS_CHSTATUS_USRRDY(value) (EVSYS_CHSTATUS_USRRDY_Msk & ((value) << EVSYS_CHSTATUS_USRRDY_Pos))
+#define EVSYS_CHSTATUS_CHBUSY0_Pos  8            /**< \brief (EVSYS_CHSTATUS) Channel 0 Busy */
+#define EVSYS_CHSTATUS_CHBUSY0      (_U_(1) << EVSYS_CHSTATUS_CHBUSY0_Pos)
+#define EVSYS_CHSTATUS_CHBUSY1_Pos  9            /**< \brief (EVSYS_CHSTATUS) Channel 1 Busy */
+#define EVSYS_CHSTATUS_CHBUSY1      (_U_(1) << EVSYS_CHSTATUS_CHBUSY1_Pos)
+#define EVSYS_CHSTATUS_CHBUSY2_Pos  10           /**< \brief (EVSYS_CHSTATUS) Channel 2 Busy */
+#define EVSYS_CHSTATUS_CHBUSY2      (_U_(1) << EVSYS_CHSTATUS_CHBUSY2_Pos)
+#define EVSYS_CHSTATUS_CHBUSY3_Pos  11           /**< \brief (EVSYS_CHSTATUS) Channel 3 Busy */
+#define EVSYS_CHSTATUS_CHBUSY3      (_U_(1) << EVSYS_CHSTATUS_CHBUSY3_Pos)
+#define EVSYS_CHSTATUS_CHBUSY4_Pos  12           /**< \brief (EVSYS_CHSTATUS) Channel 4 Busy */
+#define EVSYS_CHSTATUS_CHBUSY4      (_U_(1) << EVSYS_CHSTATUS_CHBUSY4_Pos)
+#define EVSYS_CHSTATUS_CHBUSY5_Pos  13           /**< \brief (EVSYS_CHSTATUS) Channel 5 Busy */
+#define EVSYS_CHSTATUS_CHBUSY5      (_U_(1) << EVSYS_CHSTATUS_CHBUSY5_Pos)
+#define EVSYS_CHSTATUS_CHBUSY6_Pos  14           /**< \brief (EVSYS_CHSTATUS) Channel 6 Busy */
+#define EVSYS_CHSTATUS_CHBUSY6      (_U_(1) << EVSYS_CHSTATUS_CHBUSY6_Pos)
+#define EVSYS_CHSTATUS_CHBUSY7_Pos  15           /**< \brief (EVSYS_CHSTATUS) Channel 7 Busy */
+#define EVSYS_CHSTATUS_CHBUSY7      (_U_(1) << EVSYS_CHSTATUS_CHBUSY7_Pos)
+#define EVSYS_CHSTATUS_CHBUSY_Pos   8            /**< \brief (EVSYS_CHSTATUS) Channel x Busy */
+#define EVSYS_CHSTATUS_CHBUSY_Msk   (_U_(0xFF) << EVSYS_CHSTATUS_CHBUSY_Pos)
+#define EVSYS_CHSTATUS_CHBUSY(value) (EVSYS_CHSTATUS_CHBUSY_Msk & ((value) << EVSYS_CHSTATUS_CHBUSY_Pos))
+#define EVSYS_CHSTATUS_MASK         _U_(0x0000FFFF) /**< \brief (EVSYS_CHSTATUS) MASK Register */
+
+/* -------- EVSYS_INTENCLR : (EVSYS Offset: 0x10) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVR0:1;           /*!< bit:      0  Channel 0 Overrun Interrupt Enable */
+    uint32_t OVR1:1;           /*!< bit:      1  Channel 1 Overrun Interrupt Enable */
+    uint32_t OVR2:1;           /*!< bit:      2  Channel 2 Overrun Interrupt Enable */
+    uint32_t OVR3:1;           /*!< bit:      3  Channel 3 Overrun Interrupt Enable */
+    uint32_t OVR4:1;           /*!< bit:      4  Channel 4 Overrun Interrupt Enable */
+    uint32_t OVR5:1;           /*!< bit:      5  Channel 5 Overrun Interrupt Enable */
+    uint32_t OVR6:1;           /*!< bit:      6  Channel 6 Overrun Interrupt Enable */
+    uint32_t OVR7:1;           /*!< bit:      7  Channel 7 Overrun Interrupt Enable */
+    uint32_t EVD0:1;           /*!< bit:      8  Channel 0 Event Detection Interrupt Enable */
+    uint32_t EVD1:1;           /*!< bit:      9  Channel 1 Event Detection Interrupt Enable */
+    uint32_t EVD2:1;           /*!< bit:     10  Channel 2 Event Detection Interrupt Enable */
+    uint32_t EVD3:1;           /*!< bit:     11  Channel 3 Event Detection Interrupt Enable */
+    uint32_t EVD4:1;           /*!< bit:     12  Channel 4 Event Detection Interrupt Enable */
+    uint32_t EVD5:1;           /*!< bit:     13  Channel 5 Event Detection Interrupt Enable */
+    uint32_t EVD6:1;           /*!< bit:     14  Channel 6 Event Detection Interrupt Enable */
+    uint32_t EVD7:1;           /*!< bit:     15  Channel 7 Event Detection Interrupt Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun Interrupt Enable */
+    uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection Interrupt Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTENCLR_OFFSET       0x10         /**< \brief (EVSYS_INTENCLR offset) Interrupt Enable Clear */
+#define EVSYS_INTENCLR_RESETVALUE   _U_(0x00000000) /**< \brief (EVSYS_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define EVSYS_INTENCLR_OVR0_Pos     0            /**< \brief (EVSYS_INTENCLR) Channel 0 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR0         (_U_(1) << EVSYS_INTENCLR_OVR0_Pos)
+#define EVSYS_INTENCLR_OVR1_Pos     1            /**< \brief (EVSYS_INTENCLR) Channel 1 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR1         (_U_(1) << EVSYS_INTENCLR_OVR1_Pos)
+#define EVSYS_INTENCLR_OVR2_Pos     2            /**< \brief (EVSYS_INTENCLR) Channel 2 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR2         (_U_(1) << EVSYS_INTENCLR_OVR2_Pos)
+#define EVSYS_INTENCLR_OVR3_Pos     3            /**< \brief (EVSYS_INTENCLR) Channel 3 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR3         (_U_(1) << EVSYS_INTENCLR_OVR3_Pos)
+#define EVSYS_INTENCLR_OVR4_Pos     4            /**< \brief (EVSYS_INTENCLR) Channel 4 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR4         (_U_(1) << EVSYS_INTENCLR_OVR4_Pos)
+#define EVSYS_INTENCLR_OVR5_Pos     5            /**< \brief (EVSYS_INTENCLR) Channel 5 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR5         (_U_(1) << EVSYS_INTENCLR_OVR5_Pos)
+#define EVSYS_INTENCLR_OVR6_Pos     6            /**< \brief (EVSYS_INTENCLR) Channel 6 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR6         (_U_(1) << EVSYS_INTENCLR_OVR6_Pos)
+#define EVSYS_INTENCLR_OVR7_Pos     7            /**< \brief (EVSYS_INTENCLR) Channel 7 Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR7         (_U_(1) << EVSYS_INTENCLR_OVR7_Pos)
+#define EVSYS_INTENCLR_OVR_Pos      0            /**< \brief (EVSYS_INTENCLR) Channel x Overrun Interrupt Enable */
+#define EVSYS_INTENCLR_OVR_Msk      (_U_(0xFF) << EVSYS_INTENCLR_OVR_Pos)
+#define EVSYS_INTENCLR_OVR(value)   (EVSYS_INTENCLR_OVR_Msk & ((value) << EVSYS_INTENCLR_OVR_Pos))
+#define EVSYS_INTENCLR_EVD0_Pos     8            /**< \brief (EVSYS_INTENCLR) Channel 0 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD0         (_U_(1) << EVSYS_INTENCLR_EVD0_Pos)
+#define EVSYS_INTENCLR_EVD1_Pos     9            /**< \brief (EVSYS_INTENCLR) Channel 1 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD1         (_U_(1) << EVSYS_INTENCLR_EVD1_Pos)
+#define EVSYS_INTENCLR_EVD2_Pos     10           /**< \brief (EVSYS_INTENCLR) Channel 2 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD2         (_U_(1) << EVSYS_INTENCLR_EVD2_Pos)
+#define EVSYS_INTENCLR_EVD3_Pos     11           /**< \brief (EVSYS_INTENCLR) Channel 3 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD3         (_U_(1) << EVSYS_INTENCLR_EVD3_Pos)
+#define EVSYS_INTENCLR_EVD4_Pos     12           /**< \brief (EVSYS_INTENCLR) Channel 4 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD4         (_U_(1) << EVSYS_INTENCLR_EVD4_Pos)
+#define EVSYS_INTENCLR_EVD5_Pos     13           /**< \brief (EVSYS_INTENCLR) Channel 5 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD5         (_U_(1) << EVSYS_INTENCLR_EVD5_Pos)
+#define EVSYS_INTENCLR_EVD6_Pos     14           /**< \brief (EVSYS_INTENCLR) Channel 6 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD6         (_U_(1) << EVSYS_INTENCLR_EVD6_Pos)
+#define EVSYS_INTENCLR_EVD7_Pos     15           /**< \brief (EVSYS_INTENCLR) Channel 7 Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD7         (_U_(1) << EVSYS_INTENCLR_EVD7_Pos)
+#define EVSYS_INTENCLR_EVD_Pos      8            /**< \brief (EVSYS_INTENCLR) Channel x Event Detection Interrupt Enable */
+#define EVSYS_INTENCLR_EVD_Msk      (_U_(0xFF) << EVSYS_INTENCLR_EVD_Pos)
+#define EVSYS_INTENCLR_EVD(value)   (EVSYS_INTENCLR_EVD_Msk & ((value) << EVSYS_INTENCLR_EVD_Pos))
+#define EVSYS_INTENCLR_MASK         _U_(0x0000FFFF) /**< \brief (EVSYS_INTENCLR) MASK Register */
+
+/* -------- EVSYS_INTENSET : (EVSYS Offset: 0x14) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OVR0:1;           /*!< bit:      0  Channel 0 Overrun Interrupt Enable */
+    uint32_t OVR1:1;           /*!< bit:      1  Channel 1 Overrun Interrupt Enable */
+    uint32_t OVR2:1;           /*!< bit:      2  Channel 2 Overrun Interrupt Enable */
+    uint32_t OVR3:1;           /*!< bit:      3  Channel 3 Overrun Interrupt Enable */
+    uint32_t OVR4:1;           /*!< bit:      4  Channel 4 Overrun Interrupt Enable */
+    uint32_t OVR5:1;           /*!< bit:      5  Channel 5 Overrun Interrupt Enable */
+    uint32_t OVR6:1;           /*!< bit:      6  Channel 6 Overrun Interrupt Enable */
+    uint32_t OVR7:1;           /*!< bit:      7  Channel 7 Overrun Interrupt Enable */
+    uint32_t EVD0:1;           /*!< bit:      8  Channel 0 Event Detection Interrupt Enable */
+    uint32_t EVD1:1;           /*!< bit:      9  Channel 1 Event Detection Interrupt Enable */
+    uint32_t EVD2:1;           /*!< bit:     10  Channel 2 Event Detection Interrupt Enable */
+    uint32_t EVD3:1;           /*!< bit:     11  Channel 3 Event Detection Interrupt Enable */
+    uint32_t EVD4:1;           /*!< bit:     12  Channel 4 Event Detection Interrupt Enable */
+    uint32_t EVD5:1;           /*!< bit:     13  Channel 5 Event Detection Interrupt Enable */
+    uint32_t EVD6:1;           /*!< bit:     14  Channel 6 Event Detection Interrupt Enable */
+    uint32_t EVD7:1;           /*!< bit:     15  Channel 7 Event Detection Interrupt Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun Interrupt Enable */
+    uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection Interrupt Enable */
+    uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTENSET_OFFSET       0x14         /**< \brief (EVSYS_INTENSET offset) Interrupt Enable Set */
+#define EVSYS_INTENSET_RESETVALUE   _U_(0x00000000) /**< \brief (EVSYS_INTENSET reset_value) Interrupt Enable Set */
+
+#define EVSYS_INTENSET_OVR0_Pos     0            /**< \brief (EVSYS_INTENSET) Channel 0 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR0         (_U_(1) << EVSYS_INTENSET_OVR0_Pos)
+#define EVSYS_INTENSET_OVR1_Pos     1            /**< \brief (EVSYS_INTENSET) Channel 1 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR1         (_U_(1) << EVSYS_INTENSET_OVR1_Pos)
+#define EVSYS_INTENSET_OVR2_Pos     2            /**< \brief (EVSYS_INTENSET) Channel 2 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR2         (_U_(1) << EVSYS_INTENSET_OVR2_Pos)
+#define EVSYS_INTENSET_OVR3_Pos     3            /**< \brief (EVSYS_INTENSET) Channel 3 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR3         (_U_(1) << EVSYS_INTENSET_OVR3_Pos)
+#define EVSYS_INTENSET_OVR4_Pos     4            /**< \brief (EVSYS_INTENSET) Channel 4 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR4         (_U_(1) << EVSYS_INTENSET_OVR4_Pos)
+#define EVSYS_INTENSET_OVR5_Pos     5            /**< \brief (EVSYS_INTENSET) Channel 5 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR5         (_U_(1) << EVSYS_INTENSET_OVR5_Pos)
+#define EVSYS_INTENSET_OVR6_Pos     6            /**< \brief (EVSYS_INTENSET) Channel 6 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR6         (_U_(1) << EVSYS_INTENSET_OVR6_Pos)
+#define EVSYS_INTENSET_OVR7_Pos     7            /**< \brief (EVSYS_INTENSET) Channel 7 Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR7         (_U_(1) << EVSYS_INTENSET_OVR7_Pos)
+#define EVSYS_INTENSET_OVR_Pos      0            /**< \brief (EVSYS_INTENSET) Channel x Overrun Interrupt Enable */
+#define EVSYS_INTENSET_OVR_Msk      (_U_(0xFF) << EVSYS_INTENSET_OVR_Pos)
+#define EVSYS_INTENSET_OVR(value)   (EVSYS_INTENSET_OVR_Msk & ((value) << EVSYS_INTENSET_OVR_Pos))
+#define EVSYS_INTENSET_EVD0_Pos     8            /**< \brief (EVSYS_INTENSET) Channel 0 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD0         (_U_(1) << EVSYS_INTENSET_EVD0_Pos)
+#define EVSYS_INTENSET_EVD1_Pos     9            /**< \brief (EVSYS_INTENSET) Channel 1 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD1         (_U_(1) << EVSYS_INTENSET_EVD1_Pos)
+#define EVSYS_INTENSET_EVD2_Pos     10           /**< \brief (EVSYS_INTENSET) Channel 2 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD2         (_U_(1) << EVSYS_INTENSET_EVD2_Pos)
+#define EVSYS_INTENSET_EVD3_Pos     11           /**< \brief (EVSYS_INTENSET) Channel 3 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD3         (_U_(1) << EVSYS_INTENSET_EVD3_Pos)
+#define EVSYS_INTENSET_EVD4_Pos     12           /**< \brief (EVSYS_INTENSET) Channel 4 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD4         (_U_(1) << EVSYS_INTENSET_EVD4_Pos)
+#define EVSYS_INTENSET_EVD5_Pos     13           /**< \brief (EVSYS_INTENSET) Channel 5 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD5         (_U_(1) << EVSYS_INTENSET_EVD5_Pos)
+#define EVSYS_INTENSET_EVD6_Pos     14           /**< \brief (EVSYS_INTENSET) Channel 6 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD6         (_U_(1) << EVSYS_INTENSET_EVD6_Pos)
+#define EVSYS_INTENSET_EVD7_Pos     15           /**< \brief (EVSYS_INTENSET) Channel 7 Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD7         (_U_(1) << EVSYS_INTENSET_EVD7_Pos)
+#define EVSYS_INTENSET_EVD_Pos      8            /**< \brief (EVSYS_INTENSET) Channel x Event Detection Interrupt Enable */
+#define EVSYS_INTENSET_EVD_Msk      (_U_(0xFF) << EVSYS_INTENSET_EVD_Pos)
+#define EVSYS_INTENSET_EVD(value)   (EVSYS_INTENSET_EVD_Msk & ((value) << EVSYS_INTENSET_EVD_Pos))
+#define EVSYS_INTENSET_MASK         _U_(0x0000FFFF) /**< \brief (EVSYS_INTENSET) MASK Register */
+
+/* -------- EVSYS_INTFLAG : (EVSYS Offset: 0x18) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t OVR0:1;           /*!< bit:      0  Channel 0 Overrun                  */
+    __I uint32_t OVR1:1;           /*!< bit:      1  Channel 1 Overrun                  */
+    __I uint32_t OVR2:1;           /*!< bit:      2  Channel 2 Overrun                  */
+    __I uint32_t OVR3:1;           /*!< bit:      3  Channel 3 Overrun                  */
+    __I uint32_t OVR4:1;           /*!< bit:      4  Channel 4 Overrun                  */
+    __I uint32_t OVR5:1;           /*!< bit:      5  Channel 5 Overrun                  */
+    __I uint32_t OVR6:1;           /*!< bit:      6  Channel 6 Overrun                  */
+    __I uint32_t OVR7:1;           /*!< bit:      7  Channel 7 Overrun                  */
+    __I uint32_t EVD0:1;           /*!< bit:      8  Channel 0 Event Detection          */
+    __I uint32_t EVD1:1;           /*!< bit:      9  Channel 1 Event Detection          */
+    __I uint32_t EVD2:1;           /*!< bit:     10  Channel 2 Event Detection          */
+    __I uint32_t EVD3:1;           /*!< bit:     11  Channel 3 Event Detection          */
+    __I uint32_t EVD4:1;           /*!< bit:     12  Channel 4 Event Detection          */
+    __I uint32_t EVD5:1;           /*!< bit:     13  Channel 5 Event Detection          */
+    __I uint32_t EVD6:1;           /*!< bit:     14  Channel 6 Event Detection          */
+    __I uint32_t EVD7:1;           /*!< bit:     15  Channel 7 Event Detection          */
+    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint32_t OVR:8;            /*!< bit:  0.. 7  Channel x Overrun                  */
+    __I uint32_t EVD:8;            /*!< bit:  8..15  Channel x Event Detection          */
+    __I uint32_t :16;              /*!< bit: 16..31  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} EVSYS_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define EVSYS_INTFLAG_OFFSET        0x18         /**< \brief (EVSYS_INTFLAG offset) Interrupt Flag Status and Clear */
+#define EVSYS_INTFLAG_RESETVALUE    _U_(0x00000000) /**< \brief (EVSYS_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define EVSYS_INTFLAG_OVR0_Pos      0            /**< \brief (EVSYS_INTFLAG) Channel 0 Overrun */
+#define EVSYS_INTFLAG_OVR0          (_U_(1) << EVSYS_INTFLAG_OVR0_Pos)
+#define EVSYS_INTFLAG_OVR1_Pos      1            /**< \brief (EVSYS_INTFLAG) Channel 1 Overrun */
+#define EVSYS_INTFLAG_OVR1          (_U_(1) << EVSYS_INTFLAG_OVR1_Pos)
+#define EVSYS_INTFLAG_OVR2_Pos      2            /**< \brief (EVSYS_INTFLAG) Channel 2 Overrun */
+#define EVSYS_INTFLAG_OVR2          (_U_(1) << EVSYS_INTFLAG_OVR2_Pos)
+#define EVSYS_INTFLAG_OVR3_Pos      3            /**< \brief (EVSYS_INTFLAG) Channel 3 Overrun */
+#define EVSYS_INTFLAG_OVR3          (_U_(1) << EVSYS_INTFLAG_OVR3_Pos)
+#define EVSYS_INTFLAG_OVR4_Pos      4            /**< \brief (EVSYS_INTFLAG) Channel 4 Overrun */
+#define EVSYS_INTFLAG_OVR4          (_U_(1) << EVSYS_INTFLAG_OVR4_Pos)
+#define EVSYS_INTFLAG_OVR5_Pos      5            /**< \brief (EVSYS_INTFLAG) Channel 5 Overrun */
+#define EVSYS_INTFLAG_OVR5          (_U_(1) << EVSYS_INTFLAG_OVR5_Pos)
+#define EVSYS_INTFLAG_OVR6_Pos      6            /**< \brief (EVSYS_INTFLAG) Channel 6 Overrun */
+#define EVSYS_INTFLAG_OVR6          (_U_(1) << EVSYS_INTFLAG_OVR6_Pos)
+#define EVSYS_INTFLAG_OVR7_Pos      7            /**< \brief (EVSYS_INTFLAG) Channel 7 Overrun */
+#define EVSYS_INTFLAG_OVR7          (_U_(1) << EVSYS_INTFLAG_OVR7_Pos)
+#define EVSYS_INTFLAG_OVR_Pos       0            /**< \brief (EVSYS_INTFLAG) Channel x Overrun */
+#define EVSYS_INTFLAG_OVR_Msk       (_U_(0xFF) << EVSYS_INTFLAG_OVR_Pos)
+#define EVSYS_INTFLAG_OVR(value)    (EVSYS_INTFLAG_OVR_Msk & ((value) << EVSYS_INTFLAG_OVR_Pos))
+#define EVSYS_INTFLAG_EVD0_Pos      8            /**< \brief (EVSYS_INTFLAG) Channel 0 Event Detection */
+#define EVSYS_INTFLAG_EVD0          (_U_(1) << EVSYS_INTFLAG_EVD0_Pos)
+#define EVSYS_INTFLAG_EVD1_Pos      9            /**< \brief (EVSYS_INTFLAG) Channel 1 Event Detection */
+#define EVSYS_INTFLAG_EVD1          (_U_(1) << EVSYS_INTFLAG_EVD1_Pos)
+#define EVSYS_INTFLAG_EVD2_Pos      10           /**< \brief (EVSYS_INTFLAG) Channel 2 Event Detection */
+#define EVSYS_INTFLAG_EVD2          (_U_(1) << EVSYS_INTFLAG_EVD2_Pos)
+#define EVSYS_INTFLAG_EVD3_Pos      11           /**< \brief (EVSYS_INTFLAG) Channel 3 Event Detection */
+#define EVSYS_INTFLAG_EVD3          (_U_(1) << EVSYS_INTFLAG_EVD3_Pos)
+#define EVSYS_INTFLAG_EVD4_Pos      12           /**< \brief (EVSYS_INTFLAG) Channel 4 Event Detection */
+#define EVSYS_INTFLAG_EVD4          (_U_(1) << EVSYS_INTFLAG_EVD4_Pos)
+#define EVSYS_INTFLAG_EVD5_Pos      13           /**< \brief (EVSYS_INTFLAG) Channel 5 Event Detection */
+#define EVSYS_INTFLAG_EVD5          (_U_(1) << EVSYS_INTFLAG_EVD5_Pos)
+#define EVSYS_INTFLAG_EVD6_Pos      14           /**< \brief (EVSYS_INTFLAG) Channel 6 Event Detection */
+#define EVSYS_INTFLAG_EVD6          (_U_(1) << EVSYS_INTFLAG_EVD6_Pos)
+#define EVSYS_INTFLAG_EVD7_Pos      15           /**< \brief (EVSYS_INTFLAG) Channel 7 Event Detection */
+#define EVSYS_INTFLAG_EVD7          (_U_(1) << EVSYS_INTFLAG_EVD7_Pos)
+#define EVSYS_INTFLAG_EVD_Pos       8            /**< \brief (EVSYS_INTFLAG) Channel x Event Detection */
+#define EVSYS_INTFLAG_EVD_Msk       (_U_(0xFF) << EVSYS_INTFLAG_EVD_Pos)
+#define EVSYS_INTFLAG_EVD(value)    (EVSYS_INTFLAG_EVD_Msk & ((value) << EVSYS_INTFLAG_EVD_Pos))
+#define EVSYS_INTFLAG_MASK          _U_(0x0000FFFF) /**< \brief (EVSYS_INTFLAG) MASK Register */
+
+/** \brief EVSYS hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __O  EVSYS_CTRL_Type           CTRL;        /**< \brief Offset: 0x00 ( /W  8) Control */
+       RoReg8                    Reserved1[0x3];
+  __IO EVSYS_CHANNEL_Type        CHANNEL;     /**< \brief Offset: 0x04 (R/W 32) Channel */
+  __IO EVSYS_USER_Type           USER;        /**< \brief Offset: 0x08 (R/W 16) User Multiplexer */
+       RoReg8                    Reserved2[0x2];
+  __I  EVSYS_CHSTATUS_Type       CHSTATUS;    /**< \brief Offset: 0x0C (R/  32) Channel Status */
+  __IO EVSYS_INTENCLR_Type       INTENCLR;    /**< \brief Offset: 0x10 (R/W 32) Interrupt Enable Clear */
+  __IO EVSYS_INTENSET_Type       INTENSET;    /**< \brief Offset: 0x14 (R/W 32) Interrupt Enable Set */
+  __IO EVSYS_INTFLAG_Type        INTFLAG;     /**< \brief Offset: 0x18 (R/W 32) Interrupt Flag Status and Clear */
+} Evsys;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_EVSYS_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/gclk.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/gclk.h
@@ -1,0 +1,312 @@
+/**
+ * \file
+ *
+ * \brief Component description for GCLK
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_GCLK_COMPONENT_
+#define _SAMD20_GCLK_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR GCLK */
+/* ========================================================================== */
+/** \addtogroup SAMD20_GCLK Generic Clock Generator */
+/*@{*/
+
+#define GCLK_U2102
+#define REV_GCLK                    0x210
+
+/* -------- GCLK_CTRL : (GCLK Offset: 0x0) (R/W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} GCLK_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_CTRL_OFFSET            0x0          /**< \brief (GCLK_CTRL offset) Control */
+#define GCLK_CTRL_RESETVALUE        _U_(0x00)    /**< \brief (GCLK_CTRL reset_value) Control */
+
+#define GCLK_CTRL_SWRST_Pos         0            /**< \brief (GCLK_CTRL) Software Reset */
+#define GCLK_CTRL_SWRST             (_U_(0x1) << GCLK_CTRL_SWRST_Pos)
+#define GCLK_CTRL_MASK              _U_(0x01)    /**< \brief (GCLK_CTRL) MASK Register */
+
+/* -------- GCLK_STATUS : (GCLK Offset: 0x1) (R/   8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy Status        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} GCLK_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_STATUS_OFFSET          0x1          /**< \brief (GCLK_STATUS offset) Status */
+#define GCLK_STATUS_RESETVALUE      _U_(0x00)    /**< \brief (GCLK_STATUS reset_value) Status */
+
+#define GCLK_STATUS_SYNCBUSY_Pos    7            /**< \brief (GCLK_STATUS) Synchronization Busy Status */
+#define GCLK_STATUS_SYNCBUSY        (_U_(0x1) << GCLK_STATUS_SYNCBUSY_Pos)
+#define GCLK_STATUS_MASK            _U_(0x80)    /**< \brief (GCLK_STATUS) MASK Register */
+
+/* -------- GCLK_CLKCTRL : (GCLK Offset: 0x2) (R/W 16) Generic Clock Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t ID:6;             /*!< bit:  0.. 5  Generic Clock Selection ID         */
+    uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t GEN:4;            /*!< bit:  8..11  Generic Clock Generator            */
+    uint16_t :2;               /*!< bit: 12..13  Reserved                           */
+    uint16_t CLKEN:1;          /*!< bit:     14  Clock Enable                       */
+    uint16_t WRTLOCK:1;        /*!< bit:     15  Write Lock                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} GCLK_CLKCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_CLKCTRL_OFFSET         0x2          /**< \brief (GCLK_CLKCTRL offset) Generic Clock Control */
+#define GCLK_CLKCTRL_RESETVALUE     _U_(0x0000)  /**< \brief (GCLK_CLKCTRL reset_value) Generic Clock Control */
+
+#define GCLK_CLKCTRL_ID_Pos         0            /**< \brief (GCLK_CLKCTRL) Generic Clock Selection ID */
+#define GCLK_CLKCTRL_ID_Msk         (_U_(0x3F) << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID(value)      (GCLK_CLKCTRL_ID_Msk & ((value) << GCLK_CLKCTRL_ID_Pos))
+#define   GCLK_CLKCTRL_ID_DFLL48M_Val     _U_(0x0)   /**< \brief (GCLK_CLKCTRL) DFLL48M Reference */
+#define   GCLK_CLKCTRL_ID_WDT_Val         _U_(0x1)   /**< \brief (GCLK_CLKCTRL) WDT */
+#define   GCLK_CLKCTRL_ID_RTC_Val         _U_(0x2)   /**< \brief (GCLK_CLKCTRL) RTC */
+#define   GCLK_CLKCTRL_ID_EIC_Val         _U_(0x3)   /**< \brief (GCLK_CLKCTRL) EIC */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_0_Val _U_(0x4)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_0 */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_1_Val _U_(0x5)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_1 */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_2_Val _U_(0x6)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_2 */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_3_Val _U_(0x7)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_3 */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_4_Val _U_(0x8)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_4 */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_5_Val _U_(0x9)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_5 */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_6_Val _U_(0xA)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_6 */
+#define   GCLK_CLKCTRL_ID_EVSYS_CHANNEL_7_Val _U_(0xB)   /**< \brief (GCLK_CLKCTRL) EVSYS_CHANNEL_7 */
+#define   GCLK_CLKCTRL_ID_SERCOMX_SLOW_Val _U_(0xC)   /**< \brief (GCLK_CLKCTRL) SERCOMx_SLOW */
+#define   GCLK_CLKCTRL_ID_SERCOM0_CORE_Val _U_(0xD)   /**< \brief (GCLK_CLKCTRL) SERCOM0_CORE */
+#define   GCLK_CLKCTRL_ID_SERCOM1_CORE_Val _U_(0xE)   /**< \brief (GCLK_CLKCTRL) SERCOM1_CORE */
+#define   GCLK_CLKCTRL_ID_SERCOM2_CORE_Val _U_(0xF)   /**< \brief (GCLK_CLKCTRL) SERCOM2_CORE */
+#define   GCLK_CLKCTRL_ID_SERCOM3_CORE_Val _U_(0x10)   /**< \brief (GCLK_CLKCTRL) SERCOM3_CORE */
+#define   GCLK_CLKCTRL_ID_SERCOM4_CORE_Val _U_(0x11)   /**< \brief (GCLK_CLKCTRL) SERCOM4_CORE */
+#define   GCLK_CLKCTRL_ID_SERCOM5_CORE_Val _U_(0x12)   /**< \brief (GCLK_CLKCTRL) SERCOM5_CORE */
+#define   GCLK_CLKCTRL_ID_TC0_TC1_Val     _U_(0x13)   /**< \brief (GCLK_CLKCTRL) TC0,TC1 */
+#define   GCLK_CLKCTRL_ID_TC2_TC3_Val     _U_(0x14)   /**< \brief (GCLK_CLKCTRL) TC2,TC3 */
+#define   GCLK_CLKCTRL_ID_TC4_TC5_Val     _U_(0x15)   /**< \brief (GCLK_CLKCTRL) TC4,TC5 */
+#define   GCLK_CLKCTRL_ID_TC6_TC7_Val     _U_(0x16)   /**< \brief (GCLK_CLKCTRL) TC6,TC7 */
+#define   GCLK_CLKCTRL_ID_ADC_Val         _U_(0x17)   /**< \brief (GCLK_CLKCTRL) ADC */
+#define   GCLK_CLKCTRL_ID_AC_DIG_Val      _U_(0x18)   /**< \brief (GCLK_CLKCTRL) AC_DIG */
+#define   GCLK_CLKCTRL_ID_AC_ANA_Val      _U_(0x19)   /**< \brief (GCLK_CLKCTRL) AC_ANA */
+#define   GCLK_CLKCTRL_ID_DAC_Val         _U_(0x1A)   /**< \brief (GCLK_CLKCTRL) DAC */
+#define   GCLK_CLKCTRL_ID_PTC_Val         _U_(0x1B)   /**< \brief (GCLK_CLKCTRL) PTC */
+#define GCLK_CLKCTRL_ID_DFLL48M     (GCLK_CLKCTRL_ID_DFLL48M_Val   << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_WDT         (GCLK_CLKCTRL_ID_WDT_Val       << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_RTC         (GCLK_CLKCTRL_ID_RTC_Val       << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EIC         (GCLK_CLKCTRL_ID_EIC_Val       << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_0 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_0_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_1 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_1_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_2 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_2_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_3 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_3_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_4 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_4_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_5 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_5_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_6 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_6_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_EVSYS_CHANNEL_7 (GCLK_CLKCTRL_ID_EVSYS_CHANNEL_7_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_SERCOMX_SLOW (GCLK_CLKCTRL_ID_SERCOMX_SLOW_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_SERCOM0_CORE (GCLK_CLKCTRL_ID_SERCOM0_CORE_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_SERCOM1_CORE (GCLK_CLKCTRL_ID_SERCOM1_CORE_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_SERCOM2_CORE (GCLK_CLKCTRL_ID_SERCOM2_CORE_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_SERCOM3_CORE (GCLK_CLKCTRL_ID_SERCOM3_CORE_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_SERCOM4_CORE (GCLK_CLKCTRL_ID_SERCOM4_CORE_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_SERCOM5_CORE (GCLK_CLKCTRL_ID_SERCOM5_CORE_Val << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_TC0_TC1     (GCLK_CLKCTRL_ID_TC0_TC1_Val   << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_TC2_TC3     (GCLK_CLKCTRL_ID_TC2_TC3_Val   << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_TC4_TC5     (GCLK_CLKCTRL_ID_TC4_TC5_Val   << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_TC6_TC7     (GCLK_CLKCTRL_ID_TC6_TC7_Val   << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_ADC         (GCLK_CLKCTRL_ID_ADC_Val       << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_AC_DIG      (GCLK_CLKCTRL_ID_AC_DIG_Val    << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_AC_ANA      (GCLK_CLKCTRL_ID_AC_ANA_Val    << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_DAC         (GCLK_CLKCTRL_ID_DAC_Val       << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_ID_PTC         (GCLK_CLKCTRL_ID_PTC_Val       << GCLK_CLKCTRL_ID_Pos)
+#define GCLK_CLKCTRL_GEN_Pos        8            /**< \brief (GCLK_CLKCTRL) Generic Clock Generator */
+#define GCLK_CLKCTRL_GEN_Msk        (_U_(0xF) << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN(value)     (GCLK_CLKCTRL_GEN_Msk & ((value) << GCLK_CLKCTRL_GEN_Pos))
+#define   GCLK_CLKCTRL_GEN_GCLK0_Val      _U_(0x0)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 0 */
+#define   GCLK_CLKCTRL_GEN_GCLK1_Val      _U_(0x1)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 1 */
+#define   GCLK_CLKCTRL_GEN_GCLK2_Val      _U_(0x2)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 2 */
+#define   GCLK_CLKCTRL_GEN_GCLK3_Val      _U_(0x3)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 3 */
+#define   GCLK_CLKCTRL_GEN_GCLK4_Val      _U_(0x4)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 4 */
+#define   GCLK_CLKCTRL_GEN_GCLK5_Val      _U_(0x5)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 5 */
+#define   GCLK_CLKCTRL_GEN_GCLK6_Val      _U_(0x6)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 6 */
+#define   GCLK_CLKCTRL_GEN_GCLK7_Val      _U_(0x7)   /**< \brief (GCLK_CLKCTRL) Generic clock generator 7 */
+#define GCLK_CLKCTRL_GEN_GCLK0      (GCLK_CLKCTRL_GEN_GCLK0_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN_GCLK1      (GCLK_CLKCTRL_GEN_GCLK1_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN_GCLK2      (GCLK_CLKCTRL_GEN_GCLK2_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN_GCLK3      (GCLK_CLKCTRL_GEN_GCLK3_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN_GCLK4      (GCLK_CLKCTRL_GEN_GCLK4_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN_GCLK5      (GCLK_CLKCTRL_GEN_GCLK5_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN_GCLK6      (GCLK_CLKCTRL_GEN_GCLK6_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_GEN_GCLK7      (GCLK_CLKCTRL_GEN_GCLK7_Val    << GCLK_CLKCTRL_GEN_Pos)
+#define GCLK_CLKCTRL_CLKEN_Pos      14           /**< \brief (GCLK_CLKCTRL) Clock Enable */
+#define GCLK_CLKCTRL_CLKEN          (_U_(0x1) << GCLK_CLKCTRL_CLKEN_Pos)
+#define GCLK_CLKCTRL_WRTLOCK_Pos    15           /**< \brief (GCLK_CLKCTRL) Write Lock */
+#define GCLK_CLKCTRL_WRTLOCK        (_U_(0x1) << GCLK_CLKCTRL_WRTLOCK_Pos)
+#define GCLK_CLKCTRL_MASK           _U_(0xCF3F)  /**< \brief (GCLK_CLKCTRL) MASK Register */
+
+/* -------- GCLK_GENCTRL : (GCLK Offset: 0x4) (R/W 32) Generic Clock Generator Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ID:4;             /*!< bit:  0.. 3  Generic Clock Generator Selection  */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t SRC:5;            /*!< bit:  8..12  Source Select                      */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t GENEN:1;          /*!< bit:     16  Generic Clock Generator Enable     */
+    uint32_t IDC:1;            /*!< bit:     17  Improve Duty Cycle                 */
+    uint32_t OOV:1;            /*!< bit:     18  Output Off Value                   */
+    uint32_t OE:1;             /*!< bit:     19  Output Enable                      */
+    uint32_t DIVSEL:1;         /*!< bit:     20  Divide Selection                   */
+    uint32_t RUNSTDBY:1;       /*!< bit:     21  Run in Standby                     */
+    uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GCLK_GENCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_GENCTRL_OFFSET         0x4          /**< \brief (GCLK_GENCTRL offset) Generic Clock Generator Control */
+#define GCLK_GENCTRL_RESETVALUE     _U_(0x00000000) /**< \brief (GCLK_GENCTRL reset_value) Generic Clock Generator Control */
+
+#define GCLK_GENCTRL_ID_Pos         0            /**< \brief (GCLK_GENCTRL) Generic Clock Generator Selection */
+#define GCLK_GENCTRL_ID_Msk         (_U_(0xF) << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID(value)      (GCLK_GENCTRL_ID_Msk & ((value) << GCLK_GENCTRL_ID_Pos))
+#define   GCLK_GENCTRL_ID_GCLK0_Val       _U_(0x0)   /**< \brief (GCLK_GENCTRL) Generic clock generator 0 */
+#define   GCLK_GENCTRL_ID_GCLK1_Val       _U_(0x1)   /**< \brief (GCLK_GENCTRL) Generic clock generator 1 */
+#define   GCLK_GENCTRL_ID_GCLK2_Val       _U_(0x2)   /**< \brief (GCLK_GENCTRL) Generic clock generator 2 */
+#define   GCLK_GENCTRL_ID_GCLK3_Val       _U_(0x3)   /**< \brief (GCLK_GENCTRL) Generic clock generator 3 */
+#define   GCLK_GENCTRL_ID_GCLK4_Val       _U_(0x4)   /**< \brief (GCLK_GENCTRL) Generic clock generator 4 */
+#define   GCLK_GENCTRL_ID_GCLK5_Val       _U_(0x5)   /**< \brief (GCLK_GENCTRL) Generic clock generator 5 */
+#define   GCLK_GENCTRL_ID_GCLK6_Val       _U_(0x6)   /**< \brief (GCLK_GENCTRL) Generic clock generator 6 */
+#define   GCLK_GENCTRL_ID_GCLK7_Val       _U_(0x7)   /**< \brief (GCLK_GENCTRL) Generic clock generator 7 */
+#define GCLK_GENCTRL_ID_GCLK0       (GCLK_GENCTRL_ID_GCLK0_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID_GCLK1       (GCLK_GENCTRL_ID_GCLK1_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID_GCLK2       (GCLK_GENCTRL_ID_GCLK2_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID_GCLK3       (GCLK_GENCTRL_ID_GCLK3_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID_GCLK4       (GCLK_GENCTRL_ID_GCLK4_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID_GCLK5       (GCLK_GENCTRL_ID_GCLK5_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID_GCLK6       (GCLK_GENCTRL_ID_GCLK6_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_ID_GCLK7       (GCLK_GENCTRL_ID_GCLK7_Val     << GCLK_GENCTRL_ID_Pos)
+#define GCLK_GENCTRL_SRC_Pos        8            /**< \brief (GCLK_GENCTRL) Source Select */
+#define GCLK_GENCTRL_SRC_Msk        (_U_(0x1F) << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC(value)     (GCLK_GENCTRL_SRC_Msk & ((value) << GCLK_GENCTRL_SRC_Pos))
+#define   GCLK_GENCTRL_SRC_XOSC_Val       _U_(0x0)   /**< \brief (GCLK_GENCTRL) XOSC oscillator output */
+#define   GCLK_GENCTRL_SRC_GCLKIN_Val     _U_(0x1)   /**< \brief (GCLK_GENCTRL) Generator input pad */
+#define   GCLK_GENCTRL_SRC_GCLKGEN1_Val   _U_(0x2)   /**< \brief (GCLK_GENCTRL) Generic clock generator 1 output */
+#define   GCLK_GENCTRL_SRC_OSCULP32K_Val  _U_(0x3)   /**< \brief (GCLK_GENCTRL) OSCULP32K oscillator output */
+#define   GCLK_GENCTRL_SRC_OSC32K_Val     _U_(0x4)   /**< \brief (GCLK_GENCTRL) OSC32K oscillator output */
+#define   GCLK_GENCTRL_SRC_XOSC32K_Val    _U_(0x5)   /**< \brief (GCLK_GENCTRL) XOSC32K oscillator output */
+#define   GCLK_GENCTRL_SRC_OSC8M_Val      _U_(0x6)   /**< \brief (GCLK_GENCTRL) OSC8M oscillator output */
+#define   GCLK_GENCTRL_SRC_DFLL48M_Val    _U_(0x7)   /**< \brief (GCLK_GENCTRL) DFLL48M output */
+#define GCLK_GENCTRL_SRC_XOSC       (GCLK_GENCTRL_SRC_XOSC_Val     << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_GCLKIN     (GCLK_GENCTRL_SRC_GCLKIN_Val   << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_GCLKGEN1   (GCLK_GENCTRL_SRC_GCLKGEN1_Val << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_OSCULP32K  (GCLK_GENCTRL_SRC_OSCULP32K_Val << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_OSC32K     (GCLK_GENCTRL_SRC_OSC32K_Val   << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_XOSC32K    (GCLK_GENCTRL_SRC_XOSC32K_Val  << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_OSC8M      (GCLK_GENCTRL_SRC_OSC8M_Val    << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_SRC_DFLL48M    (GCLK_GENCTRL_SRC_DFLL48M_Val  << GCLK_GENCTRL_SRC_Pos)
+#define GCLK_GENCTRL_GENEN_Pos      16           /**< \brief (GCLK_GENCTRL) Generic Clock Generator Enable */
+#define GCLK_GENCTRL_GENEN          (_U_(0x1) << GCLK_GENCTRL_GENEN_Pos)
+#define GCLK_GENCTRL_IDC_Pos        17           /**< \brief (GCLK_GENCTRL) Improve Duty Cycle */
+#define GCLK_GENCTRL_IDC            (_U_(0x1) << GCLK_GENCTRL_IDC_Pos)
+#define GCLK_GENCTRL_OOV_Pos        18           /**< \brief (GCLK_GENCTRL) Output Off Value */
+#define GCLK_GENCTRL_OOV            (_U_(0x1) << GCLK_GENCTRL_OOV_Pos)
+#define GCLK_GENCTRL_OE_Pos         19           /**< \brief (GCLK_GENCTRL) Output Enable */
+#define GCLK_GENCTRL_OE             (_U_(0x1) << GCLK_GENCTRL_OE_Pos)
+#define GCLK_GENCTRL_DIVSEL_Pos     20           /**< \brief (GCLK_GENCTRL) Divide Selection */
+#define GCLK_GENCTRL_DIVSEL         (_U_(0x1) << GCLK_GENCTRL_DIVSEL_Pos)
+#define   GCLK_GENCTRL_DIVSEL_DIV1_Val    _U_(0x0)   /**< \brief (GCLK_GENCTRL) Divide input directly by divider factor */
+#define   GCLK_GENCTRL_DIVSEL_DIV2_Val    _U_(0x1)   /**< \brief (GCLK_GENCTRL) Divide input by 2^(divider factor + 1) */
+#define GCLK_GENCTRL_DIVSEL_DIV1    (GCLK_GENCTRL_DIVSEL_DIV1_Val  << GCLK_GENCTRL_DIVSEL_Pos)
+#define GCLK_GENCTRL_DIVSEL_DIV2    (GCLK_GENCTRL_DIVSEL_DIV2_Val  << GCLK_GENCTRL_DIVSEL_Pos)
+#define GCLK_GENCTRL_RUNSTDBY_Pos   21           /**< \brief (GCLK_GENCTRL) Run in Standby */
+#define GCLK_GENCTRL_RUNSTDBY       (_U_(0x1) << GCLK_GENCTRL_RUNSTDBY_Pos)
+#define GCLK_GENCTRL_MASK           _U_(0x003F1F0F) /**< \brief (GCLK_GENCTRL) MASK Register */
+
+/* -------- GCLK_GENDIV : (GCLK Offset: 0x8) (R/W 32) Generic Clock Generator Division -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ID:4;             /*!< bit:  0.. 3  Generic Clock Generator Selection  */
+    uint32_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint32_t DIV:16;           /*!< bit:  8..23  Division Factor                    */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} GCLK_GENDIV_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define GCLK_GENDIV_OFFSET          0x8          /**< \brief (GCLK_GENDIV offset) Generic Clock Generator Division */
+#define GCLK_GENDIV_RESETVALUE      _U_(0x00000000) /**< \brief (GCLK_GENDIV reset_value) Generic Clock Generator Division */
+
+#define GCLK_GENDIV_ID_Pos          0            /**< \brief (GCLK_GENDIV) Generic Clock Generator Selection */
+#define GCLK_GENDIV_ID_Msk          (_U_(0xF) << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID(value)       (GCLK_GENDIV_ID_Msk & ((value) << GCLK_GENDIV_ID_Pos))
+#define   GCLK_GENDIV_ID_GCLK0_Val        _U_(0x0)   /**< \brief (GCLK_GENDIV) Generic clock generator 0 */
+#define   GCLK_GENDIV_ID_GCLK1_Val        _U_(0x1)   /**< \brief (GCLK_GENDIV) Generic clock generator 1 */
+#define   GCLK_GENDIV_ID_GCLK2_Val        _U_(0x2)   /**< \brief (GCLK_GENDIV) Generic clock generator 2 */
+#define   GCLK_GENDIV_ID_GCLK3_Val        _U_(0x3)   /**< \brief (GCLK_GENDIV) Generic clock generator 3 */
+#define   GCLK_GENDIV_ID_GCLK4_Val        _U_(0x4)   /**< \brief (GCLK_GENDIV) Generic clock generator 4 */
+#define   GCLK_GENDIV_ID_GCLK5_Val        _U_(0x5)   /**< \brief (GCLK_GENDIV) Generic clock generator 5 */
+#define   GCLK_GENDIV_ID_GCLK6_Val        _U_(0x6)   /**< \brief (GCLK_GENDIV) Generic clock generator 6 */
+#define   GCLK_GENDIV_ID_GCLK7_Val        _U_(0x7)   /**< \brief (GCLK_GENDIV) Generic clock generator 7 */
+#define GCLK_GENDIV_ID_GCLK0        (GCLK_GENDIV_ID_GCLK0_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID_GCLK1        (GCLK_GENDIV_ID_GCLK1_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID_GCLK2        (GCLK_GENDIV_ID_GCLK2_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID_GCLK3        (GCLK_GENDIV_ID_GCLK3_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID_GCLK4        (GCLK_GENDIV_ID_GCLK4_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID_GCLK5        (GCLK_GENDIV_ID_GCLK5_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID_GCLK6        (GCLK_GENDIV_ID_GCLK6_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_ID_GCLK7        (GCLK_GENDIV_ID_GCLK7_Val      << GCLK_GENDIV_ID_Pos)
+#define GCLK_GENDIV_DIV_Pos         8            /**< \brief (GCLK_GENDIV) Division Factor */
+#define GCLK_GENDIV_DIV_Msk         (_U_(0xFFFF) << GCLK_GENDIV_DIV_Pos)
+#define GCLK_GENDIV_DIV(value)      (GCLK_GENDIV_DIV_Msk & ((value) << GCLK_GENDIV_DIV_Pos))
+#define GCLK_GENDIV_MASK            _U_(0x00FFFF0F) /**< \brief (GCLK_GENDIV) MASK Register */
+
+/** \brief GCLK hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO GCLK_CTRL_Type            CTRL;        /**< \brief Offset: 0x0 (R/W  8) Control */
+  __I  GCLK_STATUS_Type          STATUS;      /**< \brief Offset: 0x1 (R/   8) Status */
+  __IO GCLK_CLKCTRL_Type         CLKCTRL;     /**< \brief Offset: 0x2 (R/W 16) Generic Clock Control */
+  __IO GCLK_GENCTRL_Type         GENCTRL;     /**< \brief Offset: 0x4 (R/W 32) Generic Clock Generator Control */
+  __IO GCLK_GENDIV_Type          GENDIV;      /**< \brief Offset: 0x8 (R/W 32) Generic Clock Generator Division */
+} Gclk;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_GCLK_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/nvmctrl.h
@@ -1,0 +1,493 @@
+/**
+ * \file
+ *
+ * \brief Component description for NVMCTRL
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_NVMCTRL_COMPONENT_
+#define _SAMD20_NVMCTRL_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR NVMCTRL */
+/* ========================================================================== */
+/** \addtogroup SAMD20_NVMCTRL Non-Volatile Memory Controller */
+/*@{*/
+
+#define NVMCTRL_U2207
+#define REV_NVMCTRL                 0x109
+
+/* -------- NVMCTRL_CTRLA : (NVMCTRL Offset: 0x00) (R/W 16) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t CMD:7;            /*!< bit:  0.. 6  Command                            */
+    uint16_t :1;               /*!< bit:      7  Reserved                           */
+    uint16_t CMDEX:8;          /*!< bit:  8..15  Command Execution                  */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_CTRLA_OFFSET        0x00         /**< \brief (NVMCTRL_CTRLA offset) Control A */
+#define NVMCTRL_CTRLA_RESETVALUE    _U_(0x0000)  /**< \brief (NVMCTRL_CTRLA reset_value) Control A */
+
+#define NVMCTRL_CTRLA_CMD_Pos       0            /**< \brief (NVMCTRL_CTRLA) Command */
+#define NVMCTRL_CTRLA_CMD_Msk       (_U_(0x7F) << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD(value)    (NVMCTRL_CTRLA_CMD_Msk & ((value) << NVMCTRL_CTRLA_CMD_Pos))
+#define   NVMCTRL_CTRLA_CMD_ER_Val        _U_(0x2)   /**< \brief (NVMCTRL_CTRLA) Erase Row - Erases the row addressed by the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_WP_Val        _U_(0x4)   /**< \brief (NVMCTRL_CTRLA) Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_EAR_Val       _U_(0x5)   /**< \brief (NVMCTRL_CTRLA) Erase Auxiliary Row - Erases the auxiliary row addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row. */
+#define   NVMCTRL_CTRLA_CMD_WAP_Val       _U_(0x6)   /**< \brief (NVMCTRL_CTRLA) Write Auxiliary Page - Writes the contents of the page buffer to the page addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row. */
+#define   NVMCTRL_CTRLA_CMD_SF_Val        _U_(0xA)   /**< \brief (NVMCTRL_CTRLA) Security Flow Command */
+#define   NVMCTRL_CTRLA_CMD_WL_Val        _U_(0xF)   /**< \brief (NVMCTRL_CTRLA) Write lockbits */
+#define   NVMCTRL_CTRLA_CMD_LR_Val        _U_(0x40)   /**< \brief (NVMCTRL_CTRLA) Lock Region - Locks the region containing the address location in the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_UR_Val        _U_(0x41)   /**< \brief (NVMCTRL_CTRLA) Unlock Region - Unlocks the region containing the address location in the ADDR register. */
+#define   NVMCTRL_CTRLA_CMD_SPRM_Val      _U_(0x42)   /**< \brief (NVMCTRL_CTRLA) Sets the power reduction mode. */
+#define   NVMCTRL_CTRLA_CMD_CPRM_Val      _U_(0x43)   /**< \brief (NVMCTRL_CTRLA) Clears the power reduction mode. */
+#define   NVMCTRL_CTRLA_CMD_PBC_Val       _U_(0x44)   /**< \brief (NVMCTRL_CTRLA) Page Buffer Clear - Clears the page buffer. */
+#define   NVMCTRL_CTRLA_CMD_SSB_Val       _U_(0x45)   /**< \brief (NVMCTRL_CTRLA) Set Security Bit - Sets the security bit by writing 0x00 to the first byte in the lockbit row. */
+#define   NVMCTRL_CTRLA_CMD_INVALL_Val    _U_(0x46)   /**< \brief (NVMCTRL_CTRLA) Invalidate all cache lines. */
+#define NVMCTRL_CTRLA_CMD_ER        (NVMCTRL_CTRLA_CMD_ER_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_WP        (NVMCTRL_CTRLA_CMD_WP_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_EAR       (NVMCTRL_CTRLA_CMD_EAR_Val     << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_WAP       (NVMCTRL_CTRLA_CMD_WAP_Val     << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_SF        (NVMCTRL_CTRLA_CMD_SF_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_WL        (NVMCTRL_CTRLA_CMD_WL_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_LR        (NVMCTRL_CTRLA_CMD_LR_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_UR        (NVMCTRL_CTRLA_CMD_UR_Val      << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_SPRM      (NVMCTRL_CTRLA_CMD_SPRM_Val    << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_CPRM      (NVMCTRL_CTRLA_CMD_CPRM_Val    << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_PBC       (NVMCTRL_CTRLA_CMD_PBC_Val     << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_SSB       (NVMCTRL_CTRLA_CMD_SSB_Val     << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMD_INVALL    (NVMCTRL_CTRLA_CMD_INVALL_Val  << NVMCTRL_CTRLA_CMD_Pos)
+#define NVMCTRL_CTRLA_CMDEX_Pos     8            /**< \brief (NVMCTRL_CTRLA) Command Execution */
+#define NVMCTRL_CTRLA_CMDEX_Msk     (_U_(0xFF) << NVMCTRL_CTRLA_CMDEX_Pos)
+#define NVMCTRL_CTRLA_CMDEX(value)  (NVMCTRL_CTRLA_CMDEX_Msk & ((value) << NVMCTRL_CTRLA_CMDEX_Pos))
+#define   NVMCTRL_CTRLA_CMDEX_KEY_Val     _U_(0xA5)   /**< \brief (NVMCTRL_CTRLA) Execution Key */
+#define NVMCTRL_CTRLA_CMDEX_KEY     (NVMCTRL_CTRLA_CMDEX_KEY_Val   << NVMCTRL_CTRLA_CMDEX_Pos)
+#define NVMCTRL_CTRLA_MASK          _U_(0xFF7F)  /**< \brief (NVMCTRL_CTRLA) MASK Register */
+
+/* -------- NVMCTRL_CTRLB : (NVMCTRL Offset: 0x04) (R/W 32) Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t RWS:4;            /*!< bit:  1.. 4  NVM Read Wait States               */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t MANW:1;           /*!< bit:      7  Manual Write                       */
+    uint32_t SLEEPPRM:2;       /*!< bit:  8.. 9  Power Reduction Mode during Sleep  */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t READMODE:2;       /*!< bit: 16..17  NVMCTRL Read Mode                  */
+    uint32_t CACHEDIS:1;       /*!< bit:     18  Cache Disable                      */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_CTRLB_OFFSET        0x04         /**< \brief (NVMCTRL_CTRLB offset) Control B */
+#define NVMCTRL_CTRLB_RESETVALUE    _U_(0x00000000) /**< \brief (NVMCTRL_CTRLB reset_value) Control B */
+
+#define NVMCTRL_CTRLB_RWS_Pos       1            /**< \brief (NVMCTRL_CTRLB) NVM Read Wait States */
+#define NVMCTRL_CTRLB_RWS_Msk       (_U_(0xF) << NVMCTRL_CTRLB_RWS_Pos)
+#define NVMCTRL_CTRLB_RWS(value)    (NVMCTRL_CTRLB_RWS_Msk & ((value) << NVMCTRL_CTRLB_RWS_Pos))
+#define   NVMCTRL_CTRLB_RWS_SINGLE_Val    _U_(0x0)   /**< \brief (NVMCTRL_CTRLB) Single Auto Wait State */
+#define   NVMCTRL_CTRLB_RWS_HALF_Val      _U_(0x1)   /**< \brief (NVMCTRL_CTRLB) Half Auto Wait State */
+#define   NVMCTRL_CTRLB_RWS_DUAL_Val      _U_(0x2)   /**< \brief (NVMCTRL_CTRLB) Dual Auto Wait State */
+#define NVMCTRL_CTRLB_RWS_SINGLE    (NVMCTRL_CTRLB_RWS_SINGLE_Val  << NVMCTRL_CTRLB_RWS_Pos)
+#define NVMCTRL_CTRLB_RWS_HALF      (NVMCTRL_CTRLB_RWS_HALF_Val    << NVMCTRL_CTRLB_RWS_Pos)
+#define NVMCTRL_CTRLB_RWS_DUAL      (NVMCTRL_CTRLB_RWS_DUAL_Val    << NVMCTRL_CTRLB_RWS_Pos)
+#define NVMCTRL_CTRLB_MANW_Pos      7            /**< \brief (NVMCTRL_CTRLB) Manual Write */
+#define NVMCTRL_CTRLB_MANW          (_U_(0x1) << NVMCTRL_CTRLB_MANW_Pos)
+#define NVMCTRL_CTRLB_SLEEPPRM_Pos  8            /**< \brief (NVMCTRL_CTRLB) Power Reduction Mode during Sleep */
+#define NVMCTRL_CTRLB_SLEEPPRM_Msk  (_U_(0x3) << NVMCTRL_CTRLB_SLEEPPRM_Pos)
+#define NVMCTRL_CTRLB_SLEEPPRM(value) (NVMCTRL_CTRLB_SLEEPPRM_Msk & ((value) << NVMCTRL_CTRLB_SLEEPPRM_Pos))
+#define   NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS_Val _U_(0x0)   /**< \brief (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access. */
+#define   NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT_Val _U_(0x1)   /**< \brief (NVMCTRL_CTRLB) NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep. */
+#define   NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val _U_(0x3)   /**< \brief (NVMCTRL_CTRLB) Auto power reduction disabled. */
+#define NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS (NVMCTRL_CTRLB_SLEEPPRM_WAKEONACCESS_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)
+#define NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT (NVMCTRL_CTRLB_SLEEPPRM_WAKEUPINSTANT_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)
+#define NVMCTRL_CTRLB_SLEEPPRM_DISABLED (NVMCTRL_CTRLB_SLEEPPRM_DISABLED_Val << NVMCTRL_CTRLB_SLEEPPRM_Pos)
+#define NVMCTRL_CTRLB_READMODE_Pos  16           /**< \brief (NVMCTRL_CTRLB) NVMCTRL Read Mode */
+#define NVMCTRL_CTRLB_READMODE_Msk  (_U_(0x3) << NVMCTRL_CTRLB_READMODE_Pos)
+#define NVMCTRL_CTRLB_READMODE(value) (NVMCTRL_CTRLB_READMODE_Msk & ((value) << NVMCTRL_CTRLB_READMODE_Pos))
+#define   NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY_Val _U_(0x0)   /**< \brief (NVMCTRL_CTRLB) The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance. */
+#define   NVMCTRL_CTRLB_READMODE_LOW_POWER_Val _U_(0x1)   /**< \brief (NVMCTRL_CTRLB) Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time. */
+#define   NVMCTRL_CTRLB_READMODE_DETERMINISTIC_Val _U_(0x2)   /**< \brief (NVMCTRL_CTRLB) The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings. */
+#define NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY (NVMCTRL_CTRLB_READMODE_NO_MISS_PENALTY_Val << NVMCTRL_CTRLB_READMODE_Pos)
+#define NVMCTRL_CTRLB_READMODE_LOW_POWER (NVMCTRL_CTRLB_READMODE_LOW_POWER_Val << NVMCTRL_CTRLB_READMODE_Pos)
+#define NVMCTRL_CTRLB_READMODE_DETERMINISTIC (NVMCTRL_CTRLB_READMODE_DETERMINISTIC_Val << NVMCTRL_CTRLB_READMODE_Pos)
+#define NVMCTRL_CTRLB_CACHEDIS_Pos  18           /**< \brief (NVMCTRL_CTRLB) Cache Disable */
+#define NVMCTRL_CTRLB_CACHEDIS      (_U_(0x1) << NVMCTRL_CTRLB_CACHEDIS_Pos)
+#define NVMCTRL_CTRLB_MASK          _U_(0x0007039E) /**< \brief (NVMCTRL_CTRLB) MASK Register */
+
+/* -------- NVMCTRL_PARAM : (NVMCTRL Offset: 0x08) (R/W 32) NVM Parameter -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t NVMP:16;          /*!< bit:  0..15  NVM Pages                          */
+    uint32_t PSZ:3;            /*!< bit: 16..18  Page Size                          */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_PARAM_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_PARAM_OFFSET        0x08         /**< \brief (NVMCTRL_PARAM offset) NVM Parameter */
+#define NVMCTRL_PARAM_RESETVALUE    _U_(0x00000000) /**< \brief (NVMCTRL_PARAM reset_value) NVM Parameter */
+
+#define NVMCTRL_PARAM_NVMP_Pos      0            /**< \brief (NVMCTRL_PARAM) NVM Pages */
+#define NVMCTRL_PARAM_NVMP_Msk      (_U_(0xFFFF) << NVMCTRL_PARAM_NVMP_Pos)
+#define NVMCTRL_PARAM_NVMP(value)   (NVMCTRL_PARAM_NVMP_Msk & ((value) << NVMCTRL_PARAM_NVMP_Pos))
+#define NVMCTRL_PARAM_PSZ_Pos       16           /**< \brief (NVMCTRL_PARAM) Page Size */
+#define NVMCTRL_PARAM_PSZ_Msk       (_U_(0x7) << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ(value)    (NVMCTRL_PARAM_PSZ_Msk & ((value) << NVMCTRL_PARAM_PSZ_Pos))
+#define   NVMCTRL_PARAM_PSZ_8_Val         _U_(0x0)   /**< \brief (NVMCTRL_PARAM) 8 bytes */
+#define   NVMCTRL_PARAM_PSZ_16_Val        _U_(0x1)   /**< \brief (NVMCTRL_PARAM) 16 bytes */
+#define   NVMCTRL_PARAM_PSZ_32_Val        _U_(0x2)   /**< \brief (NVMCTRL_PARAM) 32 bytes */
+#define   NVMCTRL_PARAM_PSZ_64_Val        _U_(0x3)   /**< \brief (NVMCTRL_PARAM) 64 bytes */
+#define   NVMCTRL_PARAM_PSZ_128_Val       _U_(0x4)   /**< \brief (NVMCTRL_PARAM) 128 bytes */
+#define   NVMCTRL_PARAM_PSZ_256_Val       _U_(0x5)   /**< \brief (NVMCTRL_PARAM) 256 bytes */
+#define   NVMCTRL_PARAM_PSZ_512_Val       _U_(0x6)   /**< \brief (NVMCTRL_PARAM) 512 bytes */
+#define   NVMCTRL_PARAM_PSZ_1024_Val      _U_(0x7)   /**< \brief (NVMCTRL_PARAM) 1024 bytes */
+#define NVMCTRL_PARAM_PSZ_8         (NVMCTRL_PARAM_PSZ_8_Val       << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_16        (NVMCTRL_PARAM_PSZ_16_Val      << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_32        (NVMCTRL_PARAM_PSZ_32_Val      << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_64        (NVMCTRL_PARAM_PSZ_64_Val      << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_128       (NVMCTRL_PARAM_PSZ_128_Val     << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_256       (NVMCTRL_PARAM_PSZ_256_Val     << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_512       (NVMCTRL_PARAM_PSZ_512_Val     << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_PSZ_1024      (NVMCTRL_PARAM_PSZ_1024_Val    << NVMCTRL_PARAM_PSZ_Pos)
+#define NVMCTRL_PARAM_MASK          _U_(0x0007FFFF) /**< \brief (NVMCTRL_PARAM) MASK Register */
+
+/* -------- NVMCTRL_INTENCLR : (NVMCTRL Offset: 0x0C) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  READY:1;          /*!< bit:      0  NVM Ready Interrupt Enable         */
+    uint8_t  ERROR:1;          /*!< bit:      1  Error Interrupt Enable             */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} NVMCTRL_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_INTENCLR_OFFSET     0x0C         /**< \brief (NVMCTRL_INTENCLR offset) Interrupt Enable Clear */
+#define NVMCTRL_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (NVMCTRL_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define NVMCTRL_INTENCLR_READY_Pos  0            /**< \brief (NVMCTRL_INTENCLR) NVM Ready Interrupt Enable */
+#define NVMCTRL_INTENCLR_READY      (_U_(0x1) << NVMCTRL_INTENCLR_READY_Pos)
+#define NVMCTRL_INTENCLR_ERROR_Pos  1            /**< \brief (NVMCTRL_INTENCLR) Error Interrupt Enable */
+#define NVMCTRL_INTENCLR_ERROR      (_U_(0x1) << NVMCTRL_INTENCLR_ERROR_Pos)
+#define NVMCTRL_INTENCLR_MASK       _U_(0x03)    /**< \brief (NVMCTRL_INTENCLR) MASK Register */
+
+/* -------- NVMCTRL_INTENSET : (NVMCTRL Offset: 0x10) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  READY:1;          /*!< bit:      0  NVM Ready Interrupt Enable         */
+    uint8_t  ERROR:1;          /*!< bit:      1  Error Interrupt Enable             */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} NVMCTRL_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_INTENSET_OFFSET     0x10         /**< \brief (NVMCTRL_INTENSET offset) Interrupt Enable Set */
+#define NVMCTRL_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (NVMCTRL_INTENSET reset_value) Interrupt Enable Set */
+
+#define NVMCTRL_INTENSET_READY_Pos  0            /**< \brief (NVMCTRL_INTENSET) NVM Ready Interrupt Enable */
+#define NVMCTRL_INTENSET_READY      (_U_(0x1) << NVMCTRL_INTENSET_READY_Pos)
+#define NVMCTRL_INTENSET_ERROR_Pos  1            /**< \brief (NVMCTRL_INTENSET) Error Interrupt Enable */
+#define NVMCTRL_INTENSET_ERROR      (_U_(0x1) << NVMCTRL_INTENSET_ERROR_Pos)
+#define NVMCTRL_INTENSET_MASK       _U_(0x03)    /**< \brief (NVMCTRL_INTENSET) MASK Register */
+
+/* -------- NVMCTRL_INTFLAG : (NVMCTRL Offset: 0x14) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  READY:1;          /*!< bit:      0  NVM Ready                          */
+    __I uint8_t  ERROR:1;          /*!< bit:      1  Error                              */
+    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} NVMCTRL_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_INTFLAG_OFFSET      0x14         /**< \brief (NVMCTRL_INTFLAG offset) Interrupt Flag Status and Clear */
+#define NVMCTRL_INTFLAG_RESETVALUE  _U_(0x00)    /**< \brief (NVMCTRL_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define NVMCTRL_INTFLAG_READY_Pos   0            /**< \brief (NVMCTRL_INTFLAG) NVM Ready */
+#define NVMCTRL_INTFLAG_READY       (_U_(0x1) << NVMCTRL_INTFLAG_READY_Pos)
+#define NVMCTRL_INTFLAG_ERROR_Pos   1            /**< \brief (NVMCTRL_INTFLAG) Error */
+#define NVMCTRL_INTFLAG_ERROR       (_U_(0x1) << NVMCTRL_INTFLAG_ERROR_Pos)
+#define NVMCTRL_INTFLAG_MASK        _U_(0x03)    /**< \brief (NVMCTRL_INTFLAG) MASK Register */
+
+/* -------- NVMCTRL_STATUS : (NVMCTRL Offset: 0x18) (R/W 16) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PRM:1;            /*!< bit:      0  Power Reduction Mode               */
+    uint16_t LOAD:1;           /*!< bit:      1  NVM Page Buffer Active Loading     */
+    uint16_t PROGE:1;          /*!< bit:      2  Programming Error Status           */
+    uint16_t LOCKE:1;          /*!< bit:      3  Lock Error Status                  */
+    uint16_t NVME:1;           /*!< bit:      4  NVM Error                          */
+    uint16_t :3;               /*!< bit:  5.. 7  Reserved                           */
+    uint16_t SB:1;             /*!< bit:      8  Security Bit Status                */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_STATUS_OFFSET       0x18         /**< \brief (NVMCTRL_STATUS offset) Status */
+#define NVMCTRL_STATUS_RESETVALUE   _U_(0x0000)  /**< \brief (NVMCTRL_STATUS reset_value) Status */
+
+#define NVMCTRL_STATUS_PRM_Pos      0            /**< \brief (NVMCTRL_STATUS) Power Reduction Mode */
+#define NVMCTRL_STATUS_PRM          (_U_(0x1) << NVMCTRL_STATUS_PRM_Pos)
+#define NVMCTRL_STATUS_LOAD_Pos     1            /**< \brief (NVMCTRL_STATUS) NVM Page Buffer Active Loading */
+#define NVMCTRL_STATUS_LOAD         (_U_(0x1) << NVMCTRL_STATUS_LOAD_Pos)
+#define NVMCTRL_STATUS_PROGE_Pos    2            /**< \brief (NVMCTRL_STATUS) Programming Error Status */
+#define NVMCTRL_STATUS_PROGE        (_U_(0x1) << NVMCTRL_STATUS_PROGE_Pos)
+#define NVMCTRL_STATUS_LOCKE_Pos    3            /**< \brief (NVMCTRL_STATUS) Lock Error Status */
+#define NVMCTRL_STATUS_LOCKE        (_U_(0x1) << NVMCTRL_STATUS_LOCKE_Pos)
+#define NVMCTRL_STATUS_NVME_Pos     4            /**< \brief (NVMCTRL_STATUS) NVM Error */
+#define NVMCTRL_STATUS_NVME         (_U_(0x1) << NVMCTRL_STATUS_NVME_Pos)
+#define NVMCTRL_STATUS_SB_Pos       8            /**< \brief (NVMCTRL_STATUS) Security Bit Status */
+#define NVMCTRL_STATUS_SB           (_U_(0x1) << NVMCTRL_STATUS_SB_Pos)
+#define NVMCTRL_STATUS_MASK         _U_(0x011F)  /**< \brief (NVMCTRL_STATUS) MASK Register */
+
+/* -------- NVMCTRL_ADDR : (NVMCTRL Offset: 0x1C) (R/W 32) Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ADDR:22;          /*!< bit:  0..21  NVM Address                        */
+    uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_ADDR_OFFSET         0x1C         /**< \brief (NVMCTRL_ADDR offset) Address */
+#define NVMCTRL_ADDR_RESETVALUE     _U_(0x00000000) /**< \brief (NVMCTRL_ADDR reset_value) Address */
+
+#define NVMCTRL_ADDR_ADDR_Pos       0            /**< \brief (NVMCTRL_ADDR) NVM Address */
+#define NVMCTRL_ADDR_ADDR_Msk       (_U_(0x3FFFFF) << NVMCTRL_ADDR_ADDR_Pos)
+#define NVMCTRL_ADDR_ADDR(value)    (NVMCTRL_ADDR_ADDR_Msk & ((value) << NVMCTRL_ADDR_ADDR_Pos))
+#define NVMCTRL_ADDR_MASK           _U_(0x003FFFFF) /**< \brief (NVMCTRL_ADDR) MASK Register */
+
+/* -------- NVMCTRL_LOCK : (NVMCTRL Offset: 0x20) (R/W 16) Lock Section -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t LOCK:16;          /*!< bit:  0..15  Region Lock Bits                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} NVMCTRL_LOCK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define NVMCTRL_LOCK_OFFSET         0x20         /**< \brief (NVMCTRL_LOCK offset) Lock Section */
+#define NVMCTRL_LOCK_RESETVALUE     _U_(0x0000)  /**< \brief (NVMCTRL_LOCK reset_value) Lock Section */
+
+#define NVMCTRL_LOCK_LOCK_Pos       0            /**< \brief (NVMCTRL_LOCK) Region Lock Bits */
+#define NVMCTRL_LOCK_LOCK_Msk       (_U_(0xFFFF) << NVMCTRL_LOCK_LOCK_Pos)
+#define NVMCTRL_LOCK_LOCK(value)    (NVMCTRL_LOCK_LOCK_Msk & ((value) << NVMCTRL_LOCK_LOCK_Pos))
+#define NVMCTRL_LOCK_MASK           _U_(0xFFFF)  /**< \brief (NVMCTRL_LOCK) MASK Register */
+
+/** \brief NVMCTRL APB hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO NVMCTRL_CTRLA_Type        CTRLA;       /**< \brief Offset: 0x00 (R/W 16) Control A */
+       RoReg8                    Reserved1[0x2];
+  __IO NVMCTRL_CTRLB_Type        CTRLB;       /**< \brief Offset: 0x04 (R/W 32) Control B */
+  __IO NVMCTRL_PARAM_Type        PARAM;       /**< \brief Offset: 0x08 (R/W 32) NVM Parameter */
+  __IO NVMCTRL_INTENCLR_Type     INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) Interrupt Enable Clear */
+       RoReg8                    Reserved2[0x3];
+  __IO NVMCTRL_INTENSET_Type     INTENSET;    /**< \brief Offset: 0x10 (R/W  8) Interrupt Enable Set */
+       RoReg8                    Reserved3[0x3];
+  __IO NVMCTRL_INTFLAG_Type      INTFLAG;     /**< \brief Offset: 0x14 (R/W  8) Interrupt Flag Status and Clear */
+       RoReg8                    Reserved4[0x3];
+  __IO NVMCTRL_STATUS_Type       STATUS;      /**< \brief Offset: 0x18 (R/W 16) Status */
+       RoReg8                    Reserved5[0x2];
+  __IO NVMCTRL_ADDR_Type         ADDR;        /**< \brief Offset: 0x1C (R/W 32) Address */
+  __IO NVMCTRL_LOCK_Type         LOCK;        /**< \brief Offset: 0x20 (R/W 16) Lock Section */
+} Nvmctrl;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SECTION_NVMCTRL_CAL
+#define SECTION_NVMCTRL_LOCKBIT
+#define SECTION_NVMCTRL_OTP1
+#define SECTION_NVMCTRL_OTP2
+#define SECTION_NVMCTRL_OTP4
+#define SECTION_NVMCTRL_TEMP_LOG
+#define SECTION_NVMCTRL_USER
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR NON-VOLATILE FUSES */
+/* ************************************************************************** */
+/** \addtogroup fuses_api Peripheral Software API */
+/*@{*/
+
+
+#define ADC_FUSES_BIASCAL_ADDR      (NVMCTRL_OTP4 + 4)
+#define ADC_FUSES_BIASCAL_Pos       3            /**< \brief (NVMCTRL_OTP4) ADC Bias Calibration */
+#define ADC_FUSES_BIASCAL_Msk       (_U_(0x7) << ADC_FUSES_BIASCAL_Pos)
+#define ADC_FUSES_BIASCAL(value)    (ADC_FUSES_BIASCAL_Msk & ((value) << ADC_FUSES_BIASCAL_Pos))
+
+#define ADC_FUSES_LINEARITY_0_ADDR  NVMCTRL_OTP4
+#define ADC_FUSES_LINEARITY_0_Pos   27           /**< \brief (NVMCTRL_OTP4) ADC Linearity bits 4:0 */
+#define ADC_FUSES_LINEARITY_0_Msk   (_U_(0x1F) << ADC_FUSES_LINEARITY_0_Pos)
+#define ADC_FUSES_LINEARITY_0(value) (ADC_FUSES_LINEARITY_0_Msk & ((value) << ADC_FUSES_LINEARITY_0_Pos))
+
+#define ADC_FUSES_LINEARITY_1_ADDR  (NVMCTRL_OTP4 + 4)
+#define ADC_FUSES_LINEARITY_1_Pos   0            /**< \brief (NVMCTRL_OTP4) ADC Linearity bits 7:5 */
+#define ADC_FUSES_LINEARITY_1_Msk   (_U_(0x7) << ADC_FUSES_LINEARITY_1_Pos)
+#define ADC_FUSES_LINEARITY_1(value) (ADC_FUSES_LINEARITY_1_Msk & ((value) << ADC_FUSES_LINEARITY_1_Pos))
+
+#define FUSES_BOD33USERLEVEL_ADDR   NVMCTRL_USER
+#define FUSES_BOD33USERLEVEL_Pos    8            /**< \brief (NVMCTRL_USER) BOD33 User Level */
+#define FUSES_BOD33USERLEVEL_Msk    (_U_(0x3F) << FUSES_BOD33USERLEVEL_Pos)
+#define FUSES_BOD33USERLEVEL(value) (FUSES_BOD33USERLEVEL_Msk & ((value) << FUSES_BOD33USERLEVEL_Pos))
+
+#define FUSES_BOD33_ACTION_ADDR     NVMCTRL_USER
+#define FUSES_BOD33_ACTION_Pos      15           /**< \brief (NVMCTRL_USER) BOD33 Action */
+#define FUSES_BOD33_ACTION_Msk      (_U_(0x3) << FUSES_BOD33_ACTION_Pos)
+#define FUSES_BOD33_ACTION(value)   (FUSES_BOD33_ACTION_Msk & ((value) << FUSES_BOD33_ACTION_Pos))
+
+#define FUSES_BOD33_EN_ADDR         NVMCTRL_USER
+#define FUSES_BOD33_EN_Pos          14           /**< \brief (NVMCTRL_USER) BOD33 Enable */
+#define FUSES_BOD33_EN_Msk          (_U_(0x1) << FUSES_BOD33_EN_Pos)
+
+#define FUSES_BOD33_HYST_ADDR       (NVMCTRL_USER + 4)
+#define FUSES_BOD33_HYST_Pos        8            /**< \brief (NVMCTRL_USER) BOD33 Hysteresis */
+#define FUSES_BOD33_HYST_Msk        (_U_(0x1) << FUSES_BOD33_HYST_Pos)
+
+#define FUSES_DFLL48M_COARSE_CAL_ADDR (NVMCTRL_OTP4 + 4)
+#define FUSES_DFLL48M_COARSE_CAL_Pos 26           /**< \brief (NVMCTRL_OTP4) DFLL48M Coarse Calibration */
+#define FUSES_DFLL48M_COARSE_CAL_Msk (_U_(0x3F) << FUSES_DFLL48M_COARSE_CAL_Pos)
+#define FUSES_DFLL48M_COARSE_CAL(value) (FUSES_DFLL48M_COARSE_CAL_Msk & ((value) << FUSES_DFLL48M_COARSE_CAL_Pos))
+
+#define FUSES_DFLL48M_FINE_CAL_ADDR (NVMCTRL_OTP4 + 8)
+#define FUSES_DFLL48M_FINE_CAL_Pos  0            /**< \brief (NVMCTRL_OTP4) DFLL48M Fine Calibration */
+#define FUSES_DFLL48M_FINE_CAL_Msk  (_U_(0x3FF) << FUSES_DFLL48M_FINE_CAL_Pos)
+#define FUSES_DFLL48M_FINE_CAL(value) (FUSES_DFLL48M_FINE_CAL_Msk & ((value) << FUSES_DFLL48M_FINE_CAL_Pos))
+
+#define FUSES_OSC32KCAL_ADDR        (NVMCTRL_OTP4 + 4)
+#define FUSES_OSC32KCAL_Pos         6            /**< \brief (NVMCTRL_OTP4) OSC32K Calibration */
+#define FUSES_OSC32KCAL_Msk         (_U_(0x7F) << FUSES_OSC32KCAL_Pos)
+#define FUSES_OSC32KCAL(value)      (FUSES_OSC32KCAL_Msk & ((value) << FUSES_OSC32KCAL_Pos))
+
+#define NVMCTRL_FUSES_BOOTPROT_ADDR NVMCTRL_USER
+#define NVMCTRL_FUSES_BOOTPROT_Pos  0            /**< \brief (NVMCTRL_USER) Bootloader Size */
+#define NVMCTRL_FUSES_BOOTPROT_Msk  (_U_(0x7) << NVMCTRL_FUSES_BOOTPROT_Pos)
+#define NVMCTRL_FUSES_BOOTPROT(value) (NVMCTRL_FUSES_BOOTPROT_Msk & ((value) << NVMCTRL_FUSES_BOOTPROT_Pos))
+
+#define NVMCTRL_FUSES_EEPROM_SIZE_ADDR NVMCTRL_USER
+#define NVMCTRL_FUSES_EEPROM_SIZE_Pos 4            /**< \brief (NVMCTRL_USER) EEPROM Size */
+#define NVMCTRL_FUSES_EEPROM_SIZE_Msk (_U_(0x7) << NVMCTRL_FUSES_EEPROM_SIZE_Pos)
+#define NVMCTRL_FUSES_EEPROM_SIZE(value) (NVMCTRL_FUSES_EEPROM_SIZE_Msk & ((value) << NVMCTRL_FUSES_EEPROM_SIZE_Pos))
+
+#define NVMCTRL_FUSES_HOT_ADC_VAL_ADDR (NVMCTRL_TEMP_LOG + 4)
+#define NVMCTRL_FUSES_HOT_ADC_VAL_Pos 20           /**< \brief (NVMCTRL_TEMP_LOG) 12-bit ADC conversion at hot temperature */
+#define NVMCTRL_FUSES_HOT_ADC_VAL_Msk (_U_(0xFFF) << NVMCTRL_FUSES_HOT_ADC_VAL_Pos)
+#define NVMCTRL_FUSES_HOT_ADC_VAL(value) (NVMCTRL_FUSES_HOT_ADC_VAL_Msk & ((value) << NVMCTRL_FUSES_HOT_ADC_VAL_Pos))
+
+#define NVMCTRL_FUSES_HOT_INT1V_VAL_ADDR (NVMCTRL_TEMP_LOG + 4)
+#define NVMCTRL_FUSES_HOT_INT1V_VAL_Pos 0            /**< \brief (NVMCTRL_TEMP_LOG) 2's complement of the internal 1V reference drift at hot temperature (versus a 1.0 centered value) */
+#define NVMCTRL_FUSES_HOT_INT1V_VAL_Msk (_U_(0xFF) << NVMCTRL_FUSES_HOT_INT1V_VAL_Pos)
+#define NVMCTRL_FUSES_HOT_INT1V_VAL(value) (NVMCTRL_FUSES_HOT_INT1V_VAL_Msk & ((value) << NVMCTRL_FUSES_HOT_INT1V_VAL_Pos))
+
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_DEC_ADDR NVMCTRL_TEMP_LOG
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_DEC_Pos 20           /**< \brief (NVMCTRL_TEMP_LOG) Decimal part of hot temperature */
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_DEC_Msk (_U_(0xF) << NVMCTRL_FUSES_HOT_TEMP_VAL_DEC_Pos)
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_DEC(value) (NVMCTRL_FUSES_HOT_TEMP_VAL_DEC_Msk & ((value) << NVMCTRL_FUSES_HOT_TEMP_VAL_DEC_Pos))
+
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_INT_ADDR NVMCTRL_TEMP_LOG
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_INT_Pos 12           /**< \brief (NVMCTRL_TEMP_LOG) Integer part of hot temperature in oC */
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_INT_Msk (_U_(0xFF) << NVMCTRL_FUSES_HOT_TEMP_VAL_INT_Pos)
+#define NVMCTRL_FUSES_HOT_TEMP_VAL_INT(value) (NVMCTRL_FUSES_HOT_TEMP_VAL_INT_Msk & ((value) << NVMCTRL_FUSES_HOT_TEMP_VAL_INT_Pos))
+
+#define NVMCTRL_FUSES_REGION_LOCKS_ADDR (NVMCTRL_USER + 4)
+#define NVMCTRL_FUSES_REGION_LOCKS_Pos 16           /**< \brief (NVMCTRL_USER) NVM Region Locks */
+#define NVMCTRL_FUSES_REGION_LOCKS_Msk (_U_(0xFFFF) << NVMCTRL_FUSES_REGION_LOCKS_Pos)
+#define NVMCTRL_FUSES_REGION_LOCKS(value) (NVMCTRL_FUSES_REGION_LOCKS_Msk & ((value) << NVMCTRL_FUSES_REGION_LOCKS_Pos))
+
+#define NVMCTRL_FUSES_ROOM_ADC_VAL_ADDR (NVMCTRL_TEMP_LOG + 4)
+#define NVMCTRL_FUSES_ROOM_ADC_VAL_Pos 8            /**< \brief (NVMCTRL_TEMP_LOG) 12-bit ADC conversion at room temperature */
+#define NVMCTRL_FUSES_ROOM_ADC_VAL_Msk (_U_(0xFFF) << NVMCTRL_FUSES_ROOM_ADC_VAL_Pos)
+#define NVMCTRL_FUSES_ROOM_ADC_VAL(value) (NVMCTRL_FUSES_ROOM_ADC_VAL_Msk & ((value) << NVMCTRL_FUSES_ROOM_ADC_VAL_Pos))
+
+#define NVMCTRL_FUSES_ROOM_INT1V_VAL_ADDR NVMCTRL_TEMP_LOG
+#define NVMCTRL_FUSES_ROOM_INT1V_VAL_Pos 24           /**< \brief (NVMCTRL_TEMP_LOG) 2's complement of the internal 1V reference drift at room temperature (versus a 1.0 centered value) */
+#define NVMCTRL_FUSES_ROOM_INT1V_VAL_Msk (_U_(0xFF) << NVMCTRL_FUSES_ROOM_INT1V_VAL_Pos)
+#define NVMCTRL_FUSES_ROOM_INT1V_VAL(value) (NVMCTRL_FUSES_ROOM_INT1V_VAL_Msk & ((value) << NVMCTRL_FUSES_ROOM_INT1V_VAL_Pos))
+
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_DEC_ADDR NVMCTRL_TEMP_LOG
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_DEC_Pos 8            /**< \brief (NVMCTRL_TEMP_LOG) Decimal part of room temperature */
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_DEC_Msk (_U_(0xF) << NVMCTRL_FUSES_ROOM_TEMP_VAL_DEC_Pos)
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_DEC(value) (NVMCTRL_FUSES_ROOM_TEMP_VAL_DEC_Msk & ((value) << NVMCTRL_FUSES_ROOM_TEMP_VAL_DEC_Pos))
+
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_INT_ADDR NVMCTRL_TEMP_LOG
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_INT_Pos 0            /**< \brief (NVMCTRL_TEMP_LOG) Integer part of room temperature in oC */
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_INT_Msk (_U_(0xFF) << NVMCTRL_FUSES_ROOM_TEMP_VAL_INT_Pos)
+#define NVMCTRL_FUSES_ROOM_TEMP_VAL_INT(value) (NVMCTRL_FUSES_ROOM_TEMP_VAL_INT_Msk & ((value) << NVMCTRL_FUSES_ROOM_TEMP_VAL_INT_Pos))
+
+#define WDT_FUSES_ALWAYSON_ADDR     NVMCTRL_USER
+#define WDT_FUSES_ALWAYSON_Pos      26           /**< \brief (NVMCTRL_USER) WDT Always On */
+#define WDT_FUSES_ALWAYSON_Msk      (_U_(0x1) << WDT_FUSES_ALWAYSON_Pos)
+
+#define WDT_FUSES_ENABLE_ADDR       NVMCTRL_USER
+#define WDT_FUSES_ENABLE_Pos        25           /**< \brief (NVMCTRL_USER) WDT Enable */
+#define WDT_FUSES_ENABLE_Msk        (_U_(0x1) << WDT_FUSES_ENABLE_Pos)
+
+#define WDT_FUSES_EWOFFSET_ADDR     (NVMCTRL_USER + 4)
+#define WDT_FUSES_EWOFFSET_Pos      3            /**< \brief (NVMCTRL_USER) WDT Early Warning Offset */
+#define WDT_FUSES_EWOFFSET_Msk      (_U_(0xF) << WDT_FUSES_EWOFFSET_Pos)
+#define WDT_FUSES_EWOFFSET(value)   (WDT_FUSES_EWOFFSET_Msk & ((value) << WDT_FUSES_EWOFFSET_Pos))
+
+#define WDT_FUSES_PER_ADDR          NVMCTRL_USER
+#define WDT_FUSES_PER_Pos           27           /**< \brief (NVMCTRL_USER) WDT Period */
+#define WDT_FUSES_PER_Msk           (_U_(0xF) << WDT_FUSES_PER_Pos)
+#define WDT_FUSES_PER(value)        (WDT_FUSES_PER_Msk & ((value) << WDT_FUSES_PER_Pos))
+
+#define WDT_FUSES_WEN_ADDR          (NVMCTRL_USER + 4)
+#define WDT_FUSES_WEN_Pos           7            /**< \brief (NVMCTRL_USER) WDT Window Mode Enable */
+#define WDT_FUSES_WEN_Msk           (_U_(0x1) << WDT_FUSES_WEN_Pos)
+
+#define WDT_FUSES_WINDOW_0_ADDR     NVMCTRL_USER
+#define WDT_FUSES_WINDOW_0_Pos      31           /**< \brief (NVMCTRL_USER) WDT Window bit 0 */
+#define WDT_FUSES_WINDOW_0_Msk      (_U_(0x1) << WDT_FUSES_WINDOW_0_Pos)
+
+#define WDT_FUSES_WINDOW_1_ADDR     (NVMCTRL_USER + 4)
+#define WDT_FUSES_WINDOW_1_Pos      0            /**< \brief (NVMCTRL_USER) WDT Window bits 3:1 */
+#define WDT_FUSES_WINDOW_1_Msk      (_U_(0x7) << WDT_FUSES_WINDOW_1_Pos)
+#define WDT_FUSES_WINDOW_1(value)   (WDT_FUSES_WINDOW_1_Msk & ((value) << WDT_FUSES_WINDOW_1_Pos))
+
+/*@}*/
+
+#endif /* _SAMD20_NVMCTRL_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/pac.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/pac.h
@@ -1,0 +1,90 @@
+/**
+ * \file
+ *
+ * \brief Component description for PAC
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PAC_COMPONENT_
+#define _SAMD20_PAC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PAC */
+/* ========================================================================== */
+/** \addtogroup SAMD20_PAC Peripheral Access Controller */
+/*@{*/
+
+#define PAC_U2211
+#define REV_PAC                     0x101
+
+/* -------- PAC_WPCLR : (PAC Offset: 0x0) (R/W 32) Write Protection Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t WP:31;            /*!< bit:  1..31  Write Protection Clear             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_WPCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_WPCLR_OFFSET            0x0          /**< \brief (PAC_WPCLR offset) Write Protection Clear */
+#define PAC_WPCLR_RESETVALUE        _U_(0x00000000) /**< \brief (PAC_WPCLR reset_value) Write Protection Clear */
+
+#define PAC_WPCLR_WP_Pos            1            /**< \brief (PAC_WPCLR) Write Protection Clear */
+#define PAC_WPCLR_WP_Msk            (_U_(0x7FFFFFFF) << PAC_WPCLR_WP_Pos)
+#define PAC_WPCLR_WP(value)         (PAC_WPCLR_WP_Msk & ((value) << PAC_WPCLR_WP_Pos))
+#define PAC_WPCLR_MASK              _U_(0xFFFFFFFE) /**< \brief (PAC_WPCLR) MASK Register */
+
+/* -------- PAC_WPSET : (PAC Offset: 0x4) (R/W 32) Write Protection Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t WP:31;            /*!< bit:  1..31  Write Protection Set               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PAC_WPSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PAC_WPSET_OFFSET            0x4          /**< \brief (PAC_WPSET offset) Write Protection Set */
+#define PAC_WPSET_RESETVALUE        _U_(0x00000000) /**< \brief (PAC_WPSET reset_value) Write Protection Set */
+
+#define PAC_WPSET_WP_Pos            1            /**< \brief (PAC_WPSET) Write Protection Set */
+#define PAC_WPSET_WP_Msk            (_U_(0x7FFFFFFF) << PAC_WPSET_WP_Pos)
+#define PAC_WPSET_WP(value)         (PAC_WPSET_WP_Msk & ((value) << PAC_WPSET_WP_Pos))
+#define PAC_WPSET_MASK              _U_(0xFFFFFFFE) /**< \brief (PAC_WPSET) MASK Register */
+
+/** \brief PAC hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO PAC_WPCLR_Type            WPCLR;       /**< \brief Offset: 0x0 (R/W 32) Write Protection Clear */
+  __IO PAC_WPSET_Type            WPSET;       /**< \brief Offset: 0x4 (R/W 32) Write Protection Set */
+} Pac;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_PAC_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/pm.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/pm.h
@@ -1,0 +1,501 @@
+/**
+ * \file
+ *
+ * \brief Component description for PM
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PM_COMPONENT_
+#define _SAMD20_PM_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PM */
+/* ========================================================================== */
+/** \addtogroup SAMD20_PM Power Manager */
+/*@{*/
+
+#define PM_U2206
+#define REV_PM                      0x202
+
+/* -------- PM_CTRL : (PM Offset: 0x00) (R/W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_CTRL_OFFSET              0x00         /**< \brief (PM_CTRL offset) Control */
+#define PM_CTRL_RESETVALUE          _U_(0x00)    /**< \brief (PM_CTRL reset_value) Control */
+
+#define PM_CTRL_MASK                _U_(0x00)    /**< \brief (PM_CTRL) MASK Register */
+
+/* -------- PM_SLEEP : (PM Offset: 0x01) (R/W  8) Sleep Mode -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  IDLE:2;           /*!< bit:  0.. 1  Idle Mode Configuration            */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_SLEEP_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_SLEEP_OFFSET             0x01         /**< \brief (PM_SLEEP offset) Sleep Mode */
+#define PM_SLEEP_RESETVALUE         _U_(0x00)    /**< \brief (PM_SLEEP reset_value) Sleep Mode */
+
+#define PM_SLEEP_IDLE_Pos           0            /**< \brief (PM_SLEEP) Idle Mode Configuration */
+#define PM_SLEEP_IDLE_Msk           (_U_(0x3) << PM_SLEEP_IDLE_Pos)
+#define PM_SLEEP_IDLE(value)        (PM_SLEEP_IDLE_Msk & ((value) << PM_SLEEP_IDLE_Pos))
+#define   PM_SLEEP_IDLE_CPU_Val           _U_(0x0)   /**< \brief (PM_SLEEP) The CPU clock domain is stopped */
+#define   PM_SLEEP_IDLE_AHB_Val           _U_(0x1)   /**< \brief (PM_SLEEP) The CPU and AHB clock domains are stopped */
+#define   PM_SLEEP_IDLE_APB_Val           _U_(0x2)   /**< \brief (PM_SLEEP) The CPU, AHB and APB clock domains are stopped */
+#define PM_SLEEP_IDLE_CPU           (PM_SLEEP_IDLE_CPU_Val         << PM_SLEEP_IDLE_Pos)
+#define PM_SLEEP_IDLE_AHB           (PM_SLEEP_IDLE_AHB_Val         << PM_SLEEP_IDLE_Pos)
+#define PM_SLEEP_IDLE_APB           (PM_SLEEP_IDLE_APB_Val         << PM_SLEEP_IDLE_Pos)
+#define PM_SLEEP_MASK               _U_(0x03)    /**< \brief (PM_SLEEP) MASK Register */
+
+/* -------- PM_CPUSEL : (PM Offset: 0x08) (R/W  8) CPU Clock Select -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CPUDIV:3;         /*!< bit:  0.. 2  CPU Prescaler Selection            */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_CPUSEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_CPUSEL_OFFSET            0x08         /**< \brief (PM_CPUSEL offset) CPU Clock Select */
+#define PM_CPUSEL_RESETVALUE        _U_(0x00)    /**< \brief (PM_CPUSEL reset_value) CPU Clock Select */
+
+#define PM_CPUSEL_CPUDIV_Pos        0            /**< \brief (PM_CPUSEL) CPU Prescaler Selection */
+#define PM_CPUSEL_CPUDIV_Msk        (_U_(0x7) << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV(value)     (PM_CPUSEL_CPUDIV_Msk & ((value) << PM_CPUSEL_CPUDIV_Pos))
+#define   PM_CPUSEL_CPUDIV_DIV1_Val       _U_(0x0)   /**< \brief (PM_CPUSEL) Divide by 1 */
+#define   PM_CPUSEL_CPUDIV_DIV2_Val       _U_(0x1)   /**< \brief (PM_CPUSEL) Divide by 2 */
+#define   PM_CPUSEL_CPUDIV_DIV4_Val       _U_(0x2)   /**< \brief (PM_CPUSEL) Divide by 4 */
+#define   PM_CPUSEL_CPUDIV_DIV8_Val       _U_(0x3)   /**< \brief (PM_CPUSEL) Divide by 8 */
+#define   PM_CPUSEL_CPUDIV_DIV16_Val      _U_(0x4)   /**< \brief (PM_CPUSEL) Divide by 16 */
+#define   PM_CPUSEL_CPUDIV_DIV32_Val      _U_(0x5)   /**< \brief (PM_CPUSEL) Divide by 32 */
+#define   PM_CPUSEL_CPUDIV_DIV64_Val      _U_(0x6)   /**< \brief (PM_CPUSEL) Divide by 64 */
+#define   PM_CPUSEL_CPUDIV_DIV128_Val     _U_(0x7)   /**< \brief (PM_CPUSEL) Divide by 128 */
+#define PM_CPUSEL_CPUDIV_DIV1       (PM_CPUSEL_CPUDIV_DIV1_Val     << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV_DIV2       (PM_CPUSEL_CPUDIV_DIV2_Val     << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV_DIV4       (PM_CPUSEL_CPUDIV_DIV4_Val     << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV_DIV8       (PM_CPUSEL_CPUDIV_DIV8_Val     << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV_DIV16      (PM_CPUSEL_CPUDIV_DIV16_Val    << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV_DIV32      (PM_CPUSEL_CPUDIV_DIV32_Val    << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV_DIV64      (PM_CPUSEL_CPUDIV_DIV64_Val    << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_CPUDIV_DIV128     (PM_CPUSEL_CPUDIV_DIV128_Val   << PM_CPUSEL_CPUDIV_Pos)
+#define PM_CPUSEL_MASK              _U_(0x07)    /**< \brief (PM_CPUSEL) MASK Register */
+
+/* -------- PM_APBASEL : (PM Offset: 0x09) (R/W  8) APBA Clock Select -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  APBADIV:3;        /*!< bit:  0.. 2  APBA Prescaler Selection           */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_APBASEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_APBASEL_OFFSET           0x09         /**< \brief (PM_APBASEL offset) APBA Clock Select */
+#define PM_APBASEL_RESETVALUE       _U_(0x00)    /**< \brief (PM_APBASEL reset_value) APBA Clock Select */
+
+#define PM_APBASEL_APBADIV_Pos      0            /**< \brief (PM_APBASEL) APBA Prescaler Selection */
+#define PM_APBASEL_APBADIV_Msk      (_U_(0x7) << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV(value)   (PM_APBASEL_APBADIV_Msk & ((value) << PM_APBASEL_APBADIV_Pos))
+#define   PM_APBASEL_APBADIV_DIV1_Val     _U_(0x0)   /**< \brief (PM_APBASEL) Divide by 1 */
+#define   PM_APBASEL_APBADIV_DIV2_Val     _U_(0x1)   /**< \brief (PM_APBASEL) Divide by 2 */
+#define   PM_APBASEL_APBADIV_DIV4_Val     _U_(0x2)   /**< \brief (PM_APBASEL) Divide by 4 */
+#define   PM_APBASEL_APBADIV_DIV8_Val     _U_(0x3)   /**< \brief (PM_APBASEL) Divide by 8 */
+#define   PM_APBASEL_APBADIV_DIV16_Val    _U_(0x4)   /**< \brief (PM_APBASEL) Divide by 16 */
+#define   PM_APBASEL_APBADIV_DIV32_Val    _U_(0x5)   /**< \brief (PM_APBASEL) Divide by 32 */
+#define   PM_APBASEL_APBADIV_DIV64_Val    _U_(0x6)   /**< \brief (PM_APBASEL) Divide by 64 */
+#define   PM_APBASEL_APBADIV_DIV128_Val   _U_(0x7)   /**< \brief (PM_APBASEL) Divide by 128 */
+#define PM_APBASEL_APBADIV_DIV1     (PM_APBASEL_APBADIV_DIV1_Val   << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV_DIV2     (PM_APBASEL_APBADIV_DIV2_Val   << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV_DIV4     (PM_APBASEL_APBADIV_DIV4_Val   << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV_DIV8     (PM_APBASEL_APBADIV_DIV8_Val   << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV_DIV16    (PM_APBASEL_APBADIV_DIV16_Val  << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV_DIV32    (PM_APBASEL_APBADIV_DIV32_Val  << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV_DIV64    (PM_APBASEL_APBADIV_DIV64_Val  << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_APBADIV_DIV128   (PM_APBASEL_APBADIV_DIV128_Val << PM_APBASEL_APBADIV_Pos)
+#define PM_APBASEL_MASK             _U_(0x07)    /**< \brief (PM_APBASEL) MASK Register */
+
+/* -------- PM_APBBSEL : (PM Offset: 0x0A) (R/W  8) APBB Clock Select -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  APBBDIV:3;        /*!< bit:  0.. 2  APBB Prescaler Selection           */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_APBBSEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_APBBSEL_OFFSET           0x0A         /**< \brief (PM_APBBSEL offset) APBB Clock Select */
+#define PM_APBBSEL_RESETVALUE       _U_(0x00)    /**< \brief (PM_APBBSEL reset_value) APBB Clock Select */
+
+#define PM_APBBSEL_APBBDIV_Pos      0            /**< \brief (PM_APBBSEL) APBB Prescaler Selection */
+#define PM_APBBSEL_APBBDIV_Msk      (_U_(0x7) << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV(value)   (PM_APBBSEL_APBBDIV_Msk & ((value) << PM_APBBSEL_APBBDIV_Pos))
+#define   PM_APBBSEL_APBBDIV_DIV1_Val     _U_(0x0)   /**< \brief (PM_APBBSEL) Divide by 1 */
+#define   PM_APBBSEL_APBBDIV_DIV2_Val     _U_(0x1)   /**< \brief (PM_APBBSEL) Divide by 2 */
+#define   PM_APBBSEL_APBBDIV_DIV4_Val     _U_(0x2)   /**< \brief (PM_APBBSEL) Divide by 4 */
+#define   PM_APBBSEL_APBBDIV_DIV8_Val     _U_(0x3)   /**< \brief (PM_APBBSEL) Divide by 8 */
+#define   PM_APBBSEL_APBBDIV_DIV16_Val    _U_(0x4)   /**< \brief (PM_APBBSEL) Divide by 16 */
+#define   PM_APBBSEL_APBBDIV_DIV32_Val    _U_(0x5)   /**< \brief (PM_APBBSEL) Divide by 32 */
+#define   PM_APBBSEL_APBBDIV_DIV64_Val    _U_(0x6)   /**< \brief (PM_APBBSEL) Divide by 64 */
+#define   PM_APBBSEL_APBBDIV_DIV128_Val   _U_(0x7)   /**< \brief (PM_APBBSEL) Divide by 128 */
+#define PM_APBBSEL_APBBDIV_DIV1     (PM_APBBSEL_APBBDIV_DIV1_Val   << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV_DIV2     (PM_APBBSEL_APBBDIV_DIV2_Val   << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV_DIV4     (PM_APBBSEL_APBBDIV_DIV4_Val   << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV_DIV8     (PM_APBBSEL_APBBDIV_DIV8_Val   << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV_DIV16    (PM_APBBSEL_APBBDIV_DIV16_Val  << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV_DIV32    (PM_APBBSEL_APBBDIV_DIV32_Val  << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV_DIV64    (PM_APBBSEL_APBBDIV_DIV64_Val  << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_APBBDIV_DIV128   (PM_APBBSEL_APBBDIV_DIV128_Val << PM_APBBSEL_APBBDIV_Pos)
+#define PM_APBBSEL_MASK             _U_(0x07)    /**< \brief (PM_APBBSEL) MASK Register */
+
+/* -------- PM_APBCSEL : (PM Offset: 0x0B) (R/W  8) APBC Clock Select -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  APBCDIV:3;        /*!< bit:  0.. 2  APBC Prescaler Selection           */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_APBCSEL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_APBCSEL_OFFSET           0x0B         /**< \brief (PM_APBCSEL offset) APBC Clock Select */
+#define PM_APBCSEL_RESETVALUE       _U_(0x00)    /**< \brief (PM_APBCSEL reset_value) APBC Clock Select */
+
+#define PM_APBCSEL_APBCDIV_Pos      0            /**< \brief (PM_APBCSEL) APBC Prescaler Selection */
+#define PM_APBCSEL_APBCDIV_Msk      (_U_(0x7) << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV(value)   (PM_APBCSEL_APBCDIV_Msk & ((value) << PM_APBCSEL_APBCDIV_Pos))
+#define   PM_APBCSEL_APBCDIV_DIV1_Val     _U_(0x0)   /**< \brief (PM_APBCSEL) Divide by 1 */
+#define   PM_APBCSEL_APBCDIV_DIV2_Val     _U_(0x1)   /**< \brief (PM_APBCSEL) Divide by 2 */
+#define   PM_APBCSEL_APBCDIV_DIV4_Val     _U_(0x2)   /**< \brief (PM_APBCSEL) Divide by 4 */
+#define   PM_APBCSEL_APBCDIV_DIV8_Val     _U_(0x3)   /**< \brief (PM_APBCSEL) Divide by 8 */
+#define   PM_APBCSEL_APBCDIV_DIV16_Val    _U_(0x4)   /**< \brief (PM_APBCSEL) Divide by 16 */
+#define   PM_APBCSEL_APBCDIV_DIV32_Val    _U_(0x5)   /**< \brief (PM_APBCSEL) Divide by 32 */
+#define   PM_APBCSEL_APBCDIV_DIV64_Val    _U_(0x6)   /**< \brief (PM_APBCSEL) Divide by 64 */
+#define   PM_APBCSEL_APBCDIV_DIV128_Val   _U_(0x7)   /**< \brief (PM_APBCSEL) Divide by 128 */
+#define PM_APBCSEL_APBCDIV_DIV1     (PM_APBCSEL_APBCDIV_DIV1_Val   << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV_DIV2     (PM_APBCSEL_APBCDIV_DIV2_Val   << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV_DIV4     (PM_APBCSEL_APBCDIV_DIV4_Val   << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV_DIV8     (PM_APBCSEL_APBCDIV_DIV8_Val   << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV_DIV16    (PM_APBCSEL_APBCDIV_DIV16_Val  << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV_DIV32    (PM_APBCSEL_APBCDIV_DIV32_Val  << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV_DIV64    (PM_APBCSEL_APBCDIV_DIV64_Val  << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_APBCDIV_DIV128   (PM_APBCSEL_APBCDIV_DIV128_Val << PM_APBCSEL_APBCDIV_Pos)
+#define PM_APBCSEL_MASK             _U_(0x07)    /**< \brief (PM_APBCSEL) MASK Register */
+
+/* -------- PM_AHBMASK : (PM Offset: 0x14) (R/W 32) AHB Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t HPB0_:1;          /*!< bit:      0  HPB0 AHB Clock Mask                */
+    uint32_t HPB1_:1;          /*!< bit:      1  HPB1 AHB Clock Mask                */
+    uint32_t HPB2_:1;          /*!< bit:      2  HPB2 AHB Clock Mask                */
+    uint32_t DSU_:1;           /*!< bit:      3  DSU AHB Clock Mask                 */
+    uint32_t NVMCTRL_:1;       /*!< bit:      4  NVMCTRL AHB Clock Mask             */
+    uint32_t :27;              /*!< bit:  5..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_AHBMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_AHBMASK_OFFSET           0x14         /**< \brief (PM_AHBMASK offset) AHB Mask */
+#define PM_AHBMASK_RESETVALUE       _U_(0x0000001F) /**< \brief (PM_AHBMASK reset_value) AHB Mask */
+
+#define PM_AHBMASK_HPB0_Pos         0            /**< \brief (PM_AHBMASK) HPB0 AHB Clock Mask */
+#define PM_AHBMASK_HPB0             (_U_(0x1) << PM_AHBMASK_HPB0_Pos)
+#define PM_AHBMASK_HPB1_Pos         1            /**< \brief (PM_AHBMASK) HPB1 AHB Clock Mask */
+#define PM_AHBMASK_HPB1             (_U_(0x1) << PM_AHBMASK_HPB1_Pos)
+#define PM_AHBMASK_HPB2_Pos         2            /**< \brief (PM_AHBMASK) HPB2 AHB Clock Mask */
+#define PM_AHBMASK_HPB2             (_U_(0x1) << PM_AHBMASK_HPB2_Pos)
+#define PM_AHBMASK_DSU_Pos          3            /**< \brief (PM_AHBMASK) DSU AHB Clock Mask */
+#define PM_AHBMASK_DSU              (_U_(0x1) << PM_AHBMASK_DSU_Pos)
+#define PM_AHBMASK_NVMCTRL_Pos      4            /**< \brief (PM_AHBMASK) NVMCTRL AHB Clock Mask */
+#define PM_AHBMASK_NVMCTRL          (_U_(0x1) << PM_AHBMASK_NVMCTRL_Pos)
+#define PM_AHBMASK_MASK             _U_(0x0000001F) /**< \brief (PM_AHBMASK) MASK Register */
+
+/* -------- PM_APBAMASK : (PM Offset: 0x18) (R/W 32) APBA Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PAC0_:1;          /*!< bit:      0  PAC0 APB Clock Enable              */
+    uint32_t PM_:1;            /*!< bit:      1  PM APB Clock Enable                */
+    uint32_t SYSCTRL_:1;       /*!< bit:      2  SYSCTRL APB Clock Enable           */
+    uint32_t GCLK_:1;          /*!< bit:      3  GCLK APB Clock Enable              */
+    uint32_t WDT_:1;           /*!< bit:      4  WDT APB Clock Enable               */
+    uint32_t RTC_:1;           /*!< bit:      5  RTC APB Clock Enable               */
+    uint32_t EIC_:1;           /*!< bit:      6  EIC APB Clock Enable               */
+    uint32_t :25;              /*!< bit:  7..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_APBAMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_APBAMASK_OFFSET          0x18         /**< \brief (PM_APBAMASK offset) APBA Mask */
+#define PM_APBAMASK_RESETVALUE      _U_(0x0000007F) /**< \brief (PM_APBAMASK reset_value) APBA Mask */
+
+#define PM_APBAMASK_PAC0_Pos        0            /**< \brief (PM_APBAMASK) PAC0 APB Clock Enable */
+#define PM_APBAMASK_PAC0            (_U_(0x1) << PM_APBAMASK_PAC0_Pos)
+#define PM_APBAMASK_PM_Pos          1            /**< \brief (PM_APBAMASK) PM APB Clock Enable */
+#define PM_APBAMASK_PM              (_U_(0x1) << PM_APBAMASK_PM_Pos)
+#define PM_APBAMASK_SYSCTRL_Pos     2            /**< \brief (PM_APBAMASK) SYSCTRL APB Clock Enable */
+#define PM_APBAMASK_SYSCTRL         (_U_(0x1) << PM_APBAMASK_SYSCTRL_Pos)
+#define PM_APBAMASK_GCLK_Pos        3            /**< \brief (PM_APBAMASK) GCLK APB Clock Enable */
+#define PM_APBAMASK_GCLK            (_U_(0x1) << PM_APBAMASK_GCLK_Pos)
+#define PM_APBAMASK_WDT_Pos         4            /**< \brief (PM_APBAMASK) WDT APB Clock Enable */
+#define PM_APBAMASK_WDT             (_U_(0x1) << PM_APBAMASK_WDT_Pos)
+#define PM_APBAMASK_RTC_Pos         5            /**< \brief (PM_APBAMASK) RTC APB Clock Enable */
+#define PM_APBAMASK_RTC             (_U_(0x1) << PM_APBAMASK_RTC_Pos)
+#define PM_APBAMASK_EIC_Pos         6            /**< \brief (PM_APBAMASK) EIC APB Clock Enable */
+#define PM_APBAMASK_EIC             (_U_(0x1) << PM_APBAMASK_EIC_Pos)
+#define PM_APBAMASK_MASK            _U_(0x0000007F) /**< \brief (PM_APBAMASK) MASK Register */
+
+/* -------- PM_APBBMASK : (PM Offset: 0x1C) (R/W 32) APBB Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PAC1_:1;          /*!< bit:      0  PAC1 APB Clock Enable              */
+    uint32_t DSU_:1;           /*!< bit:      1  DSU APB Clock Enable               */
+    uint32_t NVMCTRL_:1;       /*!< bit:      2  NVMCTRL APB Clock Enable           */
+    uint32_t PORT_:1;          /*!< bit:      3  PORT APB Clock Enable              */
+    uint32_t :28;              /*!< bit:  4..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_APBBMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_APBBMASK_OFFSET          0x1C         /**< \brief (PM_APBBMASK offset) APBB Mask */
+#define PM_APBBMASK_RESETVALUE      _U_(0x0000001F) /**< \brief (PM_APBBMASK reset_value) APBB Mask */
+
+#define PM_APBBMASK_PAC1_Pos        0            /**< \brief (PM_APBBMASK) PAC1 APB Clock Enable */
+#define PM_APBBMASK_PAC1            (_U_(0x1) << PM_APBBMASK_PAC1_Pos)
+#define PM_APBBMASK_DSU_Pos         1            /**< \brief (PM_APBBMASK) DSU APB Clock Enable */
+#define PM_APBBMASK_DSU             (_U_(0x1) << PM_APBBMASK_DSU_Pos)
+#define PM_APBBMASK_NVMCTRL_Pos     2            /**< \brief (PM_APBBMASK) NVMCTRL APB Clock Enable */
+#define PM_APBBMASK_NVMCTRL         (_U_(0x1) << PM_APBBMASK_NVMCTRL_Pos)
+#define PM_APBBMASK_PORT_Pos        3            /**< \brief (PM_APBBMASK) PORT APB Clock Enable */
+#define PM_APBBMASK_PORT            (_U_(0x1) << PM_APBBMASK_PORT_Pos)
+#define PM_APBBMASK_MASK            _U_(0x0000000F) /**< \brief (PM_APBBMASK) MASK Register */
+
+/* -------- PM_APBCMASK : (PM Offset: 0x20) (R/W 32) APBC Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PAC2_:1;          /*!< bit:      0  PAC2 APB Clock Enable              */
+    uint32_t EVSYS_:1;         /*!< bit:      1  EVSYS APB Clock Enable             */
+    uint32_t SERCOM0_:1;       /*!< bit:      2  SERCOM0 APB Clock Enable           */
+    uint32_t SERCOM1_:1;       /*!< bit:      3  SERCOM1 APB Clock Enable           */
+    uint32_t SERCOM2_:1;       /*!< bit:      4  SERCOM2 APB Clock Enable           */
+    uint32_t SERCOM3_:1;       /*!< bit:      5  SERCOM3 APB Clock Enable           */
+    uint32_t SERCOM4_:1;       /*!< bit:      6  SERCOM4 APB Clock Enable           */
+    uint32_t SERCOM5_:1;       /*!< bit:      7  SERCOM5 APB Clock Enable           */
+    uint32_t TC0_:1;           /*!< bit:      8  TC0 APB Clock Enable               */
+    uint32_t TC1_:1;           /*!< bit:      9  TC1 APB Clock Enable               */
+    uint32_t TC2_:1;           /*!< bit:     10  TC2 APB Clock Enable               */
+    uint32_t TC3_:1;           /*!< bit:     11  TC3 APB Clock Enable               */
+    uint32_t TC4_:1;           /*!< bit:     12  TC4 APB Clock Enable               */
+    uint32_t TC5_:1;           /*!< bit:     13  TC5 APB Clock Enable               */
+    uint32_t TC6_:1;           /*!< bit:     14  TC6 APB Clock Enable               */
+    uint32_t TC7_:1;           /*!< bit:     15  TC7 APB Clock Enable               */
+    uint32_t ADC_:1;           /*!< bit:     16  ADC APB Clock Enable               */
+    uint32_t AC_:1;            /*!< bit:     17  AC APB Clock Enable                */
+    uint32_t DAC_:1;           /*!< bit:     18  DAC APB Clock Enable               */
+    uint32_t PTC_:1;           /*!< bit:     19  PTC APB Clock Enable               */
+    uint32_t :12;              /*!< bit: 20..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PM_APBCMASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_APBCMASK_OFFSET          0x20         /**< \brief (PM_APBCMASK offset) APBC Mask */
+#define PM_APBCMASK_RESETVALUE      _U_(0x00010000) /**< \brief (PM_APBCMASK reset_value) APBC Mask */
+
+#define PM_APBCMASK_PAC2_Pos        0            /**< \brief (PM_APBCMASK) PAC2 APB Clock Enable */
+#define PM_APBCMASK_PAC2            (_U_(0x1) << PM_APBCMASK_PAC2_Pos)
+#define PM_APBCMASK_EVSYS_Pos       1            /**< \brief (PM_APBCMASK) EVSYS APB Clock Enable */
+#define PM_APBCMASK_EVSYS           (_U_(0x1) << PM_APBCMASK_EVSYS_Pos)
+#define PM_APBCMASK_SERCOM0_Pos     2            /**< \brief (PM_APBCMASK) SERCOM0 APB Clock Enable */
+#define PM_APBCMASK_SERCOM0         (_U_(0x1) << PM_APBCMASK_SERCOM0_Pos)
+#define PM_APBCMASK_SERCOM1_Pos     3            /**< \brief (PM_APBCMASK) SERCOM1 APB Clock Enable */
+#define PM_APBCMASK_SERCOM1         (_U_(0x1) << PM_APBCMASK_SERCOM1_Pos)
+#define PM_APBCMASK_SERCOM2_Pos     4            /**< \brief (PM_APBCMASK) SERCOM2 APB Clock Enable */
+#define PM_APBCMASK_SERCOM2         (_U_(0x1) << PM_APBCMASK_SERCOM2_Pos)
+#define PM_APBCMASK_SERCOM3_Pos     5            /**< \brief (PM_APBCMASK) SERCOM3 APB Clock Enable */
+#define PM_APBCMASK_SERCOM3         (_U_(0x1) << PM_APBCMASK_SERCOM3_Pos)
+#define PM_APBCMASK_SERCOM4_Pos     6            /**< \brief (PM_APBCMASK) SERCOM4 APB Clock Enable */
+#define PM_APBCMASK_SERCOM4         (_U_(0x1) << PM_APBCMASK_SERCOM4_Pos)
+#define PM_APBCMASK_SERCOM5_Pos     7            /**< \brief (PM_APBCMASK) SERCOM5 APB Clock Enable */
+#define PM_APBCMASK_SERCOM5         (_U_(0x1) << PM_APBCMASK_SERCOM5_Pos)
+#define PM_APBCMASK_TC0_Pos         8            /**< \brief (PM_APBCMASK) TC0 APB Clock Enable */
+#define PM_APBCMASK_TC0             (_U_(0x1) << PM_APBCMASK_TC0_Pos)
+#define PM_APBCMASK_TC1_Pos         9            /**< \brief (PM_APBCMASK) TC1 APB Clock Enable */
+#define PM_APBCMASK_TC1             (_U_(0x1) << PM_APBCMASK_TC1_Pos)
+#define PM_APBCMASK_TC2_Pos         10           /**< \brief (PM_APBCMASK) TC2 APB Clock Enable */
+#define PM_APBCMASK_TC2             (_U_(0x1) << PM_APBCMASK_TC2_Pos)
+#define PM_APBCMASK_TC3_Pos         11           /**< \brief (PM_APBCMASK) TC3 APB Clock Enable */
+#define PM_APBCMASK_TC3             (_U_(0x1) << PM_APBCMASK_TC3_Pos)
+#define PM_APBCMASK_TC4_Pos         12           /**< \brief (PM_APBCMASK) TC4 APB Clock Enable */
+#define PM_APBCMASK_TC4             (_U_(0x1) << PM_APBCMASK_TC4_Pos)
+#define PM_APBCMASK_TC5_Pos         13           /**< \brief (PM_APBCMASK) TC5 APB Clock Enable */
+#define PM_APBCMASK_TC5             (_U_(0x1) << PM_APBCMASK_TC5_Pos)
+#define PM_APBCMASK_TC6_Pos         14           /**< \brief (PM_APBCMASK) TC6 APB Clock Enable */
+#define PM_APBCMASK_TC6             (_U_(0x1) << PM_APBCMASK_TC6_Pos)
+#define PM_APBCMASK_TC7_Pos         15           /**< \brief (PM_APBCMASK) TC7 APB Clock Enable */
+#define PM_APBCMASK_TC7             (_U_(0x1) << PM_APBCMASK_TC7_Pos)
+#define PM_APBCMASK_ADC_Pos         16           /**< \brief (PM_APBCMASK) ADC APB Clock Enable */
+#define PM_APBCMASK_ADC             (_U_(0x1) << PM_APBCMASK_ADC_Pos)
+#define PM_APBCMASK_AC_Pos          17           /**< \brief (PM_APBCMASK) AC APB Clock Enable */
+#define PM_APBCMASK_AC              (_U_(0x1) << PM_APBCMASK_AC_Pos)
+#define PM_APBCMASK_DAC_Pos         18           /**< \brief (PM_APBCMASK) DAC APB Clock Enable */
+#define PM_APBCMASK_DAC             (_U_(0x1) << PM_APBCMASK_DAC_Pos)
+#define PM_APBCMASK_PTC_Pos         19           /**< \brief (PM_APBCMASK) PTC APB Clock Enable */
+#define PM_APBCMASK_PTC             (_U_(0x1) << PM_APBCMASK_PTC_Pos)
+#define PM_APBCMASK_MASK            _U_(0x000FFFFF) /**< \brief (PM_APBCMASK) MASK Register */
+
+/* -------- PM_INTENCLR : (PM Offset: 0x34) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready Interrupt Enable       */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_INTENCLR_OFFSET          0x34         /**< \brief (PM_INTENCLR offset) Interrupt Enable Clear */
+#define PM_INTENCLR_RESETVALUE      _U_(0x00)    /**< \brief (PM_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define PM_INTENCLR_CKRDY_Pos       0            /**< \brief (PM_INTENCLR) Clock Ready Interrupt Enable */
+#define PM_INTENCLR_CKRDY           (_U_(0x1) << PM_INTENCLR_CKRDY_Pos)
+#define PM_INTENCLR_MASK            _U_(0x01)    /**< \brief (PM_INTENCLR) MASK Register */
+
+/* -------- PM_INTENSET : (PM Offset: 0x35) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready Interrupt Enable       */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_INTENSET_OFFSET          0x35         /**< \brief (PM_INTENSET offset) Interrupt Enable Set */
+#define PM_INTENSET_RESETVALUE      _U_(0x00)    /**< \brief (PM_INTENSET reset_value) Interrupt Enable Set */
+
+#define PM_INTENSET_CKRDY_Pos       0            /**< \brief (PM_INTENSET) Clock Ready Interrupt Enable */
+#define PM_INTENSET_CKRDY           (_U_(0x1) << PM_INTENSET_CKRDY_Pos)
+#define PM_INTENSET_MASK            _U_(0x01)    /**< \brief (PM_INTENSET) MASK Register */
+
+/* -------- PM_INTFLAG : (PM Offset: 0x36) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  CKRDY:1;          /*!< bit:      0  Clock Ready                        */
+    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_INTFLAG_OFFSET           0x36         /**< \brief (PM_INTFLAG offset) Interrupt Flag Status and Clear */
+#define PM_INTFLAG_RESETVALUE       _U_(0x00)    /**< \brief (PM_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define PM_INTFLAG_CKRDY_Pos        0            /**< \brief (PM_INTFLAG) Clock Ready */
+#define PM_INTFLAG_CKRDY            (_U_(0x1) << PM_INTFLAG_CKRDY_Pos)
+#define PM_INTFLAG_MASK             _U_(0x01)    /**< \brief (PM_INTFLAG) MASK Register */
+
+/* -------- PM_RCAUSE : (PM Offset: 0x38) (R/   8) Reset Cause -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  POR:1;            /*!< bit:      0  Power On Reset                     */
+    uint8_t  BOD12:1;          /*!< bit:      1  Brown Out 12 Detector Reset        */
+    uint8_t  BOD33:1;          /*!< bit:      2  Brown Out 33 Detector Reset        */
+    uint8_t  :1;               /*!< bit:      3  Reserved                           */
+    uint8_t  EXT:1;            /*!< bit:      4  External Reset                     */
+    uint8_t  WDT:1;            /*!< bit:      5  Watchdog Reset                     */
+    uint8_t  SYST:1;           /*!< bit:      6  System Reset Request               */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PM_RCAUSE_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PM_RCAUSE_OFFSET            0x38         /**< \brief (PM_RCAUSE offset) Reset Cause */
+#define PM_RCAUSE_RESETVALUE        _U_(0x01)    /**< \brief (PM_RCAUSE reset_value) Reset Cause */
+
+#define PM_RCAUSE_POR_Pos           0            /**< \brief (PM_RCAUSE) Power On Reset */
+#define PM_RCAUSE_POR               (_U_(0x1) << PM_RCAUSE_POR_Pos)
+#define PM_RCAUSE_BOD12_Pos         1            /**< \brief (PM_RCAUSE) Brown Out 12 Detector Reset */
+#define PM_RCAUSE_BOD12             (_U_(0x1) << PM_RCAUSE_BOD12_Pos)
+#define PM_RCAUSE_BOD33_Pos         2            /**< \brief (PM_RCAUSE) Brown Out 33 Detector Reset */
+#define PM_RCAUSE_BOD33             (_U_(0x1) << PM_RCAUSE_BOD33_Pos)
+#define PM_RCAUSE_EXT_Pos           4            /**< \brief (PM_RCAUSE) External Reset */
+#define PM_RCAUSE_EXT               (_U_(0x1) << PM_RCAUSE_EXT_Pos)
+#define PM_RCAUSE_WDT_Pos           5            /**< \brief (PM_RCAUSE) Watchdog Reset */
+#define PM_RCAUSE_WDT               (_U_(0x1) << PM_RCAUSE_WDT_Pos)
+#define PM_RCAUSE_SYST_Pos          6            /**< \brief (PM_RCAUSE) System Reset Request */
+#define PM_RCAUSE_SYST              (_U_(0x1) << PM_RCAUSE_SYST_Pos)
+#define PM_RCAUSE_MASK              _U_(0x77)    /**< \brief (PM_RCAUSE) MASK Register */
+
+/** \brief PM hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO PM_CTRL_Type              CTRL;        /**< \brief Offset: 0x00 (R/W  8) Control */
+  __IO PM_SLEEP_Type             SLEEP;       /**< \brief Offset: 0x01 (R/W  8) Sleep Mode */
+       RoReg8                    Reserved1[0x6];
+  __IO PM_CPUSEL_Type            CPUSEL;      /**< \brief Offset: 0x08 (R/W  8) CPU Clock Select */
+  __IO PM_APBASEL_Type           APBASEL;     /**< \brief Offset: 0x09 (R/W  8) APBA Clock Select */
+  __IO PM_APBBSEL_Type           APBBSEL;     /**< \brief Offset: 0x0A (R/W  8) APBB Clock Select */
+  __IO PM_APBCSEL_Type           APBCSEL;     /**< \brief Offset: 0x0B (R/W  8) APBC Clock Select */
+       RoReg8                    Reserved2[0x8];
+  __IO PM_AHBMASK_Type           AHBMASK;     /**< \brief Offset: 0x14 (R/W 32) AHB Mask */
+  __IO PM_APBAMASK_Type          APBAMASK;    /**< \brief Offset: 0x18 (R/W 32) APBA Mask */
+  __IO PM_APBBMASK_Type          APBBMASK;    /**< \brief Offset: 0x1C (R/W 32) APBB Mask */
+  __IO PM_APBCMASK_Type          APBCMASK;    /**< \brief Offset: 0x20 (R/W 32) APBC Mask */
+       RoReg8                    Reserved3[0x10];
+  __IO PM_INTENCLR_Type          INTENCLR;    /**< \brief Offset: 0x34 (R/W  8) Interrupt Enable Clear */
+  __IO PM_INTENSET_Type          INTENSET;    /**< \brief Offset: 0x35 (R/W  8) Interrupt Enable Set */
+  __IO PM_INTFLAG_Type           INTFLAG;     /**< \brief Offset: 0x36 (R/W  8) Interrupt Flag Status and Clear */
+       RoReg8                    Reserved4[0x1];
+  __I  PM_RCAUSE_Type            RCAUSE;      /**< \brief Offset: 0x38 (R/   8) Reset Cause */
+} Pm;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_PM_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/port.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/port.h
@@ -1,0 +1,380 @@
+/**
+ * \file
+ *
+ * \brief Component description for PORT
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PORT_COMPONENT_
+#define _SAMD20_PORT_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR PORT */
+/* ========================================================================== */
+/** \addtogroup SAMD20_PORT Port Module */
+/*@{*/
+
+#define PORT_U2210
+#define REV_PORT                    0x100
+
+/* -------- PORT_DIR : (PORT Offset: 0x00) (R/W 32) GROUP Data Direction -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DIR:32;           /*!< bit:  0..31  Port Data Direction                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIR_OFFSET             0x00         /**< \brief (PORT_DIR offset) Data Direction */
+#define PORT_DIR_RESETVALUE         _U_(0x00000000) /**< \brief (PORT_DIR reset_value) Data Direction */
+
+#define PORT_DIR_DIR_Pos            0            /**< \brief (PORT_DIR) Port Data Direction */
+#define PORT_DIR_DIR_Msk            (_U_(0xFFFFFFFF) << PORT_DIR_DIR_Pos)
+#define PORT_DIR_DIR(value)         (PORT_DIR_DIR_Msk & ((value) << PORT_DIR_DIR_Pos))
+#define PORT_DIR_MASK               _U_(0xFFFFFFFF) /**< \brief (PORT_DIR) MASK Register */
+
+/* -------- PORT_DIRCLR : (PORT Offset: 0x04) (R/W 32) GROUP Data Direction Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DIRCLR:32;        /*!< bit:  0..31  Port Data Direction Clear          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIRCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIRCLR_OFFSET          0x04         /**< \brief (PORT_DIRCLR offset) Data Direction Clear */
+#define PORT_DIRCLR_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_DIRCLR reset_value) Data Direction Clear */
+
+#define PORT_DIRCLR_DIRCLR_Pos      0            /**< \brief (PORT_DIRCLR) Port Data Direction Clear */
+#define PORT_DIRCLR_DIRCLR_Msk      (_U_(0xFFFFFFFF) << PORT_DIRCLR_DIRCLR_Pos)
+#define PORT_DIRCLR_DIRCLR(value)   (PORT_DIRCLR_DIRCLR_Msk & ((value) << PORT_DIRCLR_DIRCLR_Pos))
+#define PORT_DIRCLR_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_DIRCLR) MASK Register */
+
+/* -------- PORT_DIRSET : (PORT Offset: 0x08) (R/W 32) GROUP Data Direction Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DIRSET:32;        /*!< bit:  0..31  Port Data Direction Set            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIRSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIRSET_OFFSET          0x08         /**< \brief (PORT_DIRSET offset) Data Direction Set */
+#define PORT_DIRSET_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_DIRSET reset_value) Data Direction Set */
+
+#define PORT_DIRSET_DIRSET_Pos      0            /**< \brief (PORT_DIRSET) Port Data Direction Set */
+#define PORT_DIRSET_DIRSET_Msk      (_U_(0xFFFFFFFF) << PORT_DIRSET_DIRSET_Pos)
+#define PORT_DIRSET_DIRSET(value)   (PORT_DIRSET_DIRSET_Msk & ((value) << PORT_DIRSET_DIRSET_Pos))
+#define PORT_DIRSET_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_DIRSET) MASK Register */
+
+/* -------- PORT_DIRTGL : (PORT Offset: 0x0C) (R/W 32) GROUP Data Direction Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t DIRTGL:32;        /*!< bit:  0..31  Port Data Direction Toggle         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_DIRTGL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_DIRTGL_OFFSET          0x0C         /**< \brief (PORT_DIRTGL offset) Data Direction Toggle */
+#define PORT_DIRTGL_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_DIRTGL reset_value) Data Direction Toggle */
+
+#define PORT_DIRTGL_DIRTGL_Pos      0            /**< \brief (PORT_DIRTGL) Port Data Direction Toggle */
+#define PORT_DIRTGL_DIRTGL_Msk      (_U_(0xFFFFFFFF) << PORT_DIRTGL_DIRTGL_Pos)
+#define PORT_DIRTGL_DIRTGL(value)   (PORT_DIRTGL_DIRTGL_Msk & ((value) << PORT_DIRTGL_DIRTGL_Pos))
+#define PORT_DIRTGL_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_DIRTGL) MASK Register */
+
+/* -------- PORT_OUT : (PORT Offset: 0x10) (R/W 32) GROUP Data Output Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OUT:32;           /*!< bit:  0..31  Port Data Output Value             */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUT_OFFSET             0x10         /**< \brief (PORT_OUT offset) Data Output Value */
+#define PORT_OUT_RESETVALUE         _U_(0x00000000) /**< \brief (PORT_OUT reset_value) Data Output Value */
+
+#define PORT_OUT_OUT_Pos            0            /**< \brief (PORT_OUT) Port Data Output Value */
+#define PORT_OUT_OUT_Msk            (_U_(0xFFFFFFFF) << PORT_OUT_OUT_Pos)
+#define PORT_OUT_OUT(value)         (PORT_OUT_OUT_Msk & ((value) << PORT_OUT_OUT_Pos))
+#define PORT_OUT_MASK               _U_(0xFFFFFFFF) /**< \brief (PORT_OUT) MASK Register */
+
+/* -------- PORT_OUTCLR : (PORT Offset: 0x14) (R/W 32) GROUP Data Output Value Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OUTCLR:32;        /*!< bit:  0..31  Port Data Output Value Clear       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUTCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUTCLR_OFFSET          0x14         /**< \brief (PORT_OUTCLR offset) Data Output Value Clear */
+#define PORT_OUTCLR_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_OUTCLR reset_value) Data Output Value Clear */
+
+#define PORT_OUTCLR_OUTCLR_Pos      0            /**< \brief (PORT_OUTCLR) Port Data Output Value Clear */
+#define PORT_OUTCLR_OUTCLR_Msk      (_U_(0xFFFFFFFF) << PORT_OUTCLR_OUTCLR_Pos)
+#define PORT_OUTCLR_OUTCLR(value)   (PORT_OUTCLR_OUTCLR_Msk & ((value) << PORT_OUTCLR_OUTCLR_Pos))
+#define PORT_OUTCLR_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_OUTCLR) MASK Register */
+
+/* -------- PORT_OUTSET : (PORT Offset: 0x18) (R/W 32) GROUP Data Output Value Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OUTSET:32;        /*!< bit:  0..31  Port Data Output Value Set         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUTSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUTSET_OFFSET          0x18         /**< \brief (PORT_OUTSET offset) Data Output Value Set */
+#define PORT_OUTSET_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_OUTSET reset_value) Data Output Value Set */
+
+#define PORT_OUTSET_OUTSET_Pos      0            /**< \brief (PORT_OUTSET) Port Data Output Value Set */
+#define PORT_OUTSET_OUTSET_Msk      (_U_(0xFFFFFFFF) << PORT_OUTSET_OUTSET_Pos)
+#define PORT_OUTSET_OUTSET(value)   (PORT_OUTSET_OUTSET_Msk & ((value) << PORT_OUTSET_OUTSET_Pos))
+#define PORT_OUTSET_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_OUTSET) MASK Register */
+
+/* -------- PORT_OUTTGL : (PORT Offset: 0x1C) (R/W 32) GROUP Data Output Value Toggle -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t OUTTGL:32;        /*!< bit:  0..31  Port Data Output Value Toggle      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_OUTTGL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_OUTTGL_OFFSET          0x1C         /**< \brief (PORT_OUTTGL offset) Data Output Value Toggle */
+#define PORT_OUTTGL_RESETVALUE      _U_(0x00000000) /**< \brief (PORT_OUTTGL reset_value) Data Output Value Toggle */
+
+#define PORT_OUTTGL_OUTTGL_Pos      0            /**< \brief (PORT_OUTTGL) Port Data Output Value Toggle */
+#define PORT_OUTTGL_OUTTGL_Msk      (_U_(0xFFFFFFFF) << PORT_OUTTGL_OUTTGL_Pos)
+#define PORT_OUTTGL_OUTTGL(value)   (PORT_OUTTGL_OUTTGL_Msk & ((value) << PORT_OUTTGL_OUTTGL_Pos))
+#define PORT_OUTTGL_MASK            _U_(0xFFFFFFFF) /**< \brief (PORT_OUTTGL) MASK Register */
+
+/* -------- PORT_IN : (PORT Offset: 0x20) (R/  32) GROUP Data Input Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t IN:32;            /*!< bit:  0..31  Port Data Input Value              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_IN_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_IN_OFFSET              0x20         /**< \brief (PORT_IN offset) Data Input Value */
+#define PORT_IN_RESETVALUE          _U_(0x00000000) /**< \brief (PORT_IN reset_value) Data Input Value */
+
+#define PORT_IN_IN_Pos              0            /**< \brief (PORT_IN) Port Data Input Value */
+#define PORT_IN_IN_Msk              (_U_(0xFFFFFFFF) << PORT_IN_IN_Pos)
+#define PORT_IN_IN(value)           (PORT_IN_IN_Msk & ((value) << PORT_IN_IN_Pos))
+#define PORT_IN_MASK                _U_(0xFFFFFFFF) /**< \brief (PORT_IN) MASK Register */
+
+/* -------- PORT_CTRL : (PORT Offset: 0x24) (R/W 32) GROUP Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SAMPLING:32;      /*!< bit:  0..31  Input Sampling Mode                */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_CTRL_OFFSET            0x24         /**< \brief (PORT_CTRL offset) Control */
+#define PORT_CTRL_RESETVALUE        _U_(0x00000000) /**< \brief (PORT_CTRL reset_value) Control */
+
+#define PORT_CTRL_SAMPLING_Pos      0            /**< \brief (PORT_CTRL) Input Sampling Mode */
+#define PORT_CTRL_SAMPLING_Msk      (_U_(0xFFFFFFFF) << PORT_CTRL_SAMPLING_Pos)
+#define PORT_CTRL_SAMPLING(value)   (PORT_CTRL_SAMPLING_Msk & ((value) << PORT_CTRL_SAMPLING_Pos))
+#define PORT_CTRL_MASK              _U_(0xFFFFFFFF) /**< \brief (PORT_CTRL) MASK Register */
+
+/* -------- PORT_WRCONFIG : (PORT Offset: 0x28) ( /W 32) GROUP Write Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t PINMASK:16;       /*!< bit:  0..15  Pin Mask for Multiple Pin Configuration */
+    uint32_t PMUXEN:1;         /*!< bit:     16  Peripheral Multiplexer Enable      */
+    uint32_t INEN:1;           /*!< bit:     17  Input Enable                       */
+    uint32_t PULLEN:1;         /*!< bit:     18  Pull Enable                        */
+    uint32_t :3;               /*!< bit: 19..21  Reserved                           */
+    uint32_t DRVSTR:1;         /*!< bit:     22  Output Driver Strength Selection   */
+    uint32_t :1;               /*!< bit:     23  Reserved                           */
+    uint32_t PMUX:4;           /*!< bit: 24..27  Peripheral Multiplexing            */
+    uint32_t WRPMUX:1;         /*!< bit:     28  Write PMUX                         */
+    uint32_t :1;               /*!< bit:     29  Reserved                           */
+    uint32_t WRPINCFG:1;       /*!< bit:     30  Write PINCFG                       */
+    uint32_t HWSEL:1;          /*!< bit:     31  Half-Word Select                   */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} PORT_WRCONFIG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_WRCONFIG_OFFSET        0x28         /**< \brief (PORT_WRCONFIG offset) Write Configuration */
+#define PORT_WRCONFIG_RESETVALUE    _U_(0x00000000) /**< \brief (PORT_WRCONFIG reset_value) Write Configuration */
+
+#define PORT_WRCONFIG_PINMASK_Pos   0            /**< \brief (PORT_WRCONFIG) Pin Mask for Multiple Pin Configuration */
+#define PORT_WRCONFIG_PINMASK_Msk   (_U_(0xFFFF) << PORT_WRCONFIG_PINMASK_Pos)
+#define PORT_WRCONFIG_PINMASK(value) (PORT_WRCONFIG_PINMASK_Msk & ((value) << PORT_WRCONFIG_PINMASK_Pos))
+#define PORT_WRCONFIG_PMUXEN_Pos    16           /**< \brief (PORT_WRCONFIG) Peripheral Multiplexer Enable */
+#define PORT_WRCONFIG_PMUXEN        (_U_(0x1) << PORT_WRCONFIG_PMUXEN_Pos)
+#define PORT_WRCONFIG_INEN_Pos      17           /**< \brief (PORT_WRCONFIG) Input Enable */
+#define PORT_WRCONFIG_INEN          (_U_(0x1) << PORT_WRCONFIG_INEN_Pos)
+#define PORT_WRCONFIG_PULLEN_Pos    18           /**< \brief (PORT_WRCONFIG) Pull Enable */
+#define PORT_WRCONFIG_PULLEN        (_U_(0x1) << PORT_WRCONFIG_PULLEN_Pos)
+#define PORT_WRCONFIG_DRVSTR_Pos    22           /**< \brief (PORT_WRCONFIG) Output Driver Strength Selection */
+#define PORT_WRCONFIG_DRVSTR        (_U_(0x1) << PORT_WRCONFIG_DRVSTR_Pos)
+#define PORT_WRCONFIG_PMUX_Pos      24           /**< \brief (PORT_WRCONFIG) Peripheral Multiplexing */
+#define PORT_WRCONFIG_PMUX_Msk      (_U_(0xF) << PORT_WRCONFIG_PMUX_Pos)
+#define PORT_WRCONFIG_PMUX(value)   (PORT_WRCONFIG_PMUX_Msk & ((value) << PORT_WRCONFIG_PMUX_Pos))
+#define PORT_WRCONFIG_WRPMUX_Pos    28           /**< \brief (PORT_WRCONFIG) Write PMUX */
+#define PORT_WRCONFIG_WRPMUX        (_U_(0x1) << PORT_WRCONFIG_WRPMUX_Pos)
+#define PORT_WRCONFIG_WRPINCFG_Pos  30           /**< \brief (PORT_WRCONFIG) Write PINCFG */
+#define PORT_WRCONFIG_WRPINCFG      (_U_(0x1) << PORT_WRCONFIG_WRPINCFG_Pos)
+#define PORT_WRCONFIG_HWSEL_Pos     31           /**< \brief (PORT_WRCONFIG) Half-Word Select */
+#define PORT_WRCONFIG_HWSEL         (_U_(0x1) << PORT_WRCONFIG_HWSEL_Pos)
+#define PORT_WRCONFIG_MASK          _U_(0xDF47FFFF) /**< \brief (PORT_WRCONFIG) MASK Register */
+
+/* -------- PORT_PMUX : (PORT Offset: 0x30) (R/W  8) GROUP Peripheral Multiplexing n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PMUXE:4;          /*!< bit:  0.. 3  Peripheral Multiplexing Even       */
+    uint8_t  PMUXO:4;          /*!< bit:  4.. 7  Peripheral Multiplexing Odd        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PORT_PMUX_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_PMUX_OFFSET            0x30         /**< \brief (PORT_PMUX offset) Peripheral Multiplexing n */
+#define PORT_PMUX_RESETVALUE        _U_(0x00)    /**< \brief (PORT_PMUX reset_value) Peripheral Multiplexing n */
+
+#define PORT_PMUX_PMUXE_Pos         0            /**< \brief (PORT_PMUX) Peripheral Multiplexing Even */
+#define PORT_PMUX_PMUXE_Msk         (_U_(0xF) << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE(value)      (PORT_PMUX_PMUXE_Msk & ((value) << PORT_PMUX_PMUXE_Pos))
+#define   PORT_PMUX_PMUXE_A_Val           _U_(0x0)   /**< \brief (PORT_PMUX) Peripheral function A selected */
+#define   PORT_PMUX_PMUXE_B_Val           _U_(0x1)   /**< \brief (PORT_PMUX) Peripheral function B selected */
+#define   PORT_PMUX_PMUXE_C_Val           _U_(0x2)   /**< \brief (PORT_PMUX) Peripheral function C selected */
+#define   PORT_PMUX_PMUXE_D_Val           _U_(0x3)   /**< \brief (PORT_PMUX) Peripheral function D selected */
+#define   PORT_PMUX_PMUXE_E_Val           _U_(0x4)   /**< \brief (PORT_PMUX) Peripheral function E selected */
+#define   PORT_PMUX_PMUXE_F_Val           _U_(0x5)   /**< \brief (PORT_PMUX) Peripheral function F selected */
+#define   PORT_PMUX_PMUXE_G_Val           _U_(0x6)   /**< \brief (PORT_PMUX) Peripheral function G selected */
+#define   PORT_PMUX_PMUXE_H_Val           _U_(0x7)   /**< \brief (PORT_PMUX) Peripheral function H selected */
+#define PORT_PMUX_PMUXE_A           (PORT_PMUX_PMUXE_A_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE_B           (PORT_PMUX_PMUXE_B_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE_C           (PORT_PMUX_PMUXE_C_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE_D           (PORT_PMUX_PMUXE_D_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE_E           (PORT_PMUX_PMUXE_E_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE_F           (PORT_PMUX_PMUXE_F_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE_G           (PORT_PMUX_PMUXE_G_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXE_H           (PORT_PMUX_PMUXE_H_Val         << PORT_PMUX_PMUXE_Pos)
+#define PORT_PMUX_PMUXO_Pos         4            /**< \brief (PORT_PMUX) Peripheral Multiplexing Odd */
+#define PORT_PMUX_PMUXO_Msk         (_U_(0xF) << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO(value)      (PORT_PMUX_PMUXO_Msk & ((value) << PORT_PMUX_PMUXO_Pos))
+#define   PORT_PMUX_PMUXO_A_Val           _U_(0x0)   /**< \brief (PORT_PMUX) Peripheral function A selected */
+#define   PORT_PMUX_PMUXO_B_Val           _U_(0x1)   /**< \brief (PORT_PMUX) Peripheral function B selected */
+#define   PORT_PMUX_PMUXO_C_Val           _U_(0x2)   /**< \brief (PORT_PMUX) Peripheral function C selected */
+#define   PORT_PMUX_PMUXO_D_Val           _U_(0x3)   /**< \brief (PORT_PMUX) Peripheral function D selected */
+#define   PORT_PMUX_PMUXO_E_Val           _U_(0x4)   /**< \brief (PORT_PMUX) Peripheral function E selected */
+#define   PORT_PMUX_PMUXO_F_Val           _U_(0x5)   /**< \brief (PORT_PMUX) Peripheral function F selected */
+#define   PORT_PMUX_PMUXO_G_Val           _U_(0x6)   /**< \brief (PORT_PMUX) Peripheral function G selected */
+#define   PORT_PMUX_PMUXO_H_Val           _U_(0x7)   /**< \brief (PORT_PMUX) Peripheral function H selected */
+#define PORT_PMUX_PMUXO_A           (PORT_PMUX_PMUXO_A_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO_B           (PORT_PMUX_PMUXO_B_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO_C           (PORT_PMUX_PMUXO_C_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO_D           (PORT_PMUX_PMUXO_D_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO_E           (PORT_PMUX_PMUXO_E_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO_F           (PORT_PMUX_PMUXO_F_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO_G           (PORT_PMUX_PMUXO_G_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_PMUXO_H           (PORT_PMUX_PMUXO_H_Val         << PORT_PMUX_PMUXO_Pos)
+#define PORT_PMUX_MASK              _U_(0xFF)    /**< \brief (PORT_PMUX) MASK Register */
+
+/* -------- PORT_PINCFG : (PORT Offset: 0x40) (R/W  8) GROUP Pin Configuration n -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PMUXEN:1;         /*!< bit:      0  Peripheral Multiplexer Enable      */
+    uint8_t  INEN:1;           /*!< bit:      1  Input Enable                       */
+    uint8_t  PULLEN:1;         /*!< bit:      2  Pull Enable                        */
+    uint8_t  :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint8_t  DRVSTR:1;         /*!< bit:      6  Output Driver Strength Selection   */
+    uint8_t  :1;               /*!< bit:      7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} PORT_PINCFG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define PORT_PINCFG_OFFSET          0x40         /**< \brief (PORT_PINCFG offset) Pin Configuration n */
+#define PORT_PINCFG_RESETVALUE      _U_(0x00)    /**< \brief (PORT_PINCFG reset_value) Pin Configuration n */
+
+#define PORT_PINCFG_PMUXEN_Pos      0            /**< \brief (PORT_PINCFG) Peripheral Multiplexer Enable */
+#define PORT_PINCFG_PMUXEN          (_U_(0x1) << PORT_PINCFG_PMUXEN_Pos)
+#define PORT_PINCFG_INEN_Pos        1            /**< \brief (PORT_PINCFG) Input Enable */
+#define PORT_PINCFG_INEN            (_U_(0x1) << PORT_PINCFG_INEN_Pos)
+#define PORT_PINCFG_PULLEN_Pos      2            /**< \brief (PORT_PINCFG) Pull Enable */
+#define PORT_PINCFG_PULLEN          (_U_(0x1) << PORT_PINCFG_PULLEN_Pos)
+#define PORT_PINCFG_DRVSTR_Pos      6            /**< \brief (PORT_PINCFG) Output Driver Strength Selection */
+#define PORT_PINCFG_DRVSTR          (_U_(0x1) << PORT_PINCFG_DRVSTR_Pos)
+#define PORT_PINCFG_MASK            _U_(0x47)    /**< \brief (PORT_PINCFG) MASK Register */
+
+/** \brief PortGroup hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO PORT_DIR_Type             DIR;         /**< \brief Offset: 0x00 (R/W 32) Data Direction */
+  __IO PORT_DIRCLR_Type          DIRCLR;      /**< \brief Offset: 0x04 (R/W 32) Data Direction Clear */
+  __IO PORT_DIRSET_Type          DIRSET;      /**< \brief Offset: 0x08 (R/W 32) Data Direction Set */
+  __IO PORT_DIRTGL_Type          DIRTGL;      /**< \brief Offset: 0x0C (R/W 32) Data Direction Toggle */
+  __IO PORT_OUT_Type             OUT;         /**< \brief Offset: 0x10 (R/W 32) Data Output Value */
+  __IO PORT_OUTCLR_Type          OUTCLR;      /**< \brief Offset: 0x14 (R/W 32) Data Output Value Clear */
+  __IO PORT_OUTSET_Type          OUTSET;      /**< \brief Offset: 0x18 (R/W 32) Data Output Value Set */
+  __IO PORT_OUTTGL_Type          OUTTGL;      /**< \brief Offset: 0x1C (R/W 32) Data Output Value Toggle */
+  __I  PORT_IN_Type              IN;          /**< \brief Offset: 0x20 (R/  32) Data Input Value */
+  __IO PORT_CTRL_Type            CTRL;        /**< \brief Offset: 0x24 (R/W 32) Control */
+  __O  PORT_WRCONFIG_Type        WRCONFIG;    /**< \brief Offset: 0x28 ( /W 32) Write Configuration */
+       RoReg8                    Reserved1[0x4];
+  __IO PORT_PMUX_Type            PMUX[16];    /**< \brief Offset: 0x30 (R/W  8) Peripheral Multiplexing n */
+  __IO PORT_PINCFG_Type          PINCFG[32];  /**< \brief Offset: 0x40 (R/W  8) Pin Configuration n */
+       RoReg8                    Reserved2[0x20];
+} PortGroup;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief PORT hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+       PortGroup                 Group[2];    /**< \brief Offset: 0x00 PortGroup groups [GROUPS] */
+} Port;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_PORT_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/rtc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/rtc.h
@@ -1,0 +1,1054 @@
+/**
+ * \file
+ *
+ * \brief Component description for RTC
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_RTC_COMPONENT_
+#define _SAMD20_RTC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR RTC */
+/* ========================================================================== */
+/** \addtogroup SAMD20_RTC Real-Time Counter */
+/*@{*/
+
+#define RTC_U2202
+#define REV_RTC                     0x101
+
+/* -------- RTC_MODE0_CTRL : (RTC Offset: 0x00) (R/W 16) MODE0 MODE0 Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t MODE:2;           /*!< bit:  2.. 3  Operating Mode                     */
+    uint16_t :3;               /*!< bit:  4.. 6  Reserved                           */
+    uint16_t MATCHCLR:1;       /*!< bit:      7  Clear on Match                     */
+    uint16_t PRESCALER:4;      /*!< bit:  8..11  Prescaler                          */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_CTRL_OFFSET       0x00         /**< \brief (RTC_MODE0_CTRL offset) MODE0 Control */
+#define RTC_MODE0_CTRL_RESETVALUE   _U_(0x0000)  /**< \brief (RTC_MODE0_CTRL reset_value) MODE0 Control */
+
+#define RTC_MODE0_CTRL_SWRST_Pos    0            /**< \brief (RTC_MODE0_CTRL) Software Reset */
+#define RTC_MODE0_CTRL_SWRST        (_U_(0x1) << RTC_MODE0_CTRL_SWRST_Pos)
+#define RTC_MODE0_CTRL_ENABLE_Pos   1            /**< \brief (RTC_MODE0_CTRL) Enable */
+#define RTC_MODE0_CTRL_ENABLE       (_U_(0x1) << RTC_MODE0_CTRL_ENABLE_Pos)
+#define RTC_MODE0_CTRL_MODE_Pos     2            /**< \brief (RTC_MODE0_CTRL) Operating Mode */
+#define RTC_MODE0_CTRL_MODE_Msk     (_U_(0x3) << RTC_MODE0_CTRL_MODE_Pos)
+#define RTC_MODE0_CTRL_MODE(value)  (RTC_MODE0_CTRL_MODE_Msk & ((value) << RTC_MODE0_CTRL_MODE_Pos))
+#define   RTC_MODE0_CTRL_MODE_COUNT32_Val _U_(0x0)   /**< \brief (RTC_MODE0_CTRL) Mode 0: 32-bit Counter */
+#define   RTC_MODE0_CTRL_MODE_COUNT16_Val _U_(0x1)   /**< \brief (RTC_MODE0_CTRL) Mode 1: 16-bit Counter */
+#define   RTC_MODE0_CTRL_MODE_CLOCK_Val   _U_(0x2)   /**< \brief (RTC_MODE0_CTRL) Mode 2: Clock/Calendar */
+#define RTC_MODE0_CTRL_MODE_COUNT32 (RTC_MODE0_CTRL_MODE_COUNT32_Val << RTC_MODE0_CTRL_MODE_Pos)
+#define RTC_MODE0_CTRL_MODE_COUNT16 (RTC_MODE0_CTRL_MODE_COUNT16_Val << RTC_MODE0_CTRL_MODE_Pos)
+#define RTC_MODE0_CTRL_MODE_CLOCK   (RTC_MODE0_CTRL_MODE_CLOCK_Val << RTC_MODE0_CTRL_MODE_Pos)
+#define RTC_MODE0_CTRL_MATCHCLR_Pos 7            /**< \brief (RTC_MODE0_CTRL) Clear on Match */
+#define RTC_MODE0_CTRL_MATCHCLR     (_U_(0x1) << RTC_MODE0_CTRL_MATCHCLR_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_Pos 8            /**< \brief (RTC_MODE0_CTRL) Prescaler */
+#define RTC_MODE0_CTRL_PRESCALER_Msk (_U_(0xF) << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER(value) (RTC_MODE0_CTRL_PRESCALER_Msk & ((value) << RTC_MODE0_CTRL_PRESCALER_Pos))
+#define   RTC_MODE0_CTRL_PRESCALER_DIV1_Val _U_(0x0)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/1 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV2_Val _U_(0x1)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/2 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV4_Val _U_(0x2)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/4 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV8_Val _U_(0x3)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/8 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV16_Val _U_(0x4)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/16 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV32_Val _U_(0x5)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/32 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV64_Val _U_(0x6)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/64 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV128_Val _U_(0x7)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/128 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV256_Val _U_(0x8)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/256 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV512_Val _U_(0x9)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/512 */
+#define   RTC_MODE0_CTRL_PRESCALER_DIV1024_Val _U_(0xA)   /**< \brief (RTC_MODE0_CTRL) CLK_RTC_CNT = GCLK_RTC/1024 */
+#define RTC_MODE0_CTRL_PRESCALER_DIV1 (RTC_MODE0_CTRL_PRESCALER_DIV1_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV2 (RTC_MODE0_CTRL_PRESCALER_DIV2_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV4 (RTC_MODE0_CTRL_PRESCALER_DIV4_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV8 (RTC_MODE0_CTRL_PRESCALER_DIV8_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV16 (RTC_MODE0_CTRL_PRESCALER_DIV16_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV32 (RTC_MODE0_CTRL_PRESCALER_DIV32_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV64 (RTC_MODE0_CTRL_PRESCALER_DIV64_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV128 (RTC_MODE0_CTRL_PRESCALER_DIV128_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV256 (RTC_MODE0_CTRL_PRESCALER_DIV256_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV512 (RTC_MODE0_CTRL_PRESCALER_DIV512_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_PRESCALER_DIV1024 (RTC_MODE0_CTRL_PRESCALER_DIV1024_Val << RTC_MODE0_CTRL_PRESCALER_Pos)
+#define RTC_MODE0_CTRL_MASK         _U_(0x0F8F)  /**< \brief (RTC_MODE0_CTRL) MASK Register */
+
+/* -------- RTC_MODE1_CTRL : (RTC Offset: 0x00) (R/W 16) MODE1 MODE1 Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t MODE:2;           /*!< bit:  2.. 3  Operating Mode                     */
+    uint16_t :4;               /*!< bit:  4.. 7  Reserved                           */
+    uint16_t PRESCALER:4;      /*!< bit:  8..11  Prescaler                          */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_CTRL_OFFSET       0x00         /**< \brief (RTC_MODE1_CTRL offset) MODE1 Control */
+#define RTC_MODE1_CTRL_RESETVALUE   _U_(0x0000)  /**< \brief (RTC_MODE1_CTRL reset_value) MODE1 Control */
+
+#define RTC_MODE1_CTRL_SWRST_Pos    0            /**< \brief (RTC_MODE1_CTRL) Software Reset */
+#define RTC_MODE1_CTRL_SWRST        (_U_(0x1) << RTC_MODE1_CTRL_SWRST_Pos)
+#define RTC_MODE1_CTRL_ENABLE_Pos   1            /**< \brief (RTC_MODE1_CTRL) Enable */
+#define RTC_MODE1_CTRL_ENABLE       (_U_(0x1) << RTC_MODE1_CTRL_ENABLE_Pos)
+#define RTC_MODE1_CTRL_MODE_Pos     2            /**< \brief (RTC_MODE1_CTRL) Operating Mode */
+#define RTC_MODE1_CTRL_MODE_Msk     (_U_(0x3) << RTC_MODE1_CTRL_MODE_Pos)
+#define RTC_MODE1_CTRL_MODE(value)  (RTC_MODE1_CTRL_MODE_Msk & ((value) << RTC_MODE1_CTRL_MODE_Pos))
+#define   RTC_MODE1_CTRL_MODE_COUNT32_Val _U_(0x0)   /**< \brief (RTC_MODE1_CTRL) Mode 0: 32-bit Counter */
+#define   RTC_MODE1_CTRL_MODE_COUNT16_Val _U_(0x1)   /**< \brief (RTC_MODE1_CTRL) Mode 1: 16-bit Counter */
+#define   RTC_MODE1_CTRL_MODE_CLOCK_Val   _U_(0x2)   /**< \brief (RTC_MODE1_CTRL) Mode 2: Clock/Calendar */
+#define RTC_MODE1_CTRL_MODE_COUNT32 (RTC_MODE1_CTRL_MODE_COUNT32_Val << RTC_MODE1_CTRL_MODE_Pos)
+#define RTC_MODE1_CTRL_MODE_COUNT16 (RTC_MODE1_CTRL_MODE_COUNT16_Val << RTC_MODE1_CTRL_MODE_Pos)
+#define RTC_MODE1_CTRL_MODE_CLOCK   (RTC_MODE1_CTRL_MODE_CLOCK_Val << RTC_MODE1_CTRL_MODE_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_Pos 8            /**< \brief (RTC_MODE1_CTRL) Prescaler */
+#define RTC_MODE1_CTRL_PRESCALER_Msk (_U_(0xF) << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER(value) (RTC_MODE1_CTRL_PRESCALER_Msk & ((value) << RTC_MODE1_CTRL_PRESCALER_Pos))
+#define   RTC_MODE1_CTRL_PRESCALER_DIV1_Val _U_(0x0)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/1 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV2_Val _U_(0x1)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/2 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV4_Val _U_(0x2)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/4 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV8_Val _U_(0x3)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/8 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV16_Val _U_(0x4)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/16 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV32_Val _U_(0x5)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/32 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV64_Val _U_(0x6)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/64 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV128_Val _U_(0x7)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/128 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV256_Val _U_(0x8)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/256 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV512_Val _U_(0x9)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/512 */
+#define   RTC_MODE1_CTRL_PRESCALER_DIV1024_Val _U_(0xA)   /**< \brief (RTC_MODE1_CTRL) CLK_RTC_CNT = GCLK_RTC/1024 */
+#define RTC_MODE1_CTRL_PRESCALER_DIV1 (RTC_MODE1_CTRL_PRESCALER_DIV1_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV2 (RTC_MODE1_CTRL_PRESCALER_DIV2_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV4 (RTC_MODE1_CTRL_PRESCALER_DIV4_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV8 (RTC_MODE1_CTRL_PRESCALER_DIV8_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV16 (RTC_MODE1_CTRL_PRESCALER_DIV16_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV32 (RTC_MODE1_CTRL_PRESCALER_DIV32_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV64 (RTC_MODE1_CTRL_PRESCALER_DIV64_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV128 (RTC_MODE1_CTRL_PRESCALER_DIV128_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV256 (RTC_MODE1_CTRL_PRESCALER_DIV256_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV512 (RTC_MODE1_CTRL_PRESCALER_DIV512_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_PRESCALER_DIV1024 (RTC_MODE1_CTRL_PRESCALER_DIV1024_Val << RTC_MODE1_CTRL_PRESCALER_Pos)
+#define RTC_MODE1_CTRL_MASK         _U_(0x0F0F)  /**< \brief (RTC_MODE1_CTRL) MASK Register */
+
+/* -------- RTC_MODE2_CTRL : (RTC Offset: 0x00) (R/W 16) MODE2 MODE2 Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t MODE:2;           /*!< bit:  2.. 3  Operating Mode                     */
+    uint16_t :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint16_t CLKREP:1;         /*!< bit:      6  Clock Representation               */
+    uint16_t MATCHCLR:1;       /*!< bit:      7  Clear on Match                     */
+    uint16_t PRESCALER:4;      /*!< bit:  8..11  Prescaler                          */
+    uint16_t :4;               /*!< bit: 12..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_CTRL_OFFSET       0x00         /**< \brief (RTC_MODE2_CTRL offset) MODE2 Control */
+#define RTC_MODE2_CTRL_RESETVALUE   _U_(0x0000)  /**< \brief (RTC_MODE2_CTRL reset_value) MODE2 Control */
+
+#define RTC_MODE2_CTRL_SWRST_Pos    0            /**< \brief (RTC_MODE2_CTRL) Software Reset */
+#define RTC_MODE2_CTRL_SWRST        (_U_(0x1) << RTC_MODE2_CTRL_SWRST_Pos)
+#define RTC_MODE2_CTRL_ENABLE_Pos   1            /**< \brief (RTC_MODE2_CTRL) Enable */
+#define RTC_MODE2_CTRL_ENABLE       (_U_(0x1) << RTC_MODE2_CTRL_ENABLE_Pos)
+#define RTC_MODE2_CTRL_MODE_Pos     2            /**< \brief (RTC_MODE2_CTRL) Operating Mode */
+#define RTC_MODE2_CTRL_MODE_Msk     (_U_(0x3) << RTC_MODE2_CTRL_MODE_Pos)
+#define RTC_MODE2_CTRL_MODE(value)  (RTC_MODE2_CTRL_MODE_Msk & ((value) << RTC_MODE2_CTRL_MODE_Pos))
+#define   RTC_MODE2_CTRL_MODE_COUNT32_Val _U_(0x0)   /**< \brief (RTC_MODE2_CTRL) Mode 0: 32-bit Counter */
+#define   RTC_MODE2_CTRL_MODE_COUNT16_Val _U_(0x1)   /**< \brief (RTC_MODE2_CTRL) Mode 1: 16-bit Counter */
+#define   RTC_MODE2_CTRL_MODE_CLOCK_Val   _U_(0x2)   /**< \brief (RTC_MODE2_CTRL) Mode 2: Clock/Calendar */
+#define RTC_MODE2_CTRL_MODE_COUNT32 (RTC_MODE2_CTRL_MODE_COUNT32_Val << RTC_MODE2_CTRL_MODE_Pos)
+#define RTC_MODE2_CTRL_MODE_COUNT16 (RTC_MODE2_CTRL_MODE_COUNT16_Val << RTC_MODE2_CTRL_MODE_Pos)
+#define RTC_MODE2_CTRL_MODE_CLOCK   (RTC_MODE2_CTRL_MODE_CLOCK_Val << RTC_MODE2_CTRL_MODE_Pos)
+#define RTC_MODE2_CTRL_CLKREP_Pos   6            /**< \brief (RTC_MODE2_CTRL) Clock Representation */
+#define RTC_MODE2_CTRL_CLKREP       (_U_(0x1) << RTC_MODE2_CTRL_CLKREP_Pos)
+#define RTC_MODE2_CTRL_MATCHCLR_Pos 7            /**< \brief (RTC_MODE2_CTRL) Clear on Match */
+#define RTC_MODE2_CTRL_MATCHCLR     (_U_(0x1) << RTC_MODE2_CTRL_MATCHCLR_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_Pos 8            /**< \brief (RTC_MODE2_CTRL) Prescaler */
+#define RTC_MODE2_CTRL_PRESCALER_Msk (_U_(0xF) << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER(value) (RTC_MODE2_CTRL_PRESCALER_Msk & ((value) << RTC_MODE2_CTRL_PRESCALER_Pos))
+#define   RTC_MODE2_CTRL_PRESCALER_DIV1_Val _U_(0x0)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/1 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV2_Val _U_(0x1)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/2 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV4_Val _U_(0x2)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/4 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV8_Val _U_(0x3)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/8 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV16_Val _U_(0x4)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/16 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV32_Val _U_(0x5)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/32 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV64_Val _U_(0x6)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/64 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV128_Val _U_(0x7)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/128 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV256_Val _U_(0x8)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/256 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV512_Val _U_(0x9)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/512 */
+#define   RTC_MODE2_CTRL_PRESCALER_DIV1024_Val _U_(0xA)   /**< \brief (RTC_MODE2_CTRL) CLK_RTC_CNT = GCLK_RTC/1024 */
+#define RTC_MODE2_CTRL_PRESCALER_DIV1 (RTC_MODE2_CTRL_PRESCALER_DIV1_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV2 (RTC_MODE2_CTRL_PRESCALER_DIV2_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV4 (RTC_MODE2_CTRL_PRESCALER_DIV4_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV8 (RTC_MODE2_CTRL_PRESCALER_DIV8_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV16 (RTC_MODE2_CTRL_PRESCALER_DIV16_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV32 (RTC_MODE2_CTRL_PRESCALER_DIV32_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV64 (RTC_MODE2_CTRL_PRESCALER_DIV64_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV128 (RTC_MODE2_CTRL_PRESCALER_DIV128_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV256 (RTC_MODE2_CTRL_PRESCALER_DIV256_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV512 (RTC_MODE2_CTRL_PRESCALER_DIV512_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_PRESCALER_DIV1024 (RTC_MODE2_CTRL_PRESCALER_DIV1024_Val << RTC_MODE2_CTRL_PRESCALER_Pos)
+#define RTC_MODE2_CTRL_MASK         _U_(0x0FCF)  /**< \brief (RTC_MODE2_CTRL) MASK Register */
+
+/* -------- RTC_READREQ : (RTC Offset: 0x02) (R/W 16) Read Request -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t ADDR:6;           /*!< bit:  0.. 5  Address                            */
+    uint16_t :8;               /*!< bit:  6..13  Reserved                           */
+    uint16_t RCONT:1;          /*!< bit:     14  Read Continuously                  */
+    uint16_t RREQ:1;           /*!< bit:     15  Read Request                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_READREQ_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_READREQ_OFFSET          0x02         /**< \brief (RTC_READREQ offset) Read Request */
+#define RTC_READREQ_RESETVALUE      _U_(0x0010)  /**< \brief (RTC_READREQ reset_value) Read Request */
+
+#define RTC_READREQ_ADDR_Pos        0            /**< \brief (RTC_READREQ) Address */
+#define RTC_READREQ_ADDR_Msk        (_U_(0x3F) << RTC_READREQ_ADDR_Pos)
+#define RTC_READREQ_ADDR(value)     (RTC_READREQ_ADDR_Msk & ((value) << RTC_READREQ_ADDR_Pos))
+#define RTC_READREQ_RCONT_Pos       14           /**< \brief (RTC_READREQ) Read Continuously */
+#define RTC_READREQ_RCONT           (_U_(0x1) << RTC_READREQ_RCONT_Pos)
+#define RTC_READREQ_RREQ_Pos        15           /**< \brief (RTC_READREQ) Read Request */
+#define RTC_READREQ_RREQ            (_U_(0x1) << RTC_READREQ_RREQ_Pos)
+#define RTC_READREQ_MASK            _U_(0xC03F)  /**< \brief (RTC_READREQ) MASK Register */
+
+/* -------- RTC_MODE0_EVCTRL : (RTC Offset: 0x04) (R/W 16) MODE0 MODE0 Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PEREO0:1;         /*!< bit:      0  Periodic Interval 0 Event Output Enable */
+    uint16_t PEREO1:1;         /*!< bit:      1  Periodic Interval 1 Event Output Enable */
+    uint16_t PEREO2:1;         /*!< bit:      2  Periodic Interval 2 Event Output Enable */
+    uint16_t PEREO3:1;         /*!< bit:      3  Periodic Interval 3 Event Output Enable */
+    uint16_t PEREO4:1;         /*!< bit:      4  Periodic Interval 4 Event Output Enable */
+    uint16_t PEREO5:1;         /*!< bit:      5  Periodic Interval 5 Event Output Enable */
+    uint16_t PEREO6:1;         /*!< bit:      6  Periodic Interval 6 Event Output Enable */
+    uint16_t PEREO7:1;         /*!< bit:      7  Periodic Interval 7 Event Output Enable */
+    uint16_t CMPEO0:1;         /*!< bit:      8  Compare 0 Event Output Enable      */
+    uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t OVFEO:1;          /*!< bit:     15  Overflow Event Output Enable       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t PEREO:8;          /*!< bit:  0.. 7  Periodic Interval x Event Output Enable */
+    uint16_t CMPEO:1;          /*!< bit:      8  Compare x Event Output Enable      */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_EVCTRL_OFFSET     0x04         /**< \brief (RTC_MODE0_EVCTRL offset) MODE0 Event Control */
+#define RTC_MODE0_EVCTRL_RESETVALUE _U_(0x0000)  /**< \brief (RTC_MODE0_EVCTRL reset_value) MODE0 Event Control */
+
+#define RTC_MODE0_EVCTRL_PEREO0_Pos 0            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 0 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO0     (_U_(1) << RTC_MODE0_EVCTRL_PEREO0_Pos)
+#define RTC_MODE0_EVCTRL_PEREO1_Pos 1            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 1 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO1     (_U_(1) << RTC_MODE0_EVCTRL_PEREO1_Pos)
+#define RTC_MODE0_EVCTRL_PEREO2_Pos 2            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 2 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO2     (_U_(1) << RTC_MODE0_EVCTRL_PEREO2_Pos)
+#define RTC_MODE0_EVCTRL_PEREO3_Pos 3            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 3 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO3     (_U_(1) << RTC_MODE0_EVCTRL_PEREO3_Pos)
+#define RTC_MODE0_EVCTRL_PEREO4_Pos 4            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 4 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO4     (_U_(1) << RTC_MODE0_EVCTRL_PEREO4_Pos)
+#define RTC_MODE0_EVCTRL_PEREO5_Pos 5            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 5 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO5     (_U_(1) << RTC_MODE0_EVCTRL_PEREO5_Pos)
+#define RTC_MODE0_EVCTRL_PEREO6_Pos 6            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 6 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO6     (_U_(1) << RTC_MODE0_EVCTRL_PEREO6_Pos)
+#define RTC_MODE0_EVCTRL_PEREO7_Pos 7            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval 7 Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO7     (_U_(1) << RTC_MODE0_EVCTRL_PEREO7_Pos)
+#define RTC_MODE0_EVCTRL_PEREO_Pos  0            /**< \brief (RTC_MODE0_EVCTRL) Periodic Interval x Event Output Enable */
+#define RTC_MODE0_EVCTRL_PEREO_Msk  (_U_(0xFF) << RTC_MODE0_EVCTRL_PEREO_Pos)
+#define RTC_MODE0_EVCTRL_PEREO(value) (RTC_MODE0_EVCTRL_PEREO_Msk & ((value) << RTC_MODE0_EVCTRL_PEREO_Pos))
+#define RTC_MODE0_EVCTRL_CMPEO0_Pos 8            /**< \brief (RTC_MODE0_EVCTRL) Compare 0 Event Output Enable */
+#define RTC_MODE0_EVCTRL_CMPEO0     (_U_(1) << RTC_MODE0_EVCTRL_CMPEO0_Pos)
+#define RTC_MODE0_EVCTRL_CMPEO_Pos  8            /**< \brief (RTC_MODE0_EVCTRL) Compare x Event Output Enable */
+#define RTC_MODE0_EVCTRL_CMPEO_Msk  (_U_(0x1) << RTC_MODE0_EVCTRL_CMPEO_Pos)
+#define RTC_MODE0_EVCTRL_CMPEO(value) (RTC_MODE0_EVCTRL_CMPEO_Msk & ((value) << RTC_MODE0_EVCTRL_CMPEO_Pos))
+#define RTC_MODE0_EVCTRL_OVFEO_Pos  15           /**< \brief (RTC_MODE0_EVCTRL) Overflow Event Output Enable */
+#define RTC_MODE0_EVCTRL_OVFEO      (_U_(0x1) << RTC_MODE0_EVCTRL_OVFEO_Pos)
+#define RTC_MODE0_EVCTRL_MASK       _U_(0x81FF)  /**< \brief (RTC_MODE0_EVCTRL) MASK Register */
+
+/* -------- RTC_MODE1_EVCTRL : (RTC Offset: 0x04) (R/W 16) MODE1 MODE1 Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PEREO0:1;         /*!< bit:      0  Periodic Interval 0 Event Output Enable */
+    uint16_t PEREO1:1;         /*!< bit:      1  Periodic Interval 1 Event Output Enable */
+    uint16_t PEREO2:1;         /*!< bit:      2  Periodic Interval 2 Event Output Enable */
+    uint16_t PEREO3:1;         /*!< bit:      3  Periodic Interval 3 Event Output Enable */
+    uint16_t PEREO4:1;         /*!< bit:      4  Periodic Interval 4 Event Output Enable */
+    uint16_t PEREO5:1;         /*!< bit:      5  Periodic Interval 5 Event Output Enable */
+    uint16_t PEREO6:1;         /*!< bit:      6  Periodic Interval 6 Event Output Enable */
+    uint16_t PEREO7:1;         /*!< bit:      7  Periodic Interval 7 Event Output Enable */
+    uint16_t CMPEO0:1;         /*!< bit:      8  Compare 0 Event Output Enable      */
+    uint16_t CMPEO1:1;         /*!< bit:      9  Compare 1 Event Output Enable      */
+    uint16_t :5;               /*!< bit: 10..14  Reserved                           */
+    uint16_t OVFEO:1;          /*!< bit:     15  Overflow Event Output Enable       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t PEREO:8;          /*!< bit:  0.. 7  Periodic Interval x Event Output Enable */
+    uint16_t CMPEO:2;          /*!< bit:  8.. 9  Compare x Event Output Enable      */
+    uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_EVCTRL_OFFSET     0x04         /**< \brief (RTC_MODE1_EVCTRL offset) MODE1 Event Control */
+#define RTC_MODE1_EVCTRL_RESETVALUE _U_(0x0000)  /**< \brief (RTC_MODE1_EVCTRL reset_value) MODE1 Event Control */
+
+#define RTC_MODE1_EVCTRL_PEREO0_Pos 0            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 0 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO0     (_U_(1) << RTC_MODE1_EVCTRL_PEREO0_Pos)
+#define RTC_MODE1_EVCTRL_PEREO1_Pos 1            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 1 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO1     (_U_(1) << RTC_MODE1_EVCTRL_PEREO1_Pos)
+#define RTC_MODE1_EVCTRL_PEREO2_Pos 2            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 2 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO2     (_U_(1) << RTC_MODE1_EVCTRL_PEREO2_Pos)
+#define RTC_MODE1_EVCTRL_PEREO3_Pos 3            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 3 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO3     (_U_(1) << RTC_MODE1_EVCTRL_PEREO3_Pos)
+#define RTC_MODE1_EVCTRL_PEREO4_Pos 4            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 4 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO4     (_U_(1) << RTC_MODE1_EVCTRL_PEREO4_Pos)
+#define RTC_MODE1_EVCTRL_PEREO5_Pos 5            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 5 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO5     (_U_(1) << RTC_MODE1_EVCTRL_PEREO5_Pos)
+#define RTC_MODE1_EVCTRL_PEREO6_Pos 6            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 6 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO6     (_U_(1) << RTC_MODE1_EVCTRL_PEREO6_Pos)
+#define RTC_MODE1_EVCTRL_PEREO7_Pos 7            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval 7 Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO7     (_U_(1) << RTC_MODE1_EVCTRL_PEREO7_Pos)
+#define RTC_MODE1_EVCTRL_PEREO_Pos  0            /**< \brief (RTC_MODE1_EVCTRL) Periodic Interval x Event Output Enable */
+#define RTC_MODE1_EVCTRL_PEREO_Msk  (_U_(0xFF) << RTC_MODE1_EVCTRL_PEREO_Pos)
+#define RTC_MODE1_EVCTRL_PEREO(value) (RTC_MODE1_EVCTRL_PEREO_Msk & ((value) << RTC_MODE1_EVCTRL_PEREO_Pos))
+#define RTC_MODE1_EVCTRL_CMPEO0_Pos 8            /**< \brief (RTC_MODE1_EVCTRL) Compare 0 Event Output Enable */
+#define RTC_MODE1_EVCTRL_CMPEO0     (_U_(1) << RTC_MODE1_EVCTRL_CMPEO0_Pos)
+#define RTC_MODE1_EVCTRL_CMPEO1_Pos 9            /**< \brief (RTC_MODE1_EVCTRL) Compare 1 Event Output Enable */
+#define RTC_MODE1_EVCTRL_CMPEO1     (_U_(1) << RTC_MODE1_EVCTRL_CMPEO1_Pos)
+#define RTC_MODE1_EVCTRL_CMPEO_Pos  8            /**< \brief (RTC_MODE1_EVCTRL) Compare x Event Output Enable */
+#define RTC_MODE1_EVCTRL_CMPEO_Msk  (_U_(0x3) << RTC_MODE1_EVCTRL_CMPEO_Pos)
+#define RTC_MODE1_EVCTRL_CMPEO(value) (RTC_MODE1_EVCTRL_CMPEO_Msk & ((value) << RTC_MODE1_EVCTRL_CMPEO_Pos))
+#define RTC_MODE1_EVCTRL_OVFEO_Pos  15           /**< \brief (RTC_MODE1_EVCTRL) Overflow Event Output Enable */
+#define RTC_MODE1_EVCTRL_OVFEO      (_U_(0x1) << RTC_MODE1_EVCTRL_OVFEO_Pos)
+#define RTC_MODE1_EVCTRL_MASK       _U_(0x83FF)  /**< \brief (RTC_MODE1_EVCTRL) MASK Register */
+
+/* -------- RTC_MODE2_EVCTRL : (RTC Offset: 0x04) (R/W 16) MODE2 MODE2 Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PEREO0:1;         /*!< bit:      0  Periodic Interval 0 Event Output Enable */
+    uint16_t PEREO1:1;         /*!< bit:      1  Periodic Interval 1 Event Output Enable */
+    uint16_t PEREO2:1;         /*!< bit:      2  Periodic Interval 2 Event Output Enable */
+    uint16_t PEREO3:1;         /*!< bit:      3  Periodic Interval 3 Event Output Enable */
+    uint16_t PEREO4:1;         /*!< bit:      4  Periodic Interval 4 Event Output Enable */
+    uint16_t PEREO5:1;         /*!< bit:      5  Periodic Interval 5 Event Output Enable */
+    uint16_t PEREO6:1;         /*!< bit:      6  Periodic Interval 6 Event Output Enable */
+    uint16_t PEREO7:1;         /*!< bit:      7  Periodic Interval 7 Event Output Enable */
+    uint16_t ALARMEO0:1;       /*!< bit:      8  Alarm 0 Event Output Enable        */
+    uint16_t :6;               /*!< bit:  9..14  Reserved                           */
+    uint16_t OVFEO:1;          /*!< bit:     15  Overflow Event Output Enable       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t PEREO:8;          /*!< bit:  0.. 7  Periodic Interval x Event Output Enable */
+    uint16_t ALARMEO:1;        /*!< bit:      8  Alarm x Event Output Enable        */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_EVCTRL_OFFSET     0x04         /**< \brief (RTC_MODE2_EVCTRL offset) MODE2 Event Control */
+#define RTC_MODE2_EVCTRL_RESETVALUE _U_(0x0000)  /**< \brief (RTC_MODE2_EVCTRL reset_value) MODE2 Event Control */
+
+#define RTC_MODE2_EVCTRL_PEREO0_Pos 0            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 0 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO0     (_U_(1) << RTC_MODE2_EVCTRL_PEREO0_Pos)
+#define RTC_MODE2_EVCTRL_PEREO1_Pos 1            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 1 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO1     (_U_(1) << RTC_MODE2_EVCTRL_PEREO1_Pos)
+#define RTC_MODE2_EVCTRL_PEREO2_Pos 2            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 2 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO2     (_U_(1) << RTC_MODE2_EVCTRL_PEREO2_Pos)
+#define RTC_MODE2_EVCTRL_PEREO3_Pos 3            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 3 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO3     (_U_(1) << RTC_MODE2_EVCTRL_PEREO3_Pos)
+#define RTC_MODE2_EVCTRL_PEREO4_Pos 4            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 4 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO4     (_U_(1) << RTC_MODE2_EVCTRL_PEREO4_Pos)
+#define RTC_MODE2_EVCTRL_PEREO5_Pos 5            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 5 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO5     (_U_(1) << RTC_MODE2_EVCTRL_PEREO5_Pos)
+#define RTC_MODE2_EVCTRL_PEREO6_Pos 6            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 6 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO6     (_U_(1) << RTC_MODE2_EVCTRL_PEREO6_Pos)
+#define RTC_MODE2_EVCTRL_PEREO7_Pos 7            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval 7 Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO7     (_U_(1) << RTC_MODE2_EVCTRL_PEREO7_Pos)
+#define RTC_MODE2_EVCTRL_PEREO_Pos  0            /**< \brief (RTC_MODE2_EVCTRL) Periodic Interval x Event Output Enable */
+#define RTC_MODE2_EVCTRL_PEREO_Msk  (_U_(0xFF) << RTC_MODE2_EVCTRL_PEREO_Pos)
+#define RTC_MODE2_EVCTRL_PEREO(value) (RTC_MODE2_EVCTRL_PEREO_Msk & ((value) << RTC_MODE2_EVCTRL_PEREO_Pos))
+#define RTC_MODE2_EVCTRL_ALARMEO0_Pos 8            /**< \brief (RTC_MODE2_EVCTRL) Alarm 0 Event Output Enable */
+#define RTC_MODE2_EVCTRL_ALARMEO0   (_U_(1) << RTC_MODE2_EVCTRL_ALARMEO0_Pos)
+#define RTC_MODE2_EVCTRL_ALARMEO_Pos 8            /**< \brief (RTC_MODE2_EVCTRL) Alarm x Event Output Enable */
+#define RTC_MODE2_EVCTRL_ALARMEO_Msk (_U_(0x1) << RTC_MODE2_EVCTRL_ALARMEO_Pos)
+#define RTC_MODE2_EVCTRL_ALARMEO(value) (RTC_MODE2_EVCTRL_ALARMEO_Msk & ((value) << RTC_MODE2_EVCTRL_ALARMEO_Pos))
+#define RTC_MODE2_EVCTRL_OVFEO_Pos  15           /**< \brief (RTC_MODE2_EVCTRL) Overflow Event Output Enable */
+#define RTC_MODE2_EVCTRL_OVFEO      (_U_(0x1) << RTC_MODE2_EVCTRL_OVFEO_Pos)
+#define RTC_MODE2_EVCTRL_MASK       _U_(0x81FF)  /**< \brief (RTC_MODE2_EVCTRL) MASK Register */
+
+/* -------- RTC_MODE0_INTENCLR : (RTC Offset: 0x06) (R/W  8) MODE0 MODE0 Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CMP0:1;           /*!< bit:      0  Compare 0 Interrupt Enable         */
+    uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready Interrupt Enable */
+    uint8_t  OVF:1;            /*!< bit:      7  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  CMP:1;            /*!< bit:      0  Compare x Interrupt Enable         */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE0_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_INTENCLR_OFFSET   0x06         /**< \brief (RTC_MODE0_INTENCLR offset) MODE0 Interrupt Enable Clear */
+#define RTC_MODE0_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE0_INTENCLR reset_value) MODE0 Interrupt Enable Clear */
+
+#define RTC_MODE0_INTENCLR_CMP0_Pos 0            /**< \brief (RTC_MODE0_INTENCLR) Compare 0 Interrupt Enable */
+#define RTC_MODE0_INTENCLR_CMP0     (_U_(1) << RTC_MODE0_INTENCLR_CMP0_Pos)
+#define RTC_MODE0_INTENCLR_CMP_Pos  0            /**< \brief (RTC_MODE0_INTENCLR) Compare x Interrupt Enable */
+#define RTC_MODE0_INTENCLR_CMP_Msk  (_U_(0x1) << RTC_MODE0_INTENCLR_CMP_Pos)
+#define RTC_MODE0_INTENCLR_CMP(value) (RTC_MODE0_INTENCLR_CMP_Msk & ((value) << RTC_MODE0_INTENCLR_CMP_Pos))
+#define RTC_MODE0_INTENCLR_SYNCRDY_Pos 6            /**< \brief (RTC_MODE0_INTENCLR) Synchronization Ready Interrupt Enable */
+#define RTC_MODE0_INTENCLR_SYNCRDY  (_U_(0x1) << RTC_MODE0_INTENCLR_SYNCRDY_Pos)
+#define RTC_MODE0_INTENCLR_OVF_Pos  7            /**< \brief (RTC_MODE0_INTENCLR) Overflow Interrupt Enable */
+#define RTC_MODE0_INTENCLR_OVF      (_U_(0x1) << RTC_MODE0_INTENCLR_OVF_Pos)
+#define RTC_MODE0_INTENCLR_MASK     _U_(0xC1)    /**< \brief (RTC_MODE0_INTENCLR) MASK Register */
+
+/* -------- RTC_MODE1_INTENCLR : (RTC Offset: 0x06) (R/W  8) MODE1 MODE1 Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CMP0:1;           /*!< bit:      0  Compare 0 Interrupt Enable         */
+    uint8_t  CMP1:1;           /*!< bit:      1  Compare 1 Interrupt Enable         */
+    uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready Interrupt Enable */
+    uint8_t  OVF:1;            /*!< bit:      7  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x Interrupt Enable         */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE1_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_INTENCLR_OFFSET   0x06         /**< \brief (RTC_MODE1_INTENCLR offset) MODE1 Interrupt Enable Clear */
+#define RTC_MODE1_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE1_INTENCLR reset_value) MODE1 Interrupt Enable Clear */
+
+#define RTC_MODE1_INTENCLR_CMP0_Pos 0            /**< \brief (RTC_MODE1_INTENCLR) Compare 0 Interrupt Enable */
+#define RTC_MODE1_INTENCLR_CMP0     (_U_(1) << RTC_MODE1_INTENCLR_CMP0_Pos)
+#define RTC_MODE1_INTENCLR_CMP1_Pos 1            /**< \brief (RTC_MODE1_INTENCLR) Compare 1 Interrupt Enable */
+#define RTC_MODE1_INTENCLR_CMP1     (_U_(1) << RTC_MODE1_INTENCLR_CMP1_Pos)
+#define RTC_MODE1_INTENCLR_CMP_Pos  0            /**< \brief (RTC_MODE1_INTENCLR) Compare x Interrupt Enable */
+#define RTC_MODE1_INTENCLR_CMP_Msk  (_U_(0x3) << RTC_MODE1_INTENCLR_CMP_Pos)
+#define RTC_MODE1_INTENCLR_CMP(value) (RTC_MODE1_INTENCLR_CMP_Msk & ((value) << RTC_MODE1_INTENCLR_CMP_Pos))
+#define RTC_MODE1_INTENCLR_SYNCRDY_Pos 6            /**< \brief (RTC_MODE1_INTENCLR) Synchronization Ready Interrupt Enable */
+#define RTC_MODE1_INTENCLR_SYNCRDY  (_U_(0x1) << RTC_MODE1_INTENCLR_SYNCRDY_Pos)
+#define RTC_MODE1_INTENCLR_OVF_Pos  7            /**< \brief (RTC_MODE1_INTENCLR) Overflow Interrupt Enable */
+#define RTC_MODE1_INTENCLR_OVF      (_U_(0x1) << RTC_MODE1_INTENCLR_OVF_Pos)
+#define RTC_MODE1_INTENCLR_MASK     _U_(0xC3)    /**< \brief (RTC_MODE1_INTENCLR) MASK Register */
+
+/* -------- RTC_MODE2_INTENCLR : (RTC Offset: 0x06) (R/W  8) MODE2 MODE2 Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0 Interrupt Enable           */
+    uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready Interrupt Enable */
+    uint8_t  OVF:1;            /*!< bit:      7  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  ALARM:1;          /*!< bit:      0  Alarm x Interrupt Enable           */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE2_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_INTENCLR_OFFSET   0x06         /**< \brief (RTC_MODE2_INTENCLR offset) MODE2 Interrupt Enable Clear */
+#define RTC_MODE2_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE2_INTENCLR reset_value) MODE2 Interrupt Enable Clear */
+
+#define RTC_MODE2_INTENCLR_ALARM0_Pos 0            /**< \brief (RTC_MODE2_INTENCLR) Alarm 0 Interrupt Enable */
+#define RTC_MODE2_INTENCLR_ALARM0   (_U_(1) << RTC_MODE2_INTENCLR_ALARM0_Pos)
+#define RTC_MODE2_INTENCLR_ALARM_Pos 0            /**< \brief (RTC_MODE2_INTENCLR) Alarm x Interrupt Enable */
+#define RTC_MODE2_INTENCLR_ALARM_Msk (_U_(0x1) << RTC_MODE2_INTENCLR_ALARM_Pos)
+#define RTC_MODE2_INTENCLR_ALARM(value) (RTC_MODE2_INTENCLR_ALARM_Msk & ((value) << RTC_MODE2_INTENCLR_ALARM_Pos))
+#define RTC_MODE2_INTENCLR_SYNCRDY_Pos 6            /**< \brief (RTC_MODE2_INTENCLR) Synchronization Ready Interrupt Enable */
+#define RTC_MODE2_INTENCLR_SYNCRDY  (_U_(0x1) << RTC_MODE2_INTENCLR_SYNCRDY_Pos)
+#define RTC_MODE2_INTENCLR_OVF_Pos  7            /**< \brief (RTC_MODE2_INTENCLR) Overflow Interrupt Enable */
+#define RTC_MODE2_INTENCLR_OVF      (_U_(0x1) << RTC_MODE2_INTENCLR_OVF_Pos)
+#define RTC_MODE2_INTENCLR_MASK     _U_(0xC1)    /**< \brief (RTC_MODE2_INTENCLR) MASK Register */
+
+/* -------- RTC_MODE0_INTENSET : (RTC Offset: 0x07) (R/W  8) MODE0 MODE0 Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CMP0:1;           /*!< bit:      0  Compare 0 Interrupt Enable         */
+    uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready Interrupt Enable */
+    uint8_t  OVF:1;            /*!< bit:      7  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  CMP:1;            /*!< bit:      0  Compare x Interrupt Enable         */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE0_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_INTENSET_OFFSET   0x07         /**< \brief (RTC_MODE0_INTENSET offset) MODE0 Interrupt Enable Set */
+#define RTC_MODE0_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE0_INTENSET reset_value) MODE0 Interrupt Enable Set */
+
+#define RTC_MODE0_INTENSET_CMP0_Pos 0            /**< \brief (RTC_MODE0_INTENSET) Compare 0 Interrupt Enable */
+#define RTC_MODE0_INTENSET_CMP0     (_U_(1) << RTC_MODE0_INTENSET_CMP0_Pos)
+#define RTC_MODE0_INTENSET_CMP_Pos  0            /**< \brief (RTC_MODE0_INTENSET) Compare x Interrupt Enable */
+#define RTC_MODE0_INTENSET_CMP_Msk  (_U_(0x1) << RTC_MODE0_INTENSET_CMP_Pos)
+#define RTC_MODE0_INTENSET_CMP(value) (RTC_MODE0_INTENSET_CMP_Msk & ((value) << RTC_MODE0_INTENSET_CMP_Pos))
+#define RTC_MODE0_INTENSET_SYNCRDY_Pos 6            /**< \brief (RTC_MODE0_INTENSET) Synchronization Ready Interrupt Enable */
+#define RTC_MODE0_INTENSET_SYNCRDY  (_U_(0x1) << RTC_MODE0_INTENSET_SYNCRDY_Pos)
+#define RTC_MODE0_INTENSET_OVF_Pos  7            /**< \brief (RTC_MODE0_INTENSET) Overflow Interrupt Enable */
+#define RTC_MODE0_INTENSET_OVF      (_U_(0x1) << RTC_MODE0_INTENSET_OVF_Pos)
+#define RTC_MODE0_INTENSET_MASK     _U_(0xC1)    /**< \brief (RTC_MODE0_INTENSET) MASK Register */
+
+/* -------- RTC_MODE1_INTENSET : (RTC Offset: 0x07) (R/W  8) MODE1 MODE1 Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CMP0:1;           /*!< bit:      0  Compare 0 Interrupt Enable         */
+    uint8_t  CMP1:1;           /*!< bit:      1  Compare 1 Interrupt Enable         */
+    uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready Interrupt Enable */
+    uint8_t  OVF:1;            /*!< bit:      7  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x Interrupt Enable         */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE1_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_INTENSET_OFFSET   0x07         /**< \brief (RTC_MODE1_INTENSET offset) MODE1 Interrupt Enable Set */
+#define RTC_MODE1_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE1_INTENSET reset_value) MODE1 Interrupt Enable Set */
+
+#define RTC_MODE1_INTENSET_CMP0_Pos 0            /**< \brief (RTC_MODE1_INTENSET) Compare 0 Interrupt Enable */
+#define RTC_MODE1_INTENSET_CMP0     (_U_(1) << RTC_MODE1_INTENSET_CMP0_Pos)
+#define RTC_MODE1_INTENSET_CMP1_Pos 1            /**< \brief (RTC_MODE1_INTENSET) Compare 1 Interrupt Enable */
+#define RTC_MODE1_INTENSET_CMP1     (_U_(1) << RTC_MODE1_INTENSET_CMP1_Pos)
+#define RTC_MODE1_INTENSET_CMP_Pos  0            /**< \brief (RTC_MODE1_INTENSET) Compare x Interrupt Enable */
+#define RTC_MODE1_INTENSET_CMP_Msk  (_U_(0x3) << RTC_MODE1_INTENSET_CMP_Pos)
+#define RTC_MODE1_INTENSET_CMP(value) (RTC_MODE1_INTENSET_CMP_Msk & ((value) << RTC_MODE1_INTENSET_CMP_Pos))
+#define RTC_MODE1_INTENSET_SYNCRDY_Pos 6            /**< \brief (RTC_MODE1_INTENSET) Synchronization Ready Interrupt Enable */
+#define RTC_MODE1_INTENSET_SYNCRDY  (_U_(0x1) << RTC_MODE1_INTENSET_SYNCRDY_Pos)
+#define RTC_MODE1_INTENSET_OVF_Pos  7            /**< \brief (RTC_MODE1_INTENSET) Overflow Interrupt Enable */
+#define RTC_MODE1_INTENSET_OVF      (_U_(0x1) << RTC_MODE1_INTENSET_OVF_Pos)
+#define RTC_MODE1_INTENSET_MASK     _U_(0xC3)    /**< \brief (RTC_MODE1_INTENSET) MASK Register */
+
+/* -------- RTC_MODE2_INTENSET : (RTC Offset: 0x07) (R/W  8) MODE2 MODE2 Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0 Interrupt Enable           */
+    uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready Interrupt Enable */
+    uint8_t  OVF:1;            /*!< bit:      7  Overflow Interrupt Enable          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  ALARM:1;          /*!< bit:      0  Alarm x Interrupt Enable           */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE2_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_INTENSET_OFFSET   0x07         /**< \brief (RTC_MODE2_INTENSET offset) MODE2 Interrupt Enable Set */
+#define RTC_MODE2_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE2_INTENSET reset_value) MODE2 Interrupt Enable Set */
+
+#define RTC_MODE2_INTENSET_ALARM0_Pos 0            /**< \brief (RTC_MODE2_INTENSET) Alarm 0 Interrupt Enable */
+#define RTC_MODE2_INTENSET_ALARM0   (_U_(1) << RTC_MODE2_INTENSET_ALARM0_Pos)
+#define RTC_MODE2_INTENSET_ALARM_Pos 0            /**< \brief (RTC_MODE2_INTENSET) Alarm x Interrupt Enable */
+#define RTC_MODE2_INTENSET_ALARM_Msk (_U_(0x1) << RTC_MODE2_INTENSET_ALARM_Pos)
+#define RTC_MODE2_INTENSET_ALARM(value) (RTC_MODE2_INTENSET_ALARM_Msk & ((value) << RTC_MODE2_INTENSET_ALARM_Pos))
+#define RTC_MODE2_INTENSET_SYNCRDY_Pos 6            /**< \brief (RTC_MODE2_INTENSET) Synchronization Ready Interrupt Enable */
+#define RTC_MODE2_INTENSET_SYNCRDY  (_U_(0x1) << RTC_MODE2_INTENSET_SYNCRDY_Pos)
+#define RTC_MODE2_INTENSET_OVF_Pos  7            /**< \brief (RTC_MODE2_INTENSET) Overflow Interrupt Enable */
+#define RTC_MODE2_INTENSET_OVF      (_U_(0x1) << RTC_MODE2_INTENSET_OVF_Pos)
+#define RTC_MODE2_INTENSET_MASK     _U_(0xC1)    /**< \brief (RTC_MODE2_INTENSET) MASK Register */
+
+/* -------- RTC_MODE0_INTFLAG : (RTC Offset: 0x08) (R/W  8) MODE0 MODE0 Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
+    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
+    __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint8_t  CMP:1;            /*!< bit:      0  Compare x                          */
+    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE0_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_INTFLAG_OFFSET    0x08         /**< \brief (RTC_MODE0_INTFLAG offset) MODE0 Interrupt Flag Status and Clear */
+#define RTC_MODE0_INTFLAG_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE0_INTFLAG reset_value) MODE0 Interrupt Flag Status and Clear */
+
+#define RTC_MODE0_INTFLAG_CMP0_Pos  0            /**< \brief (RTC_MODE0_INTFLAG) Compare 0 */
+#define RTC_MODE0_INTFLAG_CMP0      (_U_(1) << RTC_MODE0_INTFLAG_CMP0_Pos)
+#define RTC_MODE0_INTFLAG_CMP_Pos   0            /**< \brief (RTC_MODE0_INTFLAG) Compare x */
+#define RTC_MODE0_INTFLAG_CMP_Msk   (_U_(0x1) << RTC_MODE0_INTFLAG_CMP_Pos)
+#define RTC_MODE0_INTFLAG_CMP(value) (RTC_MODE0_INTFLAG_CMP_Msk & ((value) << RTC_MODE0_INTFLAG_CMP_Pos))
+#define RTC_MODE0_INTFLAG_SYNCRDY_Pos 6            /**< \brief (RTC_MODE0_INTFLAG) Synchronization Ready */
+#define RTC_MODE0_INTFLAG_SYNCRDY   (_U_(0x1) << RTC_MODE0_INTFLAG_SYNCRDY_Pos)
+#define RTC_MODE0_INTFLAG_OVF_Pos   7            /**< \brief (RTC_MODE0_INTFLAG) Overflow */
+#define RTC_MODE0_INTFLAG_OVF       (_U_(0x1) << RTC_MODE0_INTFLAG_OVF_Pos)
+#define RTC_MODE0_INTFLAG_MASK      _U_(0xC1)    /**< \brief (RTC_MODE0_INTFLAG) MASK Register */
+
+/* -------- RTC_MODE1_INTFLAG : (RTC Offset: 0x08) (R/W  8) MODE1 MODE1 Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  CMP0:1;           /*!< bit:      0  Compare 0                          */
+    __I uint8_t  CMP1:1;           /*!< bit:      1  Compare 1                          */
+    __I uint8_t  :4;               /*!< bit:  2.. 5  Reserved                           */
+    __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
+    __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint8_t  CMP:2;            /*!< bit:  0.. 1  Compare x                          */
+    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE1_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_INTFLAG_OFFSET    0x08         /**< \brief (RTC_MODE1_INTFLAG offset) MODE1 Interrupt Flag Status and Clear */
+#define RTC_MODE1_INTFLAG_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE1_INTFLAG reset_value) MODE1 Interrupt Flag Status and Clear */
+
+#define RTC_MODE1_INTFLAG_CMP0_Pos  0            /**< \brief (RTC_MODE1_INTFLAG) Compare 0 */
+#define RTC_MODE1_INTFLAG_CMP0      (_U_(1) << RTC_MODE1_INTFLAG_CMP0_Pos)
+#define RTC_MODE1_INTFLAG_CMP1_Pos  1            /**< \brief (RTC_MODE1_INTFLAG) Compare 1 */
+#define RTC_MODE1_INTFLAG_CMP1      (_U_(1) << RTC_MODE1_INTFLAG_CMP1_Pos)
+#define RTC_MODE1_INTFLAG_CMP_Pos   0            /**< \brief (RTC_MODE1_INTFLAG) Compare x */
+#define RTC_MODE1_INTFLAG_CMP_Msk   (_U_(0x3) << RTC_MODE1_INTFLAG_CMP_Pos)
+#define RTC_MODE1_INTFLAG_CMP(value) (RTC_MODE1_INTFLAG_CMP_Msk & ((value) << RTC_MODE1_INTFLAG_CMP_Pos))
+#define RTC_MODE1_INTFLAG_SYNCRDY_Pos 6            /**< \brief (RTC_MODE1_INTFLAG) Synchronization Ready */
+#define RTC_MODE1_INTFLAG_SYNCRDY   (_U_(0x1) << RTC_MODE1_INTFLAG_SYNCRDY_Pos)
+#define RTC_MODE1_INTFLAG_OVF_Pos   7            /**< \brief (RTC_MODE1_INTFLAG) Overflow */
+#define RTC_MODE1_INTFLAG_OVF       (_U_(0x1) << RTC_MODE1_INTFLAG_OVF_Pos)
+#define RTC_MODE1_INTFLAG_MASK      _U_(0xC3)    /**< \brief (RTC_MODE1_INTFLAG) MASK Register */
+
+/* -------- RTC_MODE2_INTFLAG : (RTC Offset: 0x08) (R/W  8) MODE2 MODE2 Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  ALARM0:1;         /*!< bit:      0  Alarm 0                            */
+    __I uint8_t  :5;               /*!< bit:  1.. 5  Reserved                           */
+    __I uint8_t  SYNCRDY:1;        /*!< bit:      6  Synchronization Ready              */
+    __I uint8_t  OVF:1;            /*!< bit:      7  Overflow                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint8_t  ALARM:1;          /*!< bit:      0  Alarm x                            */
+    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE2_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_INTFLAG_OFFSET    0x08         /**< \brief (RTC_MODE2_INTFLAG offset) MODE2 Interrupt Flag Status and Clear */
+#define RTC_MODE2_INTFLAG_RESETVALUE _U_(0x00)    /**< \brief (RTC_MODE2_INTFLAG reset_value) MODE2 Interrupt Flag Status and Clear */
+
+#define RTC_MODE2_INTFLAG_ALARM0_Pos 0            /**< \brief (RTC_MODE2_INTFLAG) Alarm 0 */
+#define RTC_MODE2_INTFLAG_ALARM0    (_U_(1) << RTC_MODE2_INTFLAG_ALARM0_Pos)
+#define RTC_MODE2_INTFLAG_ALARM_Pos 0            /**< \brief (RTC_MODE2_INTFLAG) Alarm x */
+#define RTC_MODE2_INTFLAG_ALARM_Msk (_U_(0x1) << RTC_MODE2_INTFLAG_ALARM_Pos)
+#define RTC_MODE2_INTFLAG_ALARM(value) (RTC_MODE2_INTFLAG_ALARM_Msk & ((value) << RTC_MODE2_INTFLAG_ALARM_Pos))
+#define RTC_MODE2_INTFLAG_SYNCRDY_Pos 6            /**< \brief (RTC_MODE2_INTFLAG) Synchronization Ready */
+#define RTC_MODE2_INTFLAG_SYNCRDY   (_U_(0x1) << RTC_MODE2_INTFLAG_SYNCRDY_Pos)
+#define RTC_MODE2_INTFLAG_OVF_Pos   7            /**< \brief (RTC_MODE2_INTFLAG) Overflow */
+#define RTC_MODE2_INTFLAG_OVF       (_U_(0x1) << RTC_MODE2_INTFLAG_OVF_Pos)
+#define RTC_MODE2_INTFLAG_MASK      _U_(0xC1)    /**< \brief (RTC_MODE2_INTFLAG) MASK Register */
+
+/* -------- RTC_STATUS : (RTC Offset: 0x0A) (R/W  8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_STATUS_OFFSET           0x0A         /**< \brief (RTC_STATUS offset) Status */
+#define RTC_STATUS_RESETVALUE       _U_(0x00)    /**< \brief (RTC_STATUS reset_value) Status */
+
+#define RTC_STATUS_SYNCBUSY_Pos     7            /**< \brief (RTC_STATUS) Synchronization Busy */
+#define RTC_STATUS_SYNCBUSY         (_U_(0x1) << RTC_STATUS_SYNCBUSY_Pos)
+#define RTC_STATUS_MASK             _U_(0x80)    /**< \brief (RTC_STATUS) MASK Register */
+
+/* -------- RTC_DBGCTRL : (RTC Offset: 0x0B) (R/W  8) Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGRUN:1;         /*!< bit:      0  Run During Debug                   */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_DBGCTRL_OFFSET          0x0B         /**< \brief (RTC_DBGCTRL offset) Debug Control */
+#define RTC_DBGCTRL_RESETVALUE      _U_(0x00)    /**< \brief (RTC_DBGCTRL reset_value) Debug Control */
+
+#define RTC_DBGCTRL_DBGRUN_Pos      0            /**< \brief (RTC_DBGCTRL) Run During Debug */
+#define RTC_DBGCTRL_DBGRUN          (_U_(0x1) << RTC_DBGCTRL_DBGRUN_Pos)
+#define RTC_DBGCTRL_MASK            _U_(0x01)    /**< \brief (RTC_DBGCTRL) MASK Register */
+
+/* -------- RTC_FREQCORR : (RTC Offset: 0x0C) (R/W  8) Frequency Correction -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  VALUE:7;          /*!< bit:  0.. 6  Correction Value                   */
+    uint8_t  SIGN:1;           /*!< bit:      7  Correction Sign                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_FREQCORR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_FREQCORR_OFFSET         0x0C         /**< \brief (RTC_FREQCORR offset) Frequency Correction */
+#define RTC_FREQCORR_RESETVALUE     _U_(0x00)    /**< \brief (RTC_FREQCORR reset_value) Frequency Correction */
+
+#define RTC_FREQCORR_VALUE_Pos      0            /**< \brief (RTC_FREQCORR) Correction Value */
+#define RTC_FREQCORR_VALUE_Msk      (_U_(0x7F) << RTC_FREQCORR_VALUE_Pos)
+#define RTC_FREQCORR_VALUE(value)   (RTC_FREQCORR_VALUE_Msk & ((value) << RTC_FREQCORR_VALUE_Pos))
+#define RTC_FREQCORR_SIGN_Pos       7            /**< \brief (RTC_FREQCORR) Correction Sign */
+#define RTC_FREQCORR_SIGN           (_U_(0x1) << RTC_FREQCORR_SIGN_Pos)
+#define RTC_FREQCORR_MASK           _U_(0xFF)    /**< \brief (RTC_FREQCORR) MASK Register */
+
+/* -------- RTC_MODE0_COUNT : (RTC Offset: 0x10) (R/W 32) MODE0 MODE0 Counter Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t COUNT:32;         /*!< bit:  0..31  Counter Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_COUNT_OFFSET      0x10         /**< \brief (RTC_MODE0_COUNT offset) MODE0 Counter Value */
+#define RTC_MODE0_COUNT_RESETVALUE  _U_(0x00000000) /**< \brief (RTC_MODE0_COUNT reset_value) MODE0 Counter Value */
+
+#define RTC_MODE0_COUNT_COUNT_Pos   0            /**< \brief (RTC_MODE0_COUNT) Counter Value */
+#define RTC_MODE0_COUNT_COUNT_Msk   (_U_(0xFFFFFFFF) << RTC_MODE0_COUNT_COUNT_Pos)
+#define RTC_MODE0_COUNT_COUNT(value) (RTC_MODE0_COUNT_COUNT_Msk & ((value) << RTC_MODE0_COUNT_COUNT_Pos))
+#define RTC_MODE0_COUNT_MASK        _U_(0xFFFFFFFF) /**< \brief (RTC_MODE0_COUNT) MASK Register */
+
+/* -------- RTC_MODE1_COUNT : (RTC Offset: 0x10) (R/W 16) MODE1 MODE1 Counter Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t COUNT:16;         /*!< bit:  0..15  Counter Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_COUNT_OFFSET      0x10         /**< \brief (RTC_MODE1_COUNT offset) MODE1 Counter Value */
+#define RTC_MODE1_COUNT_RESETVALUE  _U_(0x0000)  /**< \brief (RTC_MODE1_COUNT reset_value) MODE1 Counter Value */
+
+#define RTC_MODE1_COUNT_COUNT_Pos   0            /**< \brief (RTC_MODE1_COUNT) Counter Value */
+#define RTC_MODE1_COUNT_COUNT_Msk   (_U_(0xFFFF) << RTC_MODE1_COUNT_COUNT_Pos)
+#define RTC_MODE1_COUNT_COUNT(value) (RTC_MODE1_COUNT_COUNT_Msk & ((value) << RTC_MODE1_COUNT_COUNT_Pos))
+#define RTC_MODE1_COUNT_MASK        _U_(0xFFFF)  /**< \brief (RTC_MODE1_COUNT) MASK Register */
+
+/* -------- RTC_MODE2_CLOCK : (RTC Offset: 0x10) (R/W 32) MODE2 MODE2 Clock Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SECOND:6;         /*!< bit:  0.. 5  Second                             */
+    uint32_t MINUTE:6;         /*!< bit:  6..11  Minute                             */
+    uint32_t HOUR:5;           /*!< bit: 12..16  Hour                               */
+    uint32_t DAY:5;            /*!< bit: 17..21  Day                                */
+    uint32_t MONTH:4;          /*!< bit: 22..25  Month                              */
+    uint32_t YEAR:6;           /*!< bit: 26..31  Year                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_CLOCK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_CLOCK_OFFSET      0x10         /**< \brief (RTC_MODE2_CLOCK offset) MODE2 Clock Value */
+#define RTC_MODE2_CLOCK_RESETVALUE  _U_(0x00000000) /**< \brief (RTC_MODE2_CLOCK reset_value) MODE2 Clock Value */
+
+#define RTC_MODE2_CLOCK_SECOND_Pos  0            /**< \brief (RTC_MODE2_CLOCK) Second */
+#define RTC_MODE2_CLOCK_SECOND_Msk  (_U_(0x3F) << RTC_MODE2_CLOCK_SECOND_Pos)
+#define RTC_MODE2_CLOCK_SECOND(value) (RTC_MODE2_CLOCK_SECOND_Msk & ((value) << RTC_MODE2_CLOCK_SECOND_Pos))
+#define RTC_MODE2_CLOCK_MINUTE_Pos  6            /**< \brief (RTC_MODE2_CLOCK) Minute */
+#define RTC_MODE2_CLOCK_MINUTE_Msk  (_U_(0x3F) << RTC_MODE2_CLOCK_MINUTE_Pos)
+#define RTC_MODE2_CLOCK_MINUTE(value) (RTC_MODE2_CLOCK_MINUTE_Msk & ((value) << RTC_MODE2_CLOCK_MINUTE_Pos))
+#define RTC_MODE2_CLOCK_HOUR_Pos    12           /**< \brief (RTC_MODE2_CLOCK) Hour */
+#define RTC_MODE2_CLOCK_HOUR_Msk    (_U_(0x1F) << RTC_MODE2_CLOCK_HOUR_Pos)
+#define RTC_MODE2_CLOCK_HOUR(value) (RTC_MODE2_CLOCK_HOUR_Msk & ((value) << RTC_MODE2_CLOCK_HOUR_Pos))
+#define   RTC_MODE2_CLOCK_HOUR_AM_Val     _U_(0x0)   /**< \brief (RTC_MODE2_CLOCK) AM when CLKREP in 12-hour */
+#define   RTC_MODE2_CLOCK_HOUR_PM_Val     _U_(0x10)   /**< \brief (RTC_MODE2_CLOCK) Afternoon Hour */
+#define RTC_MODE2_CLOCK_HOUR_AM     (RTC_MODE2_CLOCK_HOUR_AM_Val   << RTC_MODE2_CLOCK_HOUR_Pos)
+#define RTC_MODE2_CLOCK_HOUR_PM     (RTC_MODE2_CLOCK_HOUR_PM_Val   << RTC_MODE2_CLOCK_HOUR_Pos)
+#define RTC_MODE2_CLOCK_DAY_Pos     17           /**< \brief (RTC_MODE2_CLOCK) Day */
+#define RTC_MODE2_CLOCK_DAY_Msk     (_U_(0x1F) << RTC_MODE2_CLOCK_DAY_Pos)
+#define RTC_MODE2_CLOCK_DAY(value)  (RTC_MODE2_CLOCK_DAY_Msk & ((value) << RTC_MODE2_CLOCK_DAY_Pos))
+#define RTC_MODE2_CLOCK_MONTH_Pos   22           /**< \brief (RTC_MODE2_CLOCK) Month */
+#define RTC_MODE2_CLOCK_MONTH_Msk   (_U_(0xF) << RTC_MODE2_CLOCK_MONTH_Pos)
+#define RTC_MODE2_CLOCK_MONTH(value) (RTC_MODE2_CLOCK_MONTH_Msk & ((value) << RTC_MODE2_CLOCK_MONTH_Pos))
+#define RTC_MODE2_CLOCK_YEAR_Pos    26           /**< \brief (RTC_MODE2_CLOCK) Year */
+#define RTC_MODE2_CLOCK_YEAR_Msk    (_U_(0x3F) << RTC_MODE2_CLOCK_YEAR_Pos)
+#define RTC_MODE2_CLOCK_YEAR(value) (RTC_MODE2_CLOCK_YEAR_Msk & ((value) << RTC_MODE2_CLOCK_YEAR_Pos))
+#define RTC_MODE2_CLOCK_MASK        _U_(0xFFFFFFFF) /**< \brief (RTC_MODE2_CLOCK) MASK Register */
+
+/* -------- RTC_MODE1_PER : (RTC Offset: 0x14) (R/W 16) MODE1 MODE1 Counter Period -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PER:16;           /*!< bit:  0..15  Counter Period                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_PER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_PER_OFFSET        0x14         /**< \brief (RTC_MODE1_PER offset) MODE1 Counter Period */
+#define RTC_MODE1_PER_RESETVALUE    _U_(0x0000)  /**< \brief (RTC_MODE1_PER reset_value) MODE1 Counter Period */
+
+#define RTC_MODE1_PER_PER_Pos       0            /**< \brief (RTC_MODE1_PER) Counter Period */
+#define RTC_MODE1_PER_PER_Msk       (_U_(0xFFFF) << RTC_MODE1_PER_PER_Pos)
+#define RTC_MODE1_PER_PER(value)    (RTC_MODE1_PER_PER_Msk & ((value) << RTC_MODE1_PER_PER_Pos))
+#define RTC_MODE1_PER_MASK          _U_(0xFFFF)  /**< \brief (RTC_MODE1_PER) MASK Register */
+
+/* -------- RTC_MODE0_COMP : (RTC Offset: 0x18) (R/W 32) MODE0 MODE0 Compare n Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t COMP:32;          /*!< bit:  0..31  Compare Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE0_COMP_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE0_COMP_OFFSET       0x18         /**< \brief (RTC_MODE0_COMP offset) MODE0 Compare n Value */
+#define RTC_MODE0_COMP_RESETVALUE   _U_(0x00000000) /**< \brief (RTC_MODE0_COMP reset_value) MODE0 Compare n Value */
+
+#define RTC_MODE0_COMP_COMP_Pos     0            /**< \brief (RTC_MODE0_COMP) Compare Value */
+#define RTC_MODE0_COMP_COMP_Msk     (_U_(0xFFFFFFFF) << RTC_MODE0_COMP_COMP_Pos)
+#define RTC_MODE0_COMP_COMP(value)  (RTC_MODE0_COMP_COMP_Msk & ((value) << RTC_MODE0_COMP_COMP_Pos))
+#define RTC_MODE0_COMP_MASK         _U_(0xFFFFFFFF) /**< \brief (RTC_MODE0_COMP) MASK Register */
+
+/* -------- RTC_MODE1_COMP : (RTC Offset: 0x18) (R/W 16) MODE1 MODE1 Compare n Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t COMP:16;          /*!< bit:  0..15  Compare Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} RTC_MODE1_COMP_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE1_COMP_OFFSET       0x18         /**< \brief (RTC_MODE1_COMP offset) MODE1 Compare n Value */
+#define RTC_MODE1_COMP_RESETVALUE   _U_(0x0000)  /**< \brief (RTC_MODE1_COMP reset_value) MODE1 Compare n Value */
+
+#define RTC_MODE1_COMP_COMP_Pos     0            /**< \brief (RTC_MODE1_COMP) Compare Value */
+#define RTC_MODE1_COMP_COMP_Msk     (_U_(0xFFFF) << RTC_MODE1_COMP_COMP_Pos)
+#define RTC_MODE1_COMP_COMP(value)  (RTC_MODE1_COMP_COMP_Msk & ((value) << RTC_MODE1_COMP_COMP_Pos))
+#define RTC_MODE1_COMP_MASK         _U_(0xFFFF)  /**< \brief (RTC_MODE1_COMP) MASK Register */
+
+/* -------- RTC_MODE2_ALARM : (RTC Offset: 0x18) (R/W 32) MODE2 MODE2_ALARM Alarm n Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SECOND:6;         /*!< bit:  0.. 5  Second                             */
+    uint32_t MINUTE:6;         /*!< bit:  6..11  Minute                             */
+    uint32_t HOUR:5;           /*!< bit: 12..16  Hour                               */
+    uint32_t DAY:5;            /*!< bit: 17..21  Day                                */
+    uint32_t MONTH:4;          /*!< bit: 22..25  Month                              */
+    uint32_t YEAR:6;           /*!< bit: 26..31  Year                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} RTC_MODE2_ALARM_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_ALARM_OFFSET      0x18         /**< \brief (RTC_MODE2_ALARM offset) MODE2_ALARM Alarm n Value */
+#define RTC_MODE2_ALARM_RESETVALUE  _U_(0x00000000) /**< \brief (RTC_MODE2_ALARM reset_value) MODE2_ALARM Alarm n Value */
+
+#define RTC_MODE2_ALARM_SECOND_Pos  0            /**< \brief (RTC_MODE2_ALARM) Second */
+#define RTC_MODE2_ALARM_SECOND_Msk  (_U_(0x3F) << RTC_MODE2_ALARM_SECOND_Pos)
+#define RTC_MODE2_ALARM_SECOND(value) (RTC_MODE2_ALARM_SECOND_Msk & ((value) << RTC_MODE2_ALARM_SECOND_Pos))
+#define RTC_MODE2_ALARM_MINUTE_Pos  6            /**< \brief (RTC_MODE2_ALARM) Minute */
+#define RTC_MODE2_ALARM_MINUTE_Msk  (_U_(0x3F) << RTC_MODE2_ALARM_MINUTE_Pos)
+#define RTC_MODE2_ALARM_MINUTE(value) (RTC_MODE2_ALARM_MINUTE_Msk & ((value) << RTC_MODE2_ALARM_MINUTE_Pos))
+#define RTC_MODE2_ALARM_HOUR_Pos    12           /**< \brief (RTC_MODE2_ALARM) Hour */
+#define RTC_MODE2_ALARM_HOUR_Msk    (_U_(0x1F) << RTC_MODE2_ALARM_HOUR_Pos)
+#define RTC_MODE2_ALARM_HOUR(value) (RTC_MODE2_ALARM_HOUR_Msk & ((value) << RTC_MODE2_ALARM_HOUR_Pos))
+#define   RTC_MODE2_ALARM_HOUR_AM_Val     _U_(0x0)   /**< \brief (RTC_MODE2_ALARM) Morning hour */
+#define   RTC_MODE2_ALARM_HOUR_PM_Val     _U_(0x10)   /**< \brief (RTC_MODE2_ALARM) Afternoon hour */
+#define RTC_MODE2_ALARM_HOUR_AM     (RTC_MODE2_ALARM_HOUR_AM_Val   << RTC_MODE2_ALARM_HOUR_Pos)
+#define RTC_MODE2_ALARM_HOUR_PM     (RTC_MODE2_ALARM_HOUR_PM_Val   << RTC_MODE2_ALARM_HOUR_Pos)
+#define RTC_MODE2_ALARM_DAY_Pos     17           /**< \brief (RTC_MODE2_ALARM) Day */
+#define RTC_MODE2_ALARM_DAY_Msk     (_U_(0x1F) << RTC_MODE2_ALARM_DAY_Pos)
+#define RTC_MODE2_ALARM_DAY(value)  (RTC_MODE2_ALARM_DAY_Msk & ((value) << RTC_MODE2_ALARM_DAY_Pos))
+#define RTC_MODE2_ALARM_MONTH_Pos   22           /**< \brief (RTC_MODE2_ALARM) Month */
+#define RTC_MODE2_ALARM_MONTH_Msk   (_U_(0xF) << RTC_MODE2_ALARM_MONTH_Pos)
+#define RTC_MODE2_ALARM_MONTH(value) (RTC_MODE2_ALARM_MONTH_Msk & ((value) << RTC_MODE2_ALARM_MONTH_Pos))
+#define RTC_MODE2_ALARM_YEAR_Pos    26           /**< \brief (RTC_MODE2_ALARM) Year */
+#define RTC_MODE2_ALARM_YEAR_Msk    (_U_(0x3F) << RTC_MODE2_ALARM_YEAR_Pos)
+#define RTC_MODE2_ALARM_YEAR(value) (RTC_MODE2_ALARM_YEAR_Msk & ((value) << RTC_MODE2_ALARM_YEAR_Pos))
+#define RTC_MODE2_ALARM_MASK        _U_(0xFFFFFFFF) /**< \brief (RTC_MODE2_ALARM) MASK Register */
+
+/* -------- RTC_MODE2_MASK : (RTC Offset: 0x1C) (R/W  8) MODE2 MODE2_ALARM Alarm n Mask -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  SEL:3;            /*!< bit:  0.. 2  Alarm Mask Selection               */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} RTC_MODE2_MASK_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define RTC_MODE2_MASK_OFFSET       0x1C         /**< \brief (RTC_MODE2_MASK offset) MODE2_ALARM Alarm n Mask */
+#define RTC_MODE2_MASK_RESETVALUE   _U_(0x00)    /**< \brief (RTC_MODE2_MASK reset_value) MODE2_ALARM Alarm n Mask */
+
+#define RTC_MODE2_MASK_SEL_Pos      0            /**< \brief (RTC_MODE2_MASK) Alarm Mask Selection */
+#define RTC_MODE2_MASK_SEL_Msk      (_U_(0x7) << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL(value)   (RTC_MODE2_MASK_SEL_Msk & ((value) << RTC_MODE2_MASK_SEL_Pos))
+#define   RTC_MODE2_MASK_SEL_OFF_Val      _U_(0x0)   /**< \brief (RTC_MODE2_MASK) Alarm Disabled */
+#define   RTC_MODE2_MASK_SEL_SS_Val       _U_(0x1)   /**< \brief (RTC_MODE2_MASK) Match seconds only */
+#define   RTC_MODE2_MASK_SEL_MMSS_Val     _U_(0x2)   /**< \brief (RTC_MODE2_MASK) Match seconds and minutes only */
+#define   RTC_MODE2_MASK_SEL_HHMMSS_Val   _U_(0x3)   /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, and hours only */
+#define   RTC_MODE2_MASK_SEL_DDHHMMSS_Val _U_(0x4)   /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, hours, and days only */
+#define   RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val _U_(0x5)   /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, hours, days, and months only */
+#define   RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val _U_(0x6)   /**< \brief (RTC_MODE2_MASK) Match seconds, minutes, hours, days, months, and years */
+#define RTC_MODE2_MASK_SEL_OFF      (RTC_MODE2_MASK_SEL_OFF_Val    << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_SS       (RTC_MODE2_MASK_SEL_SS_Val     << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_MMSS     (RTC_MODE2_MASK_SEL_MMSS_Val   << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_HHMMSS   (RTC_MODE2_MASK_SEL_HHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_DDHHMMSS (RTC_MODE2_MASK_SEL_DDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_MMDDHHMMSS (RTC_MODE2_MASK_SEL_MMDDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_SEL_YYMMDDHHMMSS (RTC_MODE2_MASK_SEL_YYMMDDHHMMSS_Val << RTC_MODE2_MASK_SEL_Pos)
+#define RTC_MODE2_MASK_MASK         _U_(0x07)    /**< \brief (RTC_MODE2_MASK) MASK Register */
+
+/** \brief RtcMode2Alarm hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO RTC_MODE2_ALARM_Type      ALARM;       /**< \brief Offset: 0x00 (R/W 32) MODE2_ALARM Alarm n Value */
+  __IO RTC_MODE2_MASK_Type       MASK;        /**< \brief Offset: 0x04 (R/W  8) MODE2_ALARM Alarm n Mask */
+       RoReg8                    Reserved1[0x3];
+} RtcMode2Alarm;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief RTC_MODE0 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* 32-bit Counter with Single 32-bit Compare */
+  __IO RTC_MODE0_CTRL_Type       CTRL;        /**< \brief Offset: 0x00 (R/W 16) MODE0 Control */
+  __IO RTC_READREQ_Type          READREQ;     /**< \brief Offset: 0x02 (R/W 16) Read Request */
+  __IO RTC_MODE0_EVCTRL_Type     EVCTRL;      /**< \brief Offset: 0x04 (R/W 16) MODE0 Event Control */
+  __IO RTC_MODE0_INTENCLR_Type   INTENCLR;    /**< \brief Offset: 0x06 (R/W  8) MODE0 Interrupt Enable Clear */
+  __IO RTC_MODE0_INTENSET_Type   INTENSET;    /**< \brief Offset: 0x07 (R/W  8) MODE0 Interrupt Enable Set */
+  __IO RTC_MODE0_INTFLAG_Type    INTFLAG;     /**< \brief Offset: 0x08 (R/W  8) MODE0 Interrupt Flag Status and Clear */
+       RoReg8                    Reserved1[0x1];
+  __IO RTC_STATUS_Type           STATUS;      /**< \brief Offset: 0x0A (R/W  8) Status */
+  __IO RTC_DBGCTRL_Type          DBGCTRL;     /**< \brief Offset: 0x0B (R/W  8) Debug Control */
+  __IO RTC_FREQCORR_Type         FREQCORR;    /**< \brief Offset: 0x0C (R/W  8) Frequency Correction */
+       RoReg8                    Reserved2[0x3];
+  __IO RTC_MODE0_COUNT_Type      COUNT;       /**< \brief Offset: 0x10 (R/W 32) MODE0 Counter Value */
+       RoReg8                    Reserved3[0x4];
+  __IO RTC_MODE0_COMP_Type       COMP[1];     /**< \brief Offset: 0x18 (R/W 32) MODE0 Compare n Value */
+} RtcMode0;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief RTC_MODE1 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* 16-bit Counter with Two 16-bit Compares */
+  __IO RTC_MODE1_CTRL_Type       CTRL;        /**< \brief Offset: 0x00 (R/W 16) MODE1 Control */
+  __IO RTC_READREQ_Type          READREQ;     /**< \brief Offset: 0x02 (R/W 16) Read Request */
+  __IO RTC_MODE1_EVCTRL_Type     EVCTRL;      /**< \brief Offset: 0x04 (R/W 16) MODE1 Event Control */
+  __IO RTC_MODE1_INTENCLR_Type   INTENCLR;    /**< \brief Offset: 0x06 (R/W  8) MODE1 Interrupt Enable Clear */
+  __IO RTC_MODE1_INTENSET_Type   INTENSET;    /**< \brief Offset: 0x07 (R/W  8) MODE1 Interrupt Enable Set */
+  __IO RTC_MODE1_INTFLAG_Type    INTFLAG;     /**< \brief Offset: 0x08 (R/W  8) MODE1 Interrupt Flag Status and Clear */
+       RoReg8                    Reserved1[0x1];
+  __IO RTC_STATUS_Type           STATUS;      /**< \brief Offset: 0x0A (R/W  8) Status */
+  __IO RTC_DBGCTRL_Type          DBGCTRL;     /**< \brief Offset: 0x0B (R/W  8) Debug Control */
+  __IO RTC_FREQCORR_Type         FREQCORR;    /**< \brief Offset: 0x0C (R/W  8) Frequency Correction */
+       RoReg8                    Reserved2[0x3];
+  __IO RTC_MODE1_COUNT_Type      COUNT;       /**< \brief Offset: 0x10 (R/W 16) MODE1 Counter Value */
+       RoReg8                    Reserved3[0x2];
+  __IO RTC_MODE1_PER_Type        PER;         /**< \brief Offset: 0x14 (R/W 16) MODE1 Counter Period */
+       RoReg8                    Reserved4[0x2];
+  __IO RTC_MODE1_COMP_Type       COMP[2];     /**< \brief Offset: 0x18 (R/W 16) MODE1 Compare n Value */
+} RtcMode1;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief RTC_MODE2 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* Clock/Calendar with Alarm */
+  __IO RTC_MODE2_CTRL_Type       CTRL;        /**< \brief Offset: 0x00 (R/W 16) MODE2 Control */
+  __IO RTC_READREQ_Type          READREQ;     /**< \brief Offset: 0x02 (R/W 16) Read Request */
+  __IO RTC_MODE2_EVCTRL_Type     EVCTRL;      /**< \brief Offset: 0x04 (R/W 16) MODE2 Event Control */
+  __IO RTC_MODE2_INTENCLR_Type   INTENCLR;    /**< \brief Offset: 0x06 (R/W  8) MODE2 Interrupt Enable Clear */
+  __IO RTC_MODE2_INTENSET_Type   INTENSET;    /**< \brief Offset: 0x07 (R/W  8) MODE2 Interrupt Enable Set */
+  __IO RTC_MODE2_INTFLAG_Type    INTFLAG;     /**< \brief Offset: 0x08 (R/W  8) MODE2 Interrupt Flag Status and Clear */
+       RoReg8                    Reserved1[0x1];
+  __IO RTC_STATUS_Type           STATUS;      /**< \brief Offset: 0x0A (R/W  8) Status */
+  __IO RTC_DBGCTRL_Type          DBGCTRL;     /**< \brief Offset: 0x0B (R/W  8) Debug Control */
+  __IO RTC_FREQCORR_Type         FREQCORR;    /**< \brief Offset: 0x0C (R/W  8) Frequency Correction */
+       RoReg8                    Reserved2[0x3];
+  __IO RTC_MODE2_CLOCK_Type      CLOCK;       /**< \brief Offset: 0x10 (R/W 32) MODE2 Clock Value */
+       RoReg8                    Reserved3[0x4];
+       RtcMode2Alarm             Mode2Alarm[1]; /**< \brief Offset: 0x18 RtcMode2Alarm groups [ALARM_NUM] */
+} RtcMode2;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+       RtcMode0                  MODE0;       /**< \brief Offset: 0x00 32-bit Counter with Single 32-bit Compare */
+       RtcMode1                  MODE1;       /**< \brief Offset: 0x00 16-bit Counter with Two 16-bit Compares */
+       RtcMode2                  MODE2;       /**< \brief Offset: 0x00 Clock/Calendar with Alarm */
+} Rtc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_RTC_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/sercom.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/sercom.h
@@ -1,0 +1,1210 @@
+/**
+ * \file
+ *
+ * \brief Component description for SERCOM
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SERCOM_COMPONENT_
+#define _SAMD20_SERCOM_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SERCOM */
+/* ========================================================================== */
+/** \addtogroup SAMD20_SERCOM Serial Communication Interface */
+/*@{*/
+
+#define SERCOM_U2201
+#define REV_SERCOM                  0x110
+
+/* -------- SERCOM_I2CM_CTRLA : (SERCOM Offset: 0x00) (R/W 32) I2CM I2CM Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t MODE:3;           /*!< bit:  2.. 4  Operating Mode                     */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      7  Run in Standby                     */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t PINOUT:1;         /*!< bit:     16  Pin Usage                          */
+    uint32_t :3;               /*!< bit: 17..19  Reserved                           */
+    uint32_t SDAHOLD:2;        /*!< bit: 20..21  SDA Hold Time                      */
+    uint32_t :6;               /*!< bit: 22..27  Reserved                           */
+    uint32_t INACTOUT:2;       /*!< bit: 28..29  Inactive Time-out                  */
+    uint32_t LOWTOUT:1;        /*!< bit:     30  SCL Low Time-out                   */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CM_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_CTRLA_OFFSET    0x00         /**< \brief (SERCOM_I2CM_CTRLA offset) I2CM Control A */
+#define SERCOM_I2CM_CTRLA_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CM_CTRLA reset_value) I2CM Control A */
+
+#define SERCOM_I2CM_CTRLA_SWRST_Pos 0            /**< \brief (SERCOM_I2CM_CTRLA) Software Reset */
+#define SERCOM_I2CM_CTRLA_SWRST     (_U_(0x1) << SERCOM_I2CM_CTRLA_SWRST_Pos)
+#define SERCOM_I2CM_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_I2CM_CTRLA) Enable */
+#define SERCOM_I2CM_CTRLA_ENABLE    (_U_(0x1) << SERCOM_I2CM_CTRLA_ENABLE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE_Pos  2            /**< \brief (SERCOM_I2CM_CTRLA) Operating Mode */
+#define SERCOM_I2CM_CTRLA_MODE_Msk  (_U_(0x7) << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE(value) (SERCOM_I2CM_CTRLA_MODE_Msk & ((value) << SERCOM_I2CM_CTRLA_MODE_Pos))
+#define   SERCOM_I2CM_CTRLA_MODE_USART_EXT_CLK_Val _U_(0x0)   /**< \brief (SERCOM_I2CM_CTRLA) USART mode with external clock */
+#define   SERCOM_I2CM_CTRLA_MODE_USART_INT_CLK_Val _U_(0x1)   /**< \brief (SERCOM_I2CM_CTRLA) USART mode with internal clock */
+#define   SERCOM_I2CM_CTRLA_MODE_SPI_SLAVE_Val _U_(0x2)   /**< \brief (SERCOM_I2CM_CTRLA) SPI mode with external clock */
+#define   SERCOM_I2CM_CTRLA_MODE_SPI_MASTER_Val _U_(0x3)   /**< \brief (SERCOM_I2CM_CTRLA) SPI mode with internal clock */
+#define   SERCOM_I2CM_CTRLA_MODE_I2C_SLAVE_Val _U_(0x4)   /**< \brief (SERCOM_I2CM_CTRLA) I2C mode with external clock */
+#define   SERCOM_I2CM_CTRLA_MODE_I2C_MASTER_Val _U_(0x5)   /**< \brief (SERCOM_I2CM_CTRLA) I2C mode with internal clock */
+#define SERCOM_I2CM_CTRLA_MODE_USART_EXT_CLK (SERCOM_I2CM_CTRLA_MODE_USART_EXT_CLK_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE_USART_INT_CLK (SERCOM_I2CM_CTRLA_MODE_USART_INT_CLK_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE_SPI_SLAVE (SERCOM_I2CM_CTRLA_MODE_SPI_SLAVE_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE_SPI_MASTER (SERCOM_I2CM_CTRLA_MODE_SPI_MASTER_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE_I2C_SLAVE (SERCOM_I2CM_CTRLA_MODE_I2C_SLAVE_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_MODE_I2C_MASTER (SERCOM_I2CM_CTRLA_MODE_I2C_MASTER_Val << SERCOM_I2CM_CTRLA_MODE_Pos)
+#define SERCOM_I2CM_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_I2CM_CTRLA) Run in Standby */
+#define SERCOM_I2CM_CTRLA_RUNSTDBY  (_U_(0x1) << SERCOM_I2CM_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_I2CM_CTRLA_PINOUT_Pos 16           /**< \brief (SERCOM_I2CM_CTRLA) Pin Usage */
+#define SERCOM_I2CM_CTRLA_PINOUT    (_U_(0x1) << SERCOM_I2CM_CTRLA_PINOUT_Pos)
+#define SERCOM_I2CM_CTRLA_SDAHOLD_Pos 20           /**< \brief (SERCOM_I2CM_CTRLA) SDA Hold Time */
+#define SERCOM_I2CM_CTRLA_SDAHOLD_Msk (_U_(0x3) << SERCOM_I2CM_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CM_CTRLA_SDAHOLD(value) (SERCOM_I2CM_CTRLA_SDAHOLD_Msk & ((value) << SERCOM_I2CM_CTRLA_SDAHOLD_Pos))
+#define SERCOM_I2CM_CTRLA_INACTOUT_Pos 28           /**< \brief (SERCOM_I2CM_CTRLA) Inactive Time-out */
+#define SERCOM_I2CM_CTRLA_INACTOUT_Msk (_U_(0x3) << SERCOM_I2CM_CTRLA_INACTOUT_Pos)
+#define SERCOM_I2CM_CTRLA_INACTOUT(value) (SERCOM_I2CM_CTRLA_INACTOUT_Msk & ((value) << SERCOM_I2CM_CTRLA_INACTOUT_Pos))
+#define SERCOM_I2CM_CTRLA_LOWTOUT_Pos 30           /**< \brief (SERCOM_I2CM_CTRLA) SCL Low Time-out */
+#define SERCOM_I2CM_CTRLA_LOWTOUT   (_U_(0x1) << SERCOM_I2CM_CTRLA_LOWTOUT_Pos)
+#define SERCOM_I2CM_CTRLA_MASK      _U_(0x7031009F) /**< \brief (SERCOM_I2CM_CTRLA) MASK Register */
+
+/* -------- SERCOM_I2CS_CTRLA : (SERCOM Offset: 0x00) (R/W 32) I2CS I2CS Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t MODE:3;           /*!< bit:  2.. 4  Operating Mode                     */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      7  Run in Standby                     */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t PINOUT:1;         /*!< bit:     16  Pin Usage                          */
+    uint32_t :3;               /*!< bit: 17..19  Reserved                           */
+    uint32_t SDAHOLD:2;        /*!< bit: 20..21  SDA Hold Time                      */
+    uint32_t :8;               /*!< bit: 22..29  Reserved                           */
+    uint32_t LOWTOUT:1;        /*!< bit:     30  SCL Low Time-out                   */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CS_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_CTRLA_OFFSET    0x00         /**< \brief (SERCOM_I2CS_CTRLA offset) I2CS Control A */
+#define SERCOM_I2CS_CTRLA_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CS_CTRLA reset_value) I2CS Control A */
+
+#define SERCOM_I2CS_CTRLA_SWRST_Pos 0            /**< \brief (SERCOM_I2CS_CTRLA) Software Reset */
+#define SERCOM_I2CS_CTRLA_SWRST     (_U_(0x1) << SERCOM_I2CS_CTRLA_SWRST_Pos)
+#define SERCOM_I2CS_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_I2CS_CTRLA) Enable */
+#define SERCOM_I2CS_CTRLA_ENABLE    (_U_(0x1) << SERCOM_I2CS_CTRLA_ENABLE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE_Pos  2            /**< \brief (SERCOM_I2CS_CTRLA) Operating Mode */
+#define SERCOM_I2CS_CTRLA_MODE_Msk  (_U_(0x7) << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE(value) (SERCOM_I2CS_CTRLA_MODE_Msk & ((value) << SERCOM_I2CS_CTRLA_MODE_Pos))
+#define   SERCOM_I2CS_CTRLA_MODE_USART_EXT_CLK_Val _U_(0x0)   /**< \brief (SERCOM_I2CS_CTRLA) USART mode with external clock */
+#define   SERCOM_I2CS_CTRLA_MODE_USART_INT_CLK_Val _U_(0x1)   /**< \brief (SERCOM_I2CS_CTRLA) USART mode with internal clock */
+#define   SERCOM_I2CS_CTRLA_MODE_SPI_SLAVE_Val _U_(0x2)   /**< \brief (SERCOM_I2CS_CTRLA) SPI mode with external clock */
+#define   SERCOM_I2CS_CTRLA_MODE_SPI_MASTER_Val _U_(0x3)   /**< \brief (SERCOM_I2CS_CTRLA) SPI mode with internal clock */
+#define   SERCOM_I2CS_CTRLA_MODE_I2C_SLAVE_Val _U_(0x4)   /**< \brief (SERCOM_I2CS_CTRLA) I2C mode with external clock */
+#define   SERCOM_I2CS_CTRLA_MODE_I2C_MASTER_Val _U_(0x5)   /**< \brief (SERCOM_I2CS_CTRLA) I2C mode with internal clock */
+#define SERCOM_I2CS_CTRLA_MODE_USART_EXT_CLK (SERCOM_I2CS_CTRLA_MODE_USART_EXT_CLK_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE_USART_INT_CLK (SERCOM_I2CS_CTRLA_MODE_USART_INT_CLK_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE_SPI_SLAVE (SERCOM_I2CS_CTRLA_MODE_SPI_SLAVE_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE_SPI_MASTER (SERCOM_I2CS_CTRLA_MODE_SPI_MASTER_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE_I2C_SLAVE (SERCOM_I2CS_CTRLA_MODE_I2C_SLAVE_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_MODE_I2C_MASTER (SERCOM_I2CS_CTRLA_MODE_I2C_MASTER_Val << SERCOM_I2CS_CTRLA_MODE_Pos)
+#define SERCOM_I2CS_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_I2CS_CTRLA) Run in Standby */
+#define SERCOM_I2CS_CTRLA_RUNSTDBY  (_U_(0x1) << SERCOM_I2CS_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_I2CS_CTRLA_PINOUT_Pos 16           /**< \brief (SERCOM_I2CS_CTRLA) Pin Usage */
+#define SERCOM_I2CS_CTRLA_PINOUT    (_U_(0x1) << SERCOM_I2CS_CTRLA_PINOUT_Pos)
+#define SERCOM_I2CS_CTRLA_SDAHOLD_Pos 20           /**< \brief (SERCOM_I2CS_CTRLA) SDA Hold Time */
+#define SERCOM_I2CS_CTRLA_SDAHOLD_Msk (_U_(0x3) << SERCOM_I2CS_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CS_CTRLA_SDAHOLD(value) (SERCOM_I2CS_CTRLA_SDAHOLD_Msk & ((value) << SERCOM_I2CS_CTRLA_SDAHOLD_Pos))
+#define   SERCOM_I2CS_CTRLA_SDAHOLD_DIS_Val _U_(0x0)   /**< \brief (SERCOM_I2CS_CTRLA) Disabled */
+#define   SERCOM_I2CS_CTRLA_SDAHOLD_75_Val _U_(0x1)   /**< \brief (SERCOM_I2CS_CTRLA) 50-100 ns hold time */
+#define   SERCOM_I2CS_CTRLA_SDAHOLD_450_Val _U_(0x2)   /**< \brief (SERCOM_I2CS_CTRLA) 300-600 ns hold time */
+#define   SERCOM_I2CS_CTRLA_SDAHOLD_600_Val _U_(0x3)   /**< \brief (SERCOM_I2CS_CTRLA) 400-800 ns hold time */
+#define SERCOM_I2CS_CTRLA_SDAHOLD_DIS (SERCOM_I2CS_CTRLA_SDAHOLD_DIS_Val << SERCOM_I2CS_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CS_CTRLA_SDAHOLD_75 (SERCOM_I2CS_CTRLA_SDAHOLD_75_Val << SERCOM_I2CS_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CS_CTRLA_SDAHOLD_450 (SERCOM_I2CS_CTRLA_SDAHOLD_450_Val << SERCOM_I2CS_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CS_CTRLA_SDAHOLD_600 (SERCOM_I2CS_CTRLA_SDAHOLD_600_Val << SERCOM_I2CS_CTRLA_SDAHOLD_Pos)
+#define SERCOM_I2CS_CTRLA_LOWTOUT_Pos 30           /**< \brief (SERCOM_I2CS_CTRLA) SCL Low Time-out */
+#define SERCOM_I2CS_CTRLA_LOWTOUT   (_U_(0x1) << SERCOM_I2CS_CTRLA_LOWTOUT_Pos)
+#define SERCOM_I2CS_CTRLA_MASK      _U_(0x4031009F) /**< \brief (SERCOM_I2CS_CTRLA) MASK Register */
+
+/* -------- SERCOM_SPI_CTRLA : (SERCOM Offset: 0x00) (R/W 32) SPI SPI Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t MODE:3;           /*!< bit:  2.. 4  Operating Mode                     */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      7  Run In Standby                     */
+    uint32_t IBON:1;           /*!< bit:      8  Immediate Buffer Overflow Notification */
+    uint32_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint32_t DOPO:2;           /*!< bit: 16..17  Data Out Pinout                    */
+    uint32_t :2;               /*!< bit: 18..19  Reserved                           */
+    uint32_t DIPO:2;           /*!< bit: 20..21  Data In Pinout                     */
+    uint32_t :2;               /*!< bit: 22..23  Reserved                           */
+    uint32_t FORM:4;           /*!< bit: 24..27  Frame Format                       */
+    uint32_t CPHA:1;           /*!< bit:     28  Clock Phase                        */
+    uint32_t CPOL:1;           /*!< bit:     29  Clock Polarity                     */
+    uint32_t DORD:1;           /*!< bit:     30  Data Order                         */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_CTRLA_OFFSET     0x00         /**< \brief (SERCOM_SPI_CTRLA offset) SPI Control A */
+#define SERCOM_SPI_CTRLA_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_SPI_CTRLA reset_value) SPI Control A */
+
+#define SERCOM_SPI_CTRLA_SWRST_Pos  0            /**< \brief (SERCOM_SPI_CTRLA) Software Reset */
+#define SERCOM_SPI_CTRLA_SWRST      (_U_(0x1) << SERCOM_SPI_CTRLA_SWRST_Pos)
+#define SERCOM_SPI_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_SPI_CTRLA) Enable */
+#define SERCOM_SPI_CTRLA_ENABLE     (_U_(0x1) << SERCOM_SPI_CTRLA_ENABLE_Pos)
+#define SERCOM_SPI_CTRLA_MODE_Pos   2            /**< \brief (SERCOM_SPI_CTRLA) Operating Mode */
+#define SERCOM_SPI_CTRLA_MODE_Msk   (_U_(0x7) << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_MODE(value) (SERCOM_SPI_CTRLA_MODE_Msk & ((value) << SERCOM_SPI_CTRLA_MODE_Pos))
+#define   SERCOM_SPI_CTRLA_MODE_USART_EXT_CLK_Val _U_(0x0)   /**< \brief (SERCOM_SPI_CTRLA) USART mode with external clock */
+#define   SERCOM_SPI_CTRLA_MODE_USART_INT_CLK_Val _U_(0x1)   /**< \brief (SERCOM_SPI_CTRLA) USART mode with internal clock */
+#define   SERCOM_SPI_CTRLA_MODE_SPI_SLAVE_Val _U_(0x2)   /**< \brief (SERCOM_SPI_CTRLA) SPI mode with external clock */
+#define   SERCOM_SPI_CTRLA_MODE_SPI_MASTER_Val _U_(0x3)   /**< \brief (SERCOM_SPI_CTRLA) SPI mode with internal clock */
+#define   SERCOM_SPI_CTRLA_MODE_I2C_SLAVE_Val _U_(0x4)   /**< \brief (SERCOM_SPI_CTRLA) I2C mode with external clock */
+#define   SERCOM_SPI_CTRLA_MODE_I2C_MASTER_Val _U_(0x5)   /**< \brief (SERCOM_SPI_CTRLA) I2C mode with internal clock */
+#define SERCOM_SPI_CTRLA_MODE_USART_EXT_CLK (SERCOM_SPI_CTRLA_MODE_USART_EXT_CLK_Val << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_MODE_USART_INT_CLK (SERCOM_SPI_CTRLA_MODE_USART_INT_CLK_Val << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_MODE_SPI_SLAVE (SERCOM_SPI_CTRLA_MODE_SPI_SLAVE_Val << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_MODE_SPI_MASTER (SERCOM_SPI_CTRLA_MODE_SPI_MASTER_Val << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_MODE_I2C_SLAVE (SERCOM_SPI_CTRLA_MODE_I2C_SLAVE_Val << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_MODE_I2C_MASTER (SERCOM_SPI_CTRLA_MODE_I2C_MASTER_Val << SERCOM_SPI_CTRLA_MODE_Pos)
+#define SERCOM_SPI_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_SPI_CTRLA) Run In Standby */
+#define SERCOM_SPI_CTRLA_RUNSTDBY   (_U_(0x1) << SERCOM_SPI_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_SPI_CTRLA_IBON_Pos   8            /**< \brief (SERCOM_SPI_CTRLA) Immediate Buffer Overflow Notification */
+#define SERCOM_SPI_CTRLA_IBON       (_U_(0x1) << SERCOM_SPI_CTRLA_IBON_Pos)
+#define SERCOM_SPI_CTRLA_DOPO_Pos   16           /**< \brief (SERCOM_SPI_CTRLA) Data Out Pinout */
+#define SERCOM_SPI_CTRLA_DOPO_Msk   (_U_(0x3) << SERCOM_SPI_CTRLA_DOPO_Pos)
+#define SERCOM_SPI_CTRLA_DOPO(value) (SERCOM_SPI_CTRLA_DOPO_Msk & ((value) << SERCOM_SPI_CTRLA_DOPO_Pos))
+#define SERCOM_SPI_CTRLA_DIPO_Pos   20           /**< \brief (SERCOM_SPI_CTRLA) Data In Pinout */
+#define SERCOM_SPI_CTRLA_DIPO_Msk   (_U_(0x3) << SERCOM_SPI_CTRLA_DIPO_Pos)
+#define SERCOM_SPI_CTRLA_DIPO(value) (SERCOM_SPI_CTRLA_DIPO_Msk & ((value) << SERCOM_SPI_CTRLA_DIPO_Pos))
+#define SERCOM_SPI_CTRLA_FORM_Pos   24           /**< \brief (SERCOM_SPI_CTRLA) Frame Format */
+#define SERCOM_SPI_CTRLA_FORM_Msk   (_U_(0xF) << SERCOM_SPI_CTRLA_FORM_Pos)
+#define SERCOM_SPI_CTRLA_FORM(value) (SERCOM_SPI_CTRLA_FORM_Msk & ((value) << SERCOM_SPI_CTRLA_FORM_Pos))
+#define   SERCOM_SPI_CTRLA_FORM_SPI_Val   _U_(0x0)   /**< \brief (SERCOM_SPI_CTRLA) SPI frame */
+#define   SERCOM_SPI_CTRLA_FORM_SPI_ADDR_Val _U_(0x2)   /**< \brief (SERCOM_SPI_CTRLA) SPI frame with address */
+#define SERCOM_SPI_CTRLA_FORM_SPI   (SERCOM_SPI_CTRLA_FORM_SPI_Val << SERCOM_SPI_CTRLA_FORM_Pos)
+#define SERCOM_SPI_CTRLA_FORM_SPI_ADDR (SERCOM_SPI_CTRLA_FORM_SPI_ADDR_Val << SERCOM_SPI_CTRLA_FORM_Pos)
+#define SERCOM_SPI_CTRLA_CPHA_Pos   28           /**< \brief (SERCOM_SPI_CTRLA) Clock Phase */
+#define SERCOM_SPI_CTRLA_CPHA       (_U_(0x1) << SERCOM_SPI_CTRLA_CPHA_Pos)
+#define SERCOM_SPI_CTRLA_CPOL_Pos   29           /**< \brief (SERCOM_SPI_CTRLA) Clock Polarity */
+#define SERCOM_SPI_CTRLA_CPOL       (_U_(0x1) << SERCOM_SPI_CTRLA_CPOL_Pos)
+#define SERCOM_SPI_CTRLA_DORD_Pos   30           /**< \brief (SERCOM_SPI_CTRLA) Data Order */
+#define SERCOM_SPI_CTRLA_DORD       (_U_(0x1) << SERCOM_SPI_CTRLA_DORD_Pos)
+#define SERCOM_SPI_CTRLA_MASK       _U_(0x7F33019F) /**< \brief (SERCOM_SPI_CTRLA) MASK Register */
+
+/* -------- SERCOM_USART_CTRLA : (SERCOM Offset: 0x00) (R/W 32) USART USART Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t MODE:3;           /*!< bit:  2.. 4  Operating Mode                     */
+    uint32_t :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      7  Run In Standby                     */
+    uint32_t IBON:1;           /*!< bit:      8  Immediate Buffer Overflow Notification */
+    uint32_t :7;               /*!< bit:  9..15  Reserved                           */
+    uint32_t TXPO:1;           /*!< bit:     16  Transmit Data Pinout               */
+    uint32_t :3;               /*!< bit: 17..19  Reserved                           */
+    uint32_t RXPO:2;           /*!< bit: 20..21  Receive Data Pinout                */
+    uint32_t :2;               /*!< bit: 22..23  Reserved                           */
+    uint32_t FORM:4;           /*!< bit: 24..27  Frame Format                       */
+    uint32_t CMODE:1;          /*!< bit:     28  Communication Mode                 */
+    uint32_t CPOL:1;           /*!< bit:     29  Clock Polarity                     */
+    uint32_t DORD:1;           /*!< bit:     30  Data Order                         */
+    uint32_t :1;               /*!< bit:     31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_CTRLA_OFFSET   0x00         /**< \brief (SERCOM_USART_CTRLA offset) USART Control A */
+#define SERCOM_USART_CTRLA_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_USART_CTRLA reset_value) USART Control A */
+
+#define SERCOM_USART_CTRLA_SWRST_Pos 0            /**< \brief (SERCOM_USART_CTRLA) Software Reset */
+#define SERCOM_USART_CTRLA_SWRST    (_U_(0x1) << SERCOM_USART_CTRLA_SWRST_Pos)
+#define SERCOM_USART_CTRLA_ENABLE_Pos 1            /**< \brief (SERCOM_USART_CTRLA) Enable */
+#define SERCOM_USART_CTRLA_ENABLE   (_U_(0x1) << SERCOM_USART_CTRLA_ENABLE_Pos)
+#define SERCOM_USART_CTRLA_MODE_Pos 2            /**< \brief (SERCOM_USART_CTRLA) Operating Mode */
+#define SERCOM_USART_CTRLA_MODE_Msk (_U_(0x7) << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_MODE(value) (SERCOM_USART_CTRLA_MODE_Msk & ((value) << SERCOM_USART_CTRLA_MODE_Pos))
+#define   SERCOM_USART_CTRLA_MODE_USART_EXT_CLK_Val _U_(0x0)   /**< \brief (SERCOM_USART_CTRLA) USART mode with external clock */
+#define   SERCOM_USART_CTRLA_MODE_USART_INT_CLK_Val _U_(0x1)   /**< \brief (SERCOM_USART_CTRLA) USART mode with internal clock */
+#define   SERCOM_USART_CTRLA_MODE_SPI_SLAVE_Val _U_(0x2)   /**< \brief (SERCOM_USART_CTRLA) SPI mode with external clock */
+#define   SERCOM_USART_CTRLA_MODE_SPI_MASTER_Val _U_(0x3)   /**< \brief (SERCOM_USART_CTRLA) SPI mode with internal clock */
+#define   SERCOM_USART_CTRLA_MODE_I2C_SLAVE_Val _U_(0x4)   /**< \brief (SERCOM_USART_CTRLA) I2C mode with external clock */
+#define   SERCOM_USART_CTRLA_MODE_I2C_MASTER_Val _U_(0x5)   /**< \brief (SERCOM_USART_CTRLA) I2C mode with internal clock */
+#define SERCOM_USART_CTRLA_MODE_USART_EXT_CLK (SERCOM_USART_CTRLA_MODE_USART_EXT_CLK_Val << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_MODE_USART_INT_CLK (SERCOM_USART_CTRLA_MODE_USART_INT_CLK_Val << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_MODE_SPI_SLAVE (SERCOM_USART_CTRLA_MODE_SPI_SLAVE_Val << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_MODE_SPI_MASTER (SERCOM_USART_CTRLA_MODE_SPI_MASTER_Val << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_MODE_I2C_SLAVE (SERCOM_USART_CTRLA_MODE_I2C_SLAVE_Val << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_MODE_I2C_MASTER (SERCOM_USART_CTRLA_MODE_I2C_MASTER_Val << SERCOM_USART_CTRLA_MODE_Pos)
+#define SERCOM_USART_CTRLA_RUNSTDBY_Pos 7            /**< \brief (SERCOM_USART_CTRLA) Run In Standby */
+#define SERCOM_USART_CTRLA_RUNSTDBY (_U_(0x1) << SERCOM_USART_CTRLA_RUNSTDBY_Pos)
+#define SERCOM_USART_CTRLA_IBON_Pos 8            /**< \brief (SERCOM_USART_CTRLA) Immediate Buffer Overflow Notification */
+#define SERCOM_USART_CTRLA_IBON     (_U_(0x1) << SERCOM_USART_CTRLA_IBON_Pos)
+#define SERCOM_USART_CTRLA_TXPO_Pos 16           /**< \brief (SERCOM_USART_CTRLA) Transmit Data Pinout */
+#define SERCOM_USART_CTRLA_TXPO     (_U_(0x1) << SERCOM_USART_CTRLA_TXPO_Pos)
+#define   SERCOM_USART_CTRLA_TXPO_PAD0_Val _U_(0x0)   /**< \brief (SERCOM_USART_CTRLA) TXD at PAD0, XCK at PAD1 */
+#define   SERCOM_USART_CTRLA_TXPO_PAD2_Val _U_(0x1)   /**< \brief (SERCOM_USART_CTRLA) TXD at PAD2, XCK at PAD3 */
+#define SERCOM_USART_CTRLA_TXPO_PAD0 (SERCOM_USART_CTRLA_TXPO_PAD0_Val << SERCOM_USART_CTRLA_TXPO_Pos)
+#define SERCOM_USART_CTRLA_TXPO_PAD2 (SERCOM_USART_CTRLA_TXPO_PAD2_Val << SERCOM_USART_CTRLA_TXPO_Pos)
+#define SERCOM_USART_CTRLA_RXPO_Pos 20           /**< \brief (SERCOM_USART_CTRLA) Receive Data Pinout */
+#define SERCOM_USART_CTRLA_RXPO_Msk (_U_(0x3) << SERCOM_USART_CTRLA_RXPO_Pos)
+#define SERCOM_USART_CTRLA_RXPO(value) (SERCOM_USART_CTRLA_RXPO_Msk & ((value) << SERCOM_USART_CTRLA_RXPO_Pos))
+#define   SERCOM_USART_CTRLA_RXPO_PAD0_Val _U_(0x0)   /**< \brief (SERCOM_USART_CTRLA) SERCOM_PAD0 */
+#define   SERCOM_USART_CTRLA_RXPO_PAD1_Val _U_(0x1)   /**< \brief (SERCOM_USART_CTRLA) SERCOM_PAD1 */
+#define   SERCOM_USART_CTRLA_RXPO_PAD2_Val _U_(0x2)   /**< \brief (SERCOM_USART_CTRLA) SERCOM_PAD2 */
+#define   SERCOM_USART_CTRLA_RXPO_PAD3_Val _U_(0x3)   /**< \brief (SERCOM_USART_CTRLA) SERCOM_PAD3 */
+#define SERCOM_USART_CTRLA_RXPO_PAD0 (SERCOM_USART_CTRLA_RXPO_PAD0_Val << SERCOM_USART_CTRLA_RXPO_Pos)
+#define SERCOM_USART_CTRLA_RXPO_PAD1 (SERCOM_USART_CTRLA_RXPO_PAD1_Val << SERCOM_USART_CTRLA_RXPO_Pos)
+#define SERCOM_USART_CTRLA_RXPO_PAD2 (SERCOM_USART_CTRLA_RXPO_PAD2_Val << SERCOM_USART_CTRLA_RXPO_Pos)
+#define SERCOM_USART_CTRLA_RXPO_PAD3 (SERCOM_USART_CTRLA_RXPO_PAD3_Val << SERCOM_USART_CTRLA_RXPO_Pos)
+#define SERCOM_USART_CTRLA_FORM_Pos 24           /**< \brief (SERCOM_USART_CTRLA) Frame Format */
+#define SERCOM_USART_CTRLA_FORM_Msk (_U_(0xF) << SERCOM_USART_CTRLA_FORM_Pos)
+#define SERCOM_USART_CTRLA_FORM(value) (SERCOM_USART_CTRLA_FORM_Msk & ((value) << SERCOM_USART_CTRLA_FORM_Pos))
+#define   SERCOM_USART_CTRLA_FORM_0_Val   _U_(0x0)   /**< \brief (SERCOM_USART_CTRLA) USART frame */
+#define   SERCOM_USART_CTRLA_FORM_1_Val   _U_(0x1)   /**< \brief (SERCOM_USART_CTRLA) USART frame with parity */
+#define SERCOM_USART_CTRLA_FORM_0   (SERCOM_USART_CTRLA_FORM_0_Val << SERCOM_USART_CTRLA_FORM_Pos)
+#define SERCOM_USART_CTRLA_FORM_1   (SERCOM_USART_CTRLA_FORM_1_Val << SERCOM_USART_CTRLA_FORM_Pos)
+#define SERCOM_USART_CTRLA_CMODE_Pos 28           /**< \brief (SERCOM_USART_CTRLA) Communication Mode */
+#define SERCOM_USART_CTRLA_CMODE    (_U_(0x1) << SERCOM_USART_CTRLA_CMODE_Pos)
+#define SERCOM_USART_CTRLA_CPOL_Pos 29           /**< \brief (SERCOM_USART_CTRLA) Clock Polarity */
+#define SERCOM_USART_CTRLA_CPOL     (_U_(0x1) << SERCOM_USART_CTRLA_CPOL_Pos)
+#define SERCOM_USART_CTRLA_DORD_Pos 30           /**< \brief (SERCOM_USART_CTRLA) Data Order */
+#define SERCOM_USART_CTRLA_DORD     (_U_(0x1) << SERCOM_USART_CTRLA_DORD_Pos)
+#define SERCOM_USART_CTRLA_MASK     _U_(0x7F31019F) /**< \brief (SERCOM_USART_CTRLA) MASK Register */
+
+/* -------- SERCOM_I2CM_CTRLB : (SERCOM Offset: 0x04) (R/W 32) I2CM I2CM Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :8;               /*!< bit:  0.. 7  Reserved                           */
+    uint32_t SMEN:1;           /*!< bit:      8  Smart Mode Enable                  */
+    uint32_t QCEN:1;           /*!< bit:      9  Quick Command Enable               */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t CMD:2;            /*!< bit: 16..17  Command                            */
+    uint32_t ACKACT:1;         /*!< bit:     18  Acknowledge Action                 */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CM_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_CTRLB_OFFSET    0x04         /**< \brief (SERCOM_I2CM_CTRLB offset) I2CM Control B */
+#define SERCOM_I2CM_CTRLB_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CM_CTRLB reset_value) I2CM Control B */
+
+#define SERCOM_I2CM_CTRLB_SMEN_Pos  8            /**< \brief (SERCOM_I2CM_CTRLB) Smart Mode Enable */
+#define SERCOM_I2CM_CTRLB_SMEN      (_U_(0x1) << SERCOM_I2CM_CTRLB_SMEN_Pos)
+#define SERCOM_I2CM_CTRLB_QCEN_Pos  9            /**< \brief (SERCOM_I2CM_CTRLB) Quick Command Enable */
+#define SERCOM_I2CM_CTRLB_QCEN      (_U_(0x1) << SERCOM_I2CM_CTRLB_QCEN_Pos)
+#define SERCOM_I2CM_CTRLB_CMD_Pos   16           /**< \brief (SERCOM_I2CM_CTRLB) Command */
+#define SERCOM_I2CM_CTRLB_CMD_Msk   (_U_(0x3) << SERCOM_I2CM_CTRLB_CMD_Pos)
+#define SERCOM_I2CM_CTRLB_CMD(value) (SERCOM_I2CM_CTRLB_CMD_Msk & ((value) << SERCOM_I2CM_CTRLB_CMD_Pos))
+#define SERCOM_I2CM_CTRLB_ACKACT_Pos 18           /**< \brief (SERCOM_I2CM_CTRLB) Acknowledge Action */
+#define SERCOM_I2CM_CTRLB_ACKACT    (_U_(0x1) << SERCOM_I2CM_CTRLB_ACKACT_Pos)
+#define SERCOM_I2CM_CTRLB_MASK      _U_(0x00070300) /**< \brief (SERCOM_I2CM_CTRLB) MASK Register */
+
+/* -------- SERCOM_I2CS_CTRLB : (SERCOM Offset: 0x04) (R/W 32) I2CS I2CS Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :8;               /*!< bit:  0.. 7  Reserved                           */
+    uint32_t SMEN:1;           /*!< bit:      8  Smart Mode Enable                  */
+    uint32_t :5;               /*!< bit:  9..13  Reserved                           */
+    uint32_t AMODE:2;          /*!< bit: 14..15  Address Mode                       */
+    uint32_t CMD:2;            /*!< bit: 16..17  Command                            */
+    uint32_t ACKACT:1;         /*!< bit:     18  Acknowledge Action                 */
+    uint32_t :13;              /*!< bit: 19..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CS_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_CTRLB_OFFSET    0x04         /**< \brief (SERCOM_I2CS_CTRLB offset) I2CS Control B */
+#define SERCOM_I2CS_CTRLB_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CS_CTRLB reset_value) I2CS Control B */
+
+#define SERCOM_I2CS_CTRLB_SMEN_Pos  8            /**< \brief (SERCOM_I2CS_CTRLB) Smart Mode Enable */
+#define SERCOM_I2CS_CTRLB_SMEN      (_U_(0x1) << SERCOM_I2CS_CTRLB_SMEN_Pos)
+#define SERCOM_I2CS_CTRLB_AMODE_Pos 14           /**< \brief (SERCOM_I2CS_CTRLB) Address Mode */
+#define SERCOM_I2CS_CTRLB_AMODE_Msk (_U_(0x3) << SERCOM_I2CS_CTRLB_AMODE_Pos)
+#define SERCOM_I2CS_CTRLB_AMODE(value) (SERCOM_I2CS_CTRLB_AMODE_Msk & ((value) << SERCOM_I2CS_CTRLB_AMODE_Pos))
+#define SERCOM_I2CS_CTRLB_CMD_Pos   16           /**< \brief (SERCOM_I2CS_CTRLB) Command */
+#define SERCOM_I2CS_CTRLB_CMD_Msk   (_U_(0x3) << SERCOM_I2CS_CTRLB_CMD_Pos)
+#define SERCOM_I2CS_CTRLB_CMD(value) (SERCOM_I2CS_CTRLB_CMD_Msk & ((value) << SERCOM_I2CS_CTRLB_CMD_Pos))
+#define SERCOM_I2CS_CTRLB_ACKACT_Pos 18           /**< \brief (SERCOM_I2CS_CTRLB) Acknowledge Action */
+#define SERCOM_I2CS_CTRLB_ACKACT    (_U_(0x1) << SERCOM_I2CS_CTRLB_ACKACT_Pos)
+#define SERCOM_I2CS_CTRLB_MASK      _U_(0x0007C100) /**< \brief (SERCOM_I2CS_CTRLB) MASK Register */
+
+/* -------- SERCOM_SPI_CTRLB : (SERCOM Offset: 0x04) (R/W 32) SPI SPI Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CHSIZE:3;         /*!< bit:  0.. 2  Character Size                     */
+    uint32_t :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint32_t PLOADEN:1;        /*!< bit:      6  Slave Data Preload Enable          */
+    uint32_t :7;               /*!< bit:  7..13  Reserved                           */
+    uint32_t AMODE:2;          /*!< bit: 14..15  Address Mode                       */
+    uint32_t :1;               /*!< bit:     16  Reserved                           */
+    uint32_t RXEN:1;           /*!< bit:     17  Receiver Enable                    */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_CTRLB_OFFSET     0x04         /**< \brief (SERCOM_SPI_CTRLB offset) SPI Control B */
+#define SERCOM_SPI_CTRLB_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_SPI_CTRLB reset_value) SPI Control B */
+
+#define SERCOM_SPI_CTRLB_CHSIZE_Pos 0            /**< \brief (SERCOM_SPI_CTRLB) Character Size */
+#define SERCOM_SPI_CTRLB_CHSIZE_Msk (_U_(0x7) << SERCOM_SPI_CTRLB_CHSIZE_Pos)
+#define SERCOM_SPI_CTRLB_CHSIZE(value) (SERCOM_SPI_CTRLB_CHSIZE_Msk & ((value) << SERCOM_SPI_CTRLB_CHSIZE_Pos))
+#define SERCOM_SPI_CTRLB_PLOADEN_Pos 6            /**< \brief (SERCOM_SPI_CTRLB) Slave Data Preload Enable */
+#define SERCOM_SPI_CTRLB_PLOADEN    (_U_(0x1) << SERCOM_SPI_CTRLB_PLOADEN_Pos)
+#define SERCOM_SPI_CTRLB_AMODE_Pos  14           /**< \brief (SERCOM_SPI_CTRLB) Address Mode */
+#define SERCOM_SPI_CTRLB_AMODE_Msk  (_U_(0x3) << SERCOM_SPI_CTRLB_AMODE_Pos)
+#define SERCOM_SPI_CTRLB_AMODE(value) (SERCOM_SPI_CTRLB_AMODE_Msk & ((value) << SERCOM_SPI_CTRLB_AMODE_Pos))
+#define   SERCOM_SPI_CTRLB_AMODE_MASK_Val _U_(0x0)   /**< \brief (SERCOM_SPI_CTRLB) ADDRMASK is used as a mask to the ADDR register. */
+#define   SERCOM_SPI_CTRLB_AMODE_2ADDR_Val _U_(0x1)   /**< \brief (SERCOM_SPI_CTRLB) The slave responds to the 2 unique addresses in ADDR and ADDRMASK. */
+#define   SERCOM_SPI_CTRLB_AMODE_RANGE_Val _U_(0x2)   /**< \brief (SERCOM_SPI_CTRLB) The slave responds to the range of addresses between and including ADDR and ADDRMASK. ADDR is the upper limit. */
+#define SERCOM_SPI_CTRLB_AMODE_MASK (SERCOM_SPI_CTRLB_AMODE_MASK_Val << SERCOM_SPI_CTRLB_AMODE_Pos)
+#define SERCOM_SPI_CTRLB_AMODE_2ADDR (SERCOM_SPI_CTRLB_AMODE_2ADDR_Val << SERCOM_SPI_CTRLB_AMODE_Pos)
+#define SERCOM_SPI_CTRLB_AMODE_RANGE (SERCOM_SPI_CTRLB_AMODE_RANGE_Val << SERCOM_SPI_CTRLB_AMODE_Pos)
+#define SERCOM_SPI_CTRLB_RXEN_Pos   17           /**< \brief (SERCOM_SPI_CTRLB) Receiver Enable */
+#define SERCOM_SPI_CTRLB_RXEN       (_U_(0x1) << SERCOM_SPI_CTRLB_RXEN_Pos)
+#define SERCOM_SPI_CTRLB_MASK       _U_(0x0002C047) /**< \brief (SERCOM_SPI_CTRLB) MASK Register */
+
+/* -------- SERCOM_USART_CTRLB : (SERCOM Offset: 0x04) (R/W 32) USART USART Control B -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CHSIZE:3;         /*!< bit:  0.. 2  Character Size                     */
+    uint32_t :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint32_t SBMODE:1;         /*!< bit:      6  Stop Bit Mode                      */
+    uint32_t :2;               /*!< bit:  7.. 8  Reserved                           */
+    uint32_t SFDE:1;           /*!< bit:      9  Start of Frame Detection Enable    */
+    uint32_t :3;               /*!< bit: 10..12  Reserved                           */
+    uint32_t PMODE:1;          /*!< bit:     13  Parity Mode                        */
+    uint32_t :2;               /*!< bit: 14..15  Reserved                           */
+    uint32_t TXEN:1;           /*!< bit:     16  Transmitter Enable                 */
+    uint32_t RXEN:1;           /*!< bit:     17  Receiver Enable                    */
+    uint32_t :14;              /*!< bit: 18..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_CTRLB_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_CTRLB_OFFSET   0x04         /**< \brief (SERCOM_USART_CTRLB offset) USART Control B */
+#define SERCOM_USART_CTRLB_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_USART_CTRLB reset_value) USART Control B */
+
+#define SERCOM_USART_CTRLB_CHSIZE_Pos 0            /**< \brief (SERCOM_USART_CTRLB) Character Size */
+#define SERCOM_USART_CTRLB_CHSIZE_Msk (_U_(0x7) << SERCOM_USART_CTRLB_CHSIZE_Pos)
+#define SERCOM_USART_CTRLB_CHSIZE(value) (SERCOM_USART_CTRLB_CHSIZE_Msk & ((value) << SERCOM_USART_CTRLB_CHSIZE_Pos))
+#define SERCOM_USART_CTRLB_SBMODE_Pos 6            /**< \brief (SERCOM_USART_CTRLB) Stop Bit Mode */
+#define SERCOM_USART_CTRLB_SBMODE   (_U_(0x1) << SERCOM_USART_CTRLB_SBMODE_Pos)
+#define SERCOM_USART_CTRLB_SFDE_Pos 9            /**< \brief (SERCOM_USART_CTRLB) Start of Frame Detection Enable */
+#define SERCOM_USART_CTRLB_SFDE     (_U_(0x1) << SERCOM_USART_CTRLB_SFDE_Pos)
+#define SERCOM_USART_CTRLB_PMODE_Pos 13           /**< \brief (SERCOM_USART_CTRLB) Parity Mode */
+#define SERCOM_USART_CTRLB_PMODE    (_U_(0x1) << SERCOM_USART_CTRLB_PMODE_Pos)
+#define SERCOM_USART_CTRLB_TXEN_Pos 16           /**< \brief (SERCOM_USART_CTRLB) Transmitter Enable */
+#define SERCOM_USART_CTRLB_TXEN     (_U_(0x1) << SERCOM_USART_CTRLB_TXEN_Pos)
+#define SERCOM_USART_CTRLB_RXEN_Pos 17           /**< \brief (SERCOM_USART_CTRLB) Receiver Enable */
+#define SERCOM_USART_CTRLB_RXEN     (_U_(0x1) << SERCOM_USART_CTRLB_RXEN_Pos)
+#define SERCOM_USART_CTRLB_MASK     _U_(0x00032247) /**< \brief (SERCOM_USART_CTRLB) MASK Register */
+
+/* -------- SERCOM_I2CM_DBGCTRL : (SERCOM Offset: 0x08) (R/W  8) I2CM I2CM Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGSTOP:1;        /*!< bit:      0  Debug Stop Mode                    */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_DBGCTRL_OFFSET  0x08         /**< \brief (SERCOM_I2CM_DBGCTRL offset) I2CM Debug Control */
+#define SERCOM_I2CM_DBGCTRL_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CM_DBGCTRL reset_value) I2CM Debug Control */
+
+#define SERCOM_I2CM_DBGCTRL_DBGSTOP_Pos 0            /**< \brief (SERCOM_I2CM_DBGCTRL) Debug Stop Mode */
+#define SERCOM_I2CM_DBGCTRL_DBGSTOP (_U_(0x1) << SERCOM_I2CM_DBGCTRL_DBGSTOP_Pos)
+#define SERCOM_I2CM_DBGCTRL_MASK    _U_(0x01)    /**< \brief (SERCOM_I2CM_DBGCTRL) MASK Register */
+
+/* -------- SERCOM_SPI_DBGCTRL : (SERCOM Offset: 0x08) (R/W  8) SPI SPI Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGSTOP:1;        /*!< bit:      0  Debug Stop Mode                    */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_SPI_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_DBGCTRL_OFFSET   0x08         /**< \brief (SERCOM_SPI_DBGCTRL offset) SPI Debug Control */
+#define SERCOM_SPI_DBGCTRL_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_SPI_DBGCTRL reset_value) SPI Debug Control */
+
+#define SERCOM_SPI_DBGCTRL_DBGSTOP_Pos 0            /**< \brief (SERCOM_SPI_DBGCTRL) Debug Stop Mode */
+#define SERCOM_SPI_DBGCTRL_DBGSTOP  (_U_(0x1) << SERCOM_SPI_DBGCTRL_DBGSTOP_Pos)
+#define SERCOM_SPI_DBGCTRL_MASK     _U_(0x01)    /**< \brief (SERCOM_SPI_DBGCTRL) MASK Register */
+
+/* -------- SERCOM_USART_DBGCTRL : (SERCOM Offset: 0x08) (R/W  8) USART USART Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGSTOP:1;        /*!< bit:      0  Debug Stop Mode                    */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_USART_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_DBGCTRL_OFFSET 0x08         /**< \brief (SERCOM_USART_DBGCTRL offset) USART Debug Control */
+#define SERCOM_USART_DBGCTRL_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_USART_DBGCTRL reset_value) USART Debug Control */
+
+#define SERCOM_USART_DBGCTRL_DBGSTOP_Pos 0            /**< \brief (SERCOM_USART_DBGCTRL) Debug Stop Mode */
+#define SERCOM_USART_DBGCTRL_DBGSTOP (_U_(0x1) << SERCOM_USART_DBGCTRL_DBGSTOP_Pos)
+#define SERCOM_USART_DBGCTRL_MASK   _U_(0x01)    /**< \brief (SERCOM_USART_DBGCTRL) MASK Register */
+
+/* -------- SERCOM_I2CM_BAUD : (SERCOM Offset: 0x0A) (R/W 16) I2CM I2CM Baud Rate -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t BAUD:8;           /*!< bit:  0.. 7  Master Baud Rate                   */
+    uint16_t BAUDLOW:8;        /*!< bit:  8..15  Master Baud Rate Low               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CM_BAUD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_BAUD_OFFSET     0x0A         /**< \brief (SERCOM_I2CM_BAUD offset) I2CM Baud Rate */
+#define SERCOM_I2CM_BAUD_RESETVALUE _U_(0x0000)  /**< \brief (SERCOM_I2CM_BAUD reset_value) I2CM Baud Rate */
+
+#define SERCOM_I2CM_BAUD_BAUD_Pos   0            /**< \brief (SERCOM_I2CM_BAUD) Master Baud Rate */
+#define SERCOM_I2CM_BAUD_BAUD_Msk   (_U_(0xFF) << SERCOM_I2CM_BAUD_BAUD_Pos)
+#define SERCOM_I2CM_BAUD_BAUD(value) (SERCOM_I2CM_BAUD_BAUD_Msk & ((value) << SERCOM_I2CM_BAUD_BAUD_Pos))
+#define SERCOM_I2CM_BAUD_BAUDLOW_Pos 8            /**< \brief (SERCOM_I2CM_BAUD) Master Baud Rate Low */
+#define SERCOM_I2CM_BAUD_BAUDLOW_Msk (_U_(0xFF) << SERCOM_I2CM_BAUD_BAUDLOW_Pos)
+#define SERCOM_I2CM_BAUD_BAUDLOW(value) (SERCOM_I2CM_BAUD_BAUDLOW_Msk & ((value) << SERCOM_I2CM_BAUD_BAUDLOW_Pos))
+#define SERCOM_I2CM_BAUD_MASK       _U_(0xFFFF)  /**< \brief (SERCOM_I2CM_BAUD) MASK Register */
+
+/* -------- SERCOM_SPI_BAUD : (SERCOM Offset: 0x0A) (R/W  8) SPI SPI Baud Rate -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  BAUD:8;           /*!< bit:  0.. 7  Baud Register                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_SPI_BAUD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_BAUD_OFFSET      0x0A         /**< \brief (SERCOM_SPI_BAUD offset) SPI Baud Rate */
+#define SERCOM_SPI_BAUD_RESETVALUE  _U_(0x00)    /**< \brief (SERCOM_SPI_BAUD reset_value) SPI Baud Rate */
+
+#define SERCOM_SPI_BAUD_BAUD_Pos    0            /**< \brief (SERCOM_SPI_BAUD) Baud Register */
+#define SERCOM_SPI_BAUD_BAUD_Msk    (_U_(0xFF) << SERCOM_SPI_BAUD_BAUD_Pos)
+#define SERCOM_SPI_BAUD_BAUD(value) (SERCOM_SPI_BAUD_BAUD_Msk & ((value) << SERCOM_SPI_BAUD_BAUD_Pos))
+#define SERCOM_SPI_BAUD_MASK        _U_(0xFF)    /**< \brief (SERCOM_SPI_BAUD) MASK Register */
+
+/* -------- SERCOM_USART_BAUD : (SERCOM Offset: 0x0A) (R/W 16) USART USART Baud -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t BAUD:16;          /*!< bit:  0..15  Baud Value                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_BAUD_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_BAUD_OFFSET    0x0A         /**< \brief (SERCOM_USART_BAUD offset) USART Baud */
+#define SERCOM_USART_BAUD_RESETVALUE _U_(0x0000)  /**< \brief (SERCOM_USART_BAUD reset_value) USART Baud */
+
+#define SERCOM_USART_BAUD_BAUD_Pos  0            /**< \brief (SERCOM_USART_BAUD) Baud Value */
+#define SERCOM_USART_BAUD_BAUD_Msk  (_U_(0xFFFF) << SERCOM_USART_BAUD_BAUD_Pos)
+#define SERCOM_USART_BAUD_BAUD(value) (SERCOM_USART_BAUD_BAUD_Msk & ((value) << SERCOM_USART_BAUD_BAUD_Pos))
+#define SERCOM_USART_BAUD_MASK      _U_(0xFFFF)  /**< \brief (SERCOM_USART_BAUD) MASK Register */
+
+/* -------- SERCOM_I2CM_INTENCLR : (SERCOM Offset: 0x0C) (R/W  8) I2CM I2CM Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  MB:1;             /*!< bit:      0  Master on Bus Interrupt Enable     */
+    uint8_t  SB:1;             /*!< bit:      1  Slave on Bus Interrupt Enable      */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_INTENCLR_OFFSET 0x0C         /**< \brief (SERCOM_I2CM_INTENCLR offset) I2CM Interrupt Enable Clear */
+#define SERCOM_I2CM_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CM_INTENCLR reset_value) I2CM Interrupt Enable Clear */
+
+#define SERCOM_I2CM_INTENCLR_MB_Pos 0            /**< \brief (SERCOM_I2CM_INTENCLR) Master on Bus Interrupt Enable */
+#define SERCOM_I2CM_INTENCLR_MB     (_U_(0x1) << SERCOM_I2CM_INTENCLR_MB_Pos)
+#define SERCOM_I2CM_INTENCLR_SB_Pos 1            /**< \brief (SERCOM_I2CM_INTENCLR) Slave on Bus Interrupt Enable */
+#define SERCOM_I2CM_INTENCLR_SB     (_U_(0x1) << SERCOM_I2CM_INTENCLR_SB_Pos)
+#define SERCOM_I2CM_INTENCLR_MASK   _U_(0x03)    /**< \brief (SERCOM_I2CM_INTENCLR) MASK Register */
+
+/* -------- SERCOM_I2CS_INTENCLR : (SERCOM Offset: 0x0C) (R/W  8) I2CS I2CS Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt Enable     */
+    uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt Enable     */
+    uint8_t  DRDY:1;           /*!< bit:      2  Data Ready Interrupt Enable        */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CS_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_INTENCLR_OFFSET 0x0C         /**< \brief (SERCOM_I2CS_INTENCLR offset) I2CS Interrupt Enable Clear */
+#define SERCOM_I2CS_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CS_INTENCLR reset_value) I2CS Interrupt Enable Clear */
+
+#define SERCOM_I2CS_INTENCLR_PREC_Pos 0            /**< \brief (SERCOM_I2CS_INTENCLR) Stop Received Interrupt Enable */
+#define SERCOM_I2CS_INTENCLR_PREC   (_U_(0x1) << SERCOM_I2CS_INTENCLR_PREC_Pos)
+#define SERCOM_I2CS_INTENCLR_AMATCH_Pos 1            /**< \brief (SERCOM_I2CS_INTENCLR) Address Match Interrupt Enable */
+#define SERCOM_I2CS_INTENCLR_AMATCH (_U_(0x1) << SERCOM_I2CS_INTENCLR_AMATCH_Pos)
+#define SERCOM_I2CS_INTENCLR_DRDY_Pos 2            /**< \brief (SERCOM_I2CS_INTENCLR) Data Ready Interrupt Enable */
+#define SERCOM_I2CS_INTENCLR_DRDY   (_U_(0x1) << SERCOM_I2CS_INTENCLR_DRDY_Pos)
+#define SERCOM_I2CS_INTENCLR_MASK   _U_(0x07)    /**< \brief (SERCOM_I2CS_INTENCLR) MASK Register */
+
+/* -------- SERCOM_SPI_INTENCLR : (SERCOM Offset: 0x0C) (R/W  8) SPI SPI Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty Interrupt Enable */
+    uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt Enable */
+    uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt Enable  */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_SPI_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_INTENCLR_OFFSET  0x0C         /**< \brief (SERCOM_SPI_INTENCLR offset) SPI Interrupt Enable Clear */
+#define SERCOM_SPI_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_SPI_INTENCLR reset_value) SPI Interrupt Enable Clear */
+
+#define SERCOM_SPI_INTENCLR_DRE_Pos 0            /**< \brief (SERCOM_SPI_INTENCLR) Data Register Empty Interrupt Enable */
+#define SERCOM_SPI_INTENCLR_DRE     (_U_(0x1) << SERCOM_SPI_INTENCLR_DRE_Pos)
+#define SERCOM_SPI_INTENCLR_TXC_Pos 1            /**< \brief (SERCOM_SPI_INTENCLR) Transmit Complete Interrupt Enable */
+#define SERCOM_SPI_INTENCLR_TXC     (_U_(0x1) << SERCOM_SPI_INTENCLR_TXC_Pos)
+#define SERCOM_SPI_INTENCLR_RXC_Pos 2            /**< \brief (SERCOM_SPI_INTENCLR) Receive Complete Interrupt Enable */
+#define SERCOM_SPI_INTENCLR_RXC     (_U_(0x1) << SERCOM_SPI_INTENCLR_RXC_Pos)
+#define SERCOM_SPI_INTENCLR_MASK    _U_(0x07)    /**< \brief (SERCOM_SPI_INTENCLR) MASK Register */
+
+/* -------- SERCOM_USART_INTENCLR : (SERCOM Offset: 0x0C) (R/W  8) USART USART Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty Interrupt Enable */
+    uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt Enable */
+    uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt Enable  */
+    uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt Disable    */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_USART_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_INTENCLR_OFFSET 0x0C         /**< \brief (SERCOM_USART_INTENCLR offset) USART Interrupt Enable Clear */
+#define SERCOM_USART_INTENCLR_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_USART_INTENCLR reset_value) USART Interrupt Enable Clear */
+
+#define SERCOM_USART_INTENCLR_DRE_Pos 0            /**< \brief (SERCOM_USART_INTENCLR) Data Register Empty Interrupt Enable */
+#define SERCOM_USART_INTENCLR_DRE   (_U_(0x1) << SERCOM_USART_INTENCLR_DRE_Pos)
+#define SERCOM_USART_INTENCLR_TXC_Pos 1            /**< \brief (SERCOM_USART_INTENCLR) Transmit Complete Interrupt Enable */
+#define SERCOM_USART_INTENCLR_TXC   (_U_(0x1) << SERCOM_USART_INTENCLR_TXC_Pos)
+#define SERCOM_USART_INTENCLR_RXC_Pos 2            /**< \brief (SERCOM_USART_INTENCLR) Receive Complete Interrupt Enable */
+#define SERCOM_USART_INTENCLR_RXC   (_U_(0x1) << SERCOM_USART_INTENCLR_RXC_Pos)
+#define SERCOM_USART_INTENCLR_RXS_Pos 3            /**< \brief (SERCOM_USART_INTENCLR) Receive Start Interrupt Disable */
+#define SERCOM_USART_INTENCLR_RXS   (_U_(0x1) << SERCOM_USART_INTENCLR_RXS_Pos)
+#define SERCOM_USART_INTENCLR_MASK  _U_(0x0F)    /**< \brief (SERCOM_USART_INTENCLR) MASK Register */
+
+/* -------- SERCOM_I2CM_INTENSET : (SERCOM Offset: 0x0D) (R/W  8) I2CM I2CM Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  MB:1;             /*!< bit:      0  Master on Bus Interrupt Enable     */
+    uint8_t  SB:1;             /*!< bit:      1  Slave on Bus Interrupt Enable      */
+    uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_INTENSET_OFFSET 0x0D         /**< \brief (SERCOM_I2CM_INTENSET offset) I2CM Interrupt Enable Set */
+#define SERCOM_I2CM_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CM_INTENSET reset_value) I2CM Interrupt Enable Set */
+
+#define SERCOM_I2CM_INTENSET_MB_Pos 0            /**< \brief (SERCOM_I2CM_INTENSET) Master on Bus Interrupt Enable */
+#define SERCOM_I2CM_INTENSET_MB     (_U_(0x1) << SERCOM_I2CM_INTENSET_MB_Pos)
+#define SERCOM_I2CM_INTENSET_SB_Pos 1            /**< \brief (SERCOM_I2CM_INTENSET) Slave on Bus Interrupt Enable */
+#define SERCOM_I2CM_INTENSET_SB     (_U_(0x1) << SERCOM_I2CM_INTENSET_SB_Pos)
+#define SERCOM_I2CM_INTENSET_MASK   _U_(0x03)    /**< \brief (SERCOM_I2CM_INTENSET) MASK Register */
+
+/* -------- SERCOM_I2CS_INTENSET : (SERCOM Offset: 0x0D) (R/W  8) I2CS I2CS Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PREC:1;           /*!< bit:      0  Stop Received Interrupt Enable     */
+    uint8_t  AMATCH:1;         /*!< bit:      1  Address Match Interrupt Enable     */
+    uint8_t  DRDY:1;           /*!< bit:      2  Data Ready Interrupt Enable        */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CS_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_INTENSET_OFFSET 0x0D         /**< \brief (SERCOM_I2CS_INTENSET offset) I2CS Interrupt Enable Set */
+#define SERCOM_I2CS_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CS_INTENSET reset_value) I2CS Interrupt Enable Set */
+
+#define SERCOM_I2CS_INTENSET_PREC_Pos 0            /**< \brief (SERCOM_I2CS_INTENSET) Stop Received Interrupt Enable */
+#define SERCOM_I2CS_INTENSET_PREC   (_U_(0x1) << SERCOM_I2CS_INTENSET_PREC_Pos)
+#define SERCOM_I2CS_INTENSET_AMATCH_Pos 1            /**< \brief (SERCOM_I2CS_INTENSET) Address Match Interrupt Enable */
+#define SERCOM_I2CS_INTENSET_AMATCH (_U_(0x1) << SERCOM_I2CS_INTENSET_AMATCH_Pos)
+#define SERCOM_I2CS_INTENSET_DRDY_Pos 2            /**< \brief (SERCOM_I2CS_INTENSET) Data Ready Interrupt Enable */
+#define SERCOM_I2CS_INTENSET_DRDY   (_U_(0x1) << SERCOM_I2CS_INTENSET_DRDY_Pos)
+#define SERCOM_I2CS_INTENSET_MASK   _U_(0x07)    /**< \brief (SERCOM_I2CS_INTENSET) MASK Register */
+
+/* -------- SERCOM_SPI_INTENSET : (SERCOM Offset: 0x0D) (R/W  8) SPI SPI Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty Interrupt Enable */
+    uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt Enable */
+    uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt Enable  */
+    uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_SPI_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_INTENSET_OFFSET  0x0D         /**< \brief (SERCOM_SPI_INTENSET offset) SPI Interrupt Enable Set */
+#define SERCOM_SPI_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_SPI_INTENSET reset_value) SPI Interrupt Enable Set */
+
+#define SERCOM_SPI_INTENSET_DRE_Pos 0            /**< \brief (SERCOM_SPI_INTENSET) Data Register Empty Interrupt Enable */
+#define SERCOM_SPI_INTENSET_DRE     (_U_(0x1) << SERCOM_SPI_INTENSET_DRE_Pos)
+#define SERCOM_SPI_INTENSET_TXC_Pos 1            /**< \brief (SERCOM_SPI_INTENSET) Transmit Complete Interrupt Enable */
+#define SERCOM_SPI_INTENSET_TXC     (_U_(0x1) << SERCOM_SPI_INTENSET_TXC_Pos)
+#define SERCOM_SPI_INTENSET_RXC_Pos 2            /**< \brief (SERCOM_SPI_INTENSET) Receive Complete Interrupt Enable */
+#define SERCOM_SPI_INTENSET_RXC     (_U_(0x1) << SERCOM_SPI_INTENSET_RXC_Pos)
+#define SERCOM_SPI_INTENSET_MASK    _U_(0x07)    /**< \brief (SERCOM_SPI_INTENSET) MASK Register */
+
+/* -------- SERCOM_USART_INTENSET : (SERCOM Offset: 0x0D) (R/W  8) USART USART Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty Interrupt Enable */
+    uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete Interrupt Enable */
+    uint8_t  RXC:1;            /*!< bit:      2  Receive Complete Interrupt Enable  */
+    uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt Enable     */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_USART_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_INTENSET_OFFSET 0x0D         /**< \brief (SERCOM_USART_INTENSET offset) USART Interrupt Enable Set */
+#define SERCOM_USART_INTENSET_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_USART_INTENSET reset_value) USART Interrupt Enable Set */
+
+#define SERCOM_USART_INTENSET_DRE_Pos 0            /**< \brief (SERCOM_USART_INTENSET) Data Register Empty Interrupt Enable */
+#define SERCOM_USART_INTENSET_DRE   (_U_(0x1) << SERCOM_USART_INTENSET_DRE_Pos)
+#define SERCOM_USART_INTENSET_TXC_Pos 1            /**< \brief (SERCOM_USART_INTENSET) Transmit Complete Interrupt Enable */
+#define SERCOM_USART_INTENSET_TXC   (_U_(0x1) << SERCOM_USART_INTENSET_TXC_Pos)
+#define SERCOM_USART_INTENSET_RXC_Pos 2            /**< \brief (SERCOM_USART_INTENSET) Receive Complete Interrupt Enable */
+#define SERCOM_USART_INTENSET_RXC   (_U_(0x1) << SERCOM_USART_INTENSET_RXC_Pos)
+#define SERCOM_USART_INTENSET_RXS_Pos 3            /**< \brief (SERCOM_USART_INTENSET) Receive Start Interrupt Enable */
+#define SERCOM_USART_INTENSET_RXS   (_U_(0x1) << SERCOM_USART_INTENSET_RXS_Pos)
+#define SERCOM_USART_INTENSET_MASK  _U_(0x0F)    /**< \brief (SERCOM_USART_INTENSET) MASK Register */
+
+/* -------- SERCOM_I2CM_INTFLAG : (SERCOM Offset: 0x0E) (R/W  8) I2CM I2CM Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  MB:1;             /*!< bit:      0  Master on Bus                      */
+    __I uint8_t  SB:1;             /*!< bit:      1  Slave on Bus                       */
+    __I uint8_t  :6;               /*!< bit:  2.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_INTFLAG_OFFSET  0x0E         /**< \brief (SERCOM_I2CM_INTFLAG offset) I2CM Interrupt Flag Status and Clear */
+#define SERCOM_I2CM_INTFLAG_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CM_INTFLAG reset_value) I2CM Interrupt Flag Status and Clear */
+
+#define SERCOM_I2CM_INTFLAG_MB_Pos  0            /**< \brief (SERCOM_I2CM_INTFLAG) Master on Bus */
+#define SERCOM_I2CM_INTFLAG_MB      (_U_(0x1) << SERCOM_I2CM_INTFLAG_MB_Pos)
+#define SERCOM_I2CM_INTFLAG_SB_Pos  1            /**< \brief (SERCOM_I2CM_INTFLAG) Slave on Bus */
+#define SERCOM_I2CM_INTFLAG_SB      (_U_(0x1) << SERCOM_I2CM_INTFLAG_SB_Pos)
+#define SERCOM_I2CM_INTFLAG_MASK    _U_(0x03)    /**< \brief (SERCOM_I2CM_INTFLAG) MASK Register */
+
+/* -------- SERCOM_I2CS_INTFLAG : (SERCOM Offset: 0x0E) (R/W  8) I2CS I2CS Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  PREC:1;           /*!< bit:      0  Stop Received                      */
+    __I uint8_t  AMATCH:1;         /*!< bit:      1  Address Match                      */
+    __I uint8_t  DRDY:1;           /*!< bit:      2  Data Ready                         */
+    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CS_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_INTFLAG_OFFSET  0x0E         /**< \brief (SERCOM_I2CS_INTFLAG offset) I2CS Interrupt Flag Status and Clear */
+#define SERCOM_I2CS_INTFLAG_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CS_INTFLAG reset_value) I2CS Interrupt Flag Status and Clear */
+
+#define SERCOM_I2CS_INTFLAG_PREC_Pos 0            /**< \brief (SERCOM_I2CS_INTFLAG) Stop Received */
+#define SERCOM_I2CS_INTFLAG_PREC    (_U_(0x1) << SERCOM_I2CS_INTFLAG_PREC_Pos)
+#define SERCOM_I2CS_INTFLAG_AMATCH_Pos 1            /**< \brief (SERCOM_I2CS_INTFLAG) Address Match */
+#define SERCOM_I2CS_INTFLAG_AMATCH  (_U_(0x1) << SERCOM_I2CS_INTFLAG_AMATCH_Pos)
+#define SERCOM_I2CS_INTFLAG_DRDY_Pos 2            /**< \brief (SERCOM_I2CS_INTFLAG) Data Ready */
+#define SERCOM_I2CS_INTFLAG_DRDY    (_U_(0x1) << SERCOM_I2CS_INTFLAG_DRDY_Pos)
+#define SERCOM_I2CS_INTFLAG_MASK    _U_(0x07)    /**< \brief (SERCOM_I2CS_INTFLAG) MASK Register */
+
+/* -------- SERCOM_SPI_INTFLAG : (SERCOM Offset: 0x0E) (R/W  8) SPI SPI Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty                */
+    __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete                  */
+    __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete                   */
+    __I uint8_t  :5;               /*!< bit:  3.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_SPI_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_INTFLAG_OFFSET   0x0E         /**< \brief (SERCOM_SPI_INTFLAG offset) SPI Interrupt Flag Status and Clear */
+#define SERCOM_SPI_INTFLAG_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_SPI_INTFLAG reset_value) SPI Interrupt Flag Status and Clear */
+
+#define SERCOM_SPI_INTFLAG_DRE_Pos  0            /**< \brief (SERCOM_SPI_INTFLAG) Data Register Empty */
+#define SERCOM_SPI_INTFLAG_DRE      (_U_(0x1) << SERCOM_SPI_INTFLAG_DRE_Pos)
+#define SERCOM_SPI_INTFLAG_TXC_Pos  1            /**< \brief (SERCOM_SPI_INTFLAG) Transmit Complete */
+#define SERCOM_SPI_INTFLAG_TXC      (_U_(0x1) << SERCOM_SPI_INTFLAG_TXC_Pos)
+#define SERCOM_SPI_INTFLAG_RXC_Pos  2            /**< \brief (SERCOM_SPI_INTFLAG) Receive Complete */
+#define SERCOM_SPI_INTFLAG_RXC      (_U_(0x1) << SERCOM_SPI_INTFLAG_RXC_Pos)
+#define SERCOM_SPI_INTFLAG_MASK     _U_(0x07)    /**< \brief (SERCOM_SPI_INTFLAG) MASK Register */
+
+/* -------- SERCOM_USART_INTFLAG : (SERCOM Offset: 0x0E) (R/W  8) USART USART Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  DRE:1;            /*!< bit:      0  Data Register Empty                */
+    __I uint8_t  TXC:1;            /*!< bit:      1  Transmit Complete                  */
+    __I uint8_t  RXC:1;            /*!< bit:      2  Receive Complete                   */
+    __I uint8_t  RXS:1;            /*!< bit:      3  Receive Start Interrupt            */
+    __I uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_USART_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_INTFLAG_OFFSET 0x0E         /**< \brief (SERCOM_USART_INTFLAG offset) USART Interrupt Flag Status and Clear */
+#define SERCOM_USART_INTFLAG_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_USART_INTFLAG reset_value) USART Interrupt Flag Status and Clear */
+
+#define SERCOM_USART_INTFLAG_DRE_Pos 0            /**< \brief (SERCOM_USART_INTFLAG) Data Register Empty */
+#define SERCOM_USART_INTFLAG_DRE    (_U_(0x1) << SERCOM_USART_INTFLAG_DRE_Pos)
+#define SERCOM_USART_INTFLAG_TXC_Pos 1            /**< \brief (SERCOM_USART_INTFLAG) Transmit Complete */
+#define SERCOM_USART_INTFLAG_TXC    (_U_(0x1) << SERCOM_USART_INTFLAG_TXC_Pos)
+#define SERCOM_USART_INTFLAG_RXC_Pos 2            /**< \brief (SERCOM_USART_INTFLAG) Receive Complete */
+#define SERCOM_USART_INTFLAG_RXC    (_U_(0x1) << SERCOM_USART_INTFLAG_RXC_Pos)
+#define SERCOM_USART_INTFLAG_RXS_Pos 3            /**< \brief (SERCOM_USART_INTFLAG) Receive Start Interrupt */
+#define SERCOM_USART_INTFLAG_RXS    (_U_(0x1) << SERCOM_USART_INTFLAG_RXS_Pos)
+#define SERCOM_USART_INTFLAG_MASK   _U_(0x0F)    /**< \brief (SERCOM_USART_INTFLAG) MASK Register */
+
+/* -------- SERCOM_I2CM_STATUS : (SERCOM Offset: 0x10) (R/W 16) I2CM I2CM Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t BUSERR:1;         /*!< bit:      0  Bus Error                          */
+    uint16_t ARBLOST:1;        /*!< bit:      1  Arbitration Lost                   */
+    uint16_t RXNACK:1;         /*!< bit:      2  Received Not Acknowledge           */
+    uint16_t :1;               /*!< bit:      3  Reserved                           */
+    uint16_t BUSSTATE:2;       /*!< bit:  4.. 5  Bus State                          */
+    uint16_t LOWTOUT:1;        /*!< bit:      6  SCL Low Time-out                   */
+    uint16_t CLKHOLD:1;        /*!< bit:      7  Clock Hold                         */
+    uint16_t :7;               /*!< bit:  8..14  Reserved                           */
+    uint16_t SYNCBUSY:1;       /*!< bit:     15  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CM_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_STATUS_OFFSET   0x10         /**< \brief (SERCOM_I2CM_STATUS offset) I2CM Status */
+#define SERCOM_I2CM_STATUS_RESETVALUE _U_(0x0000)  /**< \brief (SERCOM_I2CM_STATUS reset_value) I2CM Status */
+
+#define SERCOM_I2CM_STATUS_BUSERR_Pos 0            /**< \brief (SERCOM_I2CM_STATUS) Bus Error */
+#define SERCOM_I2CM_STATUS_BUSERR   (_U_(0x1) << SERCOM_I2CM_STATUS_BUSERR_Pos)
+#define SERCOM_I2CM_STATUS_ARBLOST_Pos 1            /**< \brief (SERCOM_I2CM_STATUS) Arbitration Lost */
+#define SERCOM_I2CM_STATUS_ARBLOST  (_U_(0x1) << SERCOM_I2CM_STATUS_ARBLOST_Pos)
+#define SERCOM_I2CM_STATUS_RXNACK_Pos 2            /**< \brief (SERCOM_I2CM_STATUS) Received Not Acknowledge */
+#define SERCOM_I2CM_STATUS_RXNACK   (_U_(0x1) << SERCOM_I2CM_STATUS_RXNACK_Pos)
+#define SERCOM_I2CM_STATUS_BUSSTATE_Pos 4            /**< \brief (SERCOM_I2CM_STATUS) Bus State */
+#define SERCOM_I2CM_STATUS_BUSSTATE_Msk (_U_(0x3) << SERCOM_I2CM_STATUS_BUSSTATE_Pos)
+#define SERCOM_I2CM_STATUS_BUSSTATE(value) (SERCOM_I2CM_STATUS_BUSSTATE_Msk & ((value) << SERCOM_I2CM_STATUS_BUSSTATE_Pos))
+#define SERCOM_I2CM_STATUS_LOWTOUT_Pos 6            /**< \brief (SERCOM_I2CM_STATUS) SCL Low Time-out */
+#define SERCOM_I2CM_STATUS_LOWTOUT  (_U_(0x1) << SERCOM_I2CM_STATUS_LOWTOUT_Pos)
+#define SERCOM_I2CM_STATUS_CLKHOLD_Pos 7            /**< \brief (SERCOM_I2CM_STATUS) Clock Hold */
+#define SERCOM_I2CM_STATUS_CLKHOLD  (_U_(0x1) << SERCOM_I2CM_STATUS_CLKHOLD_Pos)
+#define SERCOM_I2CM_STATUS_SYNCBUSY_Pos 15           /**< \brief (SERCOM_I2CM_STATUS) Synchronization Busy */
+#define SERCOM_I2CM_STATUS_SYNCBUSY (_U_(0x1) << SERCOM_I2CM_STATUS_SYNCBUSY_Pos)
+#define SERCOM_I2CM_STATUS_MASK     _U_(0x80F7)  /**< \brief (SERCOM_I2CM_STATUS) MASK Register */
+
+/* -------- SERCOM_I2CS_STATUS : (SERCOM Offset: 0x10) (R/W 16) I2CS I2CS Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t BUSERR:1;         /*!< bit:      0  Bus Error                          */
+    uint16_t COLL:1;           /*!< bit:      1  Transmit Collision                 */
+    uint16_t RXNACK:1;         /*!< bit:      2  Received Not Acknowledge           */
+    uint16_t DIR:1;            /*!< bit:      3  Read / Write Direction             */
+    uint16_t SR:1;             /*!< bit:      4  Repeated Start                     */
+    uint16_t :1;               /*!< bit:      5  Reserved                           */
+    uint16_t LOWTOUT:1;        /*!< bit:      6  SCL Low Time-out                   */
+    uint16_t CLKHOLD:1;        /*!< bit:      7  Clock Hold                         */
+    uint16_t :7;               /*!< bit:  8..14  Reserved                           */
+    uint16_t SYNCBUSY:1;       /*!< bit:     15  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CS_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_STATUS_OFFSET   0x10         /**< \brief (SERCOM_I2CS_STATUS offset) I2CS Status */
+#define SERCOM_I2CS_STATUS_RESETVALUE _U_(0x0000)  /**< \brief (SERCOM_I2CS_STATUS reset_value) I2CS Status */
+
+#define SERCOM_I2CS_STATUS_BUSERR_Pos 0            /**< \brief (SERCOM_I2CS_STATUS) Bus Error */
+#define SERCOM_I2CS_STATUS_BUSERR   (_U_(0x1) << SERCOM_I2CS_STATUS_BUSERR_Pos)
+#define SERCOM_I2CS_STATUS_COLL_Pos 1            /**< \brief (SERCOM_I2CS_STATUS) Transmit Collision */
+#define SERCOM_I2CS_STATUS_COLL     (_U_(0x1) << SERCOM_I2CS_STATUS_COLL_Pos)
+#define SERCOM_I2CS_STATUS_RXNACK_Pos 2            /**< \brief (SERCOM_I2CS_STATUS) Received Not Acknowledge */
+#define SERCOM_I2CS_STATUS_RXNACK   (_U_(0x1) << SERCOM_I2CS_STATUS_RXNACK_Pos)
+#define SERCOM_I2CS_STATUS_DIR_Pos  3            /**< \brief (SERCOM_I2CS_STATUS) Read / Write Direction */
+#define SERCOM_I2CS_STATUS_DIR      (_U_(0x1) << SERCOM_I2CS_STATUS_DIR_Pos)
+#define SERCOM_I2CS_STATUS_SR_Pos   4            /**< \brief (SERCOM_I2CS_STATUS) Repeated Start */
+#define SERCOM_I2CS_STATUS_SR       (_U_(0x1) << SERCOM_I2CS_STATUS_SR_Pos)
+#define SERCOM_I2CS_STATUS_LOWTOUT_Pos 6            /**< \brief (SERCOM_I2CS_STATUS) SCL Low Time-out */
+#define SERCOM_I2CS_STATUS_LOWTOUT  (_U_(0x1) << SERCOM_I2CS_STATUS_LOWTOUT_Pos)
+#define SERCOM_I2CS_STATUS_CLKHOLD_Pos 7            /**< \brief (SERCOM_I2CS_STATUS) Clock Hold */
+#define SERCOM_I2CS_STATUS_CLKHOLD  (_U_(0x1) << SERCOM_I2CS_STATUS_CLKHOLD_Pos)
+#define SERCOM_I2CS_STATUS_SYNCBUSY_Pos 15           /**< \brief (SERCOM_I2CS_STATUS) Synchronization Busy */
+#define SERCOM_I2CS_STATUS_SYNCBUSY (_U_(0x1) << SERCOM_I2CS_STATUS_SYNCBUSY_Pos)
+#define SERCOM_I2CS_STATUS_MASK     _U_(0x80DF)  /**< \brief (SERCOM_I2CS_STATUS) MASK Register */
+
+/* -------- SERCOM_SPI_STATUS : (SERCOM Offset: 0x10) (R/W 16) SPI SPI Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :2;               /*!< bit:  0.. 1  Reserved                           */
+    uint16_t BUFOVF:1;         /*!< bit:      2  Buffer Overflow                    */
+    uint16_t :12;              /*!< bit:  3..14  Reserved                           */
+    uint16_t SYNCBUSY:1;       /*!< bit:     15  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_STATUS_OFFSET    0x10         /**< \brief (SERCOM_SPI_STATUS offset) SPI Status */
+#define SERCOM_SPI_STATUS_RESETVALUE _U_(0x0000)  /**< \brief (SERCOM_SPI_STATUS reset_value) SPI Status */
+
+#define SERCOM_SPI_STATUS_BUFOVF_Pos 2            /**< \brief (SERCOM_SPI_STATUS) Buffer Overflow */
+#define SERCOM_SPI_STATUS_BUFOVF    (_U_(0x1) << SERCOM_SPI_STATUS_BUFOVF_Pos)
+#define SERCOM_SPI_STATUS_SYNCBUSY_Pos 15           /**< \brief (SERCOM_SPI_STATUS) Synchronization Busy */
+#define SERCOM_SPI_STATUS_SYNCBUSY  (_U_(0x1) << SERCOM_SPI_STATUS_SYNCBUSY_Pos)
+#define SERCOM_SPI_STATUS_MASK      _U_(0x8004)  /**< \brief (SERCOM_SPI_STATUS) MASK Register */
+
+/* -------- SERCOM_USART_STATUS : (SERCOM Offset: 0x10) (R/W 16) USART USART Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t PERR:1;           /*!< bit:      0  Parity Error                       */
+    uint16_t FERR:1;           /*!< bit:      1  Frame Error                        */
+    uint16_t BUFOVF:1;         /*!< bit:      2  Buffer Overflow                    */
+    uint16_t :12;              /*!< bit:  3..14  Reserved                           */
+    uint16_t SYNCBUSY:1;       /*!< bit:     15  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_STATUS_OFFSET  0x10         /**< \brief (SERCOM_USART_STATUS offset) USART Status */
+#define SERCOM_USART_STATUS_RESETVALUE _U_(0x0000)  /**< \brief (SERCOM_USART_STATUS reset_value) USART Status */
+
+#define SERCOM_USART_STATUS_PERR_Pos 0            /**< \brief (SERCOM_USART_STATUS) Parity Error */
+#define SERCOM_USART_STATUS_PERR    (_U_(0x1) << SERCOM_USART_STATUS_PERR_Pos)
+#define SERCOM_USART_STATUS_FERR_Pos 1            /**< \brief (SERCOM_USART_STATUS) Frame Error */
+#define SERCOM_USART_STATUS_FERR    (_U_(0x1) << SERCOM_USART_STATUS_FERR_Pos)
+#define SERCOM_USART_STATUS_BUFOVF_Pos 2            /**< \brief (SERCOM_USART_STATUS) Buffer Overflow */
+#define SERCOM_USART_STATUS_BUFOVF  (_U_(0x1) << SERCOM_USART_STATUS_BUFOVF_Pos)
+#define SERCOM_USART_STATUS_SYNCBUSY_Pos 15           /**< \brief (SERCOM_USART_STATUS) Synchronization Busy */
+#define SERCOM_USART_STATUS_SYNCBUSY (_U_(0x1) << SERCOM_USART_STATUS_SYNCBUSY_Pos)
+#define SERCOM_USART_STATUS_MASK    _U_(0x8007)  /**< \brief (SERCOM_USART_STATUS) MASK Register */
+
+/* -------- SERCOM_I2CM_ADDR : (SERCOM Offset: 0x14) (R/W  8) I2CM I2CM Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  ADDR:8;           /*!< bit:  0.. 7  Address                            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_ADDR_OFFSET     0x14         /**< \brief (SERCOM_I2CM_ADDR offset) I2CM Address */
+#define SERCOM_I2CM_ADDR_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CM_ADDR reset_value) I2CM Address */
+
+#define SERCOM_I2CM_ADDR_ADDR_Pos   0            /**< \brief (SERCOM_I2CM_ADDR) Address */
+#define SERCOM_I2CM_ADDR_ADDR_Msk   (_U_(0xFF) << SERCOM_I2CM_ADDR_ADDR_Pos)
+#define SERCOM_I2CM_ADDR_ADDR(value) (SERCOM_I2CM_ADDR_ADDR_Msk & ((value) << SERCOM_I2CM_ADDR_ADDR_Pos))
+#define SERCOM_I2CM_ADDR_MASK       _U_(0xFF)    /**< \brief (SERCOM_I2CM_ADDR) MASK Register */
+
+/* -------- SERCOM_I2CS_ADDR : (SERCOM Offset: 0x14) (R/W 32) I2CS I2CS Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t GENCEN:1;         /*!< bit:      0  General Call Address Enable        */
+    uint32_t ADDR:7;           /*!< bit:  1.. 7  Address                            */
+    uint32_t :9;               /*!< bit:  8..16  Reserved                           */
+    uint32_t ADDRMASK:7;       /*!< bit: 17..23  Address Mask                       */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_I2CS_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_ADDR_OFFSET     0x14         /**< \brief (SERCOM_I2CS_ADDR offset) I2CS Address */
+#define SERCOM_I2CS_ADDR_RESETVALUE _U_(0x00000000) /**< \brief (SERCOM_I2CS_ADDR reset_value) I2CS Address */
+
+#define SERCOM_I2CS_ADDR_GENCEN_Pos 0            /**< \brief (SERCOM_I2CS_ADDR) General Call Address Enable */
+#define SERCOM_I2CS_ADDR_GENCEN     (_U_(0x1) << SERCOM_I2CS_ADDR_GENCEN_Pos)
+#define SERCOM_I2CS_ADDR_ADDR_Pos   1            /**< \brief (SERCOM_I2CS_ADDR) Address */
+#define SERCOM_I2CS_ADDR_ADDR_Msk   (_U_(0x7F) << SERCOM_I2CS_ADDR_ADDR_Pos)
+#define SERCOM_I2CS_ADDR_ADDR(value) (SERCOM_I2CS_ADDR_ADDR_Msk & ((value) << SERCOM_I2CS_ADDR_ADDR_Pos))
+#define SERCOM_I2CS_ADDR_ADDRMASK_Pos 17           /**< \brief (SERCOM_I2CS_ADDR) Address Mask */
+#define SERCOM_I2CS_ADDR_ADDRMASK_Msk (_U_(0x7F) << SERCOM_I2CS_ADDR_ADDRMASK_Pos)
+#define SERCOM_I2CS_ADDR_ADDRMASK(value) (SERCOM_I2CS_ADDR_ADDRMASK_Msk & ((value) << SERCOM_I2CS_ADDR_ADDRMASK_Pos))
+#define SERCOM_I2CS_ADDR_MASK       _U_(0x00FE00FF) /**< \brief (SERCOM_I2CS_ADDR) MASK Register */
+
+/* -------- SERCOM_SPI_ADDR : (SERCOM Offset: 0x14) (R/W 32) SPI SPI Address -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t ADDR:8;           /*!< bit:  0.. 7  Address                            */
+    uint32_t :8;               /*!< bit:  8..15  Reserved                           */
+    uint32_t ADDRMASK:8;       /*!< bit: 16..23  Address Mask                       */
+    uint32_t :8;               /*!< bit: 24..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_ADDR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_ADDR_OFFSET      0x14         /**< \brief (SERCOM_SPI_ADDR offset) SPI Address */
+#define SERCOM_SPI_ADDR_RESETVALUE  _U_(0x00000000) /**< \brief (SERCOM_SPI_ADDR reset_value) SPI Address */
+
+#define SERCOM_SPI_ADDR_ADDR_Pos    0            /**< \brief (SERCOM_SPI_ADDR) Address */
+#define SERCOM_SPI_ADDR_ADDR_Msk    (_U_(0xFF) << SERCOM_SPI_ADDR_ADDR_Pos)
+#define SERCOM_SPI_ADDR_ADDR(value) (SERCOM_SPI_ADDR_ADDR_Msk & ((value) << SERCOM_SPI_ADDR_ADDR_Pos))
+#define SERCOM_SPI_ADDR_ADDRMASK_Pos 16           /**< \brief (SERCOM_SPI_ADDR) Address Mask */
+#define SERCOM_SPI_ADDR_ADDRMASK_Msk (_U_(0xFF) << SERCOM_SPI_ADDR_ADDRMASK_Pos)
+#define SERCOM_SPI_ADDR_ADDRMASK(value) (SERCOM_SPI_ADDR_ADDRMASK_Msk & ((value) << SERCOM_SPI_ADDR_ADDRMASK_Pos))
+#define SERCOM_SPI_ADDR_MASK        _U_(0x00FF00FF) /**< \brief (SERCOM_SPI_ADDR) MASK Register */
+
+/* -------- SERCOM_I2CM_DATA : (SERCOM Offset: 0x18) (R/W  8) I2CM I2CM Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DATA:8;           /*!< bit:  0.. 7  Data                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CM_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CM_DATA_OFFSET     0x18         /**< \brief (SERCOM_I2CM_DATA offset) I2CM Data */
+#define SERCOM_I2CM_DATA_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CM_DATA reset_value) I2CM Data */
+
+#define SERCOM_I2CM_DATA_DATA_Pos   0            /**< \brief (SERCOM_I2CM_DATA) Data */
+#define SERCOM_I2CM_DATA_DATA_Msk   (_U_(0xFF) << SERCOM_I2CM_DATA_DATA_Pos)
+#define SERCOM_I2CM_DATA_DATA(value) (SERCOM_I2CM_DATA_DATA_Msk & ((value) << SERCOM_I2CM_DATA_DATA_Pos))
+#define SERCOM_I2CM_DATA_MASK       _U_(0xFF)    /**< \brief (SERCOM_I2CM_DATA) MASK Register */
+
+/* -------- SERCOM_I2CS_DATA : (SERCOM Offset: 0x18) (R/W  8) I2CS I2CS Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DATA:8;           /*!< bit:  0.. 7  Data                               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SERCOM_I2CS_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_I2CS_DATA_OFFSET     0x18         /**< \brief (SERCOM_I2CS_DATA offset) I2CS Data */
+#define SERCOM_I2CS_DATA_RESETVALUE _U_(0x00)    /**< \brief (SERCOM_I2CS_DATA reset_value) I2CS Data */
+
+#define SERCOM_I2CS_DATA_DATA_Pos   0            /**< \brief (SERCOM_I2CS_DATA) Data */
+#define SERCOM_I2CS_DATA_DATA_Msk   (_U_(0xFF) << SERCOM_I2CS_DATA_DATA_Pos)
+#define SERCOM_I2CS_DATA_DATA(value) (SERCOM_I2CS_DATA_DATA_Msk & ((value) << SERCOM_I2CS_DATA_DATA_Pos))
+#define SERCOM_I2CS_DATA_MASK       _U_(0xFF)    /**< \brief (SERCOM_I2CS_DATA) MASK Register */
+
+/* -------- SERCOM_SPI_DATA : (SERCOM Offset: 0x18) (R/W 16) SPI SPI Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DATA:9;           /*!< bit:  0.. 8  Data                               */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_SPI_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_SPI_DATA_OFFSET      0x18         /**< \brief (SERCOM_SPI_DATA offset) SPI Data */
+#define SERCOM_SPI_DATA_RESETVALUE  _U_(0x0000)  /**< \brief (SERCOM_SPI_DATA reset_value) SPI Data */
+
+#define SERCOM_SPI_DATA_DATA_Pos    0            /**< \brief (SERCOM_SPI_DATA) Data */
+#define SERCOM_SPI_DATA_DATA_Msk    (_U_(0x1FF) << SERCOM_SPI_DATA_DATA_Pos)
+#define SERCOM_SPI_DATA_DATA(value) (SERCOM_SPI_DATA_DATA_Msk & ((value) << SERCOM_SPI_DATA_DATA_Pos))
+#define SERCOM_SPI_DATA_MASK        _U_(0x01FF)  /**< \brief (SERCOM_SPI_DATA) MASK Register */
+
+/* -------- SERCOM_USART_DATA : (SERCOM Offset: 0x18) (R/W 16) USART USART Data -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t DATA:9;           /*!< bit:  0.. 8  Data                               */
+    uint16_t :7;               /*!< bit:  9..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SERCOM_USART_DATA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SERCOM_USART_DATA_OFFSET    0x18         /**< \brief (SERCOM_USART_DATA offset) USART Data */
+#define SERCOM_USART_DATA_RESETVALUE _U_(0x0000)  /**< \brief (SERCOM_USART_DATA reset_value) USART Data */
+
+#define SERCOM_USART_DATA_DATA_Pos  0            /**< \brief (SERCOM_USART_DATA) Data */
+#define SERCOM_USART_DATA_DATA_Msk  (_U_(0x1FF) << SERCOM_USART_DATA_DATA_Pos)
+#define SERCOM_USART_DATA_DATA(value) (SERCOM_USART_DATA_DATA_Msk & ((value) << SERCOM_USART_DATA_DATA_Pos))
+#define SERCOM_USART_DATA_MASK      _U_(0x01FF)  /**< \brief (SERCOM_USART_DATA) MASK Register */
+
+/** \brief SERCOM_I2CM hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* I2C Master Mode */
+  __IO SERCOM_I2CM_CTRLA_Type    CTRLA;       /**< \brief Offset: 0x00 (R/W 32) I2CM Control A */
+  __IO SERCOM_I2CM_CTRLB_Type    CTRLB;       /**< \brief Offset: 0x04 (R/W 32) I2CM Control B */
+  __IO SERCOM_I2CM_DBGCTRL_Type  DBGCTRL;     /**< \brief Offset: 0x08 (R/W  8) I2CM Debug Control */
+       RoReg8                    Reserved1[0x1];
+  __IO SERCOM_I2CM_BAUD_Type     BAUD;        /**< \brief Offset: 0x0A (R/W 16) I2CM Baud Rate */
+  __IO SERCOM_I2CM_INTENCLR_Type INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) I2CM Interrupt Enable Clear */
+  __IO SERCOM_I2CM_INTENSET_Type INTENSET;    /**< \brief Offset: 0x0D (R/W  8) I2CM Interrupt Enable Set */
+  __IO SERCOM_I2CM_INTFLAG_Type  INTFLAG;     /**< \brief Offset: 0x0E (R/W  8) I2CM Interrupt Flag Status and Clear */
+       RoReg8                    Reserved2[0x1];
+  __IO SERCOM_I2CM_STATUS_Type   STATUS;      /**< \brief Offset: 0x10 (R/W 16) I2CM Status */
+       RoReg8                    Reserved3[0x2];
+  __IO SERCOM_I2CM_ADDR_Type     ADDR;        /**< \brief Offset: 0x14 (R/W  8) I2CM Address */
+       RoReg8                    Reserved4[0x3];
+  __IO SERCOM_I2CM_DATA_Type     DATA;        /**< \brief Offset: 0x18 (R/W  8) I2CM Data */
+} SercomI2cm;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief SERCOM_I2CS hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* I2C Slave Mode */
+  __IO SERCOM_I2CS_CTRLA_Type    CTRLA;       /**< \brief Offset: 0x00 (R/W 32) I2CS Control A */
+  __IO SERCOM_I2CS_CTRLB_Type    CTRLB;       /**< \brief Offset: 0x04 (R/W 32) I2CS Control B */
+       RoReg8                    Reserved1[0x4];
+  __IO SERCOM_I2CS_INTENCLR_Type INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) I2CS Interrupt Enable Clear */
+  __IO SERCOM_I2CS_INTENSET_Type INTENSET;    /**< \brief Offset: 0x0D (R/W  8) I2CS Interrupt Enable Set */
+  __IO SERCOM_I2CS_INTFLAG_Type  INTFLAG;     /**< \brief Offset: 0x0E (R/W  8) I2CS Interrupt Flag Status and Clear */
+       RoReg8                    Reserved2[0x1];
+  __IO SERCOM_I2CS_STATUS_Type   STATUS;      /**< \brief Offset: 0x10 (R/W 16) I2CS Status */
+       RoReg8                    Reserved3[0x2];
+  __IO SERCOM_I2CS_ADDR_Type     ADDR;        /**< \brief Offset: 0x14 (R/W 32) I2CS Address */
+  __IO SERCOM_I2CS_DATA_Type     DATA;        /**< \brief Offset: 0x18 (R/W  8) I2CS Data */
+} SercomI2cs;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief SERCOM_SPI hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* SPI Mode */
+  __IO SERCOM_SPI_CTRLA_Type     CTRLA;       /**< \brief Offset: 0x00 (R/W 32) SPI Control A */
+  __IO SERCOM_SPI_CTRLB_Type     CTRLB;       /**< \brief Offset: 0x04 (R/W 32) SPI Control B */
+  __IO SERCOM_SPI_DBGCTRL_Type   DBGCTRL;     /**< \brief Offset: 0x08 (R/W  8) SPI Debug Control */
+       RoReg8                    Reserved1[0x1];
+  __IO SERCOM_SPI_BAUD_Type      BAUD;        /**< \brief Offset: 0x0A (R/W  8) SPI Baud Rate */
+       RoReg8                    Reserved2[0x1];
+  __IO SERCOM_SPI_INTENCLR_Type  INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) SPI Interrupt Enable Clear */
+  __IO SERCOM_SPI_INTENSET_Type  INTENSET;    /**< \brief Offset: 0x0D (R/W  8) SPI Interrupt Enable Set */
+  __IO SERCOM_SPI_INTFLAG_Type   INTFLAG;     /**< \brief Offset: 0x0E (R/W  8) SPI Interrupt Flag Status and Clear */
+       RoReg8                    Reserved3[0x1];
+  __IO SERCOM_SPI_STATUS_Type    STATUS;      /**< \brief Offset: 0x10 (R/W 16) SPI Status */
+       RoReg8                    Reserved4[0x2];
+  __IO SERCOM_SPI_ADDR_Type      ADDR;        /**< \brief Offset: 0x14 (R/W 32) SPI Address */
+  __IO SERCOM_SPI_DATA_Type      DATA;        /**< \brief Offset: 0x18 (R/W 16) SPI Data */
+} SercomSpi;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief SERCOM_USART hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* USART Mode */
+  __IO SERCOM_USART_CTRLA_Type   CTRLA;       /**< \brief Offset: 0x00 (R/W 32) USART Control A */
+  __IO SERCOM_USART_CTRLB_Type   CTRLB;       /**< \brief Offset: 0x04 (R/W 32) USART Control B */
+  __IO SERCOM_USART_DBGCTRL_Type DBGCTRL;     /**< \brief Offset: 0x08 (R/W  8) USART Debug Control */
+       RoReg8                    Reserved1[0x1];
+  __IO SERCOM_USART_BAUD_Type    BAUD;        /**< \brief Offset: 0x0A (R/W 16) USART Baud */
+  __IO SERCOM_USART_INTENCLR_Type INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) USART Interrupt Enable Clear */
+  __IO SERCOM_USART_INTENSET_Type INTENSET;    /**< \brief Offset: 0x0D (R/W  8) USART Interrupt Enable Set */
+  __IO SERCOM_USART_INTFLAG_Type INTFLAG;     /**< \brief Offset: 0x0E (R/W  8) USART Interrupt Flag Status and Clear */
+       RoReg8                    Reserved2[0x1];
+  __IO SERCOM_USART_STATUS_Type  STATUS;      /**< \brief Offset: 0x10 (R/W 16) USART Status */
+       RoReg8                    Reserved3[0x6];
+  __IO SERCOM_USART_DATA_Type    DATA;        /**< \brief Offset: 0x18 (R/W 16) USART Data */
+} SercomUsart;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+       SercomI2cm                I2CM;        /**< \brief Offset: 0x00 I2C Master Mode */
+       SercomI2cs                I2CS;        /**< \brief Offset: 0x00 I2C Slave Mode */
+       SercomSpi                 SPI;         /**< \brief Offset: 0x00 SPI Mode */
+       SercomUsart               USART;       /**< \brief Offset: 0x00 USART Mode */
+} Sercom;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_SERCOM_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/sysctrl.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/sysctrl.h
@@ -1,0 +1,674 @@
+/**
+ * \file
+ *
+ * \brief Component description for SYSCTRL
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SYSCTRL_COMPONENT_
+#define _SAMD20_SYSCTRL_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR SYSCTRL */
+/* ========================================================================== */
+/** \addtogroup SAMD20_SYSCTRL System Control */
+/*@{*/
+
+#define SYSCTRL_U2100
+#define REV_SYSCTRL                 0x201
+
+/* -------- SYSCTRL_INTENCLR : (SYSCTRL Offset: 0x00) (R/W 32) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
+    uint32_t XOSC32KRDY:1;     /*!< bit:      1  XOSC32K Ready                      */
+    uint32_t OSC32KRDY:1;      /*!< bit:      2  OSC32K Ready                       */
+    uint32_t OSC8MRDY:1;       /*!< bit:      3  OSC8M Ready                        */
+    uint32_t DFLLRDY:1;        /*!< bit:      4  DFLL Ready                         */
+    uint32_t DFLLOOB:1;        /*!< bit:      5  DFLL Out Of Bounds                 */
+    uint32_t DFLLLCKF:1;       /*!< bit:      6  DFLL Lock Fine                     */
+    uint32_t DFLLLCKC:1;       /*!< bit:      7  DFLL Lock Coarse                   */
+    uint32_t DFLLRCS:1;        /*!< bit:      8  DFLL Reference Clock Stopped       */
+    uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
+    uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
+    uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_INTENCLR_OFFSET     0x00         /**< \brief (SYSCTRL_INTENCLR offset) Interrupt Enable Clear */
+#define SYSCTRL_INTENCLR_RESETVALUE _U_(0x00000000) /**< \brief (SYSCTRL_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define SYSCTRL_INTENCLR_XOSCRDY_Pos 0            /**< \brief (SYSCTRL_INTENCLR) XOSC Ready */
+#define SYSCTRL_INTENCLR_XOSCRDY    (_U_(0x1) << SYSCTRL_INTENCLR_XOSCRDY_Pos)
+#define SYSCTRL_INTENCLR_XOSC32KRDY_Pos 1            /**< \brief (SYSCTRL_INTENCLR) XOSC32K Ready */
+#define SYSCTRL_INTENCLR_XOSC32KRDY (_U_(0x1) << SYSCTRL_INTENCLR_XOSC32KRDY_Pos)
+#define SYSCTRL_INTENCLR_OSC32KRDY_Pos 2            /**< \brief (SYSCTRL_INTENCLR) OSC32K Ready */
+#define SYSCTRL_INTENCLR_OSC32KRDY  (_U_(0x1) << SYSCTRL_INTENCLR_OSC32KRDY_Pos)
+#define SYSCTRL_INTENCLR_OSC8MRDY_Pos 3            /**< \brief (SYSCTRL_INTENCLR) OSC8M Ready */
+#define SYSCTRL_INTENCLR_OSC8MRDY   (_U_(0x1) << SYSCTRL_INTENCLR_OSC8MRDY_Pos)
+#define SYSCTRL_INTENCLR_DFLLRDY_Pos 4            /**< \brief (SYSCTRL_INTENCLR) DFLL Ready */
+#define SYSCTRL_INTENCLR_DFLLRDY    (_U_(0x1) << SYSCTRL_INTENCLR_DFLLRDY_Pos)
+#define SYSCTRL_INTENCLR_DFLLOOB_Pos 5            /**< \brief (SYSCTRL_INTENCLR) DFLL Out Of Bounds */
+#define SYSCTRL_INTENCLR_DFLLOOB    (_U_(0x1) << SYSCTRL_INTENCLR_DFLLOOB_Pos)
+#define SYSCTRL_INTENCLR_DFLLLCKF_Pos 6            /**< \brief (SYSCTRL_INTENCLR) DFLL Lock Fine */
+#define SYSCTRL_INTENCLR_DFLLLCKF   (_U_(0x1) << SYSCTRL_INTENCLR_DFLLLCKF_Pos)
+#define SYSCTRL_INTENCLR_DFLLLCKC_Pos 7            /**< \brief (SYSCTRL_INTENCLR) DFLL Lock Coarse */
+#define SYSCTRL_INTENCLR_DFLLLCKC   (_U_(0x1) << SYSCTRL_INTENCLR_DFLLLCKC_Pos)
+#define SYSCTRL_INTENCLR_DFLLRCS_Pos 8            /**< \brief (SYSCTRL_INTENCLR) DFLL Reference Clock Stopped */
+#define SYSCTRL_INTENCLR_DFLLRCS    (_U_(0x1) << SYSCTRL_INTENCLR_DFLLRCS_Pos)
+#define SYSCTRL_INTENCLR_BOD33RDY_Pos 9            /**< \brief (SYSCTRL_INTENCLR) BOD33 Ready */
+#define SYSCTRL_INTENCLR_BOD33RDY   (_U_(0x1) << SYSCTRL_INTENCLR_BOD33RDY_Pos)
+#define SYSCTRL_INTENCLR_BOD33DET_Pos 10           /**< \brief (SYSCTRL_INTENCLR) BOD33 Detection */
+#define SYSCTRL_INTENCLR_BOD33DET   (_U_(0x1) << SYSCTRL_INTENCLR_BOD33DET_Pos)
+#define SYSCTRL_INTENCLR_B33SRDY_Pos 11           /**< \brief (SYSCTRL_INTENCLR) BOD33 Synchronization Ready */
+#define SYSCTRL_INTENCLR_B33SRDY    (_U_(0x1) << SYSCTRL_INTENCLR_B33SRDY_Pos)
+#define SYSCTRL_INTENCLR_MASK       _U_(0x00000FFF) /**< \brief (SYSCTRL_INTENCLR) MASK Register */
+
+/* -------- SYSCTRL_INTENSET : (SYSCTRL Offset: 0x04) (R/W 32) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
+    uint32_t XOSC32KRDY:1;     /*!< bit:      1  XOSC32K Ready                      */
+    uint32_t OSC32KRDY:1;      /*!< bit:      2  OSC32K Ready                       */
+    uint32_t OSC8MRDY:1;       /*!< bit:      3  OSC8M Ready                        */
+    uint32_t DFLLRDY:1;        /*!< bit:      4  DFLL Ready                         */
+    uint32_t DFLLOOB:1;        /*!< bit:      5  DFLL Out Of Bounds                 */
+    uint32_t DFLLLCKF:1;       /*!< bit:      6  DFLL Lock Fine                     */
+    uint32_t DFLLLCKC:1;       /*!< bit:      7  DFLL Lock Coarse                   */
+    uint32_t DFLLRCS:1;        /*!< bit:      8  DFLL Reference Clock Stopped       */
+    uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
+    uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
+    uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_INTENSET_OFFSET     0x04         /**< \brief (SYSCTRL_INTENSET offset) Interrupt Enable Set */
+#define SYSCTRL_INTENSET_RESETVALUE _U_(0x00000000) /**< \brief (SYSCTRL_INTENSET reset_value) Interrupt Enable Set */
+
+#define SYSCTRL_INTENSET_XOSCRDY_Pos 0            /**< \brief (SYSCTRL_INTENSET) XOSC Ready */
+#define SYSCTRL_INTENSET_XOSCRDY    (_U_(0x1) << SYSCTRL_INTENSET_XOSCRDY_Pos)
+#define SYSCTRL_INTENSET_XOSC32KRDY_Pos 1            /**< \brief (SYSCTRL_INTENSET) XOSC32K Ready */
+#define SYSCTRL_INTENSET_XOSC32KRDY (_U_(0x1) << SYSCTRL_INTENSET_XOSC32KRDY_Pos)
+#define SYSCTRL_INTENSET_OSC32KRDY_Pos 2            /**< \brief (SYSCTRL_INTENSET) OSC32K Ready */
+#define SYSCTRL_INTENSET_OSC32KRDY  (_U_(0x1) << SYSCTRL_INTENSET_OSC32KRDY_Pos)
+#define SYSCTRL_INTENSET_OSC8MRDY_Pos 3            /**< \brief (SYSCTRL_INTENSET) OSC8M Ready */
+#define SYSCTRL_INTENSET_OSC8MRDY   (_U_(0x1) << SYSCTRL_INTENSET_OSC8MRDY_Pos)
+#define SYSCTRL_INTENSET_DFLLRDY_Pos 4            /**< \brief (SYSCTRL_INTENSET) DFLL Ready */
+#define SYSCTRL_INTENSET_DFLLRDY    (_U_(0x1) << SYSCTRL_INTENSET_DFLLRDY_Pos)
+#define SYSCTRL_INTENSET_DFLLOOB_Pos 5            /**< \brief (SYSCTRL_INTENSET) DFLL Out Of Bounds */
+#define SYSCTRL_INTENSET_DFLLOOB    (_U_(0x1) << SYSCTRL_INTENSET_DFLLOOB_Pos)
+#define SYSCTRL_INTENSET_DFLLLCKF_Pos 6            /**< \brief (SYSCTRL_INTENSET) DFLL Lock Fine */
+#define SYSCTRL_INTENSET_DFLLLCKF   (_U_(0x1) << SYSCTRL_INTENSET_DFLLLCKF_Pos)
+#define SYSCTRL_INTENSET_DFLLLCKC_Pos 7            /**< \brief (SYSCTRL_INTENSET) DFLL Lock Coarse */
+#define SYSCTRL_INTENSET_DFLLLCKC   (_U_(0x1) << SYSCTRL_INTENSET_DFLLLCKC_Pos)
+#define SYSCTRL_INTENSET_DFLLRCS_Pos 8            /**< \brief (SYSCTRL_INTENSET) DFLL Reference Clock Stopped */
+#define SYSCTRL_INTENSET_DFLLRCS    (_U_(0x1) << SYSCTRL_INTENSET_DFLLRCS_Pos)
+#define SYSCTRL_INTENSET_BOD33RDY_Pos 9            /**< \brief (SYSCTRL_INTENSET) BOD33 Ready */
+#define SYSCTRL_INTENSET_BOD33RDY   (_U_(0x1) << SYSCTRL_INTENSET_BOD33RDY_Pos)
+#define SYSCTRL_INTENSET_BOD33DET_Pos 10           /**< \brief (SYSCTRL_INTENSET) BOD33 Detection */
+#define SYSCTRL_INTENSET_BOD33DET   (_U_(0x1) << SYSCTRL_INTENSET_BOD33DET_Pos)
+#define SYSCTRL_INTENSET_B33SRDY_Pos 11           /**< \brief (SYSCTRL_INTENSET) BOD33 Synchronization Ready */
+#define SYSCTRL_INTENSET_B33SRDY    (_U_(0x1) << SYSCTRL_INTENSET_B33SRDY_Pos)
+#define SYSCTRL_INTENSET_MASK       _U_(0x00000FFF) /**< \brief (SYSCTRL_INTENSET) MASK Register */
+
+/* -------- SYSCTRL_INTFLAG : (SYSCTRL Offset: 0x08) (R/W 32) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
+    __I uint32_t XOSC32KRDY:1;     /*!< bit:      1  XOSC32K Ready                      */
+    __I uint32_t OSC32KRDY:1;      /*!< bit:      2  OSC32K Ready                       */
+    __I uint32_t OSC8MRDY:1;       /*!< bit:      3  OSC8M Ready                        */
+    __I uint32_t DFLLRDY:1;        /*!< bit:      4  DFLL Ready                         */
+    __I uint32_t DFLLOOB:1;        /*!< bit:      5  DFLL Out Of Bounds                 */
+    __I uint32_t DFLLLCKF:1;       /*!< bit:      6  DFLL Lock Fine                     */
+    __I uint32_t DFLLLCKC:1;       /*!< bit:      7  DFLL Lock Coarse                   */
+    __I uint32_t DFLLRCS:1;        /*!< bit:      8  DFLL Reference Clock Stopped       */
+    __I uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
+    __I uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
+    __I uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
+    __I uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_INTFLAG_OFFSET      0x08         /**< \brief (SYSCTRL_INTFLAG offset) Interrupt Flag Status and Clear */
+#define SYSCTRL_INTFLAG_RESETVALUE  _U_(0x00000000) /**< \brief (SYSCTRL_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define SYSCTRL_INTFLAG_XOSCRDY_Pos 0            /**< \brief (SYSCTRL_INTFLAG) XOSC Ready */
+#define SYSCTRL_INTFLAG_XOSCRDY     (_U_(0x1) << SYSCTRL_INTFLAG_XOSCRDY_Pos)
+#define SYSCTRL_INTFLAG_XOSC32KRDY_Pos 1            /**< \brief (SYSCTRL_INTFLAG) XOSC32K Ready */
+#define SYSCTRL_INTFLAG_XOSC32KRDY  (_U_(0x1) << SYSCTRL_INTFLAG_XOSC32KRDY_Pos)
+#define SYSCTRL_INTFLAG_OSC32KRDY_Pos 2            /**< \brief (SYSCTRL_INTFLAG) OSC32K Ready */
+#define SYSCTRL_INTFLAG_OSC32KRDY   (_U_(0x1) << SYSCTRL_INTFLAG_OSC32KRDY_Pos)
+#define SYSCTRL_INTFLAG_OSC8MRDY_Pos 3            /**< \brief (SYSCTRL_INTFLAG) OSC8M Ready */
+#define SYSCTRL_INTFLAG_OSC8MRDY    (_U_(0x1) << SYSCTRL_INTFLAG_OSC8MRDY_Pos)
+#define SYSCTRL_INTFLAG_DFLLRDY_Pos 4            /**< \brief (SYSCTRL_INTFLAG) DFLL Ready */
+#define SYSCTRL_INTFLAG_DFLLRDY     (_U_(0x1) << SYSCTRL_INTFLAG_DFLLRDY_Pos)
+#define SYSCTRL_INTFLAG_DFLLOOB_Pos 5            /**< \brief (SYSCTRL_INTFLAG) DFLL Out Of Bounds */
+#define SYSCTRL_INTFLAG_DFLLOOB     (_U_(0x1) << SYSCTRL_INTFLAG_DFLLOOB_Pos)
+#define SYSCTRL_INTFLAG_DFLLLCKF_Pos 6            /**< \brief (SYSCTRL_INTFLAG) DFLL Lock Fine */
+#define SYSCTRL_INTFLAG_DFLLLCKF    (_U_(0x1) << SYSCTRL_INTFLAG_DFLLLCKF_Pos)
+#define SYSCTRL_INTFLAG_DFLLLCKC_Pos 7            /**< \brief (SYSCTRL_INTFLAG) DFLL Lock Coarse */
+#define SYSCTRL_INTFLAG_DFLLLCKC    (_U_(0x1) << SYSCTRL_INTFLAG_DFLLLCKC_Pos)
+#define SYSCTRL_INTFLAG_DFLLRCS_Pos 8            /**< \brief (SYSCTRL_INTFLAG) DFLL Reference Clock Stopped */
+#define SYSCTRL_INTFLAG_DFLLRCS     (_U_(0x1) << SYSCTRL_INTFLAG_DFLLRCS_Pos)
+#define SYSCTRL_INTFLAG_BOD33RDY_Pos 9            /**< \brief (SYSCTRL_INTFLAG) BOD33 Ready */
+#define SYSCTRL_INTFLAG_BOD33RDY    (_U_(0x1) << SYSCTRL_INTFLAG_BOD33RDY_Pos)
+#define SYSCTRL_INTFLAG_BOD33DET_Pos 10           /**< \brief (SYSCTRL_INTFLAG) BOD33 Detection */
+#define SYSCTRL_INTFLAG_BOD33DET    (_U_(0x1) << SYSCTRL_INTFLAG_BOD33DET_Pos)
+#define SYSCTRL_INTFLAG_B33SRDY_Pos 11           /**< \brief (SYSCTRL_INTFLAG) BOD33 Synchronization Ready */
+#define SYSCTRL_INTFLAG_B33SRDY     (_U_(0x1) << SYSCTRL_INTFLAG_B33SRDY_Pos)
+#define SYSCTRL_INTFLAG_MASK        _U_(0x00000FFF) /**< \brief (SYSCTRL_INTFLAG) MASK Register */
+
+/* -------- SYSCTRL_PCLKSR : (SYSCTRL Offset: 0x0C) (R/  32) Power and Clocks Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t XOSCRDY:1;        /*!< bit:      0  XOSC Ready                         */
+    uint32_t XOSC32KRDY:1;     /*!< bit:      1  XOSC32K Ready                      */
+    uint32_t OSC32KRDY:1;      /*!< bit:      2  OSC32K Ready                       */
+    uint32_t OSC8MRDY:1;       /*!< bit:      3  OSC8M Ready                        */
+    uint32_t DFLLRDY:1;        /*!< bit:      4  DFLL Ready                         */
+    uint32_t DFLLOOB:1;        /*!< bit:      5  DFLL Out Of Bounds                 */
+    uint32_t DFLLLCKF:1;       /*!< bit:      6  DFLL Lock Fine                     */
+    uint32_t DFLLLCKC:1;       /*!< bit:      7  DFLL Lock Coarse                   */
+    uint32_t DFLLRCS:1;        /*!< bit:      8  DFLL Reference Clock Stopped       */
+    uint32_t BOD33RDY:1;       /*!< bit:      9  BOD33 Ready                        */
+    uint32_t BOD33DET:1;       /*!< bit:     10  BOD33 Detection                    */
+    uint32_t B33SRDY:1;        /*!< bit:     11  BOD33 Synchronization Ready        */
+    uint32_t :20;              /*!< bit: 12..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_PCLKSR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_PCLKSR_OFFSET       0x0C         /**< \brief (SYSCTRL_PCLKSR offset) Power and Clocks Status */
+#define SYSCTRL_PCLKSR_RESETVALUE   _U_(0x00000000) /**< \brief (SYSCTRL_PCLKSR reset_value) Power and Clocks Status */
+
+#define SYSCTRL_PCLKSR_XOSCRDY_Pos  0            /**< \brief (SYSCTRL_PCLKSR) XOSC Ready */
+#define SYSCTRL_PCLKSR_XOSCRDY      (_U_(0x1) << SYSCTRL_PCLKSR_XOSCRDY_Pos)
+#define SYSCTRL_PCLKSR_XOSC32KRDY_Pos 1            /**< \brief (SYSCTRL_PCLKSR) XOSC32K Ready */
+#define SYSCTRL_PCLKSR_XOSC32KRDY   (_U_(0x1) << SYSCTRL_PCLKSR_XOSC32KRDY_Pos)
+#define SYSCTRL_PCLKSR_OSC32KRDY_Pos 2            /**< \brief (SYSCTRL_PCLKSR) OSC32K Ready */
+#define SYSCTRL_PCLKSR_OSC32KRDY    (_U_(0x1) << SYSCTRL_PCLKSR_OSC32KRDY_Pos)
+#define SYSCTRL_PCLKSR_OSC8MRDY_Pos 3            /**< \brief (SYSCTRL_PCLKSR) OSC8M Ready */
+#define SYSCTRL_PCLKSR_OSC8MRDY     (_U_(0x1) << SYSCTRL_PCLKSR_OSC8MRDY_Pos)
+#define SYSCTRL_PCLKSR_DFLLRDY_Pos  4            /**< \brief (SYSCTRL_PCLKSR) DFLL Ready */
+#define SYSCTRL_PCLKSR_DFLLRDY      (_U_(0x1) << SYSCTRL_PCLKSR_DFLLRDY_Pos)
+#define SYSCTRL_PCLKSR_DFLLOOB_Pos  5            /**< \brief (SYSCTRL_PCLKSR) DFLL Out Of Bounds */
+#define SYSCTRL_PCLKSR_DFLLOOB      (_U_(0x1) << SYSCTRL_PCLKSR_DFLLOOB_Pos)
+#define SYSCTRL_PCLKSR_DFLLLCKF_Pos 6            /**< \brief (SYSCTRL_PCLKSR) DFLL Lock Fine */
+#define SYSCTRL_PCLKSR_DFLLLCKF     (_U_(0x1) << SYSCTRL_PCLKSR_DFLLLCKF_Pos)
+#define SYSCTRL_PCLKSR_DFLLLCKC_Pos 7            /**< \brief (SYSCTRL_PCLKSR) DFLL Lock Coarse */
+#define SYSCTRL_PCLKSR_DFLLLCKC     (_U_(0x1) << SYSCTRL_PCLKSR_DFLLLCKC_Pos)
+#define SYSCTRL_PCLKSR_DFLLRCS_Pos  8            /**< \brief (SYSCTRL_PCLKSR) DFLL Reference Clock Stopped */
+#define SYSCTRL_PCLKSR_DFLLRCS      (_U_(0x1) << SYSCTRL_PCLKSR_DFLLRCS_Pos)
+#define SYSCTRL_PCLKSR_BOD33RDY_Pos 9            /**< \brief (SYSCTRL_PCLKSR) BOD33 Ready */
+#define SYSCTRL_PCLKSR_BOD33RDY     (_U_(0x1) << SYSCTRL_PCLKSR_BOD33RDY_Pos)
+#define SYSCTRL_PCLKSR_BOD33DET_Pos 10           /**< \brief (SYSCTRL_PCLKSR) BOD33 Detection */
+#define SYSCTRL_PCLKSR_BOD33DET     (_U_(0x1) << SYSCTRL_PCLKSR_BOD33DET_Pos)
+#define SYSCTRL_PCLKSR_B33SRDY_Pos  11           /**< \brief (SYSCTRL_PCLKSR) BOD33 Synchronization Ready */
+#define SYSCTRL_PCLKSR_B33SRDY      (_U_(0x1) << SYSCTRL_PCLKSR_B33SRDY_Pos)
+#define SYSCTRL_PCLKSR_MASK         _U_(0x00000FFF) /**< \brief (SYSCTRL_PCLKSR) MASK Register */
+
+/* -------- SYSCTRL_XOSC : (SYSCTRL Offset: 0x10) (R/W 16) XOSC Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :1;               /*!< bit:      0  Reserved                           */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t XTALEN:1;         /*!< bit:      2  Crystal Oscillator Enable          */
+    uint16_t :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint16_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint16_t ONDEMAND:1;       /*!< bit:      7  Enable on Demand                   */
+    uint16_t GAIN:3;           /*!< bit:  8..10  Gain Value                         */
+    uint16_t AMPGC:1;          /*!< bit:     11  Automatic Amplitude Gain Control   */
+    uint16_t STARTUP:4;        /*!< bit: 12..15  Start-Up Time                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_XOSC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_XOSC_OFFSET         0x10         /**< \brief (SYSCTRL_XOSC offset) XOSC Control */
+#define SYSCTRL_XOSC_RESETVALUE     _U_(0x0080)  /**< \brief (SYSCTRL_XOSC reset_value) XOSC Control */
+
+#define SYSCTRL_XOSC_ENABLE_Pos     1            /**< \brief (SYSCTRL_XOSC) Enable */
+#define SYSCTRL_XOSC_ENABLE         (_U_(0x1) << SYSCTRL_XOSC_ENABLE_Pos)
+#define SYSCTRL_XOSC_XTALEN_Pos     2            /**< \brief (SYSCTRL_XOSC) Crystal Oscillator Enable */
+#define SYSCTRL_XOSC_XTALEN         (_U_(0x1) << SYSCTRL_XOSC_XTALEN_Pos)
+#define SYSCTRL_XOSC_RUNSTDBY_Pos   6            /**< \brief (SYSCTRL_XOSC) Run during Standby */
+#define SYSCTRL_XOSC_RUNSTDBY       (_U_(0x1) << SYSCTRL_XOSC_RUNSTDBY_Pos)
+#define SYSCTRL_XOSC_ONDEMAND_Pos   7            /**< \brief (SYSCTRL_XOSC) Enable on Demand */
+#define SYSCTRL_XOSC_ONDEMAND       (_U_(0x1) << SYSCTRL_XOSC_ONDEMAND_Pos)
+#define SYSCTRL_XOSC_GAIN_Pos       8            /**< \brief (SYSCTRL_XOSC) Gain Value */
+#define SYSCTRL_XOSC_GAIN_Msk       (_U_(0x7) << SYSCTRL_XOSC_GAIN_Pos)
+#define SYSCTRL_XOSC_GAIN(value)    (SYSCTRL_XOSC_GAIN_Msk & ((value) << SYSCTRL_XOSC_GAIN_Pos))
+#define SYSCTRL_XOSC_AMPGC_Pos      11           /**< \brief (SYSCTRL_XOSC) Automatic Amplitude Gain Control */
+#define SYSCTRL_XOSC_AMPGC          (_U_(0x1) << SYSCTRL_XOSC_AMPGC_Pos)
+#define SYSCTRL_XOSC_STARTUP_Pos    12           /**< \brief (SYSCTRL_XOSC) Start-Up Time */
+#define SYSCTRL_XOSC_STARTUP_Msk    (_U_(0xF) << SYSCTRL_XOSC_STARTUP_Pos)
+#define SYSCTRL_XOSC_STARTUP(value) (SYSCTRL_XOSC_STARTUP_Msk & ((value) << SYSCTRL_XOSC_STARTUP_Pos))
+#define SYSCTRL_XOSC_MASK           _U_(0xFFC6)  /**< \brief (SYSCTRL_XOSC) MASK Register */
+
+/* -------- SYSCTRL_XOSC32K : (SYSCTRL Offset: 0x14) (R/W 16) XOSC32K Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :1;               /*!< bit:      0  Reserved                           */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t XTALEN:1;         /*!< bit:      2  Crystal Oscillator Enable          */
+    uint16_t EN32K:1;          /*!< bit:      3  32kHz Output Enable                */
+    uint16_t EN1K:1;           /*!< bit:      4  1kHz Output Enable                 */
+    uint16_t AAMPEN:1;         /*!< bit:      5  Automatic Amplitude Control Enable */
+    uint16_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint16_t ONDEMAND:1;       /*!< bit:      7  Enable on Demand                   */
+    uint16_t STARTUP:3;        /*!< bit:  8..10  Start-Up Time                      */
+    uint16_t :1;               /*!< bit:     11  Reserved                           */
+    uint16_t WRTLOCK:1;        /*!< bit:     12  Write Lock                         */
+    uint16_t :3;               /*!< bit: 13..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_XOSC32K_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_XOSC32K_OFFSET      0x14         /**< \brief (SYSCTRL_XOSC32K offset) XOSC32K Control */
+#define SYSCTRL_XOSC32K_RESETVALUE  _U_(0x0080)  /**< \brief (SYSCTRL_XOSC32K reset_value) XOSC32K Control */
+
+#define SYSCTRL_XOSC32K_ENABLE_Pos  1            /**< \brief (SYSCTRL_XOSC32K) Enable */
+#define SYSCTRL_XOSC32K_ENABLE      (_U_(0x1) << SYSCTRL_XOSC32K_ENABLE_Pos)
+#define SYSCTRL_XOSC32K_XTALEN_Pos  2            /**< \brief (SYSCTRL_XOSC32K) Crystal Oscillator Enable */
+#define SYSCTRL_XOSC32K_XTALEN      (_U_(0x1) << SYSCTRL_XOSC32K_XTALEN_Pos)
+#define SYSCTRL_XOSC32K_EN32K_Pos   3            /**< \brief (SYSCTRL_XOSC32K) 32kHz Output Enable */
+#define SYSCTRL_XOSC32K_EN32K       (_U_(0x1) << SYSCTRL_XOSC32K_EN32K_Pos)
+#define SYSCTRL_XOSC32K_EN1K_Pos    4            /**< \brief (SYSCTRL_XOSC32K) 1kHz Output Enable */
+#define SYSCTRL_XOSC32K_EN1K        (_U_(0x1) << SYSCTRL_XOSC32K_EN1K_Pos)
+#define SYSCTRL_XOSC32K_AAMPEN_Pos  5            /**< \brief (SYSCTRL_XOSC32K) Automatic Amplitude Control Enable */
+#define SYSCTRL_XOSC32K_AAMPEN      (_U_(0x1) << SYSCTRL_XOSC32K_AAMPEN_Pos)
+#define SYSCTRL_XOSC32K_RUNSTDBY_Pos 6            /**< \brief (SYSCTRL_XOSC32K) Run during Standby */
+#define SYSCTRL_XOSC32K_RUNSTDBY    (_U_(0x1) << SYSCTRL_XOSC32K_RUNSTDBY_Pos)
+#define SYSCTRL_XOSC32K_ONDEMAND_Pos 7            /**< \brief (SYSCTRL_XOSC32K) Enable on Demand */
+#define SYSCTRL_XOSC32K_ONDEMAND    (_U_(0x1) << SYSCTRL_XOSC32K_ONDEMAND_Pos)
+#define SYSCTRL_XOSC32K_STARTUP_Pos 8            /**< \brief (SYSCTRL_XOSC32K) Start-Up Time */
+#define SYSCTRL_XOSC32K_STARTUP_Msk (_U_(0x7) << SYSCTRL_XOSC32K_STARTUP_Pos)
+#define SYSCTRL_XOSC32K_STARTUP(value) (SYSCTRL_XOSC32K_STARTUP_Msk & ((value) << SYSCTRL_XOSC32K_STARTUP_Pos))
+#define SYSCTRL_XOSC32K_WRTLOCK_Pos 12           /**< \brief (SYSCTRL_XOSC32K) Write Lock */
+#define SYSCTRL_XOSC32K_WRTLOCK     (_U_(0x1) << SYSCTRL_XOSC32K_WRTLOCK_Pos)
+#define SYSCTRL_XOSC32K_MASK        _U_(0x17FE)  /**< \brief (SYSCTRL_XOSC32K) MASK Register */
+
+/* -------- SYSCTRL_OSC32K : (SYSCTRL Offset: 0x18) (R/W 32) OSC32K Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t EN32K:1;          /*!< bit:      2  32kHz Output Enable                */
+    uint32_t EN1K:1;           /*!< bit:      3  1kHz Output Enable                 */
+    uint32_t :2;               /*!< bit:  4.. 5  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint32_t ONDEMAND:1;       /*!< bit:      7  Enable on Demand                   */
+    uint32_t STARTUP:3;        /*!< bit:  8..10  Start-Up Time                      */
+    uint32_t :1;               /*!< bit:     11  Reserved                           */
+    uint32_t WRTLOCK:1;        /*!< bit:     12  Write Lock                         */
+    uint32_t :3;               /*!< bit: 13..15  Reserved                           */
+    uint32_t CALIB:7;          /*!< bit: 16..22  Calibration Value                  */
+    uint32_t :9;               /*!< bit: 23..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_OSC32K_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_OSC32K_OFFSET       0x18         /**< \brief (SYSCTRL_OSC32K offset) OSC32K Control */
+#define SYSCTRL_OSC32K_RESETVALUE   _U_(0x003F0080) /**< \brief (SYSCTRL_OSC32K reset_value) OSC32K Control */
+
+#define SYSCTRL_OSC32K_ENABLE_Pos   1            /**< \brief (SYSCTRL_OSC32K) Enable */
+#define SYSCTRL_OSC32K_ENABLE       (_U_(0x1) << SYSCTRL_OSC32K_ENABLE_Pos)
+#define SYSCTRL_OSC32K_EN32K_Pos    2            /**< \brief (SYSCTRL_OSC32K) 32kHz Output Enable */
+#define SYSCTRL_OSC32K_EN32K        (_U_(0x1) << SYSCTRL_OSC32K_EN32K_Pos)
+#define SYSCTRL_OSC32K_EN1K_Pos     3            /**< \brief (SYSCTRL_OSC32K) 1kHz Output Enable */
+#define SYSCTRL_OSC32K_EN1K         (_U_(0x1) << SYSCTRL_OSC32K_EN1K_Pos)
+#define SYSCTRL_OSC32K_RUNSTDBY_Pos 6            /**< \brief (SYSCTRL_OSC32K) Run during Standby */
+#define SYSCTRL_OSC32K_RUNSTDBY     (_U_(0x1) << SYSCTRL_OSC32K_RUNSTDBY_Pos)
+#define SYSCTRL_OSC32K_ONDEMAND_Pos 7            /**< \brief (SYSCTRL_OSC32K) Enable on Demand */
+#define SYSCTRL_OSC32K_ONDEMAND     (_U_(0x1) << SYSCTRL_OSC32K_ONDEMAND_Pos)
+#define SYSCTRL_OSC32K_STARTUP_Pos  8            /**< \brief (SYSCTRL_OSC32K) Start-Up Time */
+#define SYSCTRL_OSC32K_STARTUP_Msk  (_U_(0x7) << SYSCTRL_OSC32K_STARTUP_Pos)
+#define SYSCTRL_OSC32K_STARTUP(value) (SYSCTRL_OSC32K_STARTUP_Msk & ((value) << SYSCTRL_OSC32K_STARTUP_Pos))
+#define SYSCTRL_OSC32K_WRTLOCK_Pos  12           /**< \brief (SYSCTRL_OSC32K) Write Lock */
+#define SYSCTRL_OSC32K_WRTLOCK      (_U_(0x1) << SYSCTRL_OSC32K_WRTLOCK_Pos)
+#define SYSCTRL_OSC32K_CALIB_Pos    16           /**< \brief (SYSCTRL_OSC32K) Calibration Value */
+#define SYSCTRL_OSC32K_CALIB_Msk    (_U_(0x7F) << SYSCTRL_OSC32K_CALIB_Pos)
+#define SYSCTRL_OSC32K_CALIB(value) (SYSCTRL_OSC32K_CALIB_Msk & ((value) << SYSCTRL_OSC32K_CALIB_Pos))
+#define SYSCTRL_OSC32K_MASK         _U_(0x007F17CE) /**< \brief (SYSCTRL_OSC32K) MASK Register */
+
+/* -------- SYSCTRL_OSCULP32K : (SYSCTRL Offset: 0x1C) (R/W  8) OSCULP32K Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CALIB:5;          /*!< bit:  0.. 4  Calibration Value                  */
+    uint8_t  :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint8_t  WRTLOCK:1;        /*!< bit:      7  Write Lock                         */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SYSCTRL_OSCULP32K_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_OSCULP32K_OFFSET    0x1C         /**< \brief (SYSCTRL_OSCULP32K offset) OSCULP32K Control */
+#define SYSCTRL_OSCULP32K_RESETVALUE _U_(0x0F)    /**< \brief (SYSCTRL_OSCULP32K reset_value) OSCULP32K Control */
+
+#define SYSCTRL_OSCULP32K_CALIB_Pos 0            /**< \brief (SYSCTRL_OSCULP32K) Calibration Value */
+#define SYSCTRL_OSCULP32K_CALIB_Msk (_U_(0x1F) << SYSCTRL_OSCULP32K_CALIB_Pos)
+#define SYSCTRL_OSCULP32K_CALIB(value) (SYSCTRL_OSCULP32K_CALIB_Msk & ((value) << SYSCTRL_OSCULP32K_CALIB_Pos))
+#define SYSCTRL_OSCULP32K_WRTLOCK_Pos 7            /**< \brief (SYSCTRL_OSCULP32K) Write Lock */
+#define SYSCTRL_OSCULP32K_WRTLOCK   (_U_(0x1) << SYSCTRL_OSCULP32K_WRTLOCK_Pos)
+#define SYSCTRL_OSCULP32K_MASK      _U_(0x9F)    /**< \brief (SYSCTRL_OSCULP32K) MASK Register */
+
+/* -------- SYSCTRL_OSC8M : (SYSCTRL Offset: 0x20) (R/W 32) OSC8M Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t :4;               /*!< bit:  2.. 5  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint32_t ONDEMAND:1;       /*!< bit:      7  Enable on Demand                   */
+    uint32_t PRESC:2;          /*!< bit:  8.. 9  Prescaler Select                   */
+    uint32_t :6;               /*!< bit: 10..15  Reserved                           */
+    uint32_t CALIB:12;         /*!< bit: 16..27  Calibration Value                  */
+    uint32_t :2;               /*!< bit: 28..29  Reserved                           */
+    uint32_t FRANGE:2;         /*!< bit: 30..31  Frequency Range                    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_OSC8M_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_OSC8M_OFFSET        0x20         /**< \brief (SYSCTRL_OSC8M offset) OSC8M Control A */
+#define SYSCTRL_OSC8M_RESETVALUE    _U_(0x87070382) /**< \brief (SYSCTRL_OSC8M reset_value) OSC8M Control A */
+
+#define SYSCTRL_OSC8M_ENABLE_Pos    1            /**< \brief (SYSCTRL_OSC8M) Enable */
+#define SYSCTRL_OSC8M_ENABLE        (_U_(0x1) << SYSCTRL_OSC8M_ENABLE_Pos)
+#define SYSCTRL_OSC8M_RUNSTDBY_Pos  6            /**< \brief (SYSCTRL_OSC8M) Run during Standby */
+#define SYSCTRL_OSC8M_RUNSTDBY      (_U_(0x1) << SYSCTRL_OSC8M_RUNSTDBY_Pos)
+#define SYSCTRL_OSC8M_ONDEMAND_Pos  7            /**< \brief (SYSCTRL_OSC8M) Enable on Demand */
+#define SYSCTRL_OSC8M_ONDEMAND      (_U_(0x1) << SYSCTRL_OSC8M_ONDEMAND_Pos)
+#define SYSCTRL_OSC8M_PRESC_Pos     8            /**< \brief (SYSCTRL_OSC8M) Prescaler Select */
+#define SYSCTRL_OSC8M_PRESC_Msk     (_U_(0x3) << SYSCTRL_OSC8M_PRESC_Pos)
+#define SYSCTRL_OSC8M_PRESC(value)  (SYSCTRL_OSC8M_PRESC_Msk & ((value) << SYSCTRL_OSC8M_PRESC_Pos))
+#define SYSCTRL_OSC8M_CALIB_Pos     16           /**< \brief (SYSCTRL_OSC8M) Calibration Value */
+#define SYSCTRL_OSC8M_CALIB_Msk     (_U_(0xFFF) << SYSCTRL_OSC8M_CALIB_Pos)
+#define SYSCTRL_OSC8M_CALIB(value)  (SYSCTRL_OSC8M_CALIB_Msk & ((value) << SYSCTRL_OSC8M_CALIB_Pos))
+#define SYSCTRL_OSC8M_FRANGE_Pos    30           /**< \brief (SYSCTRL_OSC8M) Frequency Range */
+#define SYSCTRL_OSC8M_FRANGE_Msk    (_U_(0x3) << SYSCTRL_OSC8M_FRANGE_Pos)
+#define SYSCTRL_OSC8M_FRANGE(value) (SYSCTRL_OSC8M_FRANGE_Msk & ((value) << SYSCTRL_OSC8M_FRANGE_Pos))
+#define SYSCTRL_OSC8M_MASK          _U_(0xCFFF03C2) /**< \brief (SYSCTRL_OSC8M) MASK Register */
+
+/* -------- SYSCTRL_DFLLCTRL : (SYSCTRL Offset: 0x24) (R/W 16) DFLL Config -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :1;               /*!< bit:      0  Reserved                           */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t MODE:1;           /*!< bit:      2  Mode Selection                     */
+    uint16_t STABLE:1;         /*!< bit:      3  Stable Frequency                   */
+    uint16_t LLAW:1;           /*!< bit:      4  Lose Lock After Wake               */
+    uint16_t :1;               /*!< bit:      5  Reserved                           */
+    uint16_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint16_t ONDEMAND:1;       /*!< bit:      7  Enable on Demand                   */
+    uint16_t CCDIS:1;          /*!< bit:      8  Chill Cycle Disable                */
+    uint16_t QLDIS:1;          /*!< bit:      9  Quick Lock Disable                 */
+    uint16_t :6;               /*!< bit: 10..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_DFLLCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_DFLLCTRL_OFFSET     0x24         /**< \brief (SYSCTRL_DFLLCTRL offset) DFLL Config */
+#define SYSCTRL_DFLLCTRL_RESETVALUE _U_(0x0080)  /**< \brief (SYSCTRL_DFLLCTRL reset_value) DFLL Config */
+
+#define SYSCTRL_DFLLCTRL_ENABLE_Pos 1            /**< \brief (SYSCTRL_DFLLCTRL) Enable */
+#define SYSCTRL_DFLLCTRL_ENABLE     (_U_(0x1) << SYSCTRL_DFLLCTRL_ENABLE_Pos)
+#define SYSCTRL_DFLLCTRL_MODE_Pos   2            /**< \brief (SYSCTRL_DFLLCTRL) Mode Selection */
+#define SYSCTRL_DFLLCTRL_MODE       (_U_(0x1) << SYSCTRL_DFLLCTRL_MODE_Pos)
+#define SYSCTRL_DFLLCTRL_STABLE_Pos 3            /**< \brief (SYSCTRL_DFLLCTRL) Stable Frequency */
+#define SYSCTRL_DFLLCTRL_STABLE     (_U_(0x1) << SYSCTRL_DFLLCTRL_STABLE_Pos)
+#define SYSCTRL_DFLLCTRL_LLAW_Pos   4            /**< \brief (SYSCTRL_DFLLCTRL) Lose Lock After Wake */
+#define SYSCTRL_DFLLCTRL_LLAW       (_U_(0x1) << SYSCTRL_DFLLCTRL_LLAW_Pos)
+#define SYSCTRL_DFLLCTRL_RUNSTDBY_Pos 6            /**< \brief (SYSCTRL_DFLLCTRL) Run during Standby */
+#define SYSCTRL_DFLLCTRL_RUNSTDBY   (_U_(0x1) << SYSCTRL_DFLLCTRL_RUNSTDBY_Pos)
+#define SYSCTRL_DFLLCTRL_ONDEMAND_Pos 7            /**< \brief (SYSCTRL_DFLLCTRL) Enable on Demand */
+#define SYSCTRL_DFLLCTRL_ONDEMAND   (_U_(0x1) << SYSCTRL_DFLLCTRL_ONDEMAND_Pos)
+#define SYSCTRL_DFLLCTRL_CCDIS_Pos  8            /**< \brief (SYSCTRL_DFLLCTRL) Chill Cycle Disable */
+#define SYSCTRL_DFLLCTRL_CCDIS      (_U_(0x1) << SYSCTRL_DFLLCTRL_CCDIS_Pos)
+#define SYSCTRL_DFLLCTRL_QLDIS_Pos  9            /**< \brief (SYSCTRL_DFLLCTRL) Quick Lock Disable */
+#define SYSCTRL_DFLLCTRL_QLDIS      (_U_(0x1) << SYSCTRL_DFLLCTRL_QLDIS_Pos)
+#define SYSCTRL_DFLLCTRL_MASK       _U_(0x03DE)  /**< \brief (SYSCTRL_DFLLCTRL) MASK Register */
+
+/* -------- SYSCTRL_DFLLVAL : (SYSCTRL Offset: 0x28) (R/W 32) DFLL Calibration Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t FINE:10;          /*!< bit:  0.. 9  Fine Calibration Value             */
+    uint32_t COARSE:6;         /*!< bit: 10..15  Coarse Calibration Value           */
+    uint32_t DIFF:16;          /*!< bit: 16..31  Multiplication Ratio Difference    */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_DFLLVAL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_DFLLVAL_OFFSET      0x28         /**< \brief (SYSCTRL_DFLLVAL offset) DFLL Calibration Value */
+#define SYSCTRL_DFLLVAL_RESETVALUE  _U_(0x00000000) /**< \brief (SYSCTRL_DFLLVAL reset_value) DFLL Calibration Value */
+
+#define SYSCTRL_DFLLVAL_FINE_Pos    0            /**< \brief (SYSCTRL_DFLLVAL) Fine Calibration Value */
+#define SYSCTRL_DFLLVAL_FINE_Msk    (_U_(0x3FF) << SYSCTRL_DFLLVAL_FINE_Pos)
+#define SYSCTRL_DFLLVAL_FINE(value) (SYSCTRL_DFLLVAL_FINE_Msk & ((value) << SYSCTRL_DFLLVAL_FINE_Pos))
+#define SYSCTRL_DFLLVAL_COARSE_Pos  10           /**< \brief (SYSCTRL_DFLLVAL) Coarse Calibration Value */
+#define SYSCTRL_DFLLVAL_COARSE_Msk  (_U_(0x3F) << SYSCTRL_DFLLVAL_COARSE_Pos)
+#define SYSCTRL_DFLLVAL_COARSE(value) (SYSCTRL_DFLLVAL_COARSE_Msk & ((value) << SYSCTRL_DFLLVAL_COARSE_Pos))
+#define SYSCTRL_DFLLVAL_DIFF_Pos    16           /**< \brief (SYSCTRL_DFLLVAL) Multiplication Ratio Difference */
+#define SYSCTRL_DFLLVAL_DIFF_Msk    (_U_(0xFFFF) << SYSCTRL_DFLLVAL_DIFF_Pos)
+#define SYSCTRL_DFLLVAL_DIFF(value) (SYSCTRL_DFLLVAL_DIFF_Msk & ((value) << SYSCTRL_DFLLVAL_DIFF_Pos))
+#define SYSCTRL_DFLLVAL_MASK        _U_(0xFFFFFFFF) /**< \brief (SYSCTRL_DFLLVAL) MASK Register */
+
+/* -------- SYSCTRL_DFLLMUL : (SYSCTRL Offset: 0x2C) (R/W 32) DFLL Multiplier -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t MUL:16;           /*!< bit:  0..15  Multiplication Value               */
+    uint32_t FSTEP:10;         /*!< bit: 16..25  Maximum Fine Step Size             */
+    uint32_t CSTEP:6;          /*!< bit: 26..31  Maximum Coarse Step Size           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_DFLLMUL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_DFLLMUL_OFFSET      0x2C         /**< \brief (SYSCTRL_DFLLMUL offset) DFLL Multiplier */
+#define SYSCTRL_DFLLMUL_RESETVALUE  _U_(0x00000000) /**< \brief (SYSCTRL_DFLLMUL reset_value) DFLL Multiplier */
+
+#define SYSCTRL_DFLLMUL_MUL_Pos     0            /**< \brief (SYSCTRL_DFLLMUL) Multiplication Value */
+#define SYSCTRL_DFLLMUL_MUL_Msk     (_U_(0xFFFF) << SYSCTRL_DFLLMUL_MUL_Pos)
+#define SYSCTRL_DFLLMUL_MUL(value)  (SYSCTRL_DFLLMUL_MUL_Msk & ((value) << SYSCTRL_DFLLMUL_MUL_Pos))
+#define SYSCTRL_DFLLMUL_FSTEP_Pos   16           /**< \brief (SYSCTRL_DFLLMUL) Maximum Fine Step Size */
+#define SYSCTRL_DFLLMUL_FSTEP_Msk   (_U_(0x3FF) << SYSCTRL_DFLLMUL_FSTEP_Pos)
+#define SYSCTRL_DFLLMUL_FSTEP(value) (SYSCTRL_DFLLMUL_FSTEP_Msk & ((value) << SYSCTRL_DFLLMUL_FSTEP_Pos))
+#define SYSCTRL_DFLLMUL_CSTEP_Pos   26           /**< \brief (SYSCTRL_DFLLMUL) Maximum Coarse Step Size */
+#define SYSCTRL_DFLLMUL_CSTEP_Msk   (_U_(0x3F) << SYSCTRL_DFLLMUL_CSTEP_Pos)
+#define SYSCTRL_DFLLMUL_CSTEP(value) (SYSCTRL_DFLLMUL_CSTEP_Msk & ((value) << SYSCTRL_DFLLMUL_CSTEP_Pos))
+#define SYSCTRL_DFLLMUL_MASK        _U_(0xFFFFFFFF) /**< \brief (SYSCTRL_DFLLMUL) MASK Register */
+
+/* -------- SYSCTRL_DFLLSYNC : (SYSCTRL Offset: 0x30) (R/W  8) DFLL Synchronization -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  READREQ:1;        /*!< bit:      7  Read Request Synchronization       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} SYSCTRL_DFLLSYNC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_DFLLSYNC_OFFSET     0x30         /**< \brief (SYSCTRL_DFLLSYNC offset) DFLL Synchronization */
+#define SYSCTRL_DFLLSYNC_RESETVALUE _U_(0x00)    /**< \brief (SYSCTRL_DFLLSYNC reset_value) DFLL Synchronization */
+
+#define SYSCTRL_DFLLSYNC_READREQ_Pos 7            /**< \brief (SYSCTRL_DFLLSYNC) Read Request Synchronization */
+#define SYSCTRL_DFLLSYNC_READREQ    (_U_(0x1) << SYSCTRL_DFLLSYNC_READREQ_Pos)
+#define SYSCTRL_DFLLSYNC_MASK       _U_(0x80)    /**< \brief (SYSCTRL_DFLLSYNC) MASK Register */
+
+/* -------- SYSCTRL_BOD33 : (SYSCTRL Offset: 0x34) (R/W 32) 3.3V Brown-Out Detector (BOD33) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint32_t HYST:1;           /*!< bit:      2  Hysteresis Enable                  */
+    uint32_t ACTION:2;         /*!< bit:  3.. 4  Action when Threshold Crossed      */
+    uint32_t :1;               /*!< bit:      5  Reserved                           */
+    uint32_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint32_t :1;               /*!< bit:      7  Reserved                           */
+    uint32_t MODE:1;           /*!< bit:      8  Operation Modes                    */
+    uint32_t CEN:1;            /*!< bit:      9  Clock Enable                       */
+    uint32_t :2;               /*!< bit: 10..11  Reserved                           */
+    uint32_t PSEL:4;           /*!< bit: 12..15  Prescaler Select                   */
+    uint32_t LEVEL:6;          /*!< bit: 16..21  Threshold Level                    */
+    uint32_t :10;              /*!< bit: 22..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_BOD33_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_BOD33_OFFSET        0x34         /**< \brief (SYSCTRL_BOD33 offset) 3.3V Brown-Out Detector (BOD33) Control */
+#define SYSCTRL_BOD33_RESETVALUE    _U_(0x00000000) /**< \brief (SYSCTRL_BOD33 reset_value) 3.3V Brown-Out Detector (BOD33) Control */
+
+#define SYSCTRL_BOD33_ENABLE_Pos    1            /**< \brief (SYSCTRL_BOD33) Enable */
+#define SYSCTRL_BOD33_ENABLE        (_U_(0x1) << SYSCTRL_BOD33_ENABLE_Pos)
+#define SYSCTRL_BOD33_HYST_Pos      2            /**< \brief (SYSCTRL_BOD33) Hysteresis Enable */
+#define SYSCTRL_BOD33_HYST          (_U_(0x1) << SYSCTRL_BOD33_HYST_Pos)
+#define SYSCTRL_BOD33_ACTION_Pos    3            /**< \brief (SYSCTRL_BOD33) Action when Threshold Crossed */
+#define SYSCTRL_BOD33_ACTION_Msk    (_U_(0x3) << SYSCTRL_BOD33_ACTION_Pos)
+#define SYSCTRL_BOD33_ACTION(value) (SYSCTRL_BOD33_ACTION_Msk & ((value) << SYSCTRL_BOD33_ACTION_Pos))
+#define SYSCTRL_BOD33_RUNSTDBY_Pos  6            /**< \brief (SYSCTRL_BOD33) Run during Standby */
+#define SYSCTRL_BOD33_RUNSTDBY      (_U_(0x1) << SYSCTRL_BOD33_RUNSTDBY_Pos)
+#define SYSCTRL_BOD33_MODE_Pos      8            /**< \brief (SYSCTRL_BOD33) Operation Modes */
+#define SYSCTRL_BOD33_MODE          (_U_(0x1) << SYSCTRL_BOD33_MODE_Pos)
+#define SYSCTRL_BOD33_CEN_Pos       9            /**< \brief (SYSCTRL_BOD33) Clock Enable */
+#define SYSCTRL_BOD33_CEN           (_U_(0x1) << SYSCTRL_BOD33_CEN_Pos)
+#define SYSCTRL_BOD33_PSEL_Pos      12           /**< \brief (SYSCTRL_BOD33) Prescaler Select */
+#define SYSCTRL_BOD33_PSEL_Msk      (_U_(0xF) << SYSCTRL_BOD33_PSEL_Pos)
+#define SYSCTRL_BOD33_PSEL(value)   (SYSCTRL_BOD33_PSEL_Msk & ((value) << SYSCTRL_BOD33_PSEL_Pos))
+#define SYSCTRL_BOD33_LEVEL_Pos     16           /**< \brief (SYSCTRL_BOD33) Threshold Level */
+#define SYSCTRL_BOD33_LEVEL_Msk     (_U_(0x3F) << SYSCTRL_BOD33_LEVEL_Pos)
+#define SYSCTRL_BOD33_LEVEL(value)  (SYSCTRL_BOD33_LEVEL_Msk & ((value) << SYSCTRL_BOD33_LEVEL_Pos))
+#define SYSCTRL_BOD33_MASK          _U_(0x003FF35E) /**< \brief (SYSCTRL_BOD33) MASK Register */
+
+/* -------- SYSCTRL_VREG : (SYSCTRL Offset: 0x3C) (R/W 16) VREG Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t :6;               /*!< bit:  0.. 5  Reserved                           */
+    uint16_t RUNSTDBY:1;       /*!< bit:      6  Run during Standby                 */
+    uint16_t :6;               /*!< bit:  7..12  Reserved                           */
+    uint16_t FORCELDO:1;       /*!< bit:     13  Force LDO Voltage Regulator        */
+    uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_VREG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_VREG_OFFSET         0x3C         /**< \brief (SYSCTRL_VREG offset) VREG Control */
+#define SYSCTRL_VREG_RESETVALUE     _U_(0x0402)  /**< \brief (SYSCTRL_VREG reset_value) VREG Control */
+
+#define SYSCTRL_VREG_RUNSTDBY_Pos   6            /**< \brief (SYSCTRL_VREG) Run during Standby */
+#define SYSCTRL_VREG_RUNSTDBY       (_U_(0x1) << SYSCTRL_VREG_RUNSTDBY_Pos)
+#define SYSCTRL_VREG_FORCELDO_Pos   13           /**< \brief (SYSCTRL_VREG) Force LDO Voltage Regulator */
+#define SYSCTRL_VREG_FORCELDO       (_U_(0x1) << SYSCTRL_VREG_FORCELDO_Pos)
+#define SYSCTRL_VREG_MASK           _U_(0x2040)  /**< \brief (SYSCTRL_VREG) MASK Register */
+
+/* -------- SYSCTRL_VREF : (SYSCTRL Offset: 0x40) (R/W 32) VREF Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t :1;               /*!< bit:      0  Reserved                           */
+    uint32_t TSEN:1;           /*!< bit:      1  Temperature Sensor Output Enable   */
+    uint32_t BGOUTEN:1;        /*!< bit:      2  Bandgap Output Enable              */
+    uint32_t :13;              /*!< bit:  3..15  Reserved                           */
+    uint32_t CALIB:11;         /*!< bit: 16..26  Voltage Reference Calibration Value */
+    uint32_t :5;               /*!< bit: 27..31  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} SYSCTRL_VREF_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define SYSCTRL_VREF_OFFSET         0x40         /**< \brief (SYSCTRL_VREF offset) VREF Control A */
+#define SYSCTRL_VREF_RESETVALUE     _U_(0x00000000) /**< \brief (SYSCTRL_VREF reset_value) VREF Control A */
+
+#define SYSCTRL_VREF_TSEN_Pos       1            /**< \brief (SYSCTRL_VREF) Temperature Sensor Output Enable */
+#define SYSCTRL_VREF_TSEN           (_U_(0x1) << SYSCTRL_VREF_TSEN_Pos)
+#define SYSCTRL_VREF_BGOUTEN_Pos    2            /**< \brief (SYSCTRL_VREF) Bandgap Output Enable */
+#define SYSCTRL_VREF_BGOUTEN        (_U_(0x1) << SYSCTRL_VREF_BGOUTEN_Pos)
+#define SYSCTRL_VREF_CALIB_Pos      16           /**< \brief (SYSCTRL_VREF) Voltage Reference Calibration Value */
+#define SYSCTRL_VREF_CALIB_Msk      (_U_(0x7FF) << SYSCTRL_VREF_CALIB_Pos)
+#define SYSCTRL_VREF_CALIB(value)   (SYSCTRL_VREF_CALIB_Msk & ((value) << SYSCTRL_VREF_CALIB_Pos))
+#define SYSCTRL_VREF_MASK           _U_(0x07FF0006) /**< \brief (SYSCTRL_VREF) MASK Register */
+
+/** \brief SYSCTRL hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO SYSCTRL_INTENCLR_Type     INTENCLR;    /**< \brief Offset: 0x00 (R/W 32) Interrupt Enable Clear */
+  __IO SYSCTRL_INTENSET_Type     INTENSET;    /**< \brief Offset: 0x04 (R/W 32) Interrupt Enable Set */
+  __IO SYSCTRL_INTFLAG_Type      INTFLAG;     /**< \brief Offset: 0x08 (R/W 32) Interrupt Flag Status and Clear */
+  __I  SYSCTRL_PCLKSR_Type       PCLKSR;      /**< \brief Offset: 0x0C (R/  32) Power and Clocks Status */
+  __IO SYSCTRL_XOSC_Type         XOSC;        /**< \brief Offset: 0x10 (R/W 16) XOSC Control */
+       RoReg8                    Reserved1[0x2];
+  __IO SYSCTRL_XOSC32K_Type      XOSC32K;     /**< \brief Offset: 0x14 (R/W 16) XOSC32K Control */
+       RoReg8                    Reserved2[0x2];
+  __IO SYSCTRL_OSC32K_Type       OSC32K;      /**< \brief Offset: 0x18 (R/W 32) OSC32K Control */
+  __IO SYSCTRL_OSCULP32K_Type    OSCULP32K;   /**< \brief Offset: 0x1C (R/W  8) OSCULP32K Control */
+       RoReg8                    Reserved3[0x3];
+  __IO SYSCTRL_OSC8M_Type        OSC8M;       /**< \brief Offset: 0x20 (R/W 32) OSC8M Control A */
+  __IO SYSCTRL_DFLLCTRL_Type     DFLLCTRL;    /**< \brief Offset: 0x24 (R/W 16) DFLL Config */
+       RoReg8                    Reserved4[0x2];
+  __IO SYSCTRL_DFLLVAL_Type      DFLLVAL;     /**< \brief Offset: 0x28 (R/W 32) DFLL Calibration Value */
+  __IO SYSCTRL_DFLLMUL_Type      DFLLMUL;     /**< \brief Offset: 0x2C (R/W 32) DFLL Multiplier */
+  __IO SYSCTRL_DFLLSYNC_Type     DFLLSYNC;    /**< \brief Offset: 0x30 (R/W  8) DFLL Synchronization */
+       RoReg8                    Reserved5[0x3];
+  __IO SYSCTRL_BOD33_Type        BOD33;       /**< \brief Offset: 0x34 (R/W 32) 3.3V Brown-Out Detector (BOD33) Control */
+       RoReg8                    Reserved6[0x4];
+  __IO SYSCTRL_VREG_Type         VREG;        /**< \brief Offset: 0x3C (R/W 16) VREG Control */
+       RoReg8                    Reserved7[0x2];
+  __IO SYSCTRL_VREF_Type         VREF;        /**< \brief Offset: 0x40 (R/W 32) VREF Control A */
+} Sysctrl;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_SYSCTRL_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/tc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/tc.h
@@ -1,0 +1,670 @@
+/**
+ * \file
+ *
+ * \brief Component description for TC
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC_COMPONENT_
+#define _SAMD20_TC_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR TC */
+/* ========================================================================== */
+/** \addtogroup SAMD20_TC Basic Timer Counter */
+/*@{*/
+
+#define TC_U2212
+#define REV_TC                      0x112
+
+/* -------- TC_CTRLA : (TC Offset: 0x00) (R/W 16) Control A -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t SWRST:1;          /*!< bit:      0  Software Reset                     */
+    uint16_t ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint16_t MODE:2;           /*!< bit:  2.. 3  TC Mode                            */
+    uint16_t :1;               /*!< bit:      4  Reserved                           */
+    uint16_t WAVEGEN:2;        /*!< bit:  5.. 6  Waveform Generation Operation      */
+    uint16_t :1;               /*!< bit:      7  Reserved                           */
+    uint16_t PRESCALER:3;      /*!< bit:  8..10  Prescaler                          */
+    uint16_t RUNSTDBY:1;       /*!< bit:     11  Run in Standby                     */
+    uint16_t PRESCSYNC:2;      /*!< bit: 12..13  Prescaler and Counter Synchronization */
+    uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TC_CTRLA_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLA_OFFSET             0x00         /**< \brief (TC_CTRLA offset) Control A */
+#define TC_CTRLA_RESETVALUE         _U_(0x0000)  /**< \brief (TC_CTRLA reset_value) Control A */
+
+#define TC_CTRLA_SWRST_Pos          0            /**< \brief (TC_CTRLA) Software Reset */
+#define TC_CTRLA_SWRST              (_U_(0x1) << TC_CTRLA_SWRST_Pos)
+#define TC_CTRLA_ENABLE_Pos         1            /**< \brief (TC_CTRLA) Enable */
+#define TC_CTRLA_ENABLE             (_U_(0x1) << TC_CTRLA_ENABLE_Pos)
+#define TC_CTRLA_MODE_Pos           2            /**< \brief (TC_CTRLA) TC Mode */
+#define TC_CTRLA_MODE_Msk           (_U_(0x3) << TC_CTRLA_MODE_Pos)
+#define TC_CTRLA_MODE(value)        (TC_CTRLA_MODE_Msk & ((value) << TC_CTRLA_MODE_Pos))
+#define   TC_CTRLA_MODE_COUNT16_Val       _U_(0x0)   /**< \brief (TC_CTRLA) Counter in 16-bit mode */
+#define   TC_CTRLA_MODE_COUNT8_Val        _U_(0x1)   /**< \brief (TC_CTRLA) Counter in 8-bit mode */
+#define   TC_CTRLA_MODE_COUNT32_Val       _U_(0x2)   /**< \brief (TC_CTRLA) Counter in 32-bit mode */
+#define TC_CTRLA_MODE_COUNT16       (TC_CTRLA_MODE_COUNT16_Val     << TC_CTRLA_MODE_Pos)
+#define TC_CTRLA_MODE_COUNT8        (TC_CTRLA_MODE_COUNT8_Val      << TC_CTRLA_MODE_Pos)
+#define TC_CTRLA_MODE_COUNT32       (TC_CTRLA_MODE_COUNT32_Val     << TC_CTRLA_MODE_Pos)
+#define TC_CTRLA_WAVEGEN_Pos        5            /**< \brief (TC_CTRLA) Waveform Generation Operation */
+#define TC_CTRLA_WAVEGEN_Msk        (_U_(0x3) << TC_CTRLA_WAVEGEN_Pos)
+#define TC_CTRLA_WAVEGEN(value)     (TC_CTRLA_WAVEGEN_Msk & ((value) << TC_CTRLA_WAVEGEN_Pos))
+#define   TC_CTRLA_WAVEGEN_NFRQ_Val       _U_(0x0)   /**< \brief (TC_CTRLA)  */
+#define   TC_CTRLA_WAVEGEN_MFRQ_Val       _U_(0x1)   /**< \brief (TC_CTRLA)  */
+#define   TC_CTRLA_WAVEGEN_NPWM_Val       _U_(0x2)   /**< \brief (TC_CTRLA)  */
+#define   TC_CTRLA_WAVEGEN_MPWM_Val       _U_(0x3)   /**< \brief (TC_CTRLA)  */
+#define TC_CTRLA_WAVEGEN_NFRQ       (TC_CTRLA_WAVEGEN_NFRQ_Val     << TC_CTRLA_WAVEGEN_Pos)
+#define TC_CTRLA_WAVEGEN_MFRQ       (TC_CTRLA_WAVEGEN_MFRQ_Val     << TC_CTRLA_WAVEGEN_Pos)
+#define TC_CTRLA_WAVEGEN_NPWM       (TC_CTRLA_WAVEGEN_NPWM_Val     << TC_CTRLA_WAVEGEN_Pos)
+#define TC_CTRLA_WAVEGEN_MPWM       (TC_CTRLA_WAVEGEN_MPWM_Val     << TC_CTRLA_WAVEGEN_Pos)
+#define TC_CTRLA_PRESCALER_Pos      8            /**< \brief (TC_CTRLA) Prescaler */
+#define TC_CTRLA_PRESCALER_Msk      (_U_(0x7) << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER(value)   (TC_CTRLA_PRESCALER_Msk & ((value) << TC_CTRLA_PRESCALER_Pos))
+#define   TC_CTRLA_PRESCALER_DIV1_Val     _U_(0x0)   /**< \brief (TC_CTRLA) GCLK_TC */
+#define   TC_CTRLA_PRESCALER_DIV2_Val     _U_(0x1)   /**< \brief (TC_CTRLA) GCLK_TC/2 */
+#define   TC_CTRLA_PRESCALER_DIV4_Val     _U_(0x2)   /**< \brief (TC_CTRLA) GCLK_TC/4 */
+#define   TC_CTRLA_PRESCALER_DIV8_Val     _U_(0x3)   /**< \brief (TC_CTRLA) GCLK_TC/8 */
+#define   TC_CTRLA_PRESCALER_DIV16_Val    _U_(0x4)   /**< \brief (TC_CTRLA) GCLK_TC/16 */
+#define   TC_CTRLA_PRESCALER_DIV64_Val    _U_(0x5)   /**< \brief (TC_CTRLA) GCLK_TC/64 */
+#define   TC_CTRLA_PRESCALER_DIV256_Val   _U_(0x6)   /**< \brief (TC_CTRLA) GCLK_TC/256 */
+#define   TC_CTRLA_PRESCALER_DIV1024_Val  _U_(0x7)   /**< \brief (TC_CTRLA) GCLK_TC/1024 */
+#define TC_CTRLA_PRESCALER_DIV1     (TC_CTRLA_PRESCALER_DIV1_Val   << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER_DIV2     (TC_CTRLA_PRESCALER_DIV2_Val   << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER_DIV4     (TC_CTRLA_PRESCALER_DIV4_Val   << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER_DIV8     (TC_CTRLA_PRESCALER_DIV8_Val   << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER_DIV16    (TC_CTRLA_PRESCALER_DIV16_Val  << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER_DIV64    (TC_CTRLA_PRESCALER_DIV64_Val  << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER_DIV256   (TC_CTRLA_PRESCALER_DIV256_Val << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_PRESCALER_DIV1024  (TC_CTRLA_PRESCALER_DIV1024_Val << TC_CTRLA_PRESCALER_Pos)
+#define TC_CTRLA_RUNSTDBY_Pos       11           /**< \brief (TC_CTRLA) Run in Standby */
+#define TC_CTRLA_RUNSTDBY           (_U_(0x1) << TC_CTRLA_RUNSTDBY_Pos)
+#define TC_CTRLA_PRESCSYNC_Pos      12           /**< \brief (TC_CTRLA) Prescaler and Counter Synchronization */
+#define TC_CTRLA_PRESCSYNC_Msk      (_U_(0x3) << TC_CTRLA_PRESCSYNC_Pos)
+#define TC_CTRLA_PRESCSYNC(value)   (TC_CTRLA_PRESCSYNC_Msk & ((value) << TC_CTRLA_PRESCSYNC_Pos))
+#define   TC_CTRLA_PRESCSYNC_GCLK_Val     _U_(0x0)   /**< \brief (TC_CTRLA) Reload or reset Counter on next GCLK */
+#define   TC_CTRLA_PRESCSYNC_PRESC_Val    _U_(0x1)   /**< \brief (TC_CTRLA) Reload or reset Counter on next prescaler clock */
+#define   TC_CTRLA_PRESCSYNC_RESYNC_Val   _U_(0x2)   /**< \brief (TC_CTRLA) Reload or reset Counter on next GCLK. Reset prescaler counter */
+#define TC_CTRLA_PRESCSYNC_GCLK     (TC_CTRLA_PRESCSYNC_GCLK_Val   << TC_CTRLA_PRESCSYNC_Pos)
+#define TC_CTRLA_PRESCSYNC_PRESC    (TC_CTRLA_PRESCSYNC_PRESC_Val  << TC_CTRLA_PRESCSYNC_Pos)
+#define TC_CTRLA_PRESCSYNC_RESYNC   (TC_CTRLA_PRESCSYNC_RESYNC_Val << TC_CTRLA_PRESCSYNC_Pos)
+#define TC_CTRLA_MASK               _U_(0x3F6F)  /**< \brief (TC_CTRLA) MASK Register */
+
+/* -------- TC_READREQ : (TC Offset: 0x02) (R/W 16) Read Request -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t ADDR:5;           /*!< bit:  0.. 4  Address                            */
+    uint16_t :9;               /*!< bit:  5..13  Reserved                           */
+    uint16_t RCONT:1;          /*!< bit:     14  Read Continuously                  */
+    uint16_t RREQ:1;           /*!< bit:     15  Read Request                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TC_READREQ_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_READREQ_OFFSET           0x02         /**< \brief (TC_READREQ offset) Read Request */
+#define TC_READREQ_RESETVALUE       _U_(0x0000)  /**< \brief (TC_READREQ reset_value) Read Request */
+
+#define TC_READREQ_ADDR_Pos         0            /**< \brief (TC_READREQ) Address */
+#define TC_READREQ_ADDR_Msk         (_U_(0x1F) << TC_READREQ_ADDR_Pos)
+#define TC_READREQ_ADDR(value)      (TC_READREQ_ADDR_Msk & ((value) << TC_READREQ_ADDR_Pos))
+#define TC_READREQ_RCONT_Pos        14           /**< \brief (TC_READREQ) Read Continuously */
+#define TC_READREQ_RCONT            (_U_(0x1) << TC_READREQ_RCONT_Pos)
+#define TC_READREQ_RREQ_Pos         15           /**< \brief (TC_READREQ) Read Request */
+#define TC_READREQ_RREQ             (_U_(0x1) << TC_READREQ_RREQ_Pos)
+#define TC_READREQ_MASK             _U_(0xC01F)  /**< \brief (TC_READREQ) MASK Register */
+
+/* -------- TC_CTRLBCLR : (TC Offset: 0x04) (R/W  8) Control B Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DIR:1;            /*!< bit:      0  Counter Direction                  */
+    uint8_t  :1;               /*!< bit:      1  Reserved                           */
+    uint8_t  ONESHOT:1;        /*!< bit:      2  One-Shot                           */
+    uint8_t  :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint8_t  CMD:2;            /*!< bit:  6.. 7  Command                            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_CTRLBCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLBCLR_OFFSET          0x04         /**< \brief (TC_CTRLBCLR offset) Control B Clear */
+#define TC_CTRLBCLR_RESETVALUE      _U_(0x02)    /**< \brief (TC_CTRLBCLR reset_value) Control B Clear */
+
+#define TC_CTRLBCLR_DIR_Pos         0            /**< \brief (TC_CTRLBCLR) Counter Direction */
+#define TC_CTRLBCLR_DIR             (_U_(0x1) << TC_CTRLBCLR_DIR_Pos)
+#define TC_CTRLBCLR_ONESHOT_Pos     2            /**< \brief (TC_CTRLBCLR) One-Shot */
+#define TC_CTRLBCLR_ONESHOT         (_U_(0x1) << TC_CTRLBCLR_ONESHOT_Pos)
+#define TC_CTRLBCLR_CMD_Pos         6            /**< \brief (TC_CTRLBCLR) Command */
+#define TC_CTRLBCLR_CMD_Msk         (_U_(0x3) << TC_CTRLBCLR_CMD_Pos)
+#define TC_CTRLBCLR_CMD(value)      (TC_CTRLBCLR_CMD_Msk & ((value) << TC_CTRLBCLR_CMD_Pos))
+#define   TC_CTRLBCLR_CMD_NONE_Val        _U_(0x0)   /**< \brief (TC_CTRLBCLR) No action */
+#define   TC_CTRLBCLR_CMD_RETRIGGER_Val   _U_(0x1)   /**< \brief (TC_CTRLBCLR) Force start, restart or retrigger */
+#define   TC_CTRLBCLR_CMD_STOP_Val        _U_(0x2)   /**< \brief (TC_CTRLBCLR) Force stop */
+#define TC_CTRLBCLR_CMD_NONE        (TC_CTRLBCLR_CMD_NONE_Val      << TC_CTRLBCLR_CMD_Pos)
+#define TC_CTRLBCLR_CMD_RETRIGGER   (TC_CTRLBCLR_CMD_RETRIGGER_Val << TC_CTRLBCLR_CMD_Pos)
+#define TC_CTRLBCLR_CMD_STOP        (TC_CTRLBCLR_CMD_STOP_Val      << TC_CTRLBCLR_CMD_Pos)
+#define TC_CTRLBCLR_MASK            _U_(0xC5)    /**< \brief (TC_CTRLBCLR) MASK Register */
+
+/* -------- TC_CTRLBSET : (TC Offset: 0x05) (R/W  8) Control B Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DIR:1;            /*!< bit:      0  Counter Direction                  */
+    uint8_t  :1;               /*!< bit:      1  Reserved                           */
+    uint8_t  ONESHOT:1;        /*!< bit:      2  One-shot                           */
+    uint8_t  :3;               /*!< bit:  3.. 5  Reserved                           */
+    uint8_t  CMD:2;            /*!< bit:  6.. 7  Command                            */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_CTRLBSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLBSET_OFFSET          0x05         /**< \brief (TC_CTRLBSET offset) Control B Set */
+#define TC_CTRLBSET_RESETVALUE      _U_(0x00)    /**< \brief (TC_CTRLBSET reset_value) Control B Set */
+
+#define TC_CTRLBSET_DIR_Pos         0            /**< \brief (TC_CTRLBSET) Counter Direction */
+#define TC_CTRLBSET_DIR             (_U_(0x1) << TC_CTRLBSET_DIR_Pos)
+#define TC_CTRLBSET_ONESHOT_Pos     2            /**< \brief (TC_CTRLBSET) One-shot */
+#define TC_CTRLBSET_ONESHOT         (_U_(0x1) << TC_CTRLBSET_ONESHOT_Pos)
+#define TC_CTRLBSET_CMD_Pos         6            /**< \brief (TC_CTRLBSET) Command */
+#define TC_CTRLBSET_CMD_Msk         (_U_(0x3) << TC_CTRLBSET_CMD_Pos)
+#define TC_CTRLBSET_CMD(value)      (TC_CTRLBSET_CMD_Msk & ((value) << TC_CTRLBSET_CMD_Pos))
+#define   TC_CTRLBSET_CMD_NONE_Val        _U_(0x0)   /**< \brief (TC_CTRLBSET) No action */
+#define   TC_CTRLBSET_CMD_RETRIGGER_Val   _U_(0x1)   /**< \brief (TC_CTRLBSET) Force start, restart or retrigger */
+#define   TC_CTRLBSET_CMD_STOP_Val        _U_(0x2)   /**< \brief (TC_CTRLBSET) Force stop */
+#define TC_CTRLBSET_CMD_NONE        (TC_CTRLBSET_CMD_NONE_Val      << TC_CTRLBSET_CMD_Pos)
+#define TC_CTRLBSET_CMD_RETRIGGER   (TC_CTRLBSET_CMD_RETRIGGER_Val << TC_CTRLBSET_CMD_Pos)
+#define TC_CTRLBSET_CMD_STOP        (TC_CTRLBSET_CMD_STOP_Val      << TC_CTRLBSET_CMD_Pos)
+#define TC_CTRLBSET_MASK            _U_(0xC5)    /**< \brief (TC_CTRLBSET) MASK Register */
+
+/* -------- TC_CTRLC : (TC Offset: 0x06) (R/W  8) Control C -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  INVEN0:1;         /*!< bit:      0  Output Waveform 0 Invert Enable    */
+    uint8_t  INVEN1:1;         /*!< bit:      1  Output Waveform 1 Invert Enable    */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  CPTEN0:1;         /*!< bit:      4  Capture Channel 0 Enable           */
+    uint8_t  CPTEN1:1;         /*!< bit:      5  Capture Channel 1 Enable           */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  INVEN:2;          /*!< bit:  0.. 1  Output Waveform x Invert Enable    */
+    uint8_t  :2;               /*!< bit:  2.. 3  Reserved                           */
+    uint8_t  CPTEN:2;          /*!< bit:  4.. 5  Capture Channel x Enable           */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_CTRLC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_CTRLC_OFFSET             0x06         /**< \brief (TC_CTRLC offset) Control C */
+#define TC_CTRLC_RESETVALUE         _U_(0x00)    /**< \brief (TC_CTRLC reset_value) Control C */
+
+#define TC_CTRLC_INVEN0_Pos         0            /**< \brief (TC_CTRLC) Output Waveform 0 Invert Enable */
+#define TC_CTRLC_INVEN0             (_U_(1) << TC_CTRLC_INVEN0_Pos)
+#define TC_CTRLC_INVEN1_Pos         1            /**< \brief (TC_CTRLC) Output Waveform 1 Invert Enable */
+#define TC_CTRLC_INVEN1             (_U_(1) << TC_CTRLC_INVEN1_Pos)
+#define TC_CTRLC_INVEN_Pos          0            /**< \brief (TC_CTRLC) Output Waveform x Invert Enable */
+#define TC_CTRLC_INVEN_Msk          (_U_(0x3) << TC_CTRLC_INVEN_Pos)
+#define TC_CTRLC_INVEN(value)       (TC_CTRLC_INVEN_Msk & ((value) << TC_CTRLC_INVEN_Pos))
+#define TC_CTRLC_CPTEN0_Pos         4            /**< \brief (TC_CTRLC) Capture Channel 0 Enable */
+#define TC_CTRLC_CPTEN0             (_U_(1) << TC_CTRLC_CPTEN0_Pos)
+#define TC_CTRLC_CPTEN1_Pos         5            /**< \brief (TC_CTRLC) Capture Channel 1 Enable */
+#define TC_CTRLC_CPTEN1             (_U_(1) << TC_CTRLC_CPTEN1_Pos)
+#define TC_CTRLC_CPTEN_Pos          4            /**< \brief (TC_CTRLC) Capture Channel x Enable */
+#define TC_CTRLC_CPTEN_Msk          (_U_(0x3) << TC_CTRLC_CPTEN_Pos)
+#define TC_CTRLC_CPTEN(value)       (TC_CTRLC_CPTEN_Msk & ((value) << TC_CTRLC_CPTEN_Pos))
+#define TC_CTRLC_MASK               _U_(0x33)    /**< \brief (TC_CTRLC) MASK Register */
+
+/* -------- TC_DBGCTRL : (TC Offset: 0x08) (R/W  8) Debug Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  DBGRUN:1;         /*!< bit:      0  Debug Run Mode                     */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_DBGCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_DBGCTRL_OFFSET           0x08         /**< \brief (TC_DBGCTRL offset) Debug Control */
+#define TC_DBGCTRL_RESETVALUE       _U_(0x00)    /**< \brief (TC_DBGCTRL reset_value) Debug Control */
+
+#define TC_DBGCTRL_DBGRUN_Pos       0            /**< \brief (TC_DBGCTRL) Debug Run Mode */
+#define TC_DBGCTRL_DBGRUN           (_U_(0x1) << TC_DBGCTRL_DBGRUN_Pos)
+#define TC_DBGCTRL_MASK             _U_(0x01)    /**< \brief (TC_DBGCTRL) MASK Register */
+
+/* -------- TC_EVCTRL : (TC Offset: 0x0A) (R/W 16) Event Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t EVACT:3;          /*!< bit:  0.. 2  Event Action                       */
+    uint16_t :1;               /*!< bit:      3  Reserved                           */
+    uint16_t TCINV:1;          /*!< bit:      4  TC Inverted Event Input            */
+    uint16_t TCEI:1;           /*!< bit:      5  TC Event Input                     */
+    uint16_t :2;               /*!< bit:  6.. 7  Reserved                           */
+    uint16_t OVFEO:1;          /*!< bit:      8  Overflow/Underflow Event Output Enable */
+    uint16_t :3;               /*!< bit:  9..11  Reserved                           */
+    uint16_t MCEO0:1;          /*!< bit:     12  Match or Capture Channel 0 Event Output Enable */
+    uint16_t MCEO1:1;          /*!< bit:     13  Match or Capture Channel 1 Event Output Enable */
+    uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint16_t :12;              /*!< bit:  0..11  Reserved                           */
+    uint16_t MCEO:2;           /*!< bit: 12..13  Match or Capture Channel x Event Output Enable */
+    uint16_t :2;               /*!< bit: 14..15  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TC_EVCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_EVCTRL_OFFSET            0x0A         /**< \brief (TC_EVCTRL offset) Event Control */
+#define TC_EVCTRL_RESETVALUE        _U_(0x0000)  /**< \brief (TC_EVCTRL reset_value) Event Control */
+
+#define TC_EVCTRL_EVACT_Pos         0            /**< \brief (TC_EVCTRL) Event Action */
+#define TC_EVCTRL_EVACT_Msk         (_U_(0x7) << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT(value)      (TC_EVCTRL_EVACT_Msk & ((value) << TC_EVCTRL_EVACT_Pos))
+#define   TC_EVCTRL_EVACT_OFF_Val         _U_(0x0)   /**< \brief (TC_EVCTRL) Event action disabled */
+#define   TC_EVCTRL_EVACT_RETRIGGER_Val   _U_(0x1)   /**< \brief (TC_EVCTRL) Start, restart or retrigger TC on event */
+#define   TC_EVCTRL_EVACT_COUNT_Val       _U_(0x2)   /**< \brief (TC_EVCTRL) Count on event */
+#define   TC_EVCTRL_EVACT_START_Val       _U_(0x3)   /**< \brief (TC_EVCTRL) Start TC on event */
+#define   TC_EVCTRL_EVACT_PPW_Val         _U_(0x5)   /**< \brief (TC_EVCTRL) Period captured into CC0 Pulse Width in CC1 */
+#define   TC_EVCTRL_EVACT_PWP_Val         _U_(0x6)   /**< \brief (TC_EVCTRL) Period captured into CC1 Pulse Width on CC0 */
+#define TC_EVCTRL_EVACT_OFF         (TC_EVCTRL_EVACT_OFF_Val       << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_RETRIGGER   (TC_EVCTRL_EVACT_RETRIGGER_Val << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_COUNT       (TC_EVCTRL_EVACT_COUNT_Val     << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_START       (TC_EVCTRL_EVACT_START_Val     << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_PPW         (TC_EVCTRL_EVACT_PPW_Val       << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_EVACT_PWP         (TC_EVCTRL_EVACT_PWP_Val       << TC_EVCTRL_EVACT_Pos)
+#define TC_EVCTRL_TCINV_Pos         4            /**< \brief (TC_EVCTRL) TC Inverted Event Input */
+#define TC_EVCTRL_TCINV             (_U_(0x1) << TC_EVCTRL_TCINV_Pos)
+#define TC_EVCTRL_TCEI_Pos          5            /**< \brief (TC_EVCTRL) TC Event Input */
+#define TC_EVCTRL_TCEI              (_U_(0x1) << TC_EVCTRL_TCEI_Pos)
+#define TC_EVCTRL_OVFEO_Pos         8            /**< \brief (TC_EVCTRL) Overflow/Underflow Event Output Enable */
+#define TC_EVCTRL_OVFEO             (_U_(0x1) << TC_EVCTRL_OVFEO_Pos)
+#define TC_EVCTRL_MCEO0_Pos         12           /**< \brief (TC_EVCTRL) Match or Capture Channel 0 Event Output Enable */
+#define TC_EVCTRL_MCEO0             (_U_(1) << TC_EVCTRL_MCEO0_Pos)
+#define TC_EVCTRL_MCEO1_Pos         13           /**< \brief (TC_EVCTRL) Match or Capture Channel 1 Event Output Enable */
+#define TC_EVCTRL_MCEO1             (_U_(1) << TC_EVCTRL_MCEO1_Pos)
+#define TC_EVCTRL_MCEO_Pos          12           /**< \brief (TC_EVCTRL) Match or Capture Channel x Event Output Enable */
+#define TC_EVCTRL_MCEO_Msk          (_U_(0x3) << TC_EVCTRL_MCEO_Pos)
+#define TC_EVCTRL_MCEO(value)       (TC_EVCTRL_MCEO_Msk & ((value) << TC_EVCTRL_MCEO_Pos))
+#define TC_EVCTRL_MASK              _U_(0x3137)  /**< \brief (TC_EVCTRL) MASK Register */
+
+/* -------- TC_INTENCLR : (TC Offset: 0x0C) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  OVF:1;            /*!< bit:      0  Overflow Interrupt Enable          */
+    uint8_t  ERR:1;            /*!< bit:      1  Error Interrupt Enable             */
+    uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready Interrupt Enable */
+    uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0 Interrupt Enable */
+    uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1 Interrupt Enable */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x Interrupt Enable */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_INTENCLR_OFFSET          0x0C         /**< \brief (TC_INTENCLR offset) Interrupt Enable Clear */
+#define TC_INTENCLR_RESETVALUE      _U_(0x00)    /**< \brief (TC_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define TC_INTENCLR_OVF_Pos         0            /**< \brief (TC_INTENCLR) Overflow Interrupt Enable */
+#define TC_INTENCLR_OVF             (_U_(0x1) << TC_INTENCLR_OVF_Pos)
+#define TC_INTENCLR_ERR_Pos         1            /**< \brief (TC_INTENCLR) Error Interrupt Enable */
+#define TC_INTENCLR_ERR             (_U_(0x1) << TC_INTENCLR_ERR_Pos)
+#define TC_INTENCLR_SYNCRDY_Pos     3            /**< \brief (TC_INTENCLR) Synchronization Ready Interrupt Enable */
+#define TC_INTENCLR_SYNCRDY         (_U_(0x1) << TC_INTENCLR_SYNCRDY_Pos)
+#define TC_INTENCLR_MC0_Pos         4            /**< \brief (TC_INTENCLR) Match or Capture Channel 0 Interrupt Enable */
+#define TC_INTENCLR_MC0             (_U_(1) << TC_INTENCLR_MC0_Pos)
+#define TC_INTENCLR_MC1_Pos         5            /**< \brief (TC_INTENCLR) Match or Capture Channel 1 Interrupt Enable */
+#define TC_INTENCLR_MC1             (_U_(1) << TC_INTENCLR_MC1_Pos)
+#define TC_INTENCLR_MC_Pos          4            /**< \brief (TC_INTENCLR) Match or Capture Channel x Interrupt Enable */
+#define TC_INTENCLR_MC_Msk          (_U_(0x3) << TC_INTENCLR_MC_Pos)
+#define TC_INTENCLR_MC(value)       (TC_INTENCLR_MC_Msk & ((value) << TC_INTENCLR_MC_Pos))
+#define TC_INTENCLR_MASK            _U_(0x3B)    /**< \brief (TC_INTENCLR) MASK Register */
+
+/* -------- TC_INTENSET : (TC Offset: 0x0D) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  OVF:1;            /*!< bit:      0  Overflow Interrupt Enable          */
+    uint8_t  ERR:1;            /*!< bit:      1  Error Interrupt Enable             */
+    uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready Interrupt Enable */
+    uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0 Interrupt Enable */
+    uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1 Interrupt Enable */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x Interrupt Enable */
+    uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_INTENSET_OFFSET          0x0D         /**< \brief (TC_INTENSET offset) Interrupt Enable Set */
+#define TC_INTENSET_RESETVALUE      _U_(0x00)    /**< \brief (TC_INTENSET reset_value) Interrupt Enable Set */
+
+#define TC_INTENSET_OVF_Pos         0            /**< \brief (TC_INTENSET) Overflow Interrupt Enable */
+#define TC_INTENSET_OVF             (_U_(0x1) << TC_INTENSET_OVF_Pos)
+#define TC_INTENSET_ERR_Pos         1            /**< \brief (TC_INTENSET) Error Interrupt Enable */
+#define TC_INTENSET_ERR             (_U_(0x1) << TC_INTENSET_ERR_Pos)
+#define TC_INTENSET_SYNCRDY_Pos     3            /**< \brief (TC_INTENSET) Synchronization Ready Interrupt Enable */
+#define TC_INTENSET_SYNCRDY         (_U_(0x1) << TC_INTENSET_SYNCRDY_Pos)
+#define TC_INTENSET_MC0_Pos         4            /**< \brief (TC_INTENSET) Match or Capture Channel 0 Interrupt Enable */
+#define TC_INTENSET_MC0             (_U_(1) << TC_INTENSET_MC0_Pos)
+#define TC_INTENSET_MC1_Pos         5            /**< \brief (TC_INTENSET) Match or Capture Channel 1 Interrupt Enable */
+#define TC_INTENSET_MC1             (_U_(1) << TC_INTENSET_MC1_Pos)
+#define TC_INTENSET_MC_Pos          4            /**< \brief (TC_INTENSET) Match or Capture Channel x Interrupt Enable */
+#define TC_INTENSET_MC_Msk          (_U_(0x3) << TC_INTENSET_MC_Pos)
+#define TC_INTENSET_MC(value)       (TC_INTENSET_MC_Msk & ((value) << TC_INTENSET_MC_Pos))
+#define TC_INTENSET_MASK            _U_(0x3B)    /**< \brief (TC_INTENSET) MASK Register */
+
+/* -------- TC_INTFLAG : (TC Offset: 0x0E) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  OVF:1;            /*!< bit:      0  Overflow                           */
+    __I uint8_t  ERR:1;            /*!< bit:      1  Error                              */
+    __I uint8_t  :1;               /*!< bit:      2  Reserved                           */
+    __I uint8_t  SYNCRDY:1;        /*!< bit:      3  Synchronization Ready              */
+    __I uint8_t  MC0:1;            /*!< bit:      4  Match or Capture Channel 0         */
+    __I uint8_t  MC1:1;            /*!< bit:      5  Match or Capture Channel 1         */
+    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  struct {
+    __I uint8_t  :4;               /*!< bit:  0.. 3  Reserved                           */
+    __I uint8_t  MC:2;             /*!< bit:  4.. 5  Match or Capture Channel x         */
+    __I uint8_t  :2;               /*!< bit:  6.. 7  Reserved                           */
+  } vec;                       /*!< Structure used for vec  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_INTFLAG_OFFSET           0x0E         /**< \brief (TC_INTFLAG offset) Interrupt Flag Status and Clear */
+#define TC_INTFLAG_RESETVALUE       _U_(0x00)    /**< \brief (TC_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define TC_INTFLAG_OVF_Pos          0            /**< \brief (TC_INTFLAG) Overflow */
+#define TC_INTFLAG_OVF              (_U_(0x1) << TC_INTFLAG_OVF_Pos)
+#define TC_INTFLAG_ERR_Pos          1            /**< \brief (TC_INTFLAG) Error */
+#define TC_INTFLAG_ERR              (_U_(0x1) << TC_INTFLAG_ERR_Pos)
+#define TC_INTFLAG_SYNCRDY_Pos      3            /**< \brief (TC_INTFLAG) Synchronization Ready */
+#define TC_INTFLAG_SYNCRDY          (_U_(0x1) << TC_INTFLAG_SYNCRDY_Pos)
+#define TC_INTFLAG_MC0_Pos          4            /**< \brief (TC_INTFLAG) Match or Capture Channel 0 */
+#define TC_INTFLAG_MC0              (_U_(1) << TC_INTFLAG_MC0_Pos)
+#define TC_INTFLAG_MC1_Pos          5            /**< \brief (TC_INTFLAG) Match or Capture Channel 1 */
+#define TC_INTFLAG_MC1              (_U_(1) << TC_INTFLAG_MC1_Pos)
+#define TC_INTFLAG_MC_Pos           4            /**< \brief (TC_INTFLAG) Match or Capture Channel x */
+#define TC_INTFLAG_MC_Msk           (_U_(0x3) << TC_INTFLAG_MC_Pos)
+#define TC_INTFLAG_MC(value)        (TC_INTFLAG_MC_Msk & ((value) << TC_INTFLAG_MC_Pos))
+#define TC_INTFLAG_MASK             _U_(0x3B)    /**< \brief (TC_INTFLAG) MASK Register */
+
+/* -------- TC_STATUS : (TC Offset: 0x0F) (R/   8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :3;               /*!< bit:  0.. 2  Reserved                           */
+    uint8_t  STOP:1;           /*!< bit:      3  Stop                               */
+    uint8_t  SLAVE:1;          /*!< bit:      4  Slave                              */
+    uint8_t  :2;               /*!< bit:  5.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_STATUS_OFFSET            0x0F         /**< \brief (TC_STATUS offset) Status */
+#define TC_STATUS_RESETVALUE        _U_(0x08)    /**< \brief (TC_STATUS reset_value) Status */
+
+#define TC_STATUS_STOP_Pos          3            /**< \brief (TC_STATUS) Stop */
+#define TC_STATUS_STOP              (_U_(0x1) << TC_STATUS_STOP_Pos)
+#define TC_STATUS_SLAVE_Pos         4            /**< \brief (TC_STATUS) Slave */
+#define TC_STATUS_SLAVE             (_U_(0x1) << TC_STATUS_SLAVE_Pos)
+#define TC_STATUS_SYNCBUSY_Pos      7            /**< \brief (TC_STATUS) Synchronization Busy */
+#define TC_STATUS_SYNCBUSY          (_U_(0x1) << TC_STATUS_SYNCBUSY_Pos)
+#define TC_STATUS_MASK              _U_(0x98)    /**< \brief (TC_STATUS) MASK Register */
+
+/* -------- TC_COUNT16_COUNT : (TC Offset: 0x10) (R/W 16) COUNT16 COUNT16 Counter Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t COUNT:16;         /*!< bit:  0..15  Counter Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TC_COUNT16_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_COUNT_OFFSET     0x10         /**< \brief (TC_COUNT16_COUNT offset) COUNT16 Counter Value */
+#define TC_COUNT16_COUNT_RESETVALUE _U_(0x0000)  /**< \brief (TC_COUNT16_COUNT reset_value) COUNT16 Counter Value */
+
+#define TC_COUNT16_COUNT_COUNT_Pos  0            /**< \brief (TC_COUNT16_COUNT) Counter Value */
+#define TC_COUNT16_COUNT_COUNT_Msk  (_U_(0xFFFF) << TC_COUNT16_COUNT_COUNT_Pos)
+#define TC_COUNT16_COUNT_COUNT(value) (TC_COUNT16_COUNT_COUNT_Msk & ((value) << TC_COUNT16_COUNT_COUNT_Pos))
+#define TC_COUNT16_COUNT_MASK       _U_(0xFFFF)  /**< \brief (TC_COUNT16_COUNT) MASK Register */
+
+/* -------- TC_COUNT32_COUNT : (TC Offset: 0x10) (R/W 32) COUNT32 COUNT32 Counter Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t COUNT:32;         /*!< bit:  0..31  Counter Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_COUNT32_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_COUNT_OFFSET     0x10         /**< \brief (TC_COUNT32_COUNT offset) COUNT32 Counter Value */
+#define TC_COUNT32_COUNT_RESETVALUE _U_(0x00000000) /**< \brief (TC_COUNT32_COUNT reset_value) COUNT32 Counter Value */
+
+#define TC_COUNT32_COUNT_COUNT_Pos  0            /**< \brief (TC_COUNT32_COUNT) Counter Value */
+#define TC_COUNT32_COUNT_COUNT_Msk  (_U_(0xFFFFFFFF) << TC_COUNT32_COUNT_COUNT_Pos)
+#define TC_COUNT32_COUNT_COUNT(value) (TC_COUNT32_COUNT_COUNT_Msk & ((value) << TC_COUNT32_COUNT_COUNT_Pos))
+#define TC_COUNT32_COUNT_MASK       _U_(0xFFFFFFFF) /**< \brief (TC_COUNT32_COUNT) MASK Register */
+
+/* -------- TC_COUNT8_COUNT : (TC Offset: 0x10) (R/W  8) COUNT8 COUNT8 Counter Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  COUNT:8;          /*!< bit:  0.. 7  Counter Value                      */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_COUNT8_COUNT_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_COUNT_OFFSET      0x10         /**< \brief (TC_COUNT8_COUNT offset) COUNT8 Counter Value */
+#define TC_COUNT8_COUNT_RESETVALUE  _U_(0x00)    /**< \brief (TC_COUNT8_COUNT reset_value) COUNT8 Counter Value */
+
+#define TC_COUNT8_COUNT_COUNT_Pos   0            /**< \brief (TC_COUNT8_COUNT) Counter Value */
+#define TC_COUNT8_COUNT_COUNT_Msk   (_U_(0xFF) << TC_COUNT8_COUNT_COUNT_Pos)
+#define TC_COUNT8_COUNT_COUNT(value) (TC_COUNT8_COUNT_COUNT_Msk & ((value) << TC_COUNT8_COUNT_COUNT_Pos))
+#define TC_COUNT8_COUNT_MASK        _U_(0xFF)    /**< \brief (TC_COUNT8_COUNT) MASK Register */
+
+/* -------- TC_COUNT8_PER : (TC Offset: 0x14) (R/W  8) COUNT8 COUNT8 Period Value -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PER:8;            /*!< bit:  0.. 7  Period Value                       */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_COUNT8_PER_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_PER_OFFSET        0x14         /**< \brief (TC_COUNT8_PER offset) COUNT8 Period Value */
+#define TC_COUNT8_PER_RESETVALUE    _U_(0xFF)    /**< \brief (TC_COUNT8_PER reset_value) COUNT8 Period Value */
+
+#define TC_COUNT8_PER_PER_Pos       0            /**< \brief (TC_COUNT8_PER) Period Value */
+#define TC_COUNT8_PER_PER_Msk       (_U_(0xFF) << TC_COUNT8_PER_PER_Pos)
+#define TC_COUNT8_PER_PER(value)    (TC_COUNT8_PER_PER_Msk & ((value) << TC_COUNT8_PER_PER_Pos))
+#define TC_COUNT8_PER_MASK          _U_(0xFF)    /**< \brief (TC_COUNT8_PER) MASK Register */
+
+/* -------- TC_COUNT16_CC : (TC Offset: 0x18) (R/W 16) COUNT16 COUNT16 Compare/Capture -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint16_t CC:16;            /*!< bit:  0..15  Compare/Capture Value              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint16_t reg;                /*!< Type      used for register access              */
+} TC_COUNT16_CC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT16_CC_OFFSET        0x18         /**< \brief (TC_COUNT16_CC offset) COUNT16 Compare/Capture */
+#define TC_COUNT16_CC_RESETVALUE    _U_(0x0000)  /**< \brief (TC_COUNT16_CC reset_value) COUNT16 Compare/Capture */
+
+#define TC_COUNT16_CC_CC_Pos        0            /**< \brief (TC_COUNT16_CC) Compare/Capture Value */
+#define TC_COUNT16_CC_CC_Msk        (_U_(0xFFFF) << TC_COUNT16_CC_CC_Pos)
+#define TC_COUNT16_CC_CC(value)     (TC_COUNT16_CC_CC_Msk & ((value) << TC_COUNT16_CC_CC_Pos))
+#define TC_COUNT16_CC_MASK          _U_(0xFFFF)  /**< \brief (TC_COUNT16_CC) MASK Register */
+
+/* -------- TC_COUNT32_CC : (TC Offset: 0x18) (R/W 32) COUNT32 COUNT32 Compare/Capture -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint32_t CC:32;            /*!< bit:  0..31  Compare/Capture Value              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint32_t reg;                /*!< Type      used for register access              */
+} TC_COUNT32_CC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT32_CC_OFFSET        0x18         /**< \brief (TC_COUNT32_CC offset) COUNT32 Compare/Capture */
+#define TC_COUNT32_CC_RESETVALUE    _U_(0x00000000) /**< \brief (TC_COUNT32_CC reset_value) COUNT32 Compare/Capture */
+
+#define TC_COUNT32_CC_CC_Pos        0            /**< \brief (TC_COUNT32_CC) Compare/Capture Value */
+#define TC_COUNT32_CC_CC_Msk        (_U_(0xFFFFFFFF) << TC_COUNT32_CC_CC_Pos)
+#define TC_COUNT32_CC_CC(value)     (TC_COUNT32_CC_CC_Msk & ((value) << TC_COUNT32_CC_CC_Pos))
+#define TC_COUNT32_CC_MASK          _U_(0xFFFFFFFF) /**< \brief (TC_COUNT32_CC) MASK Register */
+
+/* -------- TC_COUNT8_CC : (TC Offset: 0x18) (R/W  8) COUNT8 COUNT8 Compare/Capture -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CC:8;             /*!< bit:  0.. 7  Compare/Capture Value              */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} TC_COUNT8_CC_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define TC_COUNT8_CC_OFFSET         0x18         /**< \brief (TC_COUNT8_CC offset) COUNT8 Compare/Capture */
+#define TC_COUNT8_CC_RESETVALUE     _U_(0x00)    /**< \brief (TC_COUNT8_CC reset_value) COUNT8 Compare/Capture */
+
+#define TC_COUNT8_CC_CC_Pos         0            /**< \brief (TC_COUNT8_CC) Compare/Capture Value */
+#define TC_COUNT8_CC_CC_Msk         (_U_(0xFF) << TC_COUNT8_CC_CC_Pos)
+#define TC_COUNT8_CC_CC(value)      (TC_COUNT8_CC_CC_Msk & ((value) << TC_COUNT8_CC_CC_Pos))
+#define TC_COUNT8_CC_MASK           _U_(0xFF)    /**< \brief (TC_COUNT8_CC) MASK Register */
+
+/** \brief TC_COUNT8 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* 8-bit Counter Mode */
+  __IO TC_CTRLA_Type             CTRLA;       /**< \brief Offset: 0x00 (R/W 16) Control A */
+  __IO TC_READREQ_Type           READREQ;     /**< \brief Offset: 0x02 (R/W 16) Read Request */
+  __IO TC_CTRLBCLR_Type          CTRLBCLR;    /**< \brief Offset: 0x04 (R/W  8) Control B Clear */
+  __IO TC_CTRLBSET_Type          CTRLBSET;    /**< \brief Offset: 0x05 (R/W  8) Control B Set */
+  __IO TC_CTRLC_Type             CTRLC;       /**< \brief Offset: 0x06 (R/W  8) Control C */
+       RoReg8                    Reserved1[0x1];
+  __IO TC_DBGCTRL_Type           DBGCTRL;     /**< \brief Offset: 0x08 (R/W  8) Debug Control */
+       RoReg8                    Reserved2[0x1];
+  __IO TC_EVCTRL_Type            EVCTRL;      /**< \brief Offset: 0x0A (R/W 16) Event Control */
+  __IO TC_INTENCLR_Type          INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) Interrupt Enable Clear */
+  __IO TC_INTENSET_Type          INTENSET;    /**< \brief Offset: 0x0D (R/W  8) Interrupt Enable Set */
+  __IO TC_INTFLAG_Type           INTFLAG;     /**< \brief Offset: 0x0E (R/W  8) Interrupt Flag Status and Clear */
+  __I  TC_STATUS_Type            STATUS;      /**< \brief Offset: 0x0F (R/   8) Status */
+  __IO TC_COUNT8_COUNT_Type      COUNT;       /**< \brief Offset: 0x10 (R/W  8) COUNT8 Counter Value */
+       RoReg8                    Reserved3[0x3];
+  __IO TC_COUNT8_PER_Type        PER;         /**< \brief Offset: 0x14 (R/W  8) COUNT8 Period Value */
+       RoReg8                    Reserved4[0x3];
+  __IO TC_COUNT8_CC_Type         CC[2];       /**< \brief Offset: 0x18 (R/W  8) COUNT8 Compare/Capture */
+} TcCount8;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief TC_COUNT16 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* 16-bit Counter Mode */
+  __IO TC_CTRLA_Type             CTRLA;       /**< \brief Offset: 0x00 (R/W 16) Control A */
+  __IO TC_READREQ_Type           READREQ;     /**< \brief Offset: 0x02 (R/W 16) Read Request */
+  __IO TC_CTRLBCLR_Type          CTRLBCLR;    /**< \brief Offset: 0x04 (R/W  8) Control B Clear */
+  __IO TC_CTRLBSET_Type          CTRLBSET;    /**< \brief Offset: 0x05 (R/W  8) Control B Set */
+  __IO TC_CTRLC_Type             CTRLC;       /**< \brief Offset: 0x06 (R/W  8) Control C */
+       RoReg8                    Reserved1[0x1];
+  __IO TC_DBGCTRL_Type           DBGCTRL;     /**< \brief Offset: 0x08 (R/W  8) Debug Control */
+       RoReg8                    Reserved2[0x1];
+  __IO TC_EVCTRL_Type            EVCTRL;      /**< \brief Offset: 0x0A (R/W 16) Event Control */
+  __IO TC_INTENCLR_Type          INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) Interrupt Enable Clear */
+  __IO TC_INTENSET_Type          INTENSET;    /**< \brief Offset: 0x0D (R/W  8) Interrupt Enable Set */
+  __IO TC_INTFLAG_Type           INTFLAG;     /**< \brief Offset: 0x0E (R/W  8) Interrupt Flag Status and Clear */
+  __I  TC_STATUS_Type            STATUS;      /**< \brief Offset: 0x0F (R/   8) Status */
+  __IO TC_COUNT16_COUNT_Type     COUNT;       /**< \brief Offset: 0x10 (R/W 16) COUNT16 Counter Value */
+       RoReg8                    Reserved3[0x6];
+  __IO TC_COUNT16_CC_Type        CC[2];       /**< \brief Offset: 0x18 (R/W 16) COUNT16 Compare/Capture */
+} TcCount16;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/** \brief TC_COUNT32 hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct { /* 32-bit Counter Mode */
+  __IO TC_CTRLA_Type             CTRLA;       /**< \brief Offset: 0x00 (R/W 16) Control A */
+  __IO TC_READREQ_Type           READREQ;     /**< \brief Offset: 0x02 (R/W 16) Read Request */
+  __IO TC_CTRLBCLR_Type          CTRLBCLR;    /**< \brief Offset: 0x04 (R/W  8) Control B Clear */
+  __IO TC_CTRLBSET_Type          CTRLBSET;    /**< \brief Offset: 0x05 (R/W  8) Control B Set */
+  __IO TC_CTRLC_Type             CTRLC;       /**< \brief Offset: 0x06 (R/W  8) Control C */
+       RoReg8                    Reserved1[0x1];
+  __IO TC_DBGCTRL_Type           DBGCTRL;     /**< \brief Offset: 0x08 (R/W  8) Debug Control */
+       RoReg8                    Reserved2[0x1];
+  __IO TC_EVCTRL_Type            EVCTRL;      /**< \brief Offset: 0x0A (R/W 16) Event Control */
+  __IO TC_INTENCLR_Type          INTENCLR;    /**< \brief Offset: 0x0C (R/W  8) Interrupt Enable Clear */
+  __IO TC_INTENSET_Type          INTENSET;    /**< \brief Offset: 0x0D (R/W  8) Interrupt Enable Set */
+  __IO TC_INTFLAG_Type           INTFLAG;     /**< \brief Offset: 0x0E (R/W  8) Interrupt Flag Status and Clear */
+  __I  TC_STATUS_Type            STATUS;      /**< \brief Offset: 0x0F (R/   8) Status */
+  __IO TC_COUNT32_COUNT_Type     COUNT;       /**< \brief Offset: 0x10 (R/W 32) COUNT32 Counter Value */
+       RoReg8                    Reserved3[0x4];
+  __IO TC_COUNT32_CC_Type        CC[2];       /**< \brief Offset: 0x18 (R/W 32) COUNT32 Compare/Capture */
+} TcCount32;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+       TcCount8                  COUNT8;      /**< \brief Offset: 0x00 8-bit Counter Mode */
+       TcCount16                 COUNT16;     /**< \brief Offset: 0x00 16-bit Counter Mode */
+       TcCount32                 COUNT32;     /**< \brief Offset: 0x00 32-bit Counter Mode */
+} Tc;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_TC_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/component/wdt.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/component/wdt.h
@@ -1,0 +1,289 @@
+/**
+ * \file
+ *
+ * \brief Component description for WDT
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_WDT_COMPONENT_
+#define _SAMD20_WDT_COMPONENT_
+
+/* ========================================================================== */
+/**  SOFTWARE API DEFINITION FOR WDT */
+/* ========================================================================== */
+/** \addtogroup SAMD20_WDT Watchdog Timer */
+/*@{*/
+
+#define WDT_U2203
+#define REV_WDT                     0x200
+
+/* -------- WDT_CTRL : (WDT Offset: 0x0) (R/W  8) Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :1;               /*!< bit:      0  Reserved                           */
+    uint8_t  ENABLE:1;         /*!< bit:      1  Enable                             */
+    uint8_t  WEN:1;            /*!< bit:      2  Watchdog Timer Window Mode Enable  */
+    uint8_t  :4;               /*!< bit:  3.. 6  Reserved                           */
+    uint8_t  ALWAYSON:1;       /*!< bit:      7  Always-On                          */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_CTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CTRL_OFFSET             0x0          /**< \brief (WDT_CTRL offset) Control */
+#define WDT_CTRL_RESETVALUE         _U_(0x00)    /**< \brief (WDT_CTRL reset_value) Control */
+
+#define WDT_CTRL_ENABLE_Pos         1            /**< \brief (WDT_CTRL) Enable */
+#define WDT_CTRL_ENABLE             (_U_(0x1) << WDT_CTRL_ENABLE_Pos)
+#define WDT_CTRL_WEN_Pos            2            /**< \brief (WDT_CTRL) Watchdog Timer Window Mode Enable */
+#define WDT_CTRL_WEN                (_U_(0x1) << WDT_CTRL_WEN_Pos)
+#define WDT_CTRL_ALWAYSON_Pos       7            /**< \brief (WDT_CTRL) Always-On */
+#define WDT_CTRL_ALWAYSON           (_U_(0x1) << WDT_CTRL_ALWAYSON_Pos)
+#define WDT_CTRL_MASK               _U_(0x86)    /**< \brief (WDT_CTRL) MASK Register */
+
+/* -------- WDT_CONFIG : (WDT Offset: 0x1) (R/W  8) Configuration -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  PER:4;            /*!< bit:  0.. 3  Time-Out Period                    */
+    uint8_t  WINDOW:4;         /*!< bit:  4.. 7  Window Mode Time-Out Period        */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_CONFIG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CONFIG_OFFSET           0x1          /**< \brief (WDT_CONFIG offset) Configuration */
+#define WDT_CONFIG_RESETVALUE       _U_(0xBB)    /**< \brief (WDT_CONFIG reset_value) Configuration */
+
+#define WDT_CONFIG_PER_Pos          0            /**< \brief (WDT_CONFIG) Time-Out Period */
+#define WDT_CONFIG_PER_Msk          (_U_(0xF) << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER(value)       (WDT_CONFIG_PER_Msk & ((value) << WDT_CONFIG_PER_Pos))
+#define   WDT_CONFIG_PER_CYC8_Val         _U_(0x0)   /**< \brief (WDT_CONFIG) 8 clock cycles */
+#define   WDT_CONFIG_PER_CYC16_Val        _U_(0x1)   /**< \brief (WDT_CONFIG) 16 clock cycles */
+#define   WDT_CONFIG_PER_CYC32_Val        _U_(0x2)   /**< \brief (WDT_CONFIG) 32 clock cycles */
+#define   WDT_CONFIG_PER_CYC64_Val        _U_(0x3)   /**< \brief (WDT_CONFIG) 64 clock cycles */
+#define   WDT_CONFIG_PER_CYC128_Val       _U_(0x4)   /**< \brief (WDT_CONFIG) 128 clock cycles */
+#define   WDT_CONFIG_PER_CYC256_Val       _U_(0x5)   /**< \brief (WDT_CONFIG) 256 clock cycles */
+#define   WDT_CONFIG_PER_CYC512_Val       _U_(0x6)   /**< \brief (WDT_CONFIG) 512 clock cycles */
+#define   WDT_CONFIG_PER_CYC1024K_Val     _U_(0x7)   /**< \brief (WDT_CONFIG) 1024 clock cycles */
+#define   WDT_CONFIG_PER_CYC2048_Val      _U_(0x8)   /**< \brief (WDT_CONFIG) 2048 clock cycles */
+#define   WDT_CONFIG_PER_CYC4096_Val      _U_(0x9)   /**< \brief (WDT_CONFIG) 4096 clock cycles */
+#define   WDT_CONFIG_PER_CYC8192_Val      _U_(0xA)   /**< \brief (WDT_CONFIG) 8192 clock cycles */
+#define   WDT_CONFIG_PER_CYC16384_Val     _U_(0xB)   /**< \brief (WDT_CONFIG) 16384 clock cycles */
+#define WDT_CONFIG_PER_CYC8         (WDT_CONFIG_PER_CYC8_Val       << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC16        (WDT_CONFIG_PER_CYC16_Val      << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC32        (WDT_CONFIG_PER_CYC32_Val      << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC64        (WDT_CONFIG_PER_CYC64_Val      << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC128       (WDT_CONFIG_PER_CYC128_Val     << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC256       (WDT_CONFIG_PER_CYC256_Val     << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC512       (WDT_CONFIG_PER_CYC512_Val     << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC1024K     (WDT_CONFIG_PER_CYC1024K_Val   << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC2048      (WDT_CONFIG_PER_CYC2048_Val    << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC4096      (WDT_CONFIG_PER_CYC4096_Val    << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC8192      (WDT_CONFIG_PER_CYC8192_Val    << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_PER_CYC16384     (WDT_CONFIG_PER_CYC16384_Val   << WDT_CONFIG_PER_Pos)
+#define WDT_CONFIG_WINDOW_Pos       4            /**< \brief (WDT_CONFIG) Window Mode Time-Out Period */
+#define WDT_CONFIG_WINDOW_Msk       (_U_(0xF) << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW(value)    (WDT_CONFIG_WINDOW_Msk & ((value) << WDT_CONFIG_WINDOW_Pos))
+#define   WDT_CONFIG_WINDOW_8_Val         _U_(0x0)   /**< \brief (WDT_CONFIG) 8 clock cycles */
+#define   WDT_CONFIG_WINDOW_16_Val        _U_(0x1)   /**< \brief (WDT_CONFIG) 16 clock cycles */
+#define   WDT_CONFIG_WINDOW_32_Val        _U_(0x2)   /**< \brief (WDT_CONFIG) 32 clock cycles */
+#define   WDT_CONFIG_WINDOW_64_Val        _U_(0x3)   /**< \brief (WDT_CONFIG) 64 clock cycles */
+#define   WDT_CONFIG_WINDOW_128_Val       _U_(0x4)   /**< \brief (WDT_CONFIG) 128 clock cycles */
+#define   WDT_CONFIG_WINDOW_256_Val       _U_(0x5)   /**< \brief (WDT_CONFIG) 256 clock cycles */
+#define   WDT_CONFIG_WINDOW_512_Val       _U_(0x6)   /**< \brief (WDT_CONFIG) 512 clock cycles */
+#define   WDT_CONFIG_WINDOW_1K_Val        _U_(0x7)   /**< \brief (WDT_CONFIG) 1024 clock cycles */
+#define   WDT_CONFIG_WINDOW_2K_Val        _U_(0x8)   /**< \brief (WDT_CONFIG) 2048 clock cycles */
+#define   WDT_CONFIG_WINDOW_4K_Val        _U_(0x9)   /**< \brief (WDT_CONFIG) 4096 clock cycles */
+#define   WDT_CONFIG_WINDOW_8K_Val        _U_(0xA)   /**< \brief (WDT_CONFIG) 8192 clock cycles */
+#define   WDT_CONFIG_WINDOW_16K_Val       _U_(0xB)   /**< \brief (WDT_CONFIG) 16384 clock cycles */
+#define WDT_CONFIG_WINDOW_8         (WDT_CONFIG_WINDOW_8_Val       << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_16        (WDT_CONFIG_WINDOW_16_Val      << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_32        (WDT_CONFIG_WINDOW_32_Val      << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_64        (WDT_CONFIG_WINDOW_64_Val      << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_128       (WDT_CONFIG_WINDOW_128_Val     << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_256       (WDT_CONFIG_WINDOW_256_Val     << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_512       (WDT_CONFIG_WINDOW_512_Val     << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_1K        (WDT_CONFIG_WINDOW_1K_Val      << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_2K        (WDT_CONFIG_WINDOW_2K_Val      << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_4K        (WDT_CONFIG_WINDOW_4K_Val      << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_8K        (WDT_CONFIG_WINDOW_8K_Val      << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_WINDOW_16K       (WDT_CONFIG_WINDOW_16K_Val     << WDT_CONFIG_WINDOW_Pos)
+#define WDT_CONFIG_MASK             _U_(0xFF)    /**< \brief (WDT_CONFIG) MASK Register */
+
+/* -------- WDT_EWCTRL : (WDT Offset: 0x2) (R/W  8) Early Warning Interrupt Control -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  EWOFFSET:4;       /*!< bit:  0.. 3  Early Warning Interrupt Time Offset */
+    uint8_t  :4;               /*!< bit:  4.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_EWCTRL_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_EWCTRL_OFFSET           0x2          /**< \brief (WDT_EWCTRL offset) Early Warning Interrupt Control */
+#define WDT_EWCTRL_RESETVALUE       _U_(0x0B)    /**< \brief (WDT_EWCTRL reset_value) Early Warning Interrupt Control */
+
+#define WDT_EWCTRL_EWOFFSET_Pos     0            /**< \brief (WDT_EWCTRL) Early Warning Interrupt Time Offset */
+#define WDT_EWCTRL_EWOFFSET_Msk     (_U_(0xF) << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET(value)  (WDT_EWCTRL_EWOFFSET_Msk & ((value) << WDT_EWCTRL_EWOFFSET_Pos))
+#define   WDT_EWCTRL_EWOFFSET_CYC8_Val    _U_(0x0)   /**< \brief (WDT_EWCTRL) 8 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC16_Val   _U_(0x1)   /**< \brief (WDT_EWCTRL) 16 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC32_Val   _U_(0x2)   /**< \brief (WDT_EWCTRL) 32 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC64_Val   _U_(0x3)   /**< \brief (WDT_EWCTRL) 64 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC128_Val  _U_(0x4)   /**< \brief (WDT_EWCTRL) 128 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC256_Val  _U_(0x5)   /**< \brief (WDT_EWCTRL) 256 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC512_Val  _U_(0x6)   /**< \brief (WDT_EWCTRL) 512 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC1024_Val _U_(0x7)   /**< \brief (WDT_EWCTRL) 1024 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC2048_Val _U_(0x8)   /**< \brief (WDT_EWCTRL) 2048 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC4096_Val _U_(0x9)   /**< \brief (WDT_EWCTRL) 4096 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC8192_Val _U_(0xA)   /**< \brief (WDT_EWCTRL) 8192 clock cycles */
+#define   WDT_EWCTRL_EWOFFSET_CYC16384_Val _U_(0xB)   /**< \brief (WDT_EWCTRL) 16384 clock cycles */
+#define WDT_EWCTRL_EWOFFSET_CYC8    (WDT_EWCTRL_EWOFFSET_CYC8_Val  << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC16   (WDT_EWCTRL_EWOFFSET_CYC16_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC32   (WDT_EWCTRL_EWOFFSET_CYC32_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC64   (WDT_EWCTRL_EWOFFSET_CYC64_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC128  (WDT_EWCTRL_EWOFFSET_CYC128_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC256  (WDT_EWCTRL_EWOFFSET_CYC256_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC512  (WDT_EWCTRL_EWOFFSET_CYC512_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC1024 (WDT_EWCTRL_EWOFFSET_CYC1024_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC2048 (WDT_EWCTRL_EWOFFSET_CYC2048_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC4096 (WDT_EWCTRL_EWOFFSET_CYC4096_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC8192 (WDT_EWCTRL_EWOFFSET_CYC8192_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_EWOFFSET_CYC16384 (WDT_EWCTRL_EWOFFSET_CYC16384_Val << WDT_EWCTRL_EWOFFSET_Pos)
+#define WDT_EWCTRL_MASK             _U_(0x0F)    /**< \brief (WDT_EWCTRL) MASK Register */
+
+/* -------- WDT_INTENCLR : (WDT Offset: 0x4) (R/W  8) Interrupt Enable Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  EW:1;             /*!< bit:      0  Early Warning Interrupt Enable     */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_INTENCLR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_INTENCLR_OFFSET         0x4          /**< \brief (WDT_INTENCLR offset) Interrupt Enable Clear */
+#define WDT_INTENCLR_RESETVALUE     _U_(0x00)    /**< \brief (WDT_INTENCLR reset_value) Interrupt Enable Clear */
+
+#define WDT_INTENCLR_EW_Pos         0            /**< \brief (WDT_INTENCLR) Early Warning Interrupt Enable */
+#define WDT_INTENCLR_EW             (_U_(0x1) << WDT_INTENCLR_EW_Pos)
+#define WDT_INTENCLR_MASK           _U_(0x01)    /**< \brief (WDT_INTENCLR) MASK Register */
+
+/* -------- WDT_INTENSET : (WDT Offset: 0x5) (R/W  8) Interrupt Enable Set -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  EW:1;             /*!< bit:      0  Early Warning Interrupt Enable     */
+    uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_INTENSET_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_INTENSET_OFFSET         0x5          /**< \brief (WDT_INTENSET offset) Interrupt Enable Set */
+#define WDT_INTENSET_RESETVALUE     _U_(0x00)    /**< \brief (WDT_INTENSET reset_value) Interrupt Enable Set */
+
+#define WDT_INTENSET_EW_Pos         0            /**< \brief (WDT_INTENSET) Early Warning Interrupt Enable */
+#define WDT_INTENSET_EW             (_U_(0x1) << WDT_INTENSET_EW_Pos)
+#define WDT_INTENSET_MASK           _U_(0x01)    /**< \brief (WDT_INTENSET) MASK Register */
+
+/* -------- WDT_INTFLAG : (WDT Offset: 0x6) (R/W  8) Interrupt Flag Status and Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union { // __I to avoid read-modify-write on write-to-clear register
+  struct {
+    __I uint8_t  EW:1;             /*!< bit:      0  Early Warning                      */
+    __I uint8_t  :7;               /*!< bit:  1.. 7  Reserved                           */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_INTFLAG_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_INTFLAG_OFFSET          0x6          /**< \brief (WDT_INTFLAG offset) Interrupt Flag Status and Clear */
+#define WDT_INTFLAG_RESETVALUE      _U_(0x00)    /**< \brief (WDT_INTFLAG reset_value) Interrupt Flag Status and Clear */
+
+#define WDT_INTFLAG_EW_Pos          0            /**< \brief (WDT_INTFLAG) Early Warning */
+#define WDT_INTFLAG_EW              (_U_(0x1) << WDT_INTFLAG_EW_Pos)
+#define WDT_INTFLAG_MASK            _U_(0x01)    /**< \brief (WDT_INTFLAG) MASK Register */
+
+/* -------- WDT_STATUS : (WDT Offset: 0x7) (R/   8) Status -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  :7;               /*!< bit:  0.. 6  Reserved                           */
+    uint8_t  SYNCBUSY:1;       /*!< bit:      7  Synchronization Busy               */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_STATUS_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_STATUS_OFFSET           0x7          /**< \brief (WDT_STATUS offset) Status */
+#define WDT_STATUS_RESETVALUE       _U_(0x00)    /**< \brief (WDT_STATUS reset_value) Status */
+
+#define WDT_STATUS_SYNCBUSY_Pos     7            /**< \brief (WDT_STATUS) Synchronization Busy */
+#define WDT_STATUS_SYNCBUSY         (_U_(0x1) << WDT_STATUS_SYNCBUSY_Pos)
+#define WDT_STATUS_MASK             _U_(0x80)    /**< \brief (WDT_STATUS) MASK Register */
+
+/* -------- WDT_CLEAR : (WDT Offset: 0x8) ( /W  8) Clear -------- */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef union {
+  struct {
+    uint8_t  CLEAR:8;          /*!< bit:  0.. 7  Watchdog Clear                     */
+  } bit;                       /*!< Structure used for bit  access                  */
+  uint8_t reg;                 /*!< Type      used for register access              */
+} WDT_CLEAR_Type;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+#define WDT_CLEAR_OFFSET            0x8          /**< \brief (WDT_CLEAR offset) Clear */
+#define WDT_CLEAR_RESETVALUE        _U_(0x00)    /**< \brief (WDT_CLEAR reset_value) Clear */
+
+#define WDT_CLEAR_CLEAR_Pos         0            /**< \brief (WDT_CLEAR) Watchdog Clear */
+#define WDT_CLEAR_CLEAR_Msk         (_U_(0xFF) << WDT_CLEAR_CLEAR_Pos)
+#define WDT_CLEAR_CLEAR(value)      (WDT_CLEAR_CLEAR_Msk & ((value) << WDT_CLEAR_CLEAR_Pos))
+#define   WDT_CLEAR_CLEAR_KEY_Val         _U_(0xA5)   /**< \brief (WDT_CLEAR) Clear Key */
+#define WDT_CLEAR_CLEAR_KEY         (WDT_CLEAR_CLEAR_KEY_Val       << WDT_CLEAR_CLEAR_Pos)
+#define WDT_CLEAR_MASK              _U_(0xFF)    /**< \brief (WDT_CLEAR) MASK Register */
+
+/** \brief WDT hardware registers */
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+typedef struct {
+  __IO WDT_CTRL_Type             CTRL;        /**< \brief Offset: 0x0 (R/W  8) Control */
+  __IO WDT_CONFIG_Type           CONFIG;      /**< \brief Offset: 0x1 (R/W  8) Configuration */
+  __IO WDT_EWCTRL_Type           EWCTRL;      /**< \brief Offset: 0x2 (R/W  8) Early Warning Interrupt Control */
+       RoReg8                    Reserved1[0x1];
+  __IO WDT_INTENCLR_Type         INTENCLR;    /**< \brief Offset: 0x4 (R/W  8) Interrupt Enable Clear */
+  __IO WDT_INTENSET_Type         INTENSET;    /**< \brief Offset: 0x5 (R/W  8) Interrupt Enable Set */
+  __IO WDT_INTFLAG_Type          INTFLAG;     /**< \brief Offset: 0x6 (R/W  8) Interrupt Flag Status and Clear */
+  __I  WDT_STATUS_Type           STATUS;      /**< \brief Offset: 0x7 (R/   8) Status */
+  __O  WDT_CLEAR_Type            CLEAR;       /**< \brief Offset: 0x8 ( /W  8) Clear */
+} Wdt;
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/*@}*/
+
+#endif /* _SAMD20_WDT_COMPONENT_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/ac.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/ac.h
@@ -1,0 +1,73 @@
+/**
+ * \file
+ *
+ * \brief Instance description for AC
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_AC_INSTANCE_
+#define _SAMD20_AC_INSTANCE_
+
+/* ========== Register definition for AC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_AC_CTRLA               (0x42004400) /**< \brief (AC) Control A */
+#define REG_AC_CTRLB               (0x42004401) /**< \brief (AC) Control B */
+#define REG_AC_EVCTRL              (0x42004402) /**< \brief (AC) Event Control */
+#define REG_AC_INTENCLR            (0x42004404) /**< \brief (AC) Interrupt Enable Clear */
+#define REG_AC_INTENSET            (0x42004405) /**< \brief (AC) Interrupt Enable Set */
+#define REG_AC_INTFLAG             (0x42004406) /**< \brief (AC) Interrupt Flag Status and Clear */
+#define REG_AC_STATUSA             (0x42004408) /**< \brief (AC) Status A */
+#define REG_AC_STATUSB             (0x42004409) /**< \brief (AC) Status B */
+#define REG_AC_STATUSC             (0x4200440A) /**< \brief (AC) Status C */
+#define REG_AC_WINCTRL             (0x4200440C) /**< \brief (AC) Window Control */
+#define REG_AC_COMPCTRL0           (0x42004410) /**< \brief (AC) Comparator Control 0 */
+#define REG_AC_COMPCTRL1           (0x42004414) /**< \brief (AC) Comparator Control 1 */
+#define REG_AC_SCALER0             (0x42004420) /**< \brief (AC) Scaler 0 */
+#define REG_AC_SCALER1             (0x42004421) /**< \brief (AC) Scaler 1 */
+#else
+#define REG_AC_CTRLA               (*(RwReg8 *)0x42004400UL) /**< \brief (AC) Control A */
+#define REG_AC_CTRLB               (*(WoReg8 *)0x42004401UL) /**< \brief (AC) Control B */
+#define REG_AC_EVCTRL              (*(RwReg16*)0x42004402UL) /**< \brief (AC) Event Control */
+#define REG_AC_INTENCLR            (*(RwReg8 *)0x42004404UL) /**< \brief (AC) Interrupt Enable Clear */
+#define REG_AC_INTENSET            (*(RwReg8 *)0x42004405UL) /**< \brief (AC) Interrupt Enable Set */
+#define REG_AC_INTFLAG             (*(RwReg8 *)0x42004406UL) /**< \brief (AC) Interrupt Flag Status and Clear */
+#define REG_AC_STATUSA             (*(RoReg8 *)0x42004408UL) /**< \brief (AC) Status A */
+#define REG_AC_STATUSB             (*(RoReg8 *)0x42004409UL) /**< \brief (AC) Status B */
+#define REG_AC_STATUSC             (*(RoReg8 *)0x4200440AUL) /**< \brief (AC) Status C */
+#define REG_AC_WINCTRL             (*(RwReg8 *)0x4200440CUL) /**< \brief (AC) Window Control */
+#define REG_AC_COMPCTRL0           (*(RwReg  *)0x42004410UL) /**< \brief (AC) Comparator Control 0 */
+#define REG_AC_COMPCTRL1           (*(RwReg  *)0x42004414UL) /**< \brief (AC) Comparator Control 1 */
+#define REG_AC_SCALER0             (*(RwReg8 *)0x42004420UL) /**< \brief (AC) Scaler 0 */
+#define REG_AC_SCALER1             (*(RwReg8 *)0x42004421UL) /**< \brief (AC) Scaler 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for AC peripheral ========== */
+#define AC_CMP_NUM                  2        // Number of comparators
+#define AC_GCLK_ID_ANA              25       // Index of Generic Clock for analog
+#define AC_GCLK_ID_DIG              24       // Index of Generic Clock for digital
+#define AC_NUM_CMP                  2       
+#define AC_PAIRS                    1        // Number of pairs of comparators
+
+#endif /* _SAMD20_AC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/adc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/adc.h
@@ -1,0 +1,84 @@
+/**
+ * \file
+ *
+ * \brief Instance description for ADC
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_ADC_INSTANCE_
+#define _SAMD20_ADC_INSTANCE_
+
+/* ========== Register definition for ADC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_ADC_CTRLA              (0x42004000) /**< \brief (ADC) Control A */
+#define REG_ADC_REFCTRL            (0x42004001) /**< \brief (ADC) Reference Control */
+#define REG_ADC_AVGCTRL            (0x42004002) /**< \brief (ADC) Average Control */
+#define REG_ADC_SAMPCTRL           (0x42004003) /**< \brief (ADC) Sampling Time Control */
+#define REG_ADC_CTRLB              (0x42004004) /**< \brief (ADC) Control B */
+#define REG_ADC_WINCTRL            (0x42004008) /**< \brief (ADC) Window Monitor Control */
+#define REG_ADC_SWTRIG             (0x4200400C) /**< \brief (ADC) Software Trigger */
+#define REG_ADC_INPUTCTRL          (0x42004010) /**< \brief (ADC) Inputs Control */
+#define REG_ADC_EVCTRL             (0x42004014) /**< \brief (ADC) Event Control */
+#define REG_ADC_INTENCLR           (0x42004016) /**< \brief (ADC) Interrupt Enable Clear */
+#define REG_ADC_INTENSET           (0x42004017) /**< \brief (ADC) Interrupt Enable Set */
+#define REG_ADC_INTFLAG            (0x42004018) /**< \brief (ADC) Interrupt Flag Status and Clear */
+#define REG_ADC_STATUS             (0x42004019) /**< \brief (ADC) Status */
+#define REG_ADC_RESULT             (0x4200401A) /**< \brief (ADC) Result */
+#define REG_ADC_WINLT              (0x4200401C) /**< \brief (ADC) Window Monitor Lower Threshold */
+#define REG_ADC_WINUT              (0x42004020) /**< \brief (ADC) Window Monitor Upper Threshold */
+#define REG_ADC_GAINCORR           (0x42004024) /**< \brief (ADC) Gain Correction */
+#define REG_ADC_OFFSETCORR         (0x42004026) /**< \brief (ADC) Offset Correction */
+#define REG_ADC_CALIB              (0x42004028) /**< \brief (ADC) Calibration */
+#define REG_ADC_DBGCTRL            (0x4200402A) /**< \brief (ADC) Debug Control */
+#else
+#define REG_ADC_CTRLA              (*(RwReg8 *)0x42004000UL) /**< \brief (ADC) Control A */
+#define REG_ADC_REFCTRL            (*(RwReg8 *)0x42004001UL) /**< \brief (ADC) Reference Control */
+#define REG_ADC_AVGCTRL            (*(RwReg8 *)0x42004002UL) /**< \brief (ADC) Average Control */
+#define REG_ADC_SAMPCTRL           (*(RwReg8 *)0x42004003UL) /**< \brief (ADC) Sampling Time Control */
+#define REG_ADC_CTRLB              (*(RwReg16*)0x42004004UL) /**< \brief (ADC) Control B */
+#define REG_ADC_WINCTRL            (*(RwReg8 *)0x42004008UL) /**< \brief (ADC) Window Monitor Control */
+#define REG_ADC_SWTRIG             (*(RwReg8 *)0x4200400CUL) /**< \brief (ADC) Software Trigger */
+#define REG_ADC_INPUTCTRL          (*(RwReg  *)0x42004010UL) /**< \brief (ADC) Inputs Control */
+#define REG_ADC_EVCTRL             (*(RwReg8 *)0x42004014UL) /**< \brief (ADC) Event Control */
+#define REG_ADC_INTENCLR           (*(RwReg8 *)0x42004016UL) /**< \brief (ADC) Interrupt Enable Clear */
+#define REG_ADC_INTENSET           (*(RwReg8 *)0x42004017UL) /**< \brief (ADC) Interrupt Enable Set */
+#define REG_ADC_INTFLAG            (*(RwReg8 *)0x42004018UL) /**< \brief (ADC) Interrupt Flag Status and Clear */
+#define REG_ADC_STATUS             (*(RoReg8 *)0x42004019UL) /**< \brief (ADC) Status */
+#define REG_ADC_RESULT             (*(RoReg16*)0x4200401AUL) /**< \brief (ADC) Result */
+#define REG_ADC_WINLT              (*(RwReg16*)0x4200401CUL) /**< \brief (ADC) Window Monitor Lower Threshold */
+#define REG_ADC_WINUT              (*(RwReg16*)0x42004020UL) /**< \brief (ADC) Window Monitor Upper Threshold */
+#define REG_ADC_GAINCORR           (*(RwReg16*)0x42004024UL) /**< \brief (ADC) Gain Correction */
+#define REG_ADC_OFFSETCORR         (*(RwReg16*)0x42004026UL) /**< \brief (ADC) Offset Correction */
+#define REG_ADC_CALIB              (*(RwReg16*)0x42004028UL) /**< \brief (ADC) Calibration */
+#define REG_ADC_DBGCTRL            (*(RwReg8 *)0x4200402AUL) /**< \brief (ADC) Debug Control */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for ADC peripheral ========== */
+#define ADC_EXTCHANNEL_MSB          19       // Number of external channels
+#define ADC_GCLK_ID                 23       // Index of Generic Clock
+#define ADC_RESULT_BITS             16       // Size of RESULT.RESULT bitfield
+#define ADC_RESULT_MSB              15       // Size of Result
+
+#endif /* _SAMD20_ADC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/dac.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/dac.h
@@ -1,0 +1,59 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DAC
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_DAC_INSTANCE_
+#define _SAMD20_DAC_INSTANCE_
+
+/* ========== Register definition for DAC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_DAC_CTRLA              (0x42004800) /**< \brief (DAC) Control A */
+#define REG_DAC_CTRLB              (0x42004801) /**< \brief (DAC) Control B */
+#define REG_DAC_EVCTRL             (0x42004802) /**< \brief (DAC) Event Control */
+#define REG_DAC_INTENCLR           (0x42004804) /**< \brief (DAC) Interrupt Enable Clear */
+#define REG_DAC_INTENSET           (0x42004805) /**< \brief (DAC) Interrupt Enable Set */
+#define REG_DAC_INTFLAG            (0x42004806) /**< \brief (DAC) Interrupt Flag Status and Clear */
+#define REG_DAC_STATUS             (0x42004807) /**< \brief (DAC) Status */
+#define REG_DAC_DATA               (0x42004808) /**< \brief (DAC) Data */
+#define REG_DAC_DATABUF            (0x4200480C) /**< \brief (DAC) Data Buffer */
+#else
+#define REG_DAC_CTRLA              (*(RwReg8 *)0x42004800UL) /**< \brief (DAC) Control A */
+#define REG_DAC_CTRLB              (*(RwReg8 *)0x42004801UL) /**< \brief (DAC) Control B */
+#define REG_DAC_EVCTRL             (*(RwReg8 *)0x42004802UL) /**< \brief (DAC) Event Control */
+#define REG_DAC_INTENCLR           (*(RwReg8 *)0x42004804UL) /**< \brief (DAC) Interrupt Enable Clear */
+#define REG_DAC_INTENSET           (*(RwReg8 *)0x42004805UL) /**< \brief (DAC) Interrupt Enable Set */
+#define REG_DAC_INTFLAG            (*(RwReg8 *)0x42004806UL) /**< \brief (DAC) Interrupt Flag Status and Clear */
+#define REG_DAC_STATUS             (*(RoReg8 *)0x42004807UL) /**< \brief (DAC) Status */
+#define REG_DAC_DATA               (*(RwReg16*)0x42004808UL) /**< \brief (DAC) Data */
+#define REG_DAC_DATABUF            (*(RwReg16*)0x4200480CUL) /**< \brief (DAC) Data Buffer */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for DAC peripheral ========== */
+#define DAC_GCLK_ID                 26      
+
+#endif /* _SAMD20_DAC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/dsu.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/dsu.h
@@ -1,0 +1,95 @@
+/**
+ * \file
+ *
+ * \brief Instance description for DSU
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_DSU_INSTANCE_
+#define _SAMD20_DSU_INSTANCE_
+
+/* ========== Register definition for DSU peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_DSU_CTRL               (0x41002000) /**< \brief (DSU) Control */
+#define REG_DSU_STATUSA            (0x41002001) /**< \brief (DSU) Status A */
+#define REG_DSU_STATUSB            (0x41002002) /**< \brief (DSU) Status B */
+#define REG_DSU_ADDR               (0x41002004) /**< \brief (DSU) Address */
+#define REG_DSU_LENGTH             (0x41002008) /**< \brief (DSU) Length */
+#define REG_DSU_DATA               (0x4100200C) /**< \brief (DSU) Data */
+#define REG_DSU_DCC0               (0x41002010) /**< \brief (DSU) Debug Communication Channel 0 */
+#define REG_DSU_DCC1               (0x41002014) /**< \brief (DSU) Debug Communication Channel 1 */
+#define REG_DSU_DID                (0x41002018) /**< \brief (DSU) Device Identification */
+#define REG_DSU_DCFG0              (0x410020F0) /**< \brief (DSU) Device Configuration 0 */
+#define REG_DSU_DCFG1              (0x410020F4) /**< \brief (DSU) Device Configuration 1 */
+#define REG_DSU_ENTRY0             (0x41003000) /**< \brief (DSU) Coresight ROM Table Entry 0 */
+#define REG_DSU_ENTRY1             (0x41003004) /**< \brief (DSU) Coresight ROM Table Entry 1 */
+#define REG_DSU_END                (0x41003008) /**< \brief (DSU) Coresight ROM Table End */
+#define REG_DSU_MEMTYPE            (0x41003FCC) /**< \brief (DSU) Coresight ROM Table Memory Type */
+#define REG_DSU_PID4               (0x41003FD0) /**< \brief (DSU) Peripheral Identification 4 */
+#define REG_DSU_PID5               (0x41003FD4) /**< \brief (DSU) Peripheral Identification 5 */
+#define REG_DSU_PID6               (0x41003FD8) /**< \brief (DSU) Peripheral Identification 6 */
+#define REG_DSU_PID7               (0x41003FDC) /**< \brief (DSU) Peripheral Identification 7 */
+#define REG_DSU_PID0               (0x41003FE0) /**< \brief (DSU) Peripheral Identification 0 */
+#define REG_DSU_PID1               (0x41003FE4) /**< \brief (DSU) Peripheral Identification 1 */
+#define REG_DSU_PID2               (0x41003FE8) /**< \brief (DSU) Peripheral Identification 2 */
+#define REG_DSU_PID3               (0x41003FEC) /**< \brief (DSU) Peripheral Identification 3 */
+#define REG_DSU_CID0               (0x41003FF0) /**< \brief (DSU) Component Identification 0 */
+#define REG_DSU_CID1               (0x41003FF4) /**< \brief (DSU) Component Identification 1 */
+#define REG_DSU_CID2               (0x41003FF8) /**< \brief (DSU) Component Identification 2 */
+#define REG_DSU_CID3               (0x41003FFC) /**< \brief (DSU) Component Identification 3 */
+#else
+#define REG_DSU_CTRL               (*(WoReg8 *)0x41002000UL) /**< \brief (DSU) Control */
+#define REG_DSU_STATUSA            (*(RwReg8 *)0x41002001UL) /**< \brief (DSU) Status A */
+#define REG_DSU_STATUSB            (*(RoReg8 *)0x41002002UL) /**< \brief (DSU) Status B */
+#define REG_DSU_ADDR               (*(RwReg  *)0x41002004UL) /**< \brief (DSU) Address */
+#define REG_DSU_LENGTH             (*(RwReg  *)0x41002008UL) /**< \brief (DSU) Length */
+#define REG_DSU_DATA               (*(RwReg  *)0x4100200CUL) /**< \brief (DSU) Data */
+#define REG_DSU_DCC0               (*(RwReg  *)0x41002010UL) /**< \brief (DSU) Debug Communication Channel 0 */
+#define REG_DSU_DCC1               (*(RwReg  *)0x41002014UL) /**< \brief (DSU) Debug Communication Channel 1 */
+#define REG_DSU_DID                (*(RoReg  *)0x41002018UL) /**< \brief (DSU) Device Identification */
+#define REG_DSU_DCFG0              (*(RwReg  *)0x410020F0UL) /**< \brief (DSU) Device Configuration 0 */
+#define REG_DSU_DCFG1              (*(RwReg  *)0x410020F4UL) /**< \brief (DSU) Device Configuration 1 */
+#define REG_DSU_ENTRY0             (*(RoReg  *)0x41003000UL) /**< \brief (DSU) Coresight ROM Table Entry 0 */
+#define REG_DSU_ENTRY1             (*(RoReg  *)0x41003004UL) /**< \brief (DSU) Coresight ROM Table Entry 1 */
+#define REG_DSU_END                (*(RoReg  *)0x41003008UL) /**< \brief (DSU) Coresight ROM Table End */
+#define REG_DSU_MEMTYPE            (*(RoReg  *)0x41003FCCUL) /**< \brief (DSU) Coresight ROM Table Memory Type */
+#define REG_DSU_PID4               (*(RoReg  *)0x41003FD0UL) /**< \brief (DSU) Peripheral Identification 4 */
+#define REG_DSU_PID5               (*(RoReg  *)0x41003FD4UL) /**< \brief (DSU) Peripheral Identification 5 */
+#define REG_DSU_PID6               (*(RoReg  *)0x41003FD8UL) /**< \brief (DSU) Peripheral Identification 6 */
+#define REG_DSU_PID7               (*(RoReg  *)0x41003FDCUL) /**< \brief (DSU) Peripheral Identification 7 */
+#define REG_DSU_PID0               (*(RoReg  *)0x41003FE0UL) /**< \brief (DSU) Peripheral Identification 0 */
+#define REG_DSU_PID1               (*(RoReg  *)0x41003FE4UL) /**< \brief (DSU) Peripheral Identification 1 */
+#define REG_DSU_PID2               (*(RoReg  *)0x41003FE8UL) /**< \brief (DSU) Peripheral Identification 2 */
+#define REG_DSU_PID3               (*(RoReg  *)0x41003FECUL) /**< \brief (DSU) Peripheral Identification 3 */
+#define REG_DSU_CID0               (*(RoReg  *)0x41003FF0UL) /**< \brief (DSU) Component Identification 0 */
+#define REG_DSU_CID1               (*(RoReg  *)0x41003FF4UL) /**< \brief (DSU) Component Identification 1 */
+#define REG_DSU_CID2               (*(RoReg  *)0x41003FF8UL) /**< \brief (DSU) Component Identification 2 */
+#define REG_DSU_CID3               (*(RoReg  *)0x41003FFCUL) /**< \brief (DSU) Component Identification 3 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for DSU peripheral ========== */
+#define DSU_CLK_HSB_ID              3       
+
+#endif /* _SAMD20_DSU_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/eic.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/eic.h
@@ -1,0 +1,67 @@
+/**
+ * \file
+ *
+ * \brief Instance description for EIC
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_EIC_INSTANCE_
+#define _SAMD20_EIC_INSTANCE_
+
+/* ========== Register definition for EIC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_EIC_CTRL               (0x40001800) /**< \brief (EIC) Control */
+#define REG_EIC_STATUS             (0x40001801) /**< \brief (EIC) Status */
+#define REG_EIC_NMICTRL            (0x40001802) /**< \brief (EIC) Non-Maskable Interrupt Control */
+#define REG_EIC_NMIFLAG            (0x40001803) /**< \brief (EIC) Non-Maskable Interrupt Flag Status and Clear */
+#define REG_EIC_EVCTRL             (0x40001804) /**< \brief (EIC) Event Control */
+#define REG_EIC_INTENCLR           (0x40001808) /**< \brief (EIC) Interrupt Enable Clear */
+#define REG_EIC_INTENSET           (0x4000180C) /**< \brief (EIC) Interrupt Enable Set */
+#define REG_EIC_INTFLAG            (0x40001810) /**< \brief (EIC) Interrupt Flag Status and Clear */
+#define REG_EIC_WAKEUP             (0x40001814) /**< \brief (EIC) Wake-Up Enable */
+#define REG_EIC_CONFIG0            (0x40001818) /**< \brief (EIC) Configuration 0 */
+#define REG_EIC_CONFIG1            (0x4000181C) /**< \brief (EIC) Configuration 1 */
+#else
+#define REG_EIC_CTRL               (*(RwReg8 *)0x40001800UL) /**< \brief (EIC) Control */
+#define REG_EIC_STATUS             (*(RoReg8 *)0x40001801UL) /**< \brief (EIC) Status */
+#define REG_EIC_NMICTRL            (*(RwReg8 *)0x40001802UL) /**< \brief (EIC) Non-Maskable Interrupt Control */
+#define REG_EIC_NMIFLAG            (*(RwReg8 *)0x40001803UL) /**< \brief (EIC) Non-Maskable Interrupt Flag Status and Clear */
+#define REG_EIC_EVCTRL             (*(RwReg  *)0x40001804UL) /**< \brief (EIC) Event Control */
+#define REG_EIC_INTENCLR           (*(RwReg  *)0x40001808UL) /**< \brief (EIC) Interrupt Enable Clear */
+#define REG_EIC_INTENSET           (*(RwReg  *)0x4000180CUL) /**< \brief (EIC) Interrupt Enable Set */
+#define REG_EIC_INTFLAG            (*(RwReg  *)0x40001810UL) /**< \brief (EIC) Interrupt Flag Status and Clear */
+#define REG_EIC_WAKEUP             (*(RwReg  *)0x40001814UL) /**< \brief (EIC) Wake-Up Enable */
+#define REG_EIC_CONFIG0            (*(RwReg  *)0x40001818UL) /**< \brief (EIC) Configuration 0 */
+#define REG_EIC_CONFIG1            (*(RwReg  *)0x4000181CUL) /**< \brief (EIC) Configuration 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for EIC peripheral ========== */
+#define EIC_CONFIG_NUM              2        // Number of CONFIG registers
+#define EIC_EXTINT_NUM              16       // Number of External Interrupts
+#define EIC_GCLK_ID                 3        // Index of Generic Clock
+#define EIC_NUMBER_OF_CONFIG_REGS   2        // Number of CONFIG registers (obsolete)
+#define EIC_NUMBER_OF_INTERRUPTS    16       // Number of External Interrupts (obsolete)
+
+#endif /* _SAMD20_EIC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/evsys.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/evsys.h
@@ -1,0 +1,148 @@
+/**
+ * \file
+ *
+ * \brief Instance description for EVSYS
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_EVSYS_INSTANCE_
+#define _SAMD20_EVSYS_INSTANCE_
+
+/* ========== Register definition for EVSYS peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_EVSYS_CTRL             (0x42000400) /**< \brief (EVSYS) Control */
+#define REG_EVSYS_CHANNEL          (0x42000404) /**< \brief (EVSYS) Channel */
+#define REG_EVSYS_USER             (0x42000408) /**< \brief (EVSYS) User Multiplexer */
+#define REG_EVSYS_CHSTATUS         (0x4200040C) /**< \brief (EVSYS) Channel Status */
+#define REG_EVSYS_INTENCLR         (0x42000410) /**< \brief (EVSYS) Interrupt Enable Clear */
+#define REG_EVSYS_INTENSET         (0x42000414) /**< \brief (EVSYS) Interrupt Enable Set */
+#define REG_EVSYS_INTFLAG          (0x42000418) /**< \brief (EVSYS) Interrupt Flag Status and Clear */
+#else
+#define REG_EVSYS_CTRL             (*(WoReg8 *)0x42000400UL) /**< \brief (EVSYS) Control */
+#define REG_EVSYS_CHANNEL          (*(RwReg  *)0x42000404UL) /**< \brief (EVSYS) Channel */
+#define REG_EVSYS_USER             (*(RwReg16*)0x42000408UL) /**< \brief (EVSYS) User Multiplexer */
+#define REG_EVSYS_CHSTATUS         (*(RoReg  *)0x4200040CUL) /**< \brief (EVSYS) Channel Status */
+#define REG_EVSYS_INTENCLR         (*(RwReg  *)0x42000410UL) /**< \brief (EVSYS) Interrupt Enable Clear */
+#define REG_EVSYS_INTENSET         (*(RwReg  *)0x42000414UL) /**< \brief (EVSYS) Interrupt Enable Set */
+#define REG_EVSYS_INTFLAG          (*(RwReg  *)0x42000418UL) /**< \brief (EVSYS) Interrupt Flag Status and Clear */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for EVSYS peripheral ========== */
+#define EVSYS_CHANNELS              8        // Number of Channels
+#define EVSYS_CHANNELS_BITS         3        // Number of bits to select Channel
+#define EVSYS_CHANNELS_MSB          7        // Number of Channels - 1
+#define EVSYS_EXTEVT_NUM            0        // Number of External Event Generators
+#define EVSYS_EXT_EVT_MSB           0        // Number of External Event Generators - 1
+#define EVSYS_GCLK_ID_0             4
+#define EVSYS_GCLK_ID_1             5
+#define EVSYS_GCLK_ID_2             6
+#define EVSYS_GCLK_ID_3             7
+#define EVSYS_GCLK_ID_4             8
+#define EVSYS_GCLK_ID_5             9
+#define EVSYS_GCLK_ID_6             10
+#define EVSYS_GCLK_ID_7             11
+#define EVSYS_GCLK_ID_LSB           4
+#define EVSYS_GCLK_ID_MSB           11
+#define EVSYS_GCLK_ID_SIZE          8
+#define EVSYS_GENERATORS            59       // Total Number of Event Generators
+#define EVSYS_GENERATORS_BITS       6        // Number of bits to select Event Generator
+#define EVSYS_USERS                 14       // Total Number of Event Users
+#define EVSYS_USERS_BITS            4        // Number of bits to select Event User
+
+// GENERATORS
+#define EVSYS_ID_GEN_RTC_CMP_0      1
+#define EVSYS_ID_GEN_RTC_CMP_1      2
+#define EVSYS_ID_GEN_RTC_OVF        3
+#define EVSYS_ID_GEN_RTC_PER_0      4
+#define EVSYS_ID_GEN_RTC_PER_1      5
+#define EVSYS_ID_GEN_RTC_PER_2      6
+#define EVSYS_ID_GEN_RTC_PER_3      7
+#define EVSYS_ID_GEN_RTC_PER_4      8
+#define EVSYS_ID_GEN_RTC_PER_5      9
+#define EVSYS_ID_GEN_RTC_PER_6      10
+#define EVSYS_ID_GEN_RTC_PER_7      11
+#define EVSYS_ID_GEN_EIC_EXTINT_0   12
+#define EVSYS_ID_GEN_EIC_EXTINT_1   13
+#define EVSYS_ID_GEN_EIC_EXTINT_2   14
+#define EVSYS_ID_GEN_EIC_EXTINT_3   15
+#define EVSYS_ID_GEN_EIC_EXTINT_4   16
+#define EVSYS_ID_GEN_EIC_EXTINT_5   17
+#define EVSYS_ID_GEN_EIC_EXTINT_6   18
+#define EVSYS_ID_GEN_EIC_EXTINT_7   19
+#define EVSYS_ID_GEN_EIC_EXTINT_8   20
+#define EVSYS_ID_GEN_EIC_EXTINT_9   21
+#define EVSYS_ID_GEN_EIC_EXTINT_10  22
+#define EVSYS_ID_GEN_EIC_EXTINT_11  23
+#define EVSYS_ID_GEN_EIC_EXTINT_12  24
+#define EVSYS_ID_GEN_EIC_EXTINT_13  25
+#define EVSYS_ID_GEN_EIC_EXTINT_14  26
+#define EVSYS_ID_GEN_EIC_EXTINT_15  27
+#define EVSYS_ID_GEN_TC0_OVF        28
+#define EVSYS_ID_GEN_TC0_MC_0       29
+#define EVSYS_ID_GEN_TC0_MC_1       30
+#define EVSYS_ID_GEN_TC1_OVF        31
+#define EVSYS_ID_GEN_TC1_MC_0       32
+#define EVSYS_ID_GEN_TC1_MC_1       33
+#define EVSYS_ID_GEN_TC2_OVF        34
+#define EVSYS_ID_GEN_TC2_MC_0       35
+#define EVSYS_ID_GEN_TC2_MC_1       36
+#define EVSYS_ID_GEN_TC3_OVF        37
+#define EVSYS_ID_GEN_TC3_MC_0       38
+#define EVSYS_ID_GEN_TC3_MC_1       39
+#define EVSYS_ID_GEN_TC4_OVF        40
+#define EVSYS_ID_GEN_TC4_MC_0       41
+#define EVSYS_ID_GEN_TC4_MC_1       42
+#define EVSYS_ID_GEN_TC5_OVF        43
+#define EVSYS_ID_GEN_TC5_MC_0       44
+#define EVSYS_ID_GEN_TC5_MC_1       45
+#define EVSYS_ID_GEN_TC6_OVF        46
+#define EVSYS_ID_GEN_TC6_MC_0       47
+#define EVSYS_ID_GEN_TC6_MC_1       48
+#define EVSYS_ID_GEN_TC7_OVF        49
+#define EVSYS_ID_GEN_TC7_MC_0       50
+#define EVSYS_ID_GEN_TC7_MC_1       51
+#define EVSYS_ID_GEN_ADC_RESRDY     52
+#define EVSYS_ID_GEN_ADC_WINMON     53
+#define EVSYS_ID_GEN_AC_COMP_0      54
+#define EVSYS_ID_GEN_AC_COMP_1      55
+#define EVSYS_ID_GEN_AC_WIN_0       56
+#define EVSYS_ID_GEN_DAC_EMPTY      57
+
+// USERS
+#define EVSYS_ID_USER_TC0_EVU       0
+#define EVSYS_ID_USER_TC1_EVU       1
+#define EVSYS_ID_USER_TC2_EVU       2
+#define EVSYS_ID_USER_TC3_EVU       3
+#define EVSYS_ID_USER_TC4_EVU       4
+#define EVSYS_ID_USER_TC5_EVU       5
+#define EVSYS_ID_USER_TC6_EVU       6
+#define EVSYS_ID_USER_TC7_EVU       7
+#define EVSYS_ID_USER_ADC_START     8
+#define EVSYS_ID_USER_ADC_SYNC      9
+#define EVSYS_ID_USER_AC_SOC_0      10
+#define EVSYS_ID_USER_AC_SOC_1      11
+#define EVSYS_ID_USER_DAC_START     12
+
+#endif /* _SAMD20_EVSYS_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/gclk.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/gclk.h
@@ -1,0 +1,64 @@
+/**
+ * \file
+ *
+ * \brief Instance description for GCLK
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_GCLK_INSTANCE_
+#define _SAMD20_GCLK_INSTANCE_
+
+/* ========== Register definition for GCLK peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_GCLK_CTRL              (0x40000C00) /**< \brief (GCLK) Control */
+#define REG_GCLK_STATUS            (0x40000C01) /**< \brief (GCLK) Status */
+#define REG_GCLK_CLKCTRL           (0x40000C02) /**< \brief (GCLK) Generic Clock Control */
+#define REG_GCLK_GENCTRL           (0x40000C04) /**< \brief (GCLK) Generic Clock Generator Control */
+#define REG_GCLK_GENDIV            (0x40000C08) /**< \brief (GCLK) Generic Clock Generator Division */
+#else
+#define REG_GCLK_CTRL              (*(RwReg8 *)0x40000C00UL) /**< \brief (GCLK) Control */
+#define REG_GCLK_STATUS            (*(RoReg8 *)0x40000C01UL) /**< \brief (GCLK) Status */
+#define REG_GCLK_CLKCTRL           (*(RwReg16*)0x40000C02UL) /**< \brief (GCLK) Generic Clock Control */
+#define REG_GCLK_GENCTRL           (*(RwReg  *)0x40000C04UL) /**< \brief (GCLK) Generic Clock Generator Control */
+#define REG_GCLK_GENDIV            (*(RwReg  *)0x40000C08UL) /**< \brief (GCLK) Generic Clock Generator Division */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for GCLK peripheral ========== */
+#define GCLK_GENDIV_BITS            16      
+#define GCLK_GEN_NUM                8        // Number of Generic Clock Generators
+#define GCLK_GEN_NUM_MSB            7        // Number of Generic Clock Generators - 1
+#define GCLK_GEN_SOURCE_NUM_MSB     7        // Number of Generic Clock Sources - 1
+#define GCLK_NUM                    28       // Number of Generic Clock Users
+#define GCLK_SOURCE_DFLL48M         7       
+#define GCLK_SOURCE_GCLKGEN1        2       
+#define GCLK_SOURCE_GCLKIN          1       
+#define GCLK_SOURCE_NUM             8        // Number of Generic Clock Sources
+#define GCLK_SOURCE_OSCULP32K       3       
+#define GCLK_SOURCE_OSC8M           6       
+#define GCLK_SOURCE_OSC32K          4       
+#define GCLK_SOURCE_XOSC            0       
+#define GCLK_SOURCE_XOSC32K         5       
+
+#endif /* _SAMD20_GCLK_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/nvmctrl.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/nvmctrl.h
@@ -1,0 +1,78 @@
+/**
+ * \file
+ *
+ * \brief Instance description for NVMCTRL
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_NVMCTRL_INSTANCE_
+#define _SAMD20_NVMCTRL_INSTANCE_
+
+/* ========== Register definition for NVMCTRL peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_NVMCTRL_CTRLA          (0x41004000) /**< \brief (NVMCTRL) Control A */
+#define REG_NVMCTRL_CTRLB          (0x41004004) /**< \brief (NVMCTRL) Control B */
+#define REG_NVMCTRL_PARAM          (0x41004008) /**< \brief (NVMCTRL) NVM Parameter */
+#define REG_NVMCTRL_INTENCLR       (0x4100400C) /**< \brief (NVMCTRL) Interrupt Enable Clear */
+#define REG_NVMCTRL_INTENSET       (0x41004010) /**< \brief (NVMCTRL) Interrupt Enable Set */
+#define REG_NVMCTRL_INTFLAG        (0x41004014) /**< \brief (NVMCTRL) Interrupt Flag Status and Clear */
+#define REG_NVMCTRL_STATUS         (0x41004018) /**< \brief (NVMCTRL) Status */
+#define REG_NVMCTRL_ADDR           (0x4100401C) /**< \brief (NVMCTRL) Address */
+#define REG_NVMCTRL_LOCK           (0x41004020) /**< \brief (NVMCTRL) Lock Section */
+#else
+#define REG_NVMCTRL_CTRLA          (*(RwReg16*)0x41004000UL) /**< \brief (NVMCTRL) Control A */
+#define REG_NVMCTRL_CTRLB          (*(RwReg  *)0x41004004UL) /**< \brief (NVMCTRL) Control B */
+#define REG_NVMCTRL_PARAM          (*(RwReg  *)0x41004008UL) /**< \brief (NVMCTRL) NVM Parameter */
+#define REG_NVMCTRL_INTENCLR       (*(RwReg8 *)0x4100400CUL) /**< \brief (NVMCTRL) Interrupt Enable Clear */
+#define REG_NVMCTRL_INTENSET       (*(RwReg8 *)0x41004010UL) /**< \brief (NVMCTRL) Interrupt Enable Set */
+#define REG_NVMCTRL_INTFLAG        (*(RwReg8 *)0x41004014UL) /**< \brief (NVMCTRL) Interrupt Flag Status and Clear */
+#define REG_NVMCTRL_STATUS         (*(RwReg16*)0x41004018UL) /**< \brief (NVMCTRL) Status */
+#define REG_NVMCTRL_ADDR           (*(RwReg  *)0x4100401CUL) /**< \brief (NVMCTRL) Address */
+#define REG_NVMCTRL_LOCK           (*(RwReg16*)0x41004020UL) /**< \brief (NVMCTRL) Lock Section */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for NVMCTRL peripheral ========== */
+#define NVMCTRL_AUX0_ADDRESS        0x00804000
+#define NVMCTRL_AUX1_ADDRESS        0x00806000
+#define NVMCTRL_AUX2_ADDRESS        0x00808000
+#define NVMCTRL_AUX3_ADDRESS        0x0080A000
+#define NVMCTRL_CLK_AHB_ID          4        // Index of AHB Clock in PM.AHBMASK register
+#define NVMCTRL_FACTORY_WORD_IMPLEMENTED_MASK 0xC0000007FFFFFFFF
+#define NVMCTRL_FLASH_SIZE          65536   
+#define NVMCTRL_LOCKBIT_ADDRESS     0x00802000
+#define NVMCTRL_PAGES               1024    
+#define NVMCTRL_PAGE_HW             32      
+#define NVMCTRL_PAGE_SIZE           64      
+#define NVMCTRL_PAGE_W              16      
+#define NVMCTRL_PMSB                3       
+#define NVMCTRL_PSZ_BITS            6       
+#define NVMCTRL_ROW_PAGES           4       
+#define NVMCTRL_ROW_SIZE            256     
+#define NVMCTRL_TEMP_LOG_ADDRESS    0x00806030
+#define NVMCTRL_USER_PAGE_ADDRESS   0x00800000
+#define NVMCTRL_USER_PAGE_OFFSET    0x00800000
+#define NVMCTRL_USER_WORD_IMPLEMENTED_MASK 0xC01FFFFFFFFFFFFF
+
+#endif /* _SAMD20_NVMCTRL_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/pac0.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/pac0.h
@@ -1,0 +1,45 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PAC0
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PAC0_INSTANCE_
+#define _SAMD20_PAC0_INSTANCE_
+
+/* ========== Register definition for PAC0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PAC0_WPCLR             (0x40000000) /**< \brief (PAC0) Write Protection Clear */
+#define REG_PAC0_WPSET             (0x40000004) /**< \brief (PAC0) Write Protection Set */
+#else
+#define REG_PAC0_WPCLR             (*(RwReg  *)0x40000000UL) /**< \brief (PAC0) Write Protection Clear */
+#define REG_PAC0_WPSET             (*(RwReg  *)0x40000004UL) /**< \brief (PAC0) Write Protection Set */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PAC0 peripheral ========== */
+#define PAC0_WPROT_DEFAULT_VAL      0x00000000 // PAC protection mask at reset
+
+#endif /* _SAMD20_PAC0_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/pac1.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/pac1.h
@@ -1,0 +1,45 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PAC1
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PAC1_INSTANCE_
+#define _SAMD20_PAC1_INSTANCE_
+
+/* ========== Register definition for PAC1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PAC1_WPCLR             (0x41000000) /**< \brief (PAC1) Write Protection Clear */
+#define REG_PAC1_WPSET             (0x41000004) /**< \brief (PAC1) Write Protection Set */
+#else
+#define REG_PAC1_WPCLR             (*(RwReg  *)0x41000000UL) /**< \brief (PAC1) Write Protection Clear */
+#define REG_PAC1_WPSET             (*(RwReg  *)0x41000004UL) /**< \brief (PAC1) Write Protection Set */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PAC1 peripheral ========== */
+#define PAC1_WPROT_DEFAULT_VAL      0x00000002 // PAC protection mask at reset
+
+#endif /* _SAMD20_PAC1_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/pac2.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/pac2.h
@@ -1,0 +1,45 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PAC2
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PAC2_INSTANCE_
+#define _SAMD20_PAC2_INSTANCE_
+
+/* ========== Register definition for PAC2 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PAC2_WPCLR             (0x42000000) /**< \brief (PAC2) Write Protection Clear */
+#define REG_PAC2_WPSET             (0x42000004) /**< \brief (PAC2) Write Protection Set */
+#else
+#define REG_PAC2_WPCLR             (*(RwReg  *)0x42000000UL) /**< \brief (PAC2) Write Protection Clear */
+#define REG_PAC2_WPSET             (*(RwReg  *)0x42000004UL) /**< \brief (PAC2) Write Protection Set */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PAC2 peripheral ========== */
+#define PAC2_WPROT_DEFAULT_VAL      0x00100000 // PAC protection mask at reset
+
+#endif /* _SAMD20_PAC2_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/pm.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/pm.h
@@ -1,0 +1,74 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PM
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PM_INSTANCE_
+#define _SAMD20_PM_INSTANCE_
+
+/* ========== Register definition for PM peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PM_CTRL                (0x40000400) /**< \brief (PM) Control */
+#define REG_PM_SLEEP               (0x40000401) /**< \brief (PM) Sleep Mode */
+#define REG_PM_CPUSEL              (0x40000408) /**< \brief (PM) CPU Clock Select */
+#define REG_PM_APBASEL             (0x40000409) /**< \brief (PM) APBA Clock Select */
+#define REG_PM_APBBSEL             (0x4000040A) /**< \brief (PM) APBB Clock Select */
+#define REG_PM_APBCSEL             (0x4000040B) /**< \brief (PM) APBC Clock Select */
+#define REG_PM_AHBMASK             (0x40000414) /**< \brief (PM) AHB Mask */
+#define REG_PM_APBAMASK            (0x40000418) /**< \brief (PM) APBA Mask */
+#define REG_PM_APBBMASK            (0x4000041C) /**< \brief (PM) APBB Mask */
+#define REG_PM_APBCMASK            (0x40000420) /**< \brief (PM) APBC Mask */
+#define REG_PM_INTENCLR            (0x40000434) /**< \brief (PM) Interrupt Enable Clear */
+#define REG_PM_INTENSET            (0x40000435) /**< \brief (PM) Interrupt Enable Set */
+#define REG_PM_INTFLAG             (0x40000436) /**< \brief (PM) Interrupt Flag Status and Clear */
+#define REG_PM_RCAUSE              (0x40000438) /**< \brief (PM) Reset Cause */
+#else
+#define REG_PM_CTRL                (*(RwReg8 *)0x40000400UL) /**< \brief (PM) Control */
+#define REG_PM_SLEEP               (*(RwReg8 *)0x40000401UL) /**< \brief (PM) Sleep Mode */
+#define REG_PM_CPUSEL              (*(RwReg8 *)0x40000408UL) /**< \brief (PM) CPU Clock Select */
+#define REG_PM_APBASEL             (*(RwReg8 *)0x40000409UL) /**< \brief (PM) APBA Clock Select */
+#define REG_PM_APBBSEL             (*(RwReg8 *)0x4000040AUL) /**< \brief (PM) APBB Clock Select */
+#define REG_PM_APBCSEL             (*(RwReg8 *)0x4000040BUL) /**< \brief (PM) APBC Clock Select */
+#define REG_PM_AHBMASK             (*(RwReg  *)0x40000414UL) /**< \brief (PM) AHB Mask */
+#define REG_PM_APBAMASK            (*(RwReg  *)0x40000418UL) /**< \brief (PM) APBA Mask */
+#define REG_PM_APBBMASK            (*(RwReg  *)0x4000041CUL) /**< \brief (PM) APBB Mask */
+#define REG_PM_APBCMASK            (*(RwReg  *)0x40000420UL) /**< \brief (PM) APBC Mask */
+#define REG_PM_INTENCLR            (*(RwReg8 *)0x40000434UL) /**< \brief (PM) Interrupt Enable Clear */
+#define REG_PM_INTENSET            (*(RwReg8 *)0x40000435UL) /**< \brief (PM) Interrupt Enable Set */
+#define REG_PM_INTFLAG             (*(RwReg8 *)0x40000436UL) /**< \brief (PM) Interrupt Flag Status and Clear */
+#define REG_PM_RCAUSE              (*(RoReg8 *)0x40000438UL) /**< \brief (PM) Reset Cause */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PM peripheral ========== */
+#define PM_CTRL_MCSEL_DFLL48M       3       
+#define PM_CTRL_MCSEL_GCLK          0       
+#define PM_CTRL_MCSEL_OSC8M         1       
+#define PM_CTRL_MCSEL_XOSC          2       
+#define PM_PM_CLK_APB_NUM           2       
+#define PM_SYSTEM_CLOCK             1000000  // System Clock Frequency at Reset
+
+#endif /* _SAMD20_PM_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/port.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/port.h
@@ -1,0 +1,122 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PORT
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PORT_INSTANCE_
+#define _SAMD20_PORT_INSTANCE_
+
+/* ========== Register definition for PORT peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_PORT_DIR0              (0x41004400) /**< \brief (PORT) Data Direction 0 */
+#define REG_PORT_DIRCLR0           (0x41004404) /**< \brief (PORT) Data Direction Clear 0 */
+#define REG_PORT_DIRSET0           (0x41004408) /**< \brief (PORT) Data Direction Set 0 */
+#define REG_PORT_DIRTGL0           (0x4100440C) /**< \brief (PORT) Data Direction Toggle 0 */
+#define REG_PORT_OUT0              (0x41004410) /**< \brief (PORT) Data Output Value 0 */
+#define REG_PORT_OUTCLR0           (0x41004414) /**< \brief (PORT) Data Output Value Clear 0 */
+#define REG_PORT_OUTSET0           (0x41004418) /**< \brief (PORT) Data Output Value Set 0 */
+#define REG_PORT_OUTTGL0           (0x4100441C) /**< \brief (PORT) Data Output Value Toggle 0 */
+#define REG_PORT_IN0               (0x41004420) /**< \brief (PORT) Data Input Value 0 */
+#define REG_PORT_CTRL0             (0x41004424) /**< \brief (PORT) Control 0 */
+#define REG_PORT_WRCONFIG0         (0x41004428) /**< \brief (PORT) Write Configuration 0 */
+#define REG_PORT_PMUX0             (0x41004430) /**< \brief (PORT) Peripheral Multiplexing 0 */
+#define REG_PORT_PINCFG0           (0x41004440) /**< \brief (PORT) Pin Configuration 0 */
+#define REG_PORT_DIR1              (0x41004480) /**< \brief (PORT) Data Direction 1 */
+#define REG_PORT_DIRCLR1           (0x41004484) /**< \brief (PORT) Data Direction Clear 1 */
+#define REG_PORT_DIRSET1           (0x41004488) /**< \brief (PORT) Data Direction Set 1 */
+#define REG_PORT_DIRTGL1           (0x4100448C) /**< \brief (PORT) Data Direction Toggle 1 */
+#define REG_PORT_OUT1              (0x41004490) /**< \brief (PORT) Data Output Value 1 */
+#define REG_PORT_OUTCLR1           (0x41004494) /**< \brief (PORT) Data Output Value Clear 1 */
+#define REG_PORT_OUTSET1           (0x41004498) /**< \brief (PORT) Data Output Value Set 1 */
+#define REG_PORT_OUTTGL1           (0x4100449C) /**< \brief (PORT) Data Output Value Toggle 1 */
+#define REG_PORT_IN1               (0x410044A0) /**< \brief (PORT) Data Input Value 1 */
+#define REG_PORT_CTRL1             (0x410044A4) /**< \brief (PORT) Control 1 */
+#define REG_PORT_WRCONFIG1         (0x410044A8) /**< \brief (PORT) Write Configuration 1 */
+#define REG_PORT_PMUX1             (0x410044B0) /**< \brief (PORT) Peripheral Multiplexing 1 */
+#define REG_PORT_PINCFG1           (0x410044C0) /**< \brief (PORT) Pin Configuration 1 */
+#else
+#define REG_PORT_DIR0              (*(RwReg  *)0x41004400UL) /**< \brief (PORT) Data Direction 0 */
+#define REG_PORT_DIRCLR0           (*(RwReg  *)0x41004404UL) /**< \brief (PORT) Data Direction Clear 0 */
+#define REG_PORT_DIRSET0           (*(RwReg  *)0x41004408UL) /**< \brief (PORT) Data Direction Set 0 */
+#define REG_PORT_DIRTGL0           (*(RwReg  *)0x4100440CUL) /**< \brief (PORT) Data Direction Toggle 0 */
+#define REG_PORT_OUT0              (*(RwReg  *)0x41004410UL) /**< \brief (PORT) Data Output Value 0 */
+#define REG_PORT_OUTCLR0           (*(RwReg  *)0x41004414UL) /**< \brief (PORT) Data Output Value Clear 0 */
+#define REG_PORT_OUTSET0           (*(RwReg  *)0x41004418UL) /**< \brief (PORT) Data Output Value Set 0 */
+#define REG_PORT_OUTTGL0           (*(RwReg  *)0x4100441CUL) /**< \brief (PORT) Data Output Value Toggle 0 */
+#define REG_PORT_IN0               (*(RoReg  *)0x41004420UL) /**< \brief (PORT) Data Input Value 0 */
+#define REG_PORT_CTRL0             (*(RwReg  *)0x41004424UL) /**< \brief (PORT) Control 0 */
+#define REG_PORT_WRCONFIG0         (*(WoReg  *)0x41004428UL) /**< \brief (PORT) Write Configuration 0 */
+#define REG_PORT_PMUX0             (*(RwReg8 *)0x41004430UL) /**< \brief (PORT) Peripheral Multiplexing 0 */
+#define REG_PORT_PINCFG0           (*(RwReg8 *)0x41004440UL) /**< \brief (PORT) Pin Configuration 0 */
+#define REG_PORT_DIR1              (*(RwReg  *)0x41004480UL) /**< \brief (PORT) Data Direction 1 */
+#define REG_PORT_DIRCLR1           (*(RwReg  *)0x41004484UL) /**< \brief (PORT) Data Direction Clear 1 */
+#define REG_PORT_DIRSET1           (*(RwReg  *)0x41004488UL) /**< \brief (PORT) Data Direction Set 1 */
+#define REG_PORT_DIRTGL1           (*(RwReg  *)0x4100448CUL) /**< \brief (PORT) Data Direction Toggle 1 */
+#define REG_PORT_OUT1              (*(RwReg  *)0x41004490UL) /**< \brief (PORT) Data Output Value 1 */
+#define REG_PORT_OUTCLR1           (*(RwReg  *)0x41004494UL) /**< \brief (PORT) Data Output Value Clear 1 */
+#define REG_PORT_OUTSET1           (*(RwReg  *)0x41004498UL) /**< \brief (PORT) Data Output Value Set 1 */
+#define REG_PORT_OUTTGL1           (*(RwReg  *)0x4100449CUL) /**< \brief (PORT) Data Output Value Toggle 1 */
+#define REG_PORT_IN1               (*(RoReg  *)0x410044A0UL) /**< \brief (PORT) Data Input Value 1 */
+#define REG_PORT_CTRL1             (*(RwReg  *)0x410044A4UL) /**< \brief (PORT) Control 1 */
+#define REG_PORT_WRCONFIG1         (*(WoReg  *)0x410044A8UL) /**< \brief (PORT) Write Configuration 1 */
+#define REG_PORT_PMUX1             (*(RwReg8 *)0x410044B0UL) /**< \brief (PORT) Peripheral Multiplexing 1 */
+#define REG_PORT_PINCFG1           (*(RwReg8 *)0x410044C0UL) /**< \brief (PORT) Pin Configuration 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for PORT peripheral ========== */
+#define PORT_BITS                   64       // Number of PORT pins
+#define PORT_DIR_DEFAULT_VAL        { 0x00000000, 0x00000000 } // Default value for DIR of all pins
+#define PORT_DIR_IMPLEMENTED        { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for DIR of all pins
+#define PORT_DRVSTR                 1        // DRVSTR supported
+#define PORT_DRVSTR_DEFAULT_VAL     { 0xDBFFFFFF, 0xC0C3FFFF } // Default value for DRVSTR of all pins
+#define PORT_DRVSTR_IMPLEMENTED     { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for DRVSTR of all pins
+#define PORT_EVENT_IMPLEMENTED      { 0x00000000, 0x00000000 }
+#define PORT_INEN_DEFAULT_VAL       { 0x00000000, 0x00000000 } // Default value for INEN of all pins
+#define PORT_INEN_IMPLEMENTED       { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for INEN of all pins
+#define PORT_ODRAIN                 0        // ODRAIN supported
+#define PORT_ODRAIN_DEFAULT_VAL     { 0x00000000, 0x00000000 } // Default value for ODRAIN of all pins
+#define PORT_ODRAIN_IMPLEMENTED     { 0x00000000, 0x00000000 } // Implementation mask for ODRAIN of all pins
+#define PORT_OUT_DEFAULT_VAL        { 0x00000000, 0x00000000 } // Default value for OUT of all pins
+#define PORT_OUT_IMPLEMENTED        { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for OUT of all pins
+#define PORT_PIN_IMPLEMENTED        { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for all PORT pins
+#define PORT_PMUXBIT0_DEFAULT_VAL   { 0x00000000, 0x00000000 } // Default value for PMUX[0] of all pins
+#define PORT_PMUXBIT0_IMPLEMENTED   { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for PMUX[0] of all pins
+#define PORT_PMUXBIT1_DEFAULT_VAL   { 0x40000000, 0x00000000 } // Default value for PMUX[1] of all pins
+#define PORT_PMUXBIT1_IMPLEMENTED   { 0xDBFFFFF3, 0xC0C3FF0F } // Implementation mask for PMUX[1] of all pins
+#define PORT_PMUXBIT2_DEFAULT_VAL   { 0x40000000, 0x00000000 } // Default value for PMUX[2] of all pins
+#define PORT_PMUXBIT2_IMPLEMENTED   { 0xDBFFFFF3, 0xC0C3FF0F } // Implementation mask for PMUX[2] of all pins
+#define PORT_PMUXBIT3_DEFAULT_VAL   { 0x00000000, 0x00000000 } // Default value for PMUX[3] of all pins
+#define PORT_PMUXBIT3_IMPLEMENTED   { 0x00000000, 0x00000000 } // Implementation mask for PMUX[3] of all pins
+#define PORT_PMUXEN_DEFAULT_VAL     { 0x64000000, 0x3F3C0000 } // Default value for PMUXEN of all pins
+#define PORT_PMUXEN_IMPLEMENTED     { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for PMUXEN of all pins
+#define PORT_PULLEN_DEFAULT_VAL     { 0x00000000, 0x00000000 } // Default value for PULLEN of all pins
+#define PORT_PULLEN_IMPLEMENTED     { 0xDBFFFFFF, 0xC0C3FFFF } // Implementation mask for PULLEN of all pins
+#define PORT_SLEWLIM                0        // SLEWLIM supported
+#define PORT_SLEWLIM_DEFAULT_VAL    { 0x00000000, 0x00000000 } // Default value for SLEWLIM of all pins
+#define PORT_SLEWLIM_IMPLEMENTED    { 0x00000000, 0x00000000 } // Implementation mask for SLEWLIM of all pins
+
+#endif /* _SAMD20_PORT_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/ptc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/ptc.h
@@ -1,0 +1,36 @@
+/**
+ * \file
+ *
+ * \brief Instance description for PTC
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_PTC_INSTANCE_
+#define _SAMD20_PTC_INSTANCE_
+
+/* ========== Instance parameters for PTC peripheral ========== */
+#define PTC_GCLK_ID                 27       // Index of Generic Clock
+
+#endif /* _SAMD20_PTC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/rtc.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/rtc.h
@@ -1,0 +1,103 @@
+/**
+ * \file
+ *
+ * \brief Instance description for RTC
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_RTC_INSTANCE_
+#define _SAMD20_RTC_INSTANCE_
+
+/* ========== Register definition for RTC peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_RTC_READREQ            (0x40001402) /**< \brief (RTC) Read Request */
+#define REG_RTC_STATUS             (0x4000140A) /**< \brief (RTC) Status */
+#define REG_RTC_DBGCTRL            (0x4000140B) /**< \brief (RTC) Debug Control */
+#define REG_RTC_FREQCORR           (0x4000140C) /**< \brief (RTC) Frequency Correction */
+#define REG_RTC_MODE0_CTRL         (0x40001400) /**< \brief (RTC) MODE0 Control */
+#define REG_RTC_MODE0_EVCTRL       (0x40001404) /**< \brief (RTC) MODE0 Event Control */
+#define REG_RTC_MODE0_INTENCLR     (0x40001406) /**< \brief (RTC) MODE0 Interrupt Enable Clear */
+#define REG_RTC_MODE0_INTENSET     (0x40001407) /**< \brief (RTC) MODE0 Interrupt Enable Set */
+#define REG_RTC_MODE0_INTFLAG      (0x40001408) /**< \brief (RTC) MODE0 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE0_COUNT        (0x40001410) /**< \brief (RTC) MODE0 Counter Value */
+#define REG_RTC_MODE0_COMP0        (0x40001418) /**< \brief (RTC) MODE0 Compare 0 Value */
+#define REG_RTC_MODE1_CTRL         (0x40001400) /**< \brief (RTC) MODE1 Control */
+#define REG_RTC_MODE1_EVCTRL       (0x40001404) /**< \brief (RTC) MODE1 Event Control */
+#define REG_RTC_MODE1_INTENCLR     (0x40001406) /**< \brief (RTC) MODE1 Interrupt Enable Clear */
+#define REG_RTC_MODE1_INTENSET     (0x40001407) /**< \brief (RTC) MODE1 Interrupt Enable Set */
+#define REG_RTC_MODE1_INTFLAG      (0x40001408) /**< \brief (RTC) MODE1 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE1_COUNT        (0x40001410) /**< \brief (RTC) MODE1 Counter Value */
+#define REG_RTC_MODE1_PER          (0x40001414) /**< \brief (RTC) MODE1 Counter Period */
+#define REG_RTC_MODE1_COMP0        (0x40001418) /**< \brief (RTC) MODE1 Compare 0 Value */
+#define REG_RTC_MODE1_COMP1        (0x4000141A) /**< \brief (RTC) MODE1 Compare 1 Value */
+#define REG_RTC_MODE2_CTRL         (0x40001400) /**< \brief (RTC) MODE2 Control */
+#define REG_RTC_MODE2_EVCTRL       (0x40001404) /**< \brief (RTC) MODE2 Event Control */
+#define REG_RTC_MODE2_INTENCLR     (0x40001406) /**< \brief (RTC) MODE2 Interrupt Enable Clear */
+#define REG_RTC_MODE2_INTENSET     (0x40001407) /**< \brief (RTC) MODE2 Interrupt Enable Set */
+#define REG_RTC_MODE2_INTFLAG      (0x40001408) /**< \brief (RTC) MODE2 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE2_CLOCK        (0x40001410) /**< \brief (RTC) MODE2 Clock Value */
+#define REG_RTC_MODE2_ALARM_ALARM0 (0x40001418) /**< \brief (RTC) MODE2_ALARM Alarm 0 Value */
+#define REG_RTC_MODE2_ALARM_MASK0  (0x4000141C) /**< \brief (RTC) MODE2_ALARM Alarm 0 Mask */
+#else
+#define REG_RTC_READREQ            (*(RwReg16*)0x40001402UL) /**< \brief (RTC) Read Request */
+#define REG_RTC_STATUS             (*(RwReg8 *)0x4000140AUL) /**< \brief (RTC) Status */
+#define REG_RTC_DBGCTRL            (*(RwReg8 *)0x4000140BUL) /**< \brief (RTC) Debug Control */
+#define REG_RTC_FREQCORR           (*(RwReg8 *)0x4000140CUL) /**< \brief (RTC) Frequency Correction */
+#define REG_RTC_MODE0_CTRL         (*(RwReg16*)0x40001400UL) /**< \brief (RTC) MODE0 Control */
+#define REG_RTC_MODE0_EVCTRL       (*(RwReg16*)0x40001404UL) /**< \brief (RTC) MODE0 Event Control */
+#define REG_RTC_MODE0_INTENCLR     (*(RwReg8 *)0x40001406UL) /**< \brief (RTC) MODE0 Interrupt Enable Clear */
+#define REG_RTC_MODE0_INTENSET     (*(RwReg8 *)0x40001407UL) /**< \brief (RTC) MODE0 Interrupt Enable Set */
+#define REG_RTC_MODE0_INTFLAG      (*(RwReg8 *)0x40001408UL) /**< \brief (RTC) MODE0 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE0_COUNT        (*(RwReg  *)0x40001410UL) /**< \brief (RTC) MODE0 Counter Value */
+#define REG_RTC_MODE0_COMP0        (*(RwReg  *)0x40001418UL) /**< \brief (RTC) MODE0 Compare 0 Value */
+#define REG_RTC_MODE1_CTRL         (*(RwReg16*)0x40001400UL) /**< \brief (RTC) MODE1 Control */
+#define REG_RTC_MODE1_EVCTRL       (*(RwReg16*)0x40001404UL) /**< \brief (RTC) MODE1 Event Control */
+#define REG_RTC_MODE1_INTENCLR     (*(RwReg8 *)0x40001406UL) /**< \brief (RTC) MODE1 Interrupt Enable Clear */
+#define REG_RTC_MODE1_INTENSET     (*(RwReg8 *)0x40001407UL) /**< \brief (RTC) MODE1 Interrupt Enable Set */
+#define REG_RTC_MODE1_INTFLAG      (*(RwReg8 *)0x40001408UL) /**< \brief (RTC) MODE1 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE1_COUNT        (*(RwReg16*)0x40001410UL) /**< \brief (RTC) MODE1 Counter Value */
+#define REG_RTC_MODE1_PER          (*(RwReg16*)0x40001414UL) /**< \brief (RTC) MODE1 Counter Period */
+#define REG_RTC_MODE1_COMP0        (*(RwReg16*)0x40001418UL) /**< \brief (RTC) MODE1 Compare 0 Value */
+#define REG_RTC_MODE1_COMP1        (*(RwReg16*)0x4000141AUL) /**< \brief (RTC) MODE1 Compare 1 Value */
+#define REG_RTC_MODE2_CTRL         (*(RwReg16*)0x40001400UL) /**< \brief (RTC) MODE2 Control */
+#define REG_RTC_MODE2_EVCTRL       (*(RwReg16*)0x40001404UL) /**< \brief (RTC) MODE2 Event Control */
+#define REG_RTC_MODE2_INTENCLR     (*(RwReg8 *)0x40001406UL) /**< \brief (RTC) MODE2 Interrupt Enable Clear */
+#define REG_RTC_MODE2_INTENSET     (*(RwReg8 *)0x40001407UL) /**< \brief (RTC) MODE2 Interrupt Enable Set */
+#define REG_RTC_MODE2_INTFLAG      (*(RwReg8 *)0x40001408UL) /**< \brief (RTC) MODE2 Interrupt Flag Status and Clear */
+#define REG_RTC_MODE2_CLOCK        (*(RwReg  *)0x40001410UL) /**< \brief (RTC) MODE2 Clock Value */
+#define REG_RTC_MODE2_ALARM_ALARM0 (*(RwReg  *)0x40001418UL) /**< \brief (RTC) MODE2_ALARM Alarm 0 Value */
+#define REG_RTC_MODE2_ALARM_MASK0  (*(RwReg8 *)0x4000141CUL) /**< \brief (RTC) MODE2_ALARM Alarm 0 Mask */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for RTC peripheral ========== */
+#define RTC_ALARM_NUM               1        // Number of Alarms
+#define RTC_COMP16_NUM              2        // Number of 16-bit Comparators
+#define RTC_COMP32_NUM              1        // Number of 32-bit Comparators
+#define RTC_GCLK_ID                 2        // Index of Generic Clock
+#define RTC_NUM_OF_ALARMS           1        // Number of Alarms (obsolete)
+#define RTC_NUM_OF_COMP16           2        // Number of 16-bit Comparators (obsolete)
+#define RTC_NUM_OF_COMP32           1        // Number of 32-bit Comparators (obsolete)
+
+#endif /* _SAMD20_RTC_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/sercom0.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/sercom0.h
@@ -1,0 +1,118 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM0
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SERCOM0_INSTANCE_
+#define _SAMD20_SERCOM0_INSTANCE_
+
+/* ========== Register definition for SERCOM0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM0_I2CM_CTRLA     (0x42000800) /**< \brief (SERCOM0) I2CM Control A */
+#define REG_SERCOM0_I2CM_CTRLB     (0x42000804) /**< \brief (SERCOM0) I2CM Control B */
+#define REG_SERCOM0_I2CM_DBGCTRL   (0x42000808) /**< \brief (SERCOM0) I2CM Debug Control */
+#define REG_SERCOM0_I2CM_BAUD      (0x4200080A) /**< \brief (SERCOM0) I2CM Baud Rate */
+#define REG_SERCOM0_I2CM_INTENCLR  (0x4200080C) /**< \brief (SERCOM0) I2CM Interrupt Enable Clear */
+#define REG_SERCOM0_I2CM_INTENSET  (0x4200080D) /**< \brief (SERCOM0) I2CM Interrupt Enable Set */
+#define REG_SERCOM0_I2CM_INTFLAG   (0x4200080E) /**< \brief (SERCOM0) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CM_STATUS    (0x42000810) /**< \brief (SERCOM0) I2CM Status */
+#define REG_SERCOM0_I2CM_ADDR      (0x42000814) /**< \brief (SERCOM0) I2CM Address */
+#define REG_SERCOM0_I2CM_DATA      (0x42000818) /**< \brief (SERCOM0) I2CM Data */
+#define REG_SERCOM0_I2CS_CTRLA     (0x42000800) /**< \brief (SERCOM0) I2CS Control A */
+#define REG_SERCOM0_I2CS_CTRLB     (0x42000804) /**< \brief (SERCOM0) I2CS Control B */
+#define REG_SERCOM0_I2CS_INTENCLR  (0x4200080C) /**< \brief (SERCOM0) I2CS Interrupt Enable Clear */
+#define REG_SERCOM0_I2CS_INTENSET  (0x4200080D) /**< \brief (SERCOM0) I2CS Interrupt Enable Set */
+#define REG_SERCOM0_I2CS_INTFLAG   (0x4200080E) /**< \brief (SERCOM0) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CS_STATUS    (0x42000810) /**< \brief (SERCOM0) I2CS Status */
+#define REG_SERCOM0_I2CS_ADDR      (0x42000814) /**< \brief (SERCOM0) I2CS Address */
+#define REG_SERCOM0_I2CS_DATA      (0x42000818) /**< \brief (SERCOM0) I2CS Data */
+#define REG_SERCOM0_SPI_CTRLA      (0x42000800) /**< \brief (SERCOM0) SPI Control A */
+#define REG_SERCOM0_SPI_CTRLB      (0x42000804) /**< \brief (SERCOM0) SPI Control B */
+#define REG_SERCOM0_SPI_DBGCTRL    (0x42000808) /**< \brief (SERCOM0) SPI Debug Control */
+#define REG_SERCOM0_SPI_BAUD       (0x4200080A) /**< \brief (SERCOM0) SPI Baud Rate */
+#define REG_SERCOM0_SPI_INTENCLR   (0x4200080C) /**< \brief (SERCOM0) SPI Interrupt Enable Clear */
+#define REG_SERCOM0_SPI_INTENSET   (0x4200080D) /**< \brief (SERCOM0) SPI Interrupt Enable Set */
+#define REG_SERCOM0_SPI_INTFLAG    (0x4200080E) /**< \brief (SERCOM0) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM0_SPI_STATUS     (0x42000810) /**< \brief (SERCOM0) SPI Status */
+#define REG_SERCOM0_SPI_ADDR       (0x42000814) /**< \brief (SERCOM0) SPI Address */
+#define REG_SERCOM0_SPI_DATA       (0x42000818) /**< \brief (SERCOM0) SPI Data */
+#define REG_SERCOM0_USART_CTRLA    (0x42000800) /**< \brief (SERCOM0) USART Control A */
+#define REG_SERCOM0_USART_CTRLB    (0x42000804) /**< \brief (SERCOM0) USART Control B */
+#define REG_SERCOM0_USART_DBGCTRL  (0x42000808) /**< \brief (SERCOM0) USART Debug Control */
+#define REG_SERCOM0_USART_BAUD     (0x4200080A) /**< \brief (SERCOM0) USART Baud */
+#define REG_SERCOM0_USART_INTENCLR (0x4200080C) /**< \brief (SERCOM0) USART Interrupt Enable Clear */
+#define REG_SERCOM0_USART_INTENSET (0x4200080D) /**< \brief (SERCOM0) USART Interrupt Enable Set */
+#define REG_SERCOM0_USART_INTFLAG  (0x4200080E) /**< \brief (SERCOM0) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM0_USART_STATUS   (0x42000810) /**< \brief (SERCOM0) USART Status */
+#define REG_SERCOM0_USART_DATA     (0x42000818) /**< \brief (SERCOM0) USART Data */
+#else
+#define REG_SERCOM0_I2CM_CTRLA     (*(RwReg  *)0x42000800UL) /**< \brief (SERCOM0) I2CM Control A */
+#define REG_SERCOM0_I2CM_CTRLB     (*(RwReg  *)0x42000804UL) /**< \brief (SERCOM0) I2CM Control B */
+#define REG_SERCOM0_I2CM_DBGCTRL   (*(RwReg8 *)0x42000808UL) /**< \brief (SERCOM0) I2CM Debug Control */
+#define REG_SERCOM0_I2CM_BAUD      (*(RwReg16*)0x4200080AUL) /**< \brief (SERCOM0) I2CM Baud Rate */
+#define REG_SERCOM0_I2CM_INTENCLR  (*(RwReg8 *)0x4200080CUL) /**< \brief (SERCOM0) I2CM Interrupt Enable Clear */
+#define REG_SERCOM0_I2CM_INTENSET  (*(RwReg8 *)0x4200080DUL) /**< \brief (SERCOM0) I2CM Interrupt Enable Set */
+#define REG_SERCOM0_I2CM_INTFLAG   (*(RwReg8 *)0x4200080EUL) /**< \brief (SERCOM0) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CM_STATUS    (*(RwReg16*)0x42000810UL) /**< \brief (SERCOM0) I2CM Status */
+#define REG_SERCOM0_I2CM_ADDR      (*(RwReg8 *)0x42000814UL) /**< \brief (SERCOM0) I2CM Address */
+#define REG_SERCOM0_I2CM_DATA      (*(RwReg8 *)0x42000818UL) /**< \brief (SERCOM0) I2CM Data */
+#define REG_SERCOM0_I2CS_CTRLA     (*(RwReg  *)0x42000800UL) /**< \brief (SERCOM0) I2CS Control A */
+#define REG_SERCOM0_I2CS_CTRLB     (*(RwReg  *)0x42000804UL) /**< \brief (SERCOM0) I2CS Control B */
+#define REG_SERCOM0_I2CS_INTENCLR  (*(RwReg8 *)0x4200080CUL) /**< \brief (SERCOM0) I2CS Interrupt Enable Clear */
+#define REG_SERCOM0_I2CS_INTENSET  (*(RwReg8 *)0x4200080DUL) /**< \brief (SERCOM0) I2CS Interrupt Enable Set */
+#define REG_SERCOM0_I2CS_INTFLAG   (*(RwReg8 *)0x4200080EUL) /**< \brief (SERCOM0) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM0_I2CS_STATUS    (*(RwReg16*)0x42000810UL) /**< \brief (SERCOM0) I2CS Status */
+#define REG_SERCOM0_I2CS_ADDR      (*(RwReg  *)0x42000814UL) /**< \brief (SERCOM0) I2CS Address */
+#define REG_SERCOM0_I2CS_DATA      (*(RwReg8 *)0x42000818UL) /**< \brief (SERCOM0) I2CS Data */
+#define REG_SERCOM0_SPI_CTRLA      (*(RwReg  *)0x42000800UL) /**< \brief (SERCOM0) SPI Control A */
+#define REG_SERCOM0_SPI_CTRLB      (*(RwReg  *)0x42000804UL) /**< \brief (SERCOM0) SPI Control B */
+#define REG_SERCOM0_SPI_DBGCTRL    (*(RwReg8 *)0x42000808UL) /**< \brief (SERCOM0) SPI Debug Control */
+#define REG_SERCOM0_SPI_BAUD       (*(RwReg8 *)0x4200080AUL) /**< \brief (SERCOM0) SPI Baud Rate */
+#define REG_SERCOM0_SPI_INTENCLR   (*(RwReg8 *)0x4200080CUL) /**< \brief (SERCOM0) SPI Interrupt Enable Clear */
+#define REG_SERCOM0_SPI_INTENSET   (*(RwReg8 *)0x4200080DUL) /**< \brief (SERCOM0) SPI Interrupt Enable Set */
+#define REG_SERCOM0_SPI_INTFLAG    (*(RwReg8 *)0x4200080EUL) /**< \brief (SERCOM0) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM0_SPI_STATUS     (*(RwReg16*)0x42000810UL) /**< \brief (SERCOM0) SPI Status */
+#define REG_SERCOM0_SPI_ADDR       (*(RwReg  *)0x42000814UL) /**< \brief (SERCOM0) SPI Address */
+#define REG_SERCOM0_SPI_DATA       (*(RwReg16*)0x42000818UL) /**< \brief (SERCOM0) SPI Data */
+#define REG_SERCOM0_USART_CTRLA    (*(RwReg  *)0x42000800UL) /**< \brief (SERCOM0) USART Control A */
+#define REG_SERCOM0_USART_CTRLB    (*(RwReg  *)0x42000804UL) /**< \brief (SERCOM0) USART Control B */
+#define REG_SERCOM0_USART_DBGCTRL  (*(RwReg8 *)0x42000808UL) /**< \brief (SERCOM0) USART Debug Control */
+#define REG_SERCOM0_USART_BAUD     (*(RwReg16*)0x4200080AUL) /**< \brief (SERCOM0) USART Baud */
+#define REG_SERCOM0_USART_INTENCLR (*(RwReg8 *)0x4200080CUL) /**< \brief (SERCOM0) USART Interrupt Enable Clear */
+#define REG_SERCOM0_USART_INTENSET (*(RwReg8 *)0x4200080DUL) /**< \brief (SERCOM0) USART Interrupt Enable Set */
+#define REG_SERCOM0_USART_INTFLAG  (*(RwReg8 *)0x4200080EUL) /**< \brief (SERCOM0) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM0_USART_STATUS   (*(RwReg16*)0x42000810UL) /**< \brief (SERCOM0) USART Status */
+#define REG_SERCOM0_USART_DATA     (*(RwReg16*)0x42000818UL) /**< \brief (SERCOM0) USART Data */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM0 peripheral ========== */
+#define SERCOM0_GCLK_ID_CORE        13      
+#define SERCOM0_GCLK_ID_SLOW        12      
+#define SERCOM0_INT_MSB             3       
+#define SERCOM0_PMSB                3       
+
+#endif /* _SAMD20_SERCOM0_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/sercom1.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/sercom1.h
@@ -1,0 +1,118 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM1
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SERCOM1_INSTANCE_
+#define _SAMD20_SERCOM1_INSTANCE_
+
+/* ========== Register definition for SERCOM1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM1_I2CM_CTRLA     (0x42000C00) /**< \brief (SERCOM1) I2CM Control A */
+#define REG_SERCOM1_I2CM_CTRLB     (0x42000C04) /**< \brief (SERCOM1) I2CM Control B */
+#define REG_SERCOM1_I2CM_DBGCTRL   (0x42000C08) /**< \brief (SERCOM1) I2CM Debug Control */
+#define REG_SERCOM1_I2CM_BAUD      (0x42000C0A) /**< \brief (SERCOM1) I2CM Baud Rate */
+#define REG_SERCOM1_I2CM_INTENCLR  (0x42000C0C) /**< \brief (SERCOM1) I2CM Interrupt Enable Clear */
+#define REG_SERCOM1_I2CM_INTENSET  (0x42000C0D) /**< \brief (SERCOM1) I2CM Interrupt Enable Set */
+#define REG_SERCOM1_I2CM_INTFLAG   (0x42000C0E) /**< \brief (SERCOM1) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CM_STATUS    (0x42000C10) /**< \brief (SERCOM1) I2CM Status */
+#define REG_SERCOM1_I2CM_ADDR      (0x42000C14) /**< \brief (SERCOM1) I2CM Address */
+#define REG_SERCOM1_I2CM_DATA      (0x42000C18) /**< \brief (SERCOM1) I2CM Data */
+#define REG_SERCOM1_I2CS_CTRLA     (0x42000C00) /**< \brief (SERCOM1) I2CS Control A */
+#define REG_SERCOM1_I2CS_CTRLB     (0x42000C04) /**< \brief (SERCOM1) I2CS Control B */
+#define REG_SERCOM1_I2CS_INTENCLR  (0x42000C0C) /**< \brief (SERCOM1) I2CS Interrupt Enable Clear */
+#define REG_SERCOM1_I2CS_INTENSET  (0x42000C0D) /**< \brief (SERCOM1) I2CS Interrupt Enable Set */
+#define REG_SERCOM1_I2CS_INTFLAG   (0x42000C0E) /**< \brief (SERCOM1) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CS_STATUS    (0x42000C10) /**< \brief (SERCOM1) I2CS Status */
+#define REG_SERCOM1_I2CS_ADDR      (0x42000C14) /**< \brief (SERCOM1) I2CS Address */
+#define REG_SERCOM1_I2CS_DATA      (0x42000C18) /**< \brief (SERCOM1) I2CS Data */
+#define REG_SERCOM1_SPI_CTRLA      (0x42000C00) /**< \brief (SERCOM1) SPI Control A */
+#define REG_SERCOM1_SPI_CTRLB      (0x42000C04) /**< \brief (SERCOM1) SPI Control B */
+#define REG_SERCOM1_SPI_DBGCTRL    (0x42000C08) /**< \brief (SERCOM1) SPI Debug Control */
+#define REG_SERCOM1_SPI_BAUD       (0x42000C0A) /**< \brief (SERCOM1) SPI Baud Rate */
+#define REG_SERCOM1_SPI_INTENCLR   (0x42000C0C) /**< \brief (SERCOM1) SPI Interrupt Enable Clear */
+#define REG_SERCOM1_SPI_INTENSET   (0x42000C0D) /**< \brief (SERCOM1) SPI Interrupt Enable Set */
+#define REG_SERCOM1_SPI_INTFLAG    (0x42000C0E) /**< \brief (SERCOM1) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM1_SPI_STATUS     (0x42000C10) /**< \brief (SERCOM1) SPI Status */
+#define REG_SERCOM1_SPI_ADDR       (0x42000C14) /**< \brief (SERCOM1) SPI Address */
+#define REG_SERCOM1_SPI_DATA       (0x42000C18) /**< \brief (SERCOM1) SPI Data */
+#define REG_SERCOM1_USART_CTRLA    (0x42000C00) /**< \brief (SERCOM1) USART Control A */
+#define REG_SERCOM1_USART_CTRLB    (0x42000C04) /**< \brief (SERCOM1) USART Control B */
+#define REG_SERCOM1_USART_DBGCTRL  (0x42000C08) /**< \brief (SERCOM1) USART Debug Control */
+#define REG_SERCOM1_USART_BAUD     (0x42000C0A) /**< \brief (SERCOM1) USART Baud */
+#define REG_SERCOM1_USART_INTENCLR (0x42000C0C) /**< \brief (SERCOM1) USART Interrupt Enable Clear */
+#define REG_SERCOM1_USART_INTENSET (0x42000C0D) /**< \brief (SERCOM1) USART Interrupt Enable Set */
+#define REG_SERCOM1_USART_INTFLAG  (0x42000C0E) /**< \brief (SERCOM1) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM1_USART_STATUS   (0x42000C10) /**< \brief (SERCOM1) USART Status */
+#define REG_SERCOM1_USART_DATA     (0x42000C18) /**< \brief (SERCOM1) USART Data */
+#else
+#define REG_SERCOM1_I2CM_CTRLA     (*(RwReg  *)0x42000C00UL) /**< \brief (SERCOM1) I2CM Control A */
+#define REG_SERCOM1_I2CM_CTRLB     (*(RwReg  *)0x42000C04UL) /**< \brief (SERCOM1) I2CM Control B */
+#define REG_SERCOM1_I2CM_DBGCTRL   (*(RwReg8 *)0x42000C08UL) /**< \brief (SERCOM1) I2CM Debug Control */
+#define REG_SERCOM1_I2CM_BAUD      (*(RwReg16*)0x42000C0AUL) /**< \brief (SERCOM1) I2CM Baud Rate */
+#define REG_SERCOM1_I2CM_INTENCLR  (*(RwReg8 *)0x42000C0CUL) /**< \brief (SERCOM1) I2CM Interrupt Enable Clear */
+#define REG_SERCOM1_I2CM_INTENSET  (*(RwReg8 *)0x42000C0DUL) /**< \brief (SERCOM1) I2CM Interrupt Enable Set */
+#define REG_SERCOM1_I2CM_INTFLAG   (*(RwReg8 *)0x42000C0EUL) /**< \brief (SERCOM1) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CM_STATUS    (*(RwReg16*)0x42000C10UL) /**< \brief (SERCOM1) I2CM Status */
+#define REG_SERCOM1_I2CM_ADDR      (*(RwReg8 *)0x42000C14UL) /**< \brief (SERCOM1) I2CM Address */
+#define REG_SERCOM1_I2CM_DATA      (*(RwReg8 *)0x42000C18UL) /**< \brief (SERCOM1) I2CM Data */
+#define REG_SERCOM1_I2CS_CTRLA     (*(RwReg  *)0x42000C00UL) /**< \brief (SERCOM1) I2CS Control A */
+#define REG_SERCOM1_I2CS_CTRLB     (*(RwReg  *)0x42000C04UL) /**< \brief (SERCOM1) I2CS Control B */
+#define REG_SERCOM1_I2CS_INTENCLR  (*(RwReg8 *)0x42000C0CUL) /**< \brief (SERCOM1) I2CS Interrupt Enable Clear */
+#define REG_SERCOM1_I2CS_INTENSET  (*(RwReg8 *)0x42000C0DUL) /**< \brief (SERCOM1) I2CS Interrupt Enable Set */
+#define REG_SERCOM1_I2CS_INTFLAG   (*(RwReg8 *)0x42000C0EUL) /**< \brief (SERCOM1) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM1_I2CS_STATUS    (*(RwReg16*)0x42000C10UL) /**< \brief (SERCOM1) I2CS Status */
+#define REG_SERCOM1_I2CS_ADDR      (*(RwReg  *)0x42000C14UL) /**< \brief (SERCOM1) I2CS Address */
+#define REG_SERCOM1_I2CS_DATA      (*(RwReg8 *)0x42000C18UL) /**< \brief (SERCOM1) I2CS Data */
+#define REG_SERCOM1_SPI_CTRLA      (*(RwReg  *)0x42000C00UL) /**< \brief (SERCOM1) SPI Control A */
+#define REG_SERCOM1_SPI_CTRLB      (*(RwReg  *)0x42000C04UL) /**< \brief (SERCOM1) SPI Control B */
+#define REG_SERCOM1_SPI_DBGCTRL    (*(RwReg8 *)0x42000C08UL) /**< \brief (SERCOM1) SPI Debug Control */
+#define REG_SERCOM1_SPI_BAUD       (*(RwReg8 *)0x42000C0AUL) /**< \brief (SERCOM1) SPI Baud Rate */
+#define REG_SERCOM1_SPI_INTENCLR   (*(RwReg8 *)0x42000C0CUL) /**< \brief (SERCOM1) SPI Interrupt Enable Clear */
+#define REG_SERCOM1_SPI_INTENSET   (*(RwReg8 *)0x42000C0DUL) /**< \brief (SERCOM1) SPI Interrupt Enable Set */
+#define REG_SERCOM1_SPI_INTFLAG    (*(RwReg8 *)0x42000C0EUL) /**< \brief (SERCOM1) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM1_SPI_STATUS     (*(RwReg16*)0x42000C10UL) /**< \brief (SERCOM1) SPI Status */
+#define REG_SERCOM1_SPI_ADDR       (*(RwReg  *)0x42000C14UL) /**< \brief (SERCOM1) SPI Address */
+#define REG_SERCOM1_SPI_DATA       (*(RwReg16*)0x42000C18UL) /**< \brief (SERCOM1) SPI Data */
+#define REG_SERCOM1_USART_CTRLA    (*(RwReg  *)0x42000C00UL) /**< \brief (SERCOM1) USART Control A */
+#define REG_SERCOM1_USART_CTRLB    (*(RwReg  *)0x42000C04UL) /**< \brief (SERCOM1) USART Control B */
+#define REG_SERCOM1_USART_DBGCTRL  (*(RwReg8 *)0x42000C08UL) /**< \brief (SERCOM1) USART Debug Control */
+#define REG_SERCOM1_USART_BAUD     (*(RwReg16*)0x42000C0AUL) /**< \brief (SERCOM1) USART Baud */
+#define REG_SERCOM1_USART_INTENCLR (*(RwReg8 *)0x42000C0CUL) /**< \brief (SERCOM1) USART Interrupt Enable Clear */
+#define REG_SERCOM1_USART_INTENSET (*(RwReg8 *)0x42000C0DUL) /**< \brief (SERCOM1) USART Interrupt Enable Set */
+#define REG_SERCOM1_USART_INTFLAG  (*(RwReg8 *)0x42000C0EUL) /**< \brief (SERCOM1) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM1_USART_STATUS   (*(RwReg16*)0x42000C10UL) /**< \brief (SERCOM1) USART Status */
+#define REG_SERCOM1_USART_DATA     (*(RwReg16*)0x42000C18UL) /**< \brief (SERCOM1) USART Data */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM1 peripheral ========== */
+#define SERCOM1_GCLK_ID_CORE        14      
+#define SERCOM1_GCLK_ID_SLOW        12      
+#define SERCOM1_INT_MSB             3       
+#define SERCOM1_PMSB                3       
+
+#endif /* _SAMD20_SERCOM1_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/sercom2.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/sercom2.h
@@ -1,0 +1,118 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM2
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SERCOM2_INSTANCE_
+#define _SAMD20_SERCOM2_INSTANCE_
+
+/* ========== Register definition for SERCOM2 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM2_I2CM_CTRLA     (0x42001000) /**< \brief (SERCOM2) I2CM Control A */
+#define REG_SERCOM2_I2CM_CTRLB     (0x42001004) /**< \brief (SERCOM2) I2CM Control B */
+#define REG_SERCOM2_I2CM_DBGCTRL   (0x42001008) /**< \brief (SERCOM2) I2CM Debug Control */
+#define REG_SERCOM2_I2CM_BAUD      (0x4200100A) /**< \brief (SERCOM2) I2CM Baud Rate */
+#define REG_SERCOM2_I2CM_INTENCLR  (0x4200100C) /**< \brief (SERCOM2) I2CM Interrupt Enable Clear */
+#define REG_SERCOM2_I2CM_INTENSET  (0x4200100D) /**< \brief (SERCOM2) I2CM Interrupt Enable Set */
+#define REG_SERCOM2_I2CM_INTFLAG   (0x4200100E) /**< \brief (SERCOM2) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CM_STATUS    (0x42001010) /**< \brief (SERCOM2) I2CM Status */
+#define REG_SERCOM2_I2CM_ADDR      (0x42001014) /**< \brief (SERCOM2) I2CM Address */
+#define REG_SERCOM2_I2CM_DATA      (0x42001018) /**< \brief (SERCOM2) I2CM Data */
+#define REG_SERCOM2_I2CS_CTRLA     (0x42001000) /**< \brief (SERCOM2) I2CS Control A */
+#define REG_SERCOM2_I2CS_CTRLB     (0x42001004) /**< \brief (SERCOM2) I2CS Control B */
+#define REG_SERCOM2_I2CS_INTENCLR  (0x4200100C) /**< \brief (SERCOM2) I2CS Interrupt Enable Clear */
+#define REG_SERCOM2_I2CS_INTENSET  (0x4200100D) /**< \brief (SERCOM2) I2CS Interrupt Enable Set */
+#define REG_SERCOM2_I2CS_INTFLAG   (0x4200100E) /**< \brief (SERCOM2) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CS_STATUS    (0x42001010) /**< \brief (SERCOM2) I2CS Status */
+#define REG_SERCOM2_I2CS_ADDR      (0x42001014) /**< \brief (SERCOM2) I2CS Address */
+#define REG_SERCOM2_I2CS_DATA      (0x42001018) /**< \brief (SERCOM2) I2CS Data */
+#define REG_SERCOM2_SPI_CTRLA      (0x42001000) /**< \brief (SERCOM2) SPI Control A */
+#define REG_SERCOM2_SPI_CTRLB      (0x42001004) /**< \brief (SERCOM2) SPI Control B */
+#define REG_SERCOM2_SPI_DBGCTRL    (0x42001008) /**< \brief (SERCOM2) SPI Debug Control */
+#define REG_SERCOM2_SPI_BAUD       (0x4200100A) /**< \brief (SERCOM2) SPI Baud Rate */
+#define REG_SERCOM2_SPI_INTENCLR   (0x4200100C) /**< \brief (SERCOM2) SPI Interrupt Enable Clear */
+#define REG_SERCOM2_SPI_INTENSET   (0x4200100D) /**< \brief (SERCOM2) SPI Interrupt Enable Set */
+#define REG_SERCOM2_SPI_INTFLAG    (0x4200100E) /**< \brief (SERCOM2) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM2_SPI_STATUS     (0x42001010) /**< \brief (SERCOM2) SPI Status */
+#define REG_SERCOM2_SPI_ADDR       (0x42001014) /**< \brief (SERCOM2) SPI Address */
+#define REG_SERCOM2_SPI_DATA       (0x42001018) /**< \brief (SERCOM2) SPI Data */
+#define REG_SERCOM2_USART_CTRLA    (0x42001000) /**< \brief (SERCOM2) USART Control A */
+#define REG_SERCOM2_USART_CTRLB    (0x42001004) /**< \brief (SERCOM2) USART Control B */
+#define REG_SERCOM2_USART_DBGCTRL  (0x42001008) /**< \brief (SERCOM2) USART Debug Control */
+#define REG_SERCOM2_USART_BAUD     (0x4200100A) /**< \brief (SERCOM2) USART Baud */
+#define REG_SERCOM2_USART_INTENCLR (0x4200100C) /**< \brief (SERCOM2) USART Interrupt Enable Clear */
+#define REG_SERCOM2_USART_INTENSET (0x4200100D) /**< \brief (SERCOM2) USART Interrupt Enable Set */
+#define REG_SERCOM2_USART_INTFLAG  (0x4200100E) /**< \brief (SERCOM2) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM2_USART_STATUS   (0x42001010) /**< \brief (SERCOM2) USART Status */
+#define REG_SERCOM2_USART_DATA     (0x42001018) /**< \brief (SERCOM2) USART Data */
+#else
+#define REG_SERCOM2_I2CM_CTRLA     (*(RwReg  *)0x42001000UL) /**< \brief (SERCOM2) I2CM Control A */
+#define REG_SERCOM2_I2CM_CTRLB     (*(RwReg  *)0x42001004UL) /**< \brief (SERCOM2) I2CM Control B */
+#define REG_SERCOM2_I2CM_DBGCTRL   (*(RwReg8 *)0x42001008UL) /**< \brief (SERCOM2) I2CM Debug Control */
+#define REG_SERCOM2_I2CM_BAUD      (*(RwReg16*)0x4200100AUL) /**< \brief (SERCOM2) I2CM Baud Rate */
+#define REG_SERCOM2_I2CM_INTENCLR  (*(RwReg8 *)0x4200100CUL) /**< \brief (SERCOM2) I2CM Interrupt Enable Clear */
+#define REG_SERCOM2_I2CM_INTENSET  (*(RwReg8 *)0x4200100DUL) /**< \brief (SERCOM2) I2CM Interrupt Enable Set */
+#define REG_SERCOM2_I2CM_INTFLAG   (*(RwReg8 *)0x4200100EUL) /**< \brief (SERCOM2) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CM_STATUS    (*(RwReg16*)0x42001010UL) /**< \brief (SERCOM2) I2CM Status */
+#define REG_SERCOM2_I2CM_ADDR      (*(RwReg8 *)0x42001014UL) /**< \brief (SERCOM2) I2CM Address */
+#define REG_SERCOM2_I2CM_DATA      (*(RwReg8 *)0x42001018UL) /**< \brief (SERCOM2) I2CM Data */
+#define REG_SERCOM2_I2CS_CTRLA     (*(RwReg  *)0x42001000UL) /**< \brief (SERCOM2) I2CS Control A */
+#define REG_SERCOM2_I2CS_CTRLB     (*(RwReg  *)0x42001004UL) /**< \brief (SERCOM2) I2CS Control B */
+#define REG_SERCOM2_I2CS_INTENCLR  (*(RwReg8 *)0x4200100CUL) /**< \brief (SERCOM2) I2CS Interrupt Enable Clear */
+#define REG_SERCOM2_I2CS_INTENSET  (*(RwReg8 *)0x4200100DUL) /**< \brief (SERCOM2) I2CS Interrupt Enable Set */
+#define REG_SERCOM2_I2CS_INTFLAG   (*(RwReg8 *)0x4200100EUL) /**< \brief (SERCOM2) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM2_I2CS_STATUS    (*(RwReg16*)0x42001010UL) /**< \brief (SERCOM2) I2CS Status */
+#define REG_SERCOM2_I2CS_ADDR      (*(RwReg  *)0x42001014UL) /**< \brief (SERCOM2) I2CS Address */
+#define REG_SERCOM2_I2CS_DATA      (*(RwReg8 *)0x42001018UL) /**< \brief (SERCOM2) I2CS Data */
+#define REG_SERCOM2_SPI_CTRLA      (*(RwReg  *)0x42001000UL) /**< \brief (SERCOM2) SPI Control A */
+#define REG_SERCOM2_SPI_CTRLB      (*(RwReg  *)0x42001004UL) /**< \brief (SERCOM2) SPI Control B */
+#define REG_SERCOM2_SPI_DBGCTRL    (*(RwReg8 *)0x42001008UL) /**< \brief (SERCOM2) SPI Debug Control */
+#define REG_SERCOM2_SPI_BAUD       (*(RwReg8 *)0x4200100AUL) /**< \brief (SERCOM2) SPI Baud Rate */
+#define REG_SERCOM2_SPI_INTENCLR   (*(RwReg8 *)0x4200100CUL) /**< \brief (SERCOM2) SPI Interrupt Enable Clear */
+#define REG_SERCOM2_SPI_INTENSET   (*(RwReg8 *)0x4200100DUL) /**< \brief (SERCOM2) SPI Interrupt Enable Set */
+#define REG_SERCOM2_SPI_INTFLAG    (*(RwReg8 *)0x4200100EUL) /**< \brief (SERCOM2) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM2_SPI_STATUS     (*(RwReg16*)0x42001010UL) /**< \brief (SERCOM2) SPI Status */
+#define REG_SERCOM2_SPI_ADDR       (*(RwReg  *)0x42001014UL) /**< \brief (SERCOM2) SPI Address */
+#define REG_SERCOM2_SPI_DATA       (*(RwReg16*)0x42001018UL) /**< \brief (SERCOM2) SPI Data */
+#define REG_SERCOM2_USART_CTRLA    (*(RwReg  *)0x42001000UL) /**< \brief (SERCOM2) USART Control A */
+#define REG_SERCOM2_USART_CTRLB    (*(RwReg  *)0x42001004UL) /**< \brief (SERCOM2) USART Control B */
+#define REG_SERCOM2_USART_DBGCTRL  (*(RwReg8 *)0x42001008UL) /**< \brief (SERCOM2) USART Debug Control */
+#define REG_SERCOM2_USART_BAUD     (*(RwReg16*)0x4200100AUL) /**< \brief (SERCOM2) USART Baud */
+#define REG_SERCOM2_USART_INTENCLR (*(RwReg8 *)0x4200100CUL) /**< \brief (SERCOM2) USART Interrupt Enable Clear */
+#define REG_SERCOM2_USART_INTENSET (*(RwReg8 *)0x4200100DUL) /**< \brief (SERCOM2) USART Interrupt Enable Set */
+#define REG_SERCOM2_USART_INTFLAG  (*(RwReg8 *)0x4200100EUL) /**< \brief (SERCOM2) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM2_USART_STATUS   (*(RwReg16*)0x42001010UL) /**< \brief (SERCOM2) USART Status */
+#define REG_SERCOM2_USART_DATA     (*(RwReg16*)0x42001018UL) /**< \brief (SERCOM2) USART Data */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM2 peripheral ========== */
+#define SERCOM2_GCLK_ID_CORE        15      
+#define SERCOM2_GCLK_ID_SLOW        12      
+#define SERCOM2_INT_MSB             3       
+#define SERCOM2_PMSB                3       
+
+#endif /* _SAMD20_SERCOM2_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/sercom3.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/sercom3.h
@@ -1,0 +1,118 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM3
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SERCOM3_INSTANCE_
+#define _SAMD20_SERCOM3_INSTANCE_
+
+/* ========== Register definition for SERCOM3 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM3_I2CM_CTRLA     (0x42001400) /**< \brief (SERCOM3) I2CM Control A */
+#define REG_SERCOM3_I2CM_CTRLB     (0x42001404) /**< \brief (SERCOM3) I2CM Control B */
+#define REG_SERCOM3_I2CM_DBGCTRL   (0x42001408) /**< \brief (SERCOM3) I2CM Debug Control */
+#define REG_SERCOM3_I2CM_BAUD      (0x4200140A) /**< \brief (SERCOM3) I2CM Baud Rate */
+#define REG_SERCOM3_I2CM_INTENCLR  (0x4200140C) /**< \brief (SERCOM3) I2CM Interrupt Enable Clear */
+#define REG_SERCOM3_I2CM_INTENSET  (0x4200140D) /**< \brief (SERCOM3) I2CM Interrupt Enable Set */
+#define REG_SERCOM3_I2CM_INTFLAG   (0x4200140E) /**< \brief (SERCOM3) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CM_STATUS    (0x42001410) /**< \brief (SERCOM3) I2CM Status */
+#define REG_SERCOM3_I2CM_ADDR      (0x42001414) /**< \brief (SERCOM3) I2CM Address */
+#define REG_SERCOM3_I2CM_DATA      (0x42001418) /**< \brief (SERCOM3) I2CM Data */
+#define REG_SERCOM3_I2CS_CTRLA     (0x42001400) /**< \brief (SERCOM3) I2CS Control A */
+#define REG_SERCOM3_I2CS_CTRLB     (0x42001404) /**< \brief (SERCOM3) I2CS Control B */
+#define REG_SERCOM3_I2CS_INTENCLR  (0x4200140C) /**< \brief (SERCOM3) I2CS Interrupt Enable Clear */
+#define REG_SERCOM3_I2CS_INTENSET  (0x4200140D) /**< \brief (SERCOM3) I2CS Interrupt Enable Set */
+#define REG_SERCOM3_I2CS_INTFLAG   (0x4200140E) /**< \brief (SERCOM3) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CS_STATUS    (0x42001410) /**< \brief (SERCOM3) I2CS Status */
+#define REG_SERCOM3_I2CS_ADDR      (0x42001414) /**< \brief (SERCOM3) I2CS Address */
+#define REG_SERCOM3_I2CS_DATA      (0x42001418) /**< \brief (SERCOM3) I2CS Data */
+#define REG_SERCOM3_SPI_CTRLA      (0x42001400) /**< \brief (SERCOM3) SPI Control A */
+#define REG_SERCOM3_SPI_CTRLB      (0x42001404) /**< \brief (SERCOM3) SPI Control B */
+#define REG_SERCOM3_SPI_DBGCTRL    (0x42001408) /**< \brief (SERCOM3) SPI Debug Control */
+#define REG_SERCOM3_SPI_BAUD       (0x4200140A) /**< \brief (SERCOM3) SPI Baud Rate */
+#define REG_SERCOM3_SPI_INTENCLR   (0x4200140C) /**< \brief (SERCOM3) SPI Interrupt Enable Clear */
+#define REG_SERCOM3_SPI_INTENSET   (0x4200140D) /**< \brief (SERCOM3) SPI Interrupt Enable Set */
+#define REG_SERCOM3_SPI_INTFLAG    (0x4200140E) /**< \brief (SERCOM3) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM3_SPI_STATUS     (0x42001410) /**< \brief (SERCOM3) SPI Status */
+#define REG_SERCOM3_SPI_ADDR       (0x42001414) /**< \brief (SERCOM3) SPI Address */
+#define REG_SERCOM3_SPI_DATA       (0x42001418) /**< \brief (SERCOM3) SPI Data */
+#define REG_SERCOM3_USART_CTRLA    (0x42001400) /**< \brief (SERCOM3) USART Control A */
+#define REG_SERCOM3_USART_CTRLB    (0x42001404) /**< \brief (SERCOM3) USART Control B */
+#define REG_SERCOM3_USART_DBGCTRL  (0x42001408) /**< \brief (SERCOM3) USART Debug Control */
+#define REG_SERCOM3_USART_BAUD     (0x4200140A) /**< \brief (SERCOM3) USART Baud */
+#define REG_SERCOM3_USART_INTENCLR (0x4200140C) /**< \brief (SERCOM3) USART Interrupt Enable Clear */
+#define REG_SERCOM3_USART_INTENSET (0x4200140D) /**< \brief (SERCOM3) USART Interrupt Enable Set */
+#define REG_SERCOM3_USART_INTFLAG  (0x4200140E) /**< \brief (SERCOM3) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM3_USART_STATUS   (0x42001410) /**< \brief (SERCOM3) USART Status */
+#define REG_SERCOM3_USART_DATA     (0x42001418) /**< \brief (SERCOM3) USART Data */
+#else
+#define REG_SERCOM3_I2CM_CTRLA     (*(RwReg  *)0x42001400UL) /**< \brief (SERCOM3) I2CM Control A */
+#define REG_SERCOM3_I2CM_CTRLB     (*(RwReg  *)0x42001404UL) /**< \brief (SERCOM3) I2CM Control B */
+#define REG_SERCOM3_I2CM_DBGCTRL   (*(RwReg8 *)0x42001408UL) /**< \brief (SERCOM3) I2CM Debug Control */
+#define REG_SERCOM3_I2CM_BAUD      (*(RwReg16*)0x4200140AUL) /**< \brief (SERCOM3) I2CM Baud Rate */
+#define REG_SERCOM3_I2CM_INTENCLR  (*(RwReg8 *)0x4200140CUL) /**< \brief (SERCOM3) I2CM Interrupt Enable Clear */
+#define REG_SERCOM3_I2CM_INTENSET  (*(RwReg8 *)0x4200140DUL) /**< \brief (SERCOM3) I2CM Interrupt Enable Set */
+#define REG_SERCOM3_I2CM_INTFLAG   (*(RwReg8 *)0x4200140EUL) /**< \brief (SERCOM3) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CM_STATUS    (*(RwReg16*)0x42001410UL) /**< \brief (SERCOM3) I2CM Status */
+#define REG_SERCOM3_I2CM_ADDR      (*(RwReg8 *)0x42001414UL) /**< \brief (SERCOM3) I2CM Address */
+#define REG_SERCOM3_I2CM_DATA      (*(RwReg8 *)0x42001418UL) /**< \brief (SERCOM3) I2CM Data */
+#define REG_SERCOM3_I2CS_CTRLA     (*(RwReg  *)0x42001400UL) /**< \brief (SERCOM3) I2CS Control A */
+#define REG_SERCOM3_I2CS_CTRLB     (*(RwReg  *)0x42001404UL) /**< \brief (SERCOM3) I2CS Control B */
+#define REG_SERCOM3_I2CS_INTENCLR  (*(RwReg8 *)0x4200140CUL) /**< \brief (SERCOM3) I2CS Interrupt Enable Clear */
+#define REG_SERCOM3_I2CS_INTENSET  (*(RwReg8 *)0x4200140DUL) /**< \brief (SERCOM3) I2CS Interrupt Enable Set */
+#define REG_SERCOM3_I2CS_INTFLAG   (*(RwReg8 *)0x4200140EUL) /**< \brief (SERCOM3) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM3_I2CS_STATUS    (*(RwReg16*)0x42001410UL) /**< \brief (SERCOM3) I2CS Status */
+#define REG_SERCOM3_I2CS_ADDR      (*(RwReg  *)0x42001414UL) /**< \brief (SERCOM3) I2CS Address */
+#define REG_SERCOM3_I2CS_DATA      (*(RwReg8 *)0x42001418UL) /**< \brief (SERCOM3) I2CS Data */
+#define REG_SERCOM3_SPI_CTRLA      (*(RwReg  *)0x42001400UL) /**< \brief (SERCOM3) SPI Control A */
+#define REG_SERCOM3_SPI_CTRLB      (*(RwReg  *)0x42001404UL) /**< \brief (SERCOM3) SPI Control B */
+#define REG_SERCOM3_SPI_DBGCTRL    (*(RwReg8 *)0x42001408UL) /**< \brief (SERCOM3) SPI Debug Control */
+#define REG_SERCOM3_SPI_BAUD       (*(RwReg8 *)0x4200140AUL) /**< \brief (SERCOM3) SPI Baud Rate */
+#define REG_SERCOM3_SPI_INTENCLR   (*(RwReg8 *)0x4200140CUL) /**< \brief (SERCOM3) SPI Interrupt Enable Clear */
+#define REG_SERCOM3_SPI_INTENSET   (*(RwReg8 *)0x4200140DUL) /**< \brief (SERCOM3) SPI Interrupt Enable Set */
+#define REG_SERCOM3_SPI_INTFLAG    (*(RwReg8 *)0x4200140EUL) /**< \brief (SERCOM3) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM3_SPI_STATUS     (*(RwReg16*)0x42001410UL) /**< \brief (SERCOM3) SPI Status */
+#define REG_SERCOM3_SPI_ADDR       (*(RwReg  *)0x42001414UL) /**< \brief (SERCOM3) SPI Address */
+#define REG_SERCOM3_SPI_DATA       (*(RwReg16*)0x42001418UL) /**< \brief (SERCOM3) SPI Data */
+#define REG_SERCOM3_USART_CTRLA    (*(RwReg  *)0x42001400UL) /**< \brief (SERCOM3) USART Control A */
+#define REG_SERCOM3_USART_CTRLB    (*(RwReg  *)0x42001404UL) /**< \brief (SERCOM3) USART Control B */
+#define REG_SERCOM3_USART_DBGCTRL  (*(RwReg8 *)0x42001408UL) /**< \brief (SERCOM3) USART Debug Control */
+#define REG_SERCOM3_USART_BAUD     (*(RwReg16*)0x4200140AUL) /**< \brief (SERCOM3) USART Baud */
+#define REG_SERCOM3_USART_INTENCLR (*(RwReg8 *)0x4200140CUL) /**< \brief (SERCOM3) USART Interrupt Enable Clear */
+#define REG_SERCOM3_USART_INTENSET (*(RwReg8 *)0x4200140DUL) /**< \brief (SERCOM3) USART Interrupt Enable Set */
+#define REG_SERCOM3_USART_INTFLAG  (*(RwReg8 *)0x4200140EUL) /**< \brief (SERCOM3) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM3_USART_STATUS   (*(RwReg16*)0x42001410UL) /**< \brief (SERCOM3) USART Status */
+#define REG_SERCOM3_USART_DATA     (*(RwReg16*)0x42001418UL) /**< \brief (SERCOM3) USART Data */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM3 peripheral ========== */
+#define SERCOM3_GCLK_ID_CORE        16      
+#define SERCOM3_GCLK_ID_SLOW        12      
+#define SERCOM3_INT_MSB             3       
+#define SERCOM3_PMSB                3       
+
+#endif /* _SAMD20_SERCOM3_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/sercom4.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/sercom4.h
@@ -1,0 +1,118 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM4
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SERCOM4_INSTANCE_
+#define _SAMD20_SERCOM4_INSTANCE_
+
+/* ========== Register definition for SERCOM4 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM4_I2CM_CTRLA     (0x42001800) /**< \brief (SERCOM4) I2CM Control A */
+#define REG_SERCOM4_I2CM_CTRLB     (0x42001804) /**< \brief (SERCOM4) I2CM Control B */
+#define REG_SERCOM4_I2CM_DBGCTRL   (0x42001808) /**< \brief (SERCOM4) I2CM Debug Control */
+#define REG_SERCOM4_I2CM_BAUD      (0x4200180A) /**< \brief (SERCOM4) I2CM Baud Rate */
+#define REG_SERCOM4_I2CM_INTENCLR  (0x4200180C) /**< \brief (SERCOM4) I2CM Interrupt Enable Clear */
+#define REG_SERCOM4_I2CM_INTENSET  (0x4200180D) /**< \brief (SERCOM4) I2CM Interrupt Enable Set */
+#define REG_SERCOM4_I2CM_INTFLAG   (0x4200180E) /**< \brief (SERCOM4) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CM_STATUS    (0x42001810) /**< \brief (SERCOM4) I2CM Status */
+#define REG_SERCOM4_I2CM_ADDR      (0x42001814) /**< \brief (SERCOM4) I2CM Address */
+#define REG_SERCOM4_I2CM_DATA      (0x42001818) /**< \brief (SERCOM4) I2CM Data */
+#define REG_SERCOM4_I2CS_CTRLA     (0x42001800) /**< \brief (SERCOM4) I2CS Control A */
+#define REG_SERCOM4_I2CS_CTRLB     (0x42001804) /**< \brief (SERCOM4) I2CS Control B */
+#define REG_SERCOM4_I2CS_INTENCLR  (0x4200180C) /**< \brief (SERCOM4) I2CS Interrupt Enable Clear */
+#define REG_SERCOM4_I2CS_INTENSET  (0x4200180D) /**< \brief (SERCOM4) I2CS Interrupt Enable Set */
+#define REG_SERCOM4_I2CS_INTFLAG   (0x4200180E) /**< \brief (SERCOM4) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CS_STATUS    (0x42001810) /**< \brief (SERCOM4) I2CS Status */
+#define REG_SERCOM4_I2CS_ADDR      (0x42001814) /**< \brief (SERCOM4) I2CS Address */
+#define REG_SERCOM4_I2CS_DATA      (0x42001818) /**< \brief (SERCOM4) I2CS Data */
+#define REG_SERCOM4_SPI_CTRLA      (0x42001800) /**< \brief (SERCOM4) SPI Control A */
+#define REG_SERCOM4_SPI_CTRLB      (0x42001804) /**< \brief (SERCOM4) SPI Control B */
+#define REG_SERCOM4_SPI_DBGCTRL    (0x42001808) /**< \brief (SERCOM4) SPI Debug Control */
+#define REG_SERCOM4_SPI_BAUD       (0x4200180A) /**< \brief (SERCOM4) SPI Baud Rate */
+#define REG_SERCOM4_SPI_INTENCLR   (0x4200180C) /**< \brief (SERCOM4) SPI Interrupt Enable Clear */
+#define REG_SERCOM4_SPI_INTENSET   (0x4200180D) /**< \brief (SERCOM4) SPI Interrupt Enable Set */
+#define REG_SERCOM4_SPI_INTFLAG    (0x4200180E) /**< \brief (SERCOM4) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM4_SPI_STATUS     (0x42001810) /**< \brief (SERCOM4) SPI Status */
+#define REG_SERCOM4_SPI_ADDR       (0x42001814) /**< \brief (SERCOM4) SPI Address */
+#define REG_SERCOM4_SPI_DATA       (0x42001818) /**< \brief (SERCOM4) SPI Data */
+#define REG_SERCOM4_USART_CTRLA    (0x42001800) /**< \brief (SERCOM4) USART Control A */
+#define REG_SERCOM4_USART_CTRLB    (0x42001804) /**< \brief (SERCOM4) USART Control B */
+#define REG_SERCOM4_USART_DBGCTRL  (0x42001808) /**< \brief (SERCOM4) USART Debug Control */
+#define REG_SERCOM4_USART_BAUD     (0x4200180A) /**< \brief (SERCOM4) USART Baud */
+#define REG_SERCOM4_USART_INTENCLR (0x4200180C) /**< \brief (SERCOM4) USART Interrupt Enable Clear */
+#define REG_SERCOM4_USART_INTENSET (0x4200180D) /**< \brief (SERCOM4) USART Interrupt Enable Set */
+#define REG_SERCOM4_USART_INTFLAG  (0x4200180E) /**< \brief (SERCOM4) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM4_USART_STATUS   (0x42001810) /**< \brief (SERCOM4) USART Status */
+#define REG_SERCOM4_USART_DATA     (0x42001818) /**< \brief (SERCOM4) USART Data */
+#else
+#define REG_SERCOM4_I2CM_CTRLA     (*(RwReg  *)0x42001800UL) /**< \brief (SERCOM4) I2CM Control A */
+#define REG_SERCOM4_I2CM_CTRLB     (*(RwReg  *)0x42001804UL) /**< \brief (SERCOM4) I2CM Control B */
+#define REG_SERCOM4_I2CM_DBGCTRL   (*(RwReg8 *)0x42001808UL) /**< \brief (SERCOM4) I2CM Debug Control */
+#define REG_SERCOM4_I2CM_BAUD      (*(RwReg16*)0x4200180AUL) /**< \brief (SERCOM4) I2CM Baud Rate */
+#define REG_SERCOM4_I2CM_INTENCLR  (*(RwReg8 *)0x4200180CUL) /**< \brief (SERCOM4) I2CM Interrupt Enable Clear */
+#define REG_SERCOM4_I2CM_INTENSET  (*(RwReg8 *)0x4200180DUL) /**< \brief (SERCOM4) I2CM Interrupt Enable Set */
+#define REG_SERCOM4_I2CM_INTFLAG   (*(RwReg8 *)0x4200180EUL) /**< \brief (SERCOM4) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CM_STATUS    (*(RwReg16*)0x42001810UL) /**< \brief (SERCOM4) I2CM Status */
+#define REG_SERCOM4_I2CM_ADDR      (*(RwReg8 *)0x42001814UL) /**< \brief (SERCOM4) I2CM Address */
+#define REG_SERCOM4_I2CM_DATA      (*(RwReg8 *)0x42001818UL) /**< \brief (SERCOM4) I2CM Data */
+#define REG_SERCOM4_I2CS_CTRLA     (*(RwReg  *)0x42001800UL) /**< \brief (SERCOM4) I2CS Control A */
+#define REG_SERCOM4_I2CS_CTRLB     (*(RwReg  *)0x42001804UL) /**< \brief (SERCOM4) I2CS Control B */
+#define REG_SERCOM4_I2CS_INTENCLR  (*(RwReg8 *)0x4200180CUL) /**< \brief (SERCOM4) I2CS Interrupt Enable Clear */
+#define REG_SERCOM4_I2CS_INTENSET  (*(RwReg8 *)0x4200180DUL) /**< \brief (SERCOM4) I2CS Interrupt Enable Set */
+#define REG_SERCOM4_I2CS_INTFLAG   (*(RwReg8 *)0x4200180EUL) /**< \brief (SERCOM4) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM4_I2CS_STATUS    (*(RwReg16*)0x42001810UL) /**< \brief (SERCOM4) I2CS Status */
+#define REG_SERCOM4_I2CS_ADDR      (*(RwReg  *)0x42001814UL) /**< \brief (SERCOM4) I2CS Address */
+#define REG_SERCOM4_I2CS_DATA      (*(RwReg8 *)0x42001818UL) /**< \brief (SERCOM4) I2CS Data */
+#define REG_SERCOM4_SPI_CTRLA      (*(RwReg  *)0x42001800UL) /**< \brief (SERCOM4) SPI Control A */
+#define REG_SERCOM4_SPI_CTRLB      (*(RwReg  *)0x42001804UL) /**< \brief (SERCOM4) SPI Control B */
+#define REG_SERCOM4_SPI_DBGCTRL    (*(RwReg8 *)0x42001808UL) /**< \brief (SERCOM4) SPI Debug Control */
+#define REG_SERCOM4_SPI_BAUD       (*(RwReg8 *)0x4200180AUL) /**< \brief (SERCOM4) SPI Baud Rate */
+#define REG_SERCOM4_SPI_INTENCLR   (*(RwReg8 *)0x4200180CUL) /**< \brief (SERCOM4) SPI Interrupt Enable Clear */
+#define REG_SERCOM4_SPI_INTENSET   (*(RwReg8 *)0x4200180DUL) /**< \brief (SERCOM4) SPI Interrupt Enable Set */
+#define REG_SERCOM4_SPI_INTFLAG    (*(RwReg8 *)0x4200180EUL) /**< \brief (SERCOM4) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM4_SPI_STATUS     (*(RwReg16*)0x42001810UL) /**< \brief (SERCOM4) SPI Status */
+#define REG_SERCOM4_SPI_ADDR       (*(RwReg  *)0x42001814UL) /**< \brief (SERCOM4) SPI Address */
+#define REG_SERCOM4_SPI_DATA       (*(RwReg16*)0x42001818UL) /**< \brief (SERCOM4) SPI Data */
+#define REG_SERCOM4_USART_CTRLA    (*(RwReg  *)0x42001800UL) /**< \brief (SERCOM4) USART Control A */
+#define REG_SERCOM4_USART_CTRLB    (*(RwReg  *)0x42001804UL) /**< \brief (SERCOM4) USART Control B */
+#define REG_SERCOM4_USART_DBGCTRL  (*(RwReg8 *)0x42001808UL) /**< \brief (SERCOM4) USART Debug Control */
+#define REG_SERCOM4_USART_BAUD     (*(RwReg16*)0x4200180AUL) /**< \brief (SERCOM4) USART Baud */
+#define REG_SERCOM4_USART_INTENCLR (*(RwReg8 *)0x4200180CUL) /**< \brief (SERCOM4) USART Interrupt Enable Clear */
+#define REG_SERCOM4_USART_INTENSET (*(RwReg8 *)0x4200180DUL) /**< \brief (SERCOM4) USART Interrupt Enable Set */
+#define REG_SERCOM4_USART_INTFLAG  (*(RwReg8 *)0x4200180EUL) /**< \brief (SERCOM4) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM4_USART_STATUS   (*(RwReg16*)0x42001810UL) /**< \brief (SERCOM4) USART Status */
+#define REG_SERCOM4_USART_DATA     (*(RwReg16*)0x42001818UL) /**< \brief (SERCOM4) USART Data */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM4 peripheral ========== */
+#define SERCOM4_GCLK_ID_CORE        17      
+#define SERCOM4_GCLK_ID_SLOW        12      
+#define SERCOM4_INT_MSB             3       
+#define SERCOM4_PMSB                3       
+
+#endif /* _SAMD20_SERCOM4_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/sercom5.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/sercom5.h
@@ -1,0 +1,118 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SERCOM5
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SERCOM5_INSTANCE_
+#define _SAMD20_SERCOM5_INSTANCE_
+
+/* ========== Register definition for SERCOM5 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SERCOM5_I2CM_CTRLA     (0x42001C00) /**< \brief (SERCOM5) I2CM Control A */
+#define REG_SERCOM5_I2CM_CTRLB     (0x42001C04) /**< \brief (SERCOM5) I2CM Control B */
+#define REG_SERCOM5_I2CM_DBGCTRL   (0x42001C08) /**< \brief (SERCOM5) I2CM Debug Control */
+#define REG_SERCOM5_I2CM_BAUD      (0x42001C0A) /**< \brief (SERCOM5) I2CM Baud Rate */
+#define REG_SERCOM5_I2CM_INTENCLR  (0x42001C0C) /**< \brief (SERCOM5) I2CM Interrupt Enable Clear */
+#define REG_SERCOM5_I2CM_INTENSET  (0x42001C0D) /**< \brief (SERCOM5) I2CM Interrupt Enable Set */
+#define REG_SERCOM5_I2CM_INTFLAG   (0x42001C0E) /**< \brief (SERCOM5) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CM_STATUS    (0x42001C10) /**< \brief (SERCOM5) I2CM Status */
+#define REG_SERCOM5_I2CM_ADDR      (0x42001C14) /**< \brief (SERCOM5) I2CM Address */
+#define REG_SERCOM5_I2CM_DATA      (0x42001C18) /**< \brief (SERCOM5) I2CM Data */
+#define REG_SERCOM5_I2CS_CTRLA     (0x42001C00) /**< \brief (SERCOM5) I2CS Control A */
+#define REG_SERCOM5_I2CS_CTRLB     (0x42001C04) /**< \brief (SERCOM5) I2CS Control B */
+#define REG_SERCOM5_I2CS_INTENCLR  (0x42001C0C) /**< \brief (SERCOM5) I2CS Interrupt Enable Clear */
+#define REG_SERCOM5_I2CS_INTENSET  (0x42001C0D) /**< \brief (SERCOM5) I2CS Interrupt Enable Set */
+#define REG_SERCOM5_I2CS_INTFLAG   (0x42001C0E) /**< \brief (SERCOM5) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CS_STATUS    (0x42001C10) /**< \brief (SERCOM5) I2CS Status */
+#define REG_SERCOM5_I2CS_ADDR      (0x42001C14) /**< \brief (SERCOM5) I2CS Address */
+#define REG_SERCOM5_I2CS_DATA      (0x42001C18) /**< \brief (SERCOM5) I2CS Data */
+#define REG_SERCOM5_SPI_CTRLA      (0x42001C00) /**< \brief (SERCOM5) SPI Control A */
+#define REG_SERCOM5_SPI_CTRLB      (0x42001C04) /**< \brief (SERCOM5) SPI Control B */
+#define REG_SERCOM5_SPI_DBGCTRL    (0x42001C08) /**< \brief (SERCOM5) SPI Debug Control */
+#define REG_SERCOM5_SPI_BAUD       (0x42001C0A) /**< \brief (SERCOM5) SPI Baud Rate */
+#define REG_SERCOM5_SPI_INTENCLR   (0x42001C0C) /**< \brief (SERCOM5) SPI Interrupt Enable Clear */
+#define REG_SERCOM5_SPI_INTENSET   (0x42001C0D) /**< \brief (SERCOM5) SPI Interrupt Enable Set */
+#define REG_SERCOM5_SPI_INTFLAG    (0x42001C0E) /**< \brief (SERCOM5) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM5_SPI_STATUS     (0x42001C10) /**< \brief (SERCOM5) SPI Status */
+#define REG_SERCOM5_SPI_ADDR       (0x42001C14) /**< \brief (SERCOM5) SPI Address */
+#define REG_SERCOM5_SPI_DATA       (0x42001C18) /**< \brief (SERCOM5) SPI Data */
+#define REG_SERCOM5_USART_CTRLA    (0x42001C00) /**< \brief (SERCOM5) USART Control A */
+#define REG_SERCOM5_USART_CTRLB    (0x42001C04) /**< \brief (SERCOM5) USART Control B */
+#define REG_SERCOM5_USART_DBGCTRL  (0x42001C08) /**< \brief (SERCOM5) USART Debug Control */
+#define REG_SERCOM5_USART_BAUD     (0x42001C0A) /**< \brief (SERCOM5) USART Baud */
+#define REG_SERCOM5_USART_INTENCLR (0x42001C0C) /**< \brief (SERCOM5) USART Interrupt Enable Clear */
+#define REG_SERCOM5_USART_INTENSET (0x42001C0D) /**< \brief (SERCOM5) USART Interrupt Enable Set */
+#define REG_SERCOM5_USART_INTFLAG  (0x42001C0E) /**< \brief (SERCOM5) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM5_USART_STATUS   (0x42001C10) /**< \brief (SERCOM5) USART Status */
+#define REG_SERCOM5_USART_DATA     (0x42001C18) /**< \brief (SERCOM5) USART Data */
+#else
+#define REG_SERCOM5_I2CM_CTRLA     (*(RwReg  *)0x42001C00UL) /**< \brief (SERCOM5) I2CM Control A */
+#define REG_SERCOM5_I2CM_CTRLB     (*(RwReg  *)0x42001C04UL) /**< \brief (SERCOM5) I2CM Control B */
+#define REG_SERCOM5_I2CM_DBGCTRL   (*(RwReg8 *)0x42001C08UL) /**< \brief (SERCOM5) I2CM Debug Control */
+#define REG_SERCOM5_I2CM_BAUD      (*(RwReg16*)0x42001C0AUL) /**< \brief (SERCOM5) I2CM Baud Rate */
+#define REG_SERCOM5_I2CM_INTENCLR  (*(RwReg8 *)0x42001C0CUL) /**< \brief (SERCOM5) I2CM Interrupt Enable Clear */
+#define REG_SERCOM5_I2CM_INTENSET  (*(RwReg8 *)0x42001C0DUL) /**< \brief (SERCOM5) I2CM Interrupt Enable Set */
+#define REG_SERCOM5_I2CM_INTFLAG   (*(RwReg8 *)0x42001C0EUL) /**< \brief (SERCOM5) I2CM Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CM_STATUS    (*(RwReg16*)0x42001C10UL) /**< \brief (SERCOM5) I2CM Status */
+#define REG_SERCOM5_I2CM_ADDR      (*(RwReg8 *)0x42001C14UL) /**< \brief (SERCOM5) I2CM Address */
+#define REG_SERCOM5_I2CM_DATA      (*(RwReg8 *)0x42001C18UL) /**< \brief (SERCOM5) I2CM Data */
+#define REG_SERCOM5_I2CS_CTRLA     (*(RwReg  *)0x42001C00UL) /**< \brief (SERCOM5) I2CS Control A */
+#define REG_SERCOM5_I2CS_CTRLB     (*(RwReg  *)0x42001C04UL) /**< \brief (SERCOM5) I2CS Control B */
+#define REG_SERCOM5_I2CS_INTENCLR  (*(RwReg8 *)0x42001C0CUL) /**< \brief (SERCOM5) I2CS Interrupt Enable Clear */
+#define REG_SERCOM5_I2CS_INTENSET  (*(RwReg8 *)0x42001C0DUL) /**< \brief (SERCOM5) I2CS Interrupt Enable Set */
+#define REG_SERCOM5_I2CS_INTFLAG   (*(RwReg8 *)0x42001C0EUL) /**< \brief (SERCOM5) I2CS Interrupt Flag Status and Clear */
+#define REG_SERCOM5_I2CS_STATUS    (*(RwReg16*)0x42001C10UL) /**< \brief (SERCOM5) I2CS Status */
+#define REG_SERCOM5_I2CS_ADDR      (*(RwReg  *)0x42001C14UL) /**< \brief (SERCOM5) I2CS Address */
+#define REG_SERCOM5_I2CS_DATA      (*(RwReg8 *)0x42001C18UL) /**< \brief (SERCOM5) I2CS Data */
+#define REG_SERCOM5_SPI_CTRLA      (*(RwReg  *)0x42001C00UL) /**< \brief (SERCOM5) SPI Control A */
+#define REG_SERCOM5_SPI_CTRLB      (*(RwReg  *)0x42001C04UL) /**< \brief (SERCOM5) SPI Control B */
+#define REG_SERCOM5_SPI_DBGCTRL    (*(RwReg8 *)0x42001C08UL) /**< \brief (SERCOM5) SPI Debug Control */
+#define REG_SERCOM5_SPI_BAUD       (*(RwReg8 *)0x42001C0AUL) /**< \brief (SERCOM5) SPI Baud Rate */
+#define REG_SERCOM5_SPI_INTENCLR   (*(RwReg8 *)0x42001C0CUL) /**< \brief (SERCOM5) SPI Interrupt Enable Clear */
+#define REG_SERCOM5_SPI_INTENSET   (*(RwReg8 *)0x42001C0DUL) /**< \brief (SERCOM5) SPI Interrupt Enable Set */
+#define REG_SERCOM5_SPI_INTFLAG    (*(RwReg8 *)0x42001C0EUL) /**< \brief (SERCOM5) SPI Interrupt Flag Status and Clear */
+#define REG_SERCOM5_SPI_STATUS     (*(RwReg16*)0x42001C10UL) /**< \brief (SERCOM5) SPI Status */
+#define REG_SERCOM5_SPI_ADDR       (*(RwReg  *)0x42001C14UL) /**< \brief (SERCOM5) SPI Address */
+#define REG_SERCOM5_SPI_DATA       (*(RwReg16*)0x42001C18UL) /**< \brief (SERCOM5) SPI Data */
+#define REG_SERCOM5_USART_CTRLA    (*(RwReg  *)0x42001C00UL) /**< \brief (SERCOM5) USART Control A */
+#define REG_SERCOM5_USART_CTRLB    (*(RwReg  *)0x42001C04UL) /**< \brief (SERCOM5) USART Control B */
+#define REG_SERCOM5_USART_DBGCTRL  (*(RwReg8 *)0x42001C08UL) /**< \brief (SERCOM5) USART Debug Control */
+#define REG_SERCOM5_USART_BAUD     (*(RwReg16*)0x42001C0AUL) /**< \brief (SERCOM5) USART Baud */
+#define REG_SERCOM5_USART_INTENCLR (*(RwReg8 *)0x42001C0CUL) /**< \brief (SERCOM5) USART Interrupt Enable Clear */
+#define REG_SERCOM5_USART_INTENSET (*(RwReg8 *)0x42001C0DUL) /**< \brief (SERCOM5) USART Interrupt Enable Set */
+#define REG_SERCOM5_USART_INTFLAG  (*(RwReg8 *)0x42001C0EUL) /**< \brief (SERCOM5) USART Interrupt Flag Status and Clear */
+#define REG_SERCOM5_USART_STATUS   (*(RwReg16*)0x42001C10UL) /**< \brief (SERCOM5) USART Status */
+#define REG_SERCOM5_USART_DATA     (*(RwReg16*)0x42001C18UL) /**< \brief (SERCOM5) USART Data */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SERCOM5 peripheral ========== */
+#define SERCOM5_GCLK_ID_CORE        18      
+#define SERCOM5_GCLK_ID_SLOW        12      
+#define SERCOM5_INT_MSB             3       
+#define SERCOM5_PMSB                3       
+
+#endif /* _SAMD20_SERCOM5_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/sysctrl.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/sysctrl.h
@@ -1,0 +1,96 @@
+/**
+ * \file
+ *
+ * \brief Instance description for SYSCTRL
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_SYSCTRL_INSTANCE_
+#define _SAMD20_SYSCTRL_INSTANCE_
+
+/* ========== Register definition for SYSCTRL peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_SYSCTRL_INTENCLR       (0x40000800) /**< \brief (SYSCTRL) Interrupt Enable Clear */
+#define REG_SYSCTRL_INTENSET       (0x40000804) /**< \brief (SYSCTRL) Interrupt Enable Set */
+#define REG_SYSCTRL_INTFLAG        (0x40000808) /**< \brief (SYSCTRL) Interrupt Flag Status and Clear */
+#define REG_SYSCTRL_PCLKSR         (0x4000080C) /**< \brief (SYSCTRL) Power and Clocks Status */
+#define REG_SYSCTRL_XOSC           (0x40000810) /**< \brief (SYSCTRL) XOSC Control */
+#define REG_SYSCTRL_XOSC32K        (0x40000814) /**< \brief (SYSCTRL) XOSC32K Control */
+#define REG_SYSCTRL_OSC32K         (0x40000818) /**< \brief (SYSCTRL) OSC32K Control */
+#define REG_SYSCTRL_OSCULP32K      (0x4000081C) /**< \brief (SYSCTRL) OSCULP32K Control */
+#define REG_SYSCTRL_OSC8M          (0x40000820) /**< \brief (SYSCTRL) OSC8M Control A */
+#define REG_SYSCTRL_DFLLCTRL       (0x40000824) /**< \brief (SYSCTRL) DFLL Config */
+#define REG_SYSCTRL_DFLLVAL        (0x40000828) /**< \brief (SYSCTRL) DFLL Calibration Value */
+#define REG_SYSCTRL_DFLLMUL        (0x4000082C) /**< \brief (SYSCTRL) DFLL Multiplier */
+#define REG_SYSCTRL_DFLLSYNC       (0x40000830) /**< \brief (SYSCTRL) DFLL Synchronization */
+#define REG_SYSCTRL_BOD33          (0x40000834) /**< \brief (SYSCTRL) 3.3V Brown-Out Detector (BOD33) Control */
+#define REG_SYSCTRL_VREG           (0x4000083C) /**< \brief (SYSCTRL) VREG Control */
+#define REG_SYSCTRL_VREF           (0x40000840) /**< \brief (SYSCTRL) VREF Control A */
+#else
+#define REG_SYSCTRL_INTENCLR       (*(RwReg  *)0x40000800UL) /**< \brief (SYSCTRL) Interrupt Enable Clear */
+#define REG_SYSCTRL_INTENSET       (*(RwReg  *)0x40000804UL) /**< \brief (SYSCTRL) Interrupt Enable Set */
+#define REG_SYSCTRL_INTFLAG        (*(RwReg  *)0x40000808UL) /**< \brief (SYSCTRL) Interrupt Flag Status and Clear */
+#define REG_SYSCTRL_PCLKSR         (*(RoReg  *)0x4000080CUL) /**< \brief (SYSCTRL) Power and Clocks Status */
+#define REG_SYSCTRL_XOSC           (*(RwReg16*)0x40000810UL) /**< \brief (SYSCTRL) XOSC Control */
+#define REG_SYSCTRL_XOSC32K        (*(RwReg16*)0x40000814UL) /**< \brief (SYSCTRL) XOSC32K Control */
+#define REG_SYSCTRL_OSC32K         (*(RwReg  *)0x40000818UL) /**< \brief (SYSCTRL) OSC32K Control */
+#define REG_SYSCTRL_OSCULP32K      (*(RwReg8 *)0x4000081CUL) /**< \brief (SYSCTRL) OSCULP32K Control */
+#define REG_SYSCTRL_OSC8M          (*(RwReg  *)0x40000820UL) /**< \brief (SYSCTRL) OSC8M Control A */
+#define REG_SYSCTRL_DFLLCTRL       (*(RwReg16*)0x40000824UL) /**< \brief (SYSCTRL) DFLL Config */
+#define REG_SYSCTRL_DFLLVAL        (*(RwReg  *)0x40000828UL) /**< \brief (SYSCTRL) DFLL Calibration Value */
+#define REG_SYSCTRL_DFLLMUL        (*(RwReg  *)0x4000082CUL) /**< \brief (SYSCTRL) DFLL Multiplier */
+#define REG_SYSCTRL_DFLLSYNC       (*(RwReg8 *)0x40000830UL) /**< \brief (SYSCTRL) DFLL Synchronization */
+#define REG_SYSCTRL_BOD33          (*(RwReg  *)0x40000834UL) /**< \brief (SYSCTRL) 3.3V Brown-Out Detector (BOD33) Control */
+#define REG_SYSCTRL_VREG           (*(RwReg16*)0x4000083CUL) /**< \brief (SYSCTRL) VREG Control */
+#define REG_SYSCTRL_VREF           (*(RwReg  *)0x40000840UL) /**< \brief (SYSCTRL) VREF Control A */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for SYSCTRL peripheral ========== */
+#define SYSCTRL_BGAP_CALIB_MSB      11      
+#define SYSCTRL_BOD33_CALIB_MSB     5       
+#define SYSCTRL_DFLL48M_COARSE_MSB  4       
+#define SYSCTRL_DFLL48M_FINE_MSB    7       
+#define SYSCTRL_GCLK_ID_DFLL48      0       
+#define SYSCTRL_OSC32K_COARSE_CALIB_MSB 6       
+#define SYSCTRL_POR33_ENTEST_MSB    1       
+#define SYSCTRL_ULPVREF_DIVLEV_MSB  3       
+#define SYSCTRL_ULPVREG_FORCEGAIN_MSB 1       
+#define SYSCTRL_ULPVREG_RAMREFSEL_MSB 2       
+#define SYSCTRL_VREF_CONTROL_MSB    48      
+#define SYSCTRL_VREF_STATUS_MSB     7       
+#define SYSCTRL_VREG_LEVEL_MSB      2       
+#define SYSCTRL_BOD12_VERSION       0x112   
+#define SYSCTRL_BOD33_VERSION       0x112   
+#define SYSCTRL_DFLL48M_VERSION     0x211   
+#define SYSCTRL_GCLK_VERSION        0x210   
+#define SYSCTRL_OSCULP32K_VERSION   0x111   
+#define SYSCTRL_OSC8M_VERSION       0x120   
+#define SYSCTRL_OSC32K_VERSION      0x1101  
+#define SYSCTRL_VREF_VERSION        0x200   
+#define SYSCTRL_VREG_VERSION        0x201   
+#define SYSCTRL_XOSC_VERSION        0x1101  
+#define SYSCTRL_XOSC32K_VERSION     0x1101  
+
+#endif /* _SAMD20_SYSCTRL_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc0.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc0.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC0
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC0_INSTANCE_
+#define _SAMD20_TC0_INSTANCE_
+
+/* ========== Register definition for TC0 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC0_CTRLA              (0x42002000) /**< \brief (TC0) Control A */
+#define REG_TC0_READREQ            (0x42002002) /**< \brief (TC0) Read Request */
+#define REG_TC0_CTRLBCLR           (0x42002004) /**< \brief (TC0) Control B Clear */
+#define REG_TC0_CTRLBSET           (0x42002005) /**< \brief (TC0) Control B Set */
+#define REG_TC0_CTRLC              (0x42002006) /**< \brief (TC0) Control C */
+#define REG_TC0_DBGCTRL            (0x42002008) /**< \brief (TC0) Debug Control */
+#define REG_TC0_EVCTRL             (0x4200200A) /**< \brief (TC0) Event Control */
+#define REG_TC0_INTENCLR           (0x4200200C) /**< \brief (TC0) Interrupt Enable Clear */
+#define REG_TC0_INTENSET           (0x4200200D) /**< \brief (TC0) Interrupt Enable Set */
+#define REG_TC0_INTFLAG            (0x4200200E) /**< \brief (TC0) Interrupt Flag Status and Clear */
+#define REG_TC0_STATUS             (0x4200200F) /**< \brief (TC0) Status */
+#define REG_TC0_COUNT16_COUNT      (0x42002010) /**< \brief (TC0) COUNT16 Counter Value */
+#define REG_TC0_COUNT16_CC0        (0x42002018) /**< \brief (TC0) COUNT16 Compare/Capture 0 */
+#define REG_TC0_COUNT16_CC1        (0x4200201A) /**< \brief (TC0) COUNT16 Compare/Capture 1 */
+#define REG_TC0_COUNT32_COUNT      (0x42002010) /**< \brief (TC0) COUNT32 Counter Value */
+#define REG_TC0_COUNT32_CC0        (0x42002018) /**< \brief (TC0) COUNT32 Compare/Capture 0 */
+#define REG_TC0_COUNT32_CC1        (0x4200201C) /**< \brief (TC0) COUNT32 Compare/Capture 1 */
+#define REG_TC0_COUNT8_COUNT       (0x42002010) /**< \brief (TC0) COUNT8 Counter Value */
+#define REG_TC0_COUNT8_PER         (0x42002014) /**< \brief (TC0) COUNT8 Period Value */
+#define REG_TC0_COUNT8_CC0         (0x42002018) /**< \brief (TC0) COUNT8 Compare/Capture 0 */
+#define REG_TC0_COUNT8_CC1         (0x42002019) /**< \brief (TC0) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC0_CTRLA              (*(RwReg16*)0x42002000UL) /**< \brief (TC0) Control A */
+#define REG_TC0_READREQ            (*(RwReg16*)0x42002002UL) /**< \brief (TC0) Read Request */
+#define REG_TC0_CTRLBCLR           (*(RwReg8 *)0x42002004UL) /**< \brief (TC0) Control B Clear */
+#define REG_TC0_CTRLBSET           (*(RwReg8 *)0x42002005UL) /**< \brief (TC0) Control B Set */
+#define REG_TC0_CTRLC              (*(RwReg8 *)0x42002006UL) /**< \brief (TC0) Control C */
+#define REG_TC0_DBGCTRL            (*(RwReg8 *)0x42002008UL) /**< \brief (TC0) Debug Control */
+#define REG_TC0_EVCTRL             (*(RwReg16*)0x4200200AUL) /**< \brief (TC0) Event Control */
+#define REG_TC0_INTENCLR           (*(RwReg8 *)0x4200200CUL) /**< \brief (TC0) Interrupt Enable Clear */
+#define REG_TC0_INTENSET           (*(RwReg8 *)0x4200200DUL) /**< \brief (TC0) Interrupt Enable Set */
+#define REG_TC0_INTFLAG            (*(RwReg8 *)0x4200200EUL) /**< \brief (TC0) Interrupt Flag Status and Clear */
+#define REG_TC0_STATUS             (*(RoReg8 *)0x4200200FUL) /**< \brief (TC0) Status */
+#define REG_TC0_COUNT16_COUNT      (*(RwReg16*)0x42002010UL) /**< \brief (TC0) COUNT16 Counter Value */
+#define REG_TC0_COUNT16_CC0        (*(RwReg16*)0x42002018UL) /**< \brief (TC0) COUNT16 Compare/Capture 0 */
+#define REG_TC0_COUNT16_CC1        (*(RwReg16*)0x4200201AUL) /**< \brief (TC0) COUNT16 Compare/Capture 1 */
+#define REG_TC0_COUNT32_COUNT      (*(RwReg  *)0x42002010UL) /**< \brief (TC0) COUNT32 Counter Value */
+#define REG_TC0_COUNT32_CC0        (*(RwReg  *)0x42002018UL) /**< \brief (TC0) COUNT32 Compare/Capture 0 */
+#define REG_TC0_COUNT32_CC1        (*(RwReg  *)0x4200201CUL) /**< \brief (TC0) COUNT32 Compare/Capture 1 */
+#define REG_TC0_COUNT8_COUNT       (*(RwReg8 *)0x42002010UL) /**< \brief (TC0) COUNT8 Counter Value */
+#define REG_TC0_COUNT8_PER         (*(RwReg8 *)0x42002014UL) /**< \brief (TC0) COUNT8 Period Value */
+#define REG_TC0_COUNT8_CC0         (*(RwReg8 *)0x42002018UL) /**< \brief (TC0) COUNT8 Compare/Capture 0 */
+#define REG_TC0_COUNT8_CC1         (*(RwReg8 *)0x42002019UL) /**< \brief (TC0) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC0 peripheral ========== */
+#define TC0_CC8_NUM                 2       
+#define TC0_CC16_NUM                2       
+#define TC0_CC32_NUM                2       
+#define TC0_DITHERING_EXT           0       
+#define TC0_GCLK_ID                 19      
+#define TC0_MASTER                  1       
+#define TC0_OW_NUM                  2       
+#define TC0_PERIOD_EXT              0       
+#define TC0_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC0_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc1.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc1.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC1
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC1_INSTANCE_
+#define _SAMD20_TC1_INSTANCE_
+
+/* ========== Register definition for TC1 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC1_CTRLA              (0x42002400) /**< \brief (TC1) Control A */
+#define REG_TC1_READREQ            (0x42002402) /**< \brief (TC1) Read Request */
+#define REG_TC1_CTRLBCLR           (0x42002404) /**< \brief (TC1) Control B Clear */
+#define REG_TC1_CTRLBSET           (0x42002405) /**< \brief (TC1) Control B Set */
+#define REG_TC1_CTRLC              (0x42002406) /**< \brief (TC1) Control C */
+#define REG_TC1_DBGCTRL            (0x42002408) /**< \brief (TC1) Debug Control */
+#define REG_TC1_EVCTRL             (0x4200240A) /**< \brief (TC1) Event Control */
+#define REG_TC1_INTENCLR           (0x4200240C) /**< \brief (TC1) Interrupt Enable Clear */
+#define REG_TC1_INTENSET           (0x4200240D) /**< \brief (TC1) Interrupt Enable Set */
+#define REG_TC1_INTFLAG            (0x4200240E) /**< \brief (TC1) Interrupt Flag Status and Clear */
+#define REG_TC1_STATUS             (0x4200240F) /**< \brief (TC1) Status */
+#define REG_TC1_COUNT16_COUNT      (0x42002410) /**< \brief (TC1) COUNT16 Counter Value */
+#define REG_TC1_COUNT16_CC0        (0x42002418) /**< \brief (TC1) COUNT16 Compare/Capture 0 */
+#define REG_TC1_COUNT16_CC1        (0x4200241A) /**< \brief (TC1) COUNT16 Compare/Capture 1 */
+#define REG_TC1_COUNT32_COUNT      (0x42002410) /**< \brief (TC1) COUNT32 Counter Value */
+#define REG_TC1_COUNT32_CC0        (0x42002418) /**< \brief (TC1) COUNT32 Compare/Capture 0 */
+#define REG_TC1_COUNT32_CC1        (0x4200241C) /**< \brief (TC1) COUNT32 Compare/Capture 1 */
+#define REG_TC1_COUNT8_COUNT       (0x42002410) /**< \brief (TC1) COUNT8 Counter Value */
+#define REG_TC1_COUNT8_PER         (0x42002414) /**< \brief (TC1) COUNT8 Period Value */
+#define REG_TC1_COUNT8_CC0         (0x42002418) /**< \brief (TC1) COUNT8 Compare/Capture 0 */
+#define REG_TC1_COUNT8_CC1         (0x42002419) /**< \brief (TC1) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC1_CTRLA              (*(RwReg16*)0x42002400UL) /**< \brief (TC1) Control A */
+#define REG_TC1_READREQ            (*(RwReg16*)0x42002402UL) /**< \brief (TC1) Read Request */
+#define REG_TC1_CTRLBCLR           (*(RwReg8 *)0x42002404UL) /**< \brief (TC1) Control B Clear */
+#define REG_TC1_CTRLBSET           (*(RwReg8 *)0x42002405UL) /**< \brief (TC1) Control B Set */
+#define REG_TC1_CTRLC              (*(RwReg8 *)0x42002406UL) /**< \brief (TC1) Control C */
+#define REG_TC1_DBGCTRL            (*(RwReg8 *)0x42002408UL) /**< \brief (TC1) Debug Control */
+#define REG_TC1_EVCTRL             (*(RwReg16*)0x4200240AUL) /**< \brief (TC1) Event Control */
+#define REG_TC1_INTENCLR           (*(RwReg8 *)0x4200240CUL) /**< \brief (TC1) Interrupt Enable Clear */
+#define REG_TC1_INTENSET           (*(RwReg8 *)0x4200240DUL) /**< \brief (TC1) Interrupt Enable Set */
+#define REG_TC1_INTFLAG            (*(RwReg8 *)0x4200240EUL) /**< \brief (TC1) Interrupt Flag Status and Clear */
+#define REG_TC1_STATUS             (*(RoReg8 *)0x4200240FUL) /**< \brief (TC1) Status */
+#define REG_TC1_COUNT16_COUNT      (*(RwReg16*)0x42002410UL) /**< \brief (TC1) COUNT16 Counter Value */
+#define REG_TC1_COUNT16_CC0        (*(RwReg16*)0x42002418UL) /**< \brief (TC1) COUNT16 Compare/Capture 0 */
+#define REG_TC1_COUNT16_CC1        (*(RwReg16*)0x4200241AUL) /**< \brief (TC1) COUNT16 Compare/Capture 1 */
+#define REG_TC1_COUNT32_COUNT      (*(RwReg  *)0x42002410UL) /**< \brief (TC1) COUNT32 Counter Value */
+#define REG_TC1_COUNT32_CC0        (*(RwReg  *)0x42002418UL) /**< \brief (TC1) COUNT32 Compare/Capture 0 */
+#define REG_TC1_COUNT32_CC1        (*(RwReg  *)0x4200241CUL) /**< \brief (TC1) COUNT32 Compare/Capture 1 */
+#define REG_TC1_COUNT8_COUNT       (*(RwReg8 *)0x42002410UL) /**< \brief (TC1) COUNT8 Counter Value */
+#define REG_TC1_COUNT8_PER         (*(RwReg8 *)0x42002414UL) /**< \brief (TC1) COUNT8 Period Value */
+#define REG_TC1_COUNT8_CC0         (*(RwReg8 *)0x42002418UL) /**< \brief (TC1) COUNT8 Compare/Capture 0 */
+#define REG_TC1_COUNT8_CC1         (*(RwReg8 *)0x42002419UL) /**< \brief (TC1) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC1 peripheral ========== */
+#define TC1_CC8_NUM                 2       
+#define TC1_CC16_NUM                2       
+#define TC1_CC32_NUM                2       
+#define TC1_DITHERING_EXT           0       
+#define TC1_GCLK_ID                 19      
+#define TC1_MASTER                  0       
+#define TC1_OW_NUM                  2       
+#define TC1_PERIOD_EXT              0       
+#define TC1_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC1_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc2.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc2.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC2
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC2_INSTANCE_
+#define _SAMD20_TC2_INSTANCE_
+
+/* ========== Register definition for TC2 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC2_CTRLA              (0x42002800) /**< \brief (TC2) Control A */
+#define REG_TC2_READREQ            (0x42002802) /**< \brief (TC2) Read Request */
+#define REG_TC2_CTRLBCLR           (0x42002804) /**< \brief (TC2) Control B Clear */
+#define REG_TC2_CTRLBSET           (0x42002805) /**< \brief (TC2) Control B Set */
+#define REG_TC2_CTRLC              (0x42002806) /**< \brief (TC2) Control C */
+#define REG_TC2_DBGCTRL            (0x42002808) /**< \brief (TC2) Debug Control */
+#define REG_TC2_EVCTRL             (0x4200280A) /**< \brief (TC2) Event Control */
+#define REG_TC2_INTENCLR           (0x4200280C) /**< \brief (TC2) Interrupt Enable Clear */
+#define REG_TC2_INTENSET           (0x4200280D) /**< \brief (TC2) Interrupt Enable Set */
+#define REG_TC2_INTFLAG            (0x4200280E) /**< \brief (TC2) Interrupt Flag Status and Clear */
+#define REG_TC2_STATUS             (0x4200280F) /**< \brief (TC2) Status */
+#define REG_TC2_COUNT16_COUNT      (0x42002810) /**< \brief (TC2) COUNT16 Counter Value */
+#define REG_TC2_COUNT16_CC0        (0x42002818) /**< \brief (TC2) COUNT16 Compare/Capture 0 */
+#define REG_TC2_COUNT16_CC1        (0x4200281A) /**< \brief (TC2) COUNT16 Compare/Capture 1 */
+#define REG_TC2_COUNT32_COUNT      (0x42002810) /**< \brief (TC2) COUNT32 Counter Value */
+#define REG_TC2_COUNT32_CC0        (0x42002818) /**< \brief (TC2) COUNT32 Compare/Capture 0 */
+#define REG_TC2_COUNT32_CC1        (0x4200281C) /**< \brief (TC2) COUNT32 Compare/Capture 1 */
+#define REG_TC2_COUNT8_COUNT       (0x42002810) /**< \brief (TC2) COUNT8 Counter Value */
+#define REG_TC2_COUNT8_PER         (0x42002814) /**< \brief (TC2) COUNT8 Period Value */
+#define REG_TC2_COUNT8_CC0         (0x42002818) /**< \brief (TC2) COUNT8 Compare/Capture 0 */
+#define REG_TC2_COUNT8_CC1         (0x42002819) /**< \brief (TC2) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC2_CTRLA              (*(RwReg16*)0x42002800UL) /**< \brief (TC2) Control A */
+#define REG_TC2_READREQ            (*(RwReg16*)0x42002802UL) /**< \brief (TC2) Read Request */
+#define REG_TC2_CTRLBCLR           (*(RwReg8 *)0x42002804UL) /**< \brief (TC2) Control B Clear */
+#define REG_TC2_CTRLBSET           (*(RwReg8 *)0x42002805UL) /**< \brief (TC2) Control B Set */
+#define REG_TC2_CTRLC              (*(RwReg8 *)0x42002806UL) /**< \brief (TC2) Control C */
+#define REG_TC2_DBGCTRL            (*(RwReg8 *)0x42002808UL) /**< \brief (TC2) Debug Control */
+#define REG_TC2_EVCTRL             (*(RwReg16*)0x4200280AUL) /**< \brief (TC2) Event Control */
+#define REG_TC2_INTENCLR           (*(RwReg8 *)0x4200280CUL) /**< \brief (TC2) Interrupt Enable Clear */
+#define REG_TC2_INTENSET           (*(RwReg8 *)0x4200280DUL) /**< \brief (TC2) Interrupt Enable Set */
+#define REG_TC2_INTFLAG            (*(RwReg8 *)0x4200280EUL) /**< \brief (TC2) Interrupt Flag Status and Clear */
+#define REG_TC2_STATUS             (*(RoReg8 *)0x4200280FUL) /**< \brief (TC2) Status */
+#define REG_TC2_COUNT16_COUNT      (*(RwReg16*)0x42002810UL) /**< \brief (TC2) COUNT16 Counter Value */
+#define REG_TC2_COUNT16_CC0        (*(RwReg16*)0x42002818UL) /**< \brief (TC2) COUNT16 Compare/Capture 0 */
+#define REG_TC2_COUNT16_CC1        (*(RwReg16*)0x4200281AUL) /**< \brief (TC2) COUNT16 Compare/Capture 1 */
+#define REG_TC2_COUNT32_COUNT      (*(RwReg  *)0x42002810UL) /**< \brief (TC2) COUNT32 Counter Value */
+#define REG_TC2_COUNT32_CC0        (*(RwReg  *)0x42002818UL) /**< \brief (TC2) COUNT32 Compare/Capture 0 */
+#define REG_TC2_COUNT32_CC1        (*(RwReg  *)0x4200281CUL) /**< \brief (TC2) COUNT32 Compare/Capture 1 */
+#define REG_TC2_COUNT8_COUNT       (*(RwReg8 *)0x42002810UL) /**< \brief (TC2) COUNT8 Counter Value */
+#define REG_TC2_COUNT8_PER         (*(RwReg8 *)0x42002814UL) /**< \brief (TC2) COUNT8 Period Value */
+#define REG_TC2_COUNT8_CC0         (*(RwReg8 *)0x42002818UL) /**< \brief (TC2) COUNT8 Compare/Capture 0 */
+#define REG_TC2_COUNT8_CC1         (*(RwReg8 *)0x42002819UL) /**< \brief (TC2) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC2 peripheral ========== */
+#define TC2_CC8_NUM                 2       
+#define TC2_CC16_NUM                2       
+#define TC2_CC32_NUM                2       
+#define TC2_DITHERING_EXT           0       
+#define TC2_GCLK_ID                 20      
+#define TC2_MASTER                  1       
+#define TC2_OW_NUM                  2       
+#define TC2_PERIOD_EXT              0       
+#define TC2_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC2_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc3.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc3.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC3
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC3_INSTANCE_
+#define _SAMD20_TC3_INSTANCE_
+
+/* ========== Register definition for TC3 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC3_CTRLA              (0x42002C00) /**< \brief (TC3) Control A */
+#define REG_TC3_READREQ            (0x42002C02) /**< \brief (TC3) Read Request */
+#define REG_TC3_CTRLBCLR           (0x42002C04) /**< \brief (TC3) Control B Clear */
+#define REG_TC3_CTRLBSET           (0x42002C05) /**< \brief (TC3) Control B Set */
+#define REG_TC3_CTRLC              (0x42002C06) /**< \brief (TC3) Control C */
+#define REG_TC3_DBGCTRL            (0x42002C08) /**< \brief (TC3) Debug Control */
+#define REG_TC3_EVCTRL             (0x42002C0A) /**< \brief (TC3) Event Control */
+#define REG_TC3_INTENCLR           (0x42002C0C) /**< \brief (TC3) Interrupt Enable Clear */
+#define REG_TC3_INTENSET           (0x42002C0D) /**< \brief (TC3) Interrupt Enable Set */
+#define REG_TC3_INTFLAG            (0x42002C0E) /**< \brief (TC3) Interrupt Flag Status and Clear */
+#define REG_TC3_STATUS             (0x42002C0F) /**< \brief (TC3) Status */
+#define REG_TC3_COUNT16_COUNT      (0x42002C10) /**< \brief (TC3) COUNT16 Counter Value */
+#define REG_TC3_COUNT16_CC0        (0x42002C18) /**< \brief (TC3) COUNT16 Compare/Capture 0 */
+#define REG_TC3_COUNT16_CC1        (0x42002C1A) /**< \brief (TC3) COUNT16 Compare/Capture 1 */
+#define REG_TC3_COUNT32_COUNT      (0x42002C10) /**< \brief (TC3) COUNT32 Counter Value */
+#define REG_TC3_COUNT32_CC0        (0x42002C18) /**< \brief (TC3) COUNT32 Compare/Capture 0 */
+#define REG_TC3_COUNT32_CC1        (0x42002C1C) /**< \brief (TC3) COUNT32 Compare/Capture 1 */
+#define REG_TC3_COUNT8_COUNT       (0x42002C10) /**< \brief (TC3) COUNT8 Counter Value */
+#define REG_TC3_COUNT8_PER         (0x42002C14) /**< \brief (TC3) COUNT8 Period Value */
+#define REG_TC3_COUNT8_CC0         (0x42002C18) /**< \brief (TC3) COUNT8 Compare/Capture 0 */
+#define REG_TC3_COUNT8_CC1         (0x42002C19) /**< \brief (TC3) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC3_CTRLA              (*(RwReg16*)0x42002C00UL) /**< \brief (TC3) Control A */
+#define REG_TC3_READREQ            (*(RwReg16*)0x42002C02UL) /**< \brief (TC3) Read Request */
+#define REG_TC3_CTRLBCLR           (*(RwReg8 *)0x42002C04UL) /**< \brief (TC3) Control B Clear */
+#define REG_TC3_CTRLBSET           (*(RwReg8 *)0x42002C05UL) /**< \brief (TC3) Control B Set */
+#define REG_TC3_CTRLC              (*(RwReg8 *)0x42002C06UL) /**< \brief (TC3) Control C */
+#define REG_TC3_DBGCTRL            (*(RwReg8 *)0x42002C08UL) /**< \brief (TC3) Debug Control */
+#define REG_TC3_EVCTRL             (*(RwReg16*)0x42002C0AUL) /**< \brief (TC3) Event Control */
+#define REG_TC3_INTENCLR           (*(RwReg8 *)0x42002C0CUL) /**< \brief (TC3) Interrupt Enable Clear */
+#define REG_TC3_INTENSET           (*(RwReg8 *)0x42002C0DUL) /**< \brief (TC3) Interrupt Enable Set */
+#define REG_TC3_INTFLAG            (*(RwReg8 *)0x42002C0EUL) /**< \brief (TC3) Interrupt Flag Status and Clear */
+#define REG_TC3_STATUS             (*(RoReg8 *)0x42002C0FUL) /**< \brief (TC3) Status */
+#define REG_TC3_COUNT16_COUNT      (*(RwReg16*)0x42002C10UL) /**< \brief (TC3) COUNT16 Counter Value */
+#define REG_TC3_COUNT16_CC0        (*(RwReg16*)0x42002C18UL) /**< \brief (TC3) COUNT16 Compare/Capture 0 */
+#define REG_TC3_COUNT16_CC1        (*(RwReg16*)0x42002C1AUL) /**< \brief (TC3) COUNT16 Compare/Capture 1 */
+#define REG_TC3_COUNT32_COUNT      (*(RwReg  *)0x42002C10UL) /**< \brief (TC3) COUNT32 Counter Value */
+#define REG_TC3_COUNT32_CC0        (*(RwReg  *)0x42002C18UL) /**< \brief (TC3) COUNT32 Compare/Capture 0 */
+#define REG_TC3_COUNT32_CC1        (*(RwReg  *)0x42002C1CUL) /**< \brief (TC3) COUNT32 Compare/Capture 1 */
+#define REG_TC3_COUNT8_COUNT       (*(RwReg8 *)0x42002C10UL) /**< \brief (TC3) COUNT8 Counter Value */
+#define REG_TC3_COUNT8_PER         (*(RwReg8 *)0x42002C14UL) /**< \brief (TC3) COUNT8 Period Value */
+#define REG_TC3_COUNT8_CC0         (*(RwReg8 *)0x42002C18UL) /**< \brief (TC3) COUNT8 Compare/Capture 0 */
+#define REG_TC3_COUNT8_CC1         (*(RwReg8 *)0x42002C19UL) /**< \brief (TC3) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC3 peripheral ========== */
+#define TC3_CC8_NUM                 2       
+#define TC3_CC16_NUM                2       
+#define TC3_CC32_NUM                2       
+#define TC3_DITHERING_EXT           0       
+#define TC3_GCLK_ID                 20      
+#define TC3_MASTER                  0       
+#define TC3_OW_NUM                  2       
+#define TC3_PERIOD_EXT              0       
+#define TC3_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC3_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc4.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc4.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC4
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC4_INSTANCE_
+#define _SAMD20_TC4_INSTANCE_
+
+/* ========== Register definition for TC4 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC4_CTRLA              (0x42003000) /**< \brief (TC4) Control A */
+#define REG_TC4_READREQ            (0x42003002) /**< \brief (TC4) Read Request */
+#define REG_TC4_CTRLBCLR           (0x42003004) /**< \brief (TC4) Control B Clear */
+#define REG_TC4_CTRLBSET           (0x42003005) /**< \brief (TC4) Control B Set */
+#define REG_TC4_CTRLC              (0x42003006) /**< \brief (TC4) Control C */
+#define REG_TC4_DBGCTRL            (0x42003008) /**< \brief (TC4) Debug Control */
+#define REG_TC4_EVCTRL             (0x4200300A) /**< \brief (TC4) Event Control */
+#define REG_TC4_INTENCLR           (0x4200300C) /**< \brief (TC4) Interrupt Enable Clear */
+#define REG_TC4_INTENSET           (0x4200300D) /**< \brief (TC4) Interrupt Enable Set */
+#define REG_TC4_INTFLAG            (0x4200300E) /**< \brief (TC4) Interrupt Flag Status and Clear */
+#define REG_TC4_STATUS             (0x4200300F) /**< \brief (TC4) Status */
+#define REG_TC4_COUNT16_COUNT      (0x42003010) /**< \brief (TC4) COUNT16 Counter Value */
+#define REG_TC4_COUNT16_CC0        (0x42003018) /**< \brief (TC4) COUNT16 Compare/Capture 0 */
+#define REG_TC4_COUNT16_CC1        (0x4200301A) /**< \brief (TC4) COUNT16 Compare/Capture 1 */
+#define REG_TC4_COUNT32_COUNT      (0x42003010) /**< \brief (TC4) COUNT32 Counter Value */
+#define REG_TC4_COUNT32_CC0        (0x42003018) /**< \brief (TC4) COUNT32 Compare/Capture 0 */
+#define REG_TC4_COUNT32_CC1        (0x4200301C) /**< \brief (TC4) COUNT32 Compare/Capture 1 */
+#define REG_TC4_COUNT8_COUNT       (0x42003010) /**< \brief (TC4) COUNT8 Counter Value */
+#define REG_TC4_COUNT8_PER         (0x42003014) /**< \brief (TC4) COUNT8 Period Value */
+#define REG_TC4_COUNT8_CC0         (0x42003018) /**< \brief (TC4) COUNT8 Compare/Capture 0 */
+#define REG_TC4_COUNT8_CC1         (0x42003019) /**< \brief (TC4) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC4_CTRLA              (*(RwReg16*)0x42003000UL) /**< \brief (TC4) Control A */
+#define REG_TC4_READREQ            (*(RwReg16*)0x42003002UL) /**< \brief (TC4) Read Request */
+#define REG_TC4_CTRLBCLR           (*(RwReg8 *)0x42003004UL) /**< \brief (TC4) Control B Clear */
+#define REG_TC4_CTRLBSET           (*(RwReg8 *)0x42003005UL) /**< \brief (TC4) Control B Set */
+#define REG_TC4_CTRLC              (*(RwReg8 *)0x42003006UL) /**< \brief (TC4) Control C */
+#define REG_TC4_DBGCTRL            (*(RwReg8 *)0x42003008UL) /**< \brief (TC4) Debug Control */
+#define REG_TC4_EVCTRL             (*(RwReg16*)0x4200300AUL) /**< \brief (TC4) Event Control */
+#define REG_TC4_INTENCLR           (*(RwReg8 *)0x4200300CUL) /**< \brief (TC4) Interrupt Enable Clear */
+#define REG_TC4_INTENSET           (*(RwReg8 *)0x4200300DUL) /**< \brief (TC4) Interrupt Enable Set */
+#define REG_TC4_INTFLAG            (*(RwReg8 *)0x4200300EUL) /**< \brief (TC4) Interrupt Flag Status and Clear */
+#define REG_TC4_STATUS             (*(RoReg8 *)0x4200300FUL) /**< \brief (TC4) Status */
+#define REG_TC4_COUNT16_COUNT      (*(RwReg16*)0x42003010UL) /**< \brief (TC4) COUNT16 Counter Value */
+#define REG_TC4_COUNT16_CC0        (*(RwReg16*)0x42003018UL) /**< \brief (TC4) COUNT16 Compare/Capture 0 */
+#define REG_TC4_COUNT16_CC1        (*(RwReg16*)0x4200301AUL) /**< \brief (TC4) COUNT16 Compare/Capture 1 */
+#define REG_TC4_COUNT32_COUNT      (*(RwReg  *)0x42003010UL) /**< \brief (TC4) COUNT32 Counter Value */
+#define REG_TC4_COUNT32_CC0        (*(RwReg  *)0x42003018UL) /**< \brief (TC4) COUNT32 Compare/Capture 0 */
+#define REG_TC4_COUNT32_CC1        (*(RwReg  *)0x4200301CUL) /**< \brief (TC4) COUNT32 Compare/Capture 1 */
+#define REG_TC4_COUNT8_COUNT       (*(RwReg8 *)0x42003010UL) /**< \brief (TC4) COUNT8 Counter Value */
+#define REG_TC4_COUNT8_PER         (*(RwReg8 *)0x42003014UL) /**< \brief (TC4) COUNT8 Period Value */
+#define REG_TC4_COUNT8_CC0         (*(RwReg8 *)0x42003018UL) /**< \brief (TC4) COUNT8 Compare/Capture 0 */
+#define REG_TC4_COUNT8_CC1         (*(RwReg8 *)0x42003019UL) /**< \brief (TC4) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC4 peripheral ========== */
+#define TC4_CC8_NUM                 2       
+#define TC4_CC16_NUM                2       
+#define TC4_CC32_NUM                2       
+#define TC4_DITHERING_EXT           0       
+#define TC4_GCLK_ID                 21      
+#define TC4_MASTER                  1       
+#define TC4_OW_NUM                  2       
+#define TC4_PERIOD_EXT              0       
+#define TC4_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC4_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc5.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc5.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC5
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC5_INSTANCE_
+#define _SAMD20_TC5_INSTANCE_
+
+/* ========== Register definition for TC5 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC5_CTRLA              (0x42003400) /**< \brief (TC5) Control A */
+#define REG_TC5_READREQ            (0x42003402) /**< \brief (TC5) Read Request */
+#define REG_TC5_CTRLBCLR           (0x42003404) /**< \brief (TC5) Control B Clear */
+#define REG_TC5_CTRLBSET           (0x42003405) /**< \brief (TC5) Control B Set */
+#define REG_TC5_CTRLC              (0x42003406) /**< \brief (TC5) Control C */
+#define REG_TC5_DBGCTRL            (0x42003408) /**< \brief (TC5) Debug Control */
+#define REG_TC5_EVCTRL             (0x4200340A) /**< \brief (TC5) Event Control */
+#define REG_TC5_INTENCLR           (0x4200340C) /**< \brief (TC5) Interrupt Enable Clear */
+#define REG_TC5_INTENSET           (0x4200340D) /**< \brief (TC5) Interrupt Enable Set */
+#define REG_TC5_INTFLAG            (0x4200340E) /**< \brief (TC5) Interrupt Flag Status and Clear */
+#define REG_TC5_STATUS             (0x4200340F) /**< \brief (TC5) Status */
+#define REG_TC5_COUNT16_COUNT      (0x42003410) /**< \brief (TC5) COUNT16 Counter Value */
+#define REG_TC5_COUNT16_CC0        (0x42003418) /**< \brief (TC5) COUNT16 Compare/Capture 0 */
+#define REG_TC5_COUNT16_CC1        (0x4200341A) /**< \brief (TC5) COUNT16 Compare/Capture 1 */
+#define REG_TC5_COUNT32_COUNT      (0x42003410) /**< \brief (TC5) COUNT32 Counter Value */
+#define REG_TC5_COUNT32_CC0        (0x42003418) /**< \brief (TC5) COUNT32 Compare/Capture 0 */
+#define REG_TC5_COUNT32_CC1        (0x4200341C) /**< \brief (TC5) COUNT32 Compare/Capture 1 */
+#define REG_TC5_COUNT8_COUNT       (0x42003410) /**< \brief (TC5) COUNT8 Counter Value */
+#define REG_TC5_COUNT8_PER         (0x42003414) /**< \brief (TC5) COUNT8 Period Value */
+#define REG_TC5_COUNT8_CC0         (0x42003418) /**< \brief (TC5) COUNT8 Compare/Capture 0 */
+#define REG_TC5_COUNT8_CC1         (0x42003419) /**< \brief (TC5) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC5_CTRLA              (*(RwReg16*)0x42003400UL) /**< \brief (TC5) Control A */
+#define REG_TC5_READREQ            (*(RwReg16*)0x42003402UL) /**< \brief (TC5) Read Request */
+#define REG_TC5_CTRLBCLR           (*(RwReg8 *)0x42003404UL) /**< \brief (TC5) Control B Clear */
+#define REG_TC5_CTRLBSET           (*(RwReg8 *)0x42003405UL) /**< \brief (TC5) Control B Set */
+#define REG_TC5_CTRLC              (*(RwReg8 *)0x42003406UL) /**< \brief (TC5) Control C */
+#define REG_TC5_DBGCTRL            (*(RwReg8 *)0x42003408UL) /**< \brief (TC5) Debug Control */
+#define REG_TC5_EVCTRL             (*(RwReg16*)0x4200340AUL) /**< \brief (TC5) Event Control */
+#define REG_TC5_INTENCLR           (*(RwReg8 *)0x4200340CUL) /**< \brief (TC5) Interrupt Enable Clear */
+#define REG_TC5_INTENSET           (*(RwReg8 *)0x4200340DUL) /**< \brief (TC5) Interrupt Enable Set */
+#define REG_TC5_INTFLAG            (*(RwReg8 *)0x4200340EUL) /**< \brief (TC5) Interrupt Flag Status and Clear */
+#define REG_TC5_STATUS             (*(RoReg8 *)0x4200340FUL) /**< \brief (TC5) Status */
+#define REG_TC5_COUNT16_COUNT      (*(RwReg16*)0x42003410UL) /**< \brief (TC5) COUNT16 Counter Value */
+#define REG_TC5_COUNT16_CC0        (*(RwReg16*)0x42003418UL) /**< \brief (TC5) COUNT16 Compare/Capture 0 */
+#define REG_TC5_COUNT16_CC1        (*(RwReg16*)0x4200341AUL) /**< \brief (TC5) COUNT16 Compare/Capture 1 */
+#define REG_TC5_COUNT32_COUNT      (*(RwReg  *)0x42003410UL) /**< \brief (TC5) COUNT32 Counter Value */
+#define REG_TC5_COUNT32_CC0        (*(RwReg  *)0x42003418UL) /**< \brief (TC5) COUNT32 Compare/Capture 0 */
+#define REG_TC5_COUNT32_CC1        (*(RwReg  *)0x4200341CUL) /**< \brief (TC5) COUNT32 Compare/Capture 1 */
+#define REG_TC5_COUNT8_COUNT       (*(RwReg8 *)0x42003410UL) /**< \brief (TC5) COUNT8 Counter Value */
+#define REG_TC5_COUNT8_PER         (*(RwReg8 *)0x42003414UL) /**< \brief (TC5) COUNT8 Period Value */
+#define REG_TC5_COUNT8_CC0         (*(RwReg8 *)0x42003418UL) /**< \brief (TC5) COUNT8 Compare/Capture 0 */
+#define REG_TC5_COUNT8_CC1         (*(RwReg8 *)0x42003419UL) /**< \brief (TC5) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC5 peripheral ========== */
+#define TC5_CC8_NUM                 2       
+#define TC5_CC16_NUM                2       
+#define TC5_CC32_NUM                2       
+#define TC5_DITHERING_EXT           0       
+#define TC5_GCLK_ID                 21      
+#define TC5_MASTER                  0       
+#define TC5_OW_NUM                  2       
+#define TC5_PERIOD_EXT              0       
+#define TC5_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC5_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc6.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc6.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC6
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC6_INSTANCE_
+#define _SAMD20_TC6_INSTANCE_
+
+/* ========== Register definition for TC6 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC6_CTRLA              (0x42003800) /**< \brief (TC6) Control A */
+#define REG_TC6_READREQ            (0x42003802) /**< \brief (TC6) Read Request */
+#define REG_TC6_CTRLBCLR           (0x42003804) /**< \brief (TC6) Control B Clear */
+#define REG_TC6_CTRLBSET           (0x42003805) /**< \brief (TC6) Control B Set */
+#define REG_TC6_CTRLC              (0x42003806) /**< \brief (TC6) Control C */
+#define REG_TC6_DBGCTRL            (0x42003808) /**< \brief (TC6) Debug Control */
+#define REG_TC6_EVCTRL             (0x4200380A) /**< \brief (TC6) Event Control */
+#define REG_TC6_INTENCLR           (0x4200380C) /**< \brief (TC6) Interrupt Enable Clear */
+#define REG_TC6_INTENSET           (0x4200380D) /**< \brief (TC6) Interrupt Enable Set */
+#define REG_TC6_INTFLAG            (0x4200380E) /**< \brief (TC6) Interrupt Flag Status and Clear */
+#define REG_TC6_STATUS             (0x4200380F) /**< \brief (TC6) Status */
+#define REG_TC6_COUNT16_COUNT      (0x42003810) /**< \brief (TC6) COUNT16 Counter Value */
+#define REG_TC6_COUNT16_CC0        (0x42003818) /**< \brief (TC6) COUNT16 Compare/Capture 0 */
+#define REG_TC6_COUNT16_CC1        (0x4200381A) /**< \brief (TC6) COUNT16 Compare/Capture 1 */
+#define REG_TC6_COUNT32_COUNT      (0x42003810) /**< \brief (TC6) COUNT32 Counter Value */
+#define REG_TC6_COUNT32_CC0        (0x42003818) /**< \brief (TC6) COUNT32 Compare/Capture 0 */
+#define REG_TC6_COUNT32_CC1        (0x4200381C) /**< \brief (TC6) COUNT32 Compare/Capture 1 */
+#define REG_TC6_COUNT8_COUNT       (0x42003810) /**< \brief (TC6) COUNT8 Counter Value */
+#define REG_TC6_COUNT8_PER         (0x42003814) /**< \brief (TC6) COUNT8 Period Value */
+#define REG_TC6_COUNT8_CC0         (0x42003818) /**< \brief (TC6) COUNT8 Compare/Capture 0 */
+#define REG_TC6_COUNT8_CC1         (0x42003819) /**< \brief (TC6) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC6_CTRLA              (*(RwReg16*)0x42003800UL) /**< \brief (TC6) Control A */
+#define REG_TC6_READREQ            (*(RwReg16*)0x42003802UL) /**< \brief (TC6) Read Request */
+#define REG_TC6_CTRLBCLR           (*(RwReg8 *)0x42003804UL) /**< \brief (TC6) Control B Clear */
+#define REG_TC6_CTRLBSET           (*(RwReg8 *)0x42003805UL) /**< \brief (TC6) Control B Set */
+#define REG_TC6_CTRLC              (*(RwReg8 *)0x42003806UL) /**< \brief (TC6) Control C */
+#define REG_TC6_DBGCTRL            (*(RwReg8 *)0x42003808UL) /**< \brief (TC6) Debug Control */
+#define REG_TC6_EVCTRL             (*(RwReg16*)0x4200380AUL) /**< \brief (TC6) Event Control */
+#define REG_TC6_INTENCLR           (*(RwReg8 *)0x4200380CUL) /**< \brief (TC6) Interrupt Enable Clear */
+#define REG_TC6_INTENSET           (*(RwReg8 *)0x4200380DUL) /**< \brief (TC6) Interrupt Enable Set */
+#define REG_TC6_INTFLAG            (*(RwReg8 *)0x4200380EUL) /**< \brief (TC6) Interrupt Flag Status and Clear */
+#define REG_TC6_STATUS             (*(RoReg8 *)0x4200380FUL) /**< \brief (TC6) Status */
+#define REG_TC6_COUNT16_COUNT      (*(RwReg16*)0x42003810UL) /**< \brief (TC6) COUNT16 Counter Value */
+#define REG_TC6_COUNT16_CC0        (*(RwReg16*)0x42003818UL) /**< \brief (TC6) COUNT16 Compare/Capture 0 */
+#define REG_TC6_COUNT16_CC1        (*(RwReg16*)0x4200381AUL) /**< \brief (TC6) COUNT16 Compare/Capture 1 */
+#define REG_TC6_COUNT32_COUNT      (*(RwReg  *)0x42003810UL) /**< \brief (TC6) COUNT32 Counter Value */
+#define REG_TC6_COUNT32_CC0        (*(RwReg  *)0x42003818UL) /**< \brief (TC6) COUNT32 Compare/Capture 0 */
+#define REG_TC6_COUNT32_CC1        (*(RwReg  *)0x4200381CUL) /**< \brief (TC6) COUNT32 Compare/Capture 1 */
+#define REG_TC6_COUNT8_COUNT       (*(RwReg8 *)0x42003810UL) /**< \brief (TC6) COUNT8 Counter Value */
+#define REG_TC6_COUNT8_PER         (*(RwReg8 *)0x42003814UL) /**< \brief (TC6) COUNT8 Period Value */
+#define REG_TC6_COUNT8_CC0         (*(RwReg8 *)0x42003818UL) /**< \brief (TC6) COUNT8 Compare/Capture 0 */
+#define REG_TC6_COUNT8_CC1         (*(RwReg8 *)0x42003819UL) /**< \brief (TC6) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC6 peripheral ========== */
+#define TC6_CC8_NUM                 2       
+#define TC6_CC16_NUM                2       
+#define TC6_CC32_NUM                2       
+#define TC6_DITHERING_EXT           0       
+#define TC6_GCLK_ID                 22      
+#define TC6_MASTER                  1       
+#define TC6_OW_NUM                  2       
+#define TC6_PERIOD_EXT              0       
+#define TC6_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC6_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc7.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/tc7.h
@@ -1,0 +1,91 @@
+/**
+ * \file
+ *
+ * \brief Instance description for TC7
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_TC7_INSTANCE_
+#define _SAMD20_TC7_INSTANCE_
+
+/* ========== Register definition for TC7 peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_TC7_CTRLA              (0x42003C00) /**< \brief (TC7) Control A */
+#define REG_TC7_READREQ            (0x42003C02) /**< \brief (TC7) Read Request */
+#define REG_TC7_CTRLBCLR           (0x42003C04) /**< \brief (TC7) Control B Clear */
+#define REG_TC7_CTRLBSET           (0x42003C05) /**< \brief (TC7) Control B Set */
+#define REG_TC7_CTRLC              (0x42003C06) /**< \brief (TC7) Control C */
+#define REG_TC7_DBGCTRL            (0x42003C08) /**< \brief (TC7) Debug Control */
+#define REG_TC7_EVCTRL             (0x42003C0A) /**< \brief (TC7) Event Control */
+#define REG_TC7_INTENCLR           (0x42003C0C) /**< \brief (TC7) Interrupt Enable Clear */
+#define REG_TC7_INTENSET           (0x42003C0D) /**< \brief (TC7) Interrupt Enable Set */
+#define REG_TC7_INTFLAG            (0x42003C0E) /**< \brief (TC7) Interrupt Flag Status and Clear */
+#define REG_TC7_STATUS             (0x42003C0F) /**< \brief (TC7) Status */
+#define REG_TC7_COUNT16_COUNT      (0x42003C10) /**< \brief (TC7) COUNT16 Counter Value */
+#define REG_TC7_COUNT16_CC0        (0x42003C18) /**< \brief (TC7) COUNT16 Compare/Capture 0 */
+#define REG_TC7_COUNT16_CC1        (0x42003C1A) /**< \brief (TC7) COUNT16 Compare/Capture 1 */
+#define REG_TC7_COUNT32_COUNT      (0x42003C10) /**< \brief (TC7) COUNT32 Counter Value */
+#define REG_TC7_COUNT32_CC0        (0x42003C18) /**< \brief (TC7) COUNT32 Compare/Capture 0 */
+#define REG_TC7_COUNT32_CC1        (0x42003C1C) /**< \brief (TC7) COUNT32 Compare/Capture 1 */
+#define REG_TC7_COUNT8_COUNT       (0x42003C10) /**< \brief (TC7) COUNT8 Counter Value */
+#define REG_TC7_COUNT8_PER         (0x42003C14) /**< \brief (TC7) COUNT8 Period Value */
+#define REG_TC7_COUNT8_CC0         (0x42003C18) /**< \brief (TC7) COUNT8 Compare/Capture 0 */
+#define REG_TC7_COUNT8_CC1         (0x42003C19) /**< \brief (TC7) COUNT8 Compare/Capture 1 */
+#else
+#define REG_TC7_CTRLA              (*(RwReg16*)0x42003C00UL) /**< \brief (TC7) Control A */
+#define REG_TC7_READREQ            (*(RwReg16*)0x42003C02UL) /**< \brief (TC7) Read Request */
+#define REG_TC7_CTRLBCLR           (*(RwReg8 *)0x42003C04UL) /**< \brief (TC7) Control B Clear */
+#define REG_TC7_CTRLBSET           (*(RwReg8 *)0x42003C05UL) /**< \brief (TC7) Control B Set */
+#define REG_TC7_CTRLC              (*(RwReg8 *)0x42003C06UL) /**< \brief (TC7) Control C */
+#define REG_TC7_DBGCTRL            (*(RwReg8 *)0x42003C08UL) /**< \brief (TC7) Debug Control */
+#define REG_TC7_EVCTRL             (*(RwReg16*)0x42003C0AUL) /**< \brief (TC7) Event Control */
+#define REG_TC7_INTENCLR           (*(RwReg8 *)0x42003C0CUL) /**< \brief (TC7) Interrupt Enable Clear */
+#define REG_TC7_INTENSET           (*(RwReg8 *)0x42003C0DUL) /**< \brief (TC7) Interrupt Enable Set */
+#define REG_TC7_INTFLAG            (*(RwReg8 *)0x42003C0EUL) /**< \brief (TC7) Interrupt Flag Status and Clear */
+#define REG_TC7_STATUS             (*(RoReg8 *)0x42003C0FUL) /**< \brief (TC7) Status */
+#define REG_TC7_COUNT16_COUNT      (*(RwReg16*)0x42003C10UL) /**< \brief (TC7) COUNT16 Counter Value */
+#define REG_TC7_COUNT16_CC0        (*(RwReg16*)0x42003C18UL) /**< \brief (TC7) COUNT16 Compare/Capture 0 */
+#define REG_TC7_COUNT16_CC1        (*(RwReg16*)0x42003C1AUL) /**< \brief (TC7) COUNT16 Compare/Capture 1 */
+#define REG_TC7_COUNT32_COUNT      (*(RwReg  *)0x42003C10UL) /**< \brief (TC7) COUNT32 Counter Value */
+#define REG_TC7_COUNT32_CC0        (*(RwReg  *)0x42003C18UL) /**< \brief (TC7) COUNT32 Compare/Capture 0 */
+#define REG_TC7_COUNT32_CC1        (*(RwReg  *)0x42003C1CUL) /**< \brief (TC7) COUNT32 Compare/Capture 1 */
+#define REG_TC7_COUNT8_COUNT       (*(RwReg8 *)0x42003C10UL) /**< \brief (TC7) COUNT8 Counter Value */
+#define REG_TC7_COUNT8_PER         (*(RwReg8 *)0x42003C14UL) /**< \brief (TC7) COUNT8 Period Value */
+#define REG_TC7_COUNT8_CC0         (*(RwReg8 *)0x42003C18UL) /**< \brief (TC7) COUNT8 Compare/Capture 0 */
+#define REG_TC7_COUNT8_CC1         (*(RwReg8 *)0x42003C19UL) /**< \brief (TC7) COUNT8 Compare/Capture 1 */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for TC7 peripheral ========== */
+#define TC7_CC8_NUM                 2       
+#define TC7_CC16_NUM                2       
+#define TC7_CC32_NUM                2       
+#define TC7_DITHERING_EXT           0       
+#define TC7_GCLK_ID                 22      
+#define TC7_MASTER                  0       
+#define TC7_OW_NUM                  2       
+#define TC7_PERIOD_EXT              0       
+#define TC7_SHADOW_EXT              0       
+
+#endif /* _SAMD20_TC7_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/instance/wdt.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/instance/wdt.h
@@ -1,0 +1,57 @@
+/**
+ * \file
+ *
+ * \brief Instance description for WDT
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_WDT_INSTANCE_
+#define _SAMD20_WDT_INSTANCE_
+
+/* ========== Register definition for WDT peripheral ========== */
+#if (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#define REG_WDT_CTRL               (0x40001000) /**< \brief (WDT) Control */
+#define REG_WDT_CONFIG             (0x40001001) /**< \brief (WDT) Configuration */
+#define REG_WDT_EWCTRL             (0x40001002) /**< \brief (WDT) Early Warning Interrupt Control */
+#define REG_WDT_INTENCLR           (0x40001004) /**< \brief (WDT) Interrupt Enable Clear */
+#define REG_WDT_INTENSET           (0x40001005) /**< \brief (WDT) Interrupt Enable Set */
+#define REG_WDT_INTFLAG            (0x40001006) /**< \brief (WDT) Interrupt Flag Status and Clear */
+#define REG_WDT_STATUS             (0x40001007) /**< \brief (WDT) Status */
+#define REG_WDT_CLEAR              (0x40001008) /**< \brief (WDT) Clear */
+#else
+#define REG_WDT_CTRL               (*(RwReg8 *)0x40001000UL) /**< \brief (WDT) Control */
+#define REG_WDT_CONFIG             (*(RwReg8 *)0x40001001UL) /**< \brief (WDT) Configuration */
+#define REG_WDT_EWCTRL             (*(RwReg8 *)0x40001002UL) /**< \brief (WDT) Early Warning Interrupt Control */
+#define REG_WDT_INTENCLR           (*(RwReg8 *)0x40001004UL) /**< \brief (WDT) Interrupt Enable Clear */
+#define REG_WDT_INTENSET           (*(RwReg8 *)0x40001005UL) /**< \brief (WDT) Interrupt Enable Set */
+#define REG_WDT_INTFLAG            (*(RwReg8 *)0x40001006UL) /**< \brief (WDT) Interrupt Flag Status and Clear */
+#define REG_WDT_STATUS             (*(RoReg8 *)0x40001007UL) /**< \brief (WDT) Status */
+#define REG_WDT_CLEAR              (*(WoReg8 *)0x40001008UL) /**< \brief (WDT) Clear */
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+
+/* ========== Instance parameters for WDT peripheral ========== */
+#define WDT_GCLK_ID                 1        // Index of Generic Clock
+
+#endif /* _SAMD20_WDT_INSTANCE_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20e14b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20e14b.h
@@ -1,0 +1,558 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20E14B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E14B_PIO_
+#define _SAMD20E14B_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20E14B_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20e15b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20e15b.h
@@ -1,0 +1,558 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20E15B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E15B_PIO_
+#define _SAMD20E15B_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20E15B_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20e15bu.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20e15bu.h
@@ -1,0 +1,497 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20E15BU
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E15BU_PIO_
+#define _SAMD20E15BU_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20E15BU_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20e16b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20e16b.h
@@ -1,0 +1,558 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20E16B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E16B_PIO_
+#define _SAMD20E16B_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20E16B_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20e16bu.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20e16bu.h
@@ -1,0 +1,497 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20E16BU
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E16BU_PIO_
+#define _SAMD20E16BU_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20E16BU_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20g14b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20g14b.h
@@ -1,0 +1,804 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20G14B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G14B_PIO_
+#define _SAMD20G14B_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20G14B_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20g15b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20g15b.h
@@ -1,0 +1,804 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20G15B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G15B_PIO_
+#define _SAMD20G15B_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20G15B_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20g16b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20g16b.h
@@ -1,0 +1,804 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20G16B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G16B_PIO_
+#define _SAMD20G16B_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20G16B_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20j14b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20j14b.h
@@ -1,0 +1,1056 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20J14B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J14B_PIO_
+#define _SAMD20J14B_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB00                           32  /**< \brief Pin Number for PB00 */
+#define PORT_PB00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PB00 */
+#define PIN_PB01                           33  /**< \brief Pin Number for PB01 */
+#define PORT_PB01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PB01 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB04                           36  /**< \brief Pin Number for PB04 */
+#define PORT_PB04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PB04 */
+#define PIN_PB05                           37  /**< \brief Pin Number for PB05 */
+#define PORT_PB05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PB05 */
+#define PIN_PB06                           38  /**< \brief Pin Number for PB06 */
+#define PORT_PB06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PB06 */
+#define PIN_PB07                           39  /**< \brief Pin Number for PB07 */
+#define PORT_PB07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PB07 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB12                           44  /**< \brief Pin Number for PB12 */
+#define PORT_PB12              (_UL_(1) << 12) /**< \brief PORT Mask  for PB12 */
+#define PIN_PB13                           45  /**< \brief Pin Number for PB13 */
+#define PORT_PB13              (_UL_(1) << 13) /**< \brief PORT Mask  for PB13 */
+#define PIN_PB14                           46  /**< \brief Pin Number for PB14 */
+#define PORT_PB14              (_UL_(1) << 14) /**< \brief PORT Mask  for PB14 */
+#define PIN_PB15                           47  /**< \brief Pin Number for PB15 */
+#define PORT_PB15              (_UL_(1) << 15) /**< \brief PORT Mask  for PB15 */
+#define PIN_PB16                           48  /**< \brief Pin Number for PB16 */
+#define PORT_PB16              (_UL_(1) << 16) /**< \brief PORT Mask  for PB16 */
+#define PIN_PB17                           49  /**< \brief Pin Number for PB17 */
+#define PORT_PB17              (_UL_(1) << 17) /**< \brief PORT Mask  for PB17 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+#define PIN_PB30                           62  /**< \brief Pin Number for PB30 */
+#define PORT_PB30              (_UL_(1) << 30) /**< \brief PORT Mask  for PB30 */
+#define PIN_PB31                           63  /**< \brief Pin Number for PB31 */
+#define PORT_PB31              (_UL_(1) << 31) /**< \brief PORT Mask  for PB31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB14H_GCLK_IO0             _L_(46) /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0              _L_(7)
+#define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
+#define PORT_PB14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB15H_GCLK_IO1             _L_(47) /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1              _L_(7)
+#define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
+#define PORT_PB15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB16H_GCLK_IO2             _L_(48) /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2              _L_(7)
+#define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
+#define PORT_PB16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PB17H_GCLK_IO3             _L_(49) /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3              _L_(7)
+#define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
+#define PORT_PB17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PB12H_GCLK_IO6             _L_(44) /**< \brief GCLK signal: IO6 on PB12 mux H */
+#define MUX_PB12H_GCLK_IO6              _L_(7)
+#define PINMUX_PB12H_GCLK_IO6      ((PIN_PB12H_GCLK_IO6 << 16) | MUX_PB12H_GCLK_IO6)
+#define PORT_PB12H_GCLK_IO6    (_UL_(1) << 12)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+#define PIN_PB13H_GCLK_IO7             _L_(45) /**< \brief GCLK signal: IO7 on PB13 mux H */
+#define MUX_PB13H_GCLK_IO7              _L_(7)
+#define PINMUX_PB13H_GCLK_IO7      ((PIN_PB13H_GCLK_IO7 << 16) | MUX_PB13H_GCLK_IO7)
+#define PORT_PB13H_GCLK_IO7    (_UL_(1) << 13)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PB00A_EIC_EXTINT0          _L_(32) /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
+#define PORT_PB00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PB00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB00 External Interrupt Line */
+#define PIN_PB16A_EIC_EXTINT0          _L_(48) /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
+#define PORT_PB16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PB16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PB01A_EIC_EXTINT1          _L_(33) /**< \brief EIC signal: EXTINT1 on PB01 mux A */
+#define MUX_PB01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB01A_EIC_EXTINT1   ((PIN_PB01A_EIC_EXTINT1 << 16) | MUX_PB01A_EIC_EXTINT1)
+#define PORT_PB01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PB01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PB17A_EIC_EXTINT1          _L_(49) /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
+#define PORT_PB17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PB17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PB04A_EIC_EXTINT4          _L_(36) /**< \brief EIC signal: EXTINT4 on PB04 mux A */
+#define MUX_PB04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PB04A_EIC_EXTINT4   ((PIN_PB04A_EIC_EXTINT4 << 16) | MUX_PB04A_EIC_EXTINT4)
+#define PORT_PB04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PB04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PB04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PB05A_EIC_EXTINT5          _L_(37) /**< \brief EIC signal: EXTINT5 on PB05 mux A */
+#define MUX_PB05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PB05A_EIC_EXTINT5   ((PIN_PB05A_EIC_EXTINT5 << 16) | MUX_PB05A_EIC_EXTINT5)
+#define PORT_PB05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PB05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PB05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB06A_EIC_EXTINT6          _L_(38) /**< \brief EIC signal: EXTINT6 on PB06 mux A */
+#define MUX_PB06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB06A_EIC_EXTINT6   ((PIN_PB06A_EIC_EXTINT6 << 16) | MUX_PB06A_EIC_EXTINT6)
+#define PORT_PB06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PB06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB06 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB07A_EIC_EXTINT7          _L_(39) /**< \brief EIC signal: EXTINT7 on PB07 mux A */
+#define MUX_PB07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB07A_EIC_EXTINT7   ((PIN_PB07A_EIC_EXTINT7 << 16) | MUX_PB07A_EIC_EXTINT7)
+#define PORT_PB07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PB07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB07 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PB12A_EIC_EXTINT12         _L_(44) /**< \brief EIC signal: EXTINT12 on PB12 mux A */
+#define MUX_PB12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PB12A_EIC_EXTINT12  ((PIN_PB12A_EIC_EXTINT12 << 16) | MUX_PB12A_EIC_EXTINT12)
+#define PORT_PB12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PB12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PB12 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PB13A_EIC_EXTINT13         _L_(45) /**< \brief EIC signal: EXTINT13 on PB13 mux A */
+#define MUX_PB13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PB13A_EIC_EXTINT13  ((PIN_PB13A_EIC_EXTINT13 << 16) | MUX_PB13A_EIC_EXTINT13)
+#define PORT_PB13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PB13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PB13 External Interrupt Line */
+#define PIN_PB14A_EIC_EXTINT14         _L_(46) /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
+#define PORT_PB14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PB14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB14 External Interrupt Line */
+#define PIN_PB30A_EIC_EXTINT14         _L_(62) /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
+#define PORT_PB30A_EIC_EXTINT14  (_UL_(1) << 30)
+#define PIN_PB30A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB30 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PB15A_EIC_EXTINT15         _L_(47) /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
+#define PORT_PB15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PB15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB15 External Interrupt Line */
+#define PIN_PB31A_EIC_EXTINT15         _L_(63) /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
+#define PORT_PB31A_EIC_EXTINT15  (_UL_(1) << 31)
+#define PIN_PB31A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB31 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PB12C_SERCOM4_PAD0         _L_(44) /**< \brief SERCOM4 signal: PAD0 on PB12 mux C */
+#define MUX_PB12C_SERCOM4_PAD0          _L_(2)
+#define PINMUX_PB12C_SERCOM4_PAD0  ((PIN_PB12C_SERCOM4_PAD0 << 16) | MUX_PB12C_SERCOM4_PAD0)
+#define PORT_PB12C_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PB13C_SERCOM4_PAD1         _L_(45) /**< \brief SERCOM4 signal: PAD1 on PB13 mux C */
+#define MUX_PB13C_SERCOM4_PAD1          _L_(2)
+#define PINMUX_PB13C_SERCOM4_PAD1  ((PIN_PB13C_SERCOM4_PAD1 << 16) | MUX_PB13C_SERCOM4_PAD1)
+#define PORT_PB13C_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PB14C_SERCOM4_PAD2         _L_(46) /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2          _L_(2)
+#define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
+#define PORT_PB14C_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+#define PIN_PB15C_SERCOM4_PAD3         _L_(47) /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3          _L_(2)
+#define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
+#define PORT_PB15C_SERCOM4_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PB30D_SERCOM5_PAD0         _L_(62) /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
+#define PORT_PB30D_SERCOM5_PAD0  (_UL_(1) << 30)
+#define PIN_PB16C_SERCOM5_PAD0         _L_(48) /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0          _L_(2)
+#define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
+#define PORT_PB16C_SERCOM5_PAD0  (_UL_(1) << 16)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PB31D_SERCOM5_PAD1         _L_(63) /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
+#define PORT_PB31D_SERCOM5_PAD1  (_UL_(1) << 31)
+#define PIN_PB17C_SERCOM5_PAD1         _L_(49) /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1          _L_(2)
+#define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
+#define PORT_PB17C_SERCOM5_PAD1  (_UL_(1) << 17)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB00D_SERCOM5_PAD2         _L_(32) /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
+#define PORT_PB00D_SERCOM5_PAD2  (_UL_(1) <<  0)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB01D_SERCOM5_PAD3         _L_(33) /**< \brief SERCOM5 signal: PAD3 on PB01 mux D */
+#define MUX_PB01D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB01D_SERCOM5_PAD3  ((PIN_PB01D_SERCOM5_PAD3 << 16) | MUX_PB01D_SERCOM5_PAD3)
+#define PORT_PB01D_SERCOM5_PAD3  (_UL_(1) <<  1)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PB30F_TC0_WO0              _L_(62) /**< \brief TC0 signal: WO0 on PB30 mux F */
+#define MUX_PB30F_TC0_WO0               _L_(5)
+#define PINMUX_PB30F_TC0_WO0       ((PIN_PB30F_TC0_WO0 << 16) | MUX_PB30F_TC0_WO0)
+#define PORT_PB30F_TC0_WO0     (_UL_(1) << 30)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PB31F_TC0_WO1              _L_(63) /**< \brief TC0 signal: WO1 on PB31 mux F */
+#define MUX_PB31F_TC0_WO1               _L_(5)
+#define PINMUX_PB31F_TC0_WO1       ((PIN_PB31F_TC0_WO1 << 16) | MUX_PB31F_TC0_WO1)
+#define PORT_PB31F_TC0_WO1     (_UL_(1) << 31)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PB12E_TC4_WO0              _L_(44) /**< \brief TC4 signal: WO0 on PB12 mux E */
+#define MUX_PB12E_TC4_WO0               _L_(4)
+#define PINMUX_PB12E_TC4_WO0       ((PIN_PB12E_TC4_WO0 << 16) | MUX_PB12E_TC4_WO0)
+#define PORT_PB12E_TC4_WO0     (_UL_(1) << 12)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+#define PIN_PB13E_TC4_WO1              _L_(45) /**< \brief TC4 signal: WO1 on PB13 mux E */
+#define MUX_PB13E_TC4_WO1               _L_(4)
+#define PINMUX_PB13E_TC4_WO1       ((PIN_PB13E_TC4_WO1 << 16) | MUX_PB13E_TC4_WO1)
+#define PORT_PB13E_TC4_WO1     (_UL_(1) << 13)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PB14E_TC5_WO0              _L_(46) /**< \brief TC5 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC5_WO0               _L_(4)
+#define PINMUX_PB14E_TC5_WO0       ((PIN_PB14E_TC5_WO0 << 16) | MUX_PB14E_TC5_WO0)
+#define PORT_PB14E_TC5_WO0     (_UL_(1) << 14)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+#define PIN_PB15E_TC5_WO1              _L_(47) /**< \brief TC5 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC5_WO1               _L_(4)
+#define PINMUX_PB15E_TC5_WO1       ((PIN_PB15E_TC5_WO1 << 16) | MUX_PB15E_TC5_WO1)
+#define PORT_PB15E_TC5_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC6 peripheral ========== */
+#define PIN_PB02F_TC6_WO0              _L_(34) /**< \brief TC6 signal: WO0 on PB02 mux F */
+#define MUX_PB02F_TC6_WO0               _L_(5)
+#define PINMUX_PB02F_TC6_WO0       ((PIN_PB02F_TC6_WO0 << 16) | MUX_PB02F_TC6_WO0)
+#define PORT_PB02F_TC6_WO0     (_UL_(1) <<  2)
+#define PIN_PB16E_TC6_WO0              _L_(48) /**< \brief TC6 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC6_WO0               _L_(4)
+#define PINMUX_PB16E_TC6_WO0       ((PIN_PB16E_TC6_WO0 << 16) | MUX_PB16E_TC6_WO0)
+#define PORT_PB16E_TC6_WO0     (_UL_(1) << 16)
+#define PIN_PB03F_TC6_WO1              _L_(35) /**< \brief TC6 signal: WO1 on PB03 mux F */
+#define MUX_PB03F_TC6_WO1               _L_(5)
+#define PINMUX_PB03F_TC6_WO1       ((PIN_PB03F_TC6_WO1 << 16) | MUX_PB03F_TC6_WO1)
+#define PORT_PB03F_TC6_WO1     (_UL_(1) <<  3)
+#define PIN_PB17E_TC6_WO1              _L_(49) /**< \brief TC6 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC6_WO1               _L_(4)
+#define PINMUX_PB17E_TC6_WO1       ((PIN_PB17E_TC6_WO1 << 16) | MUX_PB17E_TC6_WO1)
+#define PORT_PB17E_TC6_WO1     (_UL_(1) << 17)
+/* ========== PORT definition for TC7 peripheral ========== */
+#define PIN_PB00F_TC7_WO0              _L_(32) /**< \brief TC7 signal: WO0 on PB00 mux F */
+#define MUX_PB00F_TC7_WO0               _L_(5)
+#define PINMUX_PB00F_TC7_WO0       ((PIN_PB00F_TC7_WO0 << 16) | MUX_PB00F_TC7_WO0)
+#define PORT_PB00F_TC7_WO0     (_UL_(1) <<  0)
+#define PIN_PB22F_TC7_WO0              _L_(54) /**< \brief TC7 signal: WO0 on PB22 mux F */
+#define MUX_PB22F_TC7_WO0               _L_(5)
+#define PINMUX_PB22F_TC7_WO0       ((PIN_PB22F_TC7_WO0 << 16) | MUX_PB22F_TC7_WO0)
+#define PORT_PB22F_TC7_WO0     (_UL_(1) << 22)
+#define PIN_PA20E_TC7_WO0              _L_(20) /**< \brief TC7 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC7_WO0               _L_(4)
+#define PINMUX_PA20E_TC7_WO0       ((PIN_PA20E_TC7_WO0 << 16) | MUX_PA20E_TC7_WO0)
+#define PORT_PA20E_TC7_WO0     (_UL_(1) << 20)
+#define PIN_PB01F_TC7_WO1              _L_(33) /**< \brief TC7 signal: WO1 on PB01 mux F */
+#define MUX_PB01F_TC7_WO1               _L_(5)
+#define PINMUX_PB01F_TC7_WO1       ((PIN_PB01F_TC7_WO1 << 16) | MUX_PB01F_TC7_WO1)
+#define PORT_PB01F_TC7_WO1     (_UL_(1) <<  1)
+#define PIN_PB23F_TC7_WO1              _L_(55) /**< \brief TC7 signal: WO1 on PB23 mux F */
+#define MUX_PB23F_TC7_WO1               _L_(5)
+#define PINMUX_PB23F_TC7_WO1       ((PIN_PB23F_TC7_WO1 << 16) | MUX_PB23F_TC7_WO1)
+#define PORT_PB23F_TC7_WO1     (_UL_(1) << 23)
+#define PIN_PA21E_TC7_WO1              _L_(21) /**< \brief TC7 signal: WO1 on PA21 mux E */
+#define MUX_PA21E_TC7_WO1               _L_(4)
+#define PINMUX_PA21E_TC7_WO1       ((PIN_PA21E_TC7_WO1 << 16) | MUX_PA21E_TC7_WO1)
+#define PORT_PA21E_TC7_WO1     (_UL_(1) << 21)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB00B_ADC_AIN8             _L_(32) /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8              _L_(1)
+#define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
+#define PORT_PB00B_ADC_AIN8    (_UL_(1) <<  0)
+#define PIN_PB01B_ADC_AIN9             _L_(33) /**< \brief ADC signal: AIN9 on PB01 mux B */
+#define MUX_PB01B_ADC_AIN9              _L_(1)
+#define PINMUX_PB01B_ADC_AIN9      ((PIN_PB01B_ADC_AIN9 << 16) | MUX_PB01B_ADC_AIN9)
+#define PORT_PB01B_ADC_AIN9    (_UL_(1) <<  1)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PB04B_ADC_AIN12            _L_(36) /**< \brief ADC signal: AIN12 on PB04 mux B */
+#define MUX_PB04B_ADC_AIN12             _L_(1)
+#define PINMUX_PB04B_ADC_AIN12     ((PIN_PB04B_ADC_AIN12 << 16) | MUX_PB04B_ADC_AIN12)
+#define PORT_PB04B_ADC_AIN12   (_UL_(1) <<  4)
+#define PIN_PB05B_ADC_AIN13            _L_(37) /**< \brief ADC signal: AIN13 on PB05 mux B */
+#define MUX_PB05B_ADC_AIN13             _L_(1)
+#define PINMUX_PB05B_ADC_AIN13     ((PIN_PB05B_ADC_AIN13 << 16) | MUX_PB05B_ADC_AIN13)
+#define PORT_PB05B_ADC_AIN13   (_UL_(1) <<  5)
+#define PIN_PB06B_ADC_AIN14            _L_(38) /**< \brief ADC signal: AIN14 on PB06 mux B */
+#define MUX_PB06B_ADC_AIN14             _L_(1)
+#define PINMUX_PB06B_ADC_AIN14     ((PIN_PB06B_ADC_AIN14 << 16) | MUX_PB06B_ADC_AIN14)
+#define PORT_PB06B_ADC_AIN14   (_UL_(1) <<  6)
+#define PIN_PB07B_ADC_AIN15            _L_(39) /**< \brief ADC signal: AIN15 on PB07 mux B */
+#define MUX_PB07B_ADC_AIN15             _L_(1)
+#define PINMUX_PB07B_ADC_AIN15     ((PIN_PB07B_ADC_AIN15 << 16) | MUX_PB07B_ADC_AIN15)
+#define PORT_PB07B_ADC_AIN15   (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20J14B_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20j15b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20j15b.h
@@ -1,0 +1,1056 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20J15B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J15B_PIO_
+#define _SAMD20J15B_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB00                           32  /**< \brief Pin Number for PB00 */
+#define PORT_PB00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PB00 */
+#define PIN_PB01                           33  /**< \brief Pin Number for PB01 */
+#define PORT_PB01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PB01 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB04                           36  /**< \brief Pin Number for PB04 */
+#define PORT_PB04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PB04 */
+#define PIN_PB05                           37  /**< \brief Pin Number for PB05 */
+#define PORT_PB05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PB05 */
+#define PIN_PB06                           38  /**< \brief Pin Number for PB06 */
+#define PORT_PB06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PB06 */
+#define PIN_PB07                           39  /**< \brief Pin Number for PB07 */
+#define PORT_PB07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PB07 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB12                           44  /**< \brief Pin Number for PB12 */
+#define PORT_PB12              (_UL_(1) << 12) /**< \brief PORT Mask  for PB12 */
+#define PIN_PB13                           45  /**< \brief Pin Number for PB13 */
+#define PORT_PB13              (_UL_(1) << 13) /**< \brief PORT Mask  for PB13 */
+#define PIN_PB14                           46  /**< \brief Pin Number for PB14 */
+#define PORT_PB14              (_UL_(1) << 14) /**< \brief PORT Mask  for PB14 */
+#define PIN_PB15                           47  /**< \brief Pin Number for PB15 */
+#define PORT_PB15              (_UL_(1) << 15) /**< \brief PORT Mask  for PB15 */
+#define PIN_PB16                           48  /**< \brief Pin Number for PB16 */
+#define PORT_PB16              (_UL_(1) << 16) /**< \brief PORT Mask  for PB16 */
+#define PIN_PB17                           49  /**< \brief Pin Number for PB17 */
+#define PORT_PB17              (_UL_(1) << 17) /**< \brief PORT Mask  for PB17 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+#define PIN_PB30                           62  /**< \brief Pin Number for PB30 */
+#define PORT_PB30              (_UL_(1) << 30) /**< \brief PORT Mask  for PB30 */
+#define PIN_PB31                           63  /**< \brief Pin Number for PB31 */
+#define PORT_PB31              (_UL_(1) << 31) /**< \brief PORT Mask  for PB31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB14H_GCLK_IO0             _L_(46) /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0              _L_(7)
+#define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
+#define PORT_PB14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB15H_GCLK_IO1             _L_(47) /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1              _L_(7)
+#define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
+#define PORT_PB15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB16H_GCLK_IO2             _L_(48) /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2              _L_(7)
+#define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
+#define PORT_PB16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PB17H_GCLK_IO3             _L_(49) /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3              _L_(7)
+#define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
+#define PORT_PB17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PB12H_GCLK_IO6             _L_(44) /**< \brief GCLK signal: IO6 on PB12 mux H */
+#define MUX_PB12H_GCLK_IO6              _L_(7)
+#define PINMUX_PB12H_GCLK_IO6      ((PIN_PB12H_GCLK_IO6 << 16) | MUX_PB12H_GCLK_IO6)
+#define PORT_PB12H_GCLK_IO6    (_UL_(1) << 12)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+#define PIN_PB13H_GCLK_IO7             _L_(45) /**< \brief GCLK signal: IO7 on PB13 mux H */
+#define MUX_PB13H_GCLK_IO7              _L_(7)
+#define PINMUX_PB13H_GCLK_IO7      ((PIN_PB13H_GCLK_IO7 << 16) | MUX_PB13H_GCLK_IO7)
+#define PORT_PB13H_GCLK_IO7    (_UL_(1) << 13)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PB00A_EIC_EXTINT0          _L_(32) /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
+#define PORT_PB00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PB00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB00 External Interrupt Line */
+#define PIN_PB16A_EIC_EXTINT0          _L_(48) /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
+#define PORT_PB16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PB16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PB01A_EIC_EXTINT1          _L_(33) /**< \brief EIC signal: EXTINT1 on PB01 mux A */
+#define MUX_PB01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB01A_EIC_EXTINT1   ((PIN_PB01A_EIC_EXTINT1 << 16) | MUX_PB01A_EIC_EXTINT1)
+#define PORT_PB01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PB01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PB17A_EIC_EXTINT1          _L_(49) /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
+#define PORT_PB17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PB17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PB04A_EIC_EXTINT4          _L_(36) /**< \brief EIC signal: EXTINT4 on PB04 mux A */
+#define MUX_PB04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PB04A_EIC_EXTINT4   ((PIN_PB04A_EIC_EXTINT4 << 16) | MUX_PB04A_EIC_EXTINT4)
+#define PORT_PB04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PB04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PB04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PB05A_EIC_EXTINT5          _L_(37) /**< \brief EIC signal: EXTINT5 on PB05 mux A */
+#define MUX_PB05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PB05A_EIC_EXTINT5   ((PIN_PB05A_EIC_EXTINT5 << 16) | MUX_PB05A_EIC_EXTINT5)
+#define PORT_PB05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PB05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PB05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB06A_EIC_EXTINT6          _L_(38) /**< \brief EIC signal: EXTINT6 on PB06 mux A */
+#define MUX_PB06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB06A_EIC_EXTINT6   ((PIN_PB06A_EIC_EXTINT6 << 16) | MUX_PB06A_EIC_EXTINT6)
+#define PORT_PB06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PB06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB06 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB07A_EIC_EXTINT7          _L_(39) /**< \brief EIC signal: EXTINT7 on PB07 mux A */
+#define MUX_PB07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB07A_EIC_EXTINT7   ((PIN_PB07A_EIC_EXTINT7 << 16) | MUX_PB07A_EIC_EXTINT7)
+#define PORT_PB07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PB07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB07 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PB12A_EIC_EXTINT12         _L_(44) /**< \brief EIC signal: EXTINT12 on PB12 mux A */
+#define MUX_PB12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PB12A_EIC_EXTINT12  ((PIN_PB12A_EIC_EXTINT12 << 16) | MUX_PB12A_EIC_EXTINT12)
+#define PORT_PB12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PB12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PB12 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PB13A_EIC_EXTINT13         _L_(45) /**< \brief EIC signal: EXTINT13 on PB13 mux A */
+#define MUX_PB13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PB13A_EIC_EXTINT13  ((PIN_PB13A_EIC_EXTINT13 << 16) | MUX_PB13A_EIC_EXTINT13)
+#define PORT_PB13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PB13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PB13 External Interrupt Line */
+#define PIN_PB14A_EIC_EXTINT14         _L_(46) /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
+#define PORT_PB14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PB14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB14 External Interrupt Line */
+#define PIN_PB30A_EIC_EXTINT14         _L_(62) /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
+#define PORT_PB30A_EIC_EXTINT14  (_UL_(1) << 30)
+#define PIN_PB30A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB30 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PB15A_EIC_EXTINT15         _L_(47) /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
+#define PORT_PB15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PB15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB15 External Interrupt Line */
+#define PIN_PB31A_EIC_EXTINT15         _L_(63) /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
+#define PORT_PB31A_EIC_EXTINT15  (_UL_(1) << 31)
+#define PIN_PB31A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB31 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PB12C_SERCOM4_PAD0         _L_(44) /**< \brief SERCOM4 signal: PAD0 on PB12 mux C */
+#define MUX_PB12C_SERCOM4_PAD0          _L_(2)
+#define PINMUX_PB12C_SERCOM4_PAD0  ((PIN_PB12C_SERCOM4_PAD0 << 16) | MUX_PB12C_SERCOM4_PAD0)
+#define PORT_PB12C_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PB13C_SERCOM4_PAD1         _L_(45) /**< \brief SERCOM4 signal: PAD1 on PB13 mux C */
+#define MUX_PB13C_SERCOM4_PAD1          _L_(2)
+#define PINMUX_PB13C_SERCOM4_PAD1  ((PIN_PB13C_SERCOM4_PAD1 << 16) | MUX_PB13C_SERCOM4_PAD1)
+#define PORT_PB13C_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PB14C_SERCOM4_PAD2         _L_(46) /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2          _L_(2)
+#define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
+#define PORT_PB14C_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+#define PIN_PB15C_SERCOM4_PAD3         _L_(47) /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3          _L_(2)
+#define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
+#define PORT_PB15C_SERCOM4_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PB30D_SERCOM5_PAD0         _L_(62) /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
+#define PORT_PB30D_SERCOM5_PAD0  (_UL_(1) << 30)
+#define PIN_PB16C_SERCOM5_PAD0         _L_(48) /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0          _L_(2)
+#define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
+#define PORT_PB16C_SERCOM5_PAD0  (_UL_(1) << 16)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PB31D_SERCOM5_PAD1         _L_(63) /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
+#define PORT_PB31D_SERCOM5_PAD1  (_UL_(1) << 31)
+#define PIN_PB17C_SERCOM5_PAD1         _L_(49) /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1          _L_(2)
+#define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
+#define PORT_PB17C_SERCOM5_PAD1  (_UL_(1) << 17)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB00D_SERCOM5_PAD2         _L_(32) /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
+#define PORT_PB00D_SERCOM5_PAD2  (_UL_(1) <<  0)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB01D_SERCOM5_PAD3         _L_(33) /**< \brief SERCOM5 signal: PAD3 on PB01 mux D */
+#define MUX_PB01D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB01D_SERCOM5_PAD3  ((PIN_PB01D_SERCOM5_PAD3 << 16) | MUX_PB01D_SERCOM5_PAD3)
+#define PORT_PB01D_SERCOM5_PAD3  (_UL_(1) <<  1)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PB30F_TC0_WO0              _L_(62) /**< \brief TC0 signal: WO0 on PB30 mux F */
+#define MUX_PB30F_TC0_WO0               _L_(5)
+#define PINMUX_PB30F_TC0_WO0       ((PIN_PB30F_TC0_WO0 << 16) | MUX_PB30F_TC0_WO0)
+#define PORT_PB30F_TC0_WO0     (_UL_(1) << 30)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PB31F_TC0_WO1              _L_(63) /**< \brief TC0 signal: WO1 on PB31 mux F */
+#define MUX_PB31F_TC0_WO1               _L_(5)
+#define PINMUX_PB31F_TC0_WO1       ((PIN_PB31F_TC0_WO1 << 16) | MUX_PB31F_TC0_WO1)
+#define PORT_PB31F_TC0_WO1     (_UL_(1) << 31)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PB12E_TC4_WO0              _L_(44) /**< \brief TC4 signal: WO0 on PB12 mux E */
+#define MUX_PB12E_TC4_WO0               _L_(4)
+#define PINMUX_PB12E_TC4_WO0       ((PIN_PB12E_TC4_WO0 << 16) | MUX_PB12E_TC4_WO0)
+#define PORT_PB12E_TC4_WO0     (_UL_(1) << 12)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+#define PIN_PB13E_TC4_WO1              _L_(45) /**< \brief TC4 signal: WO1 on PB13 mux E */
+#define MUX_PB13E_TC4_WO1               _L_(4)
+#define PINMUX_PB13E_TC4_WO1       ((PIN_PB13E_TC4_WO1 << 16) | MUX_PB13E_TC4_WO1)
+#define PORT_PB13E_TC4_WO1     (_UL_(1) << 13)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PB14E_TC5_WO0              _L_(46) /**< \brief TC5 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC5_WO0               _L_(4)
+#define PINMUX_PB14E_TC5_WO0       ((PIN_PB14E_TC5_WO0 << 16) | MUX_PB14E_TC5_WO0)
+#define PORT_PB14E_TC5_WO0     (_UL_(1) << 14)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+#define PIN_PB15E_TC5_WO1              _L_(47) /**< \brief TC5 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC5_WO1               _L_(4)
+#define PINMUX_PB15E_TC5_WO1       ((PIN_PB15E_TC5_WO1 << 16) | MUX_PB15E_TC5_WO1)
+#define PORT_PB15E_TC5_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC6 peripheral ========== */
+#define PIN_PB02F_TC6_WO0              _L_(34) /**< \brief TC6 signal: WO0 on PB02 mux F */
+#define MUX_PB02F_TC6_WO0               _L_(5)
+#define PINMUX_PB02F_TC6_WO0       ((PIN_PB02F_TC6_WO0 << 16) | MUX_PB02F_TC6_WO0)
+#define PORT_PB02F_TC6_WO0     (_UL_(1) <<  2)
+#define PIN_PB16E_TC6_WO0              _L_(48) /**< \brief TC6 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC6_WO0               _L_(4)
+#define PINMUX_PB16E_TC6_WO0       ((PIN_PB16E_TC6_WO0 << 16) | MUX_PB16E_TC6_WO0)
+#define PORT_PB16E_TC6_WO0     (_UL_(1) << 16)
+#define PIN_PB03F_TC6_WO1              _L_(35) /**< \brief TC6 signal: WO1 on PB03 mux F */
+#define MUX_PB03F_TC6_WO1               _L_(5)
+#define PINMUX_PB03F_TC6_WO1       ((PIN_PB03F_TC6_WO1 << 16) | MUX_PB03F_TC6_WO1)
+#define PORT_PB03F_TC6_WO1     (_UL_(1) <<  3)
+#define PIN_PB17E_TC6_WO1              _L_(49) /**< \brief TC6 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC6_WO1               _L_(4)
+#define PINMUX_PB17E_TC6_WO1       ((PIN_PB17E_TC6_WO1 << 16) | MUX_PB17E_TC6_WO1)
+#define PORT_PB17E_TC6_WO1     (_UL_(1) << 17)
+/* ========== PORT definition for TC7 peripheral ========== */
+#define PIN_PB00F_TC7_WO0              _L_(32) /**< \brief TC7 signal: WO0 on PB00 mux F */
+#define MUX_PB00F_TC7_WO0               _L_(5)
+#define PINMUX_PB00F_TC7_WO0       ((PIN_PB00F_TC7_WO0 << 16) | MUX_PB00F_TC7_WO0)
+#define PORT_PB00F_TC7_WO0     (_UL_(1) <<  0)
+#define PIN_PB22F_TC7_WO0              _L_(54) /**< \brief TC7 signal: WO0 on PB22 mux F */
+#define MUX_PB22F_TC7_WO0               _L_(5)
+#define PINMUX_PB22F_TC7_WO0       ((PIN_PB22F_TC7_WO0 << 16) | MUX_PB22F_TC7_WO0)
+#define PORT_PB22F_TC7_WO0     (_UL_(1) << 22)
+#define PIN_PA20E_TC7_WO0              _L_(20) /**< \brief TC7 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC7_WO0               _L_(4)
+#define PINMUX_PA20E_TC7_WO0       ((PIN_PA20E_TC7_WO0 << 16) | MUX_PA20E_TC7_WO0)
+#define PORT_PA20E_TC7_WO0     (_UL_(1) << 20)
+#define PIN_PB01F_TC7_WO1              _L_(33) /**< \brief TC7 signal: WO1 on PB01 mux F */
+#define MUX_PB01F_TC7_WO1               _L_(5)
+#define PINMUX_PB01F_TC7_WO1       ((PIN_PB01F_TC7_WO1 << 16) | MUX_PB01F_TC7_WO1)
+#define PORT_PB01F_TC7_WO1     (_UL_(1) <<  1)
+#define PIN_PB23F_TC7_WO1              _L_(55) /**< \brief TC7 signal: WO1 on PB23 mux F */
+#define MUX_PB23F_TC7_WO1               _L_(5)
+#define PINMUX_PB23F_TC7_WO1       ((PIN_PB23F_TC7_WO1 << 16) | MUX_PB23F_TC7_WO1)
+#define PORT_PB23F_TC7_WO1     (_UL_(1) << 23)
+#define PIN_PA21E_TC7_WO1              _L_(21) /**< \brief TC7 signal: WO1 on PA21 mux E */
+#define MUX_PA21E_TC7_WO1               _L_(4)
+#define PINMUX_PA21E_TC7_WO1       ((PIN_PA21E_TC7_WO1 << 16) | MUX_PA21E_TC7_WO1)
+#define PORT_PA21E_TC7_WO1     (_UL_(1) << 21)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB00B_ADC_AIN8             _L_(32) /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8              _L_(1)
+#define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
+#define PORT_PB00B_ADC_AIN8    (_UL_(1) <<  0)
+#define PIN_PB01B_ADC_AIN9             _L_(33) /**< \brief ADC signal: AIN9 on PB01 mux B */
+#define MUX_PB01B_ADC_AIN9              _L_(1)
+#define PINMUX_PB01B_ADC_AIN9      ((PIN_PB01B_ADC_AIN9 << 16) | MUX_PB01B_ADC_AIN9)
+#define PORT_PB01B_ADC_AIN9    (_UL_(1) <<  1)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PB04B_ADC_AIN12            _L_(36) /**< \brief ADC signal: AIN12 on PB04 mux B */
+#define MUX_PB04B_ADC_AIN12             _L_(1)
+#define PINMUX_PB04B_ADC_AIN12     ((PIN_PB04B_ADC_AIN12 << 16) | MUX_PB04B_ADC_AIN12)
+#define PORT_PB04B_ADC_AIN12   (_UL_(1) <<  4)
+#define PIN_PB05B_ADC_AIN13            _L_(37) /**< \brief ADC signal: AIN13 on PB05 mux B */
+#define MUX_PB05B_ADC_AIN13             _L_(1)
+#define PINMUX_PB05B_ADC_AIN13     ((PIN_PB05B_ADC_AIN13 << 16) | MUX_PB05B_ADC_AIN13)
+#define PORT_PB05B_ADC_AIN13   (_UL_(1) <<  5)
+#define PIN_PB06B_ADC_AIN14            _L_(38) /**< \brief ADC signal: AIN14 on PB06 mux B */
+#define MUX_PB06B_ADC_AIN14             _L_(1)
+#define PINMUX_PB06B_ADC_AIN14     ((PIN_PB06B_ADC_AIN14 << 16) | MUX_PB06B_ADC_AIN14)
+#define PORT_PB06B_ADC_AIN14   (_UL_(1) <<  6)
+#define PIN_PB07B_ADC_AIN15            _L_(39) /**< \brief ADC signal: AIN15 on PB07 mux B */
+#define MUX_PB07B_ADC_AIN15             _L_(1)
+#define PINMUX_PB07B_ADC_AIN15     ((PIN_PB07B_ADC_AIN15 << 16) | MUX_PB07B_ADC_AIN15)
+#define PORT_PB07B_ADC_AIN15   (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20J15B_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20j16b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/pio/samd20j16b.h
@@ -1,0 +1,1056 @@
+/**
+ * \file
+ *
+ * \brief Peripheral I/O description for SAMD20J16B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J16B_PIO_
+#define _SAMD20J16B_PIO_
+
+#define PIN_PA00                            0  /**< \brief Pin Number for PA00 */
+#define PORT_PA00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PA00 */
+#define PIN_PA01                            1  /**< \brief Pin Number for PA01 */
+#define PORT_PA01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PA01 */
+#define PIN_PA02                            2  /**< \brief Pin Number for PA02 */
+#define PORT_PA02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PA02 */
+#define PIN_PA03                            3  /**< \brief Pin Number for PA03 */
+#define PORT_PA03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PA03 */
+#define PIN_PA04                            4  /**< \brief Pin Number for PA04 */
+#define PORT_PA04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PA04 */
+#define PIN_PA05                            5  /**< \brief Pin Number for PA05 */
+#define PORT_PA05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PA05 */
+#define PIN_PA06                            6  /**< \brief Pin Number for PA06 */
+#define PORT_PA06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PA06 */
+#define PIN_PA07                            7  /**< \brief Pin Number for PA07 */
+#define PORT_PA07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PA07 */
+#define PIN_PA08                            8  /**< \brief Pin Number for PA08 */
+#define PORT_PA08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PA08 */
+#define PIN_PA09                            9  /**< \brief Pin Number for PA09 */
+#define PORT_PA09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PA09 */
+#define PIN_PA10                           10  /**< \brief Pin Number for PA10 */
+#define PORT_PA10              (_UL_(1) << 10) /**< \brief PORT Mask  for PA10 */
+#define PIN_PA11                           11  /**< \brief Pin Number for PA11 */
+#define PORT_PA11              (_UL_(1) << 11) /**< \brief PORT Mask  for PA11 */
+#define PIN_PA12                           12  /**< \brief Pin Number for PA12 */
+#define PORT_PA12              (_UL_(1) << 12) /**< \brief PORT Mask  for PA12 */
+#define PIN_PA13                           13  /**< \brief Pin Number for PA13 */
+#define PORT_PA13              (_UL_(1) << 13) /**< \brief PORT Mask  for PA13 */
+#define PIN_PA14                           14  /**< \brief Pin Number for PA14 */
+#define PORT_PA14              (_UL_(1) << 14) /**< \brief PORT Mask  for PA14 */
+#define PIN_PA15                           15  /**< \brief Pin Number for PA15 */
+#define PORT_PA15              (_UL_(1) << 15) /**< \brief PORT Mask  for PA15 */
+#define PIN_PA16                           16  /**< \brief Pin Number for PA16 */
+#define PORT_PA16              (_UL_(1) << 16) /**< \brief PORT Mask  for PA16 */
+#define PIN_PA17                           17  /**< \brief Pin Number for PA17 */
+#define PORT_PA17              (_UL_(1) << 17) /**< \brief PORT Mask  for PA17 */
+#define PIN_PA18                           18  /**< \brief Pin Number for PA18 */
+#define PORT_PA18              (_UL_(1) << 18) /**< \brief PORT Mask  for PA18 */
+#define PIN_PA19                           19  /**< \brief Pin Number for PA19 */
+#define PORT_PA19              (_UL_(1) << 19) /**< \brief PORT Mask  for PA19 */
+#define PIN_PA20                           20  /**< \brief Pin Number for PA20 */
+#define PORT_PA20              (_UL_(1) << 20) /**< \brief PORT Mask  for PA20 */
+#define PIN_PA21                           21  /**< \brief Pin Number for PA21 */
+#define PORT_PA21              (_UL_(1) << 21) /**< \brief PORT Mask  for PA21 */
+#define PIN_PA22                           22  /**< \brief Pin Number for PA22 */
+#define PORT_PA22              (_UL_(1) << 22) /**< \brief PORT Mask  for PA22 */
+#define PIN_PA23                           23  /**< \brief Pin Number for PA23 */
+#define PORT_PA23              (_UL_(1) << 23) /**< \brief PORT Mask  for PA23 */
+#define PIN_PA24                           24  /**< \brief Pin Number for PA24 */
+#define PORT_PA24              (_UL_(1) << 24) /**< \brief PORT Mask  for PA24 */
+#define PIN_PA25                           25  /**< \brief Pin Number for PA25 */
+#define PORT_PA25              (_UL_(1) << 25) /**< \brief PORT Mask  for PA25 */
+#define PIN_PA27                           27  /**< \brief Pin Number for PA27 */
+#define PORT_PA27              (_UL_(1) << 27) /**< \brief PORT Mask  for PA27 */
+#define PIN_PA28                           28  /**< \brief Pin Number for PA28 */
+#define PORT_PA28              (_UL_(1) << 28) /**< \brief PORT Mask  for PA28 */
+#define PIN_PA30                           30  /**< \brief Pin Number for PA30 */
+#define PORT_PA30              (_UL_(1) << 30) /**< \brief PORT Mask  for PA30 */
+#define PIN_PA31                           31  /**< \brief Pin Number for PA31 */
+#define PORT_PA31              (_UL_(1) << 31) /**< \brief PORT Mask  for PA31 */
+#define PIN_PB00                           32  /**< \brief Pin Number for PB00 */
+#define PORT_PB00              (_UL_(1) <<  0) /**< \brief PORT Mask  for PB00 */
+#define PIN_PB01                           33  /**< \brief Pin Number for PB01 */
+#define PORT_PB01              (_UL_(1) <<  1) /**< \brief PORT Mask  for PB01 */
+#define PIN_PB02                           34  /**< \brief Pin Number for PB02 */
+#define PORT_PB02              (_UL_(1) <<  2) /**< \brief PORT Mask  for PB02 */
+#define PIN_PB03                           35  /**< \brief Pin Number for PB03 */
+#define PORT_PB03              (_UL_(1) <<  3) /**< \brief PORT Mask  for PB03 */
+#define PIN_PB04                           36  /**< \brief Pin Number for PB04 */
+#define PORT_PB04              (_UL_(1) <<  4) /**< \brief PORT Mask  for PB04 */
+#define PIN_PB05                           37  /**< \brief Pin Number for PB05 */
+#define PORT_PB05              (_UL_(1) <<  5) /**< \brief PORT Mask  for PB05 */
+#define PIN_PB06                           38  /**< \brief Pin Number for PB06 */
+#define PORT_PB06              (_UL_(1) <<  6) /**< \brief PORT Mask  for PB06 */
+#define PIN_PB07                           39  /**< \brief Pin Number for PB07 */
+#define PORT_PB07              (_UL_(1) <<  7) /**< \brief PORT Mask  for PB07 */
+#define PIN_PB08                           40  /**< \brief Pin Number for PB08 */
+#define PORT_PB08              (_UL_(1) <<  8) /**< \brief PORT Mask  for PB08 */
+#define PIN_PB09                           41  /**< \brief Pin Number for PB09 */
+#define PORT_PB09              (_UL_(1) <<  9) /**< \brief PORT Mask  for PB09 */
+#define PIN_PB10                           42  /**< \brief Pin Number for PB10 */
+#define PORT_PB10              (_UL_(1) << 10) /**< \brief PORT Mask  for PB10 */
+#define PIN_PB11                           43  /**< \brief Pin Number for PB11 */
+#define PORT_PB11              (_UL_(1) << 11) /**< \brief PORT Mask  for PB11 */
+#define PIN_PB12                           44  /**< \brief Pin Number for PB12 */
+#define PORT_PB12              (_UL_(1) << 12) /**< \brief PORT Mask  for PB12 */
+#define PIN_PB13                           45  /**< \brief Pin Number for PB13 */
+#define PORT_PB13              (_UL_(1) << 13) /**< \brief PORT Mask  for PB13 */
+#define PIN_PB14                           46  /**< \brief Pin Number for PB14 */
+#define PORT_PB14              (_UL_(1) << 14) /**< \brief PORT Mask  for PB14 */
+#define PIN_PB15                           47  /**< \brief Pin Number for PB15 */
+#define PORT_PB15              (_UL_(1) << 15) /**< \brief PORT Mask  for PB15 */
+#define PIN_PB16                           48  /**< \brief Pin Number for PB16 */
+#define PORT_PB16              (_UL_(1) << 16) /**< \brief PORT Mask  for PB16 */
+#define PIN_PB17                           49  /**< \brief Pin Number for PB17 */
+#define PORT_PB17              (_UL_(1) << 17) /**< \brief PORT Mask  for PB17 */
+#define PIN_PB22                           54  /**< \brief Pin Number for PB22 */
+#define PORT_PB22              (_UL_(1) << 22) /**< \brief PORT Mask  for PB22 */
+#define PIN_PB23                           55  /**< \brief Pin Number for PB23 */
+#define PORT_PB23              (_UL_(1) << 23) /**< \brief PORT Mask  for PB23 */
+#define PIN_PB30                           62  /**< \brief Pin Number for PB30 */
+#define PORT_PB30              (_UL_(1) << 30) /**< \brief PORT Mask  for PB30 */
+#define PIN_PB31                           63  /**< \brief Pin Number for PB31 */
+#define PORT_PB31              (_UL_(1) << 31) /**< \brief PORT Mask  for PB31 */
+/* ========== PORT definition for GCLK peripheral ========== */
+#define PIN_PB14H_GCLK_IO0             _L_(46) /**< \brief GCLK signal: IO0 on PB14 mux H */
+#define MUX_PB14H_GCLK_IO0              _L_(7)
+#define PINMUX_PB14H_GCLK_IO0      ((PIN_PB14H_GCLK_IO0 << 16) | MUX_PB14H_GCLK_IO0)
+#define PORT_PB14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PB22H_GCLK_IO0             _L_(54) /**< \brief GCLK signal: IO0 on PB22 mux H */
+#define MUX_PB22H_GCLK_IO0              _L_(7)
+#define PINMUX_PB22H_GCLK_IO0      ((PIN_PB22H_GCLK_IO0 << 16) | MUX_PB22H_GCLK_IO0)
+#define PORT_PB22H_GCLK_IO0    (_UL_(1) << 22)
+#define PIN_PA14H_GCLK_IO0             _L_(14) /**< \brief GCLK signal: IO0 on PA14 mux H */
+#define MUX_PA14H_GCLK_IO0              _L_(7)
+#define PINMUX_PA14H_GCLK_IO0      ((PIN_PA14H_GCLK_IO0 << 16) | MUX_PA14H_GCLK_IO0)
+#define PORT_PA14H_GCLK_IO0    (_UL_(1) << 14)
+#define PIN_PA27H_GCLK_IO0             _L_(27) /**< \brief GCLK signal: IO0 on PA27 mux H */
+#define MUX_PA27H_GCLK_IO0              _L_(7)
+#define PINMUX_PA27H_GCLK_IO0      ((PIN_PA27H_GCLK_IO0 << 16) | MUX_PA27H_GCLK_IO0)
+#define PORT_PA27H_GCLK_IO0    (_UL_(1) << 27)
+#define PIN_PA28H_GCLK_IO0             _L_(28) /**< \brief GCLK signal: IO0 on PA28 mux H */
+#define MUX_PA28H_GCLK_IO0              _L_(7)
+#define PINMUX_PA28H_GCLK_IO0      ((PIN_PA28H_GCLK_IO0 << 16) | MUX_PA28H_GCLK_IO0)
+#define PORT_PA28H_GCLK_IO0    (_UL_(1) << 28)
+#define PIN_PA30H_GCLK_IO0             _L_(30) /**< \brief GCLK signal: IO0 on PA30 mux H */
+#define MUX_PA30H_GCLK_IO0              _L_(7)
+#define PINMUX_PA30H_GCLK_IO0      ((PIN_PA30H_GCLK_IO0 << 16) | MUX_PA30H_GCLK_IO0)
+#define PORT_PA30H_GCLK_IO0    (_UL_(1) << 30)
+#define PIN_PB15H_GCLK_IO1             _L_(47) /**< \brief GCLK signal: IO1 on PB15 mux H */
+#define MUX_PB15H_GCLK_IO1              _L_(7)
+#define PINMUX_PB15H_GCLK_IO1      ((PIN_PB15H_GCLK_IO1 << 16) | MUX_PB15H_GCLK_IO1)
+#define PORT_PB15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB23H_GCLK_IO1             _L_(55) /**< \brief GCLK signal: IO1 on PB23 mux H */
+#define MUX_PB23H_GCLK_IO1              _L_(7)
+#define PINMUX_PB23H_GCLK_IO1      ((PIN_PB23H_GCLK_IO1 << 16) | MUX_PB23H_GCLK_IO1)
+#define PORT_PB23H_GCLK_IO1    (_UL_(1) << 23)
+#define PIN_PA15H_GCLK_IO1             _L_(15) /**< \brief GCLK signal: IO1 on PA15 mux H */
+#define MUX_PA15H_GCLK_IO1              _L_(7)
+#define PINMUX_PA15H_GCLK_IO1      ((PIN_PA15H_GCLK_IO1 << 16) | MUX_PA15H_GCLK_IO1)
+#define PORT_PA15H_GCLK_IO1    (_UL_(1) << 15)
+#define PIN_PB16H_GCLK_IO2             _L_(48) /**< \brief GCLK signal: IO2 on PB16 mux H */
+#define MUX_PB16H_GCLK_IO2              _L_(7)
+#define PINMUX_PB16H_GCLK_IO2      ((PIN_PB16H_GCLK_IO2 << 16) | MUX_PB16H_GCLK_IO2)
+#define PORT_PB16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA16H_GCLK_IO2             _L_(16) /**< \brief GCLK signal: IO2 on PA16 mux H */
+#define MUX_PA16H_GCLK_IO2              _L_(7)
+#define PINMUX_PA16H_GCLK_IO2      ((PIN_PA16H_GCLK_IO2 << 16) | MUX_PA16H_GCLK_IO2)
+#define PORT_PA16H_GCLK_IO2    (_UL_(1) << 16)
+#define PIN_PA17H_GCLK_IO3             _L_(17) /**< \brief GCLK signal: IO3 on PA17 mux H */
+#define MUX_PA17H_GCLK_IO3              _L_(7)
+#define PINMUX_PA17H_GCLK_IO3      ((PIN_PA17H_GCLK_IO3 << 16) | MUX_PA17H_GCLK_IO3)
+#define PORT_PA17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PB17H_GCLK_IO3             _L_(49) /**< \brief GCLK signal: IO3 on PB17 mux H */
+#define MUX_PB17H_GCLK_IO3              _L_(7)
+#define PINMUX_PB17H_GCLK_IO3      ((PIN_PB17H_GCLK_IO3 << 16) | MUX_PB17H_GCLK_IO3)
+#define PORT_PB17H_GCLK_IO3    (_UL_(1) << 17)
+#define PIN_PA10H_GCLK_IO4             _L_(10) /**< \brief GCLK signal: IO4 on PA10 mux H */
+#define MUX_PA10H_GCLK_IO4              _L_(7)
+#define PINMUX_PA10H_GCLK_IO4      ((PIN_PA10H_GCLK_IO4 << 16) | MUX_PA10H_GCLK_IO4)
+#define PORT_PA10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA20H_GCLK_IO4             _L_(20) /**< \brief GCLK signal: IO4 on PA20 mux H */
+#define MUX_PA20H_GCLK_IO4              _L_(7)
+#define PINMUX_PA20H_GCLK_IO4      ((PIN_PA20H_GCLK_IO4 << 16) | MUX_PA20H_GCLK_IO4)
+#define PORT_PA20H_GCLK_IO4    (_UL_(1) << 20)
+#define PIN_PB10H_GCLK_IO4             _L_(42) /**< \brief GCLK signal: IO4 on PB10 mux H */
+#define MUX_PB10H_GCLK_IO4              _L_(7)
+#define PINMUX_PB10H_GCLK_IO4      ((PIN_PB10H_GCLK_IO4 << 16) | MUX_PB10H_GCLK_IO4)
+#define PORT_PB10H_GCLK_IO4    (_UL_(1) << 10)
+#define PIN_PA11H_GCLK_IO5             _L_(11) /**< \brief GCLK signal: IO5 on PA11 mux H */
+#define MUX_PA11H_GCLK_IO5              _L_(7)
+#define PINMUX_PA11H_GCLK_IO5      ((PIN_PA11H_GCLK_IO5 << 16) | MUX_PA11H_GCLK_IO5)
+#define PORT_PA11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA21H_GCLK_IO5             _L_(21) /**< \brief GCLK signal: IO5 on PA21 mux H */
+#define MUX_PA21H_GCLK_IO5              _L_(7)
+#define PINMUX_PA21H_GCLK_IO5      ((PIN_PA21H_GCLK_IO5 << 16) | MUX_PA21H_GCLK_IO5)
+#define PORT_PA21H_GCLK_IO5    (_UL_(1) << 21)
+#define PIN_PB11H_GCLK_IO5             _L_(43) /**< \brief GCLK signal: IO5 on PB11 mux H */
+#define MUX_PB11H_GCLK_IO5              _L_(7)
+#define PINMUX_PB11H_GCLK_IO5      ((PIN_PB11H_GCLK_IO5 << 16) | MUX_PB11H_GCLK_IO5)
+#define PORT_PB11H_GCLK_IO5    (_UL_(1) << 11)
+#define PIN_PA22H_GCLK_IO6             _L_(22) /**< \brief GCLK signal: IO6 on PA22 mux H */
+#define MUX_PA22H_GCLK_IO6              _L_(7)
+#define PINMUX_PA22H_GCLK_IO6      ((PIN_PA22H_GCLK_IO6 << 16) | MUX_PA22H_GCLK_IO6)
+#define PORT_PA22H_GCLK_IO6    (_UL_(1) << 22)
+#define PIN_PB12H_GCLK_IO6             _L_(44) /**< \brief GCLK signal: IO6 on PB12 mux H */
+#define MUX_PB12H_GCLK_IO6              _L_(7)
+#define PINMUX_PB12H_GCLK_IO6      ((PIN_PB12H_GCLK_IO6 << 16) | MUX_PB12H_GCLK_IO6)
+#define PORT_PB12H_GCLK_IO6    (_UL_(1) << 12)
+#define PIN_PA23H_GCLK_IO7             _L_(23) /**< \brief GCLK signal: IO7 on PA23 mux H */
+#define MUX_PA23H_GCLK_IO7              _L_(7)
+#define PINMUX_PA23H_GCLK_IO7      ((PIN_PA23H_GCLK_IO7 << 16) | MUX_PA23H_GCLK_IO7)
+#define PORT_PA23H_GCLK_IO7    (_UL_(1) << 23)
+#define PIN_PB13H_GCLK_IO7             _L_(45) /**< \brief GCLK signal: IO7 on PB13 mux H */
+#define MUX_PB13H_GCLK_IO7              _L_(7)
+#define PINMUX_PB13H_GCLK_IO7      ((PIN_PB13H_GCLK_IO7 << 16) | MUX_PB13H_GCLK_IO7)
+#define PORT_PB13H_GCLK_IO7    (_UL_(1) << 13)
+/* ========== PORT definition for EIC peripheral ========== */
+#define PIN_PA16A_EIC_EXTINT0          _L_(16) /**< \brief EIC signal: EXTINT0 on PA16 mux A */
+#define MUX_PA16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA16A_EIC_EXTINT0   ((PIN_PA16A_EIC_EXTINT0 << 16) | MUX_PA16A_EIC_EXTINT0)
+#define PORT_PA16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PA16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA16 External Interrupt Line */
+#define PIN_PB00A_EIC_EXTINT0          _L_(32) /**< \brief EIC signal: EXTINT0 on PB00 mux A */
+#define MUX_PB00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB00A_EIC_EXTINT0   ((PIN_PB00A_EIC_EXTINT0 << 16) | MUX_PB00A_EIC_EXTINT0)
+#define PORT_PB00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PB00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB00 External Interrupt Line */
+#define PIN_PB16A_EIC_EXTINT0          _L_(48) /**< \brief EIC signal: EXTINT0 on PB16 mux A */
+#define MUX_PB16A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PB16A_EIC_EXTINT0   ((PIN_PB16A_EIC_EXTINT0 << 16) | MUX_PB16A_EIC_EXTINT0)
+#define PORT_PB16A_EIC_EXTINT0  (_UL_(1) << 16)
+#define PIN_PB16A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PB16 External Interrupt Line */
+#define PIN_PA00A_EIC_EXTINT0           _L_(0) /**< \brief EIC signal: EXTINT0 on PA00 mux A */
+#define MUX_PA00A_EIC_EXTINT0           _L_(0)
+#define PINMUX_PA00A_EIC_EXTINT0   ((PIN_PA00A_EIC_EXTINT0 << 16) | MUX_PA00A_EIC_EXTINT0)
+#define PORT_PA00A_EIC_EXTINT0  (_UL_(1) <<  0)
+#define PIN_PA00A_EIC_EXTINT_NUM        _L_(0) /**< \brief EIC signal: PIN_PA00 External Interrupt Line */
+#define PIN_PA17A_EIC_EXTINT1          _L_(17) /**< \brief EIC signal: EXTINT1 on PA17 mux A */
+#define MUX_PA17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA17A_EIC_EXTINT1   ((PIN_PA17A_EIC_EXTINT1 << 16) | MUX_PA17A_EIC_EXTINT1)
+#define PORT_PA17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PA17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA17 External Interrupt Line */
+#define PIN_PB01A_EIC_EXTINT1          _L_(33) /**< \brief EIC signal: EXTINT1 on PB01 mux A */
+#define MUX_PB01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB01A_EIC_EXTINT1   ((PIN_PB01A_EIC_EXTINT1 << 16) | MUX_PB01A_EIC_EXTINT1)
+#define PORT_PB01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PB01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB01 External Interrupt Line */
+#define PIN_PB17A_EIC_EXTINT1          _L_(49) /**< \brief EIC signal: EXTINT1 on PB17 mux A */
+#define MUX_PB17A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PB17A_EIC_EXTINT1   ((PIN_PB17A_EIC_EXTINT1 << 16) | MUX_PB17A_EIC_EXTINT1)
+#define PORT_PB17A_EIC_EXTINT1  (_UL_(1) << 17)
+#define PIN_PB17A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PB17 External Interrupt Line */
+#define PIN_PA01A_EIC_EXTINT1           _L_(1) /**< \brief EIC signal: EXTINT1 on PA01 mux A */
+#define MUX_PA01A_EIC_EXTINT1           _L_(0)
+#define PINMUX_PA01A_EIC_EXTINT1   ((PIN_PA01A_EIC_EXTINT1 << 16) | MUX_PA01A_EIC_EXTINT1)
+#define PORT_PA01A_EIC_EXTINT1  (_UL_(1) <<  1)
+#define PIN_PA01A_EIC_EXTINT_NUM        _L_(1) /**< \brief EIC signal: PIN_PA01 External Interrupt Line */
+#define PIN_PA02A_EIC_EXTINT2           _L_(2) /**< \brief EIC signal: EXTINT2 on PA02 mux A */
+#define MUX_PA02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA02A_EIC_EXTINT2   ((PIN_PA02A_EIC_EXTINT2 << 16) | MUX_PA02A_EIC_EXTINT2)
+#define PORT_PA02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PA02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA02 External Interrupt Line */
+#define PIN_PA18A_EIC_EXTINT2          _L_(18) /**< \brief EIC signal: EXTINT2 on PA18 mux A */
+#define MUX_PA18A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PA18A_EIC_EXTINT2   ((PIN_PA18A_EIC_EXTINT2 << 16) | MUX_PA18A_EIC_EXTINT2)
+#define PORT_PA18A_EIC_EXTINT2  (_UL_(1) << 18)
+#define PIN_PA18A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PA18 External Interrupt Line */
+#define PIN_PB02A_EIC_EXTINT2          _L_(34) /**< \brief EIC signal: EXTINT2 on PB02 mux A */
+#define MUX_PB02A_EIC_EXTINT2           _L_(0)
+#define PINMUX_PB02A_EIC_EXTINT2   ((PIN_PB02A_EIC_EXTINT2 << 16) | MUX_PB02A_EIC_EXTINT2)
+#define PORT_PB02A_EIC_EXTINT2  (_UL_(1) <<  2)
+#define PIN_PB02A_EIC_EXTINT_NUM        _L_(2) /**< \brief EIC signal: PIN_PB02 External Interrupt Line */
+#define PIN_PA03A_EIC_EXTINT3           _L_(3) /**< \brief EIC signal: EXTINT3 on PA03 mux A */
+#define MUX_PA03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA03A_EIC_EXTINT3   ((PIN_PA03A_EIC_EXTINT3 << 16) | MUX_PA03A_EIC_EXTINT3)
+#define PORT_PA03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PA03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA03 External Interrupt Line */
+#define PIN_PA19A_EIC_EXTINT3          _L_(19) /**< \brief EIC signal: EXTINT3 on PA19 mux A */
+#define MUX_PA19A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PA19A_EIC_EXTINT3   ((PIN_PA19A_EIC_EXTINT3 << 16) | MUX_PA19A_EIC_EXTINT3)
+#define PORT_PA19A_EIC_EXTINT3  (_UL_(1) << 19)
+#define PIN_PA19A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PA19 External Interrupt Line */
+#define PIN_PB03A_EIC_EXTINT3          _L_(35) /**< \brief EIC signal: EXTINT3 on PB03 mux A */
+#define MUX_PB03A_EIC_EXTINT3           _L_(0)
+#define PINMUX_PB03A_EIC_EXTINT3   ((PIN_PB03A_EIC_EXTINT3 << 16) | MUX_PB03A_EIC_EXTINT3)
+#define PORT_PB03A_EIC_EXTINT3  (_UL_(1) <<  3)
+#define PIN_PB03A_EIC_EXTINT_NUM        _L_(3) /**< \brief EIC signal: PIN_PB03 External Interrupt Line */
+#define PIN_PA04A_EIC_EXTINT4           _L_(4) /**< \brief EIC signal: EXTINT4 on PA04 mux A */
+#define MUX_PA04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA04A_EIC_EXTINT4   ((PIN_PA04A_EIC_EXTINT4 << 16) | MUX_PA04A_EIC_EXTINT4)
+#define PORT_PA04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PA04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA04 External Interrupt Line */
+#define PIN_PA20A_EIC_EXTINT4          _L_(20) /**< \brief EIC signal: EXTINT4 on PA20 mux A */
+#define MUX_PA20A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PA20A_EIC_EXTINT4   ((PIN_PA20A_EIC_EXTINT4 << 16) | MUX_PA20A_EIC_EXTINT4)
+#define PORT_PA20A_EIC_EXTINT4  (_UL_(1) << 20)
+#define PIN_PA20A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PA20 External Interrupt Line */
+#define PIN_PB04A_EIC_EXTINT4          _L_(36) /**< \brief EIC signal: EXTINT4 on PB04 mux A */
+#define MUX_PB04A_EIC_EXTINT4           _L_(0)
+#define PINMUX_PB04A_EIC_EXTINT4   ((PIN_PB04A_EIC_EXTINT4 << 16) | MUX_PB04A_EIC_EXTINT4)
+#define PORT_PB04A_EIC_EXTINT4  (_UL_(1) <<  4)
+#define PIN_PB04A_EIC_EXTINT_NUM        _L_(4) /**< \brief EIC signal: PIN_PB04 External Interrupt Line */
+#define PIN_PA05A_EIC_EXTINT5           _L_(5) /**< \brief EIC signal: EXTINT5 on PA05 mux A */
+#define MUX_PA05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA05A_EIC_EXTINT5   ((PIN_PA05A_EIC_EXTINT5 << 16) | MUX_PA05A_EIC_EXTINT5)
+#define PORT_PA05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PA05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA05 External Interrupt Line */
+#define PIN_PA21A_EIC_EXTINT5          _L_(21) /**< \brief EIC signal: EXTINT5 on PA21 mux A */
+#define MUX_PA21A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PA21A_EIC_EXTINT5   ((PIN_PA21A_EIC_EXTINT5 << 16) | MUX_PA21A_EIC_EXTINT5)
+#define PORT_PA21A_EIC_EXTINT5  (_UL_(1) << 21)
+#define PIN_PA21A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PA21 External Interrupt Line */
+#define PIN_PB05A_EIC_EXTINT5          _L_(37) /**< \brief EIC signal: EXTINT5 on PB05 mux A */
+#define MUX_PB05A_EIC_EXTINT5           _L_(0)
+#define PINMUX_PB05A_EIC_EXTINT5   ((PIN_PB05A_EIC_EXTINT5 << 16) | MUX_PB05A_EIC_EXTINT5)
+#define PORT_PB05A_EIC_EXTINT5  (_UL_(1) <<  5)
+#define PIN_PB05A_EIC_EXTINT_NUM        _L_(5) /**< \brief EIC signal: PIN_PB05 External Interrupt Line */
+#define PIN_PA06A_EIC_EXTINT6           _L_(6) /**< \brief EIC signal: EXTINT6 on PA06 mux A */
+#define MUX_PA06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA06A_EIC_EXTINT6   ((PIN_PA06A_EIC_EXTINT6 << 16) | MUX_PA06A_EIC_EXTINT6)
+#define PORT_PA06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PA06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA06 External Interrupt Line */
+#define PIN_PA22A_EIC_EXTINT6          _L_(22) /**< \brief EIC signal: EXTINT6 on PA22 mux A */
+#define MUX_PA22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PA22A_EIC_EXTINT6   ((PIN_PA22A_EIC_EXTINT6 << 16) | MUX_PA22A_EIC_EXTINT6)
+#define PORT_PA22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PA22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PA22 External Interrupt Line */
+#define PIN_PB06A_EIC_EXTINT6          _L_(38) /**< \brief EIC signal: EXTINT6 on PB06 mux A */
+#define MUX_PB06A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB06A_EIC_EXTINT6   ((PIN_PB06A_EIC_EXTINT6 << 16) | MUX_PB06A_EIC_EXTINT6)
+#define PORT_PB06A_EIC_EXTINT6  (_UL_(1) <<  6)
+#define PIN_PB06A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB06 External Interrupt Line */
+#define PIN_PB22A_EIC_EXTINT6          _L_(54) /**< \brief EIC signal: EXTINT6 on PB22 mux A */
+#define MUX_PB22A_EIC_EXTINT6           _L_(0)
+#define PINMUX_PB22A_EIC_EXTINT6   ((PIN_PB22A_EIC_EXTINT6 << 16) | MUX_PB22A_EIC_EXTINT6)
+#define PORT_PB22A_EIC_EXTINT6  (_UL_(1) << 22)
+#define PIN_PB22A_EIC_EXTINT_NUM        _L_(6) /**< \brief EIC signal: PIN_PB22 External Interrupt Line */
+#define PIN_PA07A_EIC_EXTINT7           _L_(7) /**< \brief EIC signal: EXTINT7 on PA07 mux A */
+#define MUX_PA07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA07A_EIC_EXTINT7   ((PIN_PA07A_EIC_EXTINT7 << 16) | MUX_PA07A_EIC_EXTINT7)
+#define PORT_PA07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PA07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA07 External Interrupt Line */
+#define PIN_PA23A_EIC_EXTINT7          _L_(23) /**< \brief EIC signal: EXTINT7 on PA23 mux A */
+#define MUX_PA23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PA23A_EIC_EXTINT7   ((PIN_PA23A_EIC_EXTINT7 << 16) | MUX_PA23A_EIC_EXTINT7)
+#define PORT_PA23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PA23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PA23 External Interrupt Line */
+#define PIN_PB07A_EIC_EXTINT7          _L_(39) /**< \brief EIC signal: EXTINT7 on PB07 mux A */
+#define MUX_PB07A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB07A_EIC_EXTINT7   ((PIN_PB07A_EIC_EXTINT7 << 16) | MUX_PB07A_EIC_EXTINT7)
+#define PORT_PB07A_EIC_EXTINT7  (_UL_(1) <<  7)
+#define PIN_PB07A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB07 External Interrupt Line */
+#define PIN_PB23A_EIC_EXTINT7          _L_(55) /**< \brief EIC signal: EXTINT7 on PB23 mux A */
+#define MUX_PB23A_EIC_EXTINT7           _L_(0)
+#define PINMUX_PB23A_EIC_EXTINT7   ((PIN_PB23A_EIC_EXTINT7 << 16) | MUX_PB23A_EIC_EXTINT7)
+#define PORT_PB23A_EIC_EXTINT7  (_UL_(1) << 23)
+#define PIN_PB23A_EIC_EXTINT_NUM        _L_(7) /**< \brief EIC signal: PIN_PB23 External Interrupt Line */
+#define PIN_PA28A_EIC_EXTINT8          _L_(28) /**< \brief EIC signal: EXTINT8 on PA28 mux A */
+#define MUX_PA28A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PA28A_EIC_EXTINT8   ((PIN_PA28A_EIC_EXTINT8 << 16) | MUX_PA28A_EIC_EXTINT8)
+#define PORT_PA28A_EIC_EXTINT8  (_UL_(1) << 28)
+#define PIN_PA28A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PA28 External Interrupt Line */
+#define PIN_PB08A_EIC_EXTINT8          _L_(40) /**< \brief EIC signal: EXTINT8 on PB08 mux A */
+#define MUX_PB08A_EIC_EXTINT8           _L_(0)
+#define PINMUX_PB08A_EIC_EXTINT8   ((PIN_PB08A_EIC_EXTINT8 << 16) | MUX_PB08A_EIC_EXTINT8)
+#define PORT_PB08A_EIC_EXTINT8  (_UL_(1) <<  8)
+#define PIN_PB08A_EIC_EXTINT_NUM        _L_(8) /**< \brief EIC signal: PIN_PB08 External Interrupt Line */
+#define PIN_PA09A_EIC_EXTINT9           _L_(9) /**< \brief EIC signal: EXTINT9 on PA09 mux A */
+#define MUX_PA09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PA09A_EIC_EXTINT9   ((PIN_PA09A_EIC_EXTINT9 << 16) | MUX_PA09A_EIC_EXTINT9)
+#define PORT_PA09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PA09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PA09 External Interrupt Line */
+#define PIN_PB09A_EIC_EXTINT9          _L_(41) /**< \brief EIC signal: EXTINT9 on PB09 mux A */
+#define MUX_PB09A_EIC_EXTINT9           _L_(0)
+#define PINMUX_PB09A_EIC_EXTINT9   ((PIN_PB09A_EIC_EXTINT9 << 16) | MUX_PB09A_EIC_EXTINT9)
+#define PORT_PB09A_EIC_EXTINT9  (_UL_(1) <<  9)
+#define PIN_PB09A_EIC_EXTINT_NUM        _L_(9) /**< \brief EIC signal: PIN_PB09 External Interrupt Line */
+#define PIN_PA10A_EIC_EXTINT10         _L_(10) /**< \brief EIC signal: EXTINT10 on PA10 mux A */
+#define MUX_PA10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA10A_EIC_EXTINT10  ((PIN_PA10A_EIC_EXTINT10 << 16) | MUX_PA10A_EIC_EXTINT10)
+#define PORT_PA10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PA10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA10 External Interrupt Line */
+#define PIN_PA30A_EIC_EXTINT10         _L_(30) /**< \brief EIC signal: EXTINT10 on PA30 mux A */
+#define MUX_PA30A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PA30A_EIC_EXTINT10  ((PIN_PA30A_EIC_EXTINT10 << 16) | MUX_PA30A_EIC_EXTINT10)
+#define PORT_PA30A_EIC_EXTINT10  (_UL_(1) << 30)
+#define PIN_PA30A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PA30 External Interrupt Line */
+#define PIN_PB10A_EIC_EXTINT10         _L_(42) /**< \brief EIC signal: EXTINT10 on PB10 mux A */
+#define MUX_PB10A_EIC_EXTINT10          _L_(0)
+#define PINMUX_PB10A_EIC_EXTINT10  ((PIN_PB10A_EIC_EXTINT10 << 16) | MUX_PB10A_EIC_EXTINT10)
+#define PORT_PB10A_EIC_EXTINT10  (_UL_(1) << 10)
+#define PIN_PB10A_EIC_EXTINT_NUM       _L_(10) /**< \brief EIC signal: PIN_PB10 External Interrupt Line */
+#define PIN_PA11A_EIC_EXTINT11         _L_(11) /**< \brief EIC signal: EXTINT11 on PA11 mux A */
+#define MUX_PA11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA11A_EIC_EXTINT11  ((PIN_PA11A_EIC_EXTINT11 << 16) | MUX_PA11A_EIC_EXTINT11)
+#define PORT_PA11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PA11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA11 External Interrupt Line */
+#define PIN_PA31A_EIC_EXTINT11         _L_(31) /**< \brief EIC signal: EXTINT11 on PA31 mux A */
+#define MUX_PA31A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PA31A_EIC_EXTINT11  ((PIN_PA31A_EIC_EXTINT11 << 16) | MUX_PA31A_EIC_EXTINT11)
+#define PORT_PA31A_EIC_EXTINT11  (_UL_(1) << 31)
+#define PIN_PA31A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PA31 External Interrupt Line */
+#define PIN_PB11A_EIC_EXTINT11         _L_(43) /**< \brief EIC signal: EXTINT11 on PB11 mux A */
+#define MUX_PB11A_EIC_EXTINT11          _L_(0)
+#define PINMUX_PB11A_EIC_EXTINT11  ((PIN_PB11A_EIC_EXTINT11 << 16) | MUX_PB11A_EIC_EXTINT11)
+#define PORT_PB11A_EIC_EXTINT11  (_UL_(1) << 11)
+#define PIN_PB11A_EIC_EXTINT_NUM       _L_(11) /**< \brief EIC signal: PIN_PB11 External Interrupt Line */
+#define PIN_PA12A_EIC_EXTINT12         _L_(12) /**< \brief EIC signal: EXTINT12 on PA12 mux A */
+#define MUX_PA12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA12A_EIC_EXTINT12  ((PIN_PA12A_EIC_EXTINT12 << 16) | MUX_PA12A_EIC_EXTINT12)
+#define PORT_PA12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PA12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA12 External Interrupt Line */
+#define PIN_PA24A_EIC_EXTINT12         _L_(24) /**< \brief EIC signal: EXTINT12 on PA24 mux A */
+#define MUX_PA24A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PA24A_EIC_EXTINT12  ((PIN_PA24A_EIC_EXTINT12 << 16) | MUX_PA24A_EIC_EXTINT12)
+#define PORT_PA24A_EIC_EXTINT12  (_UL_(1) << 24)
+#define PIN_PA24A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PA24 External Interrupt Line */
+#define PIN_PB12A_EIC_EXTINT12         _L_(44) /**< \brief EIC signal: EXTINT12 on PB12 mux A */
+#define MUX_PB12A_EIC_EXTINT12          _L_(0)
+#define PINMUX_PB12A_EIC_EXTINT12  ((PIN_PB12A_EIC_EXTINT12 << 16) | MUX_PB12A_EIC_EXTINT12)
+#define PORT_PB12A_EIC_EXTINT12  (_UL_(1) << 12)
+#define PIN_PB12A_EIC_EXTINT_NUM       _L_(12) /**< \brief EIC signal: PIN_PB12 External Interrupt Line */
+#define PIN_PA13A_EIC_EXTINT13         _L_(13) /**< \brief EIC signal: EXTINT13 on PA13 mux A */
+#define MUX_PA13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA13A_EIC_EXTINT13  ((PIN_PA13A_EIC_EXTINT13 << 16) | MUX_PA13A_EIC_EXTINT13)
+#define PORT_PA13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PA13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA13 External Interrupt Line */
+#define PIN_PA25A_EIC_EXTINT13         _L_(25) /**< \brief EIC signal: EXTINT13 on PA25 mux A */
+#define MUX_PA25A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PA25A_EIC_EXTINT13  ((PIN_PA25A_EIC_EXTINT13 << 16) | MUX_PA25A_EIC_EXTINT13)
+#define PORT_PA25A_EIC_EXTINT13  (_UL_(1) << 25)
+#define PIN_PA25A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PA25 External Interrupt Line */
+#define PIN_PB13A_EIC_EXTINT13         _L_(45) /**< \brief EIC signal: EXTINT13 on PB13 mux A */
+#define MUX_PB13A_EIC_EXTINT13          _L_(0)
+#define PINMUX_PB13A_EIC_EXTINT13  ((PIN_PB13A_EIC_EXTINT13 << 16) | MUX_PB13A_EIC_EXTINT13)
+#define PORT_PB13A_EIC_EXTINT13  (_UL_(1) << 13)
+#define PIN_PB13A_EIC_EXTINT_NUM       _L_(13) /**< \brief EIC signal: PIN_PB13 External Interrupt Line */
+#define PIN_PB14A_EIC_EXTINT14         _L_(46) /**< \brief EIC signal: EXTINT14 on PB14 mux A */
+#define MUX_PB14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB14A_EIC_EXTINT14  ((PIN_PB14A_EIC_EXTINT14 << 16) | MUX_PB14A_EIC_EXTINT14)
+#define PORT_PB14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PB14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB14 External Interrupt Line */
+#define PIN_PB30A_EIC_EXTINT14         _L_(62) /**< \brief EIC signal: EXTINT14 on PB30 mux A */
+#define MUX_PB30A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PB30A_EIC_EXTINT14  ((PIN_PB30A_EIC_EXTINT14 << 16) | MUX_PB30A_EIC_EXTINT14)
+#define PORT_PB30A_EIC_EXTINT14  (_UL_(1) << 30)
+#define PIN_PB30A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PB30 External Interrupt Line */
+#define PIN_PA14A_EIC_EXTINT14         _L_(14) /**< \brief EIC signal: EXTINT14 on PA14 mux A */
+#define MUX_PA14A_EIC_EXTINT14          _L_(0)
+#define PINMUX_PA14A_EIC_EXTINT14  ((PIN_PA14A_EIC_EXTINT14 << 16) | MUX_PA14A_EIC_EXTINT14)
+#define PORT_PA14A_EIC_EXTINT14  (_UL_(1) << 14)
+#define PIN_PA14A_EIC_EXTINT_NUM       _L_(14) /**< \brief EIC signal: PIN_PA14 External Interrupt Line */
+#define PIN_PA27A_EIC_EXTINT15         _L_(27) /**< \brief EIC signal: EXTINT15 on PA27 mux A */
+#define MUX_PA27A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA27A_EIC_EXTINT15  ((PIN_PA27A_EIC_EXTINT15 << 16) | MUX_PA27A_EIC_EXTINT15)
+#define PORT_PA27A_EIC_EXTINT15  (_UL_(1) << 27)
+#define PIN_PA27A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA27 External Interrupt Line */
+#define PIN_PB15A_EIC_EXTINT15         _L_(47) /**< \brief EIC signal: EXTINT15 on PB15 mux A */
+#define MUX_PB15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB15A_EIC_EXTINT15  ((PIN_PB15A_EIC_EXTINT15 << 16) | MUX_PB15A_EIC_EXTINT15)
+#define PORT_PB15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PB15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB15 External Interrupt Line */
+#define PIN_PB31A_EIC_EXTINT15         _L_(63) /**< \brief EIC signal: EXTINT15 on PB31 mux A */
+#define MUX_PB31A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PB31A_EIC_EXTINT15  ((PIN_PB31A_EIC_EXTINT15 << 16) | MUX_PB31A_EIC_EXTINT15)
+#define PORT_PB31A_EIC_EXTINT15  (_UL_(1) << 31)
+#define PIN_PB31A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PB31 External Interrupt Line */
+#define PIN_PA15A_EIC_EXTINT15         _L_(15) /**< \brief EIC signal: EXTINT15 on PA15 mux A */
+#define MUX_PA15A_EIC_EXTINT15          _L_(0)
+#define PINMUX_PA15A_EIC_EXTINT15  ((PIN_PA15A_EIC_EXTINT15 << 16) | MUX_PA15A_EIC_EXTINT15)
+#define PORT_PA15A_EIC_EXTINT15  (_UL_(1) << 15)
+#define PIN_PA15A_EIC_EXTINT_NUM       _L_(15) /**< \brief EIC signal: PIN_PA15 External Interrupt Line */
+#define PIN_PA08A_EIC_NMI               _L_(8) /**< \brief EIC signal: NMI on PA08 mux A */
+#define MUX_PA08A_EIC_NMI               _L_(0)
+#define PINMUX_PA08A_EIC_NMI       ((PIN_PA08A_EIC_NMI << 16) | MUX_PA08A_EIC_NMI)
+#define PORT_PA08A_EIC_NMI     (_UL_(1) <<  8)
+/* ========== PORT definition for SERCOM0 peripheral ========== */
+#define PIN_PA04D_SERCOM0_PAD0          _L_(4) /**< \brief SERCOM0 signal: PAD0 on PA04 mux D */
+#define MUX_PA04D_SERCOM0_PAD0          _L_(3)
+#define PINMUX_PA04D_SERCOM0_PAD0  ((PIN_PA04D_SERCOM0_PAD0 << 16) | MUX_PA04D_SERCOM0_PAD0)
+#define PORT_PA04D_SERCOM0_PAD0  (_UL_(1) <<  4)
+#define PIN_PA08C_SERCOM0_PAD0          _L_(8) /**< \brief SERCOM0 signal: PAD0 on PA08 mux C */
+#define MUX_PA08C_SERCOM0_PAD0          _L_(2)
+#define PINMUX_PA08C_SERCOM0_PAD0  ((PIN_PA08C_SERCOM0_PAD0 << 16) | MUX_PA08C_SERCOM0_PAD0)
+#define PORT_PA08C_SERCOM0_PAD0  (_UL_(1) <<  8)
+#define PIN_PA05D_SERCOM0_PAD1          _L_(5) /**< \brief SERCOM0 signal: PAD1 on PA05 mux D */
+#define MUX_PA05D_SERCOM0_PAD1          _L_(3)
+#define PINMUX_PA05D_SERCOM0_PAD1  ((PIN_PA05D_SERCOM0_PAD1 << 16) | MUX_PA05D_SERCOM0_PAD1)
+#define PORT_PA05D_SERCOM0_PAD1  (_UL_(1) <<  5)
+#define PIN_PA09C_SERCOM0_PAD1          _L_(9) /**< \brief SERCOM0 signal: PAD1 on PA09 mux C */
+#define MUX_PA09C_SERCOM0_PAD1          _L_(2)
+#define PINMUX_PA09C_SERCOM0_PAD1  ((PIN_PA09C_SERCOM0_PAD1 << 16) | MUX_PA09C_SERCOM0_PAD1)
+#define PORT_PA09C_SERCOM0_PAD1  (_UL_(1) <<  9)
+#define PIN_PA06D_SERCOM0_PAD2          _L_(6) /**< \brief SERCOM0 signal: PAD2 on PA06 mux D */
+#define MUX_PA06D_SERCOM0_PAD2          _L_(3)
+#define PINMUX_PA06D_SERCOM0_PAD2  ((PIN_PA06D_SERCOM0_PAD2 << 16) | MUX_PA06D_SERCOM0_PAD2)
+#define PORT_PA06D_SERCOM0_PAD2  (_UL_(1) <<  6)
+#define PIN_PA10C_SERCOM0_PAD2         _L_(10) /**< \brief SERCOM0 signal: PAD2 on PA10 mux C */
+#define MUX_PA10C_SERCOM0_PAD2          _L_(2)
+#define PINMUX_PA10C_SERCOM0_PAD2  ((PIN_PA10C_SERCOM0_PAD2 << 16) | MUX_PA10C_SERCOM0_PAD2)
+#define PORT_PA10C_SERCOM0_PAD2  (_UL_(1) << 10)
+#define PIN_PA07D_SERCOM0_PAD3          _L_(7) /**< \brief SERCOM0 signal: PAD3 on PA07 mux D */
+#define MUX_PA07D_SERCOM0_PAD3          _L_(3)
+#define PINMUX_PA07D_SERCOM0_PAD3  ((PIN_PA07D_SERCOM0_PAD3 << 16) | MUX_PA07D_SERCOM0_PAD3)
+#define PORT_PA07D_SERCOM0_PAD3  (_UL_(1) <<  7)
+#define PIN_PA11C_SERCOM0_PAD3         _L_(11) /**< \brief SERCOM0 signal: PAD3 on PA11 mux C */
+#define MUX_PA11C_SERCOM0_PAD3          _L_(2)
+#define PINMUX_PA11C_SERCOM0_PAD3  ((PIN_PA11C_SERCOM0_PAD3 << 16) | MUX_PA11C_SERCOM0_PAD3)
+#define PORT_PA11C_SERCOM0_PAD3  (_UL_(1) << 11)
+/* ========== PORT definition for SERCOM1 peripheral ========== */
+#define PIN_PA16C_SERCOM1_PAD0         _L_(16) /**< \brief SERCOM1 signal: PAD0 on PA16 mux C */
+#define MUX_PA16C_SERCOM1_PAD0          _L_(2)
+#define PINMUX_PA16C_SERCOM1_PAD0  ((PIN_PA16C_SERCOM1_PAD0 << 16) | MUX_PA16C_SERCOM1_PAD0)
+#define PORT_PA16C_SERCOM1_PAD0  (_UL_(1) << 16)
+#define PIN_PA00D_SERCOM1_PAD0          _L_(0) /**< \brief SERCOM1 signal: PAD0 on PA00 mux D */
+#define MUX_PA00D_SERCOM1_PAD0          _L_(3)
+#define PINMUX_PA00D_SERCOM1_PAD0  ((PIN_PA00D_SERCOM1_PAD0 << 16) | MUX_PA00D_SERCOM1_PAD0)
+#define PORT_PA00D_SERCOM1_PAD0  (_UL_(1) <<  0)
+#define PIN_PA17C_SERCOM1_PAD1         _L_(17) /**< \brief SERCOM1 signal: PAD1 on PA17 mux C */
+#define MUX_PA17C_SERCOM1_PAD1          _L_(2)
+#define PINMUX_PA17C_SERCOM1_PAD1  ((PIN_PA17C_SERCOM1_PAD1 << 16) | MUX_PA17C_SERCOM1_PAD1)
+#define PORT_PA17C_SERCOM1_PAD1  (_UL_(1) << 17)
+#define PIN_PA01D_SERCOM1_PAD1          _L_(1) /**< \brief SERCOM1 signal: PAD1 on PA01 mux D */
+#define MUX_PA01D_SERCOM1_PAD1          _L_(3)
+#define PINMUX_PA01D_SERCOM1_PAD1  ((PIN_PA01D_SERCOM1_PAD1 << 16) | MUX_PA01D_SERCOM1_PAD1)
+#define PORT_PA01D_SERCOM1_PAD1  (_UL_(1) <<  1)
+#define PIN_PA30D_SERCOM1_PAD2         _L_(30) /**< \brief SERCOM1 signal: PAD2 on PA30 mux D */
+#define MUX_PA30D_SERCOM1_PAD2          _L_(3)
+#define PINMUX_PA30D_SERCOM1_PAD2  ((PIN_PA30D_SERCOM1_PAD2 << 16) | MUX_PA30D_SERCOM1_PAD2)
+#define PORT_PA30D_SERCOM1_PAD2  (_UL_(1) << 30)
+#define PIN_PA18C_SERCOM1_PAD2         _L_(18) /**< \brief SERCOM1 signal: PAD2 on PA18 mux C */
+#define MUX_PA18C_SERCOM1_PAD2          _L_(2)
+#define PINMUX_PA18C_SERCOM1_PAD2  ((PIN_PA18C_SERCOM1_PAD2 << 16) | MUX_PA18C_SERCOM1_PAD2)
+#define PORT_PA18C_SERCOM1_PAD2  (_UL_(1) << 18)
+#define PIN_PA31D_SERCOM1_PAD3         _L_(31) /**< \brief SERCOM1 signal: PAD3 on PA31 mux D */
+#define MUX_PA31D_SERCOM1_PAD3          _L_(3)
+#define PINMUX_PA31D_SERCOM1_PAD3  ((PIN_PA31D_SERCOM1_PAD3 << 16) | MUX_PA31D_SERCOM1_PAD3)
+#define PORT_PA31D_SERCOM1_PAD3  (_UL_(1) << 31)
+#define PIN_PA19C_SERCOM1_PAD3         _L_(19) /**< \brief SERCOM1 signal: PAD3 on PA19 mux C */
+#define MUX_PA19C_SERCOM1_PAD3          _L_(2)
+#define PINMUX_PA19C_SERCOM1_PAD3  ((PIN_PA19C_SERCOM1_PAD3 << 16) | MUX_PA19C_SERCOM1_PAD3)
+#define PORT_PA19C_SERCOM1_PAD3  (_UL_(1) << 19)
+/* ========== PORT definition for SERCOM2 peripheral ========== */
+#define PIN_PA08D_SERCOM2_PAD0          _L_(8) /**< \brief SERCOM2 signal: PAD0 on PA08 mux D */
+#define MUX_PA08D_SERCOM2_PAD0          _L_(3)
+#define PINMUX_PA08D_SERCOM2_PAD0  ((PIN_PA08D_SERCOM2_PAD0 << 16) | MUX_PA08D_SERCOM2_PAD0)
+#define PORT_PA08D_SERCOM2_PAD0  (_UL_(1) <<  8)
+#define PIN_PA12C_SERCOM2_PAD0         _L_(12) /**< \brief SERCOM2 signal: PAD0 on PA12 mux C */
+#define MUX_PA12C_SERCOM2_PAD0          _L_(2)
+#define PINMUX_PA12C_SERCOM2_PAD0  ((PIN_PA12C_SERCOM2_PAD0 << 16) | MUX_PA12C_SERCOM2_PAD0)
+#define PORT_PA12C_SERCOM2_PAD0  (_UL_(1) << 12)
+#define PIN_PA09D_SERCOM2_PAD1          _L_(9) /**< \brief SERCOM2 signal: PAD1 on PA09 mux D */
+#define MUX_PA09D_SERCOM2_PAD1          _L_(3)
+#define PINMUX_PA09D_SERCOM2_PAD1  ((PIN_PA09D_SERCOM2_PAD1 << 16) | MUX_PA09D_SERCOM2_PAD1)
+#define PORT_PA09D_SERCOM2_PAD1  (_UL_(1) <<  9)
+#define PIN_PA13C_SERCOM2_PAD1         _L_(13) /**< \brief SERCOM2 signal: PAD1 on PA13 mux C */
+#define MUX_PA13C_SERCOM2_PAD1          _L_(2)
+#define PINMUX_PA13C_SERCOM2_PAD1  ((PIN_PA13C_SERCOM2_PAD1 << 16) | MUX_PA13C_SERCOM2_PAD1)
+#define PORT_PA13C_SERCOM2_PAD1  (_UL_(1) << 13)
+#define PIN_PA10D_SERCOM2_PAD2         _L_(10) /**< \brief SERCOM2 signal: PAD2 on PA10 mux D */
+#define MUX_PA10D_SERCOM2_PAD2          _L_(3)
+#define PINMUX_PA10D_SERCOM2_PAD2  ((PIN_PA10D_SERCOM2_PAD2 << 16) | MUX_PA10D_SERCOM2_PAD2)
+#define PORT_PA10D_SERCOM2_PAD2  (_UL_(1) << 10)
+#define PIN_PA14C_SERCOM2_PAD2         _L_(14) /**< \brief SERCOM2 signal: PAD2 on PA14 mux C */
+#define MUX_PA14C_SERCOM2_PAD2          _L_(2)
+#define PINMUX_PA14C_SERCOM2_PAD2  ((PIN_PA14C_SERCOM2_PAD2 << 16) | MUX_PA14C_SERCOM2_PAD2)
+#define PORT_PA14C_SERCOM2_PAD2  (_UL_(1) << 14)
+#define PIN_PA11D_SERCOM2_PAD3         _L_(11) /**< \brief SERCOM2 signal: PAD3 on PA11 mux D */
+#define MUX_PA11D_SERCOM2_PAD3          _L_(3)
+#define PINMUX_PA11D_SERCOM2_PAD3  ((PIN_PA11D_SERCOM2_PAD3 << 16) | MUX_PA11D_SERCOM2_PAD3)
+#define PORT_PA11D_SERCOM2_PAD3  (_UL_(1) << 11)
+#define PIN_PA15C_SERCOM2_PAD3         _L_(15) /**< \brief SERCOM2 signal: PAD3 on PA15 mux C */
+#define MUX_PA15C_SERCOM2_PAD3          _L_(2)
+#define PINMUX_PA15C_SERCOM2_PAD3  ((PIN_PA15C_SERCOM2_PAD3 << 16) | MUX_PA15C_SERCOM2_PAD3)
+#define PORT_PA15C_SERCOM2_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM3 peripheral ========== */
+#define PIN_PA16D_SERCOM3_PAD0         _L_(16) /**< \brief SERCOM3 signal: PAD0 on PA16 mux D */
+#define MUX_PA16D_SERCOM3_PAD0          _L_(3)
+#define PINMUX_PA16D_SERCOM3_PAD0  ((PIN_PA16D_SERCOM3_PAD0 << 16) | MUX_PA16D_SERCOM3_PAD0)
+#define PORT_PA16D_SERCOM3_PAD0  (_UL_(1) << 16)
+#define PIN_PA22C_SERCOM3_PAD0         _L_(22) /**< \brief SERCOM3 signal: PAD0 on PA22 mux C */
+#define MUX_PA22C_SERCOM3_PAD0          _L_(2)
+#define PINMUX_PA22C_SERCOM3_PAD0  ((PIN_PA22C_SERCOM3_PAD0 << 16) | MUX_PA22C_SERCOM3_PAD0)
+#define PORT_PA22C_SERCOM3_PAD0  (_UL_(1) << 22)
+#define PIN_PA17D_SERCOM3_PAD1         _L_(17) /**< \brief SERCOM3 signal: PAD1 on PA17 mux D */
+#define MUX_PA17D_SERCOM3_PAD1          _L_(3)
+#define PINMUX_PA17D_SERCOM3_PAD1  ((PIN_PA17D_SERCOM3_PAD1 << 16) | MUX_PA17D_SERCOM3_PAD1)
+#define PORT_PA17D_SERCOM3_PAD1  (_UL_(1) << 17)
+#define PIN_PA23C_SERCOM3_PAD1         _L_(23) /**< \brief SERCOM3 signal: PAD1 on PA23 mux C */
+#define MUX_PA23C_SERCOM3_PAD1          _L_(2)
+#define PINMUX_PA23C_SERCOM3_PAD1  ((PIN_PA23C_SERCOM3_PAD1 << 16) | MUX_PA23C_SERCOM3_PAD1)
+#define PORT_PA23C_SERCOM3_PAD1  (_UL_(1) << 23)
+#define PIN_PA18D_SERCOM3_PAD2         _L_(18) /**< \brief SERCOM3 signal: PAD2 on PA18 mux D */
+#define MUX_PA18D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA18D_SERCOM3_PAD2  ((PIN_PA18D_SERCOM3_PAD2 << 16) | MUX_PA18D_SERCOM3_PAD2)
+#define PORT_PA18D_SERCOM3_PAD2  (_UL_(1) << 18)
+#define PIN_PA20D_SERCOM3_PAD2         _L_(20) /**< \brief SERCOM3 signal: PAD2 on PA20 mux D */
+#define MUX_PA20D_SERCOM3_PAD2          _L_(3)
+#define PINMUX_PA20D_SERCOM3_PAD2  ((PIN_PA20D_SERCOM3_PAD2 << 16) | MUX_PA20D_SERCOM3_PAD2)
+#define PORT_PA20D_SERCOM3_PAD2  (_UL_(1) << 20)
+#define PIN_PA24C_SERCOM3_PAD2         _L_(24) /**< \brief SERCOM3 signal: PAD2 on PA24 mux C */
+#define MUX_PA24C_SERCOM3_PAD2          _L_(2)
+#define PINMUX_PA24C_SERCOM3_PAD2  ((PIN_PA24C_SERCOM3_PAD2 << 16) | MUX_PA24C_SERCOM3_PAD2)
+#define PORT_PA24C_SERCOM3_PAD2  (_UL_(1) << 24)
+#define PIN_PA19D_SERCOM3_PAD3         _L_(19) /**< \brief SERCOM3 signal: PAD3 on PA19 mux D */
+#define MUX_PA19D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA19D_SERCOM3_PAD3  ((PIN_PA19D_SERCOM3_PAD3 << 16) | MUX_PA19D_SERCOM3_PAD3)
+#define PORT_PA19D_SERCOM3_PAD3  (_UL_(1) << 19)
+#define PIN_PA21D_SERCOM3_PAD3         _L_(21) /**< \brief SERCOM3 signal: PAD3 on PA21 mux D */
+#define MUX_PA21D_SERCOM3_PAD3          _L_(3)
+#define PINMUX_PA21D_SERCOM3_PAD3  ((PIN_PA21D_SERCOM3_PAD3 << 16) | MUX_PA21D_SERCOM3_PAD3)
+#define PORT_PA21D_SERCOM3_PAD3  (_UL_(1) << 21)
+#define PIN_PA25C_SERCOM3_PAD3         _L_(25) /**< \brief SERCOM3 signal: PAD3 on PA25 mux C */
+#define MUX_PA25C_SERCOM3_PAD3          _L_(2)
+#define PINMUX_PA25C_SERCOM3_PAD3  ((PIN_PA25C_SERCOM3_PAD3 << 16) | MUX_PA25C_SERCOM3_PAD3)
+#define PORT_PA25C_SERCOM3_PAD3  (_UL_(1) << 25)
+/* ========== PORT definition for SERCOM4 peripheral ========== */
+#define PIN_PA12D_SERCOM4_PAD0         _L_(12) /**< \brief SERCOM4 signal: PAD0 on PA12 mux D */
+#define MUX_PA12D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PA12D_SERCOM4_PAD0  ((PIN_PA12D_SERCOM4_PAD0 << 16) | MUX_PA12D_SERCOM4_PAD0)
+#define PORT_PA12D_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PB08D_SERCOM4_PAD0         _L_(40) /**< \brief SERCOM4 signal: PAD0 on PB08 mux D */
+#define MUX_PB08D_SERCOM4_PAD0          _L_(3)
+#define PINMUX_PB08D_SERCOM4_PAD0  ((PIN_PB08D_SERCOM4_PAD0 << 16) | MUX_PB08D_SERCOM4_PAD0)
+#define PORT_PB08D_SERCOM4_PAD0  (_UL_(1) <<  8)
+#define PIN_PB12C_SERCOM4_PAD0         _L_(44) /**< \brief SERCOM4 signal: PAD0 on PB12 mux C */
+#define MUX_PB12C_SERCOM4_PAD0          _L_(2)
+#define PINMUX_PB12C_SERCOM4_PAD0  ((PIN_PB12C_SERCOM4_PAD0 << 16) | MUX_PB12C_SERCOM4_PAD0)
+#define PORT_PB12C_SERCOM4_PAD0  (_UL_(1) << 12)
+#define PIN_PA13D_SERCOM4_PAD1         _L_(13) /**< \brief SERCOM4 signal: PAD1 on PA13 mux D */
+#define MUX_PA13D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PA13D_SERCOM4_PAD1  ((PIN_PA13D_SERCOM4_PAD1 << 16) | MUX_PA13D_SERCOM4_PAD1)
+#define PORT_PA13D_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PB09D_SERCOM4_PAD1         _L_(41) /**< \brief SERCOM4 signal: PAD1 on PB09 mux D */
+#define MUX_PB09D_SERCOM4_PAD1          _L_(3)
+#define PINMUX_PB09D_SERCOM4_PAD1  ((PIN_PB09D_SERCOM4_PAD1 << 16) | MUX_PB09D_SERCOM4_PAD1)
+#define PORT_PB09D_SERCOM4_PAD1  (_UL_(1) <<  9)
+#define PIN_PB13C_SERCOM4_PAD1         _L_(45) /**< \brief SERCOM4 signal: PAD1 on PB13 mux C */
+#define MUX_PB13C_SERCOM4_PAD1          _L_(2)
+#define PINMUX_PB13C_SERCOM4_PAD1  ((PIN_PB13C_SERCOM4_PAD1 << 16) | MUX_PB13C_SERCOM4_PAD1)
+#define PORT_PB13C_SERCOM4_PAD1  (_UL_(1) << 13)
+#define PIN_PA14D_SERCOM4_PAD2         _L_(14) /**< \brief SERCOM4 signal: PAD2 on PA14 mux D */
+#define MUX_PA14D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PA14D_SERCOM4_PAD2  ((PIN_PA14D_SERCOM4_PAD2 << 16) | MUX_PA14D_SERCOM4_PAD2)
+#define PORT_PA14D_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PB10D_SERCOM4_PAD2         _L_(42) /**< \brief SERCOM4 signal: PAD2 on PB10 mux D */
+#define MUX_PB10D_SERCOM4_PAD2          _L_(3)
+#define PINMUX_PB10D_SERCOM4_PAD2  ((PIN_PB10D_SERCOM4_PAD2 << 16) | MUX_PB10D_SERCOM4_PAD2)
+#define PORT_PB10D_SERCOM4_PAD2  (_UL_(1) << 10)
+#define PIN_PB14C_SERCOM4_PAD2         _L_(46) /**< \brief SERCOM4 signal: PAD2 on PB14 mux C */
+#define MUX_PB14C_SERCOM4_PAD2          _L_(2)
+#define PINMUX_PB14C_SERCOM4_PAD2  ((PIN_PB14C_SERCOM4_PAD2 << 16) | MUX_PB14C_SERCOM4_PAD2)
+#define PORT_PB14C_SERCOM4_PAD2  (_UL_(1) << 14)
+#define PIN_PA15D_SERCOM4_PAD3         _L_(15) /**< \brief SERCOM4 signal: PAD3 on PA15 mux D */
+#define MUX_PA15D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PA15D_SERCOM4_PAD3  ((PIN_PA15D_SERCOM4_PAD3 << 16) | MUX_PA15D_SERCOM4_PAD3)
+#define PORT_PA15D_SERCOM4_PAD3  (_UL_(1) << 15)
+#define PIN_PB11D_SERCOM4_PAD3         _L_(43) /**< \brief SERCOM4 signal: PAD3 on PB11 mux D */
+#define MUX_PB11D_SERCOM4_PAD3          _L_(3)
+#define PINMUX_PB11D_SERCOM4_PAD3  ((PIN_PB11D_SERCOM4_PAD3 << 16) | MUX_PB11D_SERCOM4_PAD3)
+#define PORT_PB11D_SERCOM4_PAD3  (_UL_(1) << 11)
+#define PIN_PB15C_SERCOM4_PAD3         _L_(47) /**< \brief SERCOM4 signal: PAD3 on PB15 mux C */
+#define MUX_PB15C_SERCOM4_PAD3          _L_(2)
+#define PINMUX_PB15C_SERCOM4_PAD3  ((PIN_PB15C_SERCOM4_PAD3 << 16) | MUX_PB15C_SERCOM4_PAD3)
+#define PORT_PB15C_SERCOM4_PAD3  (_UL_(1) << 15)
+/* ========== PORT definition for SERCOM5 peripheral ========== */
+#define PIN_PA22D_SERCOM5_PAD0         _L_(22) /**< \brief SERCOM5 signal: PAD0 on PA22 mux D */
+#define MUX_PA22D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PA22D_SERCOM5_PAD0  ((PIN_PA22D_SERCOM5_PAD0 << 16) | MUX_PA22D_SERCOM5_PAD0)
+#define PORT_PA22D_SERCOM5_PAD0  (_UL_(1) << 22)
+#define PIN_PB02D_SERCOM5_PAD0         _L_(34) /**< \brief SERCOM5 signal: PAD0 on PB02 mux D */
+#define MUX_PB02D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB02D_SERCOM5_PAD0  ((PIN_PB02D_SERCOM5_PAD0 << 16) | MUX_PB02D_SERCOM5_PAD0)
+#define PORT_PB02D_SERCOM5_PAD0  (_UL_(1) <<  2)
+#define PIN_PB30D_SERCOM5_PAD0         _L_(62) /**< \brief SERCOM5 signal: PAD0 on PB30 mux D */
+#define MUX_PB30D_SERCOM5_PAD0          _L_(3)
+#define PINMUX_PB30D_SERCOM5_PAD0  ((PIN_PB30D_SERCOM5_PAD0 << 16) | MUX_PB30D_SERCOM5_PAD0)
+#define PORT_PB30D_SERCOM5_PAD0  (_UL_(1) << 30)
+#define PIN_PB16C_SERCOM5_PAD0         _L_(48) /**< \brief SERCOM5 signal: PAD0 on PB16 mux C */
+#define MUX_PB16C_SERCOM5_PAD0          _L_(2)
+#define PINMUX_PB16C_SERCOM5_PAD0  ((PIN_PB16C_SERCOM5_PAD0 << 16) | MUX_PB16C_SERCOM5_PAD0)
+#define PORT_PB16C_SERCOM5_PAD0  (_UL_(1) << 16)
+#define PIN_PA23D_SERCOM5_PAD1         _L_(23) /**< \brief SERCOM5 signal: PAD1 on PA23 mux D */
+#define MUX_PA23D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PA23D_SERCOM5_PAD1  ((PIN_PA23D_SERCOM5_PAD1 << 16) | MUX_PA23D_SERCOM5_PAD1)
+#define PORT_PA23D_SERCOM5_PAD1  (_UL_(1) << 23)
+#define PIN_PB03D_SERCOM5_PAD1         _L_(35) /**< \brief SERCOM5 signal: PAD1 on PB03 mux D */
+#define MUX_PB03D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB03D_SERCOM5_PAD1  ((PIN_PB03D_SERCOM5_PAD1 << 16) | MUX_PB03D_SERCOM5_PAD1)
+#define PORT_PB03D_SERCOM5_PAD1  (_UL_(1) <<  3)
+#define PIN_PB31D_SERCOM5_PAD1         _L_(63) /**< \brief SERCOM5 signal: PAD1 on PB31 mux D */
+#define MUX_PB31D_SERCOM5_PAD1          _L_(3)
+#define PINMUX_PB31D_SERCOM5_PAD1  ((PIN_PB31D_SERCOM5_PAD1 << 16) | MUX_PB31D_SERCOM5_PAD1)
+#define PORT_PB31D_SERCOM5_PAD1  (_UL_(1) << 31)
+#define PIN_PB17C_SERCOM5_PAD1         _L_(49) /**< \brief SERCOM5 signal: PAD1 on PB17 mux C */
+#define MUX_PB17C_SERCOM5_PAD1          _L_(2)
+#define PINMUX_PB17C_SERCOM5_PAD1  ((PIN_PB17C_SERCOM5_PAD1 << 16) | MUX_PB17C_SERCOM5_PAD1)
+#define PORT_PB17C_SERCOM5_PAD1  (_UL_(1) << 17)
+#define PIN_PA24D_SERCOM5_PAD2         _L_(24) /**< \brief SERCOM5 signal: PAD2 on PA24 mux D */
+#define MUX_PA24D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PA24D_SERCOM5_PAD2  ((PIN_PA24D_SERCOM5_PAD2 << 16) | MUX_PA24D_SERCOM5_PAD2)
+#define PORT_PA24D_SERCOM5_PAD2  (_UL_(1) << 24)
+#define PIN_PB00D_SERCOM5_PAD2         _L_(32) /**< \brief SERCOM5 signal: PAD2 on PB00 mux D */
+#define MUX_PB00D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB00D_SERCOM5_PAD2  ((PIN_PB00D_SERCOM5_PAD2 << 16) | MUX_PB00D_SERCOM5_PAD2)
+#define PORT_PB00D_SERCOM5_PAD2  (_UL_(1) <<  0)
+#define PIN_PB22D_SERCOM5_PAD2         _L_(54) /**< \brief SERCOM5 signal: PAD2 on PB22 mux D */
+#define MUX_PB22D_SERCOM5_PAD2          _L_(3)
+#define PINMUX_PB22D_SERCOM5_PAD2  ((PIN_PB22D_SERCOM5_PAD2 << 16) | MUX_PB22D_SERCOM5_PAD2)
+#define PORT_PB22D_SERCOM5_PAD2  (_UL_(1) << 22)
+#define PIN_PA20C_SERCOM5_PAD2         _L_(20) /**< \brief SERCOM5 signal: PAD2 on PA20 mux C */
+#define MUX_PA20C_SERCOM5_PAD2          _L_(2)
+#define PINMUX_PA20C_SERCOM5_PAD2  ((PIN_PA20C_SERCOM5_PAD2 << 16) | MUX_PA20C_SERCOM5_PAD2)
+#define PORT_PA20C_SERCOM5_PAD2  (_UL_(1) << 20)
+#define PIN_PA25D_SERCOM5_PAD3         _L_(25) /**< \brief SERCOM5 signal: PAD3 on PA25 mux D */
+#define MUX_PA25D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PA25D_SERCOM5_PAD3  ((PIN_PA25D_SERCOM5_PAD3 << 16) | MUX_PA25D_SERCOM5_PAD3)
+#define PORT_PA25D_SERCOM5_PAD3  (_UL_(1) << 25)
+#define PIN_PB01D_SERCOM5_PAD3         _L_(33) /**< \brief SERCOM5 signal: PAD3 on PB01 mux D */
+#define MUX_PB01D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB01D_SERCOM5_PAD3  ((PIN_PB01D_SERCOM5_PAD3 << 16) | MUX_PB01D_SERCOM5_PAD3)
+#define PORT_PB01D_SERCOM5_PAD3  (_UL_(1) <<  1)
+#define PIN_PB23D_SERCOM5_PAD3         _L_(55) /**< \brief SERCOM5 signal: PAD3 on PB23 mux D */
+#define MUX_PB23D_SERCOM5_PAD3          _L_(3)
+#define PINMUX_PB23D_SERCOM5_PAD3  ((PIN_PB23D_SERCOM5_PAD3 << 16) | MUX_PB23D_SERCOM5_PAD3)
+#define PORT_PB23D_SERCOM5_PAD3  (_UL_(1) << 23)
+#define PIN_PA21C_SERCOM5_PAD3         _L_(21) /**< \brief SERCOM5 signal: PAD3 on PA21 mux C */
+#define MUX_PA21C_SERCOM5_PAD3          _L_(2)
+#define PINMUX_PA21C_SERCOM5_PAD3  ((PIN_PA21C_SERCOM5_PAD3 << 16) | MUX_PA21C_SERCOM5_PAD3)
+#define PORT_PA21C_SERCOM5_PAD3  (_UL_(1) << 21)
+/* ========== PORT definition for TC0 peripheral ========== */
+#define PIN_PA04F_TC0_WO0               _L_(4) /**< \brief TC0 signal: WO0 on PA04 mux F */
+#define MUX_PA04F_TC0_WO0               _L_(5)
+#define PINMUX_PA04F_TC0_WO0       ((PIN_PA04F_TC0_WO0 << 16) | MUX_PA04F_TC0_WO0)
+#define PORT_PA04F_TC0_WO0     (_UL_(1) <<  4)
+#define PIN_PB30F_TC0_WO0              _L_(62) /**< \brief TC0 signal: WO0 on PB30 mux F */
+#define MUX_PB30F_TC0_WO0               _L_(5)
+#define PINMUX_PB30F_TC0_WO0       ((PIN_PB30F_TC0_WO0 << 16) | MUX_PB30F_TC0_WO0)
+#define PORT_PB30F_TC0_WO0     (_UL_(1) << 30)
+#define PIN_PA08E_TC0_WO0               _L_(8) /**< \brief TC0 signal: WO0 on PA08 mux E */
+#define MUX_PA08E_TC0_WO0               _L_(4)
+#define PINMUX_PA08E_TC0_WO0       ((PIN_PA08E_TC0_WO0 << 16) | MUX_PA08E_TC0_WO0)
+#define PORT_PA08E_TC0_WO0     (_UL_(1) <<  8)
+#define PIN_PA05F_TC0_WO1               _L_(5) /**< \brief TC0 signal: WO1 on PA05 mux F */
+#define MUX_PA05F_TC0_WO1               _L_(5)
+#define PINMUX_PA05F_TC0_WO1       ((PIN_PA05F_TC0_WO1 << 16) | MUX_PA05F_TC0_WO1)
+#define PORT_PA05F_TC0_WO1     (_UL_(1) <<  5)
+#define PIN_PB31F_TC0_WO1              _L_(63) /**< \brief TC0 signal: WO1 on PB31 mux F */
+#define MUX_PB31F_TC0_WO1               _L_(5)
+#define PINMUX_PB31F_TC0_WO1       ((PIN_PB31F_TC0_WO1 << 16) | MUX_PB31F_TC0_WO1)
+#define PORT_PB31F_TC0_WO1     (_UL_(1) << 31)
+#define PIN_PA09E_TC0_WO1               _L_(9) /**< \brief TC0 signal: WO1 on PA09 mux E */
+#define MUX_PA09E_TC0_WO1               _L_(4)
+#define PINMUX_PA09E_TC0_WO1       ((PIN_PA09E_TC0_WO1 << 16) | MUX_PA09E_TC0_WO1)
+#define PORT_PA09E_TC0_WO1     (_UL_(1) <<  9)
+/* ========== PORT definition for TC1 peripheral ========== */
+#define PIN_PA06F_TC1_WO0               _L_(6) /**< \brief TC1 signal: WO0 on PA06 mux F */
+#define MUX_PA06F_TC1_WO0               _L_(5)
+#define PINMUX_PA06F_TC1_WO0       ((PIN_PA06F_TC1_WO0 << 16) | MUX_PA06F_TC1_WO0)
+#define PORT_PA06F_TC1_WO0     (_UL_(1) <<  6)
+#define PIN_PA30F_TC1_WO0              _L_(30) /**< \brief TC1 signal: WO0 on PA30 mux F */
+#define MUX_PA30F_TC1_WO0               _L_(5)
+#define PINMUX_PA30F_TC1_WO0       ((PIN_PA30F_TC1_WO0 << 16) | MUX_PA30F_TC1_WO0)
+#define PORT_PA30F_TC1_WO0     (_UL_(1) << 30)
+#define PIN_PA10E_TC1_WO0              _L_(10) /**< \brief TC1 signal: WO0 on PA10 mux E */
+#define MUX_PA10E_TC1_WO0               _L_(4)
+#define PINMUX_PA10E_TC1_WO0       ((PIN_PA10E_TC1_WO0 << 16) | MUX_PA10E_TC1_WO0)
+#define PORT_PA10E_TC1_WO0     (_UL_(1) << 10)
+#define PIN_PA07F_TC1_WO1               _L_(7) /**< \brief TC1 signal: WO1 on PA07 mux F */
+#define MUX_PA07F_TC1_WO1               _L_(5)
+#define PINMUX_PA07F_TC1_WO1       ((PIN_PA07F_TC1_WO1 << 16) | MUX_PA07F_TC1_WO1)
+#define PORT_PA07F_TC1_WO1     (_UL_(1) <<  7)
+#define PIN_PA31F_TC1_WO1              _L_(31) /**< \brief TC1 signal: WO1 on PA31 mux F */
+#define MUX_PA31F_TC1_WO1               _L_(5)
+#define PINMUX_PA31F_TC1_WO1       ((PIN_PA31F_TC1_WO1 << 16) | MUX_PA31F_TC1_WO1)
+#define PORT_PA31F_TC1_WO1     (_UL_(1) << 31)
+#define PIN_PA11E_TC1_WO1              _L_(11) /**< \brief TC1 signal: WO1 on PA11 mux E */
+#define MUX_PA11E_TC1_WO1               _L_(4)
+#define PINMUX_PA11E_TC1_WO1       ((PIN_PA11E_TC1_WO1 << 16) | MUX_PA11E_TC1_WO1)
+#define PORT_PA11E_TC1_WO1     (_UL_(1) << 11)
+/* ========== PORT definition for TC2 peripheral ========== */
+#define PIN_PA16F_TC2_WO0              _L_(16) /**< \brief TC2 signal: WO0 on PA16 mux F */
+#define MUX_PA16F_TC2_WO0               _L_(5)
+#define PINMUX_PA16F_TC2_WO0       ((PIN_PA16F_TC2_WO0 << 16) | MUX_PA16F_TC2_WO0)
+#define PORT_PA16F_TC2_WO0     (_UL_(1) << 16)
+#define PIN_PA12E_TC2_WO0              _L_(12) /**< \brief TC2 signal: WO0 on PA12 mux E */
+#define MUX_PA12E_TC2_WO0               _L_(4)
+#define PINMUX_PA12E_TC2_WO0       ((PIN_PA12E_TC2_WO0 << 16) | MUX_PA12E_TC2_WO0)
+#define PORT_PA12E_TC2_WO0     (_UL_(1) << 12)
+#define PIN_PA00F_TC2_WO0               _L_(0) /**< \brief TC2 signal: WO0 on PA00 mux F */
+#define MUX_PA00F_TC2_WO0               _L_(5)
+#define PINMUX_PA00F_TC2_WO0       ((PIN_PA00F_TC2_WO0 << 16) | MUX_PA00F_TC2_WO0)
+#define PORT_PA00F_TC2_WO0     (_UL_(1) <<  0)
+#define PIN_PA17F_TC2_WO1              _L_(17) /**< \brief TC2 signal: WO1 on PA17 mux F */
+#define MUX_PA17F_TC2_WO1               _L_(5)
+#define PINMUX_PA17F_TC2_WO1       ((PIN_PA17F_TC2_WO1 << 16) | MUX_PA17F_TC2_WO1)
+#define PORT_PA17F_TC2_WO1     (_UL_(1) << 17)
+#define PIN_PA13E_TC2_WO1              _L_(13) /**< \brief TC2 signal: WO1 on PA13 mux E */
+#define MUX_PA13E_TC2_WO1               _L_(4)
+#define PINMUX_PA13E_TC2_WO1       ((PIN_PA13E_TC2_WO1 << 16) | MUX_PA13E_TC2_WO1)
+#define PORT_PA13E_TC2_WO1     (_UL_(1) << 13)
+#define PIN_PA01F_TC2_WO1               _L_(1) /**< \brief TC2 signal: WO1 on PA01 mux F */
+#define MUX_PA01F_TC2_WO1               _L_(5)
+#define PINMUX_PA01F_TC2_WO1       ((PIN_PA01F_TC2_WO1 << 16) | MUX_PA01F_TC2_WO1)
+#define PORT_PA01F_TC2_WO1     (_UL_(1) <<  1)
+/* ========== PORT definition for TC3 peripheral ========== */
+#define PIN_PA18F_TC3_WO0              _L_(18) /**< \brief TC3 signal: WO0 on PA18 mux F */
+#define MUX_PA18F_TC3_WO0               _L_(5)
+#define PINMUX_PA18F_TC3_WO0       ((PIN_PA18F_TC3_WO0 << 16) | MUX_PA18F_TC3_WO0)
+#define PORT_PA18F_TC3_WO0     (_UL_(1) << 18)
+#define PIN_PA14E_TC3_WO0              _L_(14) /**< \brief TC3 signal: WO0 on PA14 mux E */
+#define MUX_PA14E_TC3_WO0               _L_(4)
+#define PINMUX_PA14E_TC3_WO0       ((PIN_PA14E_TC3_WO0 << 16) | MUX_PA14E_TC3_WO0)
+#define PORT_PA14E_TC3_WO0     (_UL_(1) << 14)
+#define PIN_PA19F_TC3_WO1              _L_(19) /**< \brief TC3 signal: WO1 on PA19 mux F */
+#define MUX_PA19F_TC3_WO1               _L_(5)
+#define PINMUX_PA19F_TC3_WO1       ((PIN_PA19F_TC3_WO1 << 16) | MUX_PA19F_TC3_WO1)
+#define PORT_PA19F_TC3_WO1     (_UL_(1) << 19)
+#define PIN_PA15E_TC3_WO1              _L_(15) /**< \brief TC3 signal: WO1 on PA15 mux E */
+#define MUX_PA15E_TC3_WO1               _L_(4)
+#define PINMUX_PA15E_TC3_WO1       ((PIN_PA15E_TC3_WO1 << 16) | MUX_PA15E_TC3_WO1)
+#define PORT_PA15E_TC3_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC4 peripheral ========== */
+#define PIN_PA22F_TC4_WO0              _L_(22) /**< \brief TC4 signal: WO0 on PA22 mux F */
+#define MUX_PA22F_TC4_WO0               _L_(5)
+#define PINMUX_PA22F_TC4_WO0       ((PIN_PA22F_TC4_WO0 << 16) | MUX_PA22F_TC4_WO0)
+#define PORT_PA22F_TC4_WO0     (_UL_(1) << 22)
+#define PIN_PB08F_TC4_WO0              _L_(40) /**< \brief TC4 signal: WO0 on PB08 mux F */
+#define MUX_PB08F_TC4_WO0               _L_(5)
+#define PINMUX_PB08F_TC4_WO0       ((PIN_PB08F_TC4_WO0 << 16) | MUX_PB08F_TC4_WO0)
+#define PORT_PB08F_TC4_WO0     (_UL_(1) <<  8)
+#define PIN_PB12E_TC4_WO0              _L_(44) /**< \brief TC4 signal: WO0 on PB12 mux E */
+#define MUX_PB12E_TC4_WO0               _L_(4)
+#define PINMUX_PB12E_TC4_WO0       ((PIN_PB12E_TC4_WO0 << 16) | MUX_PB12E_TC4_WO0)
+#define PORT_PB12E_TC4_WO0     (_UL_(1) << 12)
+#define PIN_PA23F_TC4_WO1              _L_(23) /**< \brief TC4 signal: WO1 on PA23 mux F */
+#define MUX_PA23F_TC4_WO1               _L_(5)
+#define PINMUX_PA23F_TC4_WO1       ((PIN_PA23F_TC4_WO1 << 16) | MUX_PA23F_TC4_WO1)
+#define PORT_PA23F_TC4_WO1     (_UL_(1) << 23)
+#define PIN_PB09F_TC4_WO1              _L_(41) /**< \brief TC4 signal: WO1 on PB09 mux F */
+#define MUX_PB09F_TC4_WO1               _L_(5)
+#define PINMUX_PB09F_TC4_WO1       ((PIN_PB09F_TC4_WO1 << 16) | MUX_PB09F_TC4_WO1)
+#define PORT_PB09F_TC4_WO1     (_UL_(1) <<  9)
+#define PIN_PB13E_TC4_WO1              _L_(45) /**< \brief TC4 signal: WO1 on PB13 mux E */
+#define MUX_PB13E_TC4_WO1               _L_(4)
+#define PINMUX_PB13E_TC4_WO1       ((PIN_PB13E_TC4_WO1 << 16) | MUX_PB13E_TC4_WO1)
+#define PORT_PB13E_TC4_WO1     (_UL_(1) << 13)
+/* ========== PORT definition for TC5 peripheral ========== */
+#define PIN_PA24F_TC5_WO0              _L_(24) /**< \brief TC5 signal: WO0 on PA24 mux F */
+#define MUX_PA24F_TC5_WO0               _L_(5)
+#define PINMUX_PA24F_TC5_WO0       ((PIN_PA24F_TC5_WO0 << 16) | MUX_PA24F_TC5_WO0)
+#define PORT_PA24F_TC5_WO0     (_UL_(1) << 24)
+#define PIN_PB10F_TC5_WO0              _L_(42) /**< \brief TC5 signal: WO0 on PB10 mux F */
+#define MUX_PB10F_TC5_WO0               _L_(5)
+#define PINMUX_PB10F_TC5_WO0       ((PIN_PB10F_TC5_WO0 << 16) | MUX_PB10F_TC5_WO0)
+#define PORT_PB10F_TC5_WO0     (_UL_(1) << 10)
+#define PIN_PB14E_TC5_WO0              _L_(46) /**< \brief TC5 signal: WO0 on PB14 mux E */
+#define MUX_PB14E_TC5_WO0               _L_(4)
+#define PINMUX_PB14E_TC5_WO0       ((PIN_PB14E_TC5_WO0 << 16) | MUX_PB14E_TC5_WO0)
+#define PORT_PB14E_TC5_WO0     (_UL_(1) << 14)
+#define PIN_PA25F_TC5_WO1              _L_(25) /**< \brief TC5 signal: WO1 on PA25 mux F */
+#define MUX_PA25F_TC5_WO1               _L_(5)
+#define PINMUX_PA25F_TC5_WO1       ((PIN_PA25F_TC5_WO1 << 16) | MUX_PA25F_TC5_WO1)
+#define PORT_PA25F_TC5_WO1     (_UL_(1) << 25)
+#define PIN_PB11F_TC5_WO1              _L_(43) /**< \brief TC5 signal: WO1 on PB11 mux F */
+#define MUX_PB11F_TC5_WO1               _L_(5)
+#define PINMUX_PB11F_TC5_WO1       ((PIN_PB11F_TC5_WO1 << 16) | MUX_PB11F_TC5_WO1)
+#define PORT_PB11F_TC5_WO1     (_UL_(1) << 11)
+#define PIN_PB15E_TC5_WO1              _L_(47) /**< \brief TC5 signal: WO1 on PB15 mux E */
+#define MUX_PB15E_TC5_WO1               _L_(4)
+#define PINMUX_PB15E_TC5_WO1       ((PIN_PB15E_TC5_WO1 << 16) | MUX_PB15E_TC5_WO1)
+#define PORT_PB15E_TC5_WO1     (_UL_(1) << 15)
+/* ========== PORT definition for TC6 peripheral ========== */
+#define PIN_PB02F_TC6_WO0              _L_(34) /**< \brief TC6 signal: WO0 on PB02 mux F */
+#define MUX_PB02F_TC6_WO0               _L_(5)
+#define PINMUX_PB02F_TC6_WO0       ((PIN_PB02F_TC6_WO0 << 16) | MUX_PB02F_TC6_WO0)
+#define PORT_PB02F_TC6_WO0     (_UL_(1) <<  2)
+#define PIN_PB16E_TC6_WO0              _L_(48) /**< \brief TC6 signal: WO0 on PB16 mux E */
+#define MUX_PB16E_TC6_WO0               _L_(4)
+#define PINMUX_PB16E_TC6_WO0       ((PIN_PB16E_TC6_WO0 << 16) | MUX_PB16E_TC6_WO0)
+#define PORT_PB16E_TC6_WO0     (_UL_(1) << 16)
+#define PIN_PB03F_TC6_WO1              _L_(35) /**< \brief TC6 signal: WO1 on PB03 mux F */
+#define MUX_PB03F_TC6_WO1               _L_(5)
+#define PINMUX_PB03F_TC6_WO1       ((PIN_PB03F_TC6_WO1 << 16) | MUX_PB03F_TC6_WO1)
+#define PORT_PB03F_TC6_WO1     (_UL_(1) <<  3)
+#define PIN_PB17E_TC6_WO1              _L_(49) /**< \brief TC6 signal: WO1 on PB17 mux E */
+#define MUX_PB17E_TC6_WO1               _L_(4)
+#define PINMUX_PB17E_TC6_WO1       ((PIN_PB17E_TC6_WO1 << 16) | MUX_PB17E_TC6_WO1)
+#define PORT_PB17E_TC6_WO1     (_UL_(1) << 17)
+/* ========== PORT definition for TC7 peripheral ========== */
+#define PIN_PB00F_TC7_WO0              _L_(32) /**< \brief TC7 signal: WO0 on PB00 mux F */
+#define MUX_PB00F_TC7_WO0               _L_(5)
+#define PINMUX_PB00F_TC7_WO0       ((PIN_PB00F_TC7_WO0 << 16) | MUX_PB00F_TC7_WO0)
+#define PORT_PB00F_TC7_WO0     (_UL_(1) <<  0)
+#define PIN_PB22F_TC7_WO0              _L_(54) /**< \brief TC7 signal: WO0 on PB22 mux F */
+#define MUX_PB22F_TC7_WO0               _L_(5)
+#define PINMUX_PB22F_TC7_WO0       ((PIN_PB22F_TC7_WO0 << 16) | MUX_PB22F_TC7_WO0)
+#define PORT_PB22F_TC7_WO0     (_UL_(1) << 22)
+#define PIN_PA20E_TC7_WO0              _L_(20) /**< \brief TC7 signal: WO0 on PA20 mux E */
+#define MUX_PA20E_TC7_WO0               _L_(4)
+#define PINMUX_PA20E_TC7_WO0       ((PIN_PA20E_TC7_WO0 << 16) | MUX_PA20E_TC7_WO0)
+#define PORT_PA20E_TC7_WO0     (_UL_(1) << 20)
+#define PIN_PB01F_TC7_WO1              _L_(33) /**< \brief TC7 signal: WO1 on PB01 mux F */
+#define MUX_PB01F_TC7_WO1               _L_(5)
+#define PINMUX_PB01F_TC7_WO1       ((PIN_PB01F_TC7_WO1 << 16) | MUX_PB01F_TC7_WO1)
+#define PORT_PB01F_TC7_WO1     (_UL_(1) <<  1)
+#define PIN_PB23F_TC7_WO1              _L_(55) /**< \brief TC7 signal: WO1 on PB23 mux F */
+#define MUX_PB23F_TC7_WO1               _L_(5)
+#define PINMUX_PB23F_TC7_WO1       ((PIN_PB23F_TC7_WO1 << 16) | MUX_PB23F_TC7_WO1)
+#define PORT_PB23F_TC7_WO1     (_UL_(1) << 23)
+#define PIN_PA21E_TC7_WO1              _L_(21) /**< \brief TC7 signal: WO1 on PA21 mux E */
+#define MUX_PA21E_TC7_WO1               _L_(4)
+#define PINMUX_PA21E_TC7_WO1       ((PIN_PA21E_TC7_WO1 << 16) | MUX_PA21E_TC7_WO1)
+#define PORT_PA21E_TC7_WO1     (_UL_(1) << 21)
+/* ========== PORT definition for ADC peripheral ========== */
+#define PIN_PA02B_ADC_AIN0              _L_(2) /**< \brief ADC signal: AIN0 on PA02 mux B */
+#define MUX_PA02B_ADC_AIN0              _L_(1)
+#define PINMUX_PA02B_ADC_AIN0      ((PIN_PA02B_ADC_AIN0 << 16) | MUX_PA02B_ADC_AIN0)
+#define PORT_PA02B_ADC_AIN0    (_UL_(1) <<  2)
+#define PIN_PA03B_ADC_AIN1              _L_(3) /**< \brief ADC signal: AIN1 on PA03 mux B */
+#define MUX_PA03B_ADC_AIN1              _L_(1)
+#define PINMUX_PA03B_ADC_AIN1      ((PIN_PA03B_ADC_AIN1 << 16) | MUX_PA03B_ADC_AIN1)
+#define PORT_PA03B_ADC_AIN1    (_UL_(1) <<  3)
+#define PIN_PB08B_ADC_AIN2             _L_(40) /**< \brief ADC signal: AIN2 on PB08 mux B */
+#define MUX_PB08B_ADC_AIN2              _L_(1)
+#define PINMUX_PB08B_ADC_AIN2      ((PIN_PB08B_ADC_AIN2 << 16) | MUX_PB08B_ADC_AIN2)
+#define PORT_PB08B_ADC_AIN2    (_UL_(1) <<  8)
+#define PIN_PB09B_ADC_AIN3             _L_(41) /**< \brief ADC signal: AIN3 on PB09 mux B */
+#define MUX_PB09B_ADC_AIN3              _L_(1)
+#define PINMUX_PB09B_ADC_AIN3      ((PIN_PB09B_ADC_AIN3 << 16) | MUX_PB09B_ADC_AIN3)
+#define PORT_PB09B_ADC_AIN3    (_UL_(1) <<  9)
+#define PIN_PA04B_ADC_AIN4              _L_(4) /**< \brief ADC signal: AIN4 on PA04 mux B */
+#define MUX_PA04B_ADC_AIN4              _L_(1)
+#define PINMUX_PA04B_ADC_AIN4      ((PIN_PA04B_ADC_AIN4 << 16) | MUX_PA04B_ADC_AIN4)
+#define PORT_PA04B_ADC_AIN4    (_UL_(1) <<  4)
+#define PIN_PA05B_ADC_AIN5              _L_(5) /**< \brief ADC signal: AIN5 on PA05 mux B */
+#define MUX_PA05B_ADC_AIN5              _L_(1)
+#define PINMUX_PA05B_ADC_AIN5      ((PIN_PA05B_ADC_AIN5 << 16) | MUX_PA05B_ADC_AIN5)
+#define PORT_PA05B_ADC_AIN5    (_UL_(1) <<  5)
+#define PIN_PA06B_ADC_AIN6              _L_(6) /**< \brief ADC signal: AIN6 on PA06 mux B */
+#define MUX_PA06B_ADC_AIN6              _L_(1)
+#define PINMUX_PA06B_ADC_AIN6      ((PIN_PA06B_ADC_AIN6 << 16) | MUX_PA06B_ADC_AIN6)
+#define PORT_PA06B_ADC_AIN6    (_UL_(1) <<  6)
+#define PIN_PA07B_ADC_AIN7              _L_(7) /**< \brief ADC signal: AIN7 on PA07 mux B */
+#define MUX_PA07B_ADC_AIN7              _L_(1)
+#define PINMUX_PA07B_ADC_AIN7      ((PIN_PA07B_ADC_AIN7 << 16) | MUX_PA07B_ADC_AIN7)
+#define PORT_PA07B_ADC_AIN7    (_UL_(1) <<  7)
+#define PIN_PB00B_ADC_AIN8             _L_(32) /**< \brief ADC signal: AIN8 on PB00 mux B */
+#define MUX_PB00B_ADC_AIN8              _L_(1)
+#define PINMUX_PB00B_ADC_AIN8      ((PIN_PB00B_ADC_AIN8 << 16) | MUX_PB00B_ADC_AIN8)
+#define PORT_PB00B_ADC_AIN8    (_UL_(1) <<  0)
+#define PIN_PB01B_ADC_AIN9             _L_(33) /**< \brief ADC signal: AIN9 on PB01 mux B */
+#define MUX_PB01B_ADC_AIN9              _L_(1)
+#define PINMUX_PB01B_ADC_AIN9      ((PIN_PB01B_ADC_AIN9 << 16) | MUX_PB01B_ADC_AIN9)
+#define PORT_PB01B_ADC_AIN9    (_UL_(1) <<  1)
+#define PIN_PB02B_ADC_AIN10            _L_(34) /**< \brief ADC signal: AIN10 on PB02 mux B */
+#define MUX_PB02B_ADC_AIN10             _L_(1)
+#define PINMUX_PB02B_ADC_AIN10     ((PIN_PB02B_ADC_AIN10 << 16) | MUX_PB02B_ADC_AIN10)
+#define PORT_PB02B_ADC_AIN10   (_UL_(1) <<  2)
+#define PIN_PB03B_ADC_AIN11            _L_(35) /**< \brief ADC signal: AIN11 on PB03 mux B */
+#define MUX_PB03B_ADC_AIN11             _L_(1)
+#define PINMUX_PB03B_ADC_AIN11     ((PIN_PB03B_ADC_AIN11 << 16) | MUX_PB03B_ADC_AIN11)
+#define PORT_PB03B_ADC_AIN11   (_UL_(1) <<  3)
+#define PIN_PB04B_ADC_AIN12            _L_(36) /**< \brief ADC signal: AIN12 on PB04 mux B */
+#define MUX_PB04B_ADC_AIN12             _L_(1)
+#define PINMUX_PB04B_ADC_AIN12     ((PIN_PB04B_ADC_AIN12 << 16) | MUX_PB04B_ADC_AIN12)
+#define PORT_PB04B_ADC_AIN12   (_UL_(1) <<  4)
+#define PIN_PB05B_ADC_AIN13            _L_(37) /**< \brief ADC signal: AIN13 on PB05 mux B */
+#define MUX_PB05B_ADC_AIN13             _L_(1)
+#define PINMUX_PB05B_ADC_AIN13     ((PIN_PB05B_ADC_AIN13 << 16) | MUX_PB05B_ADC_AIN13)
+#define PORT_PB05B_ADC_AIN13   (_UL_(1) <<  5)
+#define PIN_PB06B_ADC_AIN14            _L_(38) /**< \brief ADC signal: AIN14 on PB06 mux B */
+#define MUX_PB06B_ADC_AIN14             _L_(1)
+#define PINMUX_PB06B_ADC_AIN14     ((PIN_PB06B_ADC_AIN14 << 16) | MUX_PB06B_ADC_AIN14)
+#define PORT_PB06B_ADC_AIN14   (_UL_(1) <<  6)
+#define PIN_PB07B_ADC_AIN15            _L_(39) /**< \brief ADC signal: AIN15 on PB07 mux B */
+#define MUX_PB07B_ADC_AIN15             _L_(1)
+#define PINMUX_PB07B_ADC_AIN15     ((PIN_PB07B_ADC_AIN15 << 16) | MUX_PB07B_ADC_AIN15)
+#define PORT_PB07B_ADC_AIN15   (_UL_(1) <<  7)
+#define PIN_PA08B_ADC_AIN16             _L_(8) /**< \brief ADC signal: AIN16 on PA08 mux B */
+#define MUX_PA08B_ADC_AIN16             _L_(1)
+#define PINMUX_PA08B_ADC_AIN16     ((PIN_PA08B_ADC_AIN16 << 16) | MUX_PA08B_ADC_AIN16)
+#define PORT_PA08B_ADC_AIN16   (_UL_(1) <<  8)
+#define PIN_PA09B_ADC_AIN17             _L_(9) /**< \brief ADC signal: AIN17 on PA09 mux B */
+#define MUX_PA09B_ADC_AIN17             _L_(1)
+#define PINMUX_PA09B_ADC_AIN17     ((PIN_PA09B_ADC_AIN17 << 16) | MUX_PA09B_ADC_AIN17)
+#define PORT_PA09B_ADC_AIN17   (_UL_(1) <<  9)
+#define PIN_PA10B_ADC_AIN18            _L_(10) /**< \brief ADC signal: AIN18 on PA10 mux B */
+#define MUX_PA10B_ADC_AIN18             _L_(1)
+#define PINMUX_PA10B_ADC_AIN18     ((PIN_PA10B_ADC_AIN18 << 16) | MUX_PA10B_ADC_AIN18)
+#define PORT_PA10B_ADC_AIN18   (_UL_(1) << 10)
+#define PIN_PA11B_ADC_AIN19            _L_(11) /**< \brief ADC signal: AIN19 on PA11 mux B */
+#define MUX_PA11B_ADC_AIN19             _L_(1)
+#define PINMUX_PA11B_ADC_AIN19     ((PIN_PA11B_ADC_AIN19 << 16) | MUX_PA11B_ADC_AIN19)
+#define PORT_PA11B_ADC_AIN19   (_UL_(1) << 11)
+#define PIN_PA04B_ADC_VREFP             _L_(4) /**< \brief ADC signal: VREFP on PA04 mux B */
+#define MUX_PA04B_ADC_VREFP             _L_(1)
+#define PINMUX_PA04B_ADC_VREFP     ((PIN_PA04B_ADC_VREFP << 16) | MUX_PA04B_ADC_VREFP)
+#define PORT_PA04B_ADC_VREFP   (_UL_(1) <<  4)
+/* ========== PORT definition for AC peripheral ========== */
+#define PIN_PA04B_AC_AIN0               _L_(4) /**< \brief AC signal: AIN0 on PA04 mux B */
+#define MUX_PA04B_AC_AIN0               _L_(1)
+#define PINMUX_PA04B_AC_AIN0       ((PIN_PA04B_AC_AIN0 << 16) | MUX_PA04B_AC_AIN0)
+#define PORT_PA04B_AC_AIN0     (_UL_(1) <<  4)
+#define PIN_PA05B_AC_AIN1               _L_(5) /**< \brief AC signal: AIN1 on PA05 mux B */
+#define MUX_PA05B_AC_AIN1               _L_(1)
+#define PINMUX_PA05B_AC_AIN1       ((PIN_PA05B_AC_AIN1 << 16) | MUX_PA05B_AC_AIN1)
+#define PORT_PA05B_AC_AIN1     (_UL_(1) <<  5)
+#define PIN_PA06B_AC_AIN2               _L_(6) /**< \brief AC signal: AIN2 on PA06 mux B */
+#define MUX_PA06B_AC_AIN2               _L_(1)
+#define PINMUX_PA06B_AC_AIN2       ((PIN_PA06B_AC_AIN2 << 16) | MUX_PA06B_AC_AIN2)
+#define PORT_PA06B_AC_AIN2     (_UL_(1) <<  6)
+#define PIN_PA07B_AC_AIN3               _L_(7) /**< \brief AC signal: AIN3 on PA07 mux B */
+#define MUX_PA07B_AC_AIN3               _L_(1)
+#define PINMUX_PA07B_AC_AIN3       ((PIN_PA07B_AC_AIN3 << 16) | MUX_PA07B_AC_AIN3)
+#define PORT_PA07B_AC_AIN3     (_UL_(1) <<  7)
+#define PIN_PA12H_AC_CMP0              _L_(12) /**< \brief AC signal: CMP0 on PA12 mux H */
+#define MUX_PA12H_AC_CMP0               _L_(7)
+#define PINMUX_PA12H_AC_CMP0       ((PIN_PA12H_AC_CMP0 << 16) | MUX_PA12H_AC_CMP0)
+#define PORT_PA12H_AC_CMP0     (_UL_(1) << 12)
+#define PIN_PA18H_AC_CMP0              _L_(18) /**< \brief AC signal: CMP0 on PA18 mux H */
+#define MUX_PA18H_AC_CMP0               _L_(7)
+#define PINMUX_PA18H_AC_CMP0       ((PIN_PA18H_AC_CMP0 << 16) | MUX_PA18H_AC_CMP0)
+#define PORT_PA18H_AC_CMP0     (_UL_(1) << 18)
+#define PIN_PA13H_AC_CMP1              _L_(13) /**< \brief AC signal: CMP1 on PA13 mux H */
+#define MUX_PA13H_AC_CMP1               _L_(7)
+#define PINMUX_PA13H_AC_CMP1       ((PIN_PA13H_AC_CMP1 << 16) | MUX_PA13H_AC_CMP1)
+#define PORT_PA13H_AC_CMP1     (_UL_(1) << 13)
+#define PIN_PA19H_AC_CMP1              _L_(19) /**< \brief AC signal: CMP1 on PA19 mux H */
+#define MUX_PA19H_AC_CMP1               _L_(7)
+#define PINMUX_PA19H_AC_CMP1       ((PIN_PA19H_AC_CMP1 << 16) | MUX_PA19H_AC_CMP1)
+#define PORT_PA19H_AC_CMP1     (_UL_(1) << 19)
+/* ========== PORT definition for DAC peripheral ========== */
+#define PIN_PA02B_DAC_VOUT              _L_(2) /**< \brief DAC signal: VOUT on PA02 mux B */
+#define MUX_PA02B_DAC_VOUT              _L_(1)
+#define PINMUX_PA02B_DAC_VOUT      ((PIN_PA02B_DAC_VOUT << 16) | MUX_PA02B_DAC_VOUT)
+#define PORT_PA02B_DAC_VOUT    (_UL_(1) <<  2)
+#define PIN_PA03B_DAC_VREFP             _L_(3) /**< \brief DAC signal: VREFP on PA03 mux B */
+#define MUX_PA03B_DAC_VREFP             _L_(1)
+#define PINMUX_PA03B_DAC_VREFP     ((PIN_PA03B_DAC_VREFP << 16) | MUX_PA03B_DAC_VREFP)
+#define PORT_PA03B_DAC_VREFP   (_UL_(1) <<  3)
+
+#endif /* _SAMD20J16B_PIO_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/sam.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/sam.h
@@ -1,0 +1,60 @@
+/**
+ * \file
+ *
+ * \brief Top level header file
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \license_stop
+ *
+ */
+
+#ifndef _SAM_
+#define _SAM_
+
+#if   defined(__SAMD20G16B__) || defined(__ATSAMD20G16B__)
+  #include "samd20g16b.h"
+#elif defined(__SAMD20G14B__) || defined(__ATSAMD20G14B__)
+  #include "samd20g14b.h"
+#elif defined(__SAMD20E14B__) || defined(__ATSAMD20E14B__)
+  #include "samd20e14b.h"
+#elif defined(__SAMD20J16B__) || defined(__ATSAMD20J16B__)
+  #include "samd20j16b.h"
+#elif defined(__SAMD20E16B__) || defined(__ATSAMD20E16B__)
+  #include "samd20e16b.h"
+#elif defined(__SAMD20G15B__) || defined(__ATSAMD20G15B__)
+  #include "samd20g15b.h"
+#elif defined(__SAMD20E15B__) || defined(__ATSAMD20E15B__)
+  #include "samd20e15b.h"
+#elif defined(__SAMD20E16BU__) || defined(__ATSAMD20E16BU__)
+  #include "samd20e16bu.h"
+#elif defined(__SAMD20J15B__) || defined(__ATSAMD20J15B__)
+  #include "samd20j15b.h"
+#elif defined(__SAMD20J14B__) || defined(__ATSAMD20J14B__)
+  #include "samd20j14b.h"
+#elif defined(__SAMD20E15BU__) || defined(__ATSAMD20E15BU__)
+  #include "samd20e15bu.h"
+#else
+  #error Library does not support the specified device
+#endif
+
+#endif /* _SAM_ */
+

--- a/cpu/sam0_common/include/vendor/samd20/include_b/samd20.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/samd20.h
@@ -1,0 +1,64 @@
+/**
+ * \file
+ *
+ * \brief Top header file for SAMD20
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20_
+#define _SAMD20_
+
+/**
+ * \defgroup SAMD20_definitions SAMD20 Device Definitions
+ * \brief SAMD20 CMSIS Definitions.
+ */
+
+#if   defined(__SAMD20E14B__) || defined(__ATSAMD20E14B__)
+  #include "samd20e14b.h"
+#elif defined(__SAMD20E15B__) || defined(__ATSAMD20E15B__)
+  #include "samd20e15b.h"
+#elif defined(__SAMD20E15BU__) || defined(__ATSAMD20E15BU__)
+  #include "samd20e15bu.h"
+#elif defined(__SAMD20E16B__) || defined(__ATSAMD20E16B__)
+  #include "samd20e16b.h"
+#elif defined(__SAMD20E16BU__) || defined(__ATSAMD20E16BU__)
+  #include "samd20e16bu.h"
+#elif defined(__SAMD20G14B__) || defined(__ATSAMD20G14B__)
+  #include "samd20g14b.h"
+#elif defined(__SAMD20G15B__) || defined(__ATSAMD20G15B__)
+  #include "samd20g15b.h"
+#elif defined(__SAMD20G16B__) || defined(__ATSAMD20G16B__)
+  #include "samd20g16b.h"
+#elif defined(__SAMD20J14B__) || defined(__ATSAMD20J14B__)
+  #include "samd20j14b.h"
+#elif defined(__SAMD20J15B__) || defined(__ATSAMD20J15B__)
+  #include "samd20j15b.h"
+#elif defined(__SAMD20J16B__) || defined(__ATSAMD20J16B__)
+  #include "samd20j16b.h"
+#else
+  #error Library does not support the specified device.
+#endif
+
+#endif /* _SAMD20_ */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/samd20e14b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/samd20e14b.h
@@ -1,0 +1,504 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20E14B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E14B_
+#define _SAMD20E14B_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20E14B_definitions SAMD20E14B definitions
+ * This file defines all structures and symbols for SAMD20E14B:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20E14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E14B_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20E14B-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20E14B Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20E14B System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20E14B Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20E14B Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20E14B External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20E14B Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20E14B Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20E14B Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20E14B Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20E14B Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20E14B Serial Communication Interface 3 (SERCOM3) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20E14B Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20E14B Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20E14B Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20E14B Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20E14B Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20E14B Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20E14B Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20E14B Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20E14B Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20E14B Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pvReserved11;
+  void* pvReserved12;
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20E14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E14B_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20E14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E14B_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20E14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E14B_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20E14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E14B_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM_INST_NUM   4                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20E14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E14B_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20e14b.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20E14B */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00004000) /* 16 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     256
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x1000160E)
+#define PORT_GROUPS           1
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20E14B */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20E14B_H */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/samd20e15b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/samd20e15b.h
@@ -1,0 +1,504 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20E15B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E15B_
+#define _SAMD20E15B_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20E15B_definitions SAMD20E15B definitions
+ * This file defines all structures and symbols for SAMD20E15B:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20E15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15B_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20E15B-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20E15B Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20E15B System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20E15B Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20E15B Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20E15B External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20E15B Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20E15B Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20E15B Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20E15B Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20E15B Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20E15B Serial Communication Interface 3 (SERCOM3) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20E15B Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20E15B Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20E15B Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20E15B Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20E15B Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20E15B Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20E15B Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20E15B Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20E15B Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20E15B Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pvReserved11;
+  void* pvReserved12;
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20E15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15B_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20E15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15B_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20E15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15B_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20E15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15B_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM_INST_NUM   4                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20E15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15B_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20e15b.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20E15B */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00008000) /* 32 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     512
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00001000) /* 4 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x1000160D)
+#define PORT_GROUPS           1
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20E15B */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20E15B_H */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/samd20e15bu.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/samd20e15bu.h
@@ -1,0 +1,504 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20E15BU
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E15BU_
+#define _SAMD20E15BU_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20E15BU_definitions SAMD20E15BU definitions
+ * This file defines all structures and symbols for SAMD20E15BU:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20E15BU */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15BU_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20E15BU-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20E15BU Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20E15BU System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20E15BU Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20E15BU Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20E15BU External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20E15BU Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20E15BU Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20E15BU Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20E15BU Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20E15BU Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20E15BU Serial Communication Interface 3 (SERCOM3) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20E15BU Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20E15BU Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20E15BU Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20E15BU Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20E15BU Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20E15BU Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20E15BU Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20E15BU Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20E15BU Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20E15BU Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pvReserved11;
+  void* pvReserved12;
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20E15BU */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15BU_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20E15BU */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15BU_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20E15BU */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15BU_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20E15BU */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15BU_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM_INST_NUM   4                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20E15BU */
+/* ************************************************************************** */
+/** \defgroup SAMD20E15BU_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20e15bu.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20E15BU */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00008000) /* 32 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     512
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00001000) /* 4 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001610)
+#define PORT_GROUPS           1
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20E15BU */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20E15BU_H */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/samd20e16b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/samd20e16b.h
@@ -1,0 +1,504 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20E16B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E16B_
+#define _SAMD20E16B_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20E16B_definitions SAMD20E16B definitions
+ * This file defines all structures and symbols for SAMD20E16B:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20E16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16B_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20E16B-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20E16B Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20E16B System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20E16B Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20E16B Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20E16B External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20E16B Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20E16B Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20E16B Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20E16B Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20E16B Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20E16B Serial Communication Interface 3 (SERCOM3) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20E16B Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20E16B Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20E16B Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20E16B Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20E16B Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20E16B Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20E16B Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20E16B Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20E16B Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20E16B Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pvReserved11;
+  void* pvReserved12;
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20E16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16B_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20E16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16B_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20E16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16B_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20E16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16B_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM_INST_NUM   4                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20E16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16B_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20e16b.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20E16B */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00010000) /* 64 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     1024
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00002000) /* 8 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x1000160C)
+#define PORT_GROUPS           1
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20E16B */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20E16B_H */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/samd20e16bu.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/samd20e16bu.h
@@ -1,0 +1,504 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20E16BU
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20E16BU_
+#define _SAMD20E16BU_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20E16BU_definitions SAMD20E16BU definitions
+ * This file defines all structures and symbols for SAMD20E16BU:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20E16BU */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16BU_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20E16BU-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20E16BU Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20E16BU System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20E16BU Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20E16BU Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20E16BU External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20E16BU Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20E16BU Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20E16BU Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20E16BU Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20E16BU Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20E16BU Serial Communication Interface 3 (SERCOM3) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20E16BU Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20E16BU Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20E16BU Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20E16BU Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20E16BU Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20E16BU Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20E16BU Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20E16BU Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20E16BU Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20E16BU Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pvReserved11;
+  void* pvReserved12;
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20E16BU */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16BU_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20E16BU */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16BU_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20E16BU */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16BU_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20E16BU */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16BU_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM_INST_NUM   4                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20E16BU */
+/* ************************************************************************** */
+/** \defgroup SAMD20E16BU_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20e16bu.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20E16BU */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00010000) /* 64 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     1024
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00002000) /* 8 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x1000160F)
+#define PORT_GROUPS           1
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20E16BU */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20E16BU_H */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/samd20g14b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/samd20g14b.h
@@ -1,0 +1,516 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20G14B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G14B_
+#define _SAMD20G14B_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20G14B_definitions SAMD20G14B definitions
+ * This file defines all structures and symbols for SAMD20G14B:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20G14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G14B_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20G14B-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20G14B Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20G14B System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20G14B Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20G14B Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20G14B External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20G14B Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20G14B Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20G14B Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20G14B Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20G14B Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20G14B Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20G14B Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20G14B Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20G14B Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20G14B Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20G14B Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20G14B Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20G14B Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20G14B Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20G14B Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20G14B Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20G14B Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20G14B Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20G14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G14B_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20G14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G14B_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20G14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G14B_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20G14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G14B_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20G14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G14B_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20g14b.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20G14B */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00004000) /* 16 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     256
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001609)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20G14B */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20G14B_H */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/samd20g15b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/samd20g15b.h
@@ -1,0 +1,516 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20G15B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G15B_
+#define _SAMD20G15B_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20G15B_definitions SAMD20G15B definitions
+ * This file defines all structures and symbols for SAMD20G15B:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20G15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G15B_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20G15B-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20G15B Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20G15B System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20G15B Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20G15B Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20G15B External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20G15B Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20G15B Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20G15B Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20G15B Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20G15B Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20G15B Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20G15B Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20G15B Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20G15B Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20G15B Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20G15B Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20G15B Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20G15B Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20G15B Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20G15B Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20G15B Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20G15B Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20G15B Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20G15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G15B_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20G15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G15B_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20G15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G15B_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20G15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G15B_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20G15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G15B_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20g15b.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20G15B */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00008000) /* 32 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     512
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00001000) /* 4 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001608)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20G15B */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20G15B_H */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/samd20g16b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/samd20g16b.h
@@ -1,0 +1,516 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20G16B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20G16B_
+#define _SAMD20G16B_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20G16B_definitions SAMD20G16B definitions
+ * This file defines all structures and symbols for SAMD20G16B:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20G16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G16B_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20G16B-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20G16B Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20G16B System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20G16B Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20G16B Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20G16B External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20G16B Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20G16B Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20G16B Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20G16B Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20G16B Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20G16B Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20G16B Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20G16B Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20G16B Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20G16B Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20G16B Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20G16B Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20G16B Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20G16B Basic Timer Counter 5 (TC5) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20G16B Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20G16B Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20G16B Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20G16B Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pvReserved19;
+  void* pvReserved20;
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20G16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G16B_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20G16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G16B_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20G16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G16B_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20G16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G16B_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC_INST_NUM       6                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20G16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20G16B_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20g16b.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20G16B */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00010000) /* 64 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     1024
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00002000) /* 8 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001607)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20G16B */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20G16B_H */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/samd20j14b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/samd20j14b.h
@@ -1,0 +1,528 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20J14B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J14B_
+#define _SAMD20J14B_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20J14B_definitions SAMD20J14B definitions
+ * This file defines all structures and symbols for SAMD20J14B:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20J14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J14B_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20J14B-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20J14B Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20J14B System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20J14B Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20J14B Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20J14B External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20J14B Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20J14B Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20J14B Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20J14B Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20J14B Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20J14B Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20J14B Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20J14B Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20J14B Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20J14B Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20J14B Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20J14B Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20J14B Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20J14B Basic Timer Counter 5 (TC5) */
+  TC6_IRQn                 = 19, /**< 19 SAMD20J14B Basic Timer Counter 6 (TC6) */
+  TC7_IRQn                 = 20, /**< 20 SAMD20J14B Basic Timer Counter 7 (TC7) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20J14B Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20J14B Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20J14B Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20J14B Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pfnTC6_Handler;                   /* 19 Basic Timer Counter 6 */
+  void* pfnTC7_Handler;                   /* 20 Basic Timer Counter 7 */
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void TC6_Handler                 ( void );
+void TC7_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20J14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J14B_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20J14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J14B_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/tc6.h"
+#include "instance/tc7.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20J14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J14B_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_TC6           78 /**< \brief Basic Timer Counter 6 (TC6) */
+#define ID_TC7           79 /**< \brief Basic Timer Counter 7 (TC7) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20J14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J14B_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define TC6                           (0x42003800) /**< \brief (TC6) APB Base Address */
+#define TC7                           (0x42003C00) /**< \brief (TC7) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC6               ((Tc       *)0x42003800UL) /**< \brief (TC6) APB Base Address */
+#define TC7               ((Tc       *)0x42003C00UL) /**< \brief (TC7) APB Base Address */
+#define TC_INST_NUM       8                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5, TC6, TC7 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20J14B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J14B_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20j14b.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20J14B */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00004000) /* 16 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     256
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00000800) /* 2 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001604)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20J14B */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20J14B_H */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/samd20j15b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/samd20j15b.h
@@ -1,0 +1,528 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20J15B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J15B_
+#define _SAMD20J15B_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20J15B_definitions SAMD20J15B definitions
+ * This file defines all structures and symbols for SAMD20J15B:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20J15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J15B_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20J15B-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20J15B Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20J15B System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20J15B Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20J15B Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20J15B External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20J15B Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20J15B Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20J15B Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20J15B Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20J15B Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20J15B Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20J15B Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20J15B Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20J15B Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20J15B Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20J15B Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20J15B Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20J15B Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20J15B Basic Timer Counter 5 (TC5) */
+  TC6_IRQn                 = 19, /**< 19 SAMD20J15B Basic Timer Counter 6 (TC6) */
+  TC7_IRQn                 = 20, /**< 20 SAMD20J15B Basic Timer Counter 7 (TC7) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20J15B Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20J15B Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20J15B Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20J15B Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pfnTC6_Handler;                   /* 19 Basic Timer Counter 6 */
+  void* pfnTC7_Handler;                   /* 20 Basic Timer Counter 7 */
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void TC6_Handler                 ( void );
+void TC7_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20J15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J15B_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20J15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J15B_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/tc6.h"
+#include "instance/tc7.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20J15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J15B_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_TC6           78 /**< \brief Basic Timer Counter 6 (TC6) */
+#define ID_TC7           79 /**< \brief Basic Timer Counter 7 (TC7) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20J15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J15B_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define TC6                           (0x42003800) /**< \brief (TC6) APB Base Address */
+#define TC7                           (0x42003C00) /**< \brief (TC7) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC6               ((Tc       *)0x42003800UL) /**< \brief (TC6) APB Base Address */
+#define TC7               ((Tc       *)0x42003C00UL) /**< \brief (TC7) APB Base Address */
+#define TC_INST_NUM       8                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5, TC6, TC7 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20J15B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J15B_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20j15b.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20J15B */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00008000) /* 32 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     512
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00001000) /* 4 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001603)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20J15B */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20J15B_H */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/samd20j16b.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/samd20j16b.h
@@ -1,0 +1,528 @@
+/**
+ * \file
+ *
+ * \brief Header file for SAMD20J16B
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SAMD20J16B_
+#define _SAMD20J16B_
+
+/**
+ * \ingroup SAMD20_definitions
+ * \addtogroup SAMD20J16B_definitions SAMD20J16B definitions
+ * This file defines all structures and symbols for SAMD20J16B:
+ *   - registers and bitfields
+ *   - peripheral base address
+ *   - peripheral ID
+ *   - PIO definitions
+*/
+/*@{*/
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+#include <stdint.h>
+#ifndef __cplusplus
+typedef volatile const uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile const uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile const uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#else
+typedef volatile       uint32_t RoReg;   /**< Read only 32-bit register (volatile const unsigned int) */
+typedef volatile       uint16_t RoReg16; /**< Read only 16-bit register (volatile const unsigned int) */
+typedef volatile       uint8_t  RoReg8;  /**< Read only  8-bit register (volatile const unsigned int) */
+#endif
+typedef volatile       uint32_t WoReg;   /**< Write only 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t WoReg16; /**< Write only 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  WoReg8;  /**< Write only  8-bit register (volatile unsigned int) */
+typedef volatile       uint32_t RwReg;   /**< Read-Write 32-bit register (volatile unsigned int) */
+typedef volatile       uint16_t RwReg16; /**< Read-Write 16-bit register (volatile unsigned int) */
+typedef volatile       uint8_t  RwReg8;  /**< Read-Write  8-bit register (volatile unsigned int) */
+#endif
+
+#if !defined(SKIP_INTEGER_LITERALS)
+#if defined(_U_) || defined(_L_) || defined(_UL_)
+  #error "Integer Literals macros already defined elsewhere"
+#endif
+
+#if !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__))
+/* Macros that deal with adding suffixes to integer literal constants for C/C++ */
+#define _U_(x)         x ## U            /**< C code: Unsigned integer literal constant value */
+#define _L_(x)         x ## L            /**< C code: Long integer literal constant value */
+#define _UL_(x)        x ## UL           /**< C code: Unsigned Long integer literal constant value */
+#else /* Assembler */
+#define _U_(x)         x                 /**< Assembler: Unsigned integer literal constant value */
+#define _L_(x)         x                 /**< Assembler: Long integer literal constant value */
+#define _UL_(x)        x                 /**< Assembler: Unsigned Long integer literal constant value */
+#endif /* !(defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+#endif /* SKIP_INTEGER_LITERALS */
+
+/* ************************************************************************** */
+/**  CMSIS DEFINITIONS FOR SAMD20J16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J16B_cmsis CMSIS Definitions */
+/*@{*/
+
+/** Interrupt Number Definition */
+typedef enum IRQn
+{
+  /******  Cortex-M0+ Processor Exceptions Numbers *******************/
+  NonMaskableInt_IRQn      = -14,/**<  2 Non Maskable Interrupt      */
+  HardFault_IRQn           = -13,/**<  3 Hard Fault Interrupt        */
+  SVCall_IRQn              = -5, /**< 11 SV Call Interrupt           */
+  PendSV_IRQn              = -2, /**< 14 Pend SV Interrupt           */
+  SysTick_IRQn             = -1, /**< 15 System Tick Interrupt       */
+  /******  SAMD20J16B-specific Interrupt Numbers *********************/
+  PM_IRQn                  =  0, /**<  0 SAMD20J16B Power Manager (PM) */
+  SYSCTRL_IRQn             =  1, /**<  1 SAMD20J16B System Control (SYSCTRL) */
+  WDT_IRQn                 =  2, /**<  2 SAMD20J16B Watchdog Timer (WDT) */
+  RTC_IRQn                 =  3, /**<  3 SAMD20J16B Real-Time Counter (RTC) */
+  EIC_IRQn                 =  4, /**<  4 SAMD20J16B External Interrupt Controller (EIC) */
+  NVMCTRL_IRQn             =  5, /**<  5 SAMD20J16B Non-Volatile Memory Controller (NVMCTRL) */
+  EVSYS_IRQn               =  6, /**<  6 SAMD20J16B Event System Interface (EVSYS) */
+  SERCOM0_IRQn             =  7, /**<  7 SAMD20J16B Serial Communication Interface 0 (SERCOM0) */
+  SERCOM1_IRQn             =  8, /**<  8 SAMD20J16B Serial Communication Interface 1 (SERCOM1) */
+  SERCOM2_IRQn             =  9, /**<  9 SAMD20J16B Serial Communication Interface 2 (SERCOM2) */
+  SERCOM3_IRQn             = 10, /**< 10 SAMD20J16B Serial Communication Interface 3 (SERCOM3) */
+  SERCOM4_IRQn             = 11, /**< 11 SAMD20J16B Serial Communication Interface 4 (SERCOM4) */
+  SERCOM5_IRQn             = 12, /**< 12 SAMD20J16B Serial Communication Interface 5 (SERCOM5) */
+  TC0_IRQn                 = 13, /**< 13 SAMD20J16B Basic Timer Counter 0 (TC0) */
+  TC1_IRQn                 = 14, /**< 14 SAMD20J16B Basic Timer Counter 1 (TC1) */
+  TC2_IRQn                 = 15, /**< 15 SAMD20J16B Basic Timer Counter 2 (TC2) */
+  TC3_IRQn                 = 16, /**< 16 SAMD20J16B Basic Timer Counter 3 (TC3) */
+  TC4_IRQn                 = 17, /**< 17 SAMD20J16B Basic Timer Counter 4 (TC4) */
+  TC5_IRQn                 = 18, /**< 18 SAMD20J16B Basic Timer Counter 5 (TC5) */
+  TC6_IRQn                 = 19, /**< 19 SAMD20J16B Basic Timer Counter 6 (TC6) */
+  TC7_IRQn                 = 20, /**< 20 SAMD20J16B Basic Timer Counter 7 (TC7) */
+  ADC_IRQn                 = 21, /**< 21 SAMD20J16B Analog Digital Converter (ADC) */
+  AC_IRQn                  = 22, /**< 22 SAMD20J16B Analog Comparators (AC) */
+  DAC_IRQn                 = 23, /**< 23 SAMD20J16B Digital Analog Converter (DAC) */
+  PTC_IRQn                 = 24, /**< 24 SAMD20J16B Peripheral Touch Controller (PTC) */
+
+  PERIPH_COUNT_IRQn        = 25  /**< Number of peripheral IDs */
+} IRQn_Type;
+
+typedef struct _DeviceVectors
+{
+  /* Stack pointer */
+  void* pvStack;
+
+  /* Cortex-M handlers */
+  void* pfnReset_Handler;
+  void* pfnNonMaskableInt_Handler;
+  void* pfnHardFault_Handler;
+  void* pvReservedM12;
+  void* pvReservedM11;
+  void* pvReservedM10;
+  void* pvReservedM9;
+  void* pvReservedM8;
+  void* pvReservedM7;
+  void* pvReservedM6;
+  void* pfnSVCall_Handler;
+  void* pvReservedM4;
+  void* pvReservedM3;
+  void* pfnPendSV_Handler;
+  void* pfnSysTick_Handler;
+
+  /* Peripheral handlers */
+  void* pfnPM_Handler;                    /*  0 Power Manager */
+  void* pfnSYSCTRL_Handler;               /*  1 System Control */
+  void* pfnWDT_Handler;                   /*  2 Watchdog Timer */
+  void* pfnRTC_Handler;                   /*  3 Real-Time Counter */
+  void* pfnEIC_Handler;                   /*  4 External Interrupt Controller */
+  void* pfnNVMCTRL_Handler;               /*  5 Non-Volatile Memory Controller */
+  void* pfnEVSYS_Handler;                 /*  6 Event System Interface */
+  void* pfnSERCOM0_Handler;               /*  7 Serial Communication Interface 0 */
+  void* pfnSERCOM1_Handler;               /*  8 Serial Communication Interface 1 */
+  void* pfnSERCOM2_Handler;               /*  9 Serial Communication Interface 2 */
+  void* pfnSERCOM3_Handler;               /* 10 Serial Communication Interface 3 */
+  void* pfnSERCOM4_Handler;               /* 11 Serial Communication Interface 4 */
+  void* pfnSERCOM5_Handler;               /* 12 Serial Communication Interface 5 */
+  void* pfnTC0_Handler;                   /* 13 Basic Timer Counter 0 */
+  void* pfnTC1_Handler;                   /* 14 Basic Timer Counter 1 */
+  void* pfnTC2_Handler;                   /* 15 Basic Timer Counter 2 */
+  void* pfnTC3_Handler;                   /* 16 Basic Timer Counter 3 */
+  void* pfnTC4_Handler;                   /* 17 Basic Timer Counter 4 */
+  void* pfnTC5_Handler;                   /* 18 Basic Timer Counter 5 */
+  void* pfnTC6_Handler;                   /* 19 Basic Timer Counter 6 */
+  void* pfnTC7_Handler;                   /* 20 Basic Timer Counter 7 */
+  void* pfnADC_Handler;                   /* 21 Analog Digital Converter */
+  void* pfnAC_Handler;                    /* 22 Analog Comparators */
+  void* pfnDAC_Handler;                   /* 23 Digital Analog Converter */
+  void* pfnPTC_Handler;                   /* 24 Peripheral Touch Controller */
+} DeviceVectors;
+
+/* Cortex-M0+ processor handlers */
+void Reset_Handler               ( void );
+void NonMaskableInt_Handler      ( void );
+void HardFault_Handler           ( void );
+void SVCall_Handler              ( void );
+void PendSV_Handler              ( void );
+void SysTick_Handler             ( void );
+
+/* Peripherals handlers */
+void PM_Handler                  ( void );
+void SYSCTRL_Handler             ( void );
+void WDT_Handler                 ( void );
+void RTC_Handler                 ( void );
+void EIC_Handler                 ( void );
+void NVMCTRL_Handler             ( void );
+void EVSYS_Handler               ( void );
+void SERCOM0_Handler             ( void );
+void SERCOM1_Handler             ( void );
+void SERCOM2_Handler             ( void );
+void SERCOM3_Handler             ( void );
+void SERCOM4_Handler             ( void );
+void SERCOM5_Handler             ( void );
+void TC0_Handler                 ( void );
+void TC1_Handler                 ( void );
+void TC2_Handler                 ( void );
+void TC3_Handler                 ( void );
+void TC4_Handler                 ( void );
+void TC5_Handler                 ( void );
+void TC6_Handler                 ( void );
+void TC7_Handler                 ( void );
+void ADC_Handler                 ( void );
+void AC_Handler                  ( void );
+void DAC_Handler                 ( void );
+void PTC_Handler                 ( void );
+
+/*
+ * \brief Configuration of the Cortex-M0+ Processor and Core Peripherals
+ */
+
+#define __CM0PLUS_REV          1         /*!< Core revision r0p1 */
+#define __MPU_PRESENT          0         /*!< MPU present or not */
+#define __NVIC_PRIO_BITS       2         /*!< Number of bits used for Priority Levels */
+#define __VTOR_PRESENT         1         /*!< VTOR present or not */
+#define __Vendor_SysTickConfig 0         /*!< Set to 1 if different SysTick Config is used */
+
+/**
+ * \brief CMSIS includes
+ */
+
+#include <core_cm0plus.h>
+#if !defined DONT_USE_CMSIS_INIT
+#include "system_samd20.h"
+#endif /* DONT_USE_CMSIS_INIT */
+
+/*@}*/
+
+/* ************************************************************************** */
+/**  SOFTWARE PERIPHERAL API DEFINITION FOR SAMD20J16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J16B_api Peripheral Software API */
+/*@{*/
+
+#include "component/ac.h"
+#include "component/adc.h"
+#include "component/dac.h"
+#include "component/dsu.h"
+#include "component/eic.h"
+#include "component/evsys.h"
+#include "component/gclk.h"
+#include "component/nvmctrl.h"
+#include "component/pac.h"
+#include "component/pm.h"
+#include "component/port.h"
+#include "component/rtc.h"
+#include "component/sercom.h"
+#include "component/sysctrl.h"
+#include "component/tc.h"
+#include "component/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  REGISTERS ACCESS DEFINITIONS FOR SAMD20J16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J16B_reg Registers Access Definitions */
+/*@{*/
+
+#include "instance/ac.h"
+#include "instance/adc.h"
+#include "instance/dac.h"
+#include "instance/dsu.h"
+#include "instance/eic.h"
+#include "instance/evsys.h"
+#include "instance/gclk.h"
+#include "instance/nvmctrl.h"
+#include "instance/pac0.h"
+#include "instance/pac1.h"
+#include "instance/pac2.h"
+#include "instance/pm.h"
+#include "instance/port.h"
+#include "instance/ptc.h"
+#include "instance/rtc.h"
+#include "instance/sercom0.h"
+#include "instance/sercom1.h"
+#include "instance/sercom2.h"
+#include "instance/sercom3.h"
+#include "instance/sercom4.h"
+#include "instance/sercom5.h"
+#include "instance/sysctrl.h"
+#include "instance/tc0.h"
+#include "instance/tc1.h"
+#include "instance/tc2.h"
+#include "instance/tc3.h"
+#include "instance/tc4.h"
+#include "instance/tc5.h"
+#include "instance/tc6.h"
+#include "instance/tc7.h"
+#include "instance/wdt.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  PERIPHERAL ID DEFINITIONS FOR SAMD20J16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J16B_id Peripheral Ids Definitions */
+/*@{*/
+
+// Peripheral instances on HPB0 bridge
+#define ID_PAC0           0 /**< \brief Peripheral Access Controller 0 (PAC0) */
+#define ID_PM             1 /**< \brief Power Manager (PM) */
+#define ID_SYSCTRL        2 /**< \brief System Control (SYSCTRL) */
+#define ID_GCLK           3 /**< \brief Generic Clock Generator (GCLK) */
+#define ID_WDT            4 /**< \brief Watchdog Timer (WDT) */
+#define ID_RTC            5 /**< \brief Real-Time Counter (RTC) */
+#define ID_EIC            6 /**< \brief External Interrupt Controller (EIC) */
+
+// Peripheral instances on HPB1 bridge
+#define ID_PAC1          32 /**< \brief Peripheral Access Controller 1 (PAC1) */
+#define ID_DSU           33 /**< \brief Device Service Unit (DSU) */
+#define ID_NVMCTRL       34 /**< \brief Non-Volatile Memory Controller (NVMCTRL) */
+#define ID_PORT          35 /**< \brief Port Module (PORT) */
+
+// Peripheral instances on HPB2 bridge
+#define ID_PAC2          64 /**< \brief Peripheral Access Controller 2 (PAC2) */
+#define ID_EVSYS         65 /**< \brief Event System Interface (EVSYS) */
+#define ID_SERCOM0       66 /**< \brief Serial Communication Interface 0 (SERCOM0) */
+#define ID_SERCOM1       67 /**< \brief Serial Communication Interface 1 (SERCOM1) */
+#define ID_SERCOM2       68 /**< \brief Serial Communication Interface 2 (SERCOM2) */
+#define ID_SERCOM3       69 /**< \brief Serial Communication Interface 3 (SERCOM3) */
+#define ID_SERCOM4       70 /**< \brief Serial Communication Interface 4 (SERCOM4) */
+#define ID_SERCOM5       71 /**< \brief Serial Communication Interface 5 (SERCOM5) */
+#define ID_TC0           72 /**< \brief Basic Timer Counter 0 (TC0) */
+#define ID_TC1           73 /**< \brief Basic Timer Counter 1 (TC1) */
+#define ID_TC2           74 /**< \brief Basic Timer Counter 2 (TC2) */
+#define ID_TC3           75 /**< \brief Basic Timer Counter 3 (TC3) */
+#define ID_TC4           76 /**< \brief Basic Timer Counter 4 (TC4) */
+#define ID_TC5           77 /**< \brief Basic Timer Counter 5 (TC5) */
+#define ID_TC6           78 /**< \brief Basic Timer Counter 6 (TC6) */
+#define ID_TC7           79 /**< \brief Basic Timer Counter 7 (TC7) */
+#define ID_ADC           80 /**< \brief Analog Digital Converter (ADC) */
+#define ID_AC            81 /**< \brief Analog Comparators (AC) */
+#define ID_DAC           82 /**< \brief Digital Analog Converter (DAC) */
+#define ID_PTC           83 /**< \brief Peripheral Touch Controller (PTC) */
+
+#define ID_PERIPH_COUNT  84 /**< \brief Max number of peripheral IDs */
+/*@}*/
+
+/* ************************************************************************** */
+/**  BASE ADDRESS DEFINITIONS FOR SAMD20J16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J16B_base Peripheral Base Address Definitions */
+/*@{*/
+
+#if defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)
+#define AC                            (0x42004400) /**< \brief (AC) APB Base Address */
+#define ADC                           (0x42004000) /**< \brief (ADC) APB Base Address */
+#define DAC                           (0x42004800) /**< \brief (DAC) APB Base Address */
+#define DSU                           (0x41002000) /**< \brief (DSU) APB Base Address */
+#define EIC                           (0x40001800) /**< \brief (EIC) APB Base Address */
+#define EVSYS                         (0x42000400) /**< \brief (EVSYS) APB Base Address */
+#define GCLK                          (0x40000C00) /**< \brief (GCLK) APB Base Address */
+#define NVMCTRL                       (0x41004000) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000) /**< \brief (NVMCTRL) USER Base Address */
+#define PAC0                          (0x40000000) /**< \brief (PAC0) APB Base Address */
+#define PAC1                          (0x41000000) /**< \brief (PAC1) APB Base Address */
+#define PAC2                          (0x42000000) /**< \brief (PAC2) APB Base Address */
+#define PM                            (0x40000400) /**< \brief (PM) APB Base Address */
+#define PORT                          (0x41004400) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS                    (0x60000000) /**< \brief (PORT) IOBUS Base Address */
+#define PTC                           (0x42004C00) /**< \brief (PTC) APB Base Address */
+#define RTC                           (0x40001400) /**< \brief (RTC) APB Base Address */
+#define SERCOM0                       (0x42000800) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1                       (0x42000C00) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2                       (0x42001000) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3                       (0x42001400) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4                       (0x42001800) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5                       (0x42001C00) /**< \brief (SERCOM5) APB Base Address */
+#define SYSCTRL                       (0x40000800) /**< \brief (SYSCTRL) APB Base Address */
+#define TC0                           (0x42002000) /**< \brief (TC0) APB Base Address */
+#define TC1                           (0x42002400) /**< \brief (TC1) APB Base Address */
+#define TC2                           (0x42002800) /**< \brief (TC2) APB Base Address */
+#define TC3                           (0x42002C00) /**< \brief (TC3) APB Base Address */
+#define TC4                           (0x42003000) /**< \brief (TC4) APB Base Address */
+#define TC5                           (0x42003400) /**< \brief (TC5) APB Base Address */
+#define TC6                           (0x42003800) /**< \brief (TC6) APB Base Address */
+#define TC7                           (0x42003C00) /**< \brief (TC7) APB Base Address */
+#define WDT                           (0x40001000) /**< \brief (WDT) APB Base Address */
+#else
+#define AC                ((Ac       *)0x42004400UL) /**< \brief (AC) APB Base Address */
+#define AC_INST_NUM       1                          /**< \brief (AC) Number of instances */
+#define AC_INSTS          { AC }                     /**< \brief (AC) Instances List */
+
+#define ADC               ((Adc      *)0x42004000UL) /**< \brief (ADC) APB Base Address */
+#define ADC_INST_NUM      1                          /**< \brief (ADC) Number of instances */
+#define ADC_INSTS         { ADC }                    /**< \brief (ADC) Instances List */
+
+#define DAC               ((Dac      *)0x42004800UL) /**< \brief (DAC) APB Base Address */
+#define DAC_INST_NUM      1                          /**< \brief (DAC) Number of instances */
+#define DAC_INSTS         { DAC }                    /**< \brief (DAC) Instances List */
+
+#define DSU               ((Dsu      *)0x41002000UL) /**< \brief (DSU) APB Base Address */
+#define DSU_INST_NUM      1                          /**< \brief (DSU) Number of instances */
+#define DSU_INSTS         { DSU }                    /**< \brief (DSU) Instances List */
+
+#define EIC               ((Eic      *)0x40001800UL) /**< \brief (EIC) APB Base Address */
+#define EIC_INST_NUM      1                          /**< \brief (EIC) Number of instances */
+#define EIC_INSTS         { EIC }                    /**< \brief (EIC) Instances List */
+
+#define EVSYS             ((Evsys    *)0x42000400UL) /**< \brief (EVSYS) APB Base Address */
+#define EVSYS_INST_NUM    1                          /**< \brief (EVSYS) Number of instances */
+#define EVSYS_INSTS       { EVSYS }                  /**< \brief (EVSYS) Instances List */
+
+#define GCLK              ((Gclk     *)0x40000C00UL) /**< \brief (GCLK) APB Base Address */
+#define GCLK_INST_NUM     1                          /**< \brief (GCLK) Number of instances */
+#define GCLK_INSTS        { GCLK }                   /**< \brief (GCLK) Instances List */
+
+#define NVMCTRL           ((Nvmctrl  *)0x41004000UL) /**< \brief (NVMCTRL) APB Base Address */
+#define NVMCTRL_CAL                   (0x00800000UL) /**< \brief (NVMCTRL) CAL Base Address */
+#define NVMCTRL_LOCKBIT               (0x00802000UL) /**< \brief (NVMCTRL) LOCKBIT Base Address */
+#define NVMCTRL_OTP1                  (0x00806000UL) /**< \brief (NVMCTRL) OTP1 Base Address */
+#define NVMCTRL_OTP2                  (0x00806008UL) /**< \brief (NVMCTRL) OTP2 Base Address */
+#define NVMCTRL_OTP4                  (0x00806020UL) /**< \brief (NVMCTRL) OTP4 Base Address */
+#define NVMCTRL_TEMP_LOG              (0x00806030UL) /**< \brief (NVMCTRL) TEMP_LOG Base Address */
+#define NVMCTRL_USER                  (0x00804000UL) /**< \brief (NVMCTRL) USER Base Address */
+#define NVMCTRL_INST_NUM  1                          /**< \brief (NVMCTRL) Number of instances */
+#define NVMCTRL_INSTS     { NVMCTRL }                /**< \brief (NVMCTRL) Instances List */
+
+#define PAC0              ((Pac      *)0x40000000UL) /**< \brief (PAC0) APB Base Address */
+#define PAC1              ((Pac      *)0x41000000UL) /**< \brief (PAC1) APB Base Address */
+#define PAC2              ((Pac      *)0x42000000UL) /**< \brief (PAC2) APB Base Address */
+#define PAC_INST_NUM      3                          /**< \brief (PAC) Number of instances */
+#define PAC_INSTS         { PAC0, PAC1, PAC2 }       /**< \brief (PAC) Instances List */
+
+#define PM                ((Pm       *)0x40000400UL) /**< \brief (PM) APB Base Address */
+#define PM_INST_NUM       1                          /**< \brief (PM) Number of instances */
+#define PM_INSTS          { PM }                     /**< \brief (PM) Instances List */
+
+#define PORT              ((Port     *)0x41004400UL) /**< \brief (PORT) APB Base Address */
+#define PORT_IOBUS        ((Port     *)0x60000000UL) /**< \brief (PORT) IOBUS Base Address */
+#define PORT_INST_NUM     1                          /**< \brief (PORT) Number of instances */
+#define PORT_INSTS        { PORT }                   /**< \brief (PORT) Instances List */
+#define PORT_IOBUS_INST_NUM 1                          /**< \brief (PORT) Number of instances */
+#define PORT_IOBUS_INSTS  { PORT_IOBUS }             /**< \brief (PORT) Instances List */
+
+#define PTC               ((void     *)0x42004C00UL) /**< \brief (PTC) APB Base Address */
+#define PTC_GCLK_ID       27
+#define PTC_INST_NUM      1                          /**< \brief (PTC) Number of instances */
+#define PTC_INSTS         { PTC }                    /**< \brief (PTC) Instances List */
+
+#define RTC               ((Rtc      *)0x40001400UL) /**< \brief (RTC) APB Base Address */
+#define RTC_INST_NUM      1                          /**< \brief (RTC) Number of instances */
+#define RTC_INSTS         { RTC }                    /**< \brief (RTC) Instances List */
+
+#define SERCOM0           ((Sercom   *)0x42000800UL) /**< \brief (SERCOM0) APB Base Address */
+#define SERCOM1           ((Sercom   *)0x42000C00UL) /**< \brief (SERCOM1) APB Base Address */
+#define SERCOM2           ((Sercom   *)0x42001000UL) /**< \brief (SERCOM2) APB Base Address */
+#define SERCOM3           ((Sercom   *)0x42001400UL) /**< \brief (SERCOM3) APB Base Address */
+#define SERCOM4           ((Sercom   *)0x42001800UL) /**< \brief (SERCOM4) APB Base Address */
+#define SERCOM5           ((Sercom   *)0x42001C00UL) /**< \brief (SERCOM5) APB Base Address */
+#define SERCOM_INST_NUM   6                          /**< \brief (SERCOM) Number of instances */
+#define SERCOM_INSTS      { SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5 } /**< \brief (SERCOM) Instances List */
+
+#define SYSCTRL           ((Sysctrl  *)0x40000800UL) /**< \brief (SYSCTRL) APB Base Address */
+#define SYSCTRL_INST_NUM  1                          /**< \brief (SYSCTRL) Number of instances */
+#define SYSCTRL_INSTS     { SYSCTRL }                /**< \brief (SYSCTRL) Instances List */
+
+#define TC0               ((Tc       *)0x42002000UL) /**< \brief (TC0) APB Base Address */
+#define TC1               ((Tc       *)0x42002400UL) /**< \brief (TC1) APB Base Address */
+#define TC2               ((Tc       *)0x42002800UL) /**< \brief (TC2) APB Base Address */
+#define TC3               ((Tc       *)0x42002C00UL) /**< \brief (TC3) APB Base Address */
+#define TC4               ((Tc       *)0x42003000UL) /**< \brief (TC4) APB Base Address */
+#define TC5               ((Tc       *)0x42003400UL) /**< \brief (TC5) APB Base Address */
+#define TC6               ((Tc       *)0x42003800UL) /**< \brief (TC6) APB Base Address */
+#define TC7               ((Tc       *)0x42003C00UL) /**< \brief (TC7) APB Base Address */
+#define TC_INST_NUM       8                          /**< \brief (TC) Number of instances */
+#define TC_INSTS          { TC0, TC1, TC2, TC3, TC4, TC5, TC6, TC7 } /**< \brief (TC) Instances List */
+
+#define WDT               ((Wdt      *)0x40001000UL) /**< \brief (WDT) APB Base Address */
+#define WDT_INST_NUM      1                          /**< \brief (WDT) Number of instances */
+#define WDT_INSTS         { WDT }                    /**< \brief (WDT) Instances List */
+
+#endif /* (defined(__ASSEMBLY__) || defined(__IAR_SYSTEMS_ASM__)) */
+/*@}*/
+
+/* ************************************************************************** */
+/**  PORT DEFINITIONS FOR SAMD20J16B */
+/* ************************************************************************** */
+/** \defgroup SAMD20J16B_port PORT Definitions */
+/*@{*/
+
+#include "pio/samd20j16b.h"
+/*@}*/
+
+/* ************************************************************************** */
+/**  MEMORY MAPPING DEFINITIONS FOR SAMD20J16B */
+/* ************************************************************************** */
+
+#define FLASH_SIZE            _UL_(0x00010000) /* 64 kB */
+#define FLASH_PAGE_SIZE       64
+#define FLASH_NB_OF_PAGES     1024
+#define FLASH_USER_PAGE_SIZE  64
+#define HRAMC0_SIZE           _UL_(0x00002000) /* 8 kB */
+
+#define FLASH_ADDR            _UL_(0x00000000) /**< FLASH base address */
+#define FLASH_USER_PAGE_ADDR  _UL_(0x00800000) /**< FLASH_USER_PAGE base address */
+#define HRAMC0_ADDR           _UL_(0x20000000) /**< HRAMC0 base address */
+#define HPB0_ADDR             _UL_(0x40000000) /**< HPB0 base address */
+#define HPB1_ADDR             _UL_(0x41000000) /**< HPB1 base address */
+#define HPB2_ADDR             _UL_(0x42000000) /**< HPB2 base address */
+#define PPB_ADDR              _UL_(0xE0000000) /**< PPB base address */
+
+#define DSU_DID_RESETVALUE    _UL_(0x10001602)
+#define PORT_GROUPS           2
+
+/* ************************************************************************** */
+/**  ELECTRICAL DEFINITIONS FOR SAMD20J16B */
+/* ************************************************************************** */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+/*@}*/
+
+#endif /* SAMD20J16B_H */

--- a/cpu/sam0_common/include/vendor/samd20/include_b/system_samd20.h
+++ b/cpu/sam0_common/include/vendor/samd20/include_b/system_samd20.h
@@ -1,0 +1,48 @@
+/**
+ * \file
+ *
+ * \brief Low-level initialization functions called upon chip startup
+ *
+ * Copyright (c) 2020 Microchip Technology Inc.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the Licence at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * \asf_license_stop
+ *
+ */
+
+#ifndef _SYSTEM_SAMD20_H_INCLUDED_
+#define _SYSTEM_SAMD20_H_INCLUDED_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+extern uint32_t SystemCoreClock;   /*!< System Clock Frequency (Core Clock)  */
+
+void SystemInit(void);
+void SystemCoreClockUpdate(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSTEM_SAMD20_H_INCLUDED */

--- a/cpu/sam0_common/periph/pwm.c
+++ b/cpu/sam0_common/periph/pwm.c
@@ -40,9 +40,12 @@
 /* dummy defines to not litter the code with ifdefs if no TCC is available */
 #ifndef REV_TCC
 typedef TcCount8 Tcc;
-#define TCC_SYNCBUSY_CC0 TC_SYNCBUSY_CC0
 #define TCC_CTRLA_ENABLE TC_CTRLA_ENABLE
+#define TCC_SYNCBUSY_CC0 TC_SYNCBUSY_CC0
+#ifdef TC_SYNCBUSY_MASK
+#define TCC_SYNCBUSY_MASK TC_SYNCBUSY_MASK
 #endif
+#endif /* !REV_TCC */
 
 static inline Tc *_tc(pwm_t dev)
 {
@@ -369,7 +372,11 @@ static void _tcc_set(Tcc *tcc, uint8_t chan, uint16_t value)
     /* TODO: use OTMX for pin remapping */
     chan %= _tcc_get_cc_numof(tcc);
     tcc->CC[chan].reg = value;
+#ifdef TCC_SYNCBUSY_MASK
     while (tcc->SYNCBUSY.reg & (TCC_SYNCBUSY_CC0 << chan)) {}
+#else
+    while (tcc->STATUS.bit.SYNCBUSY) {}
+#endif
 }
 
 void pwm_set(pwm_t dev, uint8_t channel, uint16_t value)

--- a/cpu/samd21/Kconfig
+++ b/cpu/samd21/Kconfig
@@ -19,10 +19,12 @@ config CPU_FAM_SAMD10
 config CPU_FAM_SAMD21
     bool
     select CPU_COMMON_SAMD21
+    select HAS_PERIPH_DMA
 
 config CPU_FAM_SAMR21
     bool
     select CPU_COMMON_SAMD21
+    select HAS_PERIPH_DMA
 
 ## Definition of specific features
 config HAS_CPU_SAMD21

--- a/cpu/samd21/Kconfig
+++ b/cpu/samd21/Kconfig
@@ -15,6 +15,11 @@ config CPU_COMMON_SAMD21
 config CPU_FAM_SAMD10
     bool
     select CPU_COMMON_SAMD21
+    select HAS_PERIPH_DMA
+
+config CPU_FAM_SAMD20
+    bool
+    select CPU_COMMON_SAMD21
 
 config CPU_FAM_SAMD21
     bool
@@ -35,6 +40,7 @@ config HAS_CPU_SAMD21
 ## Common CPU symbols
 config CPU_FAM
     default "samd10" if CPU_FAM_SAMD10
+    default "samd20" if CPU_FAM_SAMD20
     default "samd21" if CPU_FAM_SAMD21
     default "samr21" if CPU_FAM_SAMR21
 
@@ -42,6 +48,7 @@ config CPU
     default "samd21" if CPU_COMMON_SAMD21
 
 source "$(RIOTCPU)/samd21/Kconfig.samd10"
+source "$(RIOTCPU)/samd21/Kconfig.samd20"
 source "$(RIOTCPU)/samd21/Kconfig.samd21"
 source "$(RIOTCPU)/samd21/Kconfig.samr21"
 

--- a/cpu/samd21/Kconfig.samd20
+++ b/cpu/samd21/Kconfig.samd20
@@ -1,0 +1,142 @@
+## CPU Models
+config CPU_MODEL_SAMD20E14B
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20E15B
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20E15BU
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20E16B
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20E16BU
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20G14B
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20G15B
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20G16B
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20J14B
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20J15B
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20J16B
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20E14
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20E15
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20E16
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20E17
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20E18
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20G14
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20G15
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20G16
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20G17
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20G17U
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20G18
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20G18U
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20J14
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20J15
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20J16
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20J17
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL_SAMD20J18
+    bool
+    select CPU_FAM_SAMD20
+
+config CPU_MODEL
+    default "samd20e14b" if CPU_MODEL_SAMD20E14B
+    default "samd20e15b" if CPU_MODEL_SAMD20E15B
+    default "samd20e15bu" if CPU_MODEL_SAMD20E15BU
+    default "samd20e16b" if CPU_MODEL_SAMD20E16B
+    default "samd20e16bu" if CPU_MODEL_SAMD20E16BU
+    default "samd20g14b" if CPU_MODEL_SAMD20G14B
+    default "samd20g15b" if CPU_MODEL_SAMD20G15B
+    default "samd20g16b" if CPU_MODEL_SAMD20G16B
+    default "samd20j14b" if CPU_MODEL_SAMD20J14B
+    default "samd20j15b" if CPU_MODEL_SAMD20J15B
+    default "samd20j16b" if CPU_MODEL_SAMD20J16B
+    default "samd20e14" if CPU_MODEL_SAMD20E14
+    default "samd20e15" if CPU_MODEL_SAMD20E15
+    default "samd20e16" if CPU_MODEL_SAMD20E16
+    default "samd20e17" if CPU_MODEL_SAMD20E17
+    default "samd20e18" if CPU_MODEL_SAMD20E18
+    default "samd20g14" if CPU_MODEL_SAMD20G14
+    default "samd20g15" if CPU_MODEL_SAMD20G15
+    default "samd20g16" if CPU_MODEL_SAMD20G16
+    default "samd20g17" if CPU_MODEL_SAMD20G17
+    default "samd20g17u" if CPU_MODEL_SAMD20G17U
+    default "samd20g18" if CPU_MODEL_SAMD20G18
+    default "samd20g18u" if CPU_MODEL_SAMD20G18U
+    default "samd20j14" if CPU_MODEL_SAMD20J14
+    default "samd20j15" if CPU_MODEL_SAMD20J15
+    default "samd20j16" if CPU_MODEL_SAMD20J16
+    default "samd20j17" if CPU_MODEL_SAMD20J17
+    default "samd20j18" if CPU_MODEL_SAMD20J18

--- a/cpu/samd21/Makefile.include
+++ b/cpu/samd21/Makefile.include
@@ -1,6 +1,11 @@
 ifneq (,$(filter samd10%,$(CPU_MODEL)))
   CFLAGS += -DCPU_SAMD10
 endif
+ifneq (,$(filter samd20%b,$(CPU_MODEL)))
+  CFLAGS += -DCPU_SAMD20B
+else ifneq (,$(filter samd20%,$(CPU_MODEL)))
+  CFLAGS += -DCPU_SAMD20
+endif
 ifneq (,$(filter samd21%a,$(CPU_MODEL)))
   CFLAGS += -DCPU_SAMD21A
 endif

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -68,6 +68,10 @@
 #define GCLK_GENCTRL_SRC_FDPLL      (GCLK_GENCTRL_SRC_FDPLL_Val    << GCLK_GENCTRL_SRC_Pos)
 #endif
 
+#ifndef GCLK_CLKCTRL_ID_DFLL48
+#define GCLK_CLKCTRL_ID_DFLL48 GCLK_CLKCTRL_ID_DFLL48M
+#endif
+
 void sam0_gclk_enable(uint8_t id)
 {
     (void) id;

--- a/cpu/samd21/vectors/vectors_samd2x.c
+++ b/cpu/samd21/vectors/vectors_samd2x.c
@@ -49,6 +49,9 @@ WEAK_DEFAULT void isr_tcc0(void);
 WEAK_DEFAULT void isr_tcc1(void);
 WEAK_DEFAULT void isr_tcc2(void);
 WEAK_DEFAULT void isr_tcc3(void);
+WEAK_DEFAULT void isr_tc0(void);
+WEAK_DEFAULT void isr_tc1(void);
+WEAK_DEFAULT void isr_tc2(void);
 WEAK_DEFAULT void isr_tc3(void);
 WEAK_DEFAULT void isr_tc4(void);
 WEAK_DEFAULT void isr_tc5(void);
@@ -82,14 +85,26 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_sercom3,            /* 12 Serial Communication Interface 3 */
     isr_sercom4,            /* 13 Serial Communication Interface 4 */
     isr_sercom5,            /* 14 Serial Communication Interface 5 */
+#ifdef TCC0
     isr_tcc0,               /* 15 Timer Counter Control 0 */
+#else
+    isr_tc0,                /* 15 Basic Timer Counter 0 */
+#endif
+#ifdef TCC1
     isr_tcc1,               /* 16 Timer Counter Control 1 */
+#else
+    isr_tc1,                /* 16 Basic Timer Counter 1 */
+#endif
+#ifdef TCC2
     isr_tcc2,               /* 17 Timer Counter Control 2 */
-    isr_tc3,                /* 18 Basic Timer Counter 0 */
-    isr_tc4,                /* 19 Basic Timer Counter 1 */
-    isr_tc5,                /* 20 Basic Timer Counter 2 */
-    isr_tc6,                /* 21 Basic Timer Counter 3 */
-    isr_tc7,                /* 22 Basic Timer Counter 4 */
+#else
+    isr_tc2,                /* 17 Basic Timer Counter 2 */
+#endif
+    isr_tc3,                /* 18 Basic Timer Counter 3 */
+    isr_tc4,                /* 19 Basic Timer Counter 4 */
+    isr_tc5,                /* 20 Basic Timer Counter 5 */
+    isr_tc6,                /* 21 Basic Timer Counter 6 */
+    isr_tc7,                /* 22 Basic Timer Counter 7 */
     isr_adc,                /* 23 Analog Digital Converter */
     isr_ac,                 /* 24 Analog Comparators */
     isr_dac,                /* 25 Digital Analog Converter */

--- a/cpu/samd5x/Kconfig
+++ b/cpu/samd5x/Kconfig
@@ -12,6 +12,7 @@ config CPU_COMMON_SAMD5X
     select HAS_BACKUP_RAM
     select HAS_CORTEXM_MPU
     select HAS_CPU_SAMD5X
+    select HAS_PERIPH_DMA
     select HAS_PERIPH_ETH
     select HAS_PERIPH_GPIO_TAMPER_WAKE
     select HAS_PERIPH_HWRNG

--- a/cpu/saml1x/Kconfig
+++ b/cpu/saml1x/Kconfig
@@ -10,6 +10,7 @@ config CPU_COMMON_SAML1X
     select CPU_COMMON_SAM0
     select CPU_CORE_CORTEX_M23
     select HAS_CPU_SAML1X
+    select HAS_PERIPH_DMA
     select HAS_PERIPH_GPIO_FAST_READ
     select HAS_PERIPH_HWRNG
 

--- a/cpu/saml21/Kconfig
+++ b/cpu/saml21/Kconfig
@@ -11,6 +11,7 @@ config CPU_COMMON_SAML21
     select CPU_CORE_CORTEX_M0PLUS
     select HAS_BACKUP_RAM
     select HAS_CPU_SAML21
+    select HAS_PERIPH_DMA
     select HAS_PERIPH_GPIO_FAST_READ
 
 config CPU_FAM_SAML21

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -68,6 +68,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     remote-pa \
     remote-reva \
     remote-revb \
+    samd20-xpro \
     samd21-xpro \
     saml10-xpro \
     saml11-xpro \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -82,6 +82,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     openlabs-kw41z-mini-256kib \
     pba-d-01-kw2x \
     samd10-xmini \
+    samd20-xpro \
     samd21-xpro \
     saml10-xpro \
     saml11-xpro \


### PR DESCRIPTION
### Contribution description

SAM D20 is a cut-down version of the SAM D21 MCU.
The reduced set of peripherals means

 - no DMA
 - no TCC timers
 - no fractional Baud for SERCOM
 - no I2C > 400 kHz
 - no USB

### Testing procedure

I verified that the configured peripherals are working.

I ran `./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . samd20-xpro --jobs=4 --with-test-only`:

```
Failures during test:
- [tests/driver_at86rf2xx_aes](tests/driver_at86rf2xx_aes/test.failed)
- [tests/emcute](tests/emcute/test.failed)
- [tests/gnrc_dhcpv6_client](tests/gnrc_dhcpv6_client/test.failed)
- [tests/gnrc_dhcpv6_client_6lbr](tests/gnrc_dhcpv6_client_6lbr/test.failed)
- [tests/gnrc_ipv6_ext](tests/gnrc_ipv6_ext/test.failed)
- [tests/gnrc_ipv6_ext_frag](tests/gnrc_ipv6_ext_frag/test.failed)
- [tests/gnrc_ipv6_ext_opt](tests/gnrc_ipv6_ext_opt/test.failed)
- [tests/gnrc_ipv6_nib_dns](tests/gnrc_ipv6_nib_dns/test.failed)
- [tests/gnrc_rpl_srh](tests/gnrc_rpl_srh/test.failed)
- [tests/gnrc_sock_dns](tests/gnrc_sock_dns/test.failed)
- [tests/gnrc_tcp](tests/gnrc_tcp/test.failed)
- [tests/periph_timer_short_relative_set](tests/periph_timer_short_relative_set/test.failed)
- [tests/pkg_libfixmath_unittests](tests/pkg_libfixmath_unittests/test.failed)
- [tests/shell](tests/shell/test.failed)
```

No surprises except for `tests/shell` which prints

```
socat - open:/dev/ttyACM0,b115200,echo=0,raw 

> bufsize

> bufsize
128
________________________________________________________________________________________________________________________________verylong
> ________________________________________________________________�	�.�)t��/�rCkk�
> ��+�zٗ�H�>�0a&7�'�9"_g�g,6�Ž�Timeout in expect script at "child.expect('shell: maximum line length exceeded')" (tests/shell/tests/01-run.py:163)

make: *** [/home/benpicco/dev/RIOT/tests/shell/../../Makefile.include:761: test] Error 1
``` 

But the shell is working correctly, so I think this is a fluke.

### Issues/PRs references

- PWM support requires #14478
