### PR TITLE
saml1x: Remove MPU feature

### DIFF
--- a/cpu/saml1x/Kconfig
+++ b/cpu/saml1x/Kconfig
@@ -9,7 +9,6 @@ config CPU_COMMON_SAML1X
     bool
     select CPU_COMMON_SAM0
     select CPU_CORE_CORTEX_M23
-    select HAS_CORTEXM_MPU
     select HAS_CPU_SAML1X
     select HAS_PERIPH_HWRNG
 

--- a/cpu/saml1x/Makefile.features
+++ b/cpu/saml1x/Makefile.features
@@ -8,7 +8,9 @@ else
   $(error Unknown saml1x CPU Model: $(CPU_MODEL))
 endif
 
-FEATURES_PROVIDED += cortexm_mpu
+# TODO: The cortex-m23 MPU is not ported
+# FEATURES_PROVIDED += cortexm_mpu
+
 FEATURES_PROVIDED += periph_hwrng
 
 include $(RIOTCPU)/sam0_common/Makefile.features


### PR DESCRIPTION
### Contribution description

The MPU on the cortex-m23 has some differences with the MPU on the older
cortex-m devices. It is not implemented in the cortex-m MPU driver. This
removes the available feature as it gives a false sense of security by
advertising the feature, but implementing it with noop's

### Testing procedure

applications on the saml1x should no longer crash :)

### Issues/PRs references

see #14355
