### PR TITLE
sys/sched_rr: Add a simple round robin scheduler module

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1010,6 +1010,10 @@ ifneq (,$(filter tinydtls_sock_dtls, $(USEMODULE)))
     USEMODULE += sock_dtls
 endif
 
+ifneq (,$(filter sched_rr, $(USEMODULE)))
+    USEMODULE += xtimer
+endif
+
 ifneq (,$(filter sock_dtls, $(USEMODULE)))
     USEMODULE += credman
     USEMODULE += sock_udp

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1010,10 +1010,6 @@ ifneq (,$(filter tinydtls_sock_dtls, $(USEMODULE)))
     USEMODULE += sock_dtls
 endif
 
-ifneq (,$(filter sched_rr, $(USEMODULE)))
-    USEMODULE += xtimer
-endif
-
 ifneq (,$(filter sock_dtls, $(USEMODULE)))
     USEMODULE += credman
     USEMODULE += sock_udp

--- a/examples/thread-duell/Makefile
+++ b/examples/thread-duell/Makefile
@@ -1,4 +1,4 @@
-# name of your application -- needs to match Cargo.toml crate name
+# name of your application 
 APPLICATION = thread_duell
 
 # If no BOARD is found in the environment, use this default:
@@ -7,12 +7,8 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-# USEMODULE += xtimer
+USEMODULE += xtimer
 USEMODULE += sched_rr
-
-WPEDANTIC := 0
-WERROR := 0
-
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/examples/thread-duell/Makefile
+++ b/examples/thread-duell/Makefile
@@ -1,0 +1,25 @@
+# name of your application -- needs to match Cargo.toml crate name
+APPLICATION = thread_duell
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+# USEMODULE += xtimer
+USEMODULE += sched_rr
+
+WPEDANTIC := 0
+WERROR := 0
+
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/thread-duell/README.md
+++ b/examples/thread-duell/README.md
@@ -1,14 +1,9 @@
 Thread_Duel
-============
+== == == == == ==
 
-this is a thread duell application to test RIOTS mutithreading abblities
+this is a thread duel application
+    to show or not to show
+RIOTS multi-threading abilities
 
 it contains:
-* example thread that use the cpu in different patterns
-
-* a basic round robin scheuler using xtimer,
-* a sorting scheduler
-* some monitoring
-* a top like thread
-
-
+* example threads that use the CPU in different patterns

--- a/examples/thread-duell/README.md
+++ b/examples/thread-duell/README.md
@@ -1,0 +1,14 @@
+Thread_Duel
+============
+
+this is a thread duell application to test RIOTS mutithreading abblities
+
+it contains:
+* example thread that use the cpu in different patterns
+
+* a basic round robin scheuler using xtimer,
+* a sorting scheduler
+* some monitoring
+* a top like thread
+
+

--- a/examples/thread-duell/main.c
+++ b/examples/thread-duell/main.c
@@ -10,139 +10,148 @@
 #include "sched_rr.h"
 
 #define PRINT_STEPS 10
-#define WORK_SCALE 1000
+#define WORK_SCALE  1000
 
