### PR TITLE
core/bitarithm: use __builtin_clz() for bitarithm_msb()

### DIFF
--- a/core/bitarithm.c
+++ b/core/bitarithm.c
@@ -23,11 +23,9 @@
 
 #include "bitarithm.h"
 
-unsigned bitarithm_msb(unsigned v)
+unsigned bitarith_msb_32bit_no_native_clz(unsigned v)
 {
     register unsigned r; /* result of log2(v) will go here */
-
-#if ARCH_32_BIT
     register unsigned shift;
 
     /* begin{code-style-ignore} */
@@ -37,13 +35,6 @@ unsigned bitarithm_msb(unsigned v)
     shift = (v > 0x3   ) << 1; v >>= shift; r |= shift;
                                             r |= (v >> 1);
     /* end{code-style-ignore} */
-#else
-    r = 0;
-    while (v >>= 1) { /* unroll for more speed... */
-        r++;
-    }
-
-#endif
 
     return r;
 }

--- a/core/include/bitarithm.h
+++ b/core/include/bitarithm.h
@@ -102,7 +102,7 @@ extern "C" {
  *
  * Source: http://graphics.stanford.edu/~seander/bithacks.html#IntegerLogObvious
  */
-unsigned bitarithm_msb(unsigned v);
+static inline unsigned bitarithm_msb(unsigned v);
 
 /**
  * @brief   Returns the number of the lowest '1' bit in a value
@@ -136,7 +136,32 @@ static inline uint8_t bitarithm_bits_set_u32(uint32_t v)
 uint8_t bitarithm_bits_set_u32(uint32_t v);
 #endif
 
+/**
+ * @brief   Returns the number of the highest '1' bit in a value
+ *
+ *          Internal software implementation for 32 bit platforms,
+ *          use @see bitarithm_msb in application code.
+ * @param[in]   v   Input value
+ * @return          Bit Number
+ */
+unsigned bitarith_msb_32bit_no_native_clz(unsigned v);
+
 /* implementations */
+
+static inline unsigned bitarithm_msb(unsigned v)
+{
+#if defined(BITARITHM_HAS_CLZ)
+    return 8 * sizeof(v) - __builtin_clz(v) - 1;
+#elif ARCH_32_BIT
+    return bitarith_msb_32bit_no_native_clz(v);
+#else
+    unsigned r = 0;
+    while (v >>= 1) { /* unroll for more speed... */
+        ++r;
+    }
+    return r;
+#endif
+}
 
 static inline unsigned bitarithm_lsb(unsigned v)
 #if defined(BITARITHM_LSB_BUILTIN)


### PR DESCRIPTION
### Contribution description

The `clz` instruction pretty much implements getting the most significant bit
in hardware, so use it instead of the software implementation.

This reults in both a reduction in code size as in a speedup:

#### master:

```
  text    data     bss     dec     hex filename
 14816     136    2424   17376    43e0 tests/bitarithm_timings/bin/same54-xpro/tests_bitarithm_timings.elf
```

 + bitarithm_msb: 3529411 iterations per second

#### this patch:

```
  text    data     bss     dec     hex filename
 14768     136    2424   17328    43b0 tests/bitarithm_timings/bin/same54-xpro/tests_bitarithm_timings.elf
```
 + bitarithm_msb: 9230761 iterations per second

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `tests/bitarithm_timings`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
