### PR TITLE
socket_zep: allow to specify MAC address of ZEP device

### DIFF
--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -16,6 +16,7 @@ endif
 ifneq (,$(filter socket_zep,$(USEMODULE)))
   USEMODULE += iolist
   USEMODULE += netdev_ieee802154
+  USEMODULE += netif
   USEMODULE += checksum
   USEMODULE += random
 endif

--- a/cpu/native/include/socket_zep.h
+++ b/cpu/native/include/socket_zep.h
@@ -54,10 +54,11 @@ typedef struct {
  * @brief   ZEP device initialization parameters
  */
 typedef struct {
-    char *local_addr;   /**< local address string */
-    char *local_port;   /**< local address string */
+    char *local_addr;   /**< local address string  */
+    char *local_port;   /**< local address string  */
     char *remote_addr;  /**< remote address string */
-    char *remote_port;  /**< local address string */
+    char *remote_port;  /**< local address string  */
+    char *mac_addr;     /**< EUI-64 address string */
 } socket_zep_params_t;
 
 /**

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -268,23 +268,26 @@ void usage_exit(int status)
         real_printf(" <tap interface %d>", i + 1);
     }
 #endif
-    real_printf(" [-i <id>] [-d] [-e|-E] [-o] [-c <tty>]\n");
+    real_printf(" [-i <id>] [-d] [-e|-E] [-o] [-c <tty>]");
 #ifdef MODULE_PERIPH_GPIO_LINUX
-    real_printf(" [-g <gpiochip>]\n");
+    real_printf(" [-g <gpiochip>]");
 #endif
+    real_printf(" [-i <id>] [-d] [-e|-E] [-o] [-c <tty>]");
 #if defined(MODULE_SOCKET_ZEP) && (SOCKET_ZEP_MAX > 0)
-    real_printf(" -z [[<laddr>:<lport>,]<raddr>:<rport>]\n");
+    real_printf(" -z [[<laddr>:<lport>,]<raddr>:<rport>]");
     for (int i = 0; i < SOCKET_ZEP_MAX - 1; i++) {
         /* for further interfaces the local address must be different so we omit
          * the braces (marking them as optional) to be 100% clear on that */
-        real_printf(" -z <laddr>:<lport>,<raddr>:<rport>\n");
+        real_printf(" -z <laddr>:<lport>,<raddr>:<rport>");
     }
 #endif
 #ifdef MODULE_PERIPH_SPIDEV_LINUX
-    real_printf(" [-p <b>:<d>:<spidev>]\n");
+    real_printf(" [-p <b>:<d>:<spidev>]");
 #endif
 
-    real_printf(" help: %s -h\n\n", _progname);
+    real_printf("\n\n");
+
+    real_printf("help: %s -h\n", _progname);
 
     real_printf("\nOptions:\n"
 "    -h, --help\n"

--- a/cpu/native/startup.c
+++ b/cpu/native/startup.c
@@ -106,6 +106,7 @@ static const char short_opts[] = ":hi:s:deEoc:"
 #endif
 #ifdef MODULE_SOCKET_ZEP
     "z:"
+    "Z:"
 #endif
 #ifdef MODULE_PERIPH_SPIDEV_LINUX
     "p:"
@@ -132,6 +133,7 @@ static const struct option long_opts[] = {
 #endif
 #ifdef MODULE_SOCKET_ZEP
     { "zep", required_argument, NULL, 'z' },
+    { "zep_mac", required_argument, NULL, 'Z' },
 #endif
 #ifdef MODULE_PERIPH_SPIDEV_LINUX
     { "spi", required_argument, NULL, 'p' },
@@ -280,6 +282,9 @@ void usage_exit(int status)
          * the braces (marking them as optional) to be 100% clear on that */
         real_printf(" -z <laddr>:<lport>,<raddr>:<rport>");
     }
+    for (int i = 0; i < SOCKET_ZEP_MAX; i++) {
+        real_printf(" [-Z <eui64>]");
+    }
 #endif
 #ifdef MODULE_PERIPH_SPIDEV_LINUX
     real_printf(" [-p <b>:<d>:<spidev>]");
@@ -320,6 +325,9 @@ void usage_exit(int status)
 "        provide a ZEP interface with local address and port (<laddr>, <lport>)\n"
 "        and remote address and port (default local: [::]:17754).\n"
 "        Required to be provided SOCKET_ZEP_MAX times\n"
+"    -Z <eui64>, --zep_mac=<eui64>\n"
+"        provide a ZEP interface with EUI-64 (MAC address)\n"
+"        This argument can be provided SOCKET_ZEP_MAX times\n"
 #endif
     );
 #ifdef MODULE_MTD_NATIVE
@@ -446,6 +454,7 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
     int c, opt_idx = 0, uart = 0;
 #ifdef MODULE_SOCKET_ZEP
     unsigned zeps = 0;
+    unsigned zep_macs = 0;
 #endif
     bool dmn = false, force_stderr = false;
     _stdiotype_t stderrtype = _STDIOTYPE_STDIO;
@@ -523,6 +532,9 @@ __attribute__((constructor)) static void startup(int argc, char **argv, char **e
 #ifdef MODULE_SOCKET_ZEP
             case 'z':
                 _zep_params_setup(optarg, zeps++);
+                break;
+            case 'Z':
+                socket_zep_params[zep_macs++].mac_addr = optarg;
                 break;
 #endif
 #ifdef MODULE_PERIPH_SPIDEV_LINUX


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Add a command-line parameter for setting the EUI-64 of a ZEP device.
This allows a native node to use a persistent ZEP address across reboots.


### Testing procedure

Add `TERMFLAGS += -Z 00:AA:BB:CC:DD:EE:FF:11` to the `Makefile` of `examples/gnrc_networking`

```
ifconfig
Iface  7  HWaddr: FF:11  Channel: 26  NID: 0x23 
          Long HWaddr: 00:AA:BB:CC:DD:EE:FF:11 
          L2-PDU:102  MTU:1280  HL:64  RTR  
          6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::2aa:bbcc:ddee:ff11  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffee:ff11
          
          Statistics for Layer 2
            RX packets 0  bytes 0
            TX packets 2 (Multicast: 2)  bytes 86
            TX succeeded 6 errors 0
          Statistics for IPv6
            RX packets 0  bytes 0
            TX packets 2 (Multicast: 2)  bytes 128
            TX succeeded 2 errors 0
```

The address stays the same across reboots and different runs of the `native` node.
### Issues/PRs references

requires #14757 for reboots to work
needs #14755 for test instruction
