### PR TITLE
cpu/stm32/vectors/vectors_f3: a small fix for STM32F334x8

### DIFF
--- a/cpu/stm32/vectors/vectors_f3.c
+++ b/cpu/stm32/vectors/vectors_f3.c
@@ -244,9 +244,9 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     (0UL),                  /* [79] Reserved */
     (0UL),                  /* [80] Reserved */
     isr_fpu                 /* [81] Floating point Interrupt */
-#elif (CPU_LINE_STM32F334x8)
+#elif defined(CPU_LINE_STM32F334x8)
     isr_tim3,               /* [29] TIM3 global Interrupt */
-    isr_tim4,               /* [30] TIM4 global Interrupt */
+    (0UL),                  /* [30] Reserved */
     isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
     isr_i2c1_er,            /* [32] I2C1 Error Interrupt */
     (0UL),                  /* [33] Reserved */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Fix a small mistake in vectors_f3.c that I have checked with the reference manual's vector table (p. 195).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Moved from #14734.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
