### PR TITLE
pkg/cmsis-[dsp/nn]: cleanup makefiles

### DIFF
--- a/pkg/cmsis-dsp/Makefile
+++ b/pkg/cmsis-dsp/Makefile
@@ -5,7 +5,21 @@ PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk
 
-CFLAGS += -Wno-strict-aliasing -Wno-unused-parameter
+CMSIS_DSP_MODULES =                \
+    cmsis-dsp_BasicMathFunctions   \
+    cmsis-dsp_CommonTables         \
+    cmsis-dsp_ComplexMathFunctions \
+    cmsis-dsp_ControllerFunctions  \
+    cmsis-dsp_FastMathFunctions    \
+    cmsis-dsp_FilteringFunctions   \
+    cmsis-dsp_MatrixFunctions      \
+    cmsis-dsp_StatisticsFunctions  \
+    cmsis-dsp_SupportFunctions     \
+    cmsis-dsp_TransformFunctions   \
 
-all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.$(PKG_NAME) all
+.PHONY: cmsis-dsp_%
+
+all: $(CMSIS_DSP_MODULES)
+
+cmsis-dsp_%:
+	$(MAKE) -C $(PKG_SOURCE_DIR)/CMSIS/DSP/Source/$* -f $(CURDIR)/Makefile.cmsis-dsp MODULE=$@

