### PR TITLE
tests/periph_timer: Cleanup

### DIFF
--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -2,42 +2,4 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_timer
 
-BOARDS_TIMER_25kHz := \
-    arduino-duemilanove \
-    arduino-leonardo \
-    arduino-mega2560 \
-    arduino-uno \
-    atmega256rfr2-xpro \
-    atmega328p \
-    waspmote-pro \
-    #
-
-BOARDS_TIMER_32kHz := \
-    hifive1 \
-    hifive1b \
-    %-kw41z \
-    openlabs-kw41z-mini \
-    frdm-k64f \
-    frdm-k22f \
-    #
-
-BOARDS_TIMER_CLOCK_CORECLOCK := \
-  cc2538dk \
-  openmote-b \
-  openmote-cc2538 \
-  remote-reva \
-  remote-revb \
-  #
-
-ifneq (,$(filter $(BOARDS_TIMER_25kHz),$(BOARD)))
-  TIMER_SPEED ?= 250000
-else ifneq (,$(filter $(BOARDS_TIMER_32kHz),$(BOARD)))
-  TIMER_SPEED ?= 32768
-else ifneq (,$(filter $(BOARDS_TIMER_CLOCK_CORECLOCK),$(BOARD)))
-  TIMER_SPEED ?= CLOCK_CORECLOCK
-endif
-
-TIMER_SPEED ?= 1000000
-
-CFLAGS += -DTIMER_SPEED=$(TIMER_SPEED)
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_timer/main.c
+++ b/tests/periph_timer/main.c
@@ -20,6 +20,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <stdatomic.h>
 #include <stdlib.h>
 
 #include "macros/units.h"
@@ -44,10 +45,10 @@
 #define TIMER_SPEED         XTIMER_HZ
 #endif
 
-static volatile int fired;
-static volatile uint32_t sw_count;
-static volatile uint32_t timeouts[MAX_CHANNELS];
-static volatile unsigned args[MAX_CHANNELS];
+static atomic_int fired;
+static atomic_uint_least32_t sw_count;
+static atomic_uint_least32_t timeouts[MAX_CHANNELS];
+static atomic_uint args[MAX_CHANNELS];
 
 static void cb(void *arg, int chan)
 {
@@ -98,7 +99,7 @@ static int test_timer(unsigned num)
     timer_start(TIMER_DEV(num));
     /* wait for all channels to fire */
     do {
-        ++sw_count;
+        sw_count++;
     } while (fired != set);
     /* collect results */
     for (int i = 0; i < fired; i++) {

--- a/tests/periph_timer/main.c
+++ b/tests/periph_timer/main.c
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "macros/units.h"
 #include "periph/timer.h"
 
 /**
@@ -34,6 +35,14 @@
 #define MAX_CHANNELS        (10U)
 #define CHAN_OFFSET         (5000U)     /* fire every 5ms */
 #define COOKIE              (100U)      /* for checking if arg is passed */
+
+#ifndef XTIMER_HZ
+#define XTIMER_HZ MHZ(1)
+#endif
+
+#ifndef TIMER_SPEED
+#define TIMER_SPEED         XTIMER_HZ
+#endif
 
 static volatile int fired;
 static volatile uint32_t sw_count;


### PR DESCRIPTION
### Contribution description

- (ab)use `XTIMER_HZ` instead of a manual list for timer frequencies
- Use C11 atomics instead of incorrectly using `volatile`

### Testing procedure

Test should still work as previously. In fact, the manual list of timer frequencies seems to be identical to the definition of `XTIMER_HZ` for every board.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/14799