### PR TITLE
tools/usb-cdc-ecm/start_network.sh: remove parameters to read

### DIFF
--- a/dist/tools/usb-cdc-ecm/start_network.sh
+++ b/dist/tools/usb-cdc-ecm/start_network.sh
@@ -97,8 +97,8 @@ fi
 
 if [ -z "${PORT}" ]; then
     echo "Network enabled over CDC-ECM"
-    read -n 1 -s -p "Press any key to stop"
-    echo
+    echo "Press Return to stop"
+    read dummy
 else
     ${USB_CDC_ECM_DIR}/../pyterm/pyterm -p "${PORT}"
 fi


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The `read` implementation on my system doesn't know a `-n` parameter:

    tools/usb-cdc-ecm/start_network.sh: 100: read: Illegal option -n

As the command is only used to block if no terminal is started, we can as well remove them.

@trickeydan what was the purpose of those parameters?
For me it works well without any.

### Testing procedure

In `examples/gnrc_border_router` only start `uhcp` without attaching a terminal:

```
make BOARD=samr21-xpro UPLINK=cdc-ecm PORT= term
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
