### PR TITLE
drivers/cc2420: fix bogus cc2420_set_state(dev, CC2420_GOTO_RX) type

### DIFF
--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -87,7 +87,7 @@ int cc2420_init(cc2420_t *dev)
     cc2420_reg_write(dev, CC2420_REG_MDMCTRL0, reg);
 
     /* go into RX state */
-    cc2420_set_state(dev, CC2420_GOTO_RX);
+    cc2420_set_state(dev, NETOPT_STATE_IDLE);
 
     return 0;
 }


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

It doesn't compile, compiler complains that the enum type of
CC2420_GOTO_RX cannot be converted to netopt_t as required by the
function.
The numerical value of CC2420_GOTO_RX would be NETOPT_ADDRESS (2), which
can't be right.
cc2420_set_state(dev, NETOPT_STATE_RX) in turn is not implemented
(returns -ENOTSUP), so this was a noop for a while.
TODO: revisit and confirm.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- manually confirm that previous code was a NOOP
- see gcc 10.1 complain when compiling for z1, in #12457, without this patch

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Cut out of #12457 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
