### PR TITLE
boards/waspmote: Fix timer config

### DIFF
--- a/boards/waspmote-pro/Makefile.dep
+++ b/boards/waspmote-pro/Makefile.dep
@@ -1,3 +1,5 @@
 #ifneq (,$(filter saul_default,$(USEMODULE)))
 #  USEMODULE += saul_gpio
 #endif
+
+include $(RIOTMAKE)/boards/ztimer_only.dep.mk

--- a/boards/waspmote-pro/include/board.h
+++ b/boards/waspmote-pro/include/board.h
@@ -166,7 +166,8 @@ extern "C" {
  */
 #define XTIMER_WIDTH                (16)
 #define XTIMER_HZ                   (230400LU)
-#define XTIMER_BACKOFF              (40)
+#define XTIMER_BACKOFF              (80)
+#define XTIMER_ISR_BACKOFF          (120)
 /** @} */
 
 /**

--- a/boards/waspmote-pro/include/board.h
+++ b/boards/waspmote-pro/include/board.h
@@ -159,11 +159,24 @@ extern "C" {
 
 /**
  * @name    xtimer configuration values
+ * @warning This configuration is not actually compatible with xtimer. Sadly,
+ *          no compatible clock frequency can be generated with the given core
+ *          frequency
  * @{
  */
 #define XTIMER_WIDTH                (16)
-#define XTIMER_HZ                   (62500UL)
+#define XTIMER_HZ                   (230400LU)
 #define XTIMER_BACKOFF              (40)
+/** @} */
+
+/**
+ * @name    ztimer configuration values
+ * @{
+ */
+#define CONFIG_ZTIMER_USEC_TYPE     ZTIMER_TYPE_PERIPH_TIMER
+#define CONFIG_ZTIMER_USEC_DEV      (TIMER_DEV(0))
+#define CONFIG_ZTIMER_USEC_FREQ     (230400LU)
+#define CONFIG_ZTIMER_USEC_WIDTH    (16)
 /** @} */
 
 /**

--- a/makefiles/boards/ztimer_only.dep.mk
+++ b/makefiles/boards/ztimer_only.dep.mk
@@ -1,0 +1,11 @@
+# Include this for boards whose timer periph cannot generate a clock frequency
+# suitable for xtimer with the available clock sources and dividers.
+# This will use ztimer to perform the required frequency conversion.
+# By default, xtimer is still used with ztimer as backed, unless
+# ztimer_xtimer_compat is used.
+
+ifneq (,$(filter xtimer,$(USEMODULE)))
+  ifeq (,$(filter ztimer_xtimer_compat,$(USEMODULE)))
+    USEMODULE += xtimer_on_ztimer
+  endif
+endif

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -9,7 +9,6 @@ BOARDS_TIMER_250kHz := \
     arduino-uno \
     atmega256rfr2-xpro \
     atmega328p \
-    waspmote-pro \
     #
 
 BOARDS_TIMER_32kHz := \
@@ -32,6 +31,7 @@ BOARDS_TIMER_CLOCK_CORECLOCK := \
   openmote-cc2538 \
   remote-reva \
   remote-revb \
+  waspmote-pro \
   #
 
 ifneq (,$(filter $(BOARDS_TIMER_250kHz),$(BOARD)))


### PR DESCRIPTION
### Contribution description

- Set `XTIMER_HZ` to something that is actually possible to generate with one of the available clock dividers from the core frequency
- Use `xtimer_on_ztimer` if `xtimer` is used and not `ztimer_xtimer_compat` is used
    - This is needed because `xtimer` is simply not compatible with any of the possible clock frequencies of this board

### Testing procedure

The tests for `periph_timer` and `xtimer` in `tests/` should now pass on the waspmote-pro

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/14750

Includes https://github.com/RIOT-OS/RIOT/pull/14807