### PR TITLE
core: Add and use helper functions for internal data

### DIFF
--- a/core/cond.c
+++ b/core/cond.c
@@ -35,7 +35,7 @@ void cond_init(cond_t *cond)
 void cond_wait(cond_t *cond, mutex_t *mutex)
 {
     unsigned irqstate = irq_disable();
-    thread_t *me = (thread_t *)sched_active_thread;
+    thread_t *me = thread_get_active();
 
     mutex_unlock(mutex);
     sched_set_status(me, STATUS_COND_BLOCKED);

--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -46,8 +46,8 @@ extern "C" {
 #include "cpu_conf.h"
 #define DEBUG_PRINT(...) \
     do { \
-        if ((sched_active_thread == NULL) || \
-            (sched_active_thread->stack_size >= \
+        if ((thread_get_active() == NULL) || \
+            (thread_get_active()->stack_size >= \
              THREAD_EXTRA_STACKSIZE_PRINTF)) { \
             printf(__VA_ARGS__); \
         } \

--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -132,11 +132,11 @@ thread_flags_t thread_flags_clear(thread_flags_t mask);
  * immediately, otherwise, it will suspend the thread (as
  * THREAD_STATUS_WAIT_ANY) until any of the flags in mask get set.
  *
- * Both ways, it will clear and return (sched_active_thread-flags & mask).
+ * Both ways, it will clear and return (`thread_get_active()->flags & mask`).
  *
  * @param[in]   mask    mask of flags to wait for
  *
- * @returns     flags that caused return/wakeup ((sched_active_thread-flags & mask).
+ * @returns     flags that caused return/wakeup (`thread_get_active()->flags & mask`).
  */
 thread_flags_t thread_flags_wait_any(thread_flags_t mask);
 
@@ -147,7 +147,7 @@ thread_flags_t thread_flags_wait_any(thread_flags_t mask);
  * immediately, otherwise, it will suspend the thread (as
  * THREAD_STATUS_WAIT_ALL) until all of the flags in mask have been set.
  *
- * Both ways, it will clear and return (sched_active_thread-flags & mask).
+ * Both ways, it will clear and return (`thread_get_active()->flags & mask`).
  *
  * @param[in]   mask    mask of flags to wait for
  *

--- a/core/msg.c
+++ b/core/msg.c
@@ -65,7 +65,7 @@ int msg_send(msg_t *m, kernel_pid_t target_pid)
     if (irq_is_in()) {
         return msg_send_int(m, target_pid);
     }
-    if (sched_active_pid == target_pid) {
+    if (thread_getpid() == target_pid) {
         return msg_send_to_self(m);
     }
     return _msg_send(m, target_pid, true, irq_disable());
@@ -76,7 +76,7 @@ int msg_try_send(msg_t *m, kernel_pid_t target_pid)
     if (irq_is_in()) {
         return msg_send_int(m, target_pid);
     }
-    if (sched_active_pid == target_pid) {
+    if (thread_getpid() == target_pid) {
         return msg_send_to_self(m);
     }
     return _msg_send(m, target_pid, false, irq_disable());
@@ -91,9 +91,9 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block,
     }
 #endif /* DEVELHELP */
 
-    thread_t *target = (thread_t *)sched_threads[target_pid];
+    thread_t *target = thread_get_unchecked(target_pid);
 
-    m->sender_pid = sched_active_pid;
+    m->sender_pid = thread_getpid();
 
     if (target == NULL) {
         DEBUG("msg_send(): target thread %d does not exist\n", target_pid);
@@ -101,11 +101,11 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block,
         return -1;
     }
 
-    thread_t *me = (thread_t *)sched_active_thread;
+    thread_t *me = thread_get_active();
 
     DEBUG("msg_send() %s:%i: Sending from %" PRIkernel_pid " to %" PRIkernel_pid
           ". block=%i src->state=%i target->state=%i\n", RIOT_FILE_RELATIVE,
-          __LINE__, sched_active_pid, target_pid,
+          __LINE__, thread_getpid(), target_pid,
           block, me->status, target->status);
 
     if (target->status != STATUS_RECEIVE_BLOCKED) {
@@ -125,9 +125,8 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block,
         }
 
         if (!block) {
-            DEBUG(
-                "msg_send: %" PRIkernel_pid ": Receiver not waiting, block=%u\n",
-                me->pid, block);
+            DEBUG("msg_send: %" PRIkernel_pid ": Receiver not waiting, "
+                  "block=%u\n", me->pid, block);
             irq_restore(state);
             return 0;
         }
@@ -135,7 +134,7 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block,
         DEBUG("msg_send: %" PRIkernel_pid ": going send blocked.\n",
               me->pid);
 
-        me->wait_data = (void *)m;
+        me->wait_data = m;
 
         int newstatus;
 
@@ -146,7 +145,7 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block,
             newstatus = STATUS_SEND_BLOCKED;
         }
 
-        sched_set_status((thread_t *)me, newstatus);
+        sched_set_status(me, newstatus);
 
         thread_add_to_list(&(target->msg_waiters), me);
 
@@ -166,7 +165,7 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block,
               PRIkernel_pid " to %" PRIkernel_pid ".\n",
               me->pid, thread_getpid(), target_pid);
         /* copy msg to target */
-        msg_t *target_message = (msg_t *)target->wait_data;
+        msg_t *target_message = target->wait_data;
         *target_message = *m;
         sched_set_status(target, STATUS_PENDING);
 
@@ -181,8 +180,8 @@ int msg_send_to_self(msg_t *m)
 {
     unsigned state = irq_disable();
 
-    m->sender_pid = sched_active_pid;
-    int res = queue_msg((thread_t *)sched_active_thread, m);
+    m->sender_pid = thread_getpid();
+    int res = queue_msg(thread_get_active(), m);
 
     irq_restore(state);
     return res;
@@ -196,7 +195,7 @@ static int _msg_send_oneway(msg_t *m, kernel_pid_t target_pid)
     }
 #endif /* DEVELHELP */
 
-    thread_t *target = (thread_t *)sched_threads[target_pid];
+    thread_t *target = thread_get_unchecked(target_pid);
 
     if (target == NULL) {
         DEBUG("%s: target thread %d does not exist\n", __func__, target_pid);
@@ -242,7 +241,7 @@ int msg_send_bus(msg_t *m, msg_bus_t *bus)
     const uint32_t event_mask = (1UL << (m->type & 0x1F));
     int count = 0;
 
-    m->sender_pid = in_irq ? KERNEL_PID_ISR : sched_active_pid;
+    m->sender_pid = in_irq ? KERNEL_PID_ISR : thread_getpid();
 
     unsigned state = irq_disable();
 
@@ -269,11 +268,11 @@ int msg_send_bus(msg_t *m, msg_bus_t *bus)
 
 int msg_send_receive(msg_t *m, msg_t *reply, kernel_pid_t target_pid)
 {
-    assert(sched_active_pid != target_pid);
+    assert(thread_getpid() != target_pid);
     unsigned state = irq_disable();
-    thread_t *me = (thread_t *)sched_active_thread;
+    thread_t *me = thread_get_active();
     sched_set_status(me, STATUS_REPLY_BLOCKED);
-    me->wait_data = (void *)reply;
+    me->wait_data = reply;
 
     /* we re-use (abuse) reply for sending, because wait_data might be
      * overwritten if the target is not in RECEIVE_BLOCKED */
@@ -286,20 +285,20 @@ int msg_reply(msg_t *m, msg_t *reply)
 {
     unsigned state = irq_disable();
 
-    thread_t *target = (thread_t *)sched_threads[m->sender_pid];
+    thread_t *target = thread_get_unchecked(m->sender_pid);
 
     assert(target != NULL);
 
     if (target->status != STATUS_REPLY_BLOCKED) {
         DEBUG("msg_reply(): %" PRIkernel_pid ": Target \"%" PRIkernel_pid
-              "\" not waiting for reply.", sched_active_thread->pid,
+              "\" not waiting for reply.", thread_getpid(),
               target->pid);
         irq_restore(state);
         return -1;
     }
 
     DEBUG("msg_reply(): %" PRIkernel_pid ": Direct msg copy.\n",
-          sched_active_thread->pid);
+          thread_getpid());
     /* copy msg to target */
     msg_t *target_message = (msg_t *)target->wait_data;
     *target_message = *reply;
@@ -313,11 +312,11 @@ int msg_reply(msg_t *m, msg_t *reply)
 
 int msg_reply_int(msg_t *m, msg_t *reply)
 {
-    thread_t *target = (thread_t *)sched_threads[m->sender_pid];
+    thread_t *target = thread_get_unchecked(m->sender_pid);
 
     if (target->status != STATUS_REPLY_BLOCKED) {
         DEBUG("msg_reply_int(): %" PRIkernel_pid ": Target \"%" PRIkernel_pid
-              "\" not waiting for reply.", sched_active_thread->pid,
+              "\" not waiting for reply.", thread_getpid(),
               target->pid);
         return -1;
     }
@@ -344,9 +343,9 @@ static int _msg_receive(msg_t *m, int block)
     unsigned state = irq_disable();
 
     DEBUG("_msg_receive: %" PRIkernel_pid ": _msg_receive.\n",
-          sched_active_thread->pid);
+          thread_getpid());
 
-    thread_t *me = (thread_t *)sched_active_thread;
+    thread_t *me = thread_get_active();
 
     int queue_index = -1;
 
@@ -361,9 +360,8 @@ static int _msg_receive(msg_t *m, int block)
     }
 
     if (queue_index >= 0) {
-        DEBUG(
-            "_msg_receive: %" PRIkernel_pid ": _msg_receive(): We've got a queued message.\n",
-            sched_active_thread->pid);
+        DEBUG("_msg_receive: %" PRIkernel_pid ": _msg_receive(): We've got a "
+              "queued message.\n", thread_getpid());
         *m = me->msg_array[queue_index];
     }
     else {
@@ -373,21 +371,19 @@ static int _msg_receive(msg_t *m, int block)
     list_node_t *next = list_remove_head(&me->msg_waiters);
 
     if (next == NULL) {
-        DEBUG(
-            "_msg_receive: %" PRIkernel_pid ": _msg_receive(): No thread in waiting list.\n",
-            sched_active_thread->pid);
+        DEBUG("_msg_receive: %" PRIkernel_pid ": _msg_receive(): No thread in "
+              "waiting list.\n", thread_getpid());
 
         if (queue_index < 0) {
-            DEBUG(
-                "_msg_receive(): %" PRIkernel_pid ": No msg in queue. Going blocked.\n",
-                sched_active_thread->pid);
+            DEBUG("_msg_receive(): %" PRIkernel_pid ": No msg in queue. Going "
+                  "blocked.\n", thread_getpid());
             sched_set_status(me, STATUS_RECEIVE_BLOCKED);
 
             irq_restore(state);
             thread_yield_higher();
 
             /* sender copied message */
-            assert(sched_active_thread->status != STATUS_RECEIVE_BLOCKED);
+            assert(thread_get_active()->status != STATUS_RECEIVE_BLOCKED);
         }
         else {
             irq_restore(state);
@@ -396,9 +392,8 @@ static int _msg_receive(msg_t *m, int block)
         return 1;
     }
     else {
-        DEBUG(
-            "_msg_receive: %" PRIkernel_pid ": _msg_receive(): Waking up waiting thread.\n",
-            sched_active_thread->pid);
+        DEBUG("_msg_receive: %" PRIkernel_pid ": _msg_receive(): Waking up "
+             "waiting thread.\n", thread_getpid());
 
         thread_t *sender =
             container_of((clist_node_t *)next, thread_t, rq_entry);
@@ -435,9 +430,9 @@ static int _msg_receive(msg_t *m, int block)
 int msg_avail(void)
 {
     DEBUG("msg_available: %" PRIkernel_pid ": msg_available.\n",
-          sched_active_thread->pid);
+          thread_getpid());
 
-    thread_t *me = (thread_t *)sched_active_thread;
+    thread_t *me = thread_get_active();
 
     int queue_index = -1;
 
@@ -450,7 +445,7 @@ int msg_avail(void)
 
 void msg_init_queue(msg_t *array, int num)
 {
-    thread_t *me = (thread_t *)sched_active_thread;
+    thread_t *me = thread_get_active();
 
     me->msg_array = array;
     cib_init(&(me->msg_queue), num);
@@ -460,7 +455,7 @@ void msg_queue_print(void)
 {
     unsigned state = irq_disable();
 
-    thread_t *thread = (thread_t *)sched_active_thread;
+    thread_t *thread = thread_get_active();
     cib_t *msg_queue = &thread->msg_queue;
     msg_t *msg_array = thread->msg_array;
     unsigned int i = msg_queue->read_count & msg_queue->mask;

--- a/core/msg_bus.c
+++ b/core/msg_bus.c
@@ -37,7 +37,7 @@ void msg_bus_attach(msg_bus_t *bus, msg_bus_entry_t *entry)
 
     entry->next.next = NULL;
     entry->event_mask = 0;
-    entry->pid = sched_active_pid;
+    entry->pid = thread_getpid();
 
     state = irq_disable();
     list_add(&bus->subs, &entry->next);
@@ -62,7 +62,7 @@ msg_bus_entry_t *msg_bus_get_entry(msg_bus_t *bus)
 
         msg_bus_entry_t *subscriber = container_of(e, msg_bus_entry_t, next);
 
-        if (subscriber->pid == sched_active_pid) {
+        if (subscriber->pid == thread_getpid()) {
             s = subscriber;
             break;
         }

--- a/core/thread.c
+++ b/core/thread.c
@@ -32,7 +32,7 @@
 
 thread_status_t thread_getstatus(kernel_pid_t pid)
 {
-    volatile thread_t *thread = thread_get(pid);
+    thread_t *thread = thread_get(pid);
 
     return thread ? thread->status : STATUS_NOT_FOUND;
 }
@@ -40,7 +40,7 @@ thread_status_t thread_getstatus(kernel_pid_t pid)
 const char *thread_getname(kernel_pid_t pid)
 {
 #ifdef DEVELHELP
-    volatile thread_t *thread = thread_get(pid);
+    thread_t *thread = thread_get(pid);
     return thread ? thread->name : NULL;
 #else
     (void)pid;
@@ -55,7 +55,7 @@ void thread_zombify(void)
     }
 
     irq_disable();
-    sched_set_status((thread_t *)sched_active_thread, STATUS_ZOMBIE);
+    sched_set_status(thread_get_active(), STATUS_ZOMBIE);
     irq_enable();
     thread_yield_higher();
 
@@ -70,7 +70,7 @@ int thread_kill_zombie(kernel_pid_t pid)
 
     int result = (int)STATUS_NOT_FOUND;
 
-    thread_t *thread = (thread_t *)thread_get(pid);
+    thread_t *thread = thread_get(pid);
 
     if (!thread) {
         DEBUG("thread_kill: Thread does not exist!\n");
@@ -98,7 +98,7 @@ void thread_sleep(void)
     }
 
     unsigned state = irq_disable();
-    sched_set_status((thread_t *)sched_active_thread, STATUS_SLEEPING);
+    sched_set_status(thread_get_active(), STATUS_SLEEPING);
     irq_restore(state);
     thread_yield_higher();
 }
@@ -109,7 +109,7 @@ int thread_wakeup(kernel_pid_t pid)
 
     unsigned old_state = irq_disable();
 
-    thread_t *thread = (thread_t *)thread_get(pid);
+    thread_t *thread = thread_get(pid);
 
     if (!thread) {
         DEBUG("thread_wakeup: Thread does not exist!\n");
@@ -135,7 +135,7 @@ int thread_wakeup(kernel_pid_t pid)
 void thread_yield(void)
 {
     unsigned old_state = irq_disable();
-    thread_t *me = (thread_t *)sched_active_thread;
+    thread_t *me = thread_get_active();
 
     if (me->status >= STATUS_ON_RUNQUEUE) {
         clist_lpoprpush(&sched_runqueues[me->priority]);

--- a/core/thread_flags.c
+++ b/core/thread_flags.c
@@ -52,7 +52,7 @@ static void _thread_flags_wait(thread_flags_t mask, thread_t *thread,
 
 thread_flags_t thread_flags_clear(thread_flags_t mask)
 {
-    thread_t *me = (thread_t *)sched_active_thread;
+    thread_t *me = thread_get_active();
 
     mask = _thread_flags_clear_atomic(me, mask);
     DEBUG("thread_flags_clear(): pid %" PRIkernel_pid " clearing 0x%08x\n",
@@ -62,7 +62,7 @@ thread_flags_t thread_flags_clear(thread_flags_t mask)
 
 static void _thread_flags_wait_any(thread_flags_t mask)
 {
-    thread_t *me = (thread_t *)sched_active_thread;
+    thread_t *me = thread_get_active();
     unsigned state = irq_disable();
 
     if (!(me->flags & mask)) {
@@ -75,7 +75,7 @@ static void _thread_flags_wait_any(thread_flags_t mask)
 
 thread_flags_t thread_flags_wait_any(thread_flags_t mask)
 {
-    thread_t *me = (thread_t *)sched_active_thread;
+    thread_t *me = thread_get_active();
 
     _thread_flags_wait_any(mask);
     return _thread_flags_clear_atomic(me, mask);
@@ -84,7 +84,7 @@ thread_flags_t thread_flags_wait_any(thread_flags_t mask)
 thread_flags_t thread_flags_wait_one(thread_flags_t mask)
 {
     _thread_flags_wait_any(mask);
-    thread_t *me = (thread_t *)sched_active_thread;
+    thread_t *me = thread_get_active();
     thread_flags_t tmp = me->flags & mask;
     /* clear all but least significant bit */
     tmp &= (~tmp + 1);
@@ -94,7 +94,7 @@ thread_flags_t thread_flags_wait_one(thread_flags_t mask)
 thread_flags_t thread_flags_wait_all(thread_flags_t mask)
 {
     unsigned state = irq_disable();
-    thread_t *me = (thread_t *)sched_active_thread;
+    thread_t *me = thread_get_active();
 
     if (!((me->flags & mask) == mask)) {
         DEBUG(


### PR DESCRIPTION
### Contribution description

#### API changes / additions:

- Changes signature of `thread_get()`:
    - `volatile thread_t *thread_get(kernel_pid_t)` to `thread_t *thread_get(kernel_pid_t)`
- Adds `thread_t *thread_get_ative()` to return the currently running thread
- Adds `thread_t *thread_get_unchecked(kernel_pid_t)` as a faster variant of `thread_get()`, if the pid is known to be valid

#### Code changes:

- Replaced reads from `sched_active_thread` with `thread_get_active()`
- Replaced reads form `sched_active_pid` with `thread_getpid()`
- Replaces reads from `sched_threads[pid]` with `thread_get_unchecked(pid)`

### Testing procedure

Generated binaries should not change

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/14702. But also added `thread_get_unchecked()`, so that generated binaries don't change.