### PR TITLE
pkg/tinydtls: enforce the selection of a crypto secure PRNG

### DIFF
--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -20,6 +20,8 @@ USEMODULE += shell
 USEMODULE += shell_commands
 
 USEPKG += tinydtls
+# tinydtls needs crypto secure PRNG
+USEMODULE += prng_sha1prng
 
 # UDP Port to use (20220 is default for DTLS).
 DTLS_PORT ?= 20220

--- a/examples/dtls-sock/Makefile
+++ b/examples/dtls-sock/Makefile
@@ -21,6 +21,9 @@ USEMODULE += gnrc_sock_udp
 # Use tinydtls for sock_dtls
 USEMODULE += tinydtls_sock_dtls
 
+# tinydtls needs crypto secure PRNG
+USEMODULE += prng_sha1prng
+
 # Add also the shell, some shell commands
 USEMODULE += shell
 USEMODULE += shell_commands

--- a/pkg/tinydtls/Makefile.dep
+++ b/pkg/tinydtls/Makefile.dep
@@ -6,9 +6,5 @@ USEMODULE += random
 USEMODULE += tinydtls_aes
 USEMODULE += tinydtls_ecc
 
-# tinydtls needs cryptographically secure randomness
-# TODO: restore configurability, e.g. allow to use HWRNG instead if available
-USEMODULE += prng_sha1prng
-
 # TinyDTLS only has support for 32-bit architectures ATM
 FEATURES_REQUIRED += arch_32bit

--- a/pkg/tinydtls/Makefile.include
+++ b/pkg/tinydtls/Makefile.include
@@ -11,6 +11,15 @@ INCLUDES += -I$(PKG_BUILDDIR)
 # Mandatory for tinyDTLS
 CFLAGS += -DDTLSv12 -DWITH_SHA256
 
+# Check that the used PRNG implementation is cryptographically secure
+CRYPTO_SECURE_IMPLEMENTATIONS := prng_sha256prng prng_sha1prng prng_hwrng
+USED_PRNG_IMPLEMENTATIONS := $(filter prng_%,$(USEMODULE))
+ifeq (,$(filter $(CRYPTO_SECURE_IMPLEMENTATIONS),$(USEMODULE)))
+  $(info TinyDTLS needs a cryptographically secure implementation of the PRNG module.)
+  $(info Currently using: $(USED_PRNG_IMPLEMENTATIONS))
+  $(error Please use one of: $(CRYPTO_SECURE_IMPLEMENTATIONS))
+endif
+
 # Dependencies partially under control of the App's requirements
 
 # The configuration for socket overrides Sock

--- a/pkg/tinydtls/doc.txt
+++ b/pkg/tinydtls/doc.txt
@@ -12,6 +12,8 @@
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.mk}
  * USEPKG += tinydtls
+ * # a cryptographically secure implementation of PRNG is needed
+ * USEMODULE += prng_sha1prng
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
  * Supported Cipher Suites

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -117,3 +117,7 @@ endif
 ifneq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
   PSEUDOMODULES += xtimer
 endif
+
+ifneq (,$(filter prng,$(USEMODULE)))
+  include $(RIOTBASE)/sys/random/Makefile.include
+endif

--- a/sys/random/Makefile.include
+++ b/sys/random/Makefile.include
@@ -1,0 +1,15 @@
+USED_PRNG_IMPLEMENTATIONS := $(filter prng_%,$(USEMODULE))
+
+# Check that prng_shaxprng is not used by itself
+ifneq (,$(filter prng_shaxprng,$(USEMODULE)))
+  ifeq (,$(filter prng_sha1prng prng_sha256prng,$(USEMODULE)))
+    $(error prng_shaxprng should not be used directly. Select one of: prng_sha1prng, prng_sha256prng)
+  endif
+endif
+
+# Check that only one implementation of PRNG is used
+# NOTE: prng_shaxprng is filtered out because it is used by the specific implementations
+ifneq (1,$(words $(filter-out prng_shaxprng,$(USED_PRNG_IMPLEMENTATIONS))))
+  $(info Currently the following prng modules are used: $(USED_PRNG_IMPLEMENTATIONS))
+  $(error Only one implementation of PRNG should be used.)
+endif

--- a/tests/pkg_tinydtls_sock_async/Makefile
+++ b/tests/pkg_tinydtls_sock_async/Makefile
@@ -17,6 +17,8 @@ USEMODULE += event_timeout
 
 # Use tinydtls for sock_dtls
 USEMODULE += tinydtls_sock_dtls
+# tinydtls needs crypto secure PRNG
+USEMODULE += prng_sha1prng
 
 # Add also the shell, some shell commands
 USEMODULE += shell


### PR DESCRIPTION
### Contribution description
#14456 fixed the PRNG implementation used for tinyDTLS to SHA-1, but because of the order the dependencies are processed the default module `prng_tinymt32` is still selected. This PR modifies tinyDTLS's makefile to check if a cryptographically secure implementation of PRNG is being used.

**> Question**: which other implementations of PRNG provide this and should be added to the check?

Also, two sanity checks are added to `sys/random`:
- Check that `prng_shaxprng` is not used directly
- Check that only one implementation of the PRNG interface is used

### Testing procedure
- When not specified in the application the PRNG implementation should still default to `prng_tinymt32`
- Applications using tinyDTLS should compile and use `prng_sha1prng`
- Check that the sanity checks work:
    - You can try removing `USEMODULE += prng_sha1prng` from the `examples/dtls-sock` makefile, an error should be raised
    - You can specify more than one PRNG implementation, an error should be raised

### Issues/PRs references
Part of #14754