### PR TITLE
core/byteorder: Add byteorder_bebuftohll() and inverse

### DIFF
--- a/sys/include/unaligned.h
+++ b/sys/include/unaligned.h
@@ -53,6 +53,11 @@ typedef struct __attribute__((packed)) {
     uint32_t val;       /**< value */
 } uint32_una_t;
 
+/** @brief Unaligned access helper struct (uint64_t version) */
+typedef struct __attribute__((packed)) {
+    uint64_t val;       /**< value */
+} uint64_una_t;
+
 /**
  * @brief    Get uint16_t from possibly unaligned pointer
  *
@@ -76,6 +81,19 @@ static inline uint16_t unaligned_get_u16(const void *ptr)
 static inline uint32_t unaligned_get_u32(const void *ptr)
 {
     const uint32_una_t *tmp = (const uint32_una_t *)ptr;
+    return tmp->val;
+}
+
+/**
+ * @brief    Get uint64_t from possibly unaligned pointer
+ *
+ * @param[in]   ptr pointer to read from
+ *
+ * @returns value read from @p ptr
+ */
+static inline uint64_t unaligned_get_u64(const void *ptr)
+{
+    const uint64_una_t *tmp = (const uint64_una_t *)ptr;
     return tmp->val;
 }
 


### PR DESCRIPTION
### Contribution description

This PR adds 64 bit version of the helper functions to read from or write into big endian byte buffers.

### Testing procedure

IMO, code review should be sufficient. The implementation is identical to the flavors with 32 or 16 bit.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/14759