### PR TITLE
sys/luid: add luid_netdev_get_eui48() & luid_netdev_get_eui64() 

### DIFF
--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -66,7 +66,7 @@ void at86rf215_reset_and_cfg(at86rf215_t *dev)
 
     /* set device address */
     luid_get_short((network_uint16_t *)&dev->netdev.short_addr);
-    luid_get_eui64((eui64_t *)&dev->netdev.long_addr);
+    luid_netdev_get_eui64(&dev->netdev.netdev, (eui64_t *)&dev->netdev.long_addr);
 
     if (is_subGHz(dev)) {
         dev->netdev.chan = CONFIG_AT86RF215_DEFAULT_SUBGHZ_CHANNEL;

--- a/sys/include/luid.h
+++ b/sys/include/luid.h
@@ -57,6 +57,7 @@
 
 #include "net/eui48.h"
 #include "net/eui64.h"
+#include "net/netdev.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -128,6 +129,17 @@ void luid_get_short(network_uint16_t *addr);
 void luid_get_eui48(eui48_t *addr);
 
 /**
+ * @brief   Get a unique EUI48 address
+ *
+ * The resulting address is built from the base ID generated with luid_base(), which
+ * isXORed with the netdev type and netdev index in the least significant bytes.
+ *
+ * @param[in]  netdev   Netdev to generate the EUI48 for.
+ * @param[out] addr     memory location to copy the address into.
+ */
+void luid_netdev_get_eui48(const netdev_t *netdev, eui48_t *addr);
+
+/**
  * @brief   Get a unique EUI64 address
  *
  * The resulting address is built from the base ID generated with luid_base(), which
@@ -138,6 +150,17 @@ void luid_get_eui48(eui48_t *addr);
  * @param[out] addr     memory location to copy the address into.
  */
 void luid_get_eui64(eui64_t *addr);
+
+/**
+ * @brief   Get a unique EUI64 address
+ *
+ * The resulting address is built from the base ID generated with luid_base(), which
+ * isXORed with the netdev type and netdev index in the least significant bytes.
+ *
+ * @param[in]  netdev   Netdev to generate the EUI64 for.
+ * @param[out] addr     memory location to copy the address into.
+ */
+void luid_netdev_get_eui64(const netdev_t *netdev, eui64_t *addr);
 
 /**
  * @brief   Get a custom unique ID based on a user given generator value

--- a/sys/luid/luid.c
+++ b/sys/luid/luid.c
@@ -89,10 +89,30 @@ void luid_get_eui48(eui48_t *addr)
     eui48_clear_group(addr);
 }
 
+void luid_netdev_get_eui48(const netdev_t *netdev, eui48_t *addr)
+{
+    luid_base(addr, sizeof(*addr));
+    addr->uint8[4] ^= netdev->type;
+    addr->uint8[5] ^= netdev->index;
+
+    eui48_set_local(addr);
+    eui48_clear_group(addr);
+}
+
 void luid_get_eui64(eui64_t *addr)
 {
     luid_base(addr, sizeof(*addr));
     addr->uint8[7] ^= lastused++;
+
+    eui64_set_local(addr);
+    eui64_clear_group(addr);
+}
+
+void luid_netdev_get_eui64(const netdev_t *netdev, eui64_t *addr)
+{
+    luid_base(addr, sizeof(*addr));
+    addr->uint8[6] ^= netdev->type;
+    addr->uint8[7] ^= netdev->index;
 
     eui64_set_local(addr);
     eui64_clear_group(addr);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Add functions to generate an EUI based on the netdev ID.
This will always return the same EUI for the same netdev, so it is stable across netdev resets.
 
### Testing procedure

As a demonstration, the `at86rf215` has been converted to the new function.

It shows that the two interfaces still get distinct MAC addresses

```
2020-08-18 10:39:31,996 # Iface  7  HWaddr: 3A:A7  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2020-08-18 10:39:31,997 #           
2020-08-18 10:39:31,998 #           Long HWaddr: 22:68:31:23:59:F5:D3:3A 
2020-08-18 10:39:32,000 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-08-18 10:39:32,013 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2020-08-18 10:39:32,014 #           6LO  IPHC  
2020-08-18 10:39:32,015 #           Source address length: 8
2020-08-18 10:39:32,016 #           Link type: wireless
2020-08-18 10:39:32,028 #           inet6 addr: fe80::2068:3123:59f5:d33a  scope: link  VAL
2020-08-18 10:39:32,029 #           inet6 group: ff02::2
2020-08-18 10:39:32,030 #           inet6 group: ff02::1
2020-08-18 10:39:32,031 #           inet6 group: ff02::1:fff5:d33a
2020-08-18 10:39:32,032 #           
2020-08-18 10:39:32,033 #           Statistics for Layer 2
2020-08-18 10:39:32,044 #             RX packets 0  bytes 0
2020-08-18 10:39:32,045 #             TX packets 2 (Multicast: 2)  bytes 86
2020-08-18 10:39:32,046 #             TX succeeded 2 errors 0
2020-08-18 10:39:32,047 #           Statistics for IPv6
2020-08-18 10:39:32,047 #             RX packets 0  bytes 0
2020-08-18 10:39:32,061 #             TX packets 2 (Multicast: 2)  bytes 128
2020-08-18 10:39:32,062 #             TX succeeded 2 errors 0
2020-08-18 10:39:32,062 # 
2020-08-18 10:39:32,063 # Iface  6  HWaddr: 3A:A6  Channel: 0  Page: 2  NID: 0x23  PHY: O-QPSK 
2020-08-18 10:39:32,064 #           
2020-08-18 10:39:32,077 #           Long HWaddr: 22:68:31:23:59:F5:D3:3B 
2020-08-18 10:39:32,079 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-08-18 10:39:32,092 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2020-08-18 10:39:32,093 #           6LO  IPHC  
2020-08-18 10:39:32,094 #           Source address length: 8
2020-08-18 10:39:32,095 #           Link type: wireless
2020-08-18 10:39:32,096 #           inet6 addr: fe80::2068:3123:59f5:d33b  scope: link  VAL
2020-08-18 10:39:32,108 #           inet6 group: ff02::2
2020-08-18 10:39:32,109 #           inet6 group: ff02::1
2020-08-18 10:39:32,110 #           inet6 group: ff02::1:fff5:d33b
2020-08-18 10:39:32,110 #           
2020-08-18 10:39:32,111 #           Statistics for Layer 2
2020-08-18 10:39:32,112 #             RX packets 0  bytes 0
2020-08-18 10:39:32,125 #             TX packets 2 (Multicast: 2)  bytes 86
2020-08-18 10:39:32,126 #             TX succeeded 2 errors 0
2020-08-18 10:39:32,127 #           Statistics for IPv6
2020-08-18 10:39:32,127 #             RX packets 0  bytes 0
2020-08-18 10:39:32,140 #             TX packets 2 (Multicast: 2)  bytes 128
2020-08-18 10:39:32,141 #             TX succeeded 2 errors 0
```

They are also stable across resets

```
2020-08-18 10:43:53,870 #  ifconfig 6 set state reset
2020-08-18 10:43:53,886 # success: set state of interface 6 to RESET

2020-08-18 10:43:56,253 #  ifconfig 6
2020-08-18 10:43:56,336 # Iface  6  HWaddr: 3A:A6  Channel: 0  Page: 2  NID: 0x23  PHY: O-QPSK 
2020-08-18 10:43:56,336 #           
2020-08-18 10:43:56,338 #           Long HWaddr: 22:68:31:23:59:F5:D3:3B 
2020-08-18 10:43:56,351 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-08-18 10:43:56,353 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2020-08-18 10:43:56,353 #           6LO  IPHC  
2020-08-18 10:43:56,366 #           Source address length: 8
2020-08-18 10:43:56,367 #           Link type: wireless
2020-08-18 10:43:56,368 #           inet6 addr: fe80::2068:3123:59f5:d33b  scope: link  VAL
2020-08-18 10:43:56,369 #           inet6 group: ff02::2
2020-08-18 10:43:56,381 #           inet6 group: ff02::1
2020-08-18 10:43:56,382 #           inet6 group: ff02::1:fff5:d33b
2020-08-18 10:43:56,383 #           
2020-08-18 10:43:56,384 #           Statistics for Layer 2
2020-08-18 10:43:56,385 #             RX packets 0  bytes 0
2020-08-18 10:43:56,386 #             TX packets 10 (Multicast: 10)  bytes 430
2020-08-18 10:43:56,398 #             TX succeeded 10 errors 0
2020-08-18 10:43:56,399 #           Statistics for IPv6
2020-08-18 10:43:56,400 #             RX packets 0  bytes 0
2020-08-18 10:43:56,401 #             TX packets 10 (Multicast: 10)  bytes 640
2020-08-18 10:43:56,413 #             TX succeeded 10 errors 0
```



### Issues/PRs references

Will be used by #14634, but can also be used independently.