### PR TITLE
drivers/sps30: Add sleep mode

### DIFF
--- a/drivers/include/sps30.h
+++ b/drivers/include/sps30.h
@@ -287,6 +287,24 @@ int sps30_read_serial_number(const sps30_t *dev, char *str, size_t len);
  */
 int sps30_reset(const sps30_t *dev);
 
+/**
+ * @brief       Put the sensor in sleep mode
+ *
+ * @param[in]   dev        Pointer to an SPS30 device handle
+ *
+ * @return      #SPS30_OK on success, negative #sps30_error_code_t on error
+ */
+int sps30_sleep(const sps30_t *dev);
+
+/**
+ * @brief       Wake up sensor from sleep mode (returns sensor to Idle mode)
+ *
+ * @param[in]   dev        Pointer to an SPS30 device handle
+ *
+ * @return      #SPS30_OK on success, negative #sps30_error_code_t on error
+ */
+int sps30_wakeup(const sps30_t *dev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/sps30/sps30.c
+++ b/drivers/sps30/sps30.c
@@ -50,6 +50,8 @@ typedef enum {
     SPS30_CMD_RD_ARTICLE      = 0xD025, /**< Read article code */
     SPS30_CMD_RD_SERIAL       = 0xD033, /**< Read serial number */
     SPS30_CMD_RESET           = 0xD304, /**< Reset */
+    SPS30_CMD_SLEEP           = 0x1001, /**< Sleep */
+    SPS30_CMD_WAKE_UP         = 0x1103  /**< Wake-up */
 } sps30_cmd_t;
 /** @} */
 
@@ -282,4 +284,19 @@ int sps30_reset(const sps30_t *dev)
 {
     assert(dev);
     return _rx_tx_data(dev, SPS30_CMD_RESET, NULL, 0, false);
+}
+
+int sps30_sleep(const sps30_t *dev)
+{
+    assert(dev);
+    sps30_stop_measurement(dev);
+    return _rx_tx_data(dev, SPS30_CMD_SLEEP, NULL, 0, false);
+}
+
+int sps30_wakeup(const sps30_t *dev)
+{
+    assert(dev);
+    /* Send I2C start stop sequence to re-enable I2C interface on sensor */
+    i2c_write_bytes(dev->p.i2c_dev, SPS30_I2C_ADDR, NULL, 0, 0);
+    return _rx_tx_data(dev, SPS30_CMD_WAKE_UP, NULL, 0, false);
 }

--- a/tests/driver_sps30/main.c
+++ b/tests/driver_sps30/main.c
@@ -25,6 +25,7 @@
 #define TEST_START_DELAY_S          (2U)
 #define SENSOR_RESET_DELAY_S        (10U)
 #define SENSOR_STARTUP_DELAY_S      (10U)
+#define SENSOR_SLEEP_WAKE_DELAY_S   (5U)
 #define POLL_FOR_READY_S            (1U)
 #define NUM_OF_MEASUREMENTS         (10U)
 
@@ -101,6 +102,16 @@ int main(void)
     error |= _print_error("reset", ec);
 
     xtimer_sleep(SENSOR_RESET_DELAY_S);
+
+    /* Put the sensor in sleep */
+    ec = sps30_sleep(&dev);
+    error |= _print_error("sleep", ec);
+    xtimer_sleep(SENSOR_SLEEP_WAKE_DELAY_S);
+
+    /* Wake-up the sensor */
+    ec = sps30_wakeup(&dev);
+    error |= _print_error("wake-up", ec);
+    xtimer_sleep(SENSOR_SLEEP_WAKE_DELAY_S);
 
     /* start the sensor again again... */
     ec = sps30_start_measurement(&dev);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
The current Sensirion sps30 sensor's driver implementation did not implement sleep and wake commands provided by the implementation. This PR implements it.

For more information on sensor: [Sensor's datasheet](https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/9.6_Particulate_Matter/Datasheets/Sensirion_PM_Sensors_SPS30_Datasheet.pdf)

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Run the test for sps30 driver using the command:
`BOARD= ... make clean flash term -j4 -C tests/driver_sps30`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
