### PR TITLE
makefiles/info-global.inc.mk: include FEATURES_CONFLICTS

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -176,6 +176,7 @@ include $(RIOTMAKE)/dependencies_debug.inc.mk
 GLOBAL_GOALS += buildtest \
                 buildtest-indocker \
                 info-boards-features-blacklisted \
+                info-boards-features-conflicting \
                 info-boards-features-missing \
                 info-boards-supported \
                 info-buildsizes info-buildsizes-diff \

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -3,6 +3,7 @@
         info-boards-supported \
         info-boards-features-missing \
         info-boards-features-blacklisted \
+        info-boards-features-conflicting \
         #
 
 BOARDDIR_GLOBAL := $(BOARDDIR)
@@ -66,6 +67,11 @@ define board_unsatisfied_features
       BOARDS_FEATURES_USED_BLACKLISTED += "$$(BOARD) $$(FEATURES_USED_BLACKLISTED)"
       BOARDS_WITH_BLACKLISTED_FEATURES += $$(BOARD)
     endif
+
+    ifneq (,$$(FEATURES_CONFLICTING))
+      BOARDS_FEATURES_CONFLICTING += "$$(BOARD) $$(FEATURES_CONFLICTING)"
+      BOARDS_WITH_CONFLICTING_FEATURES += $$(BOARD)
+    endif
   endif
 
   ifneq (,$$(DEPENDENCY_DEBUG))
@@ -80,9 +86,13 @@ BOARDS_WITH_MISSING_FEATURES :=
 BOARDS_FEATURES_MISSING :=
 BOARDS_WITH_BLACKLISTED_FEATURES :=
 BOARDS_FEATURES_USED_BLACKLISTED :=
+BOARDS_FEATURES_CONFLICTING :=
+BOARDS_WITH_CONFLICTING_FEATURES :=
 
 $(foreach board,$(BOARDS),$(eval $(call board_unsatisfied_features,$(board))))
-BOARDS := $(filter-out $(BOARDS_WITH_MISSING_FEATURES) $(BOARDS_WITH_BLACKLISTED_FEATURES), $(BOARDS))
+BOARDS := $(filter-out $(BOARDS_WITH_MISSING_FEATURES) \
+                       $(BOARDS_WITH_BLACKLISTED_FEATURES) \
+                       $(BOARDS_WITH_CONFLICTING_FEATURES), $(BOARDS))
 
 info-buildsizes: SHELL=bash
 info-buildsizes:
@@ -123,6 +133,9 @@ info-boards-features-missing:
 
 info-boards-features-blacklisted:
 	@for f in $(BOARDS_FEATURES_USED_BLACKLISTED); do echo $${f}; done | column -t
+
+info-boards-features-conflicting:
+	@for f in $(BOARDS_FEATURES_CONFLICTING); do echo $${f}; done | column -t
 
 # Reset BOARDSDIR so unchanged for makefiles included after, for now only
 # needed for buildtests.inc.mk


### PR DESCRIPTION
### Contribution description

If there are FEATURES_CONFLICTING consider the application not supported for the BOARD.

### Testing procedure

https://github.com/RIOT-OS/RIOT/pull/14547 can be used to test that no `efm32` should be supported since there is a conflict between `rtt` and `rtc`. On master simply require `periph_rtt`.


- master

```
FEATURES_REQUIRED=periph_rtt make -C examples/lorawan/ info-boards-supported | grep slstk
arduino-mkr1000 arduino-mkrfox1200 arduino-mkrwan1300 arduino-mkrzero arduino-zero atmega256rfr2-xpro avr-rss2 avsextrem b-l072z-lrwan1 b-l475e-iot01a blackpill blackpill-128kib bluepill bluepill-128kib derfmega128 derfmega256 esp32-heltec-lora32-v2 esp32-mh-et-live-minikit esp32-olimex-evb esp32-ttgo-t-beam esp32-wemos-lolin-d32-pro esp32-wroom-32 esp32-wrover-kit esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing feather-m0 feather-m0-wifi fox frdm-k22f frdm-k64f frdm-kw41z hamilton hifive1 hifive1b i-nucleo-lrwan1 ikea-tradfri im880b iotlab-a8-m3 iotlab-m3 lobaro-lorabox lsn50 mcb2388 mega-xplained microduino-corerf msba2 mulle nucleo-f031k6 nucleo-f042k6 nucleo-f072rb nucleo-f091rc nucleo-f103rb nucleo-f207zg nucleo-f302r8 nucleo-f303k8 nucleo-f303re nucleo-f303ze nucleo-f334r8 nucleo-f401re nucleo-f410rb nucleo-f411re nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f446re nucleo-f446ze nucleo-f767zi nucleo-g474re nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nucleo-l432kc nucleo-l433rc nucleo-l452re nucleo-l476rg nucleo-l496zg nucleo-l4r5zi nz32-sc151 olimexino-stm32 openlabs-kw41z-mini openlabs-kw41z-mini-256kib p-l496g-cell02 p-nucleo-wb55 pba-d-01-kw2x phynode-kw41z pyboard samd21-xpro same54-xpro saml10-xpro saml11-xpro saml21-xpro samr21-xpro samr30-xpro samr34-xpro sensebox_samd21 serpente slstk3401a slstk3402a sltb001a slwstk6000b-slwrb4150a slwstk6000b-slwrb4162a sodaq-autonomo sodaq-explorer sodaq-one sodaq-sara-aff sodaq-sara-sff stk3600 stk3700 stm32f030f4-demo
```


- this pr

```
FEATURES_REQUIRED=periph_rtt make -C examples/lorawan/ info-boards-supported | grep slstk
#empty
```

Is there a reason not do do this ci wise? @kaspar030?

### Issues/PRs references

Found with https://github.com/RIOT-OS/RIOT/pull/14547.
