### PR TITLE
boards/yarm: Support for YARM board

### DIFF
--- a/boards/yarm/Kconfig
+++ b/boards/yarm/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 Antonio Galea
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "yarm" if BOARD_YARM
+
+config BOARD_YARM
+    bool
+    default y
+    select CPU_MODEL_SAML21J18B
+    select HAS_PERIPH_ADC
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_RIOTBOOT

--- a/boards/yarm/Makefile
+++ b/boards/yarm/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/yarm/Makefile.dep
+++ b/boards/yarm/Makefile.dep
@@ -1,0 +1,3 @@
+ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+  USEMODULE += stdio_cdc_acm
+endif

--- a/boards/yarm/Makefile.features
+++ b/boards/yarm/Makefile.features
@@ -1,0 +1,15 @@
+CPU = saml21
+CPU_MODEL = saml21j18b
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot

--- a/boards/yarm/Makefile.include
+++ b/boards/yarm/Makefile.include
@@ -1,0 +1,1 @@
+include $(RIOTMAKE)/boards/sam0.inc.mk

--- a/boards/yarm/Makefile.include
+++ b/boards/yarm/Makefile.include
@@ -1,1 +1,16 @@
 include $(RIOTMAKE)/boards/sam0.inc.mk
+
+TERMDELAYDEPS := $(filter reset flash flash-only, $(MAKECMDGOALS))
+ifneq (,$(TERMDELAYDEPS))
+  # By default, add 2 seconds delay before opening terminal: this is required
+  # when opening the terminal right after flashing. In this case, the stdio
+  # over USB needs some time after reset before being ready.
+  TERM_DELAY ?= 2
+  TERMDEPS += term-delay
+endif
+
+TESTRUNNER_CONNECT_DELAY ?= $(TERM_DELAY)
+$(call target-export-variables,test,TESTRUNNER_CONNECT_DELAY)
+
+term-delay: $(TERMDELAYDEPS)
+	sleep $(TERM_DELAY)

