### PR TITLE
treewide: compile fixes for native

### DIFF
--- a/drivers/atwinc15x0/atwinc15x0_bsp.c
+++ b/drivers/atwinc15x0/atwinc15x0_bsp.c
@@ -83,7 +83,7 @@ void nm_bsp_register_isr(tpfNmBspIsr pfIsr)
 {
     assert(atwinc15x0);
 
-    DEBUG("%s %p\n", __func__, pfIsr);
+    DEBUG("%s %p\n", __func__, (void *)(uintptr_t)pfIsr);
 
     atwinc15x0->bsp_isr = pfIsr;
 }

--- a/drivers/atwinc15x0/atwinc15x0_netdev.c
+++ b/drivers/atwinc15x0/atwinc15x0_netdev.c
@@ -345,7 +345,7 @@ static int _atwinc15x0_get(netdev_t *netdev, netopt_t opt, void *val,
     assert(dev == atwinc15x0);
 
     DEBUG("%s dev=%p opt=%u val=%p max_len=%u\n", __func__,
-          netdev, opt, val, max_len);
+          (void *)netdev, opt, val, max_len);
 
     switch (opt) {
         case NETOPT_IS_WIRED:
@@ -395,7 +395,7 @@ static int _atwinc15x0_set(netdev_t *netdev, netopt_t opt, const void *val,
     assert(val);
 
     DEBUG("%s dev=%p opt=%u val=%p max_len=%u\n", __func__,
-          netdev, opt, val, max_len);
+          (void *)netdev, opt, val, max_len);
 
     switch (opt) {
         case NETOPT_ADDRESS:
@@ -415,7 +415,7 @@ static int _atwinc15x0_init(netdev_t *netdev)
     assert(dev);
     assert(dev == atwinc15x0);
 
-    DEBUG("%s dev=%p\n", __func__, dev);
+    DEBUG("%s dev=%p\n", __func__, (void *)dev);
 
     atwinc15x0->bsp_isr = NULL;
     atwinc15x0->bsp_irq_enabled = true;
@@ -492,7 +492,7 @@ static void _atwinc15x0_isr(netdev_t *netdev)
     assert(dev);
     assert(dev == atwinc15x0);
 
-    DEBUG("%s dev=%p\n", __func__, dev);
+    DEBUG("%s dev=%p\n", __func__, (void *)dev);
 
     /* handle pending ATWINC15x0 module events */
     while (m2m_wifi_handle_events(NULL) != M2M_SUCCESS) { }

--- a/drivers/cc110x/cc110x_settings.c
+++ b/drivers/cc110x/cc110x_settings.c
@@ -20,7 +20,7 @@
 #include "cc110x.h"
 #include "cc110x_internal.h"
 
-const char cc110x_conf[CC110X_CONF_SIZE] = {
+const uint8_t cc110x_conf[CC110X_CONF_SIZE] = {
     /*
      * IOCFG2; default: 0x29 (CHIP_RDYn)
      * Invert GDO2: off,
@@ -327,4 +327,4 @@ const char cc110x_conf[CC110X_CONF_SIZE] = {
     0x00,   /*< RCCTRL0 */
 };
 
-const char cc110x_magic_registers[3] = { 0x88, 0x31, 0x09 };
+const uint8_t cc110x_magic_registers[3] = { 0x88, 0x31, 0x09 };

--- a/drivers/cc110x/include/cc110x_settings.h
+++ b/drivers/cc110x/include/cc110x_settings.h
@@ -38,7 +38,7 @@ extern "C" {
 /**
  * @brief   Configuration register values for CC1100/CC1101 transceivers
  */
-extern const char cc110x_conf[CC110X_CONF_SIZE];
+extern const uint8_t cc110x_conf[CC110X_CONF_SIZE];
 
 /**
  * @brief   Magic numbers to write to the TEST2, TEST1 and TEST0 configuration
@@ -51,7 +51,7 @@ extern const char cc110x_conf[CC110X_CONF_SIZE];
  * transceiver configuration, those numbers should be checked again with the
  * SmartRF Studio
  */
-extern const char cc110x_magic_registers[3];
+extern const uint8_t cc110x_magic_registers[3];
 
 /**
  * @name    Configuration data that specify the 8 available output power levels

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -50,7 +50,7 @@
 #define TX_BUFFER_END           (RX_BUFFER_START)
 #define TX_BUFFER_START         (TX_BUFFER_END - TX_BUFFER_LEN)
 
-static void cmd(encx24j600_t *dev, char cmd);
+static void cmd(encx24j600_t *dev, uint8_t cmd);
 static void reg_set(encx24j600_t *dev, uint8_t reg, uint16_t value);
 static uint16_t reg_get(encx24j600_t *dev, uint8_t reg);
 static void reg_clear_bits(encx24j600_t *dev, uint8_t reg, uint16_t mask);
@@ -163,8 +163,8 @@ static void phy_reg_set(encx24j600_t *dev, uint8_t reg, uint16_t value) {
     reg_set(dev, ENC_MIWR, value);
 }
 
-static void cmd(encx24j600_t *dev, char cmd) {
-    spi_transfer_byte(dev->spi, dev->cs, false, (uint8_t)cmd);
+static void cmd(encx24j600_t *dev, uint8_t cmd) {
+    spi_transfer_byte(dev->spi, dev->cs, false, cmd);
 }
 
 static void cmdn(encx24j600_t *dev, uint8_t cmd, char *out, char *in, int len) {

--- a/drivers/include/cc110x.h
+++ b/drivers/include/cc110x.h
@@ -261,13 +261,13 @@ extern "C" {
  * page 31 in the data sheet for the possible states in the status byte.
  */
 typedef enum {
-    CC110X_STATE_IDLE               = 0b00000000,   /**< IDLE state */
+    CC110X_STATE_IDLE               = 0x00,   /**< IDLE state */
     /**
      * @brief   Frame received, waiting for upper layer to retrieve it
      *
      * Transceiver is in IDLE state.
      */
-    CC110X_STATE_FRAME_READY        = 0b00001000,
+    CC110X_STATE_FRAME_READY        = 0x08,
     /**
      * @brief   Frame received, waiting for upper layer to retrieve it
      *
@@ -276,26 +276,26 @@ typedef enum {
      * bring it in the IDLE state. Thus, we set the three least significant bits
      * to the IDLE state
      */
-    CC110X_STATE_OFF                = 0b00010000,
-    CC110X_STATE_RX_MODE            = 0b00000001,   /**< Listening for frames */
+    CC110X_STATE_OFF                = 0x10,
+    CC110X_STATE_RX_MODE            = 0x01,   /**< Listening for frames */
     /**
      * @brief   Receiving a frame just now
      *
      * Transceiver is in RX state.
      */
-    CC110X_STATE_RECEIVING          = 0b00001001,
-    CC110X_STATE_TX_MODE            = 0b00000010,   /**< Transmit mode */
+    CC110X_STATE_RECEIVING          = 0x09,
+    CC110X_STATE_TX_MODE            = 0x02,   /**< Transmit mode */
     /**
      * @brief   Waiting for transceiver to complete outgoing transmission
      *
      * Transceiver is in TX state
      */
-    CC110X_STATE_TX_COMPLETING      = 0b00001010,
-    CC110X_STATE_FSTXON             = 0b00000011,   /**< Fast TX ready */
-    CC110X_STATE_CALIBRATE          = 0b00000100,   /**< Device is calibrating */
-    CC110X_STATE_SETTLING           = 0b00000101,   /**< PLL is settling */
-    CC110X_STATE_RXFIFO_OVERFLOW    = 0b00000110,   /**< RX FIFO overflown */
-    CC110X_STATE_TXFIFO_UNDERFLOW   = 0b00000111,   /**< TX FIFO underflown */
+    CC110X_STATE_TX_COMPLETING      = 0x0A,
+    CC110X_STATE_FSTXON             = 0x03,   /**< Fast TX ready */
+    CC110X_STATE_CALIBRATE          = 0x04,   /**< Device is calibrating */
+    CC110X_STATE_SETTLING           = 0x05,   /**< PLL is settling */
+    CC110X_STATE_RXFIFO_OVERFLOW    = 0x06,   /**< RX FIFO overflown */
+    CC110X_STATE_TXFIFO_UNDERFLOW   = 0x07,   /**< TX FIFO underflown */
 } cc110x_state_t;
 
 /**

--- a/drivers/include/nrf24l01p.h
+++ b/drivers/include/nrf24l01p.h
@@ -340,7 +340,7 @@ int nrf24l01p_set_payload_width(const nrf24l01p_t *dev,
 * @return           Address length on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_tx_address(const nrf24l01p_t *dev, const char *saddr, unsigned int length);
+int nrf24l01p_set_tx_address(const nrf24l01p_t *dev, const uint8_t *saddr, unsigned int length);
 
 /**
 * @brief   Set the TX address for the nrf24l01+ transceiver (long int).
@@ -370,7 +370,7 @@ int nrf24l01p_set_tx_address_long(const nrf24l01p_t *dev, uint64_t saddr, unsign
 * @return           Address length on success.
 * @return           -1 on error.
 */
-int nrf24l01p_set_rx_address(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, const char *saddr, unsigned int length);
+int nrf24l01p_set_rx_address(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, const uint8_t *saddr, unsigned int length);
 
 /**
 * @brief   Set the RX address for the nrf24l01+ transceiver (long int).

--- a/drivers/kw2xrf/include/overwrites.h
+++ b/drivers/kw2xrf/include/overwrites.h
@@ -39,8 +39,8 @@ extern "C" {
 #endif
 
 typedef struct overwrites_tag {
-    char address;
-    char data;
+    uint8_t address;
+    uint8_t data;
 } overwrites_t;
 
 

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -65,8 +65,8 @@ int nrf24l01p_write_reg(const nrf24l01p_t *dev, char reg, char write)
 int nrf24l01p_init(nrf24l01p_t *dev, spi_t spi, gpio_t ce, gpio_t cs, gpio_t irq)
 {
     int status;
-    static const char INITIAL_TX_ADDRESS[] =  {0xe7, 0xe7, 0xe7, 0xe7, 0xe7,};
-    static const char INITIAL_RX_ADDRESS[] =  {0xe7, 0xe7, 0xe7, 0xe7, 0xe7,};
+    static const uint8_t INITIAL_TX_ADDRESS[] =  {0xe7, 0xe7, 0xe7, 0xe7, 0xe7,};
+    static const uint8_t INITIAL_RX_ADDRESS[] =  {0xe7, 0xe7, 0xe7, 0xe7, 0xe7,};
 
     dev->spi = spi;
     dev->ce = ce;
@@ -363,7 +363,7 @@ int nrf24l01p_set_payload_width(const nrf24l01p_t *dev,
 
 
 
-int nrf24l01p_set_tx_address(const nrf24l01p_t *dev, const char *saddr, unsigned int length)
+int nrf24l01p_set_tx_address(const nrf24l01p_t *dev, const uint8_t *saddr, unsigned int length)
 {
     /* Acquire exclusive access to the bus. */
     spi_acquire(dev->spi, dev->cs, SPI_MODE, SPI_CLK);
@@ -427,7 +427,7 @@ uint64_t nrf24l01p_get_tx_address_long(const nrf24l01p_t *dev)
 }
 
 
-int nrf24l01p_set_rx_address(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, const char *saddr, unsigned int length)
+int nrf24l01p_set_rx_address(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, const uint8_t *saddr, unsigned int length)
 {
     char pipe_addr;
 
@@ -477,7 +477,7 @@ int nrf24l01p_set_rx_address(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, c
 
 int nrf24l01p_set_rx_address_long(const nrf24l01p_t *dev, nrf24l01p_rx_pipe_t pipe, uint64_t saddr, unsigned int length)
 {
-    char buf[length];
+    uint8_t buf[length];
 
     if (length <= INITIAL_ADDRESS_WIDTH) {
         for (unsigned int i = 0; i < length; i++) {

--- a/pkg/driver_atwinc15x0/Makefile
+++ b/pkg/driver_atwinc15x0/Makefile
@@ -14,6 +14,8 @@ CFLAGS += -Wno-incompatible-pointer-types-discards-qualifiers
 CFLAGS += -DETH_MODE
 CFLAGS += -I$(PKG_SOURCE_DIR)/src
 
+CFLAGS += -Wno-pedantic
+
 all:
 	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/driver/source -f $(RIOTBASE)/Makefile.base MODULE=driver_atwinc15x0
 	"$(MAKE)" -C $(PKG_SOURCE_DIR)/src/common/source -f $(RIOTBASE)/Makefile.base MODULE=driver_atwinc15x0_common

--- a/pkg/semtech-loramac/contrib/semtech_loramac.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac.c
@@ -609,7 +609,7 @@ void *_semtech_loramac_event_loop(void *arg)
                 case MSG_TYPE_MAC_TIMEOUT:
                 {
                     DEBUG("[semtech-loramac] MAC timer timeout\n");
-                    void (*callback)(void) = msg.content.ptr;
+                    void (*callback)(void) = (void (*)(void))(uintptr_t)msg.content.value;
                     callback();
                     break;
                 }

--- a/pkg/semtech-loramac/contrib/semtech_loramac_timer.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_timer.c
@@ -44,7 +44,7 @@ void TimerStart(TimerEvent_t *obj)
     xtimer_t *timer = &(obj->dev);
     msg_t *msg = &(obj->msg);
     msg->type = MSG_TYPE_MAC_TIMEOUT;
-    msg->content.ptr = obj->cb;
+    msg->content.value = (uintptr_t)obj->cb;
     xtimer_set_msg(timer, obj->timeout, msg, semtech_loramac_pid);
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`char` is unsigned on ARM but signed on x86.
This lead to a few compile errors when adding the `periph_gpio` feature to `native`, because now code that was previously never build for x86 got hit by this difference.
The host compiler is also usually newer than the embedded one, which usually means it is stricter.

This makes offending `chars` explicitly `unsigned` and works around some pedantry.

### Testing procedure

No logic changes. In fact, the binaries should stay the same.


### Issues/PRs references

split off & needed for  #12451
fixes #14667
