### PR TITLE
treewide: Fix direct access to scheduler internals

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -184,19 +184,9 @@ extern volatile unsigned int sched_context_switch_request;
 extern volatile thread_t *sched_threads[KERNEL_PID_LAST + 1];
 
 /**
- *  Currently active thread
- */
-extern volatile thread_t *sched_active_thread;
-
-/**
  *  Number of running (non-terminated) threads
  */
 extern volatile int sched_num_threads;
-
-/**
- *  Process ID of active thread
- */
-extern volatile kernel_pid_t sched_active_pid;
 
 /**
  * List of runqueues per priority level

--- a/cpu/esp_common/freertos/task.c
+++ b/cpu/esp_common/freertos/task.c
@@ -103,6 +103,7 @@ BaseType_t xTaskCreate (TaskFunction_t pvTaskCode,
 
 void vTaskDelete (TaskHandle_t xTaskToDelete)
 {
+    extern volatile thread_t *sched_active_thread;
     DEBUG("%s pid=%d task=%p\n", __func__, thread_getpid(), xTaskToDelete);
 
     assert(xTaskToDelete != NULL);

--- a/cpu/esp_common/thread_arch.c
+++ b/cpu/esp_common/thread_arch.c
@@ -416,6 +416,8 @@ NORETURN void cpu_switch_context_exit(void)
  */
 NORETURN void task_exit(void)
 {
+    extern volatile thread_t *sched_active_thread;
+    extern volatile kernel_pid_t sched_active_pid;
     DEBUG("sched_task_exit: ending thread %" PRIkernel_pid "...\n",
           thread_getpid());
 

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -71,7 +71,7 @@ static int _init(netdev_t *netdev)
 {
     kw2xrf_t *dev = (kw2xrf_t *)netdev;
 
-    dev->thread = (thread_t *)thread_get(thread_getpid());
+    dev->thread = thread_get_active();
 
     /* initialize SPI and GPIOs */
     if (kw2xrf_init(dev, &_irq_handler)) {

--- a/drivers/kw41zrf/kw41zrf_netdev.c
+++ b/drivers/kw41zrf/kw41zrf_netdev.c
@@ -86,7 +86,7 @@ static void kw41zrf_irq_handler(void *arg)
 static int kw41zrf_netdev_init(netdev_t *netdev)
 {
     kw41zrf_t *dev = (kw41zrf_t *)netdev;
-    dev->thread = (thread_t *)thread_get(thread_getpid());
+    dev->thread = thread_get_active();
 
     /* initialize hardware */
     if (kw41zrf_init(dev, kw41zrf_irq_handler)) {

--- a/examples/riot_and_cpp/main.cpp
+++ b/examples/riot_and_cpp/main.cpp
@@ -48,7 +48,8 @@ int main()
                                         THREAD_CREATE_WOUT_YIELD,
                                         threadA_func, NULL, "thread A");
 
-    printf("******** Hello, you're in thread #%" PRIkernel_pid " ********\n", sched_active_pid);
+    printf("******** Hello, you're in thread #%" PRIkernel_pid " ********\n",
+           thread_getpid());
     printf("We'll test C++ class and methods here!\n");
 
     cpp_class cpp_obj;
@@ -83,7 +84,8 @@ void *threadA_func(void *)
     int day = 13, month = 6, year = 2014;
     int ret_day;
 
-    printf("******** Hello, you're in thread #%" PRIkernel_pid " ********\n", sched_active_pid);
+    printf("******** Hello, you're in thread #%" PRIkernel_pid " ********\n",
+           thread_getpid());
     printf("We'll test some C functions here!\n");
 
     printf("\n-= hello function =-\n");

--- a/pkg/lvgl/contrib/lvgl.c
+++ b/pkg/lvgl/contrib/lvgl.c
@@ -162,6 +162,6 @@ void lvgl_init(screen_dev_t *screen_dev)
 
 void lvgl_wakeup(void)
 {
-    thread_t *tcb = (thread_t *)sched_threads[_task_thread_pid];
+    thread_t *tcb = thread_get(_task_thread_pid);
     thread_flags_set(tcb, LVGL_THREAD_FLAG);
 }

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -93,7 +93,7 @@ static void _netif_init(gnrc_netif_t *netif)
 
     gnrc_netif_default_init(netif);
     /* save the threads context pointer, so we can set its flags */
-    _netif_thread = (thread_t *)thread_get(thread_getpid());
+    _netif_thread = thread_get_active();
 
 #if IS_USED(MODULE_GNRC_NETIF_6LO)
     /* we disable fragmentation for this device, as the L2CAP layer takes care


### PR DESCRIPTION
### Contribution description

Replace direct accesses to sched_active_thread and sched_active_pid with the helper functions thread_getpid() and thread_getactive(). This serves two purposes:

1. It makes accidental writes to those variable from outside core less likely.
2. Casting off the volatile qualifier is now well contained to those two functions

### Testing procedure

The automatic tests will be our friend here :-)

### Issues/PRs references

None