### PR TITLE
gnrc/nib: fix _idx_dsts() calculation [backport 2020.07]

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -527,7 +527,7 @@ static inline bool _in_dsts(const _nib_offl_entry_t *dst)
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_MULTIHOP_P6C)
 static inline unsigned _idx_dsts(const _nib_offl_entry_t *dst)
 {
-    return (dst - _dsts) / sizeof(*dst);
+    return (dst - _dsts);
 }
 
 static inline bool _in_abrs(const _nib_abr_entry_t *abr)


### PR DESCRIPTION
# Backport of #14680



<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Using pointer difference already gives us the number of elements of size of what the pointer is pointing to.
Dividing by size will lead to the wrong (always 0) result.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/13741#issuecomment-667911895
