### PR TITLE
cortexm_common: Enable MPU after configuring regions

### DIFF
--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -140,10 +140,6 @@ void reset_handler_default(void)
     }
 #endif /* CPU_HAS_BACKUP_RAM */
 
-#if defined(MODULE_MPU_STACK_GUARD) || defined(MODULE_MPU_NOEXEC_RAM)
-    mpu_enable();
-#endif
-
 #ifdef MODULE_MPU_NOEXEC_RAM
     /* Mark the RAM non executable. This is a protection mechanism which
      * makes exploitation of buffer overflows significantly harder.
@@ -167,6 +163,10 @@ void reset_handler_default(void)
         );
 
     }
+#endif
+
+#if defined(MODULE_MPU_STACK_GUARD) || defined(MODULE_MPU_NOEXEC_RAM)
+    mpu_enable();
 #endif
 
     post_startup();


### PR DESCRIPTION
### Contribution description

Reordering this ensures that the MPU regions are configured before
enabling the MPU and restricting the memory access.

### Testing procedure

`tests/mpu_stack_guard` and `tests/mpu_noexec_ram` must still work as usual.

### Issues/PRs references

None