### PR TITLE
cpu/fe310: add unified rtt configuration

### DIFF
--- a/boards/hifive1/include/periph_conf.h
+++ b/boards/hifive1/include/periph_conf.h
@@ -169,17 +169,6 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name    RTT/RTC configuration
- *
- * @{
- */
-#define RTT_FREQUENCY               (1)             /* in Hz */
-#define RTT_MAX_VALUE               (0xFFFFFFFF)
-#define RTT_INTR_PRIORITY           (2)
-
-/** @} */
-
-/**
  * @name    PWM configuration
  *
  * @{

--- a/boards/hifive1b/include/periph_conf.h
+++ b/boards/hifive1b/include/periph_conf.h
@@ -170,17 +170,6 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
- * @name    RTT/RTC configuration
- *
- * @{
- */
-#define RTT_FREQUENCY               (1)             /* in Hz */
-#define RTT_MAX_VALUE               (0xFFFFFFFF)
-#define RTT_INTR_PRIORITY           (2)
-
-/** @} */
-
-/**
  * @name    PWM configuration
  *
  * @{

--- a/cpu/fe310/include/periph_cpu.h
+++ b/cpu/fe310/include/periph_cpu.h
@@ -160,6 +160,25 @@ typedef struct {
  */
 #define WDT_HAS_STOP                    (1)
 
+/**
+ * @name    RTT/RTC configuration
+ *
+ * @{
+ */
+#define RTT_INTR_PRIORITY   (2)
+
+#define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_CLOCK_FREQUENCY (32768U)                /* in Hz */
+#define RTT_MAX_FREQUENCY   (RTT_CLOCK_FREQUENCY)   /* in Hz */
+#define RTT_MIN_FREQUENCY   (1U)                    /* in Hz */
+
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (RTT_MAX_FREQUENCY)     /* in Hz */
+#endif
+
+
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/fe310/periph/rtt.c
+++ b/cpu/fe310/periph/rtt.c
@@ -37,41 +37,12 @@
 #include "debug.h"
 
 /* Convert RTT freq to pre-scaler value */
-#if (RTT_FREQUENCY == 32768)
-#define RTT_SCALE       (0)
-#elif (RTT_FREQUENCY == 16384)
-#define RTT_SCALE       (1)
-#elif (RTT_FREQUENCY == 8192)
-#define RTT_SCALE       (2)
-#elif (RTT_FREQUENCY == 4096)
-#define RTT_SCALE       (3)
-#elif (RTT_FREQUENCY == 2048)
-#define RTT_SCALE       (4)
-#elif (RTT_FREQUENCY == 1024)
-#define RTT_SCALE       (5)
-#elif (RTT_FREQUENCY == 512)
-#define RTT_SCALE       (6)
-#elif (RTT_FREQUENCY == 256)
-#define RTT_SCALE       (7)
-#elif (RTT_FREQUENCY == 128)
-#define RTT_SCALE       (8)
-#elif (RTT_FREQUENCY == 64)
-#define RTT_SCALE       (9)
-#elif (RTT_FREQUENCY == 32)
-#define RTT_SCALE       (10)
-#elif (RTT_FREQUENCY == 16)
-#define RTT_SCALE       (11)
-#elif (RTT_FREQUENCY == 8)
-#define RTT_SCALE       (12)
-#elif (RTT_FREQUENCY == 4)
-#define RTT_SCALE       (13)
-#elif (RTT_FREQUENCY == 2)
-#define RTT_SCALE       (14)
-#elif (RTT_FREQUENCY == 1)
-#define RTT_SCALE       (15)
-#else
+#ifdef RTT_FREQUENCY
+#if ((RTT_CLOCK_FREQUENCY % RTT_FREQUENCY) != 0)
 #error "Invalid RTT_FREQUENCY: Must be power of 2"
 #endif
+#endif
+#define RTT_SCALE __builtin_ctz(RTT_CLOCK_FREQUENCY / RTT_FREQUENCY)
 
 typedef struct {
     uint32_t alarm_val;     /**< cached alarm val */
@@ -161,8 +132,14 @@ void rtt_set_counter(uint32_t counter)
      * Must program HI/LO regs
      * Write scaled counter reg value
      */
-    AON_REG(AON_RTCLO) = counter << RTT_SCALE;
-    AON_REG(AON_RTCHI) = counter >> (32 - RTT_SCALE);
+    /* Use ifdef to avoid out of bound shift when RTT_SCALE == 0 */
+#if RTT_CLOCK_FREQUENCY == RTT_FREQUENCY
+        AON_REG(AON_RTCLO) = counter;
+        AON_REG(AON_RTCHI) = 0;
+#else
+        AON_REG(AON_RTCLO) = counter << RTT_SCALE;
+        AON_REG(AON_RTCHI) = counter >> (32 - RTT_SCALE);
+#endif
 }
 
 void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)


### PR DESCRIPTION
### Contribution description

This PR is split from https://github.com/RIOT-OS/RIOT/pull/13874. It unifies `rtt` configuration for `fe310` and make the `RTT_FREQUENCY` configurable.

As in #13874 max and min values for the RTT are documented.

### Testing procedure

- `BOARD=hifive1b make -C tests/periph_rtt flash test --no-print-directory -j3`

```
Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2020.10-devel-670-g8114da-pr_fe310_configurable_rtt)

RIOT RTT low-level driver test
This test will display 'Hello' every 5 seconds

Initializing the RTT driver
RTT now: 11
Setting initial alarm to now + 5 s (163851)
Done setting up the RTT, wait for many Hellos
Hello
Hello
Hello
Hello
Hello
```

- `CFLAGS+=-DRTT_FREQUENCY=1 BOARD=hifive1b make -C tests/periph_rtt clean flash test --no-print-directory -j3`

```
Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2020.10-devel-670-g8114da-pr_fe310_configurable_rtt)

RIOT RTT low-level driver test
This test will display 'Hello' every 5 seconds

Initializing the RTT driver
RTT now: 0
Setting initial alarm to now + 5 s (5)
Done setting up the RTT, wait for many Hellos
Hello
Hello
Hello
Hello
Hello
```

### Issues/PRs references

Closes #13874.
