### PR TITLE
stm32: Add define for when DMA channel selection is not supported

### DIFF
--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -442,6 +442,12 @@ typedef enum {
 } dma_mode_t;
 
 /**
+ * @brief   DMA channel/trigger configuration for DMA peripherals without
+ *          channel/trigger filtering such as the stm32f1 and stm32f3.
+ */
+#define DMA_CHAN_CONFIG_UNSUPPORTED  (UINT8_MAX)
+
+/**
  * @name    DMA Increment modes
  * @{
  */


### PR DESCRIPTION

### Contribution description

This adds a placeholder define for when the DMA peripheral available on
the MCU doesn't support channel/trigger filtering. This is the case on
the stm32f1 and stm32f3 family.

This way we have a self-describing define for the unused `dma_chan` configuration on stm32f(1|3) boards.

### Testing procedure

Read the documentation and check if the name makes sense.

### Issues/PRs references

None