### PR TITLE
examples/lorawan: fix typo in automatic test script

### DIFF
--- a/examples/lorawan/tests/01-run.py
+++ b/examples/lorawan/tests/01-run.py
@@ -21,7 +21,7 @@ def testfunc(child):
         child.expect_exact("Sending: This is RIOT!")
         time.sleep(20)
 
-    print("TESST PASSED")
+    print("TEST PASSED")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing an obvious typo in the Python test script used to test the `examples/lorawan` application.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Build, flash and test the `examples/lorawan` application.

on master, you would get this (copy-pasted from https://github.com/RIOT-OS/RIOT/pull/14547#issuecomment-671859348)

```
LoRaWAN Class A low-power application
=====================================
Starting join procedure
Join procedure succeeded
Sending: This is RIOT!
Sending: This is RIOT!
Sending: This is RIOT!
Sending: This is RIOT!
Sending: This is RIOT!
TESST PASSED
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Noticed that when I read https://github.com/RIOT-OS/RIOT/pull/14547#issuecomment-671859348

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
