### PR TITLE
cc2538: fix RSSI offset

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -350,11 +350,9 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
     if (info != NULL) {
         netdev_ieee802154_rx_info_t *radio_info = info;
 
-        RFCORE_ASSERT(rssi_val > CC2538_RF_SENSITIVITY);
-
         /* The number of dB above maximum sensitivity detected for the
          * received packet */
-        radio_info->rssi = -CC2538_RF_SENSITIVITY + rssi_val;
+        radio_info->rssi = rssi_val;
 
         uint8_t corr_val = crc_corr_val & CC2538_CORR_VAL_MASK;
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the offset for the RSSI calculation of CC2538 radios and removes an RFCORE_ASSERT that checks that the internal RSSI value is greater than the sensitivity. 

The latter produced crashes while testing #14655 when measured values of RSSI were below the RX sensitivity (-97 dBm).

Also according to the [Reference Manual, section 23.10.3](https://www.ti.com/lit/ug/swru319c/swru319c.pdf?ts=1596202513590&ref_url=https%253A%252F%252Fwww.ti.com%252Ftool%252FCC2538EM-RD), the actual power of the reception is calculated with the RSSI register and the RSSI offset (-73).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Check the RSSI values when receiving data.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes the crash in #14655 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
