### PR TITLE
[take-over] boards/omote: add support for OMote board

### DIFF
--- a/boards/omote/Kconfig
+++ b/boards/omote/Kconfig
@@ -1,0 +1,19 @@
+# Copyright (C) 2020 Oppila Microsystems - http://www.oppila.in
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "omote" if BOARD_OMOTE
+
+config BOARD_OMOTE
+    bool
+    default y
+    select CPU_MODEL_CC2538SF53
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/omote/Makefile
+++ b/boards/omote/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/omote/Makefile.dep
+++ b/boards/omote/Makefile.dep
@@ -1,0 +1,9 @@
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += cc2538_rf
+endif
+
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+  USEMODULE += adxl345
+  USEMODULE += bmp180
+endif

--- a/boards/omote/Makefile.features
+++ b/boards/omote/Makefile.features
@@ -1,0 +1,10 @@
+CPU = cc2538
+CPU_MODEL = cc2538sf53
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart

--- a/boards/omote/Makefile.include
+++ b/boards/omote/Makefile.include
@@ -1,0 +1,5 @@
+# define the default port depending on the host OS
+PORT_LINUX  ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+include $(RIOTBOARD)/common/remote/Makefile.include

--- a/boards/omote/board.c
+++ b/boards/omote/board.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Oppila Microsystems - http://www.oppila.in
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_omote
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the omote board
+ * @}
+ */
+
+#include "board.h"
+#include "cpu.h"
+
+static inline void leds_init(void);
+
+void board_init(void)
+{
+    /* initialize the boards LEDs */
+    leds_init();
+    /* initialize the CPU */
+    cpu_init();
+    /* The boot pin must be set to input otherwise it may lock the bootloader */
+    gpio_init(BOOT_PIN, GPIO_IN);
+
+    gpio_init(BTN0_PIN, BTN0_MODE);
+}
+
+/**
+ * @brief Initialize the boards on-board LEDs
+ *
+ * The LED initialization is hard-coded in this function. As the LEDs are
+ * soldered onto the board they are fixed to their CPU pins.
+ */
+static inline void leds_init(void)
+{
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+}

--- a/boards/omote/doc.txt
+++ b/boards/omote/doc.txt
@@ -1,0 +1,101 @@
+/**
+@defgroup    boards_omote omote
+@ingroup     boards
+@brief       Support for the omote board
+
+Oppila Microsystems omote platform -  http://www.oppila.in
+
+The omote platform is a IoT Hardware development platform based
+on TI's CC2538 system on chip (SoC), featuring an ARM Cortex-M3 with 512KB
+flash, 32Kb RAM, 2.4GHz RF interface , and the
+following goodies:
+
+* ISM 2.4-GHz IEEE 802.15.4 & Zigbee compliant.
+* AES-128/256, SHA2 Hardware Encryption Engine.
+* ECC-128/256, RSA Hardware Acceleration Engine for Secure Key Exchange.
+* On board sensors LDR, ADXL345 and BMP180
+* Power input with wide range 3.7-30VDC.
+
+Port Features
+=============
+In terms of hardware support, the following drivers have been implemented:
+
+  * CC2538 System-on-Chip:
+    * UART
+    * General-Purpose Timers
+    * I2C/SPI library
+    * LEDs
+    * Buttons
+    * RF 2.4GHz built-in in CC2538
+
+Requirements
+============
+
+ * Toolchain to compile RIOT for the CC2538
+ * Drivers to enable your host to communicate with the platform
+
+Install a Toolchain
+-------------------
+The toolchain used to build is arm-gcc, to check if it is currently installed run:
+
+    $ arm-none-eabi-gcc -v
+    Using built-in specs.
+    COLLECT-GCC=arm-none-eabi-gcc
+    Target: arm-none-eabi
+    ...
+    ...
+    ...
+Thread model: single
+gcc version 8.2.1 20181213 (release) [gcc-8-branch revision 267074] (GNU Tools for Arm Embedded Processors 8-2018-q4-major)
+if not installed, install from <https://launchpad.net/gcc-arm-embedded>
+
+Drivers
+-------
+The omote features a CP2104 serial-to-USB module, the driver is commonly found in most OS, but if required it can be downloaded
+from <https://www.silabs.com/products/mcu/Pages/USBtoUARTBridgeVCPDrivers.aspx>
+
+### Device Enumerations
+For the UART, serial line settings are 115200 8N1, no flow control.
+
+Once all drivers have been installed correctly:
+
+On Windows, devices will appear as a virtual `COM` port.
+
+On Linux, devices will appear under `/dev/`.
+
+On macOS, `/dev/tty.SLAB_USBtoUARTx`.
+
+On Linux:
+
+* omote over CP2104: `ttyUSB0`
+
+##  Flashing and Debugging
+
+Currently RIOT supports flashing the omote using a Segger JLink JTAG
+adapter or via USB, using the bootloader on the board.
+
+### Flashing via JTAG
+
+To be able to flash the board via JTAG you need to install Seggers JFlashLite
+tool. Once you have this in place, you can simply flash by calling
+	$ JFlashLite
+### Flashing via USB
+
+The omote has built-in support to flash over USB using the BSL.It requires to unlock the bootloader by manually pressing the `BSL
+button` and `reset button`
+
+e.g
+
+```
+make BOARD=omote flash
+```
+
+The omote has 13 pinouts to connect boolean,digital and analog sensors based on I2C,UART,and SPI Protocols as well as other sensors or actuators you may need to connect.
+
+More Reading
+============
+1. [Oppila Microsystems omote website](http://www.oppila.in)
+2. [CC2538 System-on-Chip Solution for 2.4-GHz IEEE 802.15.4 and ZigBee applications (SWRU319B)][cc2538]
+
+[cc2538]: http://www.ti.com/product/cc2538     "CC2538"
+*/

