### PR TITLE
pkg/cn-cbor bump to 1.0.0

### DIFF
--- a/pkg/cn-cbor/Makefile
+++ b/pkg/cn-cbor/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=cn-cbor
-PKG_URL=https://github.com/cabo/cn-cbor
-PKG_VERSION=f1cf9ffdf5cfab935a45900556f9b68af925c256
+PKG_URL=https://github.com/jimsch/cn-cbor
+PKG_VERSION=821797f9421c04dc783561dc465066857839e108 # 1.0.0
 PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Upstream changed, original upstream is archived now with this note:

> Jim Schaad now is so far ahead of this repo that you are most
> likely better off using his repo as your upstream.


### Testing procedure

`tests/pkg_cn-cbor` still runs on `native`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
