### PR TITLE
drivers/stm32_eth: add 'NETDEV_EVENT_LINK_UP' event

### DIFF
--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -21,6 +21,7 @@ ifneq (,$(filter stm32_eth,$(USEMODULE)))
   USEMODULE += netdev_eth
   USEMODULE += iolist
   USEMODULE += luid
+  USEMODULE += xtimer
 endif
 
 ifneq (STM32F030x4, $(CPU_LINE))

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -115,6 +115,7 @@ PSEUDOMODULES += stdio_cdc_acm
 PSEUDOMODULES += stdio_ethos
 PSEUDOMODULES += stdio_uart_rx
 PSEUDOMODULES += stm32_eth
+PSEUDOMODULES += stm32_eth_link_up
 PSEUDOMODULES += suit_transport_%
 PSEUDOMODULES += wakaama_objects_%
 PSEUDOMODULES += wifi_enterprise

--- a/pkg/lwip/Makefile.dep
+++ b/pkg/lwip/Makefile.dep
@@ -7,3 +7,9 @@ DEFAULT_MODULE += auto_init_lwip
 ifneq (,$(filter lwip_sock_async,$(USEMODULE)))
   USEMODULE += sock_async
 endif
+
+ifneq (,$(filter stm32_eth,$(USEMODULE)))
+  ifneq (,$(filter lwip_dhcp_auto,$(USEMODULE)))
+    USEMODULE += stm32_eth_link_up
+  endif
+endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR offers the possibility to check the link status of stm32 devices to issue the `NETDEV_EVENT_LINK_UP` event. To achieve this the link status is periodically checked with the initialization of the netdev and as soon as a link is detected the event `NETDEV_EVENT_LINK_UP` is triggered.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try running the test under /tests/lwip/ for IPv4 and typing in `ifconfig` with an ethernet cable connected. The device should have a valid IPv4 address.

This PR was testing using a Nucleo-F207ZG board. 

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#14150

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
