### PR TITLE
pkg/tinycbor: bump to v0.5.3

### DIFF
--- a/pkg/tinycbor/Makefile
+++ b/pkg/tinycbor/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=tinycbor
 PKG_URL=https://github.com/intel/tinycbor
-# Tinycbor v0.5.2
-PKG_VERSION=d94ca09aa91f5b3c581527aa8bca179a82b79874
+# Tinycbor v0.5.3
+PKG_VERSION=755f9ef932f9830a63a712fd2ac971d838b131f1
 PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION


### Contribution description

Just a minor version bump.


### Testing procedure

`tests/pkg_tinycbor` should still work (tested on `native`) 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
