### PR TITLE
openocd-adapters/raspi.inc.mk-fix: fix typo

### DIFF
--- a/makefiles/tools/openocd-adapters/raspi.inc.mk
+++ b/makefiles/tools/openocd-adapters/raspi.inc.mk
@@ -28,7 +28,7 @@ OPENOCD_ADAPTER_INIT ?= \
   -c 'adapter driver bcm2835gpio' \
   -c 'bcm2835gpio_peripheral_base $(PERIPH_BASE)' \
   -c 'bcm2835gpio_speed_coeffs $(SPEED_COEFF) $(SPEED_OFFSET)' \
-  -c 'bcm2835gpio_swd_nums $(SWCLK_PIN ) $(SWDIO_PIN)' \
+  -c 'bcm2835gpio_swd_nums $(SWCLK_PIN) $(SWDIO_PIN)' \
   -c 'bcm2835gpio_srst_num $(SRST_PIN)'
 
 # Default to SWD


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Somehow a space has sneaked in here, breaking the variable expansion.



### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
