### PR TITLE
Makefile.include: add capability to log `make term` to file

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -713,6 +713,9 @@ flash-only: $(FLASHDEPS)
 preflash: $(BUILD_BEFORE_FLASH)
 	$(PREFLASHER_PREFIX)$(PREFLASHER) $(PREFFLAGS)
 
+ifneq (,$(TERMLOG)$(TERMTEE))
+  TERMTEE ?= | tee -a $(TERMLOG)
+endif
 TERMFLASHDEPS ?= $(filter flash flash-only,$(MAKECMDGOALS))
 # Add TERMFLASHDEPS to TERMDEPS so it also applies to `test`
 TERMDEPS += $(TERMFLASHDEPS)
@@ -720,14 +723,14 @@ termdeps: $(TERMDEPS)
 
 term: $(TERMDEPS)
 	$(call check_cmd,$(TERMPROG),Terminal program)
-	$(TERMPROG) $(TERMFLAGS)
+	$(TERMPROG) $(TERMFLAGS) $(TERMTEE)
 
 # Term without the pyterm added logging
 # PYTERMFLAGS must be exported for `jlink.sh term-rtt`.
 cleanterm: export PYTERMFLAGS += --no-reconnect --noprefix --no-repeat-command-on-empty-line
 cleanterm: $(TERMDEPS)
 	$(call check_cmd,$(TERMPROG),Terminal program)
-	$(TERMPROG) $(TERMFLAGS)
+	$(TERMPROG) $(TERMFLAGS) $(TERMTEE)
 
 list-ttys:
 	$(Q)$(RIOTTOOLS)/usb-serial/list-ttys.sh

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -92,6 +92,8 @@ export WPEDANTIC             # Issue all (extensive) compiler warnings demanded 
 export FLASH_ADDR            # Define an offset to flash code into ROM memory.
 # TERMPROG                   # The command to call on "make term".
 # TERMFLAGS                  # Additional parameters to supply to TERMPROG.
+# TERMLOG                    # Optional file to log "make term" output to.
+# TERMTEE                    # Optional pipe to redirect "make term" output. Default: '| tee -a ${TERMLOG}' when TERMLOG is defined else undefined.
 # PORT                       # The port to connect the TERMPROG to.
 export ELFFILE               # The unstripped result of the compilation.
 export HEXFILE               # The 'intel hex' stripped result of the compilation.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Originally, I used this to debug some problems in the automated [release tests](https://github.com/RIOT-OS/RIOT/pull/14646), but I think there is some value in providing this upstream.

This is helpful, when one can't just `make term | tee <logfile>` externally e.g. in `pexpect` tests. Though `pexpect` tests and `riotctrl` as well provide the ability to log to `stdout`, this log is only printed, when the expected line is hit, so we can have some loss on timeout.

With the help of this tooling, one can provide a filename to log the output of `make term` to that file.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```sh
make term
```

works normally for any arbitrary application

```sh
TERMLOG=${PWD}/logfile.log make term
```

also works normally, but additionally creates a file `${PWD}/logfile.log` that contains the output of `make term`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
