### PR TITLE
drivers/sps30: Update units of measurement

### DIFF
--- a/drivers/include/sps30.h
+++ b/drivers/include/sps30.h
@@ -91,15 +91,15 @@ typedef struct {
  *
  */
 typedef struct {
-    float mc_pm1;       /**< Mass concentration of PM 1.0 [µg/m^3] */
-    float mc_pm2_5;     /**< Mass concentration of PM 2.5 [µg/m^3] */
-    float mc_pm4;       /**< Mass concentration of PM 4.0 [µg/m^3] */
-    float mc_pm10;      /**< Mass concentration of PM 10 [µg/m^3] */
-    float nc_pm0_5;     /**< Number concentration of PM 0.5 [µg/m^3] */
-    float nc_pm1;       /**< Number concentration of PM 1.0 [µg/m^3] */
-    float nc_pm2_5;     /**< Number concentration of PM 2.5 [µg/m^3] */
-    float nc_pm4;       /**< Number concentration of PM 4.0 [µg/m^3] */
-    float nc_pm10;      /**< Number concentration of PM 10 [µg/m^3] */
+    float mc_pm1;       /**< Mass concentration of all particles <= 1µm [µg/m^3] */
+    float mc_pm2_5;     /**< Mass concentration of all particles <= 2.5µm [µg/m^3] */
+    float mc_pm4;       /**< Mass concentration of all particles <= 4µm [µg/m^3] */
+    float mc_pm10;      /**< Mass concentration of all particles <= 10µm [µg/m^3] */
+    float nc_pm0_5;     /**< Number concentration of all particles <= 0.5µm [#/cm^3] */
+    float nc_pm1;       /**< Number concentration of all particles <= 1µm [#/cm^3] */
+    float nc_pm2_5;     /**< Number concentration of all particles <= 2.5µm [#/cm^3] */
+    float nc_pm4;       /**< Number concentration of all particles <= 4µm [#/cm^3] */
+    float nc_pm10;      /**< Number concentration of all particles <= 10µm [#/cm^3] */
     float ps;           /**< Typical particle size [µm] */
 } sps30_data_t;
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
The units for Sensirion SPS30 sensor for number_concentration of particles were improperly mentioned as µg/m^3. Corrected them to the correct #/cm^3.

[Sensirion SPS30 Datasheet](https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/9.6_Particulate_Matter/Datasheets/Sensirion_PM_Sensors_SPS30_Datasheet.pdf)

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
No tests required since only comments updated

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
