### PR TITLE
cpu/native: RTC: implement rtc_set_alarm()

### DIFF
--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -4,6 +4,9 @@ endif
 ifeq (,$(filter stdio_%,$(USEMODULE)))
   USEMODULE += stdio_native
 endif
+ifeq (,$(filter periph_rtc,$(USEMODULE)))
+  USEMODULE += xtimer
+endif
 
 USEMODULE += periph
 

--- a/tests/periph_rtc/tests/01-run.py
+++ b/tests/periph_rtc/tests/01-run.py
@@ -32,18 +32,12 @@ def testfunc(child):
 
     child.expect(r'  Setting alarm to   ({})'.format(DATE_PATTERN))
     alarm_set = child.match.group(1)
-    if BOARD == 'native':
-        child.expect(r'.*rtc_set_alarm: not implemented')
     child.expect(r'   Alarm is set to   ({})'.format(DATE_PATTERN))
     alarm_value = child.match.group(1)
-    if BOARD != 'native':
-        # Set alarm is not implemented for native board so no need to compare
-        # alarm values
-        assert alarm_set == alarm_value
+    assert alarm_set == alarm_value
 
-    if BOARD != 'native':
-        for _ in range(alarm_count):
-            child.expect_exact('Alarm!')
+    for _ in range(alarm_count):
+        child.expect_exact('Alarm!')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Use xtimer to simulate an RTC timer.
This allows to simulate software that makes use of `rtc_set_alarm()` on native.

### Testing procedure

`tests/periph_rtc` should now work on `native`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
