### PR TITLE
sam0_common: Use Single-cycle I/O Port for GPIO when available

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -75,6 +75,8 @@ typedef uint32_t gpio_t;
  */
 #ifdef CPU_FAM_SAML11
 #define GPIO_PIN(x, y)      (((gpio_t)(&PORT_SEC->Group[x])) | y)
+#elif defined(PORT_IOBUS)   /* Use IOBUS access when available */
+#define GPIO_PIN(x, y)      (((gpio_t)(&PORT_IOBUS->Group[x])) | y)
 #else
 #define GPIO_PIN(x, y)      (((gpio_t)(&PORT->Group[x])) | y)
 #endif

--- a/cpu/samd21/Kconfig
+++ b/cpu/samd21/Kconfig
@@ -10,6 +10,7 @@ config CPU_FAM_SAMD21
     select CPU_COMMON_SAM0
     select CPU_CORE_CORTEX_M0PLUS
     select HAS_CPU_SAMD21
+    select HAS_PERIPH_GPIO_FAST_READ
     select HAS_PUF_SRAM
 
 ## CPU Models

--- a/cpu/samd21/Makefile.features
+++ b/cpu/samd21/Makefile.features
@@ -2,5 +2,6 @@ CPU_CORE = cortex-m0plus
 CPU_FAM  = samd21
 
 FEATURES_PROVIDED += puf_sram
+FEATURES_PROVIDED += periph_gpio_fast_read
 
 -include $(RIOTCPU)/sam0_common/Makefile.features

--- a/cpu/saml1x/Kconfig
+++ b/cpu/saml1x/Kconfig
@@ -11,6 +11,7 @@ config CPU_COMMON_SAML1X
     select CPU_CORE_CORTEX_M23
     select HAS_CORTEXM_MPU
     select HAS_CPU_SAML1X
+    select HAS_PERIPH_GPIO_FAST_READ
     select HAS_PERIPH_HWRNG
 
 config CPU_FAM_SAML10

--- a/cpu/saml1x/Makefile.features
+++ b/cpu/saml1x/Makefile.features
@@ -10,5 +10,6 @@ endif
 
 FEATURES_PROVIDED += cortexm_mpu
 FEATURES_PROVIDED += periph_hwrng
+FEATURES_PROVIDED += periph_gpio_fast_read
 
 include $(RIOTCPU)/sam0_common/Makefile.features

--- a/cpu/saml21/Kconfig
+++ b/cpu/saml21/Kconfig
@@ -11,6 +11,7 @@ config CPU_FAM_SAML21
     select CPU_CORE_CORTEX_M0PLUS
     select HAS_BACKUP_RAM
     select HAS_CPU_SAML21
+    select HAS_PERIPH_GPIO_FAST_READ
 
 ## CPU Models
 config CPU_MODEL_SAML21J18A

--- a/cpu/saml21/Makefile.features
+++ b/cpu/saml21/Makefile.features
@@ -4,6 +4,8 @@ CPU_FAM  = saml21
 # The SAMR30 line of MCUs does not contain a TRNG
 CPU_MODELS_WITHOUT_HWRNG += samr30%
 
+FEATURES_PROVIDED += periph_gpio_fast_read
+
 # Low Power SRAM is *not* retained during Backup Sleep.
 # It therefore does not fulfill the requirements  of the 'backup_ram' interface.
 # It can still be used in normal and standby mode, but code that relies on it

--- a/kconfigs/Kconfig.features
+++ b/kconfigs/Kconfig.features
@@ -143,6 +143,13 @@ config HAS_PERIPH_GPIO_IRQ
         Indicates that the GPIO peripheral supports external interrupts is
         present.
 
+config HAS_PERIPH_GPIO_FAST_READ
+    bool
+    help
+	Indicates that the GPIO peripheral supports a mode in which pin read
+	operations are faster, usually with a tradeoff against a different
+	property.
+
 config HAS_PERIPH_HWRNG
     bool
     help

--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -2,6 +2,7 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_gpio
 FEATURES_OPTIONAL = periph_gpio_irq
+FEATURES_OPTIONAL += periph_gpio_fast_read
 
 USEMODULE += shell
 USEMODULE += shell_commands


### PR DESCRIPTION
### Contribution description

The Cortex-m0 based ATSAM devices can use the Single-cycle I/O Port for GPIO. This commit modifies the gpio_t type to use this port when available. It is mapped back to the peripheral memory space for configuration access.  When it is not available, the _port_iobus() and _port() functions behave identical, which is the case for the samd51.

The possible downside of this PR is that continuous sampling is required for GPIO IN pins. I have no idea what the impact is on power consumption and the reference manual doesn't mention it.

### Testing procedure

Test both GPIO read and write on the samr21-xpro (or similar) and on the same54-xpro. Using SAUL on the `examples/default` is sufficient for this.

### Benchmarks

`tests/periph_gpio`:

<details><summary>Master</summary>

```
bench 1 0
2020-08-20 12:23:28,723 # bench 1 0
2020-08-20 12:23:28,724 # 
2020-08-20 12:23:28,727 # GPIO driver run-time performance benchmark
2020-08-20 12:23:28,727 # 
2020-08-20 12:23:28,750 #                  nop loop:     14592us  ---   0.145us per call  ---    6853070 calls per sec
2020-08-20 12:23:28,804 #                  gpio_set:     45842us  ---   0.458us per call  ---    2181405 calls per sec
2020-08-20 12:23:28,864 #                gpio_clear:     52092us  ---   0.520us per call  ---    1919680 calls per sec
2020-08-20 12:23:28,918 #               gpio_toggle:     45842us  ---   0.458us per call  ---    2181405 calls per sec
2020-08-20 12:23:29,006 #                 gpio_read:     79176us  ---   0.791us per call  ---    1263008 calls per sec
2020-08-20 12:23:29,083 #                gpio_write:     68759us  ---   0.687us per call  ---    1454355 calls per sec
2020-08-20 12:23:29,084 # 
2020-08-20 12:23:29,085 #  --- DONE ---
```

</details>

<details><summary>This PR</summary>

```
bench 0 0
2020-08-20 12:22:58,858 # bench 0 0
2020-08-20 12:22:58,859 # 
2020-08-20 12:22:58,862 # GPIO driver run-time performance benchmark
2020-08-20 12:22:58,862 # 
2020-08-20 12:22:58,884 #                  nop loop:     14592us  ---   0.145us per call  ---    6853070 calls per sec
2020-08-20 12:22:58,932 #                  gpio_set:     39592us  ---   0.395us per call  ---    2525762 calls per sec
2020-08-20 12:22:58,984 #                gpio_clear:     43759us  ---   0.437us per call  ---    2285244 calls per sec
2020-08-20 12:22:59,032 #               gpio_toggle:     39592us  ---   0.395us per call  ---    2525762 calls per sec
2020-08-20 12:22:59,109 #                 gpio_read:     68759us  ---   0.687us per call  ---    1454355 calls per sec
2020-08-20 12:22:59,182 #                gpio_write:     64592us  ---   0.645us per call  ---    1548179 calls per sec
2020-08-20 12:22:59,183 # 
2020-08-20 12:22:59,183 #  --- DONE ---
```

</details>

Or about 3 - 5 CPU cycles per call.

### Issues/PRs references

None