### PR TITLE
cpu/cortexm_common: enable LTO by default

### DIFF
--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -9,6 +9,9 @@ TARGET_ARCH ?= arm-none-eabi
 CFLAGS_CPU   = -mcpu=$(MCPU) -mlittle-endian -mthumb $(CFLAGS_FPU)
 
 ifneq (llvm,$(TOOLCHAIN))
+  # enable LTO by default
+  LTO ?= 1
+
   # Clang (observed with v3.7) does not understand  -mno-thumb-interwork, only add if
   # not building with LLVM
   CFLAGS += -mno-thumb-interwork

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -30,7 +30,6 @@ CXXUWFLAGS += -std=%
 CXXUWFLAGS += -Wstrict-prototypes -Wold-style-definition
 
 ifeq ($(LTO),1)
-  $(warning Building with Link-Time-Optimizations is currently an experimental feature. Expect broken binaries.)
   LTOFLAGS = -flto
   LINKFLAGS += $(LTOFLAGS)
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

LTO support in GCC should be pretty mature by now, to a point where Fedora [enables it by default](https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/CQEI3UGK5HSHZ7JHE7NRTQHBWQYWA5HM/) for it's packages.

Let's follow suit by enabling LTO for our Cortex-M target.
This is the most mature target and is well-tested regularly.
So if any issues are caused by this, they should pop up fairly quick.

### Testing procedure

Usually one would expect interrupt-related things to break if there are LTO related bugs.
Testing *everything* on *every* platform is not practicable.
But if no errors pop up during release-spec testing, this is probably fine.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
