### PR TITLE
sys/{ztimer, xtimer}: Fix issues with xtimer_on_ztimer

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1050,7 +1050,7 @@ ifneq (,$(filter periph_uart_nonblocking,$(USEMODULE)))
 endif
 
 # include ztimer dependencies
-ifneq (,$(filter ztimer%,$(USEMODULE)))
+ifneq (,$(filter ztimer% %ztimer,$(USEMODULE)))
   include $(RIOTBASE)/sys/ztimer/Makefile.dep
 endif
 

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -590,14 +590,14 @@ static inline int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t timeout);
  */
 #define XTIMER_HZ_BASE (1000000ul)
 
-#ifndef XTIMER_HZ
+#if !defined(XTIMER_HZ) && !defined(MODULE_XTIMER_ON_ZTIMER)
 /**
  * @brief  Frequency of the underlying hardware timer
  */
 #define XTIMER_HZ XTIMER_HZ_BASE
 #endif
 
-#ifndef XTIMER_SHIFT
+#if !defined(XTIMER_SHIFT) && !defined(MODULE_XTIMER_ON_ZTIMER)
 #if (XTIMER_HZ == 32768ul)
 /* No shift necessary, the conversion is not a power of two and is handled by
  * functions in tick_conversion.h */
@@ -634,7 +634,7 @@ static inline int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t timeout);
 #else
 #error "XTIMER_SHIFT cannot be derived for given XTIMER_HZ, verify settings!"
 #endif
-#else
+#elif !defined(MODULE_XTIMER_ON_ZTIMER)
 #error "XTIMER_SHIFT is set relative to XTIMER_HZ, no manual define required!"
 #endif
 

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -77,7 +77,7 @@ static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
     return (ticks << XTIMER_SHIFT); /* multiply by power of two */
 }
 #endif /* defined(XTIMER_SHIFT) && (XTIMER_SHIFT != 0) */
-#elif XTIMER_HZ == (1000000ul)
+#elif (XTIMER_HZ == (1000000ul)) || defined(MODULE_XTIMER_ON_ZTIMER)
 /* This is the most straightforward as the xtimer API is based around
  * microseconds for representing time values. */
 static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {

--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -485,6 +485,7 @@ void ztimer_update_head_offset(ztimer_clock_t *clock);
  */
 void ztimer_init(void);
 
+#if defined(MODULE_ZTIMER_EXTEND) || defined(DOXYGEN)
 /**
  * @brief   Initialize possible ztimer extension intermediate timer
  *
@@ -501,6 +502,7 @@ static inline void ztimer_init_extend(ztimer_clock_t *clock)
         clock->ops->set(clock, clock->max_value >> 1);
     }
 }
+#endif /* MODULE_ZTIMER_EXTEND */
 
 /* default ztimer virtual devices */
 /**


### PR DESCRIPTION
### Contribution description

This contains a number of smaller bug fixes:

- Compilation of `ztimer` without `ztimer_extend`
- Missing dependency for `xtimer_on_ztimer`
- Compilation of `xtimer_on_ztimer` without xtimer config

### Testing procedure

```
USEMODULE=xtimer_on_ztimer BOARD=atmega1284p ATMEGA1284P_CLOCK=12000000U make -C tests/xtimer_usleep
```

This fails on master, as xtimer is incapable of running on top of any frequency that can be derived from a 12 MHz CPU clock. However, with `xtimer_on_ztimer`, this should not be an issue, as `xtimer` will just run on top of `ztimer_usec` and lets `ztimer` do the frequency conversion.

### Issues/PRs references

Needed to f&#105;x https://github.com/RIOT-OS/RIOT/issues/14750