### PR TITLE
boards/nucleo-f303k8: DMA feature added

### DIFF
--- a/boards/nucleo-f303k8/Kconfig
+++ b/boards/nucleo-f303k8/Kconfig
@@ -15,6 +15,7 @@ config BOARD_NUCLEO_F303K8
     select CPU_MODEL_STM32F303K8
 
     # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_DMA
     select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC
     select HAS_PERIPH_SPI

--- a/boards/nucleo-f303k8/Makefile.features
+++ b/boards/nucleo-f303k8/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32f303k8
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-f303k8/include/periph_conf.h
+++ b/boards/nucleo-f303k8/include/periph_conf.h
@@ -56,6 +56,25 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+static const dma_conf_t dma_config[] = {
+    { .stream = 1 },    /* DMA1 Channel 2 - SPI1_RX */
+    { .stream = 2 },    /* DMA1 Channel 3 - SPI1_TX */
+    { .stream = 3 },    /* DMA1 Channel 4 - USART1_TX */
+    { .stream = 6 },    /* DMA1 Channel 7 - USART2_TX */
+};
+
+#define DMA_0_ISR   isr_dma1_channel2
+#define DMA_1_ISR   isr_dma1_channel3
+#define DMA_2_ISR   isr_dma1_channel4
+#define DMA_3_ISR   isr_dma1_channel7
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+/** @} */
+
+/**
  * @name   UART configuration
  * @{
  */
@@ -68,7 +87,11 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF7,
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
-        .irqn       = USART2_IRQn
+        .irqn       = USART2_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 3,
+        .dma_chan   = DMA_CHAN_CONFIG_UNSUPPORTED
+#endif
     },
     {
         .dev        = USART1,
@@ -78,7 +101,11 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF7,
         .tx_af      = GPIO_AF7,
         .bus        = APB2,
-        .irqn       = USART1_IRQn
+        .irqn       = USART1_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 2,
+        .dma_chan   = DMA_CHAN_CONFIG_UNSUPPORTED
+#endif
     }
 };
 
@@ -134,7 +161,13 @@ static const spi_conf_t spi_config[] = {
         .sclk_af  = GPIO_AF5,
         .cs_af    = GPIO_AF5,
         .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
+        .apbbus   = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma   = 1,
+        .tx_dma_chan = DMA_CHAN_CONFIG_UNSUPPORTED,
+        .rx_dma   = 0,
+        .rx_dma_chan = DMA_CHAN_CONFIG_UNSUPPORTED
+#endif
     }
 };
 

--- a/boards/nucleo-f303k8/include/periph_conf.h
+++ b/boards/nucleo-f303k8/include/periph_conf.h
@@ -129,10 +129,10 @@ static const spi_conf_t spi_config[] = {
         .miso_pin = GPIO_PIN(PORT_B, 4),
         .sclk_pin = GPIO_PIN(PORT_B, 3),
         .cs_pin   = GPIO_UNDEF,
-        .mosi_af  = GPIO_AF0,
-        .miso_af  = GPIO_AF0,
-        .sclk_af  = GPIO_AF0,
-        .cs_af    = GPIO_AF0,
+        .mosi_af  = GPIO_AF5,
+        .miso_af  = GPIO_AF5,
+        .sclk_af  = GPIO_AF5,
+        .cs_af    = GPIO_AF5,
         .rccmask  = RCC_APB2ENR_SPI1EN,
         .apbbus   = APB2
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
As tests/periph_spi was not working at all, I first addressed this issue (AF mistake).

Then I have added the DMA configuration.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
First commit tested with tests/periph_spi.

The second with tests/periph_spi_dma after applying #14764.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on #14764.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
