### PR TITLE
gh-actions: rename release test artifacts

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -120,7 +120,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       if: always()
       with:
-        name: Upload test report
+        name: Test Reports
         path: test-reports/*
   iotlab-tasks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Turns out: the name of the "upload artifact" action is the name of the artifacts, so naming it "Upload test reports" is [a bit confusing](https://github.com/RIOT-OS/RIOT/actions/runs/199999175).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Action should still work.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
