### PR TITLE
socket_zep: add support for SLEEP state

### DIFF
--- a/cpu/native/include/socket_zep.h
+++ b/cpu/native/include/socket_zep.h
@@ -23,6 +23,8 @@
 #ifndef SOCKET_ZEP_H
 #define SOCKET_ZEP_H
 
+#include <stdbool.h>
+
 #include "net/netdev.h"
 #include "net/netdev/ieee802154.h"
 #include "net/zep.h"
@@ -39,6 +41,7 @@ typedef struct {
     int sock_fd;                    /**< socket fd */
     netdev_event_t last_event;      /**< event triggered */
     uint32_t seq;                   /**< ZEP sequence number */
+    bool disabled;                  /**< simulate sleep */
     /**
      * @brief   Receive buffer
      */


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Add support for SLEEP and IDLE to socket_zep.
This allows the device to discard all incomming and outgoing
packets, simulating a sleeping transceiver.


### Testing procedure

When the interface is in the SLEEP state, it will neither receive nor send any frames.
```
ping6 ff02::1
12 bytes from fe80::25a:4550:a00:e0dd%7: icmp_seq=0 ttl=64 rssi=255 dBm time=2.293 ms
12 bytes from fe80::25a:4550:a00:b16e%7: icmp_seq=0 ttl=64 rssi=255 dBm time=3.484 ms (DUP!)
12 bytes from fe80::25a:4550:a00:b16e%7: icmp_seq=1 ttl=64 rssi=255 dBm time=3.104 ms
12 bytes from fe80::25a:4550:a00:e0dd%7: icmp_seq=1 ttl=64 rssi=255 dBm time=3.259 ms (DUP!)
12 bytes from fe80::25a:4550:a00:b16e%7: icmp_seq=2 ttl=64 rssi=255 dBm time=2.539 ms

--- ff02::1 PING statistics ---
3 packets transmitted, 3 packets received, 2 duplicates, 0% packet loss
round-trip min/avg/max = 2.293/2.935/3.484 ms
> ifconfig 7 set state sleep
ifconfig 7 set state sleep
success: set state of interface 7 to SLEEP
> ping6 ff02::1
ping6 ff02::1

--- ff02::1 PING statistics ---
3 packets transmitted, 0 packets received, 100% packet loss
> ifconfig 7 set state idle
ifconfig 7 set state idle
success: set state of interface 7 to IDLE
> ping6 ff02::1
ping6 ff02::1
12 bytes from fe80::25a:4550:a00:b16e%7: icmp_seq=0 ttl=64 rssi=255 dBm time=3.214 ms
12 bytes from fe80::25a:4550:a00:e0dd%7: icmp_seq=0 ttl=64 rssi=255 dBm time=3.399 ms (DUP!)
12 bytes from fe80::25a:4550:a00:b16e%7: icmp_seq=1 ttl=64 rssi=255 dBm time=2.901 ms
12 bytes from fe80::25a:4550:a00:e0dd%7: icmp_seq=1 ttl=64 rssi=255 dBm time=3.039 ms (DUP!)
12 bytes from fe80::25a:4550:a00:b16e%7: icmp_seq=2 ttl=64 rssi=255 dBm time=2.565 ms

--- ff02::1 PING statistics ---
3 packets transmitted, 3 packets received, 2 duplicates, 0% packet loss
round-trip min/avg/max = 2.565/3.023/3.399 ms
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
