### PR TITLE
boards/feather-m0: separate directory for the wifi version

### DIFF
--- a/boards/feather-m0-wifi/Kconfig
+++ b/boards/feather-m0-wifi/Kconfig
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "feather-m0-wifi" if BOARD_FEATHER_M0_WIFI
+
+config BOARD_FEATHER_M0_WIFI
+    bool
+    default y
+    select CPU_MODEL_SAMD21G18A
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_BOOTLOADER_ARDUINO

--- a/boards/feather-m0-wifi/Makefile
+++ b/boards/feather-m0-wifi/Makefile
@@ -1,0 +1,2 @@
+DIRS = $(RIOTBOARD)/feather-m0
+include $(RIOTBASE)/Makefile.base

--- a/boards/feather-m0-wifi/Makefile.dep
+++ b/boards/feather-m0-wifi/Makefile.dep
@@ -1,0 +1,5 @@
+ifneq (,$(filter netdev_default,$(USEMODULE)))
+  USEMODULE += atwinc15x0
+endif
+
+include $(RIOTBOARD)/feather-m0/Makefile.dep

--- a/boards/feather-m0-wifi/Makefile.features
+++ b/boards/feather-m0-wifi/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/feather-m0/Makefile.features

--- a/boards/feather-m0-wifi/Makefile.include
+++ b/boards/feather-m0-wifi/Makefile.include
@@ -1,0 +1,2 @@
+INCLUDES  += -I$(RIOTBOARD)/feather-m0/include
+include $(RIOTBOARD)/feather-m0/Makefile.include

--- a/boards/feather-m0-wifi/doc.txt
+++ b/boards/feather-m0-wifi/doc.txt
@@ -1,0 +1,12 @@
+/**
+@defgroup    boards_feather-m0-wifi Adafruit Feather M0 WiFi
+@ingroup     boards
+@brief       Support for the Adafruit Feather M0 WiFi.
+
+### General information
+
+The board is a variant of the @ref boards_feather-m0 board with
+a WiFi interface on board. Please see @ref boards_feather-m0 for detailed
+information about the board and how to flash it.
+
+*/

--- a/boards/feather-m0/Makefile.dep
+++ b/boards/feather-m0/Makefile.dep
@@ -2,12 +2,6 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
 
-ifneq (,$(filter feather-m0-wifi,$(USEMODULE)))
-  ifneq (,$(filter netdev_default,$(USEMODULE)))
-    USEMODULE += atwinc15x0
-  endif
-endif
-
 # use arduino-bootloader only if no other stdio_% other than stdio_cdc_acm
 # is requested
 ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_% slipdev_stdio,$(USEMODULE))))

--- a/boards/feather-m0/Makefile.include
+++ b/boards/feather-m0/Makefile.include
@@ -1,5 +1,3 @@
-PSEUDOMODULES += feather-m0-wifi
-
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 

--- a/boards/feather-m0/doc.txt
+++ b/boards/feather-m0/doc.txt
@@ -55,12 +55,11 @@ Example with `hello-world` application:
 ### Using the WiFi interface
 
 To enable the WiFi interface of the Feather M0 WiFi variant of the board
-automatically for networking applications, add `USEMODULE=atwin1x0` to
-the `make` command and define the required parameters, for example:
+automatically for networking applications, use `feather-m0-wifi` as board
+and define the required WiFi parameters, for example:
 ```
-     USEMODULE='feather-m0-wifi' \
      CFLAGS='-DWIFI_SSID=\"<ssid>\" -DWIFI_PASS=\"<pass>\"' \
-     make BOARD=feather-m0 -C examples/gnrc_networking
+     make BOARD=feather-m0-wifi -C examples/gnrc_networking
 ```
 
 For detailed information about the parameters, see section

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -19,6 +19,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     esp8266-olimex-mod \
     esp8266-sparkfun-thing \
     feather-m0 \
+    feather-m0-wifi \
     firefly \
     hamilton \
     i-nucleo-lrwan1 \

--- a/tests/bench_xtimer/Makefile
+++ b/tests/bench_xtimer/Makefile
@@ -25,6 +25,7 @@ LOW_MEMORY_BOARDS += \
   chronos \
   derfmega128 \
   feather-m0 \
+  feather-m0-wifi \
   hifive1 \
   hifive1b \
   i-nucleo-lrwan1 \


### PR DESCRIPTION
### Contribution description

This PR moves the board definition for the Feather M0 WiFi board to a separate board directory `feather-m0-wifi` to cover it by the CI.

Since the only difference between `feather-m0-wifi` and `feather-m0` is the WiFi module on board, the `feather-m0-wifi` board definition just enables the driver module for the WiFi interface but inclueds anything else from the `feather-m0` board definition. With this approach, `feather-m0-wifi` looks like a board definition but without any code duplicaion. The only exception is the `Kconfig` file.

### Testing procedure

Compilation of `examples/gnrc_networking` for `feather-m0-wifi` should still succeed.
```
make BOARD=feather-m0-wifi -C examples/gnrc_networking
```

### Issues/PRs references

Solves the the problem discussed in issue #14681 for `feather-m0-wifi`.