### PR TITLE
fuzzing: select gnrc_pktbuf_malloc implementation

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -636,6 +636,12 @@ ifneq (,$(filter cpp11-compat,$(USEMODULE)))
   FEATURES_REQUIRED += libstdcpp
 endif
 
+ifneq (,$(filter fuzzing,$(USEMODULE)))
+  USEMODULE += netdev_test
+  USEMODULE += gnrc_netif
+  USEMODULE += gnrc_pktbuf_malloc
+endif
+
 ifneq (,$(filter gnrc,$(USEMODULE)))
   USEMODULE += gnrc_netapi
   USEMODULE += gnrc_netreg
@@ -740,12 +746,6 @@ endif
 ifneq (,$(filter evtimer_mbox,$(USEMODULE)))
   USEMODULE += evtimer
   USEMODULE += core_mbox
-endif
-
-ifneq (,$(filter fuzzing,$(USEMODULE)))
-  USEMODULE += netdev_test
-  USEMODULE += gnrc_netif
-  USEMODULE += gnrc_pktbuf_malloc
 endif
 
 ifneq (,$(filter can_linux,$(USEMODULE)))

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -17,6 +17,10 @@ ifneq (,$(filter gnrc_sock_async,$(USEMODULE)))
   CFLAGS += -DSOCK_HAS_ASYNC
 endif
 
+ifneq (,$(filter gnrc_pktbuf,$(USEMODULE)))
+  include $(RIOTBASE)/sys/net/gnrc/pktbuf/Makefile.include
+endif
+
 ifneq (,$(filter posix_headers,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/include
 endif

--- a/sys/net/gnrc/pktbuf/Makefile.include
+++ b/sys/net/gnrc/pktbuf/Makefile.include
@@ -1,0 +1,5 @@
+# Check that only one implementation of pktbuf is used
+USED_PKTBUF_IMPLEMENTATIONS := $(filter-out gnrc_pktbuf_cmd,$(filter gnrc_pktbuf_%,$(USEMODULE)))
+ifneq (1,$(words $(USED_PKTBUF_IMPLEMENTATIONS)))
+  $(error Only one implementation of gnrc_pktbuf should be used. Currently using: $(USED_PKTBUF_IMPLEMENTATIONS))
+endif


### PR DESCRIPTION
### Contribution description
The fuzzing module needs the malloc implementation of `gnrc_pktbuf`, but GNRC is using the static version as default. This adds the module in the Fuzzing common Makefile, and also adds a check to see that only the malloc implementation is selected after dependency resolution.

### Testing procedure
`make -C fuzzing/gcoap info-modules` should only show `gnrc_pktbuf_malloc` with this PR. On master both are on the list.

### Issues/PRs references
Part of #14754