### PR TITLE
cpu: Use thread_getpid() and thread_get_active() instead of sched_active_*

### DIFF
--- a/cpu/arm7_common/arm_cpu.c
+++ b/cpu/arm7_common/arm_cpu.c
@@ -89,7 +89,8 @@ void thread_print_stack(void)
     __asm__("mov %0, sp" : "=r"(stack));
 
     register unsigned int *s = (unsigned int *)stack;
-    printf("task: %X SP: %X\n", (unsigned int) sched_active_thread, (unsigned int) stack);
+    printf("task: %" PRIkernel_pid " SP: %X\n", thread_getpid(),
+           (uintptr_t)stack);
     register int i = 0;
     s += 5;
 

--- a/cpu/atmega_common/thread_arch.c
+++ b/cpu/atmega_common/thread_arch.c
@@ -168,7 +168,7 @@ char *thread_stack_init(thread_task_func_t task_func, void *arg,
 /**
  * @brief thread_stack_print prints the stack to stdout.
  * It depends on getting the correct values for stack_start, stack_size and sp
- * from sched_active_thread.
+ * of the active thread.
  * Maybe it would be good to change that to way that is less dependent on
  * getting correct values elsewhere (since it is a debugging tool and in the
  * presence of bugs the data may be corrupted).
@@ -176,7 +176,7 @@ char *thread_stack_init(thread_task_func_t task_func, void *arg,
 void thread_stack_print(void)
 {
     uint8_t found_marker = 1;
-    uint8_t *sp = (uint8_t *)sched_active_thread->sp;
+    uint8_t *sp = (uint8_t *)thread_get_active()->sp;
     uint16_t size = 0;
 
     printf("Printing current stack of thread %" PRIkernel_pid "\n", thread_getpid());

--- a/cpu/cortexm_common/thread_arch.c
+++ b/cpu/cortexm_common/thread_arch.c
@@ -226,7 +226,7 @@ char *thread_stack_init(thread_task_func_t task_func,
 void thread_stack_print(void)
 {
     int count = 0;
-    uint32_t *sp = (uint32_t *)sched_active_thread->sp;
+    uint32_t *sp = (uint32_t *)thread_get_active()->sp;
 
     printf("printing the current stack of thread %" PRIkernel_pid "\n",
            thread_getpid());

--- a/cpu/fe310/thread_arch.c
+++ b/cpu/fe310/thread_arch.c
@@ -115,25 +115,27 @@ char *thread_stack_init(thread_task_func_t task_func,
 void thread_print_stack(void)
 {
     int count = 0;
-    uint32_t *sp = (uint32_t *) ((sched_active_thread) ? sched_active_thread->sp : NULL);
-
-    if (sp == NULL) {
+    thread_t *active_thread = thread_get_active();
+    if (!active_thread) {
         return;
     }
+
+    uint32_t *sp = (uint32_t *)active_thread->sp;
 
     printf("printing the current stack of thread %" PRIkernel_pid "\n",
            thread_getpid());
 
 #ifdef DEVELHELP
-    printf("thread name: %s\n", sched_active_thread->name);
-    printf("stack start: 0x%08x\n", (unsigned int)(sched_active_thread->stack_start));
-    printf("stack end  : 0x%08x\n", (unsigned int)(sched_active_thread->stack_start + sched_active_thread->stack_size));
+    printf("thread name: %s\n", active_thread->name);
+    printf("stack start: 0x%08x\n", (unsigned)(active_thread->stack_start));
+    printf("stack end  : 0x%08x\n",
+           (unsigned)(active_thread->stack_start + active_thread->stack_size));
 #endif
 
     printf("  address:      data:\n");
 
     do {
-        printf("  0x%08x:   0x%08x\n", (unsigned int) sp, (unsigned int) *sp);
+        printf("  0x%08x:   0x%08x\n", (unsigned)sp, (unsigned)*sp);
         sp++;
         count++;
     } while (*sp != STACK_MARKER);

--- a/cpu/mips32r2_common/newlib_syscalls_mips_uhi/syscalls.c
+++ b/cpu/mips32r2_common/newlib_syscalls_mips_uhi/syscalls.c
@@ -105,7 +105,7 @@ void *_sbrk_r(struct _reent *r, ptrdiff_t incr)
 */
 pid_t _getpid(void)
 {
-    return sched_active_pid;
+    return thread_getpid();
 }
 
 /**
@@ -115,8 +115,8 @@ pid_t _getpid(void)
 */
 pid_t _getpid_r(struct _reent *ptr)
 {
-    (void) ptr;
-    return sched_active_pid;
+    (void)ptr;
+    return thread_getpid();
 }
 
 /**
@@ -132,8 +132,8 @@ pid_t _getpid_r(struct _reent *ptr)
 __attribute__ ((weak))
 int _kill_r(struct _reent *r, pid_t pid, int sig)
 {
-    (void) pid;
-    (void) sig;
+    (void)pid;
+    (void)sig;
     r->_errno = ESRCH; /* not implemented yet */
     return -1;
 }
