### PR TITLE
drivers/periph_common: RTC: use RIOT_EPOCH as the RTC reset value

### DIFF
--- a/cpu/lpc23xx/periph/rtc.c
+++ b/cpu/lpc23xx/periph/rtc.c
@@ -57,7 +57,7 @@ void rtc_init(void)
      * after cold boot or external reset.
      */
     if ((RSIR == RSIR_POR) || (RSIR == (RSIR_POR | RSIR_EXTR))) {
-        struct tm localt = { .tm_year = 70 };
+        struct tm localt = { .tm_year = RIOT_EPOCH - 1900 };
         rtc_set_time(&localt);
     }
 

--- a/cpu/sam0_common/periph/rtc_rtt.c
+++ b/cpu/sam0_common/periph/rtc_rtt.c
@@ -62,9 +62,10 @@ static rtc_state_t alarm_cb;
 static rtc_state_t overflow_cb;
 
 /* At 1Hz, RTC goes till 63 years (2^5, see 17.8.22 in datasheet)
-* reference_year is set to 100 (offset) to be in our current time (2000)
-* Thanks to this, the user will be able to set time in 2000's*/
-static uint16_t reference_year = 100;
+ * struct tm younts the year since 1900, use the difference to RIOT_EPOCH
+ * as an offset so the user can set years in RIOT_EPOCH + 63
+ */
+static uint16_t reference_year = RIOT_EPOCH - 1900;
 
 static void _wait_syncbusy(void)
 {

--- a/cpu/stm32/periph/rtc_all.c
+++ b/cpu/stm32/periph/rtc_all.c
@@ -163,9 +163,8 @@
 #error "rtc: unable to determine RTC SYNC and ASYNC prescalers from LSI value"
 #endif
 
-/* struct tm counts years since 1900 but RTC has only two-digit year hence the
- * offset of 100 years. */
-#define YEAR_OFFSET         (100)
+/* struct tm counts years since 1900 but RTC has only two-digit year, hence the offset */
+#define YEAR_OFFSET         (RIOT_EPOCH - 1900)
 
 /* Use a magic number to determine the initial RTC source. This will be used
    to know if a reset of the RTC is required at initialization. */
@@ -273,7 +272,7 @@ int rtc_set_time(struct tm *time)
 
     rtc_unlock();
 
-    RTC->DR = (val2bcd((time->tm_year % 100), RTC_DR_YU_Pos, DR_Y_MASK) |
+    RTC->DR = (val2bcd((time->tm_year - YEAR_OFFSET), RTC_DR_YU_Pos, DR_Y_MASK) |
                val2bcd(time->tm_mon + 1,  RTC_DR_MU_Pos, DR_M_MASK) |
                val2bcd(time->tm_mday, RTC_DR_DU_Pos, DR_D_MASK));
     RTC->TR = (val2bcd(time->tm_hour, RTC_TR_HU_Pos, TR_H_MASK) |

--- a/drivers/include/periph/rtc.h
+++ b/drivers/include/periph/rtc.h
@@ -46,6 +46,18 @@
 extern "C" {
 #endif
 
+#if !defined(RIOT_EPOCH) || DOXYGEN
+/**
+ * @brief Earliest year of the RTC
+ *
+ * 01.01.$RIOT_EPOCH will be the reset value of the RTC if supported.
+ *
+ * Internal RTC helper functions such as @see rtc_mktime and @see rtc_localtime
+ * will not work on dates earlier than that.
+ */
+#define RIOT_EPOCH (2020)
+#endif
+
 /**
  * @brief Signature for alarm Callback
  *

--- a/drivers/periph_common/rtc.c
+++ b/drivers/periph_common/rtc.c
@@ -31,10 +31,6 @@
 #define HOUR    (60U * MINUTE)
 #define DAY     (24U * HOUR)
 
-#ifndef RIOT_EPOCH
-#define RIOT_EPOCH (2020)
-#endif
-
 /*
  * The rules here are (to be checked in that explicit order):
  *  1. If the year is not a multiple of four, it is not a leap year.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

RTC implementations based on a RTT and using the `rtc_` helper functions will already start counting at `RIOT_EPOCH`.
'Real' RTCs only have a limited range and will thus use an offset that makes them either start counting at 1970 or 2000.

This PR makes them calculate the offset based on `RIOT_EPOCH`, so all RTC implementations will start counting with the same reset value.

### Testing procedure

`tests/periph_rtc` should still work.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
