### PR TITLE
gnrc_sixlowpan_frag_vrb: fix cppcheck warning

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/vrb/gnrc_sixlowpan_frag_vrb.c
@@ -96,10 +96,8 @@ gnrc_sixlowpan_frag_vrb_t *gnrc_sixlowpan_frag_vrb_add(
                         while (tmp->next != NULL) {
                             if (tmp == base->ints) {
                                 tmp = NULL;
+                                break;
                             }
-                            /* cppcheck-suppress nullPointer
-                             * (reason: possible bug in cppcheck, tmp can't
-                             * clearly be a NULL pointer here) */
                             tmp = tmp->next;
                         }
                         if (tmp != NULL) {


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
... which wasn't a false positive after all. See also https://github.com/RIOT-OS/RIOT/pull/12848#pullrequestreview-459890873
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```sh
make -C tests/gnrc_sixlowpan_iphc_w_vrb flash test
```

and

```sh
make -C tests/unittests tests-gnrc_sixlowpan_frag_vrb flash-only test
```

should still succeed for any supported board of choice.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See https://github.com/RIOT-OS/RIOT/pull/12848#pullrequestreview-459890873
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