--- a/pkg/cmsis-dsp/Makefile.cmsis-dsp
+++ b/pkg/cmsis-dsp/Makefile.cmsis-dsp
@@ -1,40 +1,5 @@
-PKG_NAME=cmsis-dsp
-
-# A list of all the directories to build for CMSIS-DSP
-CMSIS_DIRS += \
-  CMSIS/DSP/Source/BasicMathFunctions \
-  CMSIS/DSP/Source/CommonTables \
-  CMSIS/DSP/Source/ComplexMathFunctions \
-  CMSIS/DSP/Source/ControllerFunctions \
-  CMSIS/DSP/Source/FastMathFunctions \
-  CMSIS/DSP/Source/FilteringFunctions \
-  CMSIS/DSP/Source/MatrixFunctions \
-  CMSIS/DSP/Source/StatisticsFunctions \
-  CMSIS/DSP/Source/SupportFunctions \
-  CMSIS/DSP/Source/TransformFunctions \
-#
-
-INCLUDES += -I$(CURDIR)/CMSIS/DSP/Include
-CMSIS_BINDIRS = $(addprefix $(BINDIR)/$(PKG_NAME)/,$(CMSIS_DIRS))
-
-# Override default RIOT search path for sources to include all of the CMSIS-DSP
-# sources in one library instead of one library per subdirectory.
-SRC := $(foreach DIR,$(CMSIS_DIRS),$(wildcard $(DIR)/*.c))
-SRCXX := $(foreach DIR,$(CMSIS_DIRS),$(wildcard $(DIR)/*.cpp))
-ASMSRC := $(foreach DIR,$(CMSIS_DIRS),$(wildcard $(DIR)/*.s))
-ASSMSRC := $(foreach DIR,$(CMSIS_DIRS),$(wildcard $(DIR)/*.S))
-
-OBJC    := $(SRC:%.c=$(BINDIR)/$(PKG_NAME)/%.o)
-OBJCXX  := $(SRCXX:%.cpp=$(BINDIR)/$(PKG_NAME)/%.o)
-ASMOBJ  := $(ASMSRC:%.s=$(BINDIR)/$(PKG_NAME)/%.o)
-ASSMOBJ := $(ASSMSRC:%.S=$(BINDIR)/$(PKG_NAME)/%.o)
-OBJ = $(OBJC) $(OBJCXX) $(ASMOBJ) $(ASSMOBJ)
-
-# Create subdirectories if they do not already exist
-$(OBJ): | $(CMSIS_BINDIRS)
-
-$(CMSIS_BINDIRS):
-	@mkdir -p $@
+CFLAGS += -Wno-strict-aliasing
+CFLAGS += -Wno-unused-parameter
 
 # Include RIOT settings and recipes
 include $(RIOTBASE)/Makefile.base

--- a/pkg/cmsis-dsp/Makefile.dep
+++ b/pkg/cmsis-dsp/Makefile.dep
@@ -1,0 +1,10 @@
+USEMODULE += cmsis-dsp_BasicMathFunctions
+USEMODULE += cmsis-dsp_CommonTables
+USEMODULE += cmsis-dsp_ComplexMathFunctions
+USEMODULE += cmsis-dsp_ControllerFunctions
+USEMODULE += cmsis-dsp_FastMathFunctions
+USEMODULE += cmsis-dsp_FilteringFunctions
+USEMODULE += cmsis-dsp_MatrixFunctions
+USEMODULE += cmsis-dsp_StatisticsFunctions
+USEMODULE += cmsis-dsp_SupportFunctions
+USEMODULE += cmsis-dsp_TransformFunctions

--- a/pkg/cmsis-dsp/Makefile.include
+++ b/pkg/cmsis-dsp/Makefile.include
@@ -1,1 +1,4 @@
 INCLUDES += -I$(PKGDIRBASE)/cmsis-dsp/CMSIS/DSP/Include
+
+# cmsis-dsp module is not a concrete module, so declare it as a pseudomodule
+PSEUDOMODULES += cmsis-dsp

--- a/pkg/cmsis-nn/Makefile
+++ b/pkg/cmsis-nn/Makefile
@@ -2,9 +2,20 @@ PKG_NAME=cmsis-nn
 PKG_URL=https://github.com/ARM-software/CMSIS_5
 PKG_VERSION=5.6.0
 PKG_LICENSE=Apache-2.0
-CFLAGS += -Wno-strict-aliasing -Wno-unused-parameter
 
 include $(RIOTBASE)/pkg/pkg.mk
 
-all:
-	"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
+CMSIS_NN_MODULES =                   \
+    cmsis-nn_ActivationFunctions     \
+    cmsis-nn_ConvolutionFunctions    \
+    cmsis-nn_FullyConnectedFunctions \
+    cmsis-nn_NNSupportFunctions      \
+    cmsis-nn_PoolingFunctions        \
+    cmsis-nn_SoftmaxFunctions        \
+
+.PHONY: cmsis-nn_%
+
+all: $(CMSIS_NN_MODULES)
+
+cmsis-nn_%:
+	$(MAKE) -C $(PKG_SOURCE_DIR)/CMSIS/NN/Source/$* -f $(CURDIR)/Makefile.cmsis-nn MODULE=$@

--- a/pkg/cmsis-nn/Makefile.cmsis-nn
+++ b/pkg/cmsis-nn/Makefile.cmsis-nn
@@ -1,42 +1,5 @@
-PKG_NAME=cmsis-nn
-
-# A list of all the directories to build for CMSIS-NN
-CMSIS_DIRS += \
-  CMSIS/NN/Source/ActivationFunctions \
-  CMSIS/NN/Source/BasicMathFunctions \
-  CMSIS/NN/Source/ConcatenationFunctions \
-  CMSIS/NN/Source/ConvolutionFunctions \
-  CMSIS/NN/Source/FullyConnectedFunctions \
-  CMSIS/NN/Source/NNSupportFunctions \
-  CMSIS/NN/Source/PoolingFunctions \
-  CMSIS/NN/Source/ReshapeFunctions \
-  CMSIS/NN/Source/SoftmaxFunctions \
-#
-
-INCLUDES += -I$(CURDIR)/CMSIS/NN/Include
-CMSIS_BINDIRS = $(addprefix $(BINDIR)/$(PKG_NAME)/,$(CMSIS_DIRS))
-
-# Override default RIOT search path for sources to include all of the CMSIS-NN
-# sources in one library instead of one library per subdirectory.
-SRC := $(foreach DIR,$(CMSIS_DIRS),$(wildcard $(DIR)/*.c))
-SRCXX := $(foreach DIR,$(CMSIS_DIRS),$(wildcard $(DIR)/*.cpp))
-ASMSRC := $(foreach DIR,$(CMSIS_DIRS),$(wildcard $(DIR)/*.s))
-ASSMSRC := $(foreach DIR,$(CMSIS_DIRS),$(wildcard $(DIR)/*.S))
-
-OBJC    := $(SRC:%.c=$(BINDIR)/$(PKG_NAME)/%.o)
-OBJCXX  := $(SRCXX:%.cpp=$(BINDIR)/$(PKG_NAME)/%.o)
-ASMOBJ  := $(ASMSRC:%.s=$(BINDIR)/$(PKG_NAME)/%.o)
-ASSMOBJ := $(ASSMSRC:%.S=$(BINDIR)/$(PKG_NAME)/%.o)
-OBJ = $(OBJC) $(OBJCXX) $(ASMOBJ) $(ASSMOBJ)
-
-# Create subdirectories if they do not already exist
-$(OBJ): | $(CMSIS_BINDIRS)
-
-$(CMSIS_BINDIRS):
-	@mkdir -p $@
-
-# Reset the default goal.
-.DEFAULT_GOAL :=
+CFLAGS += -Wno-strict-aliasing
+CFLAGS += -Wno-unused-parameter
 
 # Include RIOT settings and recipes
 include $(RIOTBASE)/Makefile.base

--- a/pkg/cmsis-nn/Makefile.dep
+++ b/pkg/cmsis-nn/Makefile.dep
@@ -1,1 +1,8 @@
 FEATURES_REQUIRED += cpu_core_cortexm
+
+USEMODULE += cmsis-nn_ActivationFunctions
+USEMODULE += cmsis-nn_ConvolutionFunctions
+USEMODULE += cmsis-nn_FullyConnectedFunctions
+USEMODULE += cmsis-nn_NNSupportFunctions
+USEMODULE += cmsis-nn_PoolingFunctions
+USEMODULE += cmsis-nn_SoftmaxFunctions

--- a/pkg/cmsis-nn/Makefile.include
+++ b/pkg/cmsis-nn/Makefile.include
@@ -4,3 +4,6 @@ INCLUDES += -I$(PKGDIRBASE)/cmsis-nn/CMSIS/NN/Include
 INCLUDES += -I$(PKGDIRBASE)/cmsis-nn/CMSIS/DSP/Include
 
 CFLAGS += -Wno-sign-compare
+
+# cmsis-nn module is not a concrete module, so declare it as a pseudomodule
+PSEUDOMODULES += cmsis-nn


### PR DESCRIPTION
### Contribution description
This PR does some cleanup on the Makefiles of `cmsis-dsp` and `cmsis-nn`. Instead of specifying the sources manually overriding the variables of `Makefile.base`, now the normal module mechanism is used. This yields one archive and one folder per group of sources. This is needed by #14754.

### Testing procedure
- Green CI
- The tests for these packages should still pass

### Issues/PRs references
Part of #14754 