### PR TITLE
tests/periph_rtc: delay RTC init

### DIFF
--- a/tests/periph_rtc/Makefile
+++ b/tests/periph_rtc/Makefile
@@ -2,6 +2,8 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_rtc
 
+DISABLE_MODULE += periph_init_rtc
+
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_rtc/main.c
+++ b/tests/periph_rtc/main.c
@@ -74,6 +74,8 @@ int main(void)
     printf("This test will display 'Alarm!' every %u seconds for %u times\n",
             PERIOD, REPEAT);
 
+    rtc_init();
+
     /* set RTC */
     print_time("  Setting clock to ", &time);
     rtc_set_time(&time);


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Just like `tests/periph_rtt`, delay the RTC init so that if init gets stuck it doesn't get stuck in early boot but inside the test.
This makes debugging easier.


### Testing procedure

Run `tests/periph_rtc`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
