### PR TITLE
boards/saml1x: add openocd.cfg

### DIFF
--- a/boards/common/saml1x/Makefile.include
+++ b/boards/common/saml1x/Makefile.include
@@ -1,3 +1,5 @@
+OPENOCD_CONFIG ?= $(RIOTBOARD)/common/saml1x/dist/openocd.cfg
+
 include $(RIOTMAKE)/boards/sam0.inc.mk
 
 # add the common header files to the include path

--- a/boards/common/saml1x/dist/openocd.cfg
+++ b/boards/common/saml1x/dist/openocd.cfg
@@ -1,0 +1,2 @@
+source [find target/atsaml1x.cfg]
+$_TARGETNAME configure -rtos auto


### PR DESCRIPTION
### Contribution description
Previously trying `make debug` on these boards would result in

    Error: Unable to locate OpenOCD configuration file
           (/home/benpicco/dev/RIOT/boards/saml10-xpro/dist/openocd.cfg)

Add a common `openocd.cfg` to fix this.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

`make BOARD=saml10-xpro debug`


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
