### PR TITLE
pkg/lwip: Use IS_ACTIVE() and bugfix [backport 2020.07]

### DIFF
--- a/pkg/lwip/contrib/sock/lwip_sock.c
+++ b/pkg/lwip/contrib/sock/lwip_sock.c
@@ -490,13 +490,15 @@ int lwip_sock_get_addr(struct netconn *conn, struct _sock_tl_ep *ep, u8_t local)
         ) {
         return res;
     }
-#if LWIP_IPV6 && LWIP_IPV4
-    ep->family = (addr.type == IPADDR_TYPE_V6) ? AF_INET6 : AF_INET;
-#elif LWIP_IPV6
-    ep->family = (conn->type & NETCONN_TYPE_IPV6) ? AF_INET6 : AF_INET;
-#elif LWIP_IPV4
-    ep->family = AF_INET;
-#endif
+    if (NETCONNTYPE_ISIPV6(conn->type)) {
+        ep->family = AF_INET6;
+    }
+    else if (IS_ACTIVE(LWIP_IPV4)) {
+        ep->family = AF_INET;
+    }
+    else {
+        ep->family = AF_UNSPEC;
+    }
     if (local) {
         ep->netif = lwip_sock_bind_addr_to_netif(&addr);
     }

--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -120,23 +120,18 @@ ssize_t sock_udp_recv_buf(sock_udp_t *sock, void **data, void **ctx,
     if (remote != NULL) {
         /* convert remote */
         size_t addr_len;
-#if LWIP_IPV6
-        if (sock->base.conn->type & NETCONN_TYPE_IPV6) {
+        if (NETCONNTYPE_ISIPV6(sock->base.conn->type)) {
             addr_len = sizeof(ipv6_addr_t);
             remote->family = AF_INET6;
         }
-        else {
-#endif
-#if LWIP_IPV4
+        else if (IS_ACTIVE(LWIP_IPV4)) {
             addr_len = sizeof(ipv4_addr_t);
             remote->family = AF_INET;
-#else
+        }
+        else {
             netbuf_delete(buf);
             return -EPROTO;
-#endif
-#if LWIP_IPV6
         }
-#endif
 #if LWIP_NETBUF_RECVINFO
         remote->netif = lwip_sock_bind_addr_to_netif(&buf->toaddr);
 #else

--- a/pkg/lwip/include/lwipopts.h
+++ b/pkg/lwip/include/lwipopts.h
@@ -33,126 +33,126 @@ extern "C" {
  * @{
  */
 #ifdef MODULE_LWIP_ARP
-#define LWIP_ARP                (1)
+#define LWIP_ARP                1
 #else  /* MODULE_LWIP_ARP */
-#define LWIP_ARP                (0)
+#define LWIP_ARP                0
 #endif /* MODULE_LWIP_ARP */
 
 #ifdef MODULE_LWIP_AUTOIP
-#define LWIP_AUTOIP             (1)
+#define LWIP_AUTOIP             1
 #else  /* MODULE_LWIP_AUTOIP */
-#define LWIP_AUTOIP             (0)
+#define LWIP_AUTOIP             0
 #endif /* MODULE_LWIP_AUTOIP */
 
 #ifdef MODULE_LWIP_DHCP
-#define LWIP_DHCP               (1)
+#define LWIP_DHCP               1
 #else  /* MODULE_LWIP_DHCP */
-#define LWIP_DHCP               (0)
+#define LWIP_DHCP               0
 #endif /* MODULE_LWIP_DHCP */
 
 #ifdef MODULE_LWIP_ETHERNET
-#define LWIP_ETHERNET           (1)
+#define LWIP_ETHERNET           1
 #else  /* MODULE_LWIP_ETHERNET */
-#define LWIP_ETHERNET           (0)
+#define LWIP_ETHERNET           0
 #endif /* MODULE_LWIP_ETHERNET */
 
 #ifdef MODULE_LWIP_IGMP
-#define LWIP_IGMP               (1)
+#define LWIP_IGMP               1
 #else  /* MODULE_LWIP_IGMP */
-#define LWIP_IGMP               (0)
+#define LWIP_IGMP               0
 #endif /* MODULE_LWIP_IGMP */
 
 #ifdef MODULE_LWIP_IPV4
-#define LWIP_IPV4               (1)
+#define LWIP_IPV4               1
 #else  /* MODULE_LWIP_IPV4 */
-#define LWIP_IPV4               (0)
+#define LWIP_IPV4               0
 #endif /* MODULE_LWIP_IPV4 */
 
 #ifdef MODULE_LWIP_IPV6_AUTOCONFIG
-#define LWIP_IPV6_AUTOCONFIG    (1)
+#define LWIP_IPV6_AUTOCONFIG    1
 #else  /* MODULE_LWIP_IPV6_AUTOCONFIG */
-#define LWIP_IPV6_AUTOCONFIG    (0)
+#define LWIP_IPV6_AUTOCONFIG    0
 #endif /* MODULE_LWIP_IPV6_AUTOCONFIG */
 
 #ifdef MODULE_LWIP_IPV6_MLD
-#define LWIP_IPV6_MLD           (1)
+#define LWIP_IPV6_MLD           1
 #else  /* MODULE_LWIP_IPV6 */
-#define LWIP_IPV6_MLD           (0)
+#define LWIP_IPV6_MLD           0
 #endif /* MODULE_LWIP_IPV6 */
 
 #ifdef MODULE_LWIP_IPV6
-#define LWIP_IPV6               (1)
+#define LWIP_IPV6               1
 #else  /* MODULE_LWIP_IPV6 */
-#define LWIP_IPV6               (0)
+#define LWIP_IPV6               0
 #endif /* MODULE_LWIP_IPV6 */
 
 #ifdef MODULE_LWIP_NETIF_PPP
-#define PPP_SUPPORT             (1)
+#define PPP_SUPPORT             1
 #else  /* MODULE_LWIP_NETIF_PPP */
-#define PPP_SUPPORT             (0)
+#define PPP_SUPPORT             0
 #endif /* MODULE_LWIP_NETIF_PPP */
 
 #ifdef MODULE_LWIP_RAW
-#define LWIP_RAW                (1)
+#define LWIP_RAW                1
 #else  /* MODULE_LWIP_RAW */
-#define LWIP_RAW                (0)
+#define LWIP_RAW                0
 #endif /* MODULE_LWIP_RAW */
 
 #ifdef MODULE_LWIP_SIXLOWPAN
-#define LWIP_6LOWPAN            (1)
+#define LWIP_6LOWPAN            1
 #else  /* MODULE_LWIP_STATS */
-#define LWIP_6LOWPAN            (0)
+#define LWIP_6LOWPAN            0
 #endif /* MODULE_LWIP_STATS */
 
 #ifdef MODULE_LWIP_STATS
-#define LWIP_STATS              (1)
+#define LWIP_STATS              1
 #else  /* MODULE_LWIP_STATS */
-#define LWIP_STATS              (0)
+#define LWIP_STATS              0
 #endif /* MODULE_LWIP_STATS */
 
 #ifdef MODULE_LWIP_TCP
-#define LWIP_TCP                (1)
+#define LWIP_TCP                1
 #else  /* MODULE_LWIP_TCP */
-#define LWIP_TCP                (0)
+#define LWIP_TCP                0
 #endif /* MODULE_LWIP_TCP */
 
 #ifdef MODULE_LWIP_UDP
-#define LWIP_UDP                (1)
+#define LWIP_UDP                1
 #else  /* MODULE_LWIP_UDP */
-#define LWIP_UDP                (0)
+#define LWIP_UDP                0
 #endif /* MODULE_LWIP_UDP */
 
 #ifdef MODULE_LWIP_UDPLITE
-#define LWIP_UDPLITE            (1)
+#define LWIP_UDPLITE            1
 #else  /* MODULE_LWIP_UDPLITE */
-#define LWIP_UDPLITE            (0)
+#define LWIP_UDPLITE            0
 #endif /* MODULE_LWIP_UDPLITE */
 
 #if defined(MODULE_LWIP_SOCK)
-#define LWIP_NETCONN            (1)
+#define LWIP_NETCONN            1
 #else
-#define LWIP_NETCONN            (0)
+#define LWIP_NETCONN            0
 #endif
 
 #ifndef TCP_LISTEN_BACKLOG
 # if defined(MODULE_LWIP_SOCK_TCP)
-# define TCP_LISTEN_BACKLOG     (1)
+# define TCP_LISTEN_BACKLOG     1
 # else
-# define TCP_LISTEN_BACKLOG     (0)
+# define TCP_LISTEN_BACKLOG     0
 # endif
 #endif /* TCP_LISTEN_BACKLOG */
 
-#define LWIP_SOCKET             (0)
+#define LWIP_SOCKET             0
 
 #define LWIP_DONT_PROVIDE_BYTEORDER_FUNCTIONS
-#define MEMP_MEM_MALLOC         (1)
+#define MEMP_MEM_MALLOC         1
 #define NETIF_MAX_HWADDR_LEN    (GNRC_NETIF_HDR_L2ADDR_MAX_LEN)
 
 #ifndef TCPIP_THREAD_STACKSIZE
 #define TCPIP_THREAD_STACKSIZE  (THREAD_STACKSIZE_DEFAULT)
 #endif
 
-#define MEM_ALIGNMENT           (4)
+#define MEM_ALIGNMENT           4
 #ifndef MEM_SIZE
 /* packet buffer size of GNRC + stack for TCP/IP */
 #define MEM_SIZE                (TCPIP_THREAD_STACKSIZE + 6144)


### PR DESCRIPTION
# Backport of #14665

### Contribution description

- Changed some code to use `IS_ACTIVE()` over `#if`/`#ifdef`
- Fixed family in `sock_udp_get_local()`

### Testing procedure

- No regressions in lwip
- `LWIP_IPV4=1 LWIP_IPV6=1 make -C tests/lwip_sock_udp flash test` should no pass

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/14622