### PR TITLE
cpu/sam0_common: ADC: add support for samd5x/same5x

### DIFF
--- a/boards/same54-xpro/Kconfig
+++ b/boards/same54-xpro/Kconfig
@@ -12,6 +12,7 @@ config BOARD_SAME54_XPRO
     default y
     select CPU_MODEL_SAME54P20A
     select HAS_PERIPH_DAC
+    select HAS_PERIPH_ADC
     select HAS_PERIPH_I2C
     select HAS_PERIPH_RTC
     select HAS_PERIPH_RTT

--- a/boards/same54-xpro/Makefile.features
+++ b/boards/same54-xpro/Makefile.features
@@ -10,6 +10,7 @@ FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_usbdev
 
 # Put other features for this board (in alphabetical order)

--- a/boards/same54-xpro/include/periph_conf.h
+++ b/boards/same54-xpro/include/periph_conf.h
@@ -310,6 +310,28 @@ static const sam0_common_usb_config_t sam_usbdev_config[] = {
 /** @} */
 
 /**
+ * @name ADC Configuration
+ * @{
+ */
+
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLA_PRESCALER_DIV128
+
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG(0x18u)
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INTVCC1
+#define ADC_DEV                             ADC0
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos */
+    {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN1)},
+    {GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN5)},
+    {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN7)}
+};
+
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
+/** @} */
+
+/**
  * @name DAC configuration
  * @{
  */

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -28,9 +28,28 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+/* The SAMD5x/SAME5x family has two ADCs: ADC0 and ADC1.
+ * Introducing ADC_DEV as alias for the respective device (ADC/ADC0/ADC1). */
+#ifndef ADC_DEV
+    #ifdef ADC0
+        #define ADC_DEV ADC0
+    #else
+        #define ADC_DEV ADC
+    #endif
+#endif
+
+#ifndef ADC_GCLK_SRC
+    #define ADC_GCLK_SRC SAM0_GCLK_MAIN
+#endif
+
+#ifndef ADC_GAIN_FACTOR_DEFAULT
+    #define ADC_GAIN_FACTOR_DEFAULT (0)
+#endif
+
 /* Prototypes */
-static bool _adc_syncing(void);
 static void _adc_poweroff(void);
+static void _setup_clock(void);
+static void _setup_calibration(void);
 static int _adc_configure(adc_res_t res);
 
 static mutex_t _lock = MUTEX_INIT;
@@ -45,35 +64,116 @@ static inline void _done(void)
     mutex_unlock(&_lock);
 }
 
