### PR TITLE
tests/candev: Prevent user from attempting to use native can interface on non-native board

### DIFF
--- a/tests/candev/Makefile
+++ b/tests/candev/Makefile
@@ -1,11 +1,21 @@
 include ../Makefile.tests_common
+BOARD_WHITELIST := native
 
 USEMODULE += shell
 USEMODULE += can
 USEMODULE += isrpipe
 
 # define the CAN driver you want to use here
-CAN_DRIVER ?= native
+CAN_DRIVER ?= CAN_NATIVE
+
+# prevent using native driver on non-native board
+ifeq ($(CAN_DRIVER), CAN_NATIVE)
+  ifneq ($(BOARD), native)
+    $(error native can driver can only be used on native board!)
+  endif
+endif
+
+
 
 ifeq ($(CAN_DRIVER), PERIPH_CAN)
 # periph_can modules/variables go here
@@ -14,7 +24,5 @@ else ifeq ($(CAN_DRIVER), CAN_NATIVE)
 # can_native modules/variables go here
 
 endif
-
-CFLAGS += -DCAN_DRIVER_$(CAN_DRIVER)
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/candev/main.c
+++ b/tests/candev/main.c
@@ -30,7 +30,7 @@
 #include "shell.h"
 #include "can/device.h"
 
-#ifdef BOARD_NATIVE
+#if IS_USED(MODULE_CAN_LINUX)
 
 #include <candev_linux.h>
 
@@ -192,7 +192,7 @@ int main(void)
     puts("candev test application\n");
 
     isrpipe_init(&rxbuf, (uint8_t *)rx_ringbuf, sizeof(rx_ringbuf));
-#ifdef BOARD_NATIVE
+#if IS_USED(MODULE_CAN_LINUX)
     puts("Initializing Linux Can device");
     candev_linux_init( &linux_dev, &(candev_linux_conf[0]));    /* vcan0 */
     candev = (candev_t *)&linux_dev;


### PR DESCRIPTION
### Contribution description

When a user tries to use tests/candev on a non-native board without specifying a can_driver (or making a typo while specifying one, like I did yesterday), the test app will default to the native Linux driver. Of course, this is fine when running the test-app on native, but using Linux drivers on (for example) stm32... that of course will not work. 
In the current form, the test app will compile without any warnings and also start without any issues. However, it will immediately go into a kernel-panic when the driver is loaded. 

If you're unfamiliar with the expected behavior of this test app this can be quite confusing, so I propose to prevent the user from making this mistake. 

### Testing procedure

* on master: 
`make all flash term BOARD=nucleo-f207zg`
--> will compile without any warnings, but will throw the following output immediately after resetting the board:
```
2020-08-22 12:13:26,564 # 0x8000eaf
2020-08-22 12:13:26,565 # *** RIOT kernel panic:
2020-08-22 12:13:26,565 # FAILED ASSERTION.
2020-08-22 12:13:26,565 # 
2020-08-22 12:13:26,566 # *** halted.
```

* with this patch:
`make all flash term BOARD=nucleo-f207zg`
compiling will fail and tell you immediately what's wrong:
```
Makefile:13: *** native can driver can only be used on native board!.  Stop.
```
