### PR TITLE
core/msg: Add submodule core_msg_prio

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -21,6 +21,10 @@ include $(RIOTBASE)/drivers/Makefile.dep
 # pull dependencies from packages
 -include $(USEPKG:%=$(RIOTPKG)/%/Makefile.dep)
 
+ifneq (,$(filter core_msg_prio,$(USEMODULE)))
+  USEMODULE += core_msg
+endif
+
 ifneq (,$(filter ssp,$(USEMODULE)))
   FEATURES_REQUIRED += ssp
 endif

--- a/core/include/msg.h
+++ b/core/include/msg.h
@@ -191,7 +191,6 @@ typedef struct {
     } content;                  /**< Content of the message. */
 } msg_t;
 
-
 /**
  * @brief Send a message (blocking).
  *
@@ -212,6 +211,22 @@ typedef struct {
  */
 int msg_send(msg_t *m, kernel_pid_t target_pid);
 
+/**
+ * @brief   Send a priority message, bypassing any the message queue
+ *
+ * @warning This might overwrite a pending priority message
+ *
+ * @note    This function is only available, if module `core_msg_prio` is
+ *          used
+ *
+ * @note    It is safe to call this function from IRQ context
+ *
+ * This function sends a priority message to the given thread. Unlike to
+ * @ref msg_send, it never fails nor blocks. This is achieved by statically
+ * allocating one message slot for priority messages. If this slot is already
+ * taken, the older message is lost in favor of the newer message.
+ */
+void msg_send_prio(msg_t *m, kernel_pid_t target_pid);
 
 /**
  * @brief Send a message (non-blocking).
@@ -230,7 +245,6 @@ int msg_send(msg_t *m, kernel_pid_t target_pid);
  * @return -1, on error (invalid PID)
  */
 int msg_try_send(msg_t *m, kernel_pid_t target_pid);
-
 
 /**
  * @brief Send a message to the current thread.
@@ -295,6 +309,19 @@ static inline int msg_sent_by_int(const msg_t *m)
  * @return  1, Function always succeeds or blocks forever.
  */
 int msg_receive(msg_t *m);
+
+/**
+ * @brief   Block until a priority message is received
+ *
+ * @note    This function is only available, if module `core_msg_prio` is
+ *          used
+ *
+ * Regular messages are ignored by this function. Incoming regular message
+ * while this function blocks will either queue up in the message queue, or are
+ * lost if the message queue is full or no message queue is set up for the
+ * calling thread.
+ */
+void msg_receive_prio(msg_t *m);
 
 /**
  * @brief Try to receive a message.

--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -107,6 +107,7 @@ typedef enum {
     STATUS_SLEEPING,                /**< sleeping                                 */
     STATUS_MUTEX_BLOCKED,           /**< waiting for a locked mutex               */
     STATUS_RECEIVE_BLOCKED,         /**< waiting for a message                    */