--- a/boards/yarm/board.c
+++ b/boards/yarm/board.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2020 Antonio Galea
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_yarm
+ * @{
+ *
+ * @file        board.c
+ * @brief       Board specific implementations for the Acmesystems
+ *              YARM board
+ *
+ * @author      Antonio Galea <antonio.galea@gmail.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "board.h"
+#include "cpu.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/yarm/doc.txt
+++ b/boards/yarm/doc.txt
@@ -1,0 +1,108 @@
+/**
+@defgroup    boards_yarm Acmesystems YARM board
+@ingroup     boards
+@brief       Support for the Acmesystems YARM board.
+
+## Overview
+
+Yarm is a smart and cost effective solution for system integrators to build
+their own RF applications at 868 MHz avoiding all the hardware design costs
+requested to start a new custom RF project.
+
+Yarm integrates:
+
+- a Microchip SAML21 low power MCU
+- a Microchip ATA8510 radio module
+
+See Acmesystems [product page](https://www.acmesystems.it/yarm) for more
+information.
+
+In the provided configuration, stdio is available via USB. The board could be
+configured to provide it on the exposed UART instead, by defining
+
+```
+USEMODULE=stdio_uart
+```
+
+Depending on the connection to your PC, you will probably also need to set
+PORT_LINUX to a different value (default is /dev/ttyACM0), for instance
+
+```
+PORT_LINUX=/dev/ttyUSB0
+```
+
+## Hardware
+
+![yarm image](https://www.acmesystems.it/www/yarm/yarm-dev-yarm.jpg)
+
+### MCU
+| MCU           | ATSAML21J18B                                                                                           |
+|:------------- |:------------------------------------------------------------------------------------------------------ |
+| Family        | ARM Cortex-M0+                                                                                         |
+| Vendor        | Microchip                                                                                              |
+| RAM           | 32Kb                                                                                                   |
+| Flash         | 256Kb                                                                                                  |
+| Frequency     | up to 48MHz                                                                                            |
+| FPU           | no                                                                                                     |
+| Timers        | 8 (16-bit)                                                                                             |
+| ADCs          | 1x 12-bit (20 channels)                                                                                |
+| UARTs         | x 6 (shared with SPI and I2C)                                                                          |
+| SPIs          | max 6 (see UART)                                                                                       |
+| I2Cs          | max 6 (see UART)                                                                                       |
+| Vcc           | 1.8V - 3.6V                                                                                            |
+| Datasheet     | [Datasheet](https://ww1.microchip.com/downloads/en/DeviceDoc/SAM_L21_Family_DataSheet_DS60001477C.pdf) |
+
+### RADIO
+| Transceiver   | ATA8510                                                                                                             |
+|:------------- |:------------------------------------------------------------------------------------------------------------------- |
+| Vendor        | Microchip                                                                                                           |
+| Sensitivity   | -123dBm                                                                                                             |
+| Output power  | -12dBm to +14.5dBm programmable in 0.4-dB steps ]                                                                   |
+| Datasheet     | [Datasheet](https://ww1.microchip.com/downloads/en/DeviceDoc/UHF-ASK-FSK-Transceiver-Product-Brief-DS00003077A.pdf) |
+
+*NOTE:* not all MCU interfaces are available on YARM; see the
+[pinout](https://www.acmesystems.it/pinout_yarm-dev) to know more.
+
+## Implementation Status
+
+| Device           | ID        | Supported | Comments                  |
+|:---------------- |:----------|:--------- |:-------------             |
+| MCU              | saml21    | partly    | PLL clock not implemented |
+| Low-level driver | GPIO      | yes       |                           |
+|                  | PWM       | yes       |                           |
+|                  | UART      | yes       |                           |
+|                  | I2C       | yes       |                           |
+|                  | SPI       | yes       |                           |
+|                  | USB       | yes       |                           |
+|                  | RTT       | yes       |                           |
+|                  | RTC       | yes       |                           |
+|                  | RNG       | yes       |                           |
+|                  | Timer     | yes       |                           |
+|                  | ADC       | yes       |                           |
+
+
+## Flashing the device
+
+Both the MCU and the radio module are flashed using
+[Atmel ICE](https://www.microchip.com/DevelopmentTools/ProductDetails/atatmel-ice),
+with the help of a small adapter. The software used is edbg, bundled with RIOT.
+
+[wiring](https://www.acmesystems.it/asquini/yarm_avr_programming/ice-wiring.jpg)
+
+On Linux you might have to add a **udev** rule for Atmel ICE, like
+```
+bash
+(
+cat <<END
+# Atmel-ICE JTAG/SWD in-circuit debugger
+ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2141", MODE="664", GROUP="plugdev"
+END
+) | sudo tee -a /etc/udev/rules.d/99-atmel-ice.rules
+sudo service udev restart
+```
+
+## Supported Toolchains
+
+Recommended toolchain for SAML21 is [GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded).
+On Debian Buster, the default [gcc-arm-none-eabi](https://packages.debian.org/buster/gcc-arm-none-eabi)
+package works well.

--- a/boards/yarm/include/board.h
+++ b/boards/yarm/include/board.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Antonio Galea
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_yarm
+ * @brief       Support for the Acmesystems YARM board.
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Acmesystems
+ *              YARM board.
+ *
+ * @author      Antonio Galea <antonio.galea@gmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/yarm/include/periph_conf.h
+++ b/boards/yarm/include/periph_conf.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2020 Antonio Galea
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_yarm
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the Acmesystems
+ *              YARM board.
+ *
+ * @author      Antonio Galea <antonio.galea@gmail.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   GCLK reference speed
+ */
+#define CLOCK_CORECLOCK     (48000000U)
+
+/**
+ * @brief Enable the internal DC/DC converter
+ *        The board is equipped with the necessary inductor.
+ */
+#define USE_VREG_BUCK       (1)
+
+/**
+ * @name    Timer peripheral configuration
+ * @{
+ */
+static const tc32_conf_t timer_config[] = {
+    {   /* Timer 0 - System Clock */
+        .dev            = TC0,
+        .irq            = TC0_IRQn,
+        .mclk           = &MCLK->APBCMASK.reg,
+        .mclk_mask      = MCLK_APBCMASK_TC0 | MCLK_APBCMASK_TC1,
+        .gclk_id        = TC0_GCLK_ID,
+        .gclk_src       = SAM0_GCLK_8MHZ,
+        .flags          = TC_CTRLA_MODE_COUNT32,
+    }
+};
+
+/* Timer 0 configuration */
+#define TIMER_0_CHANNELS    2
+#define TIMER_0_ISR         isr_tc0
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev      = &SERCOM3->USART,
+        .rx_pin   = GPIO_PIN(PA, 23),
+        .tx_pin   = GPIO_PIN(PA, 22),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin  = GPIO_UNDEF,
+        .cts_pin  = GPIO_UNDEF,
+#endif
+        .mux      = GPIO_MUX_C,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = SAM0_GCLK_MAIN,
+    }
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom3
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = &(SERCOM0->SPI),
+        .miso_pin = GPIO_PIN(PA, 4),
+        .mosi_pin = GPIO_PIN(PA, 6),
+        .clk_pin  = GPIO_PIN(PA, 7),
+        .miso_mux = GPIO_MUX_D,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux  = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3,
+        .gclk_src = SAM0_GCLK_MAIN,
+#ifdef MODULE_PERIPH_DMA
+        .tx_trigger = SERCOM0_DMAC_ID_TX,
+        .rx_trigger = SERCOM0_DMAC_ID_RX,
+#endif
+    }
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM2->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PA, 9),
+        .sda_pin  = GPIO_PIN(PA, 8),
+        .mux      = GPIO_MUX_D,
+        .gclk_src = SAM0_GCLK_MAIN,
+        .flags    = I2C_FLAG_NONE
+    }
+};
+
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+/**
+ * @name    RTC configuration
+ * @{
+ */
+#define EXTERNAL_OSC32_SOURCE                    1
+#define INTERNAL_OSC32_SOURCE                    0
+#define ULTRA_LOW_POWER_INTERNAL_OSC_SOURCE      0
+/** @} */
+
+/**
+ * @name    RTT configuration
+ * @{
+ */
+#ifndef RTT_FREQUENCY
+#define RTT_FREQUENCY       (32768U)
+#endif
+
+/** @} */
+
+/**
+ * @name ADC Configuration
+ * @{
+ */
+
+/* ADC Default values */
+#define ADC_PRESCALER                       ADC_CTRLB_PRESCALER_DIV256
+
+#define ADC_NEG_INPUT                       ADC_INPUTCTRL_MUXNEG(0x18u)
+#define ADC_REF_DEFAULT                     ADC_REFCTRL_REFSEL_INTVCC2
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos */
+    {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN18)},
+    {GPIO_PIN(PA, 11), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN19)},
+    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN0)},
+    {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN1)}
+};
+
+#define ADC_NUMOF                           ARRAY_SIZE(adc_channels)
+/** @} */
+
+/**
+ * @name USB peripheral configuration
+ * @{
+ */
+static const sam0_common_usb_config_t sam_usbdev_config[] = {
+    {
+        .dm     = GPIO_PIN(PA, 24),
+        .dp     = GPIO_PIN(PA, 25),
+        .d_mux  = GPIO_MUX_G,
+        .device = &USB->DEVICE,
+        .gclk_src = SAM0_GCLK_48MHZ,
+    }
+};
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/saml21/Kconfig
+++ b/cpu/saml21/Kconfig
@@ -18,6 +18,11 @@ config CPU_MODEL_SAML21J18A
     select CPU_FAM_SAML21
     select HAS_PERIPH_HWRNG
 