-static bool _adc_syncing(void)
+static inline void _wait_syncbusy(void)
 {
-#ifdef CPU_SAMD21
-    if (ADC->STATUS.reg & ADC_STATUS_SYNCBUSY) {
-        return true;
-    }
-#else /* CPU_SAML21 */
-    if (ADC->SYNCBUSY.reg) {
-        return true;
-    }
+#ifdef ADC_STATUS_SYNCBUSY
+    while (ADC_DEV->STATUS.reg & ADC_STATUS_SYNCBUSY) {}
+#else
+    while (ADC_DEV->SYNCBUSY.reg) {}
 #endif
-    return false;
 }
 
 static void _adc_poweroff(void)
 {
-    while (_adc_syncing()) {}
+    _wait_syncbusy();
     /* Disable */
-    ADC->CTRLA.reg &= ~ADC_CTRLA_ENABLE;
-    while (_adc_syncing()) {}
+    ADC_DEV->CTRLA.reg &= ~ADC_CTRLA_ENABLE;
+    _wait_syncbusy();
     /* Disable bandgap */
 #ifdef CPU_SAMD21
     if (ADC_REF_DEFAULT == ADC_REFCTRL_REFSEL_INT1V) {
         SYSCTRL->VREF.reg &= ~SYSCTRL_VREF_BGOUTEN;
     }
-#else /* CPU_SAML21 */
+#else
     if (ADC_REF_DEFAULT == ADC_REFCTRL_REFSEL_INTREF) {
         SUPC->VREF.reg &= ~SUPC_VREF_VREFOE;
     }
+#endif
+}
+
+static void _setup_clock(void)
+{
+    /* Enable gclk in case we are the only user */
+    sam0_gclk_enable(ADC_GCLK_SRC);
+#ifdef CPU_SAMD21
+    /* Power On */
+    PM->APBCMASK.reg |= PM_APBCMASK_ADC;
+    /* GCLK Setup */
+    GCLK->CLKCTRL.reg = (uint32_t)(GCLK_CLKCTRL_CLKEN
+            | GCLK_CLKCTRL_GEN(ADC_GCLK_SRC) | (GCLK_CLKCTRL_ID(ADC_GCLK_ID)));
+    /* Configure prescaler */
+    ADC_DEV->CTRLB.reg = ADC_PRESCALER;
+#else
+    /* Power on */
+    #ifdef MCLK_APBCMASK_ADC
+        MCLK->APBCMASK.reg |= MCLK_APBCMASK_ADC;
+    #else
+        #ifdef MCLK_APBDMASK_ADC0
+            if (ADC_DEV == ADC0) {
+                MCLK->APBDMASK.reg |= MCLK_APBDMASK_ADC0;
+            } else {
+                MCLK->APBDMASK.reg |= MCLK_APBDMASK_ADC1;
+            }
+        #else
+            MCLK->APBDMASK.reg |= MCLK_APBDMASK_ADC;
+        #endif
+    #endif
+
+    #ifdef ADC0_GCLK_ID
+        /* GCLK Setup */
+        if (ADC_DEV == ADC0) {
+            GCLK->PCHCTRL[ADC0_GCLK_ID].reg = GCLK_PCHCTRL_CHEN
+                    | GCLK_PCHCTRL_GEN(ADC_GCLK_SRC);
+        }
+        else {
+            GCLK->PCHCTRL[ADC1_GCLK_ID].reg = GCLK_PCHCTRL_CHEN
+                    | GCLK_PCHCTRL_GEN(ADC_GCLK_SRC);
+        }
+        /* Configure prescaler */
+        ADC_DEV->CTRLA.reg = ADC_PRESCALER;
+    #else
+        /* GCLK Setup */
+        GCLK->PCHCTRL[ADC_GCLK_ID].reg = GCLK_PCHCTRL_CHEN
+                | GCLK_PCHCTRL_GEN(ADC_GCLK_SRC);
+        /* Configure prescaler */
+        ADC_DEV->CTRLB.reg = ADC_PRESCALER;
+    #endif
+#endif
+}
+
+static void _setup_calibration(void)
+{
+#ifdef CPU_SAMD21
+    /* Load the fixed device calibration constants */
+    ADC_DEV->CALIB.reg =
+        ADC_CALIB_BIAS_CAL((*(uint32_t*)ADC_FUSES_BIASCAL_ADDR >>
+                            ADC_FUSES_BIASCAL_Pos)) |
+        ADC_CALIB_LINEARITY_CAL((*(uint64_t*)ADC_FUSES_LINEARITY_0_ADDR >>
+                                ADC_FUSES_LINEARITY_0_Pos));
+#else
+    /* Set default calibration from NVM */
+    #ifdef ADC0_FUSES_BIASCOMP_ADDR
+        if (ADC_DEV == ADC0) {
+            ADC_DEV->CALIB.reg =
+                ADC0_FUSES_BIASCOMP((*(uint32_t*)ADC0_FUSES_BIASCOMP_ADDR)) >>
+                ADC_CALIB_BIASCOMP_Pos |
+                ADC0_FUSES_BIASREFBUF((*(uint32_t*)ADC0_FUSES_BIASREFBUF_ADDR) >>
+                ADC0_FUSES_BIASREFBUF_Pos);
+        }
+        else {
+            ADC_DEV->CALIB.reg =
+                ADC1_FUSES_BIASCOMP((*(uint32_t*)ADC1_FUSES_BIASCOMP_ADDR)) >>
+                ADC_CALIB_BIASCOMP_Pos |
+                ADC1_FUSES_BIASREFBUF((*(uint32_t*)ADC1_FUSES_BIASREFBUF_ADDR) >>
+                ADC1_FUSES_BIASREFBUF_Pos);
+        }
+    #else
+        ADC_DEV->CALIB.reg =
+                ADC_FUSES_BIASCOMP((*(uint32_t*)ADC_FUSES_BIASCOMP_ADDR)) >>
+                ADC_CALIB_BIASCOMP_Pos |
+                ADC_FUSES_BIASREFBUF((*(uint32_t*)ADC_FUSES_BIASREFBUF_ADDR) >>
+                ADC_FUSES_BIASREFBUF_Pos);
+    #endif
 #endif
 }
 
