### PR TITLE
boards/common/blxxxpill: DMA feature added

### DIFF
--- a/boards/common/blxxxpill/Kconfig
+++ b/boards/common/blxxxpill/Kconfig
@@ -8,6 +8,7 @@
 config BOARD_COMMON_BLXXXPILL
     bool
     select HAS_PERIPH_ADC
+    select HAS_PERIPH_DMA
     select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC

--- a/boards/common/blxxxpill/Makefile.features
+++ b/boards/common/blxxxpill/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/common/blxxxpill/include/periph_conf.h
+++ b/boards/common/blxxxpill/include/periph_conf.h
@@ -91,6 +91,27 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+static const dma_conf_t dma_config[] = {
+    { .stream = 1 },    /* DMA1 Channel 2 - SPI1_RX / USART3_TX */
+    { .stream = 2 },    /* DMA1 Channel 3 - SPI1_TX */
+    { .stream = 3 },    /* DMA1 Channel 4 - SPI2_RX / USART1_TX */
+    { .stream = 4 },    /* DMA1 Channel 5 - SPI2_TX */
+    { .stream = 6 },    /* DMA1 Channel 7 - USART2_TX */
+};
+
+#define DMA_0_ISR   isr_dma1_channel2
+#define DMA_1_ISR   isr_dma1_channel3
+#define DMA_2_ISR   isr_dma1_channel4
+#define DMA_3_ISR   isr_dma1_channel5
+#define DMA_4_ISR   isr_dma1_channel7
+
+#define DMA_NUMOF           ARRAY_SIZE(dma_config)
+/** @} */
+
+/**
  * @name   Timer configuration
  * @{
  */
@@ -174,7 +195,11 @@ static const uart_conf_t uart_config[] = {
         .rx_pin     = GPIO_PIN(PORT_A, 10),
         .tx_pin     = GPIO_PIN(PORT_A, 9),
         .bus        = APB2,
-        .irqn       = USART1_IRQn
+        .irqn       = USART1_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 2,
+        .dma_chan   = DMA_CHAN_CONFIG_UNSUPPORTED
+#endif
     },
     {
         .dev        = USART2,
@@ -182,7 +207,11 @@ static const uart_conf_t uart_config[] = {
         .rx_pin     = GPIO_PIN(PORT_A, 3),
         .tx_pin     = GPIO_PIN(PORT_A, 2),
         .bus        = APB1,
-        .irqn       = USART2_IRQn
+        .irqn       = USART2_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 4,
+        .dma_chan   = DMA_CHAN_CONFIG_UNSUPPORTED
+#endif
     },
     {
         .dev        = USART3,
@@ -190,7 +219,11 @@ static const uart_conf_t uart_config[] = {
         .rx_pin     = GPIO_PIN(PORT_B, 11),
         .tx_pin     = GPIO_PIN(PORT_B, 10),
         .bus        = APB1,
-        .irqn       = USART3_IRQn
+        .irqn       = USART3_IRQn,
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 0,
+        .dma_chan   = DMA_CHAN_CONFIG_UNSUPPORTED
+#endif
     }
 };
 
@@ -267,7 +300,13 @@ static const spi_conf_t spi_config[] = {
         .sclk_pin = GPIO_PIN(PORT_A, 5),
         .cs_pin   = GPIO_PIN(PORT_A, 4),
         .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
+        .apbbus   = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma   = 1,
+        .tx_dma_chan = DMA_CHAN_CONFIG_UNSUPPORTED,
+        .rx_dma   = 0,
+        .rx_dma_chan = DMA_CHAN_CONFIG_UNSUPPORTED
+#endif
     },
     {
         .dev      = SPI2,
@@ -276,7 +315,13 @@ static const spi_conf_t spi_config[] = {
         .sclk_pin = GPIO_PIN(PORT_B, 13),
         .cs_pin   = GPIO_PIN(PORT_B, 12),
         .rccmask  = RCC_APB1ENR_SPI2EN,
-        .apbbus   = APB1
+        .apbbus   = APB1,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma   = 3,
+        .tx_dma_chan = DMA_CHAN_CONFIG_UNSUPPORTED,
+        .rx_dma   = 2,
+        .rx_dma_chan = DMA_CHAN_CONFIG_UNSUPPORTED
+#endif
     }
 };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Added DMA feature to check that dma_stop in spi.c isn't only needed by F3 family for  #14764.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Running tests/periph_spi_dma.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Forked from PR #14764.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