+config CPU_MODEL_SAML21J18B
+    bool
+    select CPU_FAM_SAML21
+    select HAS_PERIPH_HWRNG
+
 config CPU_MODEL_SAMR30G18A
     bool
     select CPU_FAM_SAML21
@@ -39,6 +44,7 @@ config CPU_FAM
 
 config CPU_MODEL
     default "saml21j18a" if CPU_MODEL_SAML21J18A
+    default "saml21j18b" if CPU_MODEL_SAML21J18B
     default "samr30g18a" if CPU_MODEL_SAMR30G18A
     default "samr34j18b" if CPU_MODEL_SAMR34J18B
 

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -86,5 +86,6 @@ BOARD_INSUFFICIENT_MEMORY := \
     stm32f3discovery \
     stm32l0538-disco \
     wemos-zero \
+    yarm \
     yunjia-nrf51822 \
     #

--- a/tests/bench_xtimer/Makefile
+++ b/tests/bench_xtimer/Makefile
@@ -62,6 +62,7 @@ LOW_MEMORY_BOARDS += \
   telosb \
   waspmote-pro \
   wemos-zero \
+  yarm \
   yunjia-nrf51822 \
   z1 \
   #

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -94,6 +94,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     teensy31 \
     telosb \
     waspmote-pro \
+    yarm \
     yunjia-nrf51822 \
     z1 \
     #


### PR DESCRIPTION
### Add support for YARM board

[Acmesystems YARM](https://www.acmesystems.it/yarm) sports a Microchip SAML21 low power CPU and a Microchip ATA8510 radio module. This PR provides definition files for the board ~~, a driver for the radio chip, and a test example app for the latter~~.

Antonio