### PR TITLE
core/bitarithm: add bitarithm_log2()

### DIFF
--- a/core/include/bitarithm.h
+++ b/core/include/bitarithm.h
@@ -136,6 +136,23 @@ static inline uint8_t bitarithm_bits_set_u32(uint32_t v)
 uint8_t bitarithm_bits_set_u32(uint32_t v);
 #endif
 
+/**
+ * @brief   Returns the base-2 logarithm of a power of 2 number
+ * @param[in]   v   Input value, must be a power of two
+ * @return          log2(v)
+ *
+ */
+static inline unsigned bitarithm_log2(unsigned v)
+{
+    assert(bitarithm_bits_set(v) == 1);
+
+#if defined(BITARITHM_HAS_CLZ)
+    return 8 * sizeof(v) - __builtin_clz(v) - 1;
+#else
+    return bitarithm_lsb(v);
+#endif
+}
+
 /* implementations */
 
 static inline unsigned bitarithm_lsb(unsigned v)


### PR DESCRIPTION
### Contribution description

Add a function to get the log2 of a power of two value (fast).
If `clz` is available, we can just use that to count from the msb.
If it's not available, rely on the De Bruijn lookup table to count from the lsb.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
