### PR TITLE
boards/particle-xenon: add UART1 to uart_config

### DIFF
--- a/boards/particle-xenon/include/periph_conf.h
+++ b/boards/particle-xenon/include/periph_conf.h
@@ -42,9 +42,20 @@ static const uart_conf_t uart_config[] = {
 #endif
         .irqn       = UARTE0_UART0_IRQn,
     },
+    {
+        .dev        = NRF_UARTE1,
+        .rx_pin     = GPIO_PIN(1,10),
+        .tx_pin     = GPIO_PIN(1,8),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin    = GPIO_PIN(1,3),
+        .cts_pin    = GPIO_PIN(1,11),
+#endif
+        .irqn       = UARTE1_IRQn,
+    },
 };
 
 #define UART_0_ISR          (isr_uart0)
+#define UART_1_ISR          (isr_uarte1)
 
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */


### PR DESCRIPTION
### Contribution description

This PR adds a second UART configuration to the particle Xenon. The second uart conf was already available on other particle boards. 

### Testing procedure

- Shortcut D5 (RX) with D4 (TX)
- Flash test periph_uart

`$ make BOARD=particle-xenon -C tests/periph_uart flash term`

- Init second uart and send some data

```
init 1 115200
send 1 Hello
```
- Data should be both sent and received: 

```
UART_DEV(1) TX: Hello
Success: UART_DEV(1) RX: [Hello]\n
```

### Issues/PRs references

Fixes issue #14666 .
