### PR TITLE
dist/tools/backport_pr: use recursive strategy 'theirs'

### DIFF
--- a/dist/tools/backport_pr/backport_pr.py
+++ b/dist/tools/backport_pr/backport_pr.py
@@ -229,7 +229,8 @@ def main():
         bp_repo = git.Repo(worktree_dir)
         # Apply commits
         for commit in commits:
-            bp_repo.git.cherry_pick('-x', commit['sha'])
+            bp_repo.git.cherry_pick('-x', '--strategy=recursive', '-X',
+                                    'theirs', commit['sha'])
         # Push to github
         origin = _find_remote(repo, username, REPO)
         print("Pushing branch {} to {}".format(new_branch, origin))


### PR DESCRIPTION

### Contribution description

To avoid conflicts when cherry-picking use `theirs`, used when creating https://github.com/RIOT-OS/RIOT/pull/14693

### Testing procedure

Use this version of the script to create a backport on some PR, should still work, best tested on a change that creates merge issues like #14693.

`./dist/tools/backport_pr/backport_pr.py --comment <PR> --noop`

### Issues/PRs references