+    STATUS_RECEIVE_PRIO_BLOCKED,    /**< waiting for a priority message           */
     STATUS_SEND_BLOCKED,            /**< waiting for message to be delivered      */
     STATUS_REPLY_BLOCKED,           /**< waiting for a message response           */
     STATUS_FLAG_BLOCKED_ANY,        /**< waiting for any flag from flag_mask      */

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -167,6 +167,9 @@ struct _thread {
                                          (thread_t::msg_array), if any  */
     msg_t *msg_array;               /**< memory holding messages sent
                                          to this thread's message queue */
+#if defined(MODULE_CORE_MSG_PRIO) || defined(DOXYGEN)
+    msg_t prio_msg;                 /**< Target for @ref msg_send_prio */
+#endif
 #endif
 #if defined(DEVELHELP) || defined(SCHED_TEST_STACK) \
     || defined(MODULE_MPU_STACK_GUARD) || defined(DOXYGEN)

--- a/core/msg.c
+++ b/core/msg.c
@@ -228,6 +228,7 @@ void msg_receive_prio(msg_t *m)
         irq_restore(state);
     }
     else {
+        me->wait_data = m;
         sched_set_status(me, STATUS_RECEIVE_PRIO_BLOCKED);
         irq_restore(state);
         thread_yield_higher();

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -40,6 +40,7 @@ static const char *state_names[] = {
     [STATUS_ZOMBIE] = "zombie",
     [STATUS_MUTEX_BLOCKED] = "bl mutex",
     [STATUS_RECEIVE_BLOCKED] = "bl rx",
+    [STATUS_RECEIVE_PRIO_BLOCKED] = "bl prx",
     [STATUS_SEND_BLOCKED] = "bl send",
     [STATUS_REPLY_BLOCKED] = "bl reply",
     [STATUS_FLAG_BLOCKED_ANY] = "bl anyfl",

--- a/tests/msg_prio/Makefile
+++ b/tests/msg_prio/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEMODULE += core_msg_prio
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/msg_prio/main.c
+++ b/tests/msg_prio/main.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test for module core_msg_prio
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "msg.h"
+#include "mutex.h"
+#include "thread.h"
+
+static char stack[THREAD_STACKSIZE_DEFAULT];
+
+static kernel_pid_t pid;
+static int failed = 0;
+static msg_t msg_queue[4];
+static mutex_t mut = MUTEX_INIT_LOCKED;
+
+static void *t1_func(void *args)
+{
+    (void)args;
+    msg_t m;
+
+    msg_init_queue(msg_queue, ARRAY_SIZE(msg_queue));
+
+    msg_receive_prio(&m);
+    if (m.content.value != 1) {
+        failed |= 1;
+    }
+
+    msg_receive(&m);
+    if (m.content.value != 0) {
+        failed |= 1;
+    }
+
+    return NULL;
+}
+
+static void *t2_func(void *args)
+{
+    (void)args;
+    msg_t m;
+
+    /* t1 exited by now, we can just reuse the message queue */
+    msg_init_queue(msg_queue, ARRAY_SIZE(msg_queue));
+    /* allow main to continue */
+    mutex_unlock(&mut);
+
+    msg_receive(&m);
+    if (m.content.value != 4) {
+        failed |= 1;
+    }
+
+    msg_receive(&m);
+    if (m.content.value != 2) {
+        failed |= 1;
+    }
+
+    msg_receive(&m);
+    if (m.content.value != 5) {
+        failed |= 1;
+    }
+
+    mutex_unlock(&mut);
+
+    return NULL;
+}
+
+int main(void)
+{
+    pid = thread_create(stack, sizeof(stack), THREAD_PRIORITY_MAIN - 1,
+                        THREAD_CREATE_STACKTEST, t1_func, NULL, "t1");
+    msg_t m = { .content.value = 0 };
+
+    msg_send(&m, pid);
+    m.content.value = 1;
+    msg_send_prio(&m, pid);
+
+    /* t1 exited by now, we can reuse the stack */
+    pid = thread_create(stack, sizeof(stack), THREAD_PRIORITY_MAIN + 1,
+                        THREAD_CREATE_STACKTEST, t2_func, NULL, "t2");
+    /* allow t2 to initialize message queue */
+    mutex_lock(&mut);
+
+    m.content.value = 2;
+    msg_send(&m, pid);
+    m.content.value = 3;
+    msg_send_prio(&m, pid);
+    m.content.value = 4;
+    msg_send_prio(&m, pid);
+    m.content.value = 5;
+    msg_send(&m, pid);
+
+    /* allow t2 to execute */
+    mutex_lock(&mut);
+
+    if (failed) {
+        puts("TEST FAILED!");
+    }
+    else {
+        puts("Test succeeded.");
+    }
+    return 0;
+}

--- a/tests/msg_prio/tests/01-run.py
+++ b/tests/msg_prio/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact("Test succeeded.")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

With submodule `core_msg_prio` enabled, priority message can be send that bypass the regular message queue. By having each thread allocate one slot for a priority message and allowing new priority messages to overwrite pending priority messages, `msg_send_prio()` never blocks or fails. A thread calling `msg_receive()` (or friends) will receive a priority message just like a regular message.
    
This new feature allows to provide both a best effort service (regular messages) and low latency service (priority messages) using the same thread. This feature will come in handy for `gnrc_netif`, which currently does not prioritize ISR requests over send requests. With this feature, it becomes trivial to prioritize ISR requests over regular messages.

The `msg_receive_prio()` is intended for implementing waiting on network devices in `gnrc_netif` until a transmission is complete (so ignoring regular messages), but still serving ISR requests (implemented as prio message) until TX is completed (implemented as prio message).

### Testing procedure

- `BOARD=<YOUR_FAVOURITE_BOARD> make -C tests/msg_prio -j flash test`
- With the exception of the additional thread state name in `ps`, no changes in compiled binaries should be present without module `core_msg_prio` being used.

### Issues/PRs references

None