### PR TITLE
riotctrl_shell: provide cord_ep interactions and parser

### DIFF
--- a/dist/pythonlibs/riotctrl_shell/cord_ep.py
+++ b/dist/pythonlibs/riotctrl_shell/cord_ep.py
@@ -1,0 +1,134 @@
+# Copyright (C) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+"""
+CORD EP-related shell interactions
+
+Defines CORD EP-related shell command interactions
+"""
+
+import re
+
+from riotctrl.shell import ShellInteraction, ShellInteractionParser
+
+
+# ==== Parsers ====
+
+class CordEpRegistrationInfoParser(ShellInteractionParser):
+
+    def __init__(self):
+        self.comps = {
+            "rdaddr": re.compile(r"RD address:\s+"
+                                 r"(?P<rdaddr>coaps?://"
+                                 r"\[[0-9a-f:]+(%\S+)?\](:\d+)?)"),
+            "epname": re.compile(r"ep name:\s+(?P<epname>.+)$"),
+            "ltime": re.compile(r"lifetime:\s+(?P<ltime>\d+)s$"),
+            "regif": re.compile(r"reg if:\s+(?P<regif>\S+)$"),
+            "location": re.compile(r"location:\s+(?P<location>\S+)$"),
+        }
+
+    def parse(self, cmd_output):
+        """
+        Parses output of CordEp::cord_ep_info() and CordEp::cord_ep_register()
+
+        >>> parser = CordEpRegistrationInfoParser()
+        >>> res = parser.parse("CoAP RD connection status:\\n"
+        ...                "RD address:"
+        ...                " coap://[fe80::48d5:9eff:fe98:6b74]:5683\\n"
+        ...                "   ep name: RIOT-760D2323760D2323\\n"
+        ...                "  lifetime: 60s\\n"
+        ...                "    reg if: /resourcedirectory\\n"
+        ...                "  location: /reg/1/")
+        >>> res['rdaddr']
+        'coap://[fe80::48d5:9eff:fe98:6b74]:5683'
+        >>> res['epname']
+        'RIOT-760D2323760D2323'
+        >>> res['ltime']
+        60
+        >>> res['regif']
+        '/resourcedirectory'
+        >>> res = parser.parse("CoAP RD connection status:\\n"
+        ...             "RD address:"
+        ...             " coaps://[fe80::48d5:9eff:fe98:6b74%iface0]:5684\\n"
+        ...             "   ep name: RIOT-760D2323760D2323\\n"
+        ...             "  lifetime: 60s\\n"
+        ...             "    reg if: /resourcedirectory\\n"
+        ...             "  location: /reg/1/")
+        >>> res['rdaddr']
+        'coaps://[fe80::48d5:9eff:fe98:6b74%iface0]:5684'
+        """
+        res = {}
+        for line in cmd_output.splitlines():
+            for key, comp in self.comps.items():
+                m = comp.search(line)
+                if m is not None:
+                    try:
+                        res[key] = int(m.group(key))
+                    except ValueError:
+                        res[key] = m.group(key)
+        return res if bool(res) else None
+
+
+class CordEpDiscoverParser(ShellInteractionParser):
+
+    def __init__(self):
+        self.comp = re.compile(r"the registration interface is"
+                               r"\s+'(?P<regif>\S+)'$")
+
+    def parse(self, cmd_output):
+        """
+        Parses output of CordEp::cord_ep_discover()
+
+        >>> parser = CordEpDiscoverParser()
+        >>> parser.parse(
+        ...     "the registration interface is '/resourcedirectory'")
+        '/resourcedirectory'
+        """
+        for line in cmd_output.splitlines():
+            m = self.comp.search(line)
+            if m is not None:
+                return m.group("regif")
+        return None
+
+
+# ==== ShellInteractions ====
+
+
+class CordEp(ShellInteraction):
+    REGISTER = "register"
+    DISCOVER = "discover"
+    UPDATE = "update"
+    REMOVE = "remove"
+    INFO = "info"
+
+    @ShellInteraction.check_term
+    def cord_ep_cmd(self, cmd, args=None, timeout=-1, async_=False):
+        cmd_str = "cord_ep {cmd}".format(cmd=cmd)
+        if args is not None:
+            cmd_str += " {args}".format(args=" ".join(str(a) for a in args))
+        res = self.cmd(cmd_str, timeout=timeout, async_=async_)
+        if ("error:" in res) or ("usage:" in res):
+            raise RuntimeError(res)
+        return res
+
+    def cord_ep_info(self, timeout=-1, async_=False):
+        return self.cord_ep_cmd(self.INFO, None, timeout, async_)
+
+    def cord_ep_register(self, uri, regif=None,
+                         timeout=-1, async_=False):
+        args = [uri]
+        if regif is not None:
+            args.append(regif)
+        return self.cord_ep_cmd(self.REGISTER, args, timeout, async_)
+
+    def cord_ep_discover(self, uri, timeout=-1, async_=False):
+        return self.cord_ep_cmd(self.DISCOVER, (uri,), timeout, async_)
+
+    def cord_ep_update(self, timeout=-1, async_=False):
+        return self.cord_ep_cmd(self.UPDATE, None, timeout, async_)
+
+    def cord_ep_remove(self, timeout=-1, async_=False):
+        return self.cord_ep_cmd(self.REMOVE, None, timeout, async_)

--- a/dist/pythonlibs/riotctrl_shell/tests/test_cord_ep.py
+++ b/dist/pythonlibs/riotctrl_shell/tests/test_cord_ep.py
@@ -1,0 +1,112 @@
+# Copyright (C) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import pytest
+import riotctrl_shell.cord_ep
+
+from .common import init_ctrl
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [("the registration interface is '/resourcedirectory'",
+      "/resourcedirectory"),
+     ("error: unable to discover registration interface", None)]
+)
+def test_cord_ep_discover_parser(input, expected):
+    parser = riotctrl_shell.cord_ep.CordEpDiscoverParser()
+    discover_res = parser.parse(input)
+    assert discover_res == expected
+
+
+@pytest.mark.parametrize(
+    "proto,port", [("coap", ":5683"), ("coaps", ":5684")]
+)
+def test_cord_ep_reg_info_parser(proto, port):
+    test_output = f"""
+Registering with RD now, this may take a short while...
+RD endpoint event: now registered with a RD
+registration successful
+
+CoAP RD connection status:
+RD address: {proto}://[fe80::4494:71ff:fec4:9cac]{port}
+   ep name: RIOT-3F2423233F242323
+  lifetime: 60s
+    reg if: /resourcedirectory
+  location: /reg/1/"""
+
+    parser = riotctrl_shell.cord_ep.CordEpRegistrationInfoParser()
+    reg_res = parser.parse(test_output)
+    assert reg_res
+    assert reg_res["rdaddr"] == f"{proto}://[fe80::4494:71ff:fec4:9cac]{port}"
+    assert reg_res["ltime"] == 60
+    assert reg_res["regif"] == "/resourcedirectory"
+    assert reg_res["location"] == "/reg/1/"
+
+
+def test_cord_ep_parser_empty():
+    reginfo_parser = riotctrl_shell.cord_ep.CordEpRegistrationInfoParser()
+    assert reginfo_parser.parse("") is None
+    discover_parser = riotctrl_shell.cord_ep.CordEpDiscoverParser()
+    assert discover_parser.parse("") is None
+
+
+@pytest.mark.parametrize(
+    "uri,regif,expected",
+    [
+        ("[fe80::1]", None, "cord_ep register [fe80::1]"),
+        ("[fe80::1%iface0]", None, "cord_ep register [fe80::1%iface0]"),
+        ("[fe80::1]:5684", None, "cord_ep register [fe80::1]:5684"),
+        ("[fe80::1]", "/regif", "cord_ep register [fe80::1] /regif"),
+    ]
+)
+def test_cord_ep_register(uri, regif, expected):
+    rc = init_ctrl()
+    si = riotctrl_shell.cord_ep.CordEp(rc)
+    res = si.cord_ep_register(uri, regif)
+    assert res == expected
+
+
+@pytest.mark.parametrize(
+    "uri,expected",
+    [
+        ("[fe80::1]", "cord_ep discover [fe80::1]"),
+        ("[fe80::1]:5684", "cord_ep discover [fe80::1]:5684"),
+        ("[fe80::1%iface0]", "cord_ep discover [fe80::1%iface0]"),
+    ]
+)
+def test_cord_ep_discover(uri, expected):
+    rc = init_ctrl()
+    si = riotctrl_shell.cord_ep.CordEp(rc)
+    res = si.cord_ep_discover(uri)
+    assert res == expected
+
+
+@pytest.mark.parametrize(
+    "method,expected",
+    [
+        ("cord_ep_info", "cord_ep info"),
+        ("cord_ep_update", "cord_ep update"),
+        ("cord_ep_remove", "cord_ep remove")
+    ]
+)
+def test_cord_ep(method, expected):
+    rc = init_ctrl()
+    si = riotctrl_shell.cord_ep.CordEp(rc)
+    res = getattr(si, method)()
+    assert res == expected
+
+
+@pytest.mark.parametrize(
+    "error_msg",
+    ["error: foobar", "usage: cord_ep register foobar"]
+)
+def test_cord_ep_error(error_msg):
+    rc = init_ctrl(error_msg)
+    si = riotctrl_shell.cord_ep.CordEp(rc)
+    with pytest.raises(RuntimeError):
+        si.cord_ep_register("[abcde]:1234", "lalala")
+    assert rc.term.last_command == "cord_ep register [abcde]:1234 lalala"


### PR DESCRIPTION
### Contribution description

This PR adds the cord_ep` module and its tests to riotctrl_shell.

### Testing procedure

```
cd dist/pythonlibs/riotctrl_shell
tox
```

### Issues/PRs references

Closes #14650 
