### PR TITLE
net/skald: Expose configurations to Kconfig 

### DIFF
--- a/sys/include/net/skald.h
+++ b/sys/include/net/skald.h
@@ -20,7 +20,7 @@
  * # Design Decisions and Limitations
  * - support for local addresses only (using `luid` to generate them)
  * - advertising interval is configured during compile time, override by setting
- *   `CFLAGS+=-DSKALD_INTERVAL=xxx`
+ *   `CFLAGS+=-DCONFIG_SKALD_INTERVAL=xxx`
  * - advertising channels are configured during compile time, override by
  *   setting `CFLAGS+=-DSKALD_ADV_CHAN={37,39}`
  *
@@ -55,10 +55,10 @@ extern "C" {
 #endif
 
 /**
- * @brief   Static advertising interval
+ * @brief   Default static advertising interval
  */
-#ifndef SKALD_INTERVAL
-#define SKALD_INTERVAL          (1 * US_PER_SEC)
+#ifndef CONFIG_SKALD_INTERVAL
+#define CONFIG_SKALD_INTERVAL          (1 * US_PER_SEC)
 #endif
 
 /**
@@ -93,7 +93,7 @@ void skald_init(void);
 /**
  * @brief   Start advertising the given packet
  *
- * The packet will be send out each advertising interval (see SKALD_INTERVAL) on
+ * The packet will be send out each advertising interval (see CONFIG_SKALD_INTERVAL) on
  * each of the defined advertising channels (see SKALD_ADV_CHAN).
  *
  * @param[in,out] ctx   start advertising this context

--- a/sys/include/net/skald.h
+++ b/sys/include/net/skald.h
@@ -55,28 +55,70 @@ extern "C" {
 #endif
 
 /**
- * @brief   Default static advertising interval
+ * @defgroup net_skald_conf Skald compile configurations
+ * @ingroup config
+ * @{
+ */
+/**
+ * @brief   Advertising interval in microseconds
  */
 #ifndef CONFIG_SKALD_INTERVAL
 #define CONFIG_SKALD_INTERVAL          (1 * US_PER_SEC)
 #endif
 
 /**
- * @brief   Configure advertising channels
+ * @brief   Configure advertising channel 37
+ *
+ * Set CONFIG_ADV_CH_37_DISABLE to disable channel 37
  */
-#ifndef CONFIG_ADV_CH_37_DISABLE
+#ifdef DOXYGEN
+#define CONFIG_ADV_CH_37_DISABLE
+#endif
+
+/**
+ * @brief   Configure advertising channel 38
+ *
+ * Set CONFIG_ADV_CH_38_DISABLE to disable channel 38
+ */
+#ifdef DOXYGEN
+#define CONFIG_ADV_CH_38_DISABLE
+#endif
+
+/**
+ * @brief   Configure advertising channel 39
+ *
+ * Set CONFIG_ADV_CH_39_DISABLE to disable channel 39
+ */
+#ifdef DOXYGEN
+#define CONFIG_ADV_CH_39_DISABLE
+#endif
+/** @} */
+
+/**
+ * @brief   Define advertising channel 37 if @ref CONFIG_ADV_CH_37_DISABLE is
+ *          not set
+ */
+#if !defined(CONFIG_ADV_CH_37_DISABLE) || defined(DOXYGEN)
 #define ADV_CH_37 37,
 #else
 #define ADV_CH_37
 #endif
 
-#ifndef CONFIG_ADV_CH_38_DISABLE
+/**
+ * @brief   Define advertising channel 38 if @ref CONFIG_ADV_CH_38_DISABLE is
+ *          not set
+ */
+#if !defined(CONFIG_ADV_CH_38_DISABLE) || defined(DOXYGEN)
 #define ADV_CH_38 38,
 #else
 #define ADV_CH_38
 #endif
 
-#ifndef CONFIG_ADV_CH_39_DISABLE
+/**
+ * @brief   Define advertising channel 39 if @ref CONFIG_ADV_CH_39_DISABLE is
+ *          not set
+ */
+#if !defined(CONFIG_ADV_CH_39_DISABLE) || defined(DOXYGEN)
 #define ADV_CH_39 39
 #else
 #define ADV_CH_39

--- a/sys/include/net/skald.h
+++ b/sys/include/net/skald.h
@@ -62,10 +62,31 @@ extern "C" {
 #endif
 
 /**
- * @brief   Static list of used advertising channels
+ * @brief   Configure advertising channels
+ */
+#ifndef CONFIG_ADV_CH_37_DISABLE
+#define ADV_CH_37 37,
+#else
+#define ADV_CH_37
+#endif
+
+#ifndef CONFIG_ADV_CH_38_DISABLE
+#define ADV_CH_38 38,
+#else
+#define ADV_CH_38
+#endif
+
+#ifndef CONFIG_ADV_CH_39_DISABLE
+#define ADV_CH_39 39
+#else
+#define ADV_CH_39
+#endif
+
+/**
+ * @brief   List of advertising channels
  */
 #ifndef SKALD_ADV_CHAN
-#define SKALD_ADV_CHAN          { 37, 38, 39 }
+#define SKALD_ADV_CHAN { ADV_CH_37 ADV_CH_38 ADV_CH_39 }
 #endif
 
 /**

--- a/sys/net/Kconfig
+++ b/sys/net/Kconfig
@@ -7,6 +7,7 @@
 menu "Networking"
 
 rsource "application_layer/Kconfig"
+rsource "ble/Kconfig"
 rsource "credman/Kconfig"
 rsource "gnrc/Kconfig"
 rsource "sock/Kconfig"

--- a/sys/net/ble/Kconfig
+++ b/sys/net/ble/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+rsource "skald/Kconfig"

--- a/sys/net/ble/skald/Kconfig
+++ b/sys/net/ble/skald/Kconfig
@@ -1,0 +1,31 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_MODULE_SKALD
+    bool "Configure SKALD"
+    depends on MODULE_SKALD
+    help
+        Configure Skald, BLE advertising stack, using Kconfig.
+
+if KCONFIG_MODULE_SKALD
+
+config SKALD_INTERVAL
+    int "Advertising interval in microseconds"
+    default 1000000
+    help
+        Configure advertising interval in microseconds. Default value is 1
+        second which is 1000000 microseconds.
+
+config ADV_CH_37_DISABLE
+    bool "Disable advertising on channel 37"
+
+config ADV_CH_38_DISABLE
+    bool "Disable advertising on channel 38"
+
+config ADV_CH_39_DISABLE
+    bool "Disable advertising on channel 39"
+
+endif # KCONFIG_MODULE_SKALD

--- a/sys/net/ble/skald/skald.c
+++ b/sys/net/ble/skald/skald.c
@@ -63,7 +63,7 @@ static void _stop_radio(void)
 
 static void _sched_next(skald_ctx_t *ctx)
 {
-    ctx->last += SKALD_INTERVAL;
+    ctx->last += CONFIG_SKALD_INTERVAL;
     /* schedule next advertising event, adding a random jitter between
      * 0ms and 10ms (see spec v5.0-vol6-b-4.4.2.2.1) */
     ctx->last += random_uint32_range(JITTER_MIN, JITTER_MAX);


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in **net/skald** to Kconfig.

### Testing procedure

1. New documentation was built using Doxygen 

   The build works fine.

  2. Test files were added to tests/net_skald/

      The test branch can be found [here](https://github.com/akshaim/RIOT/commit/1d13658430c0ad77de08429e174c292a2e16dc85)

      Compiled binaries for nrf52dk

#### Default State:

##### Firmware Output

```
main(): This is RIOT! (Version: 2020.10-devel-891-g1d136-Kconfig_skald_tests)
CONFIG_SKALD_INTERVAL=1500000
2
37
38

```
#### Usage with CFLAGS :
```
CFLAGS += -DCONFIG_SKALD_INTERVAL_S=1
CFLAGS += -DSKALD_ADV_CHAN={37,38}
```

##### Firmware Output

```
main(): This is RIOT! (Version: 2020.10-devel-891-g4038e-Kconfig_skald_tests)
SKALD_INTERVAL=1 * (1000000LU)
2
37
38
```

#### Usage with menuconfig :


`make menuconfig`

#### Default values

```
main(): This is RIOT! (Version: 2020.10-devel-891-g1d136-Kconfig_skald_tests)
CONFIG_SKALD_INTERVAL=1000000
3
37
38
39
```
##### Macros Configured output

```
main(): This is RIOT! (Version: 2020.10-devel-891-g1d136-Kconfig_skald_tests)
CONFIG_SKALD_INTERVAL=1600000
1
38
```


**MACROS were successfully configured.**

### Issues/PRs references

#12888 