### PR TITLE
tests/lwip_sock_tcp: fix -EADDRINUSE test [backport 2020.07]

### DIFF
--- a/tests/lwip_sock_tcp/main.c
+++ b/tests/lwip_sock_tcp/main.c
@@ -629,19 +629,14 @@ static void test_tcp_connect6__success_local_port(void)
 #ifdef SO_REUSE
 static void test_tcp_listen6__EADDRINUSE(void)
 {
+    static sock_tcp_t queue_array2[_QUEUE_SIZE];
+    static sock_tcp_queue_t queue2;
     static const sock_tcp_ep_t local = { .addr = { .ipv6 = _TEST_ADDR6_LOCAL },
                                          .family = AF_INET6,
                                          .port = _TEST_PORT_LOCAL,
                                          .netif = SOCK_ADDR_ANY_NETIF };
-    msg_t msg = { .type = _SERVER_MSG_START };
-
-    _server_addr.family = AF_INET6;
-    _server_addr.port = _TEST_PORT_LOCAL;
-    _server_addr.netif = SOCK_ADDR_ANY_NETIF;
-
-    msg_send(&msg, _server);    /* start server on _TEST_PORT_LOCAL */
-
-    expect(-EADDRINUSE == sock_tcp_listen(&_queue, &local, _queue_array,
+    expect(0 == sock_tcp_listen(&_queue, &local, _queue_array, _QUEUE_SIZE, 0));
+    expect(-EADDRINUSE == sock_tcp_listen(&queue2, &local, queue_array2,
                                           _QUEUE_SIZE, 0));
 }
 #endif


### PR DESCRIPTION
# Backport of #14668



<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When compiled with `LWIP_IPV4=1 LWIP_IPV6=1` this test currently fails in current master. This "regression" was introduced with 035acc2e5388. However, after some debugging I think that commit actually revealed a problem with the test rather than introducing a bug.

The test starts the central server, and then checks if opening a listening socket on the same port causes an `-EADDRINUSE` error. The server, on the other hand, starts with `SOCK_FLAGS_REUSE_EP`, so of course the listening operation may succeed. Instead, let's just call `sock_tcp_listen` twice with two distinct queue objects. Way easier and also more correct.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```sh
LWIP_IPV4=1 LWIP_IPV6=1 make -C tests/lwip_sock_tcp -j16 flash test
```

should succeed (but fails in master)
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See https://github.com/RIOT-OS/RIOT/pull/14665#issuecomment-667055998
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
