### PR TITLE
riotctrl_shell: simplify error case for cord registration info parser

### DIFF
--- a/dist/pythonlibs/riotctrl_shell/cord_ep.py
+++ b/dist/pythonlibs/riotctrl_shell/cord_ep.py
@@ -69,7 +69,7 @@ class CordEpRegistrationInfoParser(ShellInteractionParser):
                         res[key] = int(m.group(key))
                     except ValueError:
                         res[key] = m.group(key)
-        return res if bool(res) else None
+        return res
 
 
 class CordEpDiscoverParser(ShellInteractionParser):

--- a/dist/pythonlibs/riotctrl_shell/tests/test_cord_ep.py
+++ b/dist/pythonlibs/riotctrl_shell/tests/test_cord_ep.py
@@ -49,9 +49,9 @@ RD address: {proto}://[fe80::4494:71ff:fec4:9cac]{port}
 
 def test_cord_ep_parser_empty():
     reginfo_parser = riotctrl_shell.cord_ep.CordEpRegistrationInfoParser()
-    assert reginfo_parser.parse("") is None
+    assert not reginfo_parser.parse("")
     discover_parser = riotctrl_shell.cord_ep.CordEpDiscoverParser()
-    assert discover_parser.parse("") is None
+    assert not discover_parser.parse("")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The other shell parsers also just return an empty dictionary and it might solve the problem in https://github.com/RIOT-OS/Release-Specs/pull/190#pullrequestreview-462590634 in a much easier way :-)
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```
cd dist/pythonlibs/riotctrl_shell
tox
```

should succeed.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on #14715 and might help with an issue in https://github.com/RIOT-OS/Release-Specs/pull/190.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