@@ -331,8 +331,8 @@ int _isatty_r(struct _reent *r, int fd)
 __attribute__ ((weak))
 int _kill(pid_t pid, int sig)
 {
-    (void) pid;
-    (void) sig;
+    (void)pid;
+    (void)sig;
     errno = ESRCH; /* not implemented yet */
     return -1;
 }

--- a/cpu/msp430_common/cpu.c
+++ b/cpu/msp430_common/cpu.c
@@ -50,7 +50,7 @@ void thread_yield_higher(void)
 
         __save_context();
 
-        /* have sched_active_thread point to the next thread */
+        /* have thread_get_active() point to the next thread */
         sched_run();
 
         __restore_context();

--- a/cpu/msp430_common/include/cpu.h
+++ b/cpu/msp430_common/include/cpu.h
@@ -67,7 +67,7 @@ static inline void __attribute__((always_inline)) __save_context(void)
     __asm__("push r5");
     __asm__("push r4");
 
-    __asm__("mov.w r1,%0" : "=r"(sched_active_thread->sp));
+    __asm__("mov.w r1,%0" : "=r"(thread_get_active()->sp));
 }
 
 /**
@@ -75,7 +75,7 @@ static inline void __attribute__((always_inline)) __save_context(void)
  */
 static inline void __attribute__((always_inline)) __restore_context(void)
 {
-    __asm__("mov.w %0,r1" : : "m"(sched_active_thread->sp));
+    __asm__("mov.w %0,r1" : : "m"(thread_get_active()->sp));
 
     __asm__("pop r4");
     __asm__("pop r5");

--- a/cpu/native/irq_cpu.c
+++ b/cpu/native/irq_cpu.c
@@ -298,9 +298,9 @@ void native_isr_entry(int sig, siginfo_t *info, void *context)
     if (context == NULL) {
         errx(EXIT_FAILURE, "native_isr_entry: context is null - unhandled");
     }
-    if (sched_active_thread == NULL) {
+    if (thread_get_active() == NULL) {
         _native_in_isr++;
-        warnx("native_isr_entry: sched_active_thread is null - unhandled");
+        warnx("native_isr_entry: thread_get_active() is null - unhandled");
         _native_in_isr--;
         return;
     }
@@ -325,7 +325,7 @@ void native_isr_entry(int sig, siginfo_t *info, void *context)
     native_isr_context.uc_stack.ss_size = sizeof(__isr_stack);
     native_isr_context.uc_stack.ss_flags = 0;
     makecontext(&native_isr_context, native_irq_handler, 0);
-    _native_cur_ctx = (ucontext_t *)sched_active_thread->sp;
+    _native_cur_ctx = (ucontext_t *)thread_get_active()->sp;
 
     DEBUG("\n\n\t\tnative_isr_entry: return to _native_sig_leave_tramp\n\n");
     /* disable interrupts in context */

--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -125,11 +125,11 @@ void _native_syscall_leave(void)
             && (_native_in_isr == 0)
             && (_native_in_syscall == 0)
             && (native_interrupts_enabled == 1)
-            && (sched_active_thread != NULL)
+            && (thread_get_active() != NULL)
        )
     {
         _native_in_isr = 1;
-        _native_cur_ctx = (ucontext_t *)sched_active_thread->sp;
+        _native_cur_ctx = (ucontext_t *)thread_get_active()->sp;
         native_isr_context.uc_stack.ss_sp = __isr_stack;
         native_isr_context.uc_stack.ss_size = SIGSTKSZ;
         native_isr_context.uc_stack.ss_flags = 0;


### PR DESCRIPTION
### Contribution description

Replaced all occurrences of `sched_active_pid` and `sched_active_thread` with the corresponding API calls. (Noteworthy exceptions: ESP platform handled in https://github.com/RIOT-OS/RIOT/pull/14772, and all assembly code.)

### Testing procedure

In most cases the generated binaries should not change. (When repeatedly accessing `sched_active_thread` while IRQs disabled, I introduced a temporary `thread_t *` variable without the `volatile` qualifier. This could result in more efficient code being generated.)

### Issues/PRs references

Same as https://github.com/RIOT-OS/RIOT/pull/14772, but for all non-ESP platforms.