### PR TITLE
 gnrc_sixlowpan_iphc: fix issues found by Coverity scan

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -417,7 +417,7 @@ static size_t _iphc_ipv6_decode(const uint8_t *iphc_hdr,
                 ipv6_hdr->dst.u8[1] = iphc_hdr[payload_offset++];
                 ipv6_hdr->dst.u8[2] = iphc_hdr[payload_offset++];
                 ipv6_hdr->dst.u8[3] = ctx->prefix_len;
-                ipv6_addr_init_prefix((ipv6_addr_t *)ipv6_hdr->dst.u8 + 4,
+                ipv6_addr_init_prefix((ipv6_addr_t *)(ipv6_hdr->dst.u8 + 4),
                                       &ctx->prefix, ctx->prefix_len);
                 memcpy(ipv6_hdr->dst.u8 + 12, iphc_hdr + payload_offset + 2, 4);
 

--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -1033,9 +1033,9 @@ static size_t _iphc_ipv6_encode(gnrc_pktsnip_t *pkt,
             iphc_hdr[inline_pos++] = (uint8_t)((ipv6_hdr_get_fl(ipv6_hdr) & 0x000f0000) >> 16);
         }
 
-        /* copy remaining byteos of flow label */
+        /* copy remaining bytes of flow label */
         iphc_hdr[inline_pos++] = (uint8_t)((ipv6_hdr_get_fl(ipv6_hdr) & 0x0000ff00) >> 8);
-        iphc_hdr[inline_pos++] = (uint8_t)((ipv6_hdr_get_fl(ipv6_hdr) & 0x000000ff) >> 8);
+        iphc_hdr[inline_pos++] = (uint8_t)(ipv6_hdr_get_fl(ipv6_hdr) & 0x000000ff);
     }
 
     /* check for compressible next header */


### PR DESCRIPTION
### Contribution description

These two look like typos:

- [Out-of-bounds read](https://scan3.coverity.com/reports.htm#v46910/p10250/fileInstanceId=38359631&defectInstanceId=9793718&mergedDefectId=298279)
- [result_independent_of_operands](https://scan3.coverity.com/reports.htm#v46910/p10250/fileInstanceId=38359631&defectInstanceId=9793843&mergedDefectId=298295)


### Testing procedure

Not sure what tests apply, but this was likely not covered by a test before.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
