### PR TITLE
sys/posix/pthread/pthread.c: cleanup

### DIFF
--- a/sys/posix/pthread/include/pthread_threading.h
+++ b/sys/posix/pthread/include/pthread_threading.h
@@ -27,7 +27,7 @@ extern "C" {
  * @brief        Datatype to identify a POSIX thread.
  * @note         The pthread ids are one off to the index in the internal array.
  */
-typedef unsigned pthread_t;
+typedef kernel_pid_t pthread_t;
 
 /**
  * @brief        Spawn a new POSIX thread.

--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2013 Freie Universität Berlin
+ * Copyright (C) 2013 Freie Universität Berlin,
+ * Copyright (C) 2020 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @see     [The Open Group Base Specifications Issue 7: pthread.h - threads](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/pthread.h.html)
  * @author  Christian Mehlis <mehlis@inf.fu-berlin.de>
  * @author  René Kijewski <kijewski@inf.fu-berlin.de>
+ * @author  Julian Holzwarth <julian.holzwarth@fu-berlin.de>
  * @}
  */
 

--- a/sys/posix/pthread/pthread.c
+++ b/sys/posix/pthread/pthread.c
@@ -25,7 +25,6 @@
 #include "irq.h"
 #include "msg.h"
 #include "mutex.h"
-#include "priority_queue.h"
 #include "thread.h"
 #include "sched.h"
 
@@ -42,7 +41,8 @@
 #endif
 
 #if ENABLE_DEBUG
-#   define PTHREAD_REAPER_STACKSIZE ((CONFIG_PTHREAD_REAPER_BASE_STACKSIZE) + THREAD_EXTRA_STACKSIZE_PRINTF)
+#   define PTHREAD_REAPER_STACKSIZE ((CONFIG_PTHREAD_REAPER_BASE_STACKSIZE) + \
+                                     THREAD_EXTRA_STACKSIZE_PRINTF)
 #   define PTHREAD_STACKSIZE THREAD_STACKSIZE_MAIN
 #else
 #   define PTHREAD_REAPER_STACKSIZE (CONFIG_PTHREAD_REAPER_BASE_STACKSIZE)
@@ -52,7 +52,7 @@
 #include "debug.h"
 
 typedef enum {
-    PTS_RUNNING,
+    PTS_JOINABLE,
     PTS_DETACHED,
     PTS_ZOMBIE,
 } pthread_thread_status_t;
