### PR TITLE
cpu/[esp/atmega]_common: check if other STDIO implementation is selected

### DIFF
--- a/cpu/atmega_common/Makefile.dep
+++ b/cpu/atmega_common/Makefile.dep
@@ -7,8 +7,10 @@ USEMODULE += atmega_common
 # peripheral drivers are linked into the final binary
 USEMODULE += atmega_common_periph
 
-# the atmel port uses stdio_uart
-USEMODULE += stdio_uart
+# the atmel port uses stdio_uart by default
+ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+  USEMODULE += stdio_uart
+endif
 
 # expand atmega_pcint module
 ifneq (,$(filter atmega_pcint,$(USEMODULE)))

--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -13,7 +13,11 @@ USEMODULE += periph_hwrng
 USEMODULE += periph_flash
 USEMODULE += periph_uart
 USEMODULE += random
-USEMODULE += stdio_uart
+
+ifeq (,$(filter stdio_% slipdev_stdio,$(USEMODULE)))
+  USEMODULE += stdio_uart
+endif
+
 USEMODULE += xtensa
 
 # Features used by ESP*


### PR DESCRIPTION
### Contribution description
Currently `atmega_common` and `esp_common` select `stdio_uart` unconditionally as the STDIO implementation module. This adds a check to only default to this module if there is no other STDIO selected. This check will not catch every case (e.g. a module further down the dependency resolution process needs a particular STDIO implementation), but it should catch when the application or the board selects a different implementation.

### Testing procedure
- On master running `env BOARD=arduino-uno make info-modules -C tests/minimal` shows both `stdio_uart` and `stdio_null`. With the PR only `stdio_null` (which is selected by the application) should show up.

- When no other STDIO is defined, `stdio_uart` should still be the default

### Issues/PRs references
Part of #14754