### PR TITLE
core/msg: sched_threads[sched_active_pid] -> sched_active_thread

### DIFF
--- a/core/msg.c
+++ b/core/msg.c
@@ -271,7 +271,7 @@ int msg_send_receive(msg_t *m, msg_t *reply, kernel_pid_t target_pid)
 {
     assert(sched_active_pid != target_pid);
     unsigned state = irq_disable();
-    thread_t *me = (thread_t *)sched_threads[sched_active_pid];
+    thread_t *me = (thread_t *)sched_active_thread;
     sched_set_status(me, STATUS_REPLY_BLOCKED);
     me->wait_data = (void *)reply;
 
@@ -346,7 +346,7 @@ static int _msg_receive(msg_t *m, int block)
     DEBUG("_msg_receive: %" PRIkernel_pid ": _msg_receive.\n",
           sched_active_thread->pid);
 
-    thread_t *me = (thread_t *)sched_threads[sched_active_pid];
+    thread_t *me = (thread_t *)sched_active_thread;
 
     int queue_index = -1;
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Same result, but only a single volatile read.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Take a good look that the behaviour is the same.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14713

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
