### PR TITLE
cpu/stm32: disable MPU for cortex-m0+ (stm32g0 and stm32l052t8)

### DIFF
--- a/cpu/stm32/Kconfig
+++ b/cpu/stm32/Kconfig
@@ -306,7 +306,6 @@ config CPU_MODEL_STM32L031K6
 config CPU_MODEL_STM32L052T8
     bool
     select CPU_FAM_L0
-    select HAS_CORTEXM_MPU
     select HAS_PERIPH_HWRNG
 
 config CPU_MODEL_STM32L053R8

--- a/cpu/stm32/Makefile.features
+++ b/cpu/stm32/Makefile.features
@@ -36,8 +36,9 @@ ifneq (,$(filter $(CPU_FAM),f2 f4 f7 g4 l1 l4))
   FEATURES_PROVIDED += cortexm_mpu
 endif
 
-# only some stm32f3 and stm32l0 have an MPU
-STM32_WITH_MPU += stm32f303re stm32f303vc stm32f303ze stm32l052t8
+# only some stm32f3 have an MPU, stm32l052t8 provides an MPU but support is
+# broken for cortex-m0+
+STM32_WITH_MPU += stm32f303re stm32f303vc stm32f303ze
 ifneq (,$(filter $(CPU_MODEL),$(STM32_WITH_MPU)))
   FEATURES_PROVIDED += cortexm_mpu
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR remove the MPU feature from the list of features provided by the stm32g0 family and stm32l052t8 model since MPU is broken on cortex-m0+ and this results in nearly usable state for stm32g0 family and the related stm32l0 model.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

All applications are now working on nucleo-g070rb and i-nucleo-lrwan1

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This was reported in #14822 (Let's keep it open until a real fix is proposed and the feature can be re-enabled)

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
