### PR TITLE
tests/periph_timer: fix typo for boards using 250kHz timer

### DIFF
--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_timer
 
-BOARDS_TIMER_25kHz := \
+BOARDS_TIMER_250kHz := \
     arduino-duemilanove \
     arduino-leonardo \
     arduino-mega2560 \
@@ -34,7 +34,7 @@ BOARDS_TIMER_CLOCK_CORECLOCK := \
   remote-revb \
   #
 
-ifneq (,$(filter $(BOARDS_TIMER_25kHz),$(BOARD)))
+ifneq (,$(filter $(BOARDS_TIMER_250kHz),$(BOARD)))
   TIMER_SPEED ?= 250000
 else ifneq (,$(filter $(BOARDS_TIMER_32kHz),$(BOARD)))
   TIMER_SPEED ?= 32768


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a typo in the variable name containing boards with a timer running at 250kHz.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`make BOARD=atmega256rfr2-xpro -C tests/periph_timer flash test` should still work

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found while having a look at #14799

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
