### PR TITLE
tests/periph_spi: add support for printing SPI clock rates on stm32

### DIFF
--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -142,6 +142,30 @@ int cmd_init(int argc, char **argv)
         puts("\t\t2: 1 MHz");
         puts("\t\t3: 5 MHz");
         puts("\t\t4: 10 MHz");
+#ifdef CLOCK_APB1
+        for (int i = 0; i < (int)SPI_NUMOF; i++) {
+            printf("\t\tSPI_DEV(%i), ", i);
+            if (spi_config[i].apbbus == APB1) {
+                clk = CLOCK_APB1;
+                printf("CLOCK_APB1 = %luHz\n", (uint32_t)CLOCK_APB1);
+            }
+            else if (spi_config[i].apbbus == APB2) {
+                clk = CLOCK_APB2;
+                printf("CLOCK_APB2 = %luHz\n", (uint32_t)CLOCK_APB2);
+            }
+            else {
+                printf("error: apbbus configuration ");
+                printf("unrecognized parameter for SPI_DEV(%i)\n", i);
+                return 1;
+            }
+            tmp = 256;
+            for (int j = 0; j < 8; j++) {
+                printf("\t\t\t%i: %i/%i\n", (clk / tmp), clk, tmp);
+                tmp /= 2;
+            }
+            puts("\t\t\t*: other values will be rounded.");
+        }
+#endif
         puts("\tcs port:");
         puts("\t\tPort of the CS pin, set to -1 for hardware chip select");
         puts("\tcs pin:");
@@ -179,8 +203,12 @@ int cmd_init(int argc, char **argv)
         case 3: spiconf.clk = SPI_CLK_5MHZ;   break;
         case 4: spiconf.clk = SPI_CLK_10MHZ;  break;
         default:
+#ifdef CLOCK_APB1
+            spiconf.clk = clk;
+#else
             puts("error: invalid bus speed specified");
             return 1;
+#endif
     }
 
     /* parse chip select port and pin */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
cmd_init function help show possible speeds for each peripherals and directly store the clk argument in spiconf

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See also #14731.
Depends on PR #14749.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
