### PR TITLE
gnrc_sixlowpan_frag_rb: Check possibly uninitialized pointers

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rb/gnrc_sixlowpan_frag_rb.c
@@ -150,7 +150,9 @@ void gnrc_sixlowpan_frag_rb_rm_by_datagram(const gnrc_netif_hdr_t *netif_hdr,
     gnrc_sixlowpan_frag_rb_t *e = _rbuf_get_by_tag(netif_hdr, tag);
 
     if (e != NULL) {
-        gnrc_pktbuf_release(e->pkt);
+        if (e->pkt != NULL) {
+            gnrc_pktbuf_release(e->pkt);
+        }
         gnrc_sixlowpan_frag_rb_remove(e);
     }
 }
@@ -504,8 +506,10 @@ static int _rbuf_get(const void *src, size_t src_len,
         return -1;
     }
 
-    *((uint64_t *)res->pkt->data) = 0;  /* clean first few bytes for later
-                                               * look-ups */
+    if (res->pkt->data) {
+        *((uint64_t *)res->pkt->data) = 0;  /* clean first few bytes for later
+                                             * look-ups */
+    }
     res->super.datagram_size = size;
     res->super.arrival = now_usec;
     memcpy(res->super.src, src, src_len);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
In the [modifications](https://github.com/5G-I3/RIOT-public/tree/683956147c1e9e48ddb81ca4b1e5bdc494bf4abc) for my latest round of 6LoWPAN fragmentation experiments, I found two bugfixes, I noticed were not in upstream yet. Well here they are.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Probably hard to trigger, but as this only introduces checks for `NULL` pointers, this should be easy to be "tested" just by head-compiling ;-).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
