### PR TITLE
sched: Remove extra mpu_enable during context switch

### DIFF
--- a/core/sched.c
+++ b/core/sched.c
@@ -155,8 +155,6 @@ int __attribute__((used)) sched_run(void)
         (uintptr_t)sched_active_thread->stack_start + 31,   /* Base Address (rounded up) */
         MPU_ATTR(1, AP_RO_RO, 0, 1, 0, 1, MPU_SIZE_32B)     /* Attributes and Size */
         );
-
-    mpu_enable();
 #endif
 
     DEBUG("sched_run: done, changed sched_active_thread.\n");


### PR DESCRIPTION
### Contribution description

This removes the `mpu_enable()` in `sched_run`. Enabling the MPU is already done during the reset vector of the cortex-m code. Re-enabling this every context switch can result in unpredictable behaviour if the MPU ever needs to be disabled.

### Testing procedure

Test with `tests/mpu_stack_guard` that the MPU is still enabled on boot.

### Issues/PRs references

None

### Measurements

Reduces the clock ticks for a context switch by approx 21 ticks  on the nrf52840dk, measured with `tests/bench_mutex_pingpong` with `mpu_stack_guard` added as module.