### PR TITLE
sys/net/ipv6: Simplify type

### DIFF
--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -113,7 +113,7 @@ typedef struct {
 /**
  * @brief   Length of the link local prefix
  */
-#define IPV6_ADDR_LINK_LOCAL_PREFIX_LEN     (8U)
+#define IPV6_ADDR_LINK_LOCAL_PREFIX_BYTES     (8U)
 
 /**
  * @brief   Static initializer for the interface-local all nodes multicast IPv6
@@ -415,7 +415,7 @@ static inline bool ipv6_addr_is_multicast(const ipv6_addr_t *addr)
 static inline bool ipv6_addr_is_link_local(const ipv6_addr_t *addr)
 {
     return (memcmp(addr, &ipv6_addr_link_local_prefix,
-                   IPV6_ADDR_LINK_LOCAL_PREFIX_LEN) == 0) ||
+                   IPV6_ADDR_LINK_LOCAL_PREFIX_BYTES) == 0) ||
            (ipv6_addr_is_multicast(addr) &&
             (addr->u8[1] & 0x0f) == IPV6_ADDR_MCAST_SCP_LINK_LOCAL);
 }
@@ -589,7 +589,8 @@ static inline void ipv6_addr_set_loopback(ipv6_addr_t *addr)
  */
 static inline void ipv6_addr_set_link_local_prefix(ipv6_addr_t *addr)
 {
-    memcpy(addr, &ipv6_addr_link_local_prefix, IPV6_ADDR_LINK_LOCAL_PREFIX_LEN);
+    memcpy(addr, &ipv6_addr_link_local_prefix,
+           IPV6_ADDR_LINK_LOCAL_PREFIX_BYTES);
 }
 
 /**

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -48,7 +48,7 @@ bool _resolve_addr_from_ipv6(const ipv6_addr_t *dst, gnrc_netif_t *netif,
         uint8_t l2addr_len;
 
         if ((l2addr_len = gnrc_netif_ipv6_iid_to_addr(netif,
-                                                      (eui64_t *)&dst->u64[1],
+                                                      (eui64_t *)&dst->u8[8],
                                                       nce->l2addr)) > 0) {
             DEBUG("nib: resolve address %s%%%u by reverse translating to ",
                   ipv6_addr_to_str(addr_str, dst, sizeof(addr_str)),

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -299,7 +299,7 @@ static inline int _get_l2addr_from_ipv6(const gnrc_netif_t *netif,
                                         gnrc_ipv6_nib_nc_t *nce)
 {
     int res = gnrc_netif_ipv6_iid_to_addr(netif,
-                                          (eui64_t *)&node->ipv6.u64[1],
+                                          (eui64_t *)&node->ipv6.u8[8],
                                           nce->l2addr);
     if (res >= 0) {
         DEBUG("nib: resolve address %s%%%u by reverse translating to ",

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -55,7 +55,7 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
     bool new_address = false;
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN */
-    gnrc_netif_ipv6_get_iid(netif, (eui64_t *)&addr.u64[1]);
+    gnrc_netif_ipv6_get_iid(netif, (eui64_t *)&addr.u8[8]);
     ipv6_addr_init_prefix(&addr, pfx, pfx_len);
     if ((idx = gnrc_netif_ipv6_addr_idx(netif, &addr)) < 0) {
         if ((idx = gnrc_netif_ipv6_addr_add_internal(netif, &addr, pfx_len,
@@ -138,7 +138,7 @@ static bool _try_addr_reconfiguration(gnrc_netif_t *netif)
         if (remove_old) {
             for (unsigned i = 0; i < CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF; i++) {
                 ipv6_addr_t *addr = &netif->ipv6.addrs[i];
-                if (addr->u64[1].u64 == orig_iid.uint64.u64) {
+                if (!memcmp(&addr->u8[8], &orig_iid, sizeof(orig_iid))) {
                     gnrc_netif_ipv6_addr_remove_internal(netif, addr);
                 }
             }

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -44,8 +44,7 @@ gnrc_pktsnip_t *gnrc_ndp_nbr_sol_build(const ipv6_addr_t *tgt,
     if (pkt != NULL) {
         ndp_nbr_sol_t *nbr_sol = pkt->data;
         nbr_sol->resv.u32 = 0;
-        nbr_sol->tgt.u64[0].u64 = tgt->u64[0].u64;
-        nbr_sol->tgt.u64[1].u64 = tgt->u64[1].u64;
+        memcpy(&nbr_sol->tgt, tgt, sizeof(*tgt));
     }
 #if ENABLE_DEBUG
     else {
@@ -67,8 +66,7 @@ gnrc_pktsnip_t *gnrc_ndp_nbr_adv_build(const ipv6_addr_t *tgt, uint8_t flags,
         ndp_nbr_adv_t *nbr_adv = pkt->data;
         nbr_adv->flags = (flags & NDP_NBR_ADV_FLAGS_MASK);
         nbr_adv->resv[0] = nbr_adv->resv[1] = nbr_adv->resv[2] = 0;
-        nbr_adv->tgt.u64[0].u64 = tgt->u64[0].u64;
-        nbr_adv->tgt.u64[1].u64 = tgt->u64[1].u64;
+        memcpy(&nbr_adv->tgt, tgt, sizeof(*tgt));
     }
 #if ENABLE_DEBUG
     else {

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -74,8 +74,7 @@ gnrc_pktsnip_t *gnrc_sixlowpan_nd_opt_abr_build(uint32_t version, uint16_t ltime
         abr_opt->vlow = byteorder_htons(version & 0xffff);
         abr_opt->vhigh = byteorder_htons(version >> 16);
         abr_opt->ltime = byteorder_htons(ltime);
-        abr_opt->braddr.u64[0] = braddr->u64[0];
-        abr_opt->braddr.u64[1] = braddr->u64[1];
+        memcpy(&abr_opt->braddr, braddr, sizeof(*braddr));
     }
 
     return pkt;

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr.c
@@ -38,8 +38,7 @@ const ipv6_addr_t ipv6_addr_all_routers_site_local = IPV6_ADDR_ALL_ROUTERS_SITE_
 
 bool ipv6_addr_equal(const ipv6_addr_t *a, const ipv6_addr_t *b)
 {
-    return (a->u64[0].u64 == b->u64[0].u64) &&
-           (a->u64[1].u64 == b->u64[1].u64);
+    return !memcmp(a, b, sizeof(*a));
 }
 
 uint8_t ipv6_addr_match_prefix(const ipv6_addr_t *a, const ipv6_addr_t *b)

--- a/sys/net/network_layer/ipv6/addr/ipv6_addr_to_str.c
+++ b/sys/net/network_layer/ipv6/addr/ipv6_addr_to_str.c
@@ -55,7 +55,7 @@ char *ipv6_addr_to_str(char *result, const ipv6_addr_t *addr, uint8_t result_len
      *  Find the longest run of 0x0000's in address for :: shorthanding.
      */
     for (uint8_t i = 0; i < IPV6_ADDR_WORD_LEN; i++) {
-        if (addr->u16[i].u16 == 0) {
+        if ((addr->u8[2 * i] == 0) && (addr->u8[2 * i+1] == 0)) {
             if (cur.base == -1) {
                 cur.base = i;
                 cur.len = 1;
@@ -106,8 +106,9 @@ char *ipv6_addr_to_str(char *result, const ipv6_addr_t *addr, uint8_t result_len
 #ifdef MODULE_IPV4_ADDR
         /* Is this address an encapsulated IPv4? */
         if (i == 6 && best.base == 0 &&
-            (best.len == 6 || (best.len == 5 && addr->u16[5].u16 == 0xffff))) {
-            if (!ipv4_addr_to_str(tp, (const ipv4_addr_t *)&addr->u32[3],
+            (best.len == 6 || (best.len == 5 && addr->u8[10] == 0xff &&
+                                addr->u8[11] == 0xff))) {
+            if (!ipv4_addr_to_str(tp, (const ipv4_addr_t *)&addr->u8[12],
                                   sizeof(tmp) - (tp - tmp))) {
                 return (NULL);
             }
@@ -117,20 +118,20 @@ char *ipv6_addr_to_str(char *result, const ipv6_addr_t *addr, uint8_t result_len
         }
 #endif
 
-        if ((addr->u16[i].u8[0] & 0xf0) != 0x00) {
-            *tp++ = HEX_L[addr->u16[i].u8[0] >> 4];
-            *tp++ = HEX_L[addr->u16[i].u8[0] & 0x0f];
-            *tp++ = HEX_L[addr->u16[i].u8[1] >> 4];
+        if ((addr->u8[2 * i] & 0xf0) != 0x00) {
+            *tp++ = HEX_L[addr->u8[2 * i] >> 4];
+            *tp++ = HEX_L[addr->u8[2 * i] & 0x0f];
+            *tp++ = HEX_L[addr->u8[2 * i + 1] >> 4];
         }
-        else if ((addr->u16[i].u8[0] & 0x0f) != 0x00) {
-            *tp++ = HEX_L[addr->u16[i].u8[0] & 0x0f];
-            *tp++ = HEX_L[addr->u16[i].u8[1] >> 4];
+        else if ((addr->u8[2 * i] & 0x0f) != 0x00) {
+            *tp++ = HEX_L[addr->u8[2 * i] & 0x0f];
+            *tp++ = HEX_L[addr->u8[2 * i + 1] >> 4];
         }
-        else if ((addr->u16[i].u8[1] & 0xf0) != 0x00) {
-            *tp++ = HEX_L[addr->u16[i].u8[1] >> 4];
+        else if ((addr->u8[2 * i + 1] & 0xf0) != 0x00) {
+            *tp++ = HEX_L[addr->u8[2 * i + 1] >> 4];
         }
 
-        *tp++ = HEX_L[addr->u16[i].u8[1] & 0xf];
+        *tp++ = HEX_L[addr->u8[2 * i + 1] & 0xf];
 
         i++;
     }

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -238,7 +238,7 @@ static void test_ipv6_addr_add__ENOMEM(void)
     ipv6_addr_t addr = { .u8 = NETIF0_IPV6_G };
 
     for (unsigned i = 0; i < CONFIG_GNRC_NETIF_IPV6_ADDRS_NUMOF;
-         i++, addr.u16[3].u16++) {
+         i++, addr.u8[6]++) {
         TEST_ASSERT(0 <= gnrc_netif_ipv6_addr_add_internal(&netifs[0], &addr, 64U,
                                                   GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID));
     }
@@ -595,7 +595,7 @@ static void test_ipv6_group_join__ENOMEM(void)
     ipv6_addr_t addr = IPV6_ADDR_ALL_NODES_LINK_LOCAL;
 
     for (unsigned i = 0; i < GNRC_NETIF_IPV6_GROUPS_NUMOF;
-            i++, addr.u16[7].u16++) {
+            i++, addr.u8[14]++) {
         TEST_ASSERT(0 <= gnrc_netif_ipv6_group_join_internal(&netifs[0], &addr));
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM,
@@ -702,11 +702,11 @@ static void test_ipv6_get_iid(void)
 
     TEST_ASSERT_EQUAL_INT(sizeof(eui64_t),
             gnrc_netif_ipv6_get_iid(&ethernet_netif, &res));
-    TEST_ASSERT_EQUAL_INT(0, memcmp(&res, &ethernet_ipv6_ll.u64[1],
+    TEST_ASSERT_EQUAL_INT(0, memcmp(&res, &ethernet_ipv6_ll.u8[8],
                 sizeof(res)));
     TEST_ASSERT_EQUAL_INT(sizeof(eui64_t),
             gnrc_netif_ipv6_get_iid(&ieee802154_netif, &res));
-    TEST_ASSERT_EQUAL_INT(0, memcmp(&res, &ieee802154_ipv6_ll_long.u64[1],
+    TEST_ASSERT_EQUAL_INT(0, memcmp(&res, &ieee802154_ipv6_ll_long.u8[8],
                 sizeof(res)));
     TEST_ASSERT_EQUAL_INT(sizeof(ieee802154_l2addr_len),
             gnrc_netapi_set(ieee802154_netif.pid,
@@ -788,12 +788,12 @@ static void test_netapi_get__IPV6_IID(void)
     TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netapi_get(ethernet_netif.pid,
                 NETOPT_IPV6_IID,
                 0, &value, sizeof(value)));
-    TEST_ASSERT_EQUAL_INT(0, memcmp(&value, &ethernet_ipv6_ll.u64[1],
+    TEST_ASSERT_EQUAL_INT(0, memcmp(&value, &ethernet_ipv6_ll.u8[8],
                 sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(eui64_t), gnrc_netapi_get(ieee802154_netif.pid,
                 NETOPT_IPV6_IID,
                 0, &value, sizeof(value)));
-    TEST_ASSERT_EQUAL_INT(0, memcmp(&value, &ieee802154_ipv6_ll_long.u64[1],
+    TEST_ASSERT_EQUAL_INT(0, memcmp(&value, &ieee802154_ipv6_ll_long.u8[8],
                 sizeof(value)));
     TEST_ASSERT_EQUAL_INT(sizeof(ieee802154_l2addr_len),
             gnrc_netapi_set(ieee802154_netif.pid,

--- a/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-abr.c
+++ b/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-abr.c
@@ -25,7 +25,10 @@
 
 #include "tests-gnrc_ipv6_nib.h"
 
-#define GLOBAL_PREFIX       { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0 }
+#define _GLOBAL_PREFIX      0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0
+#define GLOBAL_PREFIX       { _GLOBAL_PREFIX }
+#define TEST_ADDR           { _GLOBAL_PREFIX, \
+                              0x07, 0x73, 0xc1, 0xb9, 0xc2, 0x94, 0x5a, 0xbb }
 
 static void set_up(void)
 {
@@ -47,13 +50,12 @@ static void set_up(void)
 static void test_nib_abr_add__ENOMEM(void)
 {
     void *iter_state = NULL;
-    ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t addr = { TEST_ADDR };
     gnrc_ipv6_nib_abr_t abr;
 
     for (unsigned i = 0; i < CONFIG_GNRC_IPV6_NIB_ABR_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_abr_add(&addr));
-        addr.u16[0].u16++;
+        addr.u8[0]++;
         TEST_ASSERT(gnrc_ipv6_nib_abr_iter(&iter_state, &abr));
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_abr_add(&addr));
@@ -68,12 +70,11 @@ static void test_nib_abr_add__ENOMEM(void)
 static void test_nib_abr_add__success(void)
 {
     void *iter_state = NULL;
-    ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t addr = { TEST_ADDR };
     gnrc_ipv6_nib_abr_t abr;
 
     for (unsigned i = 0; i < CONFIG_GNRC_IPV6_NIB_ABR_NUMOF; i++) {
-        addr.u16[0].u16++;
+        addr.u8[0]++;
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_abr_add(&addr));
         TEST_ASSERT(gnrc_ipv6_nib_abr_iter(&iter_state, &abr));
         TEST_ASSERT(memcmp(&abr.addr, &addr, sizeof(addr)) == 0);
@@ -89,8 +90,7 @@ static void test_nib_abr_add__success(void)
 static void test_nib_abr_del__success(void)
 {
     void *iter_state = NULL;
-    ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                  { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t addr = { TEST_ADDR };
     gnrc_ipv6_nib_abr_t abr;
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_abr_add(&addr));

--- a/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-nc.c
+++ b/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-nc.c
@@ -25,10 +25,13 @@
 
 #include "tests-gnrc_ipv6_nib.h"
 
-#define LINK_LOCAL_PREFIX   { 0xfe, 0x08, 0, 0, 0, 0, 0, 0 }
-#define GLOBAL_PREFIX       { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0 }
+#define _GLOBAL_PREFIX      0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0
+#define GLOBAL_PREFIX       { _GLOBAL_PREFIX }
 #define L2ADDR              { 0x90, 0xd5, 0x8e, 0x8c, 0x92, 0x43, 0x73, 0x5c }
 #define IFACE               (6)
+#define _GLOBAL_PREFIX      0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0
+#define GLOBAL_ADDR         { _GLOBAL_PREFIX, \
+                              0x07, 0x73, 0xc1, 0xb9, 0xc2, 0x94, 0x5a, 0xbb }
 
 static void set_up(void)
 {
@@ -42,14 +45,13 @@ static void set_up(void)
  */
 static void test_nib_nc_set__ENOMEM_diff_addr(void)
 {
-    ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                  { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t addr = { GLOBAL_ADDR };
     uint8_t l2addr[] = L2ADDR;
 
     for (unsigned i = 0; i < CONFIG_GNRC_IPV6_NIB_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_nc_set(&addr, IFACE, l2addr,
                                                       sizeof(l2addr)));
-        addr.u64[1].u64++;
+        addr.u8[8]++;
         l2addr[7]++;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_nc_set(&addr, IFACE, l2addr,
@@ -63,8 +65,7 @@ static void test_nib_nc_set__ENOMEM_diff_addr(void)
  */
 static void test_nib_nc_set__ENOMEM_diff_iface(void)
 {
-    static const ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                             { .u64 = TEST_UINT64 } } };
+    static const ipv6_addr_t addr = { GLOBAL_ADDR };
     static const uint8_t l2addr[] = L2ADDR;
     unsigned iface = IFACE;
 
@@ -84,15 +85,14 @@ static void test_nib_nc_set__ENOMEM_diff_iface(void)
  */
 static void test_nib_nc_set__ENOMEM_diff_addr_iface(void)
 {
-    ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                  { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t addr = { GLOBAL_ADDR };
     uint8_t l2addr[] = L2ADDR;
     unsigned iface = IFACE;
 
     for (unsigned i = 0; i < CONFIG_GNRC_IPV6_NIB_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_nc_set(&addr, iface, l2addr,
                                                       sizeof(l2addr)));
-        addr.u64[1].u64++;
+        addr.u8[8]++;
         iface++;
         l2addr[7]++;
     }
@@ -108,8 +108,7 @@ static void test_nib_nc_set__ENOMEM_diff_addr_iface(void)
 static void test_nib_nc_set__success(void)
 {
     void *iter_state = NULL;
-    static const ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                             { .u64 = TEST_UINT64 } } };
+    static const ipv6_addr_t addr = { GLOBAL_ADDR };
     static const uint8_t l2addr[] = L2ADDR;
     gnrc_ipv6_nib_nc_t nce;
 
@@ -135,13 +134,12 @@ static void test_nib_nc_set__success(void)
  */
 static void test_nib_nc_set__success_duplicate(void)
 {
-    ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                  { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t addr = { GLOBAL_ADDR };
     uint8_t l2addr[] = L2ADDR;
     unsigned iface = 0;
 
     for (unsigned i = 0; i < CONFIG_GNRC_IPV6_NIB_NUMOF; i++) {
-        addr.u64[1].u64++;
+        addr.u8[8]++;
         iface++;
         l2addr[7]++;
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_nc_set(&addr, iface, l2addr,
@@ -160,8 +158,7 @@ static void test_nib_nc_set__success_duplicate(void)
 static void test_nib_nc_del__unknown(void)
 {
     void *iter_state = NULL;
-    ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t addr = { GLOBAL_ADDR };
     uint8_t l2addr[] = L2ADDR;
     gnrc_ipv6_nib_nc_t nce;
     unsigned iface = IFACE, count = 0;
@@ -169,7 +166,7 @@ static void test_nib_nc_del__unknown(void)
     for (unsigned i = 0; i < CONFIG_GNRC_IPV6_NIB_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_nc_set(&addr, iface, l2addr,
                                                       sizeof(l2addr)));
-        addr.u64[1].u64++;
+        addr.u8[8]++;
         iface++;
         l2addr[7]++;
     }
@@ -187,8 +184,7 @@ static void test_nib_nc_del__unknown(void)
 static void test_nib_nc_del__success(void)
 {
     void *iter_state = NULL;
-    static const ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                             { .u64 = TEST_UINT64 } } };
+    static const ipv6_addr_t addr = { GLOBAL_ADDR };
     static const uint8_t l2addr[] = L2ADDR;
     gnrc_ipv6_nib_nc_t nce;
 
@@ -208,8 +204,7 @@ static void test_nib_nc_del__success(void)
 static void test_nib_nc_mark_reachable__not_in_neighbor_cache(void)
 {
     void *iter_state = NULL;
-    ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t addr = { GLOBAL_ADDR };
     gnrc_ipv6_nib_nc_t nce;
 
     TEST_ASSERT_NOT_NULL(_nib_nc_add(&addr, IFACE,
@@ -222,7 +217,7 @@ static void test_nib_nc_mark_reachable__not_in_neighbor_cache(void)
     TEST_ASSERT(!gnrc_ipv6_nib_nc_iter(0, &iter_state, &nce));
     TEST_ASSERT_NULL(_nib_evtimer.events);
 
-    addr.u64[1].u64++;
+    addr.u8[8]++;
     gnrc_ipv6_nib_nc_mark_reachable(&addr);
     /* check if entry is still unmanaged */
     TEST_ASSERT_EQUAL_INT(GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNREACHABLE,
@@ -244,8 +239,7 @@ static void test_nib_nc_mark_reachable__not_in_neighbor_cache(void)
 static void test_nib_nc_mark_reachable__unmanaged(void)
 {
     void *iter_state = NULL;
-    static const ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                             { .u64 = TEST_UINT64 } } };
+    static const ipv6_addr_t addr = { GLOBAL_ADDR };
     gnrc_ipv6_nib_nc_t nce;
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_nc_set(&addr, IFACE, NULL, 0));
@@ -277,8 +271,7 @@ static void test_nib_nc_mark_reachable__unmanaged(void)
 static void test_nib_nc_mark_reachable__success(void)
 {
     void *iter_state = NULL;
-    static const ipv6_addr_t addr = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                             { .u64 = TEST_UINT64 } } };
+    static const ipv6_addr_t addr = { GLOBAL_ADDR };
     gnrc_ipv6_nib_nc_t nce;
 
     TEST_ASSERT_NOT_NULL(_nib_nc_add(&addr, IFACE,

--- a/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-pl.c
+++ b/tests/unittests/tests-gnrc_ipv6_nib/tests-gnrc_ipv6_nib-pl.c
@@ -25,9 +25,15 @@
 
 #include "tests-gnrc_ipv6_nib.h"
 
-#define LINK_LOCAL_PREFIX   { 0xfe, 0x08, 0, 0, 0, 0, 0, 0 }
-#define GLOBAL_PREFIX       { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0 }
+#define _LINK_LOCAL_PREFIX  0xfe, 0x08, 0, 0, 0, 0, 0, 0
+#define LINK_LOCAL_PREFIX   { _LINK_LOCAL_PREFIX }
+#define _GLOBAL_PREFIX      0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0
+#define GLOBAL_PREFIX       { _GLOBAL_PREFIX }
 #define L2ADDR              { 0x90, 0xd5, 0x8e, 0x8c, 0x92, 0x43, 0x73, 0x5c }
+#define LOCAL_ADDR          { _LINK_LOCAL_PREFIX, \
+                              0x07, 0x73, 0xc1, 0xb9, 0xc2, 0x94, 0x5a, 0xbb }
+#define GLOBAL_ADDR         { _GLOBAL_PREFIX, \
+                              0x07, 0x73, 0xc1, 0xb9, 0xc2, 0x94, 0x5a, 0xbb }
 #define GLOBAL_PREFIX_LEN   (30)
 #define IFACE               (6)
 
@@ -90,7 +96,7 @@ static void test_nib_pl_set__EINVAL_mc_addr(void)
  */
 static void test_nib_pl_set__EINVAL_pfx_len(void)
 {
-    static const ipv6_addr_t pfx = { .u64 = { { .u8 = GLOBAL_PREFIX } } };
+    static const ipv6_addr_t pfx = { GLOBAL_PREFIX };
     TEST_ASSERT_EQUAL_INT(-EINVAL, gnrc_ipv6_nib_pl_set(IFACE, &pfx, 0,
                                                         UINT32_MAX,
                                                         UINT32_MAX));
@@ -109,8 +115,7 @@ static void test_nib_pl_set__EINVAL_pfx_len(void)
  */
 static void test_nib_pl_set__ENOMEM_diff_iface(void)
 {
-    static const ipv6_addr_t pfx = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                            { .u64 = TEST_UINT64 } } };
+    static const ipv6_addr_t pfx = { GLOBAL_ADDR };
     unsigned iface = IFACE;
 
     for (unsigned i = 0; i < MAX_NUMOF; i++) {
@@ -132,14 +137,13 @@ static void test_nib_pl_set__ENOMEM_diff_iface(void)
  */
 static void test_nib_pl_set__ENOMEM_diff_pfx(void)
 {
-    ipv6_addr_t pfx = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                               { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t pfx = { GLOBAL_ADDR };
 
     for (unsigned i = 0; i < CONFIG_GNRC_IPV6_NIB_OFFL_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_pl_set(IFACE, &pfx,
                                                       GLOBAL_PREFIX_LEN,
                                                       UINT32_MAX, UINT32_MAX));
-        pfx.u16[0].u16++;
+        pfx.u8[0]++;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_pl_set(IFACE, &pfx,
                                                         GLOBAL_PREFIX_LEN,
@@ -154,8 +158,7 @@ static void test_nib_pl_set__ENOMEM_diff_pfx(void)
  */
 static void test_nib_pl_set__ENOMEM_diff_iface_pfx(void)
 {
-    ipv6_addr_t pfx = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                               { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t pfx = { GLOBAL_ADDR };
     unsigned iface = IFACE;
 
     for (unsigned i = 0; i < MAX_NUMOF; i++) {
@@ -163,7 +166,7 @@ static void test_nib_pl_set__ENOMEM_diff_iface_pfx(void)
                                                       GLOBAL_PREFIX_LEN,
                                                       UINT32_MAX, UINT32_MAX));
         iface++;
-        pfx.u16[0].u16++;
+        pfx.u8[0]++;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_pl_set(iface, &pfx,
                                                         GLOBAL_PREFIX_LEN,
@@ -178,8 +181,7 @@ static void test_nib_pl_set__ENOMEM_diff_iface_pfx(void)
  */
 static void test_nib_pl_set__ENOMEM_diff_pfx_len(void)
 {
-    static const ipv6_addr_t pfx = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                            { .u64 = TEST_UINT64 } } };
+    static const ipv6_addr_t pfx = { GLOBAL_ADDR };
     unsigned pfx_len = GLOBAL_PREFIX_LEN;
 
     for (unsigned i = 0; i < CONFIG_GNRC_IPV6_NIB_OFFL_NUMOF; i++) {
@@ -199,8 +201,7 @@ static void test_nib_pl_set__ENOMEM_diff_pfx_len(void)
  */
 static void test_nib_pl_set__ENOMEM_diff_iface_pfx_len(void)
 {
-    static const ipv6_addr_t pfx = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                            { .u64 = TEST_UINT64 } } };
+    static const ipv6_addr_t pfx = { GLOBAL_ADDR };
     unsigned pfx_len = GLOBAL_PREFIX_LEN, iface = IFACE;
 
     for (unsigned i = 0; i < MAX_NUMOF; i++) {
@@ -221,15 +222,14 @@ static void test_nib_pl_set__ENOMEM_diff_iface_pfx_len(void)
  */
 static void test_nib_pl_set__ENOMEM_diff_pfx_pfx_len(void)
 {
-    ipv6_addr_t pfx = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                 { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t pfx = { GLOBAL_ADDR };
     unsigned pfx_len = GLOBAL_PREFIX_LEN;
 
     for (unsigned i = 0; i < CONFIG_GNRC_IPV6_NIB_OFFL_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_pl_set(IFACE, &pfx, pfx_len,
                                                       UINT32_MAX, UINT32_MAX));
         pfx_len--;
-        pfx.u16[0].u16++;
+        pfx.u8[0]++;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_pl_set(IFACE, &pfx, pfx_len,
                                                         UINT32_MAX,
@@ -243,15 +243,14 @@ static void test_nib_pl_set__ENOMEM_diff_pfx_pfx_len(void)
  */
 static void test_nib_pl_set__ENOMEM_diff_iface_pfx_pfx_len(void)
 {
-    ipv6_addr_t pfx = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                 { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t pfx = { GLOBAL_ADDR };
     unsigned pfx_len = GLOBAL_PREFIX_LEN, iface = IFACE;
 
     for (unsigned i = 0; i < MAX_NUMOF; i++) {
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_pl_set(iface, &pfx, pfx_len,
                                                       UINT32_MAX, UINT32_MAX));
         pfx_len--;
-        pfx.u16[0].u16++;
+        pfx.u8[0]++;
         iface++;
     }
     TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_ipv6_nib_pl_set(iface, &pfx, pfx_len,
@@ -266,13 +265,12 @@ static void test_nib_pl_set__ENOMEM_diff_iface_pfx_pfx_len(void)
  */
 static void test_nib_pl_set__success_duplicate(void)
 {
-    ipv6_addr_t pfx = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                 { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t pfx = { GLOBAL_ADDR };
     unsigned pfx_len = GLOBAL_PREFIX_LEN, iface = IFACE;
 
     for (unsigned i = 0; i < MAX_NUMOF; i++) {
         pfx_len--;
-        pfx.u16[0].u16++;
+        pfx.u8[0]++;
         iface++;
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_pl_set(iface, &pfx, pfx_len,
                                                       UINT32_MAX, UINT32_MAX));
@@ -291,8 +289,7 @@ static void test_nib_pl_set__success_change(void)
 {
     gnrc_ipv6_nib_pl_t ple;
     void *iter_state = NULL;
-    static const ipv6_addr_t pfx = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                            { .u64 = TEST_UINT64 } } };
+    static const ipv6_addr_t pfx = { GLOBAL_ADDR };
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_pl_set(IFACE, &pfx,
                                                   GLOBAL_PREFIX_LEN,
@@ -317,8 +314,7 @@ static void test_nib_pl_set__success(void)
 {
     gnrc_ipv6_nib_pl_t ple;
     void *iter_state = NULL;
-    static const ipv6_addr_t pfx = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                            { .u64 = TEST_UINT64 } } };
+    static const ipv6_addr_t pfx = { GLOBAL_ADDR };
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_pl_set(IFACE, &pfx,
                                                   GLOBAL_PREFIX_LEN,
@@ -341,8 +337,7 @@ static void test_nib_pl_set__success(void)
 static void test_nib_pl_del__unknown(void)
 {
     void *iter_state = NULL;
-    ipv6_addr_t pfx = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                 { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t pfx = { GLOBAL_ADDR };
     gnrc_ipv6_nib_pl_t ple;
     unsigned pfx_len = GLOBAL_PREFIX_LEN, iface = IFACE, count = 0;
 
@@ -350,7 +345,7 @@ static void test_nib_pl_del__unknown(void)
         TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_pl_set(iface, &pfx, pfx_len,
                                                       UINT32_MAX, UINT32_MAX));
         pfx_len--;
-        pfx.u16[0].u16++;
+        pfx.u8[0]++;
         iface++;
     }
     gnrc_ipv6_nib_pl_del(iface, &pfx, pfx_len);
@@ -367,8 +362,7 @@ static void test_nib_pl_del__unknown(void)
 static void test_nib_pl_del__success(void)
 {
     void *iter_state = NULL;
-    ipv6_addr_t pfx = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                                 { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t pfx = { GLOBAL_ADDR };
     gnrc_ipv6_nib_pl_t ple;
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_pl_set(IFACE, &pfx, GLOBAL_PREFIX_LEN,
@@ -387,24 +381,23 @@ static void test_nib_pl_iter__empty_in_the_middle(void)
 {
     gnrc_ipv6_nib_pl_t ple;
     void *iter_state = NULL;
-    ipv6_addr_t pfx = { .u64 = { { .u8 = GLOBAL_PREFIX },
-                               { .u64 = TEST_UINT64 } } };
+    ipv6_addr_t pfx = { GLOBAL_ADDR };
     int count = 0;
 
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_pl_set(IFACE, &pfx,
                                                   GLOBAL_PREFIX_LEN,
                                                   UINT32_MAX, UINT32_MAX));
-    pfx.u16[0].u16++;
+    pfx.u8[0]++;
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_pl_set(IFACE, &pfx,
                                                   GLOBAL_PREFIX_LEN,
                                                   UINT32_MAX, UINT32_MAX));
-    pfx.u16[0].u16++;
+    pfx.u8[0]++;
     TEST_ASSERT_EQUAL_INT(0, gnrc_ipv6_nib_pl_set(IFACE, &pfx,
                                                   GLOBAL_PREFIX_LEN,
                                                   UINT32_MAX, UINT32_MAX));
-    pfx.u16[0].u16--;
+    pfx.u8[0]--;
     gnrc_ipv6_nib_pl_del(IFACE, &pfx, GLOBAL_PREFIX_LEN);
-    pfx.u16[0].u16--;
+    pfx.u8[0]--;
     while (gnrc_ipv6_nib_pl_iter(0, &iter_state, &ple)) {
         TEST_ASSERT(ipv6_addr_match_prefix(&ple.pfx, &pfx) >= GLOBAL_PREFIX_LEN);
         TEST_ASSERT_EQUAL_INT(GLOBAL_PREFIX_LEN, ple.pfx_len);
@@ -412,7 +405,7 @@ static void test_nib_pl_iter__empty_in_the_middle(void)
         TEST_ASSERT_EQUAL_INT(UINT32_MAX, ple.valid_until);
         TEST_ASSERT_EQUAL_INT(UINT32_MAX, ple.pref_until);
         count++;
-        pfx.u16[0].u16 += 2; /* we skip the second address */
+        pfx.u8[0] += 2; /* we skip the second address */
     }
     TEST_ASSERT_EQUAL_INT(2, count);
 }

--- a/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
+++ b/tests/unittests/tests-ipv6_addr/tests-ipv6_addr.c
@@ -109,9 +109,13 @@ static void test_ipv6_addr_is_unspecified_not_unspecified(void)
 static void test_ipv6_addr_is_unspecified_unspecified(void)
 {
     ipv6_addr_t a = IPV6_ADDR_UNSPECIFIED;
+    const ipv6_addr_t expected = { {
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        }
+    };
 
-    TEST_ASSERT_EQUAL_INT(0, a.u64[0].u64); /* Don't trust the macro ;) */
-    TEST_ASSERT_EQUAL_INT(0, a.u64[1].u64);
+    TEST_ASSERT(!memcmp(expected.u8, a.u8, sizeof(a))); /* Don't trust the macro ;) */
     TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_unspecified(&a));
 }
 
@@ -300,10 +304,13 @@ static void test_ipv6_addr_is_loopback_not_loopback(void)
 static void test_ipv6_addr_is_loopback_loopback(void)
 {
     ipv6_addr_t a = IPV6_ADDR_LOOPBACK;
+    const ipv6_addr_t expected = { {
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+        }
+    };
 
-    TEST_ASSERT_EQUAL_INT(0, a.u64[0].u64); /* Don't trust the macro ;) */
-    TEST_ASSERT_EQUAL_INT(1, byteorder_ntohll(a.u64[1]));
-    TEST_ASSERT_EQUAL_INT(true, ipv6_addr_is_loopback(&a));
+    TEST_ASSERT(!memcmp(expected.u8, a.u8, sizeof(a))); /* Don't trust the macro ;) */
 }
 
 static void test_ipv6_addr_is_link_local_not_link_local(void)
@@ -653,8 +660,7 @@ static void test_ipv6_addr_set_iid(void)
         }
     };
 
-    ipv6_addr_set_iid(&a, byteorder_ntohll(b.u64[1]));
-
+    ipv6_addr_set_iid(&a, byteorder_bebuftohll(&b.u8[8]));
     TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
 }
 
@@ -694,13 +700,14 @@ static void test_ipv6_addr_set_all_nodes_multicast_if_local(void)
     ipv6_addr_t a = IPV6_ADDR_UNSPECIFIED;
     ipv6_addr_t b = IPV6_ADDR_ALL_NODES_IF_LOCAL;
     unsigned int scope = IPV6_ADDR_MCAST_SCP_IF_LOCAL;
+    const ipv6_addr_t expected = { {
+            0xff, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+        }
+    };
 
-    TEST_ASSERT_EQUAL_INT(0xff010000, byteorder_ntohl(b.u32[0])); /* Don't trust the macro ;) */
-    TEST_ASSERT_EQUAL_INT(0, b.u32[1].u32);
-    TEST_ASSERT_EQUAL_INT(1, byteorder_ntohll(b.u64[1]));
-
+    TEST_ASSERT(!memcmp(expected.u8, b.u8, sizeof(b))); /* Don't trust the macro ;) */
     ipv6_addr_set_all_nodes_multicast(&a, scope);
-
     TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
 }
 
@@ -709,13 +716,14 @@ static void test_ipv6_addr_set_all_nodes_multicast_link_local(void)
     ipv6_addr_t a = IPV6_ADDR_UNSPECIFIED;
     ipv6_addr_t b = IPV6_ADDR_ALL_NODES_LINK_LOCAL;
     unsigned int scope = IPV6_ADDR_MCAST_SCP_LINK_LOCAL;
+    const ipv6_addr_t expected = { {
+            0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+        }
+    };
 
-    TEST_ASSERT_EQUAL_INT(0xff020000, byteorder_ntohl(b.u32[0])); /* Don't trust the macro ;) */
-    TEST_ASSERT_EQUAL_INT(0, b.u32[1].u32);
-    TEST_ASSERT_EQUAL_INT(1, byteorder_ntohll(b.u64[1]));
-
+    TEST_ASSERT(!memcmp(expected.u8, b.u8, sizeof(b))); /* Don't trust the macro ;) */
     ipv6_addr_set_all_nodes_multicast(&a, scope);
-
     TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
 }
 
@@ -723,12 +731,14 @@ static void test_ipv6_addr_set_all_nodes_multicast_unusual(void)
 {
     ipv6_addr_t a;
     unsigned int scope = IPV6_ADDR_MCAST_SCP_REALM_LOCAL;
+    const ipv6_addr_t expected = { {
+            0xff, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01
+        }
+    };
 
     ipv6_addr_set_all_nodes_multicast(&a, scope);
-
-    TEST_ASSERT_EQUAL_INT(0xff030000, byteorder_ntohl(a.u32[0]));
-    TEST_ASSERT_EQUAL_INT(0, a.u32[1].u32);
-    TEST_ASSERT_EQUAL_INT(1, byteorder_ntohll(a.u64[1]));
+    TEST_ASSERT(!memcmp(expected.u8, a.u8, sizeof(a)));
 }
 
 static void test_ipv6_addr_set_all_routers_multicast_if_local(void)
@@ -736,13 +746,14 @@ static void test_ipv6_addr_set_all_routers_multicast_if_local(void)
     ipv6_addr_t a = IPV6_ADDR_UNSPECIFIED;
     ipv6_addr_t b = IPV6_ADDR_ALL_ROUTERS_IF_LOCAL;
     unsigned int scope = IPV6_ADDR_MCAST_SCP_IF_LOCAL;
+    const ipv6_addr_t expected = { {
+            0xff, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02
+        }
+    };
 
-    TEST_ASSERT_EQUAL_INT(0xff010000, byteorder_ntohl(b.u32[0])); /* Don't trust the macro ;) */
-    TEST_ASSERT_EQUAL_INT(0, b.u32[1].u32);
-    TEST_ASSERT_EQUAL_INT(2, byteorder_ntohll(b.u64[1]));
-
+    TEST_ASSERT(!memcmp(expected.u8, b.u8, sizeof(b))); /* Don't trust the macro ;) */
     ipv6_addr_set_all_routers_multicast(&a, scope);
-
     TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
 }
 
@@ -751,13 +762,14 @@ static void test_ipv6_addr_set_all_routers_multicast_link_local(void)
     ipv6_addr_t a = IPV6_ADDR_UNSPECIFIED;
     ipv6_addr_t b = IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL;
     unsigned int scope = IPV6_ADDR_MCAST_SCP_LINK_LOCAL;
+    const ipv6_addr_t expected = { {
+            0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02
+        }
+    };
 
-    TEST_ASSERT_EQUAL_INT(0xff020000, byteorder_ntohl(b.u32[0])); /* Don't trust the macro ;) */
-    TEST_ASSERT_EQUAL_INT(0, b.u32[1].u32);
-    TEST_ASSERT_EQUAL_INT(2, byteorder_ntohll(b.u64[1]));
-
+    TEST_ASSERT(!memcmp(expected.u8, b.u8, sizeof(b))); /* Don't trust the macro ;) */
     ipv6_addr_set_all_routers_multicast(&a, scope);
-
     TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
 }
 
@@ -766,13 +778,14 @@ static void test_ipv6_addr_set_all_routers_multicast_site_local(void)
     ipv6_addr_t a = IPV6_ADDR_UNSPECIFIED;
     ipv6_addr_t b = IPV6_ADDR_ALL_ROUTERS_SITE_LOCAL;
     unsigned int scope = IPV6_ADDR_MCAST_SCP_SITE_LOCAL;
+    const ipv6_addr_t expected = { {
+            0xff, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02
+        }
+    };
 
-    TEST_ASSERT_EQUAL_INT(0xff050000, byteorder_ntohl(b.u32[0])); /* Don't trust the macro ;) */
-    TEST_ASSERT_EQUAL_INT(0, b.u32[1].u32);
-    TEST_ASSERT_EQUAL_INT(2, byteorder_ntohll(b.u64[1]));
-
+    TEST_ASSERT(!memcmp(expected.u8, b.u8, sizeof(b))); /* Don't trust the macro ;) */
     ipv6_addr_set_all_routers_multicast(&a, scope);
-
     TEST_ASSERT_EQUAL_INT(true, ipv6_addr_equal(&a, &b));
 }
 
@@ -780,12 +793,14 @@ static void test_ipv6_addr_set_all_routers_multicast_unusual(void)
 {
     ipv6_addr_t a;
     unsigned int scope = IPV6_ADDR_MCAST_SCP_ORG_LOCAL;
+    const ipv6_addr_t expected = { {
+            0xff, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02
+        }
+    };
 
     ipv6_addr_set_all_routers_multicast(&a, scope);
-
-    TEST_ASSERT_EQUAL_INT(0xff080000, byteorder_ntohl(a.u32[0]));
-    TEST_ASSERT_EQUAL_INT(0, a.u32[1].u32);
-    TEST_ASSERT_EQUAL_INT(2, byteorder_ntohll(a.u64[1]));
+    TEST_ASSERT(!memcmp(expected.u8, a.u8, sizeof(expected)));
 }
 
 static void test_ipv6_addr_set_solicited_nodes(void)
@@ -796,13 +811,14 @@ static void test_ipv6_addr_set_solicited_nodes(void)
             0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
         }
     };
+    const ipv6_addr_t expected = { {
+            0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x01, 0xff, 0x0d, 0x0e, 0x0f
+        }
+    };
 
     ipv6_addr_set_solicited_nodes(&a, &b);
-
-    TEST_ASSERT_EQUAL_INT(0xff020000, byteorder_ntohl(a.u32[0]));
-    TEST_ASSERT_EQUAL_INT(0, a.u32[1].u32);
-    TEST_ASSERT_EQUAL_INT(1, byteorder_ntohl(a.u32[2]));
-    TEST_ASSERT_EQUAL_INT(0xff0d0e0f, byteorder_ntohl(a.u32[3]));
+    TEST_ASSERT(!memcmp(expected.u8, a.u8, sizeof(expected)));
 }
 
 static void test_ipv6_addr_to_str__string_too_short(void)


### PR DESCRIPTION
### Contribution description

Make `ipv6_addr_t` a simple byte array.

#### Motivation

Using complex types makes interoperability of functions using this type with external code or even with `sock_udp_ep_t` harder, especially due to the alignment requirements. Using a simple type allows using these functions in the Sock API or in external code (specifically in a pkg I want to update) and thus prevents code duplication and increases maintainability.

### Testing procedure

Luckily, @miri64 wrote many unit tests that already helped to fix many bugs this PR previously contained. In addition to automatic tests, testing IPv6 communication would nake sense.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/14737
- [x] Depends on and includes https://github.com/RIOT-OS/RIOT/pull/14761