@@ -86,18 +86,20 @@ static void *pthread_start_routine(void *pt_)
 {
     pthread_thread_t *pt = pt_;
     void *retval = pt->start_routine(pt->arg);
+
     pthread_exit(retval);
 }
 
 static int insert(pthread_thread_t *pt)
 {
     int result = KERNEL_PID_UNDEF;
+
     mutex_lock(&pthread_mutex);
 
-    for (int i = 0; i < MAXTHREADS; i++){
+    for (int i = 0; i < MAXTHREADS; i++) {
         if (!pthread_sched_threads[i]) {
             pthread_sched_threads[i] = pt;
-            result = i+1;
+            result = i + 1;
             break;
         }
     }
@@ -108,7 +110,8 @@ static int insert(pthread_thread_t *pt)
 
 static void *pthread_reaper(void *arg)
 {
-    (void) arg;
+    (void)arg;
+    DEBUG("pthread_reaper(): start\n");
 
     while (1) {
         msg_t m;
@@ -120,8 +123,10 @@ static void *pthread_reaper(void *arg)
     return NULL;
 }
 
-int pthread_create(pthread_t *newthread, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg)
+int pthread_create(pthread_t *newthread, const pthread_attr_t *attr, void *(*start_routine)(
+                       void *), void *arg)
 {
+    DEBUG("pthread_create()\n");
     pthread_thread_t *pt = calloc(1, sizeof(pthread_thread_t));
 
     if (pt == NULL) {
@@ -135,12 +140,13 @@ int pthread_create(pthread_t *newthread, const pthread_attr_t *attr, void *(*sta
     }
     *newthread = pthread_pid;
 
-    pt->status = attr && attr->detached ? PTS_DETACHED : PTS_RUNNING;
+    pt->status = attr && attr->detached ? PTS_DETACHED : PTS_JOINABLE;
     pt->start_routine = start_routine;
     pt->arg = arg;
 
     bool autofree = attr == NULL || attr->ss_sp == NULL || attr->ss_size == 0;
-    size_t stack_size = attr && attr->ss_size > 0 ? attr->ss_size : PTHREAD_STACKSIZE;
+    size_t stack_size = attr &&
+                        attr->ss_size > 0 ? attr->ss_size : PTHREAD_STACKSIZE;
     void *stack = autofree ? malloc(stack_size) : attr->ss_sp;
 
     if (stack == NULL) {
@@ -154,16 +160,16 @@ int pthread_create(pthread_t *newthread, const pthread_attr_t *attr, void *(*sta
         if (pthread_reaper_pid == KERNEL_PID_UNDEF) {
             /* volatile pid to overcome problems with double checking */
             volatile kernel_pid_t pid = thread_create(pthread_reaper_stack,
-                                             PTHREAD_REAPER_STACKSIZE,
-                                             0,
-                                             THREAD_CREATE_STACKTEST,
-                                             pthread_reaper,
-                                             NULL,
-                                             "pthread-reaper");
+                                                      PTHREAD_REAPER_STACKSIZE,
+                                                      0,
+                                                      THREAD_CREATE_STACKTEST,
+                                                      pthread_reaper,
+                                                      NULL,
+                                                      "pthread-reaper");
             if (!pid_is_valid(pid)) {
                 free(pt->stack);
                 free(pt);
-                pthread_sched_threads[pthread_pid-1] = NULL;
+                pthread_sched_threads[pthread_pid - 1] = NULL;
                 mutex_unlock(&pthread_mutex);
                 return -1;
             }
@@ -183,7 +189,7 @@ int pthread_create(pthread_t *newthread, const pthread_attr_t *attr, void *(*sta
     if (!pid_is_valid(pt->thread_pid)) {
         free(pt->stack);
         free(pt);
-        pthread_sched_threads[pthread_pid-1] = NULL;
+        pthread_sched_threads[pthread_pid - 1] = NULL;
         return -1;
     }
 
@@ -194,6 +200,7 @@ int pthread_create(pthread_t *newthread, const pthread_attr_t *attr, void *(*sta
 
 void pthread_exit(void *retval)
 {
+    DEBUG("pthread_exit()\n");
     pthread_t self_id = pthread_self();
 
     if (self_id == 0) {
@@ -216,7 +223,7 @@ void pthread_exit(void *retval)
         }
 
         self->thread_pid = KERNEL_PID_UNDEF;
-        DEBUG("pthread_exit(%p), self == %p\n", retval, (void *) self);
+        DEBUG("pthread_exit(%p), self == %p\n", retval, (void *)self);
         if (self->status != PTS_DETACHED) {
             self->returnval = retval;
             self->status = PTS_ZOMBIE;
@@ -240,30 +247,33 @@ void pthread_exit(void *retval)
 
 int pthread_join(pthread_t th, void **thread_return)
 {
+    DEBUG("pthread_join()\n");
     if (th < 1 || th > MAXTHREADS) {
-        DEBUG("passed pthread_t th (%d) exceeds bounds of pthread_sched_threads[] in \"%s\"!\n", th, __func__);
+        DEBUG(
+            "passed pthread_t th (%d) exceeds bounds of pthread_sched_threads[] in \"%s\"!\n", th,
+            __func__);
         return -3;
     }
 
-    pthread_thread_t *other = pthread_sched_threads[th-1];
+    pthread_thread_t *other = pthread_sched_threads[th - 1];
     if (!other) {
         return -1;
     }
 
     switch (other->status) {
-        case (PTS_RUNNING):
+        case (PTS_JOINABLE):
             other->joining_thread = thread_getpid();
             /* go blocked, I'm waking up if other thread exits */
             thread_sleep();
-            /* falls through */
+        /* falls through */
         case (PTS_ZOMBIE):
             if (thread_return) {
                 *thread_return = other->returnval;
             }
             free(other);
             /* we only need to free the pthread layer struct,
-            native thread stack is freed by other */
-            pthread_sched_threads[th-1] = NULL;
+               native thread stack is freed by other */
+            pthread_sched_threads[th - 1] = NULL;
             return 0;
         case (PTS_DETACHED):
             return -1;
@@ -274,12 +284,15 @@ int pthread_join(pthread_t th, void **thread_return)
 
 int pthread_detach(pthread_t th)
 {
+    DEBUG("pthread_detach()\n");
     if (th < 1 || th > MAXTHREADS) {
-        DEBUG("passed pthread_t th (%d) exceeds bounds of pthread_sched_threads[] in \"%s\"!\n", th, __func__);
+        DEBUG(
+            "passed pthread_t th (%d) exceeds bounds of pthread_sched_threads[] in \"%s\"!\n", th,
+            __func__);
         return -2;
     }
 
-    pthread_thread_t *other = pthread_sched_threads[th-1];
+    pthread_thread_t *other = pthread_sched_threads[th - 1];
     if (!other) {
         return -1;
     }
@@ -287,9 +300,10 @@ int pthread_detach(pthread_t th)
     if (other->status == PTS_ZOMBIE) {
         free(other);
         /* we only need to free the pthread layer struct,
-        native thread stack is freed by other */
-        pthread_sched_threads[th-1] = NULL;
-    } else {
+           native thread stack is freed by other */
+        pthread_sched_threads[th - 1] = NULL;
+    }
+    else {
         other->status = PTS_DETACHED;
     }
 
@@ -298,12 +312,14 @@ int pthread_detach(pthread_t th)
 
 pthread_t pthread_self(void)
 {
+    DEBUG("pthread_self()\n");
     pthread_t result = 0;
     mutex_lock(&pthread_mutex);
     kernel_pid_t pid = thread_getpid(); /* thread_getpid() is volatile */
     for (int i = 0; i < MAXTHREADS; i++) {
-        if (pthread_sched_threads[i] && pthread_sched_threads[i]->thread_pid == pid) {
-            result = i+1;
+        if (pthread_sched_threads[i] &&
+            pthread_sched_threads[i]->thread_pid == pid) {
+            result = i + 1;
             break;
         }
     }
@@ -313,7 +329,8 @@ pthread_t pthread_self(void)
 
 int pthread_cancel(pthread_t th)
 {
-    pthread_thread_t *other = pthread_sched_threads[th-1];
+    DEBUG("pthread_cancel()\n");
+    pthread_thread_t *other = pthread_sched_threads[th - 1];
     if (!other) {
         return -1;
     }
@@ -325,20 +342,23 @@ int pthread_cancel(pthread_t th)
 
 int pthread_setcancelstate(int state, int *oldstate)
 {
-    (void) state;
-    (void) oldstate;
+    (void)state;
+    (void)oldstate;
+    DEBUG("pthread_setcancelstate(): not implemented!\n");
     return -1;
 }
 
 int pthread_setcanceltype(int type, int *oldtype)
 {
-    (void) type;
-    (void) oldtype;
+    (void)type;
+    (void)oldtype;
+    DEBUG("pthread_setcanceltype(): not implemented!\n");
     return -1;
 }
 
 void pthread_testcancel(void)
 {
+    DEBUG("pthread_testcancel()\n");
     pthread_t self = pthread_self();
 
     if (self == 0) {
@@ -346,13 +366,14 @@ void pthread_testcancel(void)
         return;
     }
 
-    if (pthread_sched_threads[self-1]->should_cancel) {
+    if (pthread_sched_threads[self - 1]->should_cancel) {
         pthread_exit(PTHREAD_CANCELED);
     }
 }
 
 void __pthread_cleanup_push(__pthread_cleanup_datum_t *datum)
 {
+    DEBUG("__pthread_cleanup_push()\n");
     pthread_t self_id = pthread_self();
 
     if (self_id == 0) {
@@ -360,13 +381,14 @@ void __pthread_cleanup_push(__pthread_cleanup_datum_t *datum)
         return;
     }
 
-    pthread_thread_t *self = pthread_sched_threads[self_id-1];
+    pthread_thread_t *self = pthread_sched_threads[self_id - 1];
     datum->__next = self->cleanup_top;
     self->cleanup_top = datum;
 }
 
 void __pthread_cleanup_pop(__pthread_cleanup_datum_t *datum, int execute)
 {
+    DEBUG("__pthread_cleanup_pop()\n");
     pthread_t self_id = pthread_self();
 
     if (self_id == 0) {
@@ -374,7 +396,7 @@ void __pthread_cleanup_pop(__pthread_cleanup_datum_t *datum, int execute)
         return;
     }
 
-    pthread_thread_t *self = pthread_sched_threads[self_id-1];
+    pthread_thread_t *self = pthread_sched_threads[self_id - 1];
     self->cleanup_top = datum->__next;
 
     if (execute != 0) {
@@ -387,6 +409,7 @@ void __pthread_cleanup_pop(__pthread_cleanup_datum_t *datum, int execute)
 
 struct __pthread_tls_datum **__pthread_get_tls_head(int self_id)
 {
-    pthread_thread_t *self = pthread_sched_threads[self_id-1];
+    DEBUG("__pthread_tls_datum()\n");
+    pthread_thread_t *self = pthread_sched_threads[self_id - 1];
     return self ? &self->tls_head : NULL;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This is the cleanup for pthread. It is part of Tracking PR #13672 
This PR adds DEBUG messages for functions in pthread.c
This PR changes `pthread_t` from `unsigned` to `kernel_pid_t` to reduce memory usage.
Some coding style changes.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

run all pthread tests:
`BOARD=native make  -C tests/pthread flash test`
`BOARD=native make -C tests/pthread_barrier/ flash test`
`BOARD=native make -C tests/pthread_cleanup/ flash test`
`BOARD=native make -C tests/pthread_condition_variable/ flash test`
`BOARD=native make -C tests/pthread_cooperation/ flash test`
`BOARD=native make -C tests/pthread_flood/ flash test`
`BOARD=native make -C tests/pthread_rwlock/ flash test`
`BOARD=native make -C tests/pthread_tls/ flash test`


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Tracking PR #13672