--- a/boards/omote/include/adc_params.h
+++ b/boards/omote/include/adc_params.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ * Copyright (C) 2020 Oppila Microsystems - http://www.oppila.in
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_omote
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped ADC in omote
+ *
+ */
+
+#ifndef ADC_PARAMS_H
+#define ADC_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    ADC configuration
+ */
+static const  saul_adc_params_t saul_adc_params[] =
+{
+    {
+        .name = "ADC1",
+        .line = ADC_LINE(0),
+        .res  = ADC_RES_12BIT,
+    },
+    {
+        .name = "ADC2",
+        .line = ADC_LINE(1),
+        .res  = ADC_RES_12BIT,
+    },
+    {
+        .name = "ADC3",
+        .line = ADC_LINE(2),
+        .res  = ADC_RES_12BIT,
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_PARAMS_H */
+/** @} */

--- a/boards/omote/include/board.h
+++ b/boards/omote/include/board.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2020 Oppila Microsystems - http://www.oppila.in
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_omote
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the omote board
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph/gpio.h"
+#include "periph/spi.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @name LED pin definitions
+ * @{
+ */
+#define LED0_PIN        GPIO_PIN(3, 0)
+#define LED1_PIN        GPIO_PIN(3, 4)
+
+#define LED0_MASK       (1 << 0)
+#define LED1_MASK       (1 << 4)
+
+#define LED0_ON         (GPIO_D->DATA |=  LED0_MASK)
+#define LED0_OFF        (GPIO_D->DATA &= ~LED0_MASK)
+#define LED0_TOGGLE     (GPIO_D->DATA ^=  LED0_MASK)
+
+#define LED1_ON         (GPIO_B->DATA |=  LED1_MASK)
+#define LED1_OFF        (GPIO_B->DATA &= ~LED1_MASK)
+#define LED1_TOGGLE     (GPIO_B->DATA ^=  LED1_MASK)
+
+#define LED_ALL_OFF        LED0_OFF;   \
+                           LED1_OFF;
+#define LED_ALL_ON         LED0_ON;    \
+                           LED1_ON;
+/** @} */
+
+/**
+ * @name User button pin definition
+ * @{
+ */
+#define BTN0_PIN        GPIO_PIN(1, 0)
+#define BTN0_MODE       GPIO_IN_PU
+/** @} */
+
+/**
+ * @name Flash Customer Configuration Area (CCA) parameters
+ * @{
+ */
+#ifndef UPDATE_CCA
+#define UPDATE_CCA                (1)
+#endif
+#define CCA_BACKDOOR_ENABLE       (1)
+#define CCA_BACKDOOR_PORT_A_PIN   (3) /**< Select button */
+#define CCA_BACKDOOR_ACTIVE_LEVEL (0) /**< Active low */
+
+#define BOOT_PIN    GPIO_PIN(0, CCA_BACKDOOR_PORT_A_PIN) /**< BSL_BOOT Pin */
+/** @} */
+
+/**
+ * @name xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH        (16)
+#define XTIMER_BACKOFF      (50)
+#define XTIMER_ISR_BACKOFF  (40)
+/** @} */
+
+/**
+ * @name USB configuration
+ * @{
+ */
+#define INTERNAL_PERIPHERAL_VID         (0x0451)
+#define INTERNAL_PERIPHERAL_PID         (0x16C8)
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/omote/include/gpio_params.h
+++ b/boards/omote/include/gpio_params.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 Oppila Microsystems -  http://www.oppila.in
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_omote
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LED(green1)",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = 0x0,
+    },
+    {
+        .name  = "LED(green2)",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = 0x0,
+    },
+    {
+        .name  = "Button(User)",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/omote/include/periph_conf.h
+++ b/boards/omote/include/periph_conf.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2017 HAW Hamburg
+ *               2020 Oppila Microsystems -  http://www.oppila.in
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_omote
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the omote board
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "cc2538_gpio.h"
+#include "periph_cpu.h"
+
+#include "cfg_clk_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define SOC_ADC_ADCCON3_EREF  SOC_ADC_ADCCON3_EREF_AVDD5
+
+static const adc_conf_t adc_config[] = {
+    GPIO_PIN(PORT_A, 5), /**< GPIO_PA5 = ADC1_PIN,LDR sensor is connected */
+    GPIO_PIN(PORT_A, 4), /**< GPIO_PA4 = ADC2_PIN */
+    GPIO_PIN(PORT_A, 2), /**< GPIO_PA2 = ADC3_PIN */
+    GPIO_PIN(PORT_A, 6), /**< GPIO_PA6 = ADC4_PIN */
+    GPIO_PIN(PORT_A, 7), /**< GPIO_PA7 = ADC5_PIN */
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
+/**
+ * @name I2C configuration
+ * @{
+ */
+#define I2C_IRQ_PRIO            1
+
+static const i2c_conf_t i2c_config[] = {
+    {
+        .speed = I2C_SPEED_FAST,    /**< bus speed */
+        .scl_pin = GPIO_PIN(PORT_C, 3),  /**< GPIO_PC3 */
+        .sda_pin = GPIO_PIN(PORT_C, 2)   /**< GPIO_PC2 */
+    },
+};
+
+#define I2C_NUMOF               ARRAY_SIZE(i2c_config)
+/** @} */
+/**
+ * @name SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .num      = 0,
+        .mosi_pin = GPIO_PIN(PORT_C, 5),
+        .miso_pin = GPIO_PIN(PORT_C, 6),
+        .sck_pin  = GPIO_PIN(PORT_C, 4),
+        .cs_pin   = GPIO_PIN(PORT_A, 7)
+    }
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    /* UART0 is mapped to debug usb */
+    {
+        .dev      = UART0_BASEADDR,
+        .rx_pin   = GPIO_PIN(PORT_A, 0),
+        .tx_pin   = GPIO_PIN(PORT_A, 1),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .cts_pin  = GPIO_UNDEF,
+        .rts_pin  = GPIO_UNDEF
+#endif
+    },
+    {
+        .dev      = UART1_BASEADDR,
+        .rx_pin   = GPIO_PIN(PORT_C, 1),
+        .tx_pin   = GPIO_PIN(PORT_C, 0),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .cts_pin  = GPIO_UNDEF,
+        .rts_pin  = GPIO_UNDEF
+#endif
+    }
+};
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_uart0
+#define UART_1_ISR          isr_uart1
+
+/* macros common across all UARTs */
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -51,6 +51,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l412kb \
     nz32-sc151 \
     olimexino-stm32 \
+    omote \
     opencm904 \
     openmote-b \
     openmote-cc2538 \


### PR DESCRIPTION
# Take over PR from #14552
(see https://github.com/RIOT-OS/RIOT/pull/14552#issuecomment-669974743)
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- omote is a lightweight and powerful IOT development board which comes with 32 bit ARM cortex-M3 micro controller and IEEE 802.15.4 radio
-->Features

    • ARM cortex-M3 
    • Transceiver with PCB Antenna
    • on board sensors BMP180,ADXL345 and LDR
    • Programming over BSL
    • User LEDs and Power LEDs
    • User, BSL and reset Buttons 
    • on-board 3.3V and 5V Power output
    • Peripherals- UART, GPIO, I2C and SPI, ADC
    • RF 2.4GHz built-in in CC2538

sales@oppila.in – Oppila Microsystems pvt ltd Banglore

### Testing procedure

<!--
Details steps to test your contribution:
- The tool chain used to build is arm-gcc
        arm-none-eabi-gcc should be installed

The omote should be flashed over USB using the BSL. Bootloader should be unlocked by manually pressing the BSL button and reset button. board can be flashed using following command 

$make BOARD=omote flash 
-->
