### PR TITLE
cpu/esp32: remove the dependency of vendor code on BOARDDIR

### DIFF
--- a/cpu/esp32/include/sdk_conf.h
+++ b/cpu/esp32/include/sdk_conf.h
@@ -24,8 +24,6 @@
 
 #ifndef DOXYGEN
 
-#include "board.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/cpu/esp32/vendor/esp-idf/include/esp32/esp_system.h
+++ b/cpu/esp32/vendor/esp-idf/include/esp32/esp_system.h
@@ -18,7 +18,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "esp_err.h"
-#include "esp_sleep.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/port/Makefile
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/port/Makefile
@@ -11,7 +11,6 @@ CFLAGS += -D__ets__
 
 include $(RIOTCPU)/$(CPU)/Makefile.include
 
-INCLUDES += -I$(BOARDDIR)/include
 INCLUDES += -I$(RIOTBASE)/core/include
 INCLUDES += -I$(RIOTBASE)/drivers/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/Makefile
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/Makefile
@@ -16,4 +16,3 @@ include $(RIOTCPU)/$(CPU)/Makefile.include
 INCLUDES += -I$(RIOTBASE)/core/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/log
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
-INCLUDES += -I$(BOARDDIR)/include

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/wpa2/eap_peer/Makefile
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/wpa2/eap_peer/Makefile
@@ -17,4 +17,3 @@ include $(RIOTCPU)/$(CPU)/Makefile.include
 INCLUDES += -I$(RIOTBASE)/core/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/log
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
-INCLUDES += -I$(BOARDDIR)/include

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/wpa2/tls/Makefile
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/wpa2/tls/Makefile
@@ -16,4 +16,3 @@ include $(RIOTCPU)/$(CPU)/Makefile.include
 INCLUDES += -I$(RIOTBASE)/core/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/log
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
-INCLUDES += -I$(BOARDDIR)/include

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/wpa2/utils/Makefile
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/wpa2/utils/Makefile
@@ -16,4 +16,3 @@ include $(RIOTCPU)/$(CPU)/Makefile.include
 INCLUDES += -I$(RIOTBASE)/core/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/log
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
-INCLUDES += -I$(BOARDDIR)/include


### PR DESCRIPTION
### Contribution description

This PR removes  the dependency of vendor code on `BOARDDIR`.

### Testing procedure

Compilation of the vendor code `wpa_supplicant` shoudl succeed.
```
CFLAGS='-DESP_WIFI_EAP_USER=\"user\" -DESP_WIFI_EAP_PASS=\"password\"' USEMODULE=esp_wifi_enterprise make BOARD=esp32-wroom-32 -C examples/gnrc_networking
```

### Issues/PRs references

Caused problems in PR #14490 