### PR TITLE
cpu/sam0_common: GPIO: ignore stale interrupts

### DIFF
--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -321,6 +321,11 @@ void gpio_irq_enable(gpio_t pin)
     if (exti == -1) {
         return;
     }
+
+    /* clear stale interrupt */
+    _EIC->INTFLAG.reg = (1 << exti);
+
+    /* enable interrupt */
     _EIC->INTENSET.reg = (1 << exti);
 }
 


### PR DESCRIPTION
### Contribution description

If we disable an external interrupt, GPIO events that would generate an interrupt will still set the interrupt flag.
That means once we enable the interrupt again, a stale interrupt will be triggered.

This is surprising and probably not what the user wants, unfortunately the API documentation is not very clear about what to expect.
There is however no way to drop those intermediate interrupts with the current API.

Ignoring the events that occurred while the GPIO interrupt were disabled is probably the right (and expected) thing to do.


### Testing procedure

Run `tests/periph_gpio` and connect a wire to a GPIO.
Configure the GPIO as interrupt and connect the wire with ground.
An interrupt should occur..

Now disable the interrupt and connect the wire again. Nothing will happen.
Re-Enable the interrupt.

On master, an interrupt will be printed.
With this patch, the stale interrupt is ignored.

##### master

```
2020-08-05 16:37:21,365 #  init_int 1 1 2 1
2020-08-05 16:37:21,369 # GPIO_PIN(1, 1) successfully initialized as ext int

# touch GND with wire

2020-08-05 16:37:29,906 # INT: external interrupt from pin 1
2020-08-05 16:37:29,908 # INT: external interrupt from pin 1
2020-08-05 16:37:30,033 # INT: external interrupt from pin 1
2020-08-05 16:37:30,036 # INT: external interrupt from pin 1
2020-08-05 16:37:30,146 # INT: external interrupt from pin 1

2020-08-05 16:37:44,413 #  enable_int 1 1 0
2020-08-05 16:37:44,415 # disabling GPIO interrupt

# touch GND with wire - no IRQ

2020-08-05 16:37:49,969 #  enable_int 1 1 1
2020-08-05 16:37:49,970 # enabling GPIO interrupt
2020-08-05 16:37:49,973 # INT: external interrupt from pin 1
                          ^^^^^^^^^^^^^^^^^^^^^^^
                          stale IRQ
```

#### this PR

```
2020-08-05 16:40:14,654 #  init_int 1 1 2 1
2020-08-05 16:40:14,659 # GPIO_PIN(1, 1) successfully initialized as ext int

# touch GND with wire

2020-08-05 16:40:17,216 # INT: external interrupt from pin 1
2020-08-05 16:40:17,219 # INT: external interrupt from pin 1
2020-08-05 16:40:17,274 # INT: external interrupt from pin 1
2020-08-05 16:40:17,278 # INT: external interrupt from pin 1
2020-08-05 16:40:17,368 # INT: external interrupt from pin 1
2020-08-05 16:40:17,489 # INT: external interrupt from pin 1
2020-08-05 16:40:17,492 # INT: external interrupt from pin 1

2020-08-05 16:40:20,949 # enable_int 1 1 0
2020-08-05 16:40:20,952 # disabling GPIO interrupt

# touch GND with wire - no IRQ

> enable_int 1 1 1
2020-08-05 16:40:26,382 #  enable_int 1 1 1
2020-08-05 16:40:26,384 # enabling GPIO interrupt
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
