### PR TITLE
makefiles/openocd-adapters/iotlab: default to JTAG transport

### DIFF
--- a/makefiles/tools/openocd-adapters/iotlab.inc.mk
+++ b/makefiles/tools/openocd-adapters/iotlab.inc.mk
@@ -1,8 +1,8 @@
 # iotlab-usb debug adapter
 OPENOCD_ADAPTER_INIT ?= -c 'source [find interface/ftdi/iotlab-usb.cfg]'
 
-# default to SWD
-OPENOCD_TRANSPORT ?= swd
+# default to JTAG
+OPENOCD_TRANSPORT ?= jtag
 
 # Add serial matching command, only if DEBUG_ADAPTER_ID was specified
 ifneq (,$(DEBUG_ADAPTER_ID))


### PR DESCRIPTION
### Contribution description
This changes the default transport for OpenOCD on the iotlab adapter to use `jtag`. #14480 made some changes to allow configuration of the transport, and set the default for iotlab to `swd`, but [the configuration file](https://github.com/analogdevicesinc/openocd/blob/master/tcl/interface/ftdi/iotlab-usb.cfg) has no `SWD_EN` signal defined. This causes an error when trying to flash the board:
```
### Flashing Target ###
xPack OpenOCD, x86_64 Open On-Chip Debugger 0.10.0+dev-00378-ge5be992df (2020-06-26-09:27)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : FTDI SWD mode enabled
swd
Warn : Interface already configured, ignoring
trst_and_srst separate srst_nogate trst_push_pull srst_open_drain connect_assert_srst

Error: SWD mode is active but SWD_EN signal is not defined
```

### Testing procedure
Flash an `iotlab-m3` board with any application, it should work.

### Issues/PRs references
Fixes the issue described [here](https://github.com/RIOT-OS/RIOT/pull/14480#issuecomment-674897425).
