### PR TITLE
nanocoap: validate input with NDEBUG

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -377,6 +377,11 @@ int coap_get_blockopt(coap_pkt_t *pkt, uint16_t option, uint32_t *blknum, unsign
         return -1;
     }
 
+    if (option_len > 4) {
+        DEBUG("nanocoap: invalid option length\n");
+        return -1;
+    }
+
     uint32_t blkopt = _decode_uint(data_start, option_len);
 
     DEBUG("nanocoap: blkopt len: %i\n", option_len);


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

A malformed or malicious CoAP request may contain invalid field lengths.
`nanocoap` protects with this by using `assert()`, which safely crashes the application in debug mode.

In release mode the check is removed.

Instead of allowing arbitrary memory writes, return 0 on invalid inputs.

Discovered by [Coverity](https://scan3.coverity.com/reports.htm#v46910/p10250/fileInstanceId=38357789&defectInstanceId=9793779&mergedDefectId=297306):

> CID 297306 (#1 of 1): Untrusted value as argument (TAINTED_SCALAR)
> 4. tainted_data: Passing tainted variable option_len to a tainted sink.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
