### PR TITLE
tests/[xz]timer_msg: check result of thread_create()

### DIFF
--- a/tests/xtimer_msg/main.c
+++ b/tests/xtimer_msg/main.c
@@ -28,6 +28,8 @@
 #include "thread.h"
 #include "msg.h"
 
+#include "test_utils/expect.h"
+
 char timer_stack[THREAD_STACKSIZE_DEFAULT];
 char timer_stack_local[THREAD_STACKSIZE_DEFAULT];
 
@@ -103,6 +105,8 @@ int main(void)
                   NULL,
                   "timer");
 
+    expect(pid_is_valid(pid));
+
     puts("sending 1st msg");
     m.content.ptr = &msg_a;
     msg_try_send(&m, pid);
@@ -119,6 +123,8 @@ int main(void)
                    timer_thread_local,
                    NULL,
                    "timer local");
+
+    expect(pid_is_valid(pid2));
 
     while (1) {
         xtimer_sleep(1);

--- a/tests/ztimer_msg/main.c
+++ b/tests/ztimer_msg/main.c
@@ -29,6 +29,8 @@
 #include "msg.h"
 #include "timex.h"
 
+#include "test_utils/expect.h"
+
 #ifdef MODULE_ZTIMER_MSEC
 #define ZTIMER ZTIMER_MSEC
 #define TICKS_PER_SEC MS_PER_SEC
@@ -112,6 +114,8 @@ int main(void)
                   NULL,
                   "timer");
 
+    expect(pid_is_valid(pid));
+
     puts("sending 1st msg");
     m.content.ptr = &msg_a;
     msg_try_send(&m, pid);
@@ -128,6 +132,8 @@ int main(void)
                    timer_thread_local,
                    NULL,
                    "timer local");
+
+    expect(pid_is_valid(pid2));
 
     while (1) {
         ztimer_sleep(ZTIMER, 1 * TICKS_PER_SEC);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fix unchecked returns in thread_create().

Found by [Coverty Scan](https://scan3.coverity.com/reports.htm#v46933/p10250/fileInstanceId=38361860&defectInstanceId=9794081&mergedDefectId=298337) (only accessible if you're part of the project there).

I fixed the two tests identically, as they serve as comparison for ram/code usage between ztimer and xtimer.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
