### PR TITLE
core/byteorder: Moved to sys

### DIFF
--- a/dist/tools/riotboot_gen_hdr/Makefile
+++ b/dist/tools/riotboot_gen_hdr/Makefile
@@ -11,7 +11,7 @@ RIOT_HDR_SRC := \
 
 RIOT_HDR_HDR := $(RIOT_INCLUDE)/riotboot/hdr.h \
 	$(RIOT_INCLUDE)/checksum/fletcher32.h \
-	$(RIOTBASE)/core/include/byteorder.h
+	$(RIOTBASE)/sys/include/byteorder.h
 
 GENHDR_SRC := $(COMMON_SRC) $(RIOT_HDR_SRC) \
 	main.c genhdr.c

--- a/sys/include/byteorder.h
+++ b/sys/include/byteorder.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     core_util
+ * @ingroup     sys
  * @{
  *
  * @file


### PR DESCRIPTION
### Contribution description

As the title says.

The byteorder utilities are never used in `core`, but extensively in `sys`. They seem to be better located in `sys`.

### Testing procedure

Both `core/include` and `sys/include` are in the default include paths. This should be completely transparent.

### Issues/PRs references

- [x] Depends on and contains: https://github.com/RIOT-OS/RIOT/pull/14761