### PR TITLE
cpu/efm32/timer: cleanups and improvements

### DIFF
--- a/boards/common/slwstk6000b/include/periph_conf.h
+++ b/boards/common/slwstk6000b/include/periph_conf.h
@@ -147,7 +147,8 @@ static const timer_conf_t timer_config[] = {
             .dev = TIMER1,
             .cmu = cmuClock_TIMER1
         },
-        .irq = TIMER1_IRQn
+        .irq = TIMER1_IRQn,
+        .channel_numof = 3
     }
 };
 

--- a/boards/ikea-tradfri/include/board.h
+++ b/boards/ikea-tradfri/include/board.h
@@ -34,12 +34,15 @@ extern "C" {
  * The timer runs at 250 kHz to increase accuracy or 32768 Hz for LETIMER.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
+#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
+#define XTIMER_DEV          (TIMER_DEV(1))
 #define XTIMER_HZ           (32768UL)
 #else
+#define XTIMER_DEV          (TIMER_DEV(0))
 #define XTIMER_HZ           (250000UL)
 #endif
 #define XTIMER_WIDTH        (16)
+#define XTIMER_CHAN (0)
 /** @} */
 
 /**

--- a/boards/ikea-tradfri/include/board.h
+++ b/boards/ikea-tradfri/include/board.h
@@ -34,7 +34,7 @@ extern "C" {
  * The timer runs at 250 kHz to increase accuracy or 32768 Hz for LETIMER.
  * @{
  */
-#ifdef EFM32_USE_LETIMER
+#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
 #define XTIMER_HZ           (32768UL)
 #else
 #define XTIMER_HZ           (250000UL)

--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -85,7 +85,7 @@ static const spi_dev_t spi_config[] = {
  * or two regular timers in cascade mode.
  * @{
  */
-#if EFM32_USE_LETIMER
+#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
 static const timer_conf_t timer_config[] = {
     {
         .timer = {
@@ -113,7 +113,7 @@ static const timer_conf_t timer_config[] = {
 };
 #define TIMER_0_ISR         isr_timer1
 
-#endif /* EFM32_USE_LETIMER */
+#endif /* CONFIG_EFM32_USE_LETIMER */
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */

--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -85,19 +85,6 @@ static const spi_dev_t spi_config[] = {
  * or two regular timers in cascade mode.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
-static const timer_conf_t timer_config[] = {
-    {
-        .timer = {
-            .dev = LETIMER0,
-            .cmu = cmuClock_LETIMER0
-        },
-        .irq = LETIMER0_IRQn
-    }
-};
-#define TIMER_0_ISR         isr_letimer0
-
-#else
 static const timer_conf_t timer_config[] = {
     {
         .prescaler = {
@@ -108,12 +95,25 @@ static const timer_conf_t timer_config[] = {
             .dev = TIMER1,
             .cmu = cmuClock_TIMER1
         },
-        .irq = TIMER1_IRQn
-    }
+        .irq = TIMER1_IRQn,
+        .channel_numof = 3
+    },
+    {
+        .prescaler = {
+            .dev = NULL,
+            .cmu = cmuClock_LETIMER0
+        },
+        .timer = {
+            .dev = LETIMER0,
+            .cmu = cmuClock_LETIMER0
+        },
+        .irq = LETIMER0_IRQn,
+        .channel_numof = 2
+    },
 };
-#define TIMER_0_ISR         isr_timer1
 
-#endif /* CONFIG_EFM32_USE_LETIMER */
+#define TIMER_0_ISR         isr_timer1
+#define TIMER_1_ISR         isr_letimer0
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */

--- a/boards/slstk3401a/include/board.h
+++ b/boards/slstk3401a/include/board.h
@@ -35,7 +35,7 @@ extern "C" {
  * The timer runs at 250 KHz to increase accuracy or 32768 Hz for LETIMER.
  * @{
  */
-#ifdef EFM32_USE_LETIMER
+#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
 #define XTIMER_HZ           (32768UL)
 #else
 #define XTIMER_HZ           (250000UL)

--- a/boards/slstk3401a/include/board.h
+++ b/boards/slstk3401a/include/board.h
@@ -35,12 +35,15 @@ extern "C" {
  * The timer runs at 250 KHz to increase accuracy or 32768 Hz for LETIMER.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
+#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
+#define XTIMER_DEV          (TIMER_DEV(1))
 #define XTIMER_HZ           (32768UL)
 #else
+#define XTIMER_DEV          (TIMER_DEV(0))
 #define XTIMER_HZ           (250000UL)
 #endif
 #define XTIMER_WIDTH        (16)
+#define XTIMER_CHAN (0)
 /** @} */
 
 /**

--- a/boards/slstk3401a/include/periph_conf.h
+++ b/boards/slstk3401a/include/periph_conf.h
@@ -145,19 +145,6 @@ static const spi_dev_t spi_config[] = {
  * or two regular timers in cascade mode.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
-static const timer_conf_t timer_config[] = {
-    {
-        .timer = {
-            .dev = LETIMER0,
-            .cmu = cmuClock_LETIMER0
-        },
-        .irq = LETIMER0_IRQn
-    }
-};
-#define TIMER_0_ISR         isr_letimer0
-
-#else
 static const timer_conf_t timer_config[] = {
     {
         .prescaler = {
@@ -168,12 +155,25 @@ static const timer_conf_t timer_config[] = {
             .dev = TIMER1,
             .cmu = cmuClock_TIMER1
         },
-        .irq = TIMER1_IRQn
-    }
+        .irq = TIMER1_IRQn,
+        .channel_numof = 3
+    },
+    {
+        .prescaler = {
+            .dev = NULL,
+            .cmu = cmuClock_LETIMER0
+        },
+        .timer = {
+            .dev = LETIMER0,
+            .cmu = cmuClock_LETIMER0
+        },
+        .irq = LETIMER0_IRQn,
+        .channel_numof = 2
+    },
 };
-#define TIMER_0_ISR         isr_timer1
 
-#endif /* CONFIG_EFM32_USE_LETIMER */
+#define TIMER_0_ISR         isr_timer1
+#define TIMER_1_ISR         isr_letimer0
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */

--- a/boards/slstk3401a/include/periph_conf.h
+++ b/boards/slstk3401a/include/periph_conf.h
@@ -145,7 +145,7 @@ static const spi_dev_t spi_config[] = {
  * or two regular timers in cascade mode.
  * @{
  */
-#if EFM32_USE_LETIMER
+#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
 static const timer_conf_t timer_config[] = {
     {
         .timer = {
@@ -173,7 +173,7 @@ static const timer_conf_t timer_config[] = {
 };
 #define TIMER_0_ISR         isr_timer1
 
-#endif /* EFM32_USE_LETIMER */
+#endif /* CONFIG_EFM32_USE_LETIMER */
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */

--- a/boards/slstk3402a/include/board.h
+++ b/boards/slstk3402a/include/board.h
@@ -33,7 +33,7 @@ extern "C" {
  * @name    Xtimer configuration
  * @{
  */
-#ifdef EFM32_USE_LETIMER
+#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
 #define XTIMER_HZ           (32768UL)
 #define XTIMER_WIDTH        (16)
 #else

--- a/boards/slstk3402a/include/board.h
+++ b/boards/slstk3402a/include/board.h
@@ -33,13 +33,16 @@ extern "C" {
  * @name    Xtimer configuration
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
+#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
+#define XTIMER_DEV          (TIMER_DEV(1))
 #define XTIMER_HZ           (32768UL)
 #define XTIMER_WIDTH        (16)
 #else
+#define XTIMER_DEV          (TIMER_DEV(0))
 #define XTIMER_HZ           (1000000UL)
 #define XTIMER_WIDTH        (32)
 #endif
+#define XTIMER_CHAN (0)
 /** @} */
 
 /**

--- a/boards/slstk3402a/include/periph_conf.h
+++ b/boards/slstk3402a/include/periph_conf.h
@@ -136,19 +136,6 @@ static const spi_dev_t spi_config[] = {
  * or two regular timers in cascade mode.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
-static const timer_conf_t timer_config[] = {
-    {
-        .timer = {
-            .dev = LETIMER0,
-            .cmu = cmuClock_LETIMER0
-        },
-        .irq = LETIMER0_IRQn
-    }
-};
-#define TIMER_0_ISR         isr_letimer0
-
-#else
 static const timer_conf_t timer_config[] = {
     {
         .prescaler = {
@@ -159,12 +146,25 @@ static const timer_conf_t timer_config[] = {
             .dev = WTIMER1,
             .cmu = cmuClock_WTIMER1
         },
-        .irq = WTIMER1_IRQn
-    }
+        .irq = WTIMER1_IRQn,
+        .channel_numof = 3
+    },
+    {
+        .prescaler = {
+            .dev = NULL,
+            .cmu = cmuClock_LETIMER0
+        },
+        .timer = {
+            .dev = LETIMER0,
+            .cmu = cmuClock_LETIMER0
+        },
+        .irq = LETIMER0_IRQn,
+        .channel_numof = 2
+    },
 };
-#define TIMER_0_ISR         isr_wtimer1
 
-#endif /* CONFIG_EFM32_USE_LETIMER */
+#define TIMER_0_ISR         isr_wtimer1
+#define TIMER_1_ISR         isr_letimer0
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */

--- a/boards/slstk3402a/include/periph_conf.h
+++ b/boards/slstk3402a/include/periph_conf.h
@@ -136,7 +136,7 @@ static const spi_dev_t spi_config[] = {
  * or two regular timers in cascade mode.
  * @{
  */
-#if EFM32_USE_LETIMER
+#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
 static const timer_conf_t timer_config[] = {
     {
         .timer = {
@@ -164,7 +164,7 @@ static const timer_conf_t timer_config[] = {
 };
 #define TIMER_0_ISR         isr_wtimer1
 
-#endif /* EFM32_USE_LETIMER */
+#endif /* CONFIG_EFM32_USE_LETIMER */
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */

--- a/boards/sltb001a/include/board.h
+++ b/boards/sltb001a/include/board.h
@@ -35,13 +35,16 @@ extern "C" {
  * The timer runs at 250 KHz to increase accuracy or 32768 Hz for LETIMER.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
+#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
+#define XTIMER_DEV          (TIMER_DEV(1))
 #define XTIMER_HZ           (32768UL)
 #define XTIMER_WIDTH        (16)
 #else
+#define XTIMER_DEV          (TIMER_DEV(0))
 #define XTIMER_HZ           (250000UL)
 #define XTIMER_WIDTH        (16)
 #endif
+#define XTIMER_CHAN (0)
 /** @} */
 
 /**

--- a/boards/sltb001a/include/board.h
+++ b/boards/sltb001a/include/board.h
@@ -35,7 +35,7 @@ extern "C" {
  * The timer runs at 250 KHz to increase accuracy or 32768 Hz for LETIMER.
  * @{
  */
-#ifdef EFM32_USE_LETIMER
+#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
 #define XTIMER_HZ           (32768UL)
 #define XTIMER_WIDTH        (16)
 #else

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -145,19 +145,6 @@ static const spi_dev_t spi_config[] = {
  * or two regular timers in cascade mode.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
-static const timer_conf_t timer_config[] = {
-    {
-        .timer = {
-            .dev = LETIMER0,
-            .cmu = cmuClock_LETIMER0
-        },
-        .irq = LETIMER0_IRQn
-    }
-};
-#define TIMER_0_ISR         isr_letimer0
-
-#else
 static const timer_conf_t timer_config[] = {
     {
         .prescaler = {
@@ -168,12 +155,25 @@ static const timer_conf_t timer_config[] = {
             .dev = TIMER1,
             .cmu = cmuClock_TIMER1
         },
-        .irq = TIMER1_IRQn
-    }
+        .irq = TIMER1_IRQn,
+        .channel_numof = 3
+    },
+    {
+        .prescaler = {
+            .dev = NULL,
+            .cmu = cmuClock_LETIMER0
+        },
+        .timer = {
+            .dev = LETIMER0,
+            .cmu = cmuClock_LETIMER0
+        },
+        .irq = LETIMER0_IRQn,
+        .channel_numof = 2
+    },
 };
-#define TIMER_0_ISR         isr_timer1
 
-#endif /* CONFIG_EFM32_USE_LETIMER */
+#define TIMER_0_ISR         isr_timer1
+#define TIMER_1_ISR         isr_letimer0
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -145,7 +145,7 @@ static const spi_dev_t spi_config[] = {
  * or two regular timers in cascade mode.
  * @{
  */
-#if EFM32_USE_LETIMER
+#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
 static const timer_conf_t timer_config[] = {
     {
         .timer = {
@@ -173,7 +173,7 @@ static const timer_conf_t timer_config[] = {
 };
 #define TIMER_0_ISR         isr_timer1
 
-#endif /* EFM32_USE_LETIMER */
+#endif /* CONFIG_EFM32_USE_LETIMER */
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */

--- a/boards/stk3600/include/board.h
+++ b/boards/stk3600/include/board.h
@@ -35,13 +35,16 @@ extern "C" {
  * The timer runs at 250 KHz to increase accuracy or 32768 Hz for LETIMER.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
+#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
+#define XTIMER_DEV          (TIMER_DEV(1))
 #define XTIMER_HZ           (32768UL)
 #define XTIMER_WIDTH        (16)
 #else
+#define XTIMER_DEV          (TIMER_DEV(0))
 #define XTIMER_HZ           (250000UL)
 #define XTIMER_WIDTH        (16)
 #endif
+#define XTIMER_CHAN (0)
 /** @} */
 
 /**

--- a/boards/stk3600/include/board.h
+++ b/boards/stk3600/include/board.h
@@ -35,7 +35,7 @@ extern "C" {
  * The timer runs at 250 KHz to increase accuracy or 32768 Hz for LETIMER.
  * @{
  */
-#ifdef EFM32_USE_LETIMER
+#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
 #define XTIMER_HZ           (32768UL)
 #define XTIMER_WIDTH        (16)
 #else

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -199,7 +199,7 @@ static const spi_dev_t spi_config[] = {
  * or two regular timers in cascade mode.
  * @{
  */
-#if EFM32_USE_LETIMER
+#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
 static const timer_conf_t timer_config[] = {
     {
         .timer = {
@@ -227,7 +227,7 @@ static const timer_conf_t timer_config[] = {
 };
 #define TIMER_0_ISR         isr_timer1
 
-#endif /* EFM32_USE_LETIMER */
+#endif /* CONFIG_EFM32_USE_LETIMER */
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -199,19 +199,6 @@ static const spi_dev_t spi_config[] = {
  * or two regular timers in cascade mode.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
-static const timer_conf_t timer_config[] = {
-    {
-        .timer = {
-            .dev = LETIMER0,
-            .cmu = cmuClock_LETIMER0
-        },
-        .irq = LETIMER0_IRQn
-    }
-};
-#define TIMER_0_ISR         isr_letimer0
-
-#else
 static const timer_conf_t timer_config[] = {
     {
         .prescaler = {
@@ -222,12 +209,25 @@ static const timer_conf_t timer_config[] = {
             .dev = TIMER1,
             .cmu = cmuClock_TIMER1
         },
-        .irq = TIMER1_IRQn
-    }
+        .irq = TIMER1_IRQn,
+        .channel_numof = 3
+    },
+    {
+        .prescaler = {
+            .dev = NULL,
+            .cmu = cmuClock_LETIMER0
+        },
+        .timer = {
+            .dev = LETIMER0,
+            .cmu = cmuClock_LETIMER0
+        },
+        .irq = LETIMER0_IRQn,
+        .channel_numof = 2
+    },
 };
-#define TIMER_0_ISR         isr_timer1
 
-#endif /* CONFIG_EFM32_USE_LETIMER */
+#define TIMER_0_ISR         isr_timer1
+#define TIMER_1_ISR         isr_letimer0
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */

--- a/boards/stk3700/include/board.h
+++ b/boards/stk3700/include/board.h
@@ -35,13 +35,16 @@ extern "C" {
  * The timer runs at 250 KHz to increase accuracy or 32768 Hz for LETIMER.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
+#if IS_ACTIVE(CONFIG_EFM32_XTIMER_USE_LETIMER)
+#define XTIMER_DEV          (TIMER_DEV(1))
 #define XTIMER_HZ           (32768UL)
 #define XTIMER_WIDTH        (16)
 #else
+#define XTIMER_DEV          (TIMER_DEV(0))
 #define XTIMER_HZ           (250000UL)
 #define XTIMER_WIDTH        (16)
 #endif
+#define XTIMER_CHAN (0)
 /** @} */
 
 /**

--- a/boards/stk3700/include/board.h
+++ b/boards/stk3700/include/board.h
@@ -35,7 +35,7 @@ extern "C" {
  * The timer runs at 250 KHz to increase accuracy or 32768 Hz for LETIMER.
  * @{
  */
-#ifdef EFM32_USE_LETIMER
+#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
 #define XTIMER_HZ           (32768UL)
 #define XTIMER_WIDTH        (16)
 #else

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -199,7 +199,7 @@ static const spi_dev_t spi_config[] = {
  * or two regular timers in cascade mode.
  * @{
  */
-#if EFM32_USE_LETIMER
+#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
 static const timer_conf_t timer_config[] = {
     {
         .timer = {
@@ -227,7 +227,7 @@ static const timer_conf_t timer_config[] = {
 };
 #define TIMER_0_ISR         isr_timer1
 
-#endif /* EFM32_USE_LETIMER */
+#endif /* CONFIG_EFM32_USE_LETIMER */
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -199,19 +199,6 @@ static const spi_dev_t spi_config[] = {
  * or two regular timers in cascade mode.
  * @{
  */
-#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
-static const timer_conf_t timer_config[] = {
-    {
-        .timer = {
-            .dev = LETIMER0,
-            .cmu = cmuClock_LETIMER0
-        },
-        .irq = LETIMER0_IRQn
-    }
-};
-#define TIMER_0_ISR         isr_letimer0
-
-#else
 static const timer_conf_t timer_config[] = {
     {
         .prescaler = {
@@ -222,12 +209,25 @@ static const timer_conf_t timer_config[] = {
             .dev = TIMER1,
             .cmu = cmuClock_TIMER1
         },
-        .irq = TIMER1_IRQn
-    }
+        .irq = TIMER1_IRQn,
+        .channel_numof = 3
+    },
+    {
+        .prescaler = {
+            .dev = NULL,
+            .cmu = cmuClock_LETIMER0
+        },
+        .timer = {
+            .dev = LETIMER0,
+            .cmu = cmuClock_LETIMER0
+        },
+        .irq = LETIMER0_IRQn,
+        .channel_numof = 2
+    },
 };
-#define TIMER_0_ISR         isr_timer1
 
-#endif /* CONFIG_EFM32_USE_LETIMER */
+#define TIMER_0_ISR         isr_timer1
+#define TIMER_1_ISR         isr_letimer0
 
 #define TIMER_NUMOF         ARRAY_SIZE(timer_config)
 /** @} */

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -357,28 +357,18 @@ typedef struct {
     timer_dev_t prescaler;  /**< the lower neighboring timer (not initialized for LETIMER) */
     timer_dev_t timer;      /**< the higher numbered timer */
     IRQn_Type irq;          /**< number of the higher timer IRQ channel */
+    uint8_t channel_numof;       /**< number of channels per timer */
 } timer_conf_t;
 /** @} */
 
 
 /**
- * @brief   The implementation can use one LETIMER or two regular timers cascaded
+ * @brief   Use LETIMER as the base timer for XTIMER
  */
-#ifndef CONFIG_EFM32_USE_LETIMER
-#define CONFIG_EFM32_USE_LETIMER   0
+#ifndef CONFIG_EFM32_XTIMER_USE_LETIMER
+#define CONFIG_EFM32_XTIMER_USE_LETIMER   0
 #endif
 
-#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
-/**
- * @brief   This timer implementation has two available channels
- */
-#define TIMER_CHANNEL_NUMOF     (2)
-#else
-/**
- * @brief   This timer implementation has three available channels
- */
-#define TIMER_CHANNEL_NUMOF     (3)
-#endif
 
 /**
  * @brief   UART device configuration.

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -20,6 +20,7 @@
 #ifndef PERIPH_CPU_H
 #define PERIPH_CPU_H
 
+#include "kernel_defines.h"
 #include "mutex.h"
 
 #include "cpu_conf.h"
@@ -363,11 +364,11 @@ typedef struct {
 /**
  * @brief   The implementation can use one LETIMER or two regular timers cascaded
  */
-#ifndef EFM32_USE_LETIMER
-#define EFM32_USE_LETIMER   0
+#ifndef CONFIG_EFM32_USE_LETIMER
+#define CONFIG_EFM32_USE_LETIMER   0
 #endif
 
-#ifdef EFM32_USE_LETIMER
+#if IS_ACTIVE(CONFIG_EFM32_USE_LETIMER)
 /**
  * @brief   This timer implementation has two available channels
  */

--- a/cpu/efm32/periph/timer.c
+++ b/cpu/efm32/periph/timer.c
@@ -111,8 +111,7 @@ static void _timer_init(tim_t dev, unsigned long freq)
     TIMER_Init_TypeDef init_pre = TIMER_INIT_DEFAULT;
     TIMER_Init_TypeDef init_tim = TIMER_INIT_DEFAULT;
 
-    /* leave the prescaler enabled and toggle only the primary timer */
-    init_pre.enable = true;
+    init_pre.enable = false;
     init_pre.prescale = timerPrescale1;
     init_tim.enable = false;
     init_tim.clkSel = timerClkSelCascade;
@@ -256,6 +255,7 @@ void timer_stop(tim_t dev)
             pm_unblock(EFM32_TIMER_PM_BLOCKER);
         }
         TIMER_Enable(timer_config[dev].timer.dev, false);
+        TIMER_Enable(timer_config[dev].prescaler.dev, false);
     }
 }
 
@@ -274,6 +274,7 @@ void timer_start(tim_t dev)
             pm_block(EFM32_TIMER_PM_BLOCKER);
         }
         TIMER_Enable(timer_config[dev].timer.dev, true);
+        TIMER_Enable(timer_config[dev].prescaler.dev, true);
     }
 }
 

--- a/cpu/efm32/periph/timer.c
+++ b/cpu/efm32/periph/timer.c
@@ -165,7 +165,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
     if (!_is_letimer(dev)) {
         TIMER_TypeDef *tim = timer_config[dev].timer.dev;
 
-        if (channel < 0 || channel >= TIMER_CHANNEL_NUMOF) {
+        if (channel < 0 || channel >= timer_config[dev].channel_numof) {
             return -1;
         }
 
@@ -278,15 +278,12 @@ void timer_start(tim_t dev)
     }
 }
 
-#ifdef TIMER_0_ISR
-void TIMER_0_ISR(void)
+static void _timer_isr(tim_t dev)
 {
-    tim_t dev = 0;
-
     if (_is_letimer(dev)) {
         LETIMER_TypeDef *tim = timer_config[dev].timer.dev;
 
-        for (int i = 0; i < TIMER_CHANNEL_NUMOF; i++) {
+        for (int i = 0; i < timer_config[dev].channel_numof; i++) {
             if (tim->IF & (LETIMER_IF_COMP0 << i))
             {
                 LETIMER_IntDisable(tim, LETIMER_IEN_COMP0 << i);
@@ -298,7 +295,7 @@ void TIMER_0_ISR(void)
     else {
         TIMER_TypeDef *tim = timer_config[dev].timer.dev;
 
-        for (int i = 0; i < TIMER_CHANNEL_NUMOF; i++) {
+        for (int i = 0; i < timer_config[dev].channel_numof; i++) {
             if (tim->IF & (TIMER_IF_CC0 << i)) {
                 tim->CC[i].CTRL = _TIMER_CC_CTRL_MODE_OFF;
                 tim->IFC = (TIMER_IFC_CC0 << i);
@@ -308,4 +305,17 @@ void TIMER_0_ISR(void)
     }
     cortexm_isr_end();
 }
+
+#ifdef TIMER_0_ISR
+void TIMER_0_ISR(void)
+{
+    _timer_isr(0);
+}
 #endif /* TIMER_0_ISR */
+
+#ifdef TIMER_1_ISR
+void TIMER_1_ISR(void)
+{
+    _timer_isr(1);
+}
+#endif /* TIMER_1_ISR */

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -19,6 +19,11 @@ BOARDS_TIMER_32kHz := \
     openlabs-kw41z-mini \
     frdm-k64f \
     frdm-k22f \
+    slstk3401a \
+    slstk3402a \
+    sltb001a \
+    stk3600 \
+    stk3700 \
     #
 
 BOARDS_TIMER_CLOCK_CORECLOCK := \


### PR DESCRIPTION
### Contribution description

In #13357 support for LETIMER was added. Some of the ifdef conditionals was a little weird, I replaced them by the use of the `IS_ACTIVE` macro.

In #13357 `tests/periph_timer` no longer worked on `slstk3402a`, I don't understand why but 4eebd7c fixed the issue for me, maybe @basilfx and @benemorius know more about this and there might be a better fix? (I don't quite undestand this dual prescaler/timer timers)

This PR also enables running both timers instead of only one.

### Testing procedure

- `tests/periph_timer` passes. 

`BOARD=slstk3402a make -C tests/periph_timer/ flash test -j3 --no-print-directory`

```
main(): This is RIOT! (Version: 2020.10-devel-705-g93b4b3-pr_efm32_lpetimer_cleanup)

Test for peripheral TIMERs

Available timers: 2

Testing TIMER_0:
TIMER_0: initialization successful
TIMER_0: stopped
TIMER_0: set channel 0 to 5000
TIMER_0: set channel 1 to 10000
TIMER_0: set channel 2 to 15000
TIMER_0: starting
timer
timer
timer
TIMER_0: channel 0 fired at SW count   508415 - init:   508415
TIMER_0: channel 1 fired at SW count  1014920 - diff:   506505
TIMER_0: channel 2 fired at SW count  1521428 - diff:   506508

Testing TIMER_1:
TIMER_1: initialization successful
TIMER_1: stopped
TIMER_1: set channel 0 to 5000
TIMER_1: set channel 1 to 10000
TIMER_1: starting
letimer
letimer
TIMER_1: channel 0 fired at SW count   508661 - init:   508661
TIMER_1: channel 1 fired at SW count  1014725 - diff:   506064

TEST SUCCEEDED

```

- `tests/xtimer_%` should pass with both configurations, here an examples for `tests/xtimer_usleep`

- BOARD=slstk3402a make -C tests/xtimer_usleep/ flash test -j3

```
START
main(): This is RIOT! (Version: 2020.10-devel-706-gee9f3-pr_efm32_lpetimer_cleanup)
Running test 5 times with 7 distinct sleep times
Slept for 10028 us (expected: 10000 us) Offset: 28 us
Slept for 50028 us (expected: 50000 us) Offset: 28 us
Slept for 10261 us (expected: 10234 us) Offset: 27 us
Slept for 56808 us (expected: 56780 us) Offset: 28 us
Slept for 12149 us (expected: 12122 us) Offset: 27 us
Slept for 98793 us (expected: 98765 us) Offset: 28 us
Slept for 75027 us (expected: 75000 us) Offset: 27 us
Slept for 10027 us (expected: 10000 us) Offset: 27 us
Slept for 50028 us (expected: 50000 us) Offset: 28 us
Slept for 10261 us (expected: 10234 us) Offset: 27 us
Slept for 56808 us (expected: 56780 us) Offset: 28 us
Slept for 12149 us (expected: 12122 us) Offset: 27 us
Slept for 98793 us (expected: 98765 us) Offset: 28 us
Slept for 75027 us (expected: 75000 us) Offset: 27 us
Slept for 10027 us (expected: 10000 us) Offset: 27 us
Slept for 50028 us (expected: 50000 us) Offset: 28 us
Slept for 10261 us (expected: 10234 us) Offset: 27 us
Slept for 56808 us (expected: 56780 us) Offset: 28 us
Slept for 12149 us (expected: 12122 us) Offset: 27 us
Slept for 98793 us (expected: 98765 us) Offset: 28 us
Slept for 75027 us (expected: 75000 us) Offset: 27 us
Slept for 10027 us (expected: 10000 us) Offset: 27 us
Slept for 50028 us (expected: 50000 us) Offset: 28 us
Slept for 10261 us (expected: 10234 us) Offset: 27 us
Slept for 56808 us (expected: 56780 us) Offset: 28 us
Slept for 12149 us (expected: 12122 us) Offset: 27 us
Slept for 98793 us (expected: 98765 us) Offset: 28 us
Slept for 75027 us (expected: 75000 us) Offset: 27 us
Slept for 10027 us (expected: 10000 us) Offset: 27 us
Slept for 50028 us (expected: 50000 us) Offset: 28 us
Slept for 10261 us (expected: 10234 us) Offset: 27 us
Slept for 56808 us (expected: 56780 us) Offset: 28 us
Slept for 12149 us (expected: 12122 us) Offset: 27 us
Slept for 98793 us (expected: 98765 us) Offset: 28 us
Slept for 75027 us (expected: 75000 us) Offset: 27 us
Test ran for 1734048 us
```

- CFLAGS=-DCONFIG_EFM32_XTIMER_USE_LETIMER=1 BOARD=slstk3402a make -C tests/xtimer_usleep/ flash test -j3

```
main(): This is RIOT! (Version: 2020.10-devel-706-gee9f3-pr_efm32_lpetimer_cleanup)
Running test 5 times with 7 distinct sleep times
Slept for 10010 us (expected: 10000 us) Offset: 10 us
Slept for 50018 us (expected: 50000 us) Offset: 18 us
Slept for 10254 us (expected: 10234 us) Offset: 20 us
Slept for 56794 us (expected: 56780 us) Offset: 14 us
Slept for 12146 us (expected: 12122 us) Offset: 24 us
Slept for 98785 us (expected: 98765 us) Offset: 20 us
Slept for 75012 us (expected: 75000 us) Offset: 12 us
Slept for 10010 us (expected: 10000 us) Offset: 10 us
Slept for 50018 us (expected: 50000 us) Offset: 18 us
Slept for 10254 us (expected: 10234 us) Offset: 20 us
Slept for 56793 us (expected: 56780 us) Offset: 13 us
Slept for 12146 us (expected: 12122 us) Offset: 24 us
Slept for 98786 us (expected: 98765 us) Offset: 21 us
Slept for 75012 us (expected: 75000 us) Offset: 12 us
Slept for 10010 us (expected: 10000 us) Offset: 10 us
Slept for 50018 us (expected: 50000 us) Offset: 18 us
Slept for 10254 us (expected: 10234 us) Offset: 20 us
Slept for 56824 us (expected: 56780 us) Offset: 44 us
Slept for 12176 us (expected: 12122 us) Offset: 54 us
Slept for 98785 us (expected: 98765 us) Offset: 20 us
Slept for 75012 us (expected: 75000 us) Offset: 12 us
Slept for 10010 us (expected: 10000 us) Offset: 10 us
Slept for 50018 us (expected: 50000 us) Offset: 18 us
Slept for 10254 us (expected: 10234 us) Offset: 20 us
Slept for 56793 us (expected: 56780 us) Offset: 13 us
Slept for 12146 us (expected: 12122 us) Offset: 24 us
Slept for 98786 us (expected: 98765 us) Offset: 21 us
Slept for 75012 us (expected: 75000 us) Offset: 12 us
Slept for 10010 us (expected: 10000 us) Offset: 10 us
Slept for 50018 us (expected: 50000 us) Offset: 18 us
Slept for 10254 us (expected: 10234 us) Offset: 20 us
Slept for 56793 us (expected: 56780 us) Offset: 13 us
Slept for 12146 us (expected: 12122 us) Offset: 24 us
Slept for 98785 us (expected: 98765 us) Offset: 20 us
Slept for 75012 us (expected: 75000 us) Offset: 12 us
Test ran for 1733887 us
```

Here are the results of most timer related tests https://ci.inria.fr/ci-riot-tribe/job/build-pipeline.jk/161/artifact/ on `slstk3402a`

### Issues/PRs references

