### PR TITLE
cpu/msp430_common: fix thread_yield_higher() when called in isr [backport 2020.07]

### DIFF
--- a/cpu/msp430_common/cpu.c
+++ b/cpu/msp430_common/cpu.c
@@ -14,23 +14,49 @@
 #include "thread.h"
 
 /*
- * we must prevent the compiler to generate a prologue or an epilogue
- * for thread_yield_higher(), since we rely on the RETI instruction at the end
- * of its execution, in the inlined __restore_context() sub-function
+ * This function can both be called from ISR and from thread context.
+ *
+ * In both cases, the caller will use "CALL", which pushes the return
+ * address on the stack before executing the function's first instruction.
+ *
+ * If called within ISR, just set sched_context_switch_request and
+ * directly return to the call site. A regular function return does this.
+ *
+ * If called from stack context, it needs to prepare the stack so it looks exactly
+ * as if the thread had been interrupted by an ISR, which requires the SR to be on
+ * stack right after the return address. So we do this manually.
+ * __save_context() will then save the remaining registers, then store the stack
+ * pointer in the thread's thread_t.
+ *
+ * At this point, the thread context is properly saved. sched_run (possibly) changes
+ * the currently active thread, which __restore_context() then restores, resuming
+ * execution at the call site using reti.
+ *
  */
-__attribute__((naked)) void thread_yield_higher(void)
+void thread_yield_higher(void)
 {
-    __asm__("push r2"); /* save SR */
-    __disable_irq();
+    if (irq_is_in()) {
+        sched_context_switch_request = 1;
+    }
+    else {
+        __asm__ volatile (
+            "push r2"   "\n\t"  /* save SR */
+            "dint"      "\n\t"  /* reti will restore SR, and thus, IRQ state */
+            "nop"       "\n\t"  /* dint takes an additional CPU cycle to take into effect */
+            :                   /* no outputs */
+            :                   /* no inputs */
+            :                   /* no clobbers */
+            );
 
-    __save_context();
+        __save_context();
 
-    /* have sched_active_thread point to the next thread */
-    sched_run();
+        /* have sched_active_thread point to the next thread */
+        sched_run();
 
-    __restore_context();
+        __restore_context();
 
-    UNREACHABLE();
+        UNREACHABLE();
+    }
 }
 
 /* This function calculates the ISR_usage */


### PR DESCRIPTION
# Backport of #14624

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The previous thread_yield_higher() did not handle being called within ISR, resulting in unexpected jumps into thread context, causing all sorts of issues, mostly __breaking everything setting thread flags from within ISR__.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

At least these are broken in master and work with this PR:

- tests/event_wait_timeout
- tests/thread_flags_xtimer

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Some broken tests are tracked in https://github.com/RIOT-OS/RIOT/issues/13267.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
