### PR TITLE
cortexm_common: Add thread info to hard fault handler

### DIFF
--- a/tests/pkg_fatfs_vfs/Makefile.ci
+++ b/tests/pkg_fatfs_vfs/Makefile.ci
@@ -8,6 +8,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     msb-430h \
     nucleo-f031k6 \
     nucleo-f042k6 \
+    nucleo-l031k6 \
     stm32f030f4-demo \
     telosb \
     z1 \


### PR DESCRIPTION
### Contribution description

While the hard fault handler prints the offending program counter, it
does not print information about the context triggering the hard fault.
This commit adds a line printing the thread ID and name that triggered
the hard fault. 

~~If the hard fault is triggered during an ISR, it only~~
~~prints that the hard fault happened during ISR context, not which ISR~~
~~triggered it. This is mostly because I have no clue how to get the preempted ISR number from the cortex-m core.~~

### Testing procedure

Use `tests/fault_handler` to trigger a hard fault and print the new line.

### Issues/PRs references

None