### PR TITLE
examples/paho-mqtt: makefile improvement and typo correction

### DIFF
--- a/examples/paho-mqtt/Makefile
+++ b/examples/paho-mqtt/Makefile
@@ -17,6 +17,16 @@ QUIET ?= 1
 WIFI_SSID ?= "Your_WiFi_name"
 WIFI_PASS ?= "Your_secure_password"
 
+ifneq (,$(DEFAULT_MQTT_CLIENT_ID))
+  CFLAGS += -DDEFAULT_MQTT_CLIENT_ID=\"$(DEFAULT_MQTT_CLIENT_ID)\"
+endif
+ifneq (,$(DEFAULT_MQTT_USER))
+  CFLAGS += -DDEFAULT_MQTT_USER=\"$(DEFAULT_MQTT_USER)\"
+endif
+ifneq (,$(DEFAULT_MQTT_PWD))
+  CFLAGS += -DDEFAULT_MQTT_PWD=\"$(DEFAULT_MQTT_PWD)\"
+endif
+
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
@@ -26,7 +36,7 @@ USEPKG += paho-mqtt
 # paho-mqtt depends on TCP support, choose the stack you want
 LWIP_IPV4 ?= 0
 
-ifneq (0, $(LWIP_IPV4))
+ifneq (0,$(LWIP_IPV4))
   USEMODULE += ipv4_addr
   USEMODULE += lwip_arp
   USEMODULE += lwip_ipv4
@@ -38,7 +48,7 @@ else
   LWIP_IPV6 ?= 1
 endif
 
-ifneq (0, $(LWIP_IPV6))
+ifneq (0,$(LWIP_IPV6))
   USEMODULE += ipv6_addr
   USEMODULE += lwip_ipv6_autoconfig
 endif

--- a/examples/paho-mqtt/main.c
+++ b/examples/paho-mqtt/main.c
@@ -139,7 +139,7 @@ static int _cmd_con(int argc, char **argv)
 
     data.clientID.cstring = DEFAULT_MQTT_CLIENT_ID;
     if (argc > 3) {
-        data.username.cstring = argv[3];
+        data.clientID.cstring = argv[3];
     }
 
     data.username.cstring = DEFAULT_MQTT_USER;


### PR DESCRIPTION
### Contribution description
Regarding some comments from @Alice-For, made some makefile modifications to easily change default value and corrected a typo on main.c

With this mod, default values can be changed by CLI like this:

`DEFAULT_MQTT_USER=\"userX\" DEFAULT_MQTT_CLIENT_ID="34" DEFAULT_MQTT_PWD="Secret" make  -C examples/paho-mqtt/ `
### Issues/PRs references

Improves #12647 