### PR TITLE
cpu/saml1x: remove cortexm_mpu feature

### DIFF
--- a/cpu/saml1x/Makefile.features
+++ b/cpu/saml1x/Makefile.features
@@ -8,7 +8,6 @@ else
   $(error Unknown saml1x CPU Model: $(CPU_MODEL))
 endif
 
-FEATURES_PROVIDED += cortexm_mpu
 FEATURES_PROVIDED += periph_hwrng
 
 include $(RIOTCPU)/sam0_common/Makefile.features


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Our MPU implementation is broken on Cortex-M23, so don't advertise it.
Enabling the MPU by default would break these systems as the implementation is incomplete.


### Testing procedure

`saml10-xpro` and `saml11-xpro` should work again.


### Issues/PRs references

fixes regression introduced by #14355
