### PR TITLE
CODING_CONVENTIONS.md: default to C11

### DIFF
--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -2,7 +2,7 @@
 
 ## General
 
-* Code shall be [C99](http://www.open-std.org/jtc1/sc22/WG14/www/docs/n1256.pdf)
+* Code shall be [C11](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf)
   compliant.
 * Avoid dynamic memory allocation (malloc/free, new, etc.)! It will break
   real-time guarantees, increase code complexity, and make it more likely to use

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -23,7 +23,7 @@ export GPROF ?= gprof
 CFLAGS += -Wall -Wextra -pedantic $(CFLAGS_DBG)
 CFLAGS_DBG ?= -g3
 
-# default std set to gnu99 of not overwritten by user
+# default std set to gnu11 if not overwritten by user
 ifeq (,$(filter -std=%, $(CFLAGS)))
   CFLAGS += -std=gnu11
 endif

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -1,8 +1,8 @@
 # Test if the input language was specified externally.
-# Otherwise test if the compiler unterstands the "-std=c99" flag, and use it if so.
+# Otherwise test if the compiler unterstands the "-std=c11" flag, and use it if so.
 ifeq ($(filter -std=%,$(CFLAGS)),)
-  ifeq ($(shell $(CC) -std=c99 -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-    CFLAGS += -std=c99
+  ifeq ($(shell $(CC) -std=c11 -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+    CFLAGS += -std=c11
   endif
 endif
 

--- a/pkg/relic/Makefile
+++ b/pkg/relic/Makefile
@@ -29,7 +29,7 @@ $(PKG_BUILD_DIR)/lib/librelic_s.a: $(PKG_BUILD_DIR)/Makefile
 
 # Pass 'COMP' with a target specific export to not have issues with the shell
 # escaping evaluation.
-COMP = $(filter-out -Werror -Werror=old-style-definition -Werror=strict-prototypes -std=gnu99,$(CFLAGS))
+COMP = $(filter-out -Werror -Werror=old-style-definition -Werror=strict-prototypes -std=gnu11,$(CFLAGS))
 $(PKG_BUILD_DIR)/Makefile: export COMP ?=
 $(PKG_BUILD_DIR)/Makefile: $(PKG_PREPARED) $(TOOLCHAIN_FILE) | ..cmake_version_supported
 	cmake -B$(PKG_BUILD_DIR) -H$(PKG_SOURCE_DIR) \


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The standard is 9 years old now, it is well supported in all major compilers.
In fact, features of the 'new' standard are already used in RIOT (std_atomic).

Let's make it the default and adapt the Makefiles accordingly.

### Testing procedure

Murdock will ensure everything compiles with the new flags. 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