@@ -87,67 +187,45 @@ static int _adc_configure(adc_res_t res)
         return -1;
     }
     _adc_poweroff();
-    if (ADC->CTRLA.reg & ADC_CTRLA_SWRST ||
-        ADC->CTRLA.reg & ADC_CTRLA_ENABLE ) {
+    if (ADC_DEV->CTRLA.reg & ADC_CTRLA_SWRST ||
+        ADC_DEV->CTRLA.reg & ADC_CTRLA_ENABLE ) {
         DEBUG("adc: not ready\n");
         return -1;
     }
-#ifdef CPU_SAMD21
-    /* Power On */
-    PM->APBCMASK.reg |= PM_APBCMASK_ADC;
-    /* GCLK Setup */
-    GCLK->CLKCTRL.reg = (uint32_t)(GCLK_CLKCTRL_CLKEN | GCLK_CLKCTRL_GEN_GCLK0 |
-                        (GCLK_CLKCTRL_ID(ADC_GCLK_ID)));
-    /* Configure CTRLB Register HERE IS THE RESOLUTION SET! */
-    ADC->CTRLB.reg = ADC_PRESCALER | res;
-    /* Load the fixed device calibration constants */
-    ADC->CALIB.reg =
-        ADC_CALIB_BIAS_CAL((*(uint32_t*)ADC_FUSES_BIASCAL_ADDR >>
-                            ADC_FUSES_BIASCAL_Pos)) |
-        ADC_CALIB_LINEARITY_CAL((*(uint64_t*)ADC_FUSES_LINEARITY_0_ADDR >>
-                                ADC_FUSES_LINEARITY_0_Pos));
+    _setup_clock();
+    _setup_calibration();
+
+    /* Set ADC resolution */
+#ifdef ADC_CTRLC_RESSEL
+    /* Reset resolution bits in CTRLC */
+    ADC_DEV->CTRLC.reg &= ~ADC_CTRLC_RESSEL_Msk;
+    ADC_DEV->CTRLC.reg |= res;
+#else
+    /* Reset resolution bits in CTRLB */
+    ADC_DEV->CTRLB.reg &= ~ADC_CTRLB_RESSEL_Msk;
+    ADC_DEV->CTRLB.reg |= res;
+#endif
+
     /* Set Voltage Reference */
-    ADC->REFCTRL.reg = ADC_REF_DEFAULT;
+    ADC_DEV->REFCTRL.reg = ADC_REF_DEFAULT;
     /* Disable all interrupts */
-    ADC->INTENCLR.reg = (ADC_INTENCLR_SYNCRDY) | (ADC_INTENCLR_WINMON) |
-                              (ADC_INTENCLR_OVERRUN) | (ADC_INTENCLR_RESRDY);
-    while (_adc_syncing()) {}
+    ADC_DEV->INTENCLR.reg = 0xFF;
+
+#ifdef CPU_SAMD21
     /* Enable bandgap if VREF is internal 1V */
     if (ADC_REF_DEFAULT == ADC_REFCTRL_REFSEL_INT1V) {
         SYSCTRL->VREF.reg |= SYSCTRL_VREF_BGOUTEN;
     }
-#else /* CPU_SAML21 */
-    /* Power on */
-#ifdef CPU_SAML1X
-    MCLK->APBCMASK.reg |= MCLK_APBCMASK_ADC;
 #else
-    MCLK->APBDMASK.reg |= MCLK_APBDMASK_ADC;
-#endif
-    /* GCLK Setup */
-    GCLK->PCHCTRL[ADC_GCLK_ID].reg = GCLK_PCHCTRL_CHEN | GCLK_PCHCTRL_GEN_GCLK0;
-    /* Set Voltage Reference */
-    ADC->REFCTRL.reg = ADC_REF_DEFAULT;
-    /* Configure CTRLB & CTRLC Register */
-    ADC->CTRLB.reg = ADC_PRESCALER;
-    ADC->CTRLC.reg |= res;
-    /* Disable all interrupts */
-    ADC->INTENCLR.reg = ADC_INTENCLR_WINMON | ADC_INTENCLR_OVERRUN |
-                              ADC_INTENCLR_RESRDY;
-    /* Set default calibration from NVM */
-    ADC->CALIB.reg =
-            ADC_FUSES_BIASCOMP((*(uint32_t*)ADC_FUSES_BIASCOMP_ADDR)) >>
-            ADC_CALIB_BIASCOMP_Pos |
-            ADC_FUSES_BIASREFBUF((*(uint32_t*)ADC_FUSES_BIASREFBUF_ADDR) >>
-            ADC_FUSES_BIASREFBUF_Pos);
-    while (_adc_syncing()) {}
     /* Enable bandgap if necessary */
     if (ADC_REF_DEFAULT == ADC_REFCTRL_REFSEL_INTREF) {
         SUPC->VREF.reg |= SUPC_VREF_VREFOE;
     }
 #endif
+
     /*  Enable ADC Module */
-    ADC->CTRLA.reg |= ADC_CTRLA_ENABLE;
-    while (_adc_syncing()) {}
+    ADC_DEV->CTRLA.reg |= ADC_CTRLA_ENABLE;
+    _wait_syncbusy();
     return 0;
 }
 
