### PR TITLE
socket_zep: fix reboot

### DIFF
--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -371,6 +371,9 @@ static void _zep_params_setup(char *zep_str, int zep)
 {
     char *save_ptr, *first_ep, *second_ep;
 
+    /* reboot uses execve() so we need to preserve argv */
+    zep_str = strdup(zep_str);
+
     if ((first_ep = strtok_r(zep_str, ",", &save_ptr)) == NULL) {
         usage_exit(EXIT_FAILURE);
     }


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The `_zep_params_setup()` function will modify the `argv` string passed to it.
This is a problem because that string is re-used on reboot.

The modified string is then later processed in `socket_zep_setup()`, so we have to keep the memory around.

~~The `strdup()` fulfills all this with the only downside that we now have a minor memory leak on every native reboot with ZEP.~~

~~IMHO as this is a pretty rare event and on `native` there is plenty of memory, a few bytes lost are not a big deal.~~

Reboot will call `execve` so all memory is freed.


### Testing procedure

On a `native` instance with `socket_zep`, type `reboot`.

#### master

```
reboot


		!! REBOOT !!

usage: /home/benpicco/dev/RIOT/examples/gnrc_border_router/bin/native/gnrc_border_router.elf <tap interface 1> [-i <id>] [-d] [-e|-E] [-o] [-c <tty>]
 -z [[<laddr>:<lport>,]<raddr>:<rport>]
 help: /home/benpicco/dev/RIOT/examples/gnrc_border_router/bin/native/gnrc_border_router.elf -h


Options:
    -h, --help
        print this help message
    -i <id>, --id=<id>
        specify instance id (set by config module)
    -s <seed>, --seed=<seed>
        specify srandom(3) seed (/dev/random is used instead of random(3) if
        the option is omitted)
    -d, --daemonize
        daemonize native instance
    -e, --stderr-pipe
        redirect stderr to file
    -E, --stderr-noredirect
        do not redirect stderr (i.e. leave sterr unchanged despite
        daemon/socket io)
    -o, --stdout-pipe
        redirect stdout to file (/tmp/riot.stdout.PID) when not attached
        to socket
    -c <tty>, --uart-tty=<tty>
        specify TTY device for UART. This argument can be used multiple
        times (up to UART_NUMOF)
    -z [<laddr>:<lport>,]<raddr>:<rport> --zep=[<laddr>:<lport>,]<raddr>:<rport>
        provide a ZEP interface with local address and port (<laddr>, <lport>)
        and remote address and port (default local: [::]:17754).
        Required to be provided SOCKET_ZEP_MAX times
make: *** [/home/benpicco/dev/RIOT/examples/gnrc_border_router/../../Makefile.include:728: term] Error 1
```

#### this PR

```
reboot


		!! REBOOT !!

RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

gnrc_uhcpc: Using 6 as border interface and 7 as wireless interface.
uhcp_client(): sending REQ...
got packet from fe80::2 port 12345
got packet from fe80::64e8:efff:fe02:ec3c port 48265
uhcp: push from fe80::64e8:efff:fe02:ec3c:48265 prefix=2001:db8::/64
gnrc_uhcpc: uhcp_handle_prefix(): add compression context 0 for prefix 2001:db8::25a:4550:a00:de49/64
gnrc_uhcpc: uhcp_handle_prefix(): configured new prefix 2001:db8::25a:4550:a00:de49/64
main(): This is RIOT! (Version: 2020.10-devel-715-g538fa-examples/gnrc_border_router-native)
RIOT border router example application
All up, running the shell now
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
