### PR TITLE
core/thread: Make thread_get inlineable

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -356,7 +356,13 @@ kernel_pid_t thread_create(char *stack,
  * @param[in]   pid   Thread to retrieve.
  * @return      `NULL` if the PID is invalid or there is no such thread.
  */
-volatile thread_t *thread_get(kernel_pid_t pid);
+static inline volatile thread_t *thread_get(kernel_pid_t pid)
+{
+    if (pid_is_valid(pid)) {
+        return sched_threads[pid];
+    }
+    return NULL;
+}
 
 /**
  * @brief Returns the status of a process

--- a/core/thread.c
+++ b/core/thread.c
@@ -30,14 +30,6 @@
 #include "bitarithm.h"
 #include "sched.h"
 
-volatile thread_t *thread_get(kernel_pid_t pid)
-{
-    if (pid_is_valid(pid)) {
-        return sched_threads[pid];
-    }
-    return NULL;
-}
-
 thread_status_t thread_getstatus(kernel_pid_t pid)
 {
     volatile thread_t *thread = thread_get(pid);


### PR DESCRIPTION
### Contribution description

Moved `volatile thread_t *thread_get()` from `thread.c` to `thread.h`, making in `static inline`. This safes an incredible amount of 16 B ROM e.g. in `tests/thread_flags` on the Nucleo-F767ZI.

### Testing procedure

Confirm that no code was changed, only moved.

### Issues/PRs references

Suggested in https://github.com/RIOT-OS/RIOT/pull/14702