@@ -176,18 +254,15 @@ int32_t adc_sample(adc_t line, adc_res_t res)
         DEBUG("adc: configuration failed\n");
         return -1;
     }
-#ifdef CPU_SAMD21
-    ADC->INPUTCTRL.reg = ADC_GAIN_FACTOR_DEFAULT |
+    ADC_DEV->INPUTCTRL.reg = ADC_GAIN_FACTOR_DEFAULT |
                          adc_channels[line].muxpos | ADC_NEG_INPUT;
-#else /* CPU_SAML21 */
-    ADC->INPUTCTRL.reg = adc_channels[line].muxpos | ADC_NEG_INPUT;
-#endif
-    while (_adc_syncing()) {}
+    _wait_syncbusy();
+
     /* Start the conversion */
-    ADC->SWTRIG.reg = ADC_SWTRIG_START;
+    ADC_DEV->SWTRIG.reg = ADC_SWTRIG_START;
     /* Wait for the result */
-    while (!(ADC->INTFLAG.reg & ADC_INTFLAG_RESRDY)) {}
-    int result = ADC->RESULT.reg;
+    while (!(ADC_DEV->INTFLAG.reg & ADC_INTFLAG_RESRDY)) {}
+    int result = ADC_DEV->RESULT.reg;
     _adc_poweroff();
     _done();
     return result;

--- a/cpu/samd5x/include/periph_cpu.h
+++ b/cpu/samd5x/include/periph_cpu.h
@@ -83,6 +83,19 @@ enum {
  */
 #define SPI_HWCS(x)     (UINT_MAX - 1)
 
+#ifndef DOXYGEN
+#define HAVE_ADC_RES_T
+typedef enum {
+    ADC_RES_6BIT  = 0xff,                       /**< not supported */
+    ADC_RES_8BIT  = ADC_CTRLB_RESSEL_8BIT,      /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = ADC_CTRLB_RESSEL_10BIT,     /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = ADC_CTRLB_RESSEL_12BIT,     /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = 0xfe,                       /**< not supported */
+    ADC_RES_16BIT = 0xfd                        /**< not supported */
+} adc_res_t;
+/** @} */
+#endif /* DOXYGEN */
+
 /**
  * @brief   The MCU has a 12 bit DAC
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds ADC support for the samd5x/same5x CPU family. Those CPUs have two ADC devices: ADC0 and ADC1. To support both devices this PR adds an ADC_DEV alias for the respective device (ADC/ADC0/ADC1). By default the driver uses ADC0 as device but it can be changed to ADC1 by a define (`#define ADC_DEV ADC1`). 

It is now also possible to change the ADC clock source via `#define ADC_GCLK_SRC {}`. The default is `SAM0_GCLK_MAIN`.

Also configured the same54-xpro board to make use of these changes.
### Testing procedure
**tests/periph_adc**
Flash the test on your board. It should work with all devices supported so far and additionally with same5x/samd5x MCUs (e.g. same54-xpro). 
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
