### PR TITLE
boards/nucleo-l452re: use common L4 clock configuration

### DIFF
--- a/boards/nucleo-l452re/include/periph_conf.h
+++ b/boards/nucleo-l452re/include/periph_conf.h
@@ -26,66 +26,13 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "l4/cfg_clock_80_1.h"
 #include "cfg_rtt_default.h"
 #include "cfg_timer_tim2.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock system configuration
- * @{
- */
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (0)
-
-#ifndef CLOCK_LSE
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (0)
-#endif
-
-/* 0: enable MSI only if HSE isn't available
- * 1: always enable MSI (e.g. if USB or RNG is used)*/
-#define CLOCK_MSI_ENABLE    (1)
-
-#ifndef CLOCK_MSI_LSE_PLL
-/* 0: disable Hardware auto calibration with LSE
- * 1: enable Hardware auto calibration with LSE (PLL-mode)
- * Same as with CLOCK_LSE above this defaults to 0 because LSE is
- * mandatory for MSI/LSE-trimming to work */
-#define CLOCK_MSI_LSE_PLL   (0)
-#endif
-
-/* give the target core clock (HCLK) frequency [in Hz], maximum: 80MHz */
-#define CLOCK_CORECLOCK     (80000000U)
-/* PLL configuration: make sure your values are legit!
- *
- * compute by: CORECLOCK = (((PLL_IN / M) * N) / R)
- * with:
- * PLL_IN:  input clock, HSE or MSI @ 48MHz
- * M:       pre-divider,  allowed range: [1:8]
- * N:       multiplier,   allowed range: [8:86]
- * R:       post-divider, allowed range: [2,4,6,8]
- *
- * Also the following constraints need to be met:
- * (PLL_IN / M)     -> [4MHz:16MHz]
- * (PLL_IN / M) * N -> [64MHz:344MHz]
- * CORECLOCK        -> 80MHz MAX!
- */
-#define CLOCK_PLL_M         (6)
-#define CLOCK_PLL_N         (20)
-#define CLOCK_PLL_R         (2)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
-/** @} */
 
 /**
  * @name    UART configuration


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR changes the clock configuration of the nucleo-l452re board to make it use the L4 common one. The main difference is that it enables the LSE clock for that board and it works (so there's an LSE on that board).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

I ran compile_and_test_for_board.py and got the following results:

```
$ ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . nucleo-l452re --with-test-only --jobs=8 --applications-exclude="examples/*"

[...]

Failures during test:
- [tests/driver_at86rf2xx_aes](tests/driver_at86rf2xx_aes/test.failed)
- [tests/driver_grove_ledbar](tests/driver_grove_ledbar/test.failed)
- [tests/driver_my9221](tests/driver_my9221/test.failed)
- [tests/emcute](tests/emcute/test.failed)
- [tests/gnrc_dhcpv6_client](tests/gnrc_dhcpv6_client/test.failed)
- [tests/gnrc_dhcpv6_client_6lbr](tests/gnrc_dhcpv6_client_6lbr/test.failed)
- [tests/gnrc_ipv6_ext](tests/gnrc_ipv6_ext/test.failed)
- [tests/gnrc_ipv6_ext_frag](tests/gnrc_ipv6_ext_frag/test.failed)
- [tests/gnrc_ipv6_ext_opt](tests/gnrc_ipv6_ext_opt/test.failed)
- [tests/gnrc_ipv6_nib_dns](tests/gnrc_ipv6_nib_dns/test.failed)
- [tests/gnrc_rpl_srh](tests/gnrc_rpl_srh/test.failed)
- [tests/gnrc_sock_dns](tests/gnrc_sock_dns/test.failed)
- [tests/gnrc_tcp](tests/gnrc_tcp/test.failed)
- [tests/periph_timer_short_relative_set](tests/periph_timer_short_relative_set/test.failed)
- [tests/pkg_libfixmath_unittests](tests/pkg_libfixmath_unittests/test.failed)
- [tests/pkg_semtech-loramac](tests/pkg_semtech-loramac/test.failed)
```

All failures are expected to fail: most of them are related to missing configuration (scapy or lorawan) or know to fail (`driver_grove_ledbar`, `driver_my9221` and `pkg_libfixmath_unittests`).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