-void bad_wait(uint64_t us){
+void bad_wait(uint64_t us)
+{
     /*keep the cpu busy waiting for some time to pass simulate working*/
     uint64_t until = xtimer_now_usec64() + us;
-    while(xtimer_now_usec64() < until);//do nothing
+
+    while (xtimer_now_usec64() < until) {
+        /*do nothing*/
+    }
 }
 
-void nice_wait(uint64_t us){
+void nice_wait(uint64_t us)
+{
     /*be nice give the core some time to do other things or rest*/
     xtimer_usleep64(us);
 }
 
-void* thread_nicebreaks(void* d)
+void * thread_nicebreaks(void * d)
 {
-        uint32_t w = 0;
-        xtimer_usleep64(200*1000);/*allways be nice at start*/
-        int16_t pid = thread_getpid();
+    uint32_t w = 0;
 
-        uint32_t work = * (uint32_t *) d ;
-        if ( work  >10 ){
-            work = 5;
-        }
-        uint32_t rest = (10 - work);
-        uint32_t step = 0;
+    xtimer_usleep64(200 * 1000);  /*allways be nice at start*/
+    int16_t pid = thread_getpid();
 
-        /*work some time and rest*/
-        for (;;){
-            if (w - step >= PRINT_STEPS) {
-                printf("T-Pid %i: %u, %d\n",pid, w, work);
-                step = w;
-            }
-            bad_wait(work * WORK_SCALE);
-            w += work;
-            nice_wait(rest * WORK_SCALE);
+    uint32_t work = * (uint32_t *) d;
+    if (work > 10) {
+        work = 5;
+    }
+    uint32_t rest = (10 - work);
+    uint32_t step = 0;
+
+    /*work some time and rest*/
+    for (;;) {
+        if (w - step >= PRINT_STEPS) {
+            printf("T-Pid %i: %u, %d\n", pid, w, work);
+            step = w;
         }
+        bad_wait(work * WORK_SCALE);
+        w += work;
+        nice_wait(rest * WORK_SCALE);
+    }
 }
 
 
-void* thread_bad(void* d)
+void * thread_bad(void * d)
 {
-        uint32_t w = 0;
-        xtimer_usleep64(200*1000);/*allways be nice at start*/
-        int16_t pid = thread_getpid();
+    uint32_t w = 0;
 
-        uint32_t work = * (uint32_t *) d ;
-        if ( work  >10 ){
-            work = 5;
-        }
-        uint32_t rest = (10 - work);
-        uint32_t step = 0;
+    xtimer_usleep64(200 * 1000);  /*allways be nice at start*/
+    int16_t pid = thread_getpid();
 
-        /*work some time yield rest blocking*/
-        for (;;){
-            if (w - step >= PRINT_STEPS) {
-                printf("T-Pid %i: %u, %d\n",pid, w, work);
-                step = w;
-            }
-            bad_wait(work * WORK_SCALE);
-            w += work;
-            bad_wait(rest * WORK_SCALE);
+    uint32_t work = * (uint32_t *) d;
+    if (work > 10) {
+        work = 5;
+    }
+    uint32_t rest = (10 - work);
+    uint32_t step = 0;
+
+    /*work some time yield rest blocking*/
+    for (;;) {
+        if (w - step >= PRINT_STEPS) {
+            printf("T-Pid %i: %u, %d\n", pid, w, work);
+            step = w;
         }
+        bad_wait(work * WORK_SCALE);
+        w += work;
+        bad_wait(rest * WORK_SCALE);
+    }
 }
 
-void* thread_restless_yielding(void* d)
+void * thread_restless_yielding(void * d)
 {
-        uint32_t w = 0;
-        xtimer_usleep64(200*1000);/*allways be nice at start*/
-        int16_t pid = thread_getpid();
+    uint32_t w = 0;
 
-        uint32_t work = * (uint32_t *) d ;
-        if ( work  >10 ){
-            work = 5;
-        }
-        /*uint32_t rest = (10 - work);*/
-        uint32_t step = 0;
+    xtimer_usleep64(200 * 1000);  /*allways be nice at start*/
+    int16_t pid = thread_getpid();
 
-        /*work for some time and yield*/
-        for (;;) {
-            if (w - step >= PRINT_STEPS) {
-                printf("T-Pid %i: %u, %d\n",pid, w, work);
-                step = w;
-            }
-            bad_wait(work * WORK_SCALE);
-            w += work;
-            thread_yield();
+    uint32_t work = * (uint32_t *) d;
+    if (work > 10) {
+        work = 5;
+    }
+    /*uint32_t rest = (10 - work);*/
+    uint32_t step = 0;
+
+    /*work for some time and yield*/
+    for (;;) {
+        if (w - step >= PRINT_STEPS) {
+            printf("T-Pid %i: %u, %d\n", pid, w, work);
+            step = w;
         }
+        bad_wait(work * WORK_SCALE);
+        w += work;
+        thread_yield();
+    }
 }
 
 
-void* thread_restless(void* d)
+void * thread_restless(void * d)
 {
-        uint32_t w = 0;
-        xtimer_usleep64(200*1000);/*allways be nice at start*/
-        int16_t pid = thread_getpid();
+    uint32_t w = 0;
 
-        uint32_t work = * (uint32_t *) d ;
-        if ( work  >10 ){
-            work = 5;
-        }
-        /*uint32_t rest = (10 - work);*/
-        uint32_t step = 0;
+    xtimer_usleep64(200 * 1000);  /*allways be nice at start*/
+    int16_t pid = thread_getpid();
 
-        /*continue working*/
-        for (;;) {
-            if (w - step >= PRINT_STEPS) {
-                printf("T-Pid %i: %u, %d\n",pid, w, work);
-                step = w;
-            }
-            bad_wait(work*WORK_SCALE);
-            w += work;
+    uint32_t work = * (uint32_t *) d;
+    if (work > 10) {
+        work = 5;
+    }
+    /*uint32_t rest = (10 - work);*/
+    uint32_t step = 0;
+
+    /*continue working*/
+    for (;;) {
+        if (w - step >= PRINT_STEPS) {
+            printf("T-Pid %i: %u, %d\n", pid, w, work);
+            step = w;
         }
+        bad_wait(work * WORK_SCALE);
+        w += work;
+    }
 }
 
 int main(void)
 {
     start_schedule_rr();
     {
-        int size = THREAD_STACKSIZE_DEFAULT ;
+        int size = THREAD_STACKSIZE_DEFAULT;
         char * wech = malloc(size + 4);
-        * (uint32_t *) wech = 3; /* 0-10 workness*/
-        thread_create(wech+4, size ,7,0, thread_restless,wech,"T1");
+        * (uint32_t *) wech = 3;   /* 0-10 workness*/
+        thread_create(wech + 4, size, 7, THREAD_CREATE_STACKTEST, thread_restless, wech, "T1");
     }
     {
         int size = THREAD_STACKSIZE_DEFAULT;
         char * wech = malloc(size + 4);
-        * (uint32_t *) wech = 5; /* 0-10 workness*/
-        thread_create(wech+4, size ,7,0, thread_restless,wech,"T2");
+        * (uint32_t *) wech = 5;   /* 0-10 workness*/
+        thread_create(wech + 4, size, 7, THREAD_CREATE_STACKTEST, thread_restless, wech, "T2");
     }
     {
-        int size = THREAD_STACKSIZE_DEFAULT ;
-        char * wech = malloc(size + 4);
-        * (uint32_t *) wech = 5; /* 0-10 workness*/
-        thread_create(wech+4, size ,7,0, thread_restless,wech,"T3");
+        int size = THREAD_STACKSIZE_DEFAULT;
+        char *wech = malloc(size + 4);
+        * (uint32_t *) wech = 5;   /* 0-10 workness*/
+        thread_create(wech + 4, size, 7, THREAD_CREATE_STACKTEST, thread_restless, wech, "T3");
     }
 }

--- a/examples/thread-duell/main.c
+++ b/examples/thread-duell/main.c
@@ -1,0 +1,148 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <thread.h>
+#include <sched.h>
+
+#include <math.h>
+
+#include "xtimer.h"
+#include "sched_rr.h"
+
+#define PRINT_STEPS 10
+#define WORK_SCALE 1000
+
+void bad_wait(uint64_t us){
+    /*keep the cpu busy waiting for some time to pass simulate working*/
+    uint64_t until = xtimer_now_usec64() + us;
+    while(xtimer_now_usec64() < until);//do nothing
+}
+
+void nice_wait(uint64_t us){
+    /*be nice give the core some time to do other things or rest*/
+    xtimer_usleep64(us);
+}
+
+void* thread_nicebreaks(void* d)
+{
+        uint32_t w = 0;
+        xtimer_usleep64(200*1000);/*allways be nice at start*/
+        int16_t pid = thread_getpid();
+
+        uint32_t work = * (uint32_t *) d ;
+        if ( work  >10 ){
+            work = 5;
+        }
+        uint32_t rest = (10 - work);
+        uint32_t step = 0;
+
+        /*work some time and rest*/
+        for (;;){
+            if (w - step >= PRINT_STEPS) {
+                printf("T-Pid %i: %u, %d\n",pid, w, work);
+                step = w;
+            }
+            bad_wait(work * WORK_SCALE);
+            w += work;
+            nice_wait(rest * WORK_SCALE);
+        }
+}
+
+
+void* thread_bad(void* d)
+{
+        uint32_t w = 0;
+        xtimer_usleep64(200*1000);/*allways be nice at start*/
+        int16_t pid = thread_getpid();
+
+        uint32_t work = * (uint32_t *) d ;
+        if ( work  >10 ){
+            work = 5;
+        }
+        uint32_t rest = (10 - work);
+        uint32_t step = 0;
+
+        /*work some time yield rest blocking*/
+        for (;;){
+            if (w - step >= PRINT_STEPS) {
+                printf("T-Pid %i: %u, %d\n",pid, w, work);
+                step = w;
+            }
+            bad_wait(work * WORK_SCALE);
+            w += work;
+            bad_wait(rest * WORK_SCALE);
+        }
+}
+
+void* thread_restless_yielding(void* d)
+{
+        uint32_t w = 0;
+        xtimer_usleep64(200*1000);/*allways be nice at start*/
+        int16_t pid = thread_getpid();
+
+        uint32_t work = * (uint32_t *) d ;
+        if ( work  >10 ){
+            work = 5;
+        }
+        /*uint32_t rest = (10 - work);*/
+        uint32_t step = 0;
+
+        /*work for some time and yield*/
+        for (;;) {
+            if (w - step >= PRINT_STEPS) {
+                printf("T-Pid %i: %u, %d\n",pid, w, work);
+                step = w;
+            }
+            bad_wait(work * WORK_SCALE);
+            w += work;
+            thread_yield();
+        }
+}
+
+
+void* thread_restless(void* d)
+{
+        uint32_t w = 0;
+        xtimer_usleep64(200*1000);/*allways be nice at start*/
+        int16_t pid = thread_getpid();
+
+        uint32_t work = * (uint32_t *) d ;
+        if ( work  >10 ){
+            work = 5;
+        }
+        /*uint32_t rest = (10 - work);*/
+        uint32_t step = 0;
+
+        /*continue working*/
+        for (;;) {
+            if (w - step >= PRINT_STEPS) {
+                printf("T-Pid %i: %u, %d\n",pid, w, work);
+                step = w;
+            }
+            bad_wait(work*WORK_SCALE);
+            w += work;
+        }
+}
+
+int main(void)
+{
+    start_schedule_rr();
+    {
+        int size = THREAD_STACKSIZE_DEFAULT ;
+        char * wech = malloc(size + 4);
+        * (uint32_t *) wech = 3; /* 0-10 workness*/
+        thread_create(wech+4, size ,7,0, thread_restless,wech,"T1");
+    }
+    {
+        int size = THREAD_STACKSIZE_DEFAULT;
+        char * wech = malloc(size + 4);
+        * (uint32_t *) wech = 5; /* 0-10 workness*/
+        thread_create(wech+4, size ,7,0, thread_restless,wech,"T2");
+    }
+    {
+        int size = THREAD_STACKSIZE_DEFAULT ;
+        char * wech = malloc(size + 4);
+        * (uint32_t *) wech = 5; /* 0-10 workness*/
+        thread_create(wech+4, size ,7,0, thread_restless,wech,"T3");
+    }
+}

--- a/examples/thread-duell/main.c
+++ b/examples/thread-duell/main.c
@@ -30,11 +30,14 @@ void nice_wait(uint64_t us)
 
 void * thread_nicebreaks(void * d)
 {
-    uint32_t w = 0;
-
     xtimer_usleep64(200 * 1000);  /*allways be nice at start*/
+#ifdef DEVELHELP
+    const char * name = thread_get_active()->name;
+#else
     int16_t pid = thread_getpid();
+#endif
 
+    uint32_t w = 0;
     uint32_t work = * (uint32_t *) d;
     if (work > 10) {
         work = 5;
@@ -45,7 +48,19 @@ void * thread_nicebreaks(void * d)
     /*work some time and rest*/
     for (;;) {
         if (w - step >= PRINT_STEPS) {
-            printf("T-Pid %i: %u, %d\n", pid, w, work);
+            printf(
+#ifdef DEVELHELP
+                "%s: "
+#else
+                "T-Pid %i:"
+#endif
+                "%u, %d\n",
+#ifdef DEVELHELP
+                name,
+#else
+                pid,
+#endif
+                w, work);
             step = w;
         }
         bad_wait(work * WORK_SCALE);
@@ -57,11 +72,14 @@ void * thread_nicebreaks(void * d)
 
 void * thread_bad(void * d)
 {
-    uint32_t w = 0;
-
     xtimer_usleep64(200 * 1000);  /*allways be nice at start*/
+#ifdef DEVELHELP
+    const char * name = thread_get_active()->name;
+#else
     int16_t pid = thread_getpid();
+#endif
 
+    uint32_t w = 0;
     uint32_t work = * (uint32_t *) d;
     if (work > 10) {
         work = 5;
@@ -72,7 +90,19 @@ void * thread_bad(void * d)
     /*work some time yield rest blocking*/
     for (;;) {
         if (w - step >= PRINT_STEPS) {
-            printf("T-Pid %i: %u, %d\n", pid, w, work);
+            printf(
+#ifdef DEVELHELP
+                "%s: "
+#else
+                "T-Pid %i:"
+#endif
+                "%u, %d\n",
+#ifdef DEVELHELP
+                name,
+#else
+                pid,
+#endif
+                w, work);
             step = w;
         }
         bad_wait(work * WORK_SCALE);
@@ -83,11 +113,14 @@ void * thread_bad(void * d)
 
 void * thread_restless_yielding(void * d)
 {
-    uint32_t w = 0;
-
     xtimer_usleep64(200 * 1000);  /*allways be nice at start*/
+#ifdef DEVELHELP
+    const char * name = thread_get_active()->name;
+#else
     int16_t pid = thread_getpid();
+#endif
 
+    uint32_t w = 0;
     uint32_t work = * (uint32_t *) d;
     if (work > 10) {
         work = 5;
@@ -98,7 +131,19 @@ void * thread_restless_yielding(void * d)
     /*work for some time and yield*/
     for (;;) {
         if (w - step >= PRINT_STEPS) {
-            printf("T-Pid %i: %u, %d\n", pid, w, work);
+            printf(
+#ifdef DEVELHELP
+                "%s: "
+#else
+                "T-Pid %i:"
+#endif
+                "%u, %d\n",
+#ifdef DEVELHELP
+                name,
+#else
+                pid,
+#endif
+                w, work);
             step = w;
         }
         bad_wait(work * WORK_SCALE);
@@ -110,11 +155,14 @@ void * thread_restless_yielding(void * d)
 
 void * thread_restless(void * d)
 {
-    uint32_t w = 0;
-
     xtimer_usleep64(200 * 1000);  /*allways be nice at start*/
+#ifdef DEVELHELP
+    const char * name = thread_get_active()->name;
+#else
     int16_t pid = thread_getpid();
+#endif
 
+    uint32_t w = 0;
     uint32_t work = * (uint32_t *) d;
     if (work > 10) {
         work = 5;
@@ -125,7 +173,19 @@ void * thread_restless(void * d)
     /*continue working*/
     for (;;) {
         if (w - step >= PRINT_STEPS) {
-            printf("T-Pid %i: %u, %d\n", pid, w, work);
+            printf(
+#ifdef DEVELHELP
+                "%s: "
+#else
+                "T-Pid %i:"
+#endif
+                "%u, %d\n",
+#ifdef DEVELHELP
+                name,
+#else
+                pid,
+#endif
+                w, work);
             step = w;
         }
         bad_wait(work * WORK_SCALE);
@@ -136,22 +196,23 @@ void * thread_restless(void * d)
 int main(void)
 {
     start_schedule_rr();
+
     {
-        int size = THREAD_STACKSIZE_DEFAULT;
-        char * wech = malloc(size + 4);
-        * (uint32_t *) wech = 3;   /* 0-10 workness*/
-        thread_create(wech + 4, size, 7, THREAD_CREATE_STACKTEST, thread_restless, wech, "T1");
+        static char stack[THREAD_STACKSIZE_DEFAULT];
+        static uint32_t workness = 3;   /* 0-10 workness*/
+        thread_create(stack, sizeof(stack), 7, THREAD_CREATE_STACKTEST,
+                      thread_restless, &workness, "T1");
     }
     {
-        int size = THREAD_STACKSIZE_DEFAULT;
-        char * wech = malloc(size + 4);
-        * (uint32_t *) wech = 5;   /* 0-10 workness*/
-        thread_create(wech + 4, size, 7, THREAD_CREATE_STACKTEST, thread_restless, wech, "T2");
+        static char stack[THREAD_STACKSIZE_DEFAULT];
+        static uint32_t workness = 5;   /* 0-10 workness*/
+        thread_create(stack, sizeof(stack), 7, THREAD_CREATE_STACKTEST,
+                      thread_restless, &workness, "T2");
     }
     {
-        int size = THREAD_STACKSIZE_DEFAULT;
-        char *wech = malloc(size + 4);
-        * (uint32_t *) wech = 5;   /* 0-10 workness*/
-        thread_create(wech + 4, size, 7, THREAD_CREATE_STACKTEST, thread_restless, wech, "T3");
+        static char stack[THREAD_STACKSIZE_DEFAULT];
+        static uint32_t workness = 5;   /* 0-10 workness*/
+        thread_create(stack, sizeof(stack), 7, THREAD_CREATE_STACKTEST,
+                      thread_restless, &workness, "T3");
     }
 }

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -35,6 +35,10 @@ ifneq (,$(filter rtt_cmd,$(USEMODULE)))
   FEATURES_REQUIRED += periph_rtt
 endif
 
+ifneq (,$(filter sched_rr, $(USEMODULE)))
+    USEMODULE += xtimer
+endif
+
 ifneq (,$(filter trace,$(USEMODULE)))
   USEMODULE += xtimer
 endif

--- a/sys/include/sched_rr.h
+++ b/sys/include/sched_rr.h
@@ -17,24 +17,27 @@
  *
  * @{
  *
- * @file        /home/k_f/ws_doriot/thread_duel/sched_rr.h
+ * @file
  * @brief       Round Robin Scheduler
  *
  * @author      Karl Fessel <karl.fessel@ovgu.de>
  *
  */
+
+#if !defined(SCHED_RR_TIMER) || defined(DOXYGEN)
 /**
- * time between rond robin calls default 1ms
+ * @brief Time between round robin calls in µs
+ *
+ * @details Defaults to 1ms
  */
-#ifndef SCHED_RR_TIMER
-    #define SCHED_RR_TIMER 1000
+#define SCHED_RR_TIMER 1000
 #endif
 
+#if !defined(SCHED_RR_MASK) || defined(DOXYGEN)
 /**
- * masks off priorities that should not be scheduled default 0
+ * @brief masks off priorities that should not be scheduled default 0
  */
-#ifndef SCHED_RR_MASK
-    #define SCHED_RR_MASK 1<<0
+#define SCHED_RR_MASK 1<<0
 #endif
 
 /**

--- a/sys/include/sched_rr.h
+++ b/sys/include/sched_rr.h
@@ -9,9 +9,11 @@
 /**
  * @defgroup    Sched_RR
  * @ingroup     sys
- * @brief       This module module privides round robin scheduling within
+ * @brief       This module module provides round robin scheduling within
  *              for all runnable threads within each not masked priority.
  *              Priority 0 is masked by default.
+ *              There is no fainess involved in this scheuler. It schedules,
+ *              when the timer ticks. Keep it as simple as possible.
  *
  * @note        start using start_schedule_rr()
  *

--- a/sys/include/sched_rr.h
+++ b/sys/include/sched_rr.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 TUBA Freiberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    Sched_RR
+ * @ingroup     sys
+ * @brief       This module module privides round robin scheduling within
+ *              for all runnable threads within each not masked priority.
+ *              Priority 0 is masked by default.
+ *
+ * @note        start using start_schedule_rr()
+ *
+ * @{
+ *
+ * @file        /home/k_f/ws_doriot/thread_duel/sched_rr.h
+ * @brief       Round Robin Scheduler
+ *
+ * @author      Karl Fessel <karl.fessel@ovgu.de>
+ *
+ */
+/**
+ * time between rond robin calls default 1ms
+ */
+#ifndef SCHED_RR_TIMER
+    #define SCHED_RR_TIMER 1000
+#endif
+
+/**
+ * masks off priorities that should not be scheduled default 0
+ */
+#ifndef SCHED_RR_MASK
+    #define SCHED_RR_MASK 1<<0
+#endif
+
+/**
+ * @brief the round robin scheduler
+ */
+void schedule_rr(void *);
+
+/**
+ * @brief stop the scheduler
+ */
+void stop_schedule_rr(void);
+
+/**
+ * @brief start the scheduler
+ */
+void start_schedule_rr(void);

--- a/sys/sched_rr/Makefile
+++ b/sys/sched_rr/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/sched_rr/sched_rr.c
+++ b/sys/sched_rr/sched_rr.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 TUBA Freiberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys
+ * @{
+ *
+ * @file
+ * @brief       Round Robin Scheduler implementation
+ *
+ * @author      Karl Fessel <karl.fessel@ovgu.de>
+ *
+ * @}
+ */
+
+#include "thread.h"
+#include "xtimer.h"
+#include "clist.h"
+#include "sched_rr.h"
+
+static xtimer_t rr_timer;
+
+void schedule_rr(void * d){
+    // this lets the current thread give way
+    // simple RoundRobin
+    (void)d;
+    //this will run in an other threads context (xtimer/ISR)
+    //it can be started from any thread
+    //it will setup a timer to pull itself up
+    //this will try to reorder the current priority
+    //(put the current thread at the end of the list)
+    thread_t * active_thread = thread_get_active();
+    if(active_thread != NULL){
+        if(! (SCHED_RR_MASK & 1 << active_thread->priority)){
+            clist_lpoprpush(&sched_runqueues[active_thread->priority]);
+            thread_yield_higher();
+        }
+    }
+    // if time is shorter than XTIMER_BACKOFF we stack the stack
+    xtimer_set(&rr_timer,SCHED_RR_TIMER);
+}
+
+void stop_schedule_rr(void){
+    xtimer_remove(&rr_timer);
+}
+
+void start_schedule_rr(void){
+    rr_timer.callback = schedule_rr;
+    xtimer_set(&rr_timer,SCHED_RR_TIMER);
+}


### PR DESCRIPTION
I would like to use RIOT with multiple threads at the same priority,
that might not cooperate but should share CPU time.

### Contribution description

This contains a simple round robin scheduler module using xtimer to rearrange the current run queue
 
### Testing procedure

create multiple threads of same priority that should work in parallel
without this module only one of them will run. 

with this module and calling `start_schedule_rr()` form `#include "sched_rr.h"`
they run parallel , sharing cpu time. 

see https://github.com/kfessel/riot-thread-duel for a demonstration.

### Issues/PRs references

non yet