### PR TITLE
gh-actions: bucket test-on-iotlab artifacts to one ZIP

### DIFF
--- a/.github/workflows/test-on-iotlab.yml
+++ b/.github/workflows/test-on-iotlab.yml
@@ -113,14 +113,14 @@ jobs:
       - name: Run compile_and_test_for_board.py on ${{ matrix.boards.riot }}
         run: |
           ${COMPILE_AND_TEST_FOR_BOARD} . ${{ matrix.boards.riot }} \
-            results-${{ matrix.boards.riot }} ${COMPILE_AND_TEST_ARGS}
+            test-results ${COMPILE_AND_TEST_ARGS}
       - name: Stop IoT-LAB experiment
         if: always()
         run: iotlab-experiment stop -i ${IOTLAB_EXP_ID}
       - name: Archive results
         if: always()
-        # Store generated results-<riot board name> artifact
+        # Store generated test-results artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.boards.riot }}
-          path: results-${{ matrix.boards.riot }}
+          name: Test Results
+          path: test-results/*


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Don't know if this it was intended to separate the results in separate ZIP files, but I find it annoying that I have to download each report separately (then I can also just click through the web output... :-P). This PR moves everything in one big ZIP, like I do for the release-tests.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
I can start an action on my repo if it helps.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
