### PR TITLE
nrf802154: fix set_tx_power function

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -215,7 +215,7 @@ static void _set_txpower(int16_t txpower)
     if (txpower > 8) {
         NRF_RADIO->TXPOWER = RADIO_TXPOWER_TXPOWER_Pos8dBm;
     }
-    if (txpower > 1) {
+    else if (txpower > 1) {
         NRF_RADIO->TXPOWER = (uint32_t)txpower;
     }
     else if (txpower > -1) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes the set_tx_power function of the nrf802154 radio.

There was a missing `else` in the second if. Thus, the second `if` would always execute if the first one did.
Thus, when using high values for tx power it writes garbage data to the register.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Try setting the TX power to high values (above 8 dBm). Increasing the TX power shouldn't degrade the RSSI on a reception node.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Discovered while testing #14655 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
