### PR TITLE
cpu/stm32/f1/rtt: fixes and improvements

### DIFF
--- a/cpu/stm32/periph/rtt_f1.c
+++ b/cpu/stm32/periph/rtt_f1.c
@@ -192,11 +192,15 @@ void RTT_ISR(void)
 {
     if (RTT_DEV->CRL & RTC_CRL_ALRF) {
         RTT_DEV->CRL &= ~(RTC_CRL_ALRF);
-        alarm_cb(alarm_arg);
+        if (alarm_cb) {
+            alarm_cb(alarm_arg);
+        }
     }
     if (RTT_DEV->CRL & RTC_CRL_OWF) {
         RTT_DEV->CRL &= ~(RTC_CRL_OWF);
-        overflow_cb(overflow_arg);
+        if (overflow_cb) {
+            overflow_cb(overflow_arg);
+        }
     }
     cortexm_isr_end();
 }

--- a/cpu/stm32/periph/rtt_f1.c
+++ b/cpu/stm32/periph/rtt_f1.c
@@ -123,6 +123,12 @@ void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
 {
     _rtt_enter_config_mode();
 
+    /* Disable alarm*/
+    RTT_DEV->CRH &= ~RTC_CRH_ALRIE;
+    /* Save new cb and argument */
+    alarm_cb = cb;
+    alarm_arg = arg;
+
     /* Set the alarm MSB word */
     RTT_DEV->ALRH = alarm >> 16;
     /* Set the alarm LSB word */
@@ -132,9 +138,6 @@ void rtt_set_alarm(uint32_t alarm, rtt_cb_t cb, void *arg)
     RTT_DEV->CRH |= RTC_CRH_ALRIE;
 
     _rtt_leave_config_mode();
-
-    alarm_cb = cb;
-    alarm_arg = arg;
 }
 
 void rtt_clear_alarm(void)


### PR DESCRIPTION
### Contribution description

Currently the cb context is saved after the alarm is enabled so the ISR can trigger before the context is saved and the NULL callback or a previously set callback can be called for alarms set with a small offset.

This was found while testing #14146 while on the first iteration an offset of 0 is used.

### Testing procedure

On an stm32f1 board:

- `tests/periph_rtt` still passes:

```
main(): This is RIOT! (Version: 2020.10-devel-763-gafd56-pr_stm32f1_rtt_fixes)

RIOT RTT low-level driver test
This test will display 'Hello' every 5 seconds

Initializing the RTT driver
RTT now: 0
Setting initial alarm to now + 5 s (5)
Done setting up the RTT, wait for many Hellos
Hello
Hello
Hello
Hello
Hello
```

- #14146 does not hardfault once rebased on this PR

```
main(): This is RIOT! (Version: 2020.10-devel-765-g25678-pr_rtt_min_value_test)
Evaluate RTT_MIN_OFFSET over 1024 samples
................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
RTT_MIN_OFFSET for iotlab-m3: 1
```

- #14146 not rebased on this PR

```
main(): This is RIOT! (Version: 2020.10-devel-331-g870a29-pr_rtt_min_value_test)
Evaluate RTT_MIN_OFFSET over 1024 samples

Context before hardfault:
```

### Issues/PRs references

Found while testing #14146
