### PR TITLE
boards/common/[atmega|arduino-atmega]: use weak for common functions

### DIFF
--- a/boards/common/arduino-atmega/led_init.c
+++ b/boards/common/arduino-atmega/led_init.c
@@ -26,7 +26,7 @@
 #include "cpu.h"
 #include "periph/gpio.h"
 
-void led_init(void)
+void __attribute__((weak)) led_init(void)
 {
     /* initialize the on-board LED */
     gpio_init(LED0_PIN, GPIO_OUT);

--- a/boards/common/atmega/board.c
+++ b/boards/common/atmega/board.c
@@ -29,7 +29,7 @@
 
 void led_init(void);
 
-void board_init(void)
+void __attribute__((weak)) board_init(void)
 {
 #ifdef CPU_ATMEGA32U4
     /* disable usb interrupt on Atmega32U4 */


### PR DESCRIPTION
### Contribution description
This adds the `weak` attribute to common functions implementations of `board_init` and `led_init` (similar to what is done for the nucleo boards) for the `atmega` and `arduino-atmega` boards. This is needed because some boards that include these modules implement their own functions. Currently the correct symbol seems to be linked on master, because we are using archives. See #14754.

### Testing procedure
- Green CI
- The `.elf` file of any application compiled for an arduino-atmega board should show that `board_init` and `led_init` are still strong symbols (e.g. `nm` can be used for this).

### Issues/PRs references
Part of #14754