### PR TITLE
tests/driver_at86rf2xx_aes: only run CI test on whitelisted boards

### DIFF
--- a/tests/driver_at86rf2xx_aes/Makefile
+++ b/tests/driver_at86rf2xx_aes/Makefile
@@ -13,6 +13,8 @@ ifneq (,$(filter mulle,$(BOARD)))
   DRIVER := at86rf212b
 endif
 
+TEST_ON_CI_WHITELIST += samr21-xpro iotlab-m3 mulle
+
 # use the at86rf231 as fallback device
 DRIVER ?= at86rf231
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The test needs a at86rf2xx device attached to the board, otherwise it will always fail.


### Testing procedure

"Run tests" sould result in a green Murdock again.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
