### PR TITLE
cpu/lpc23xx: enable support for picolibc

### DIFF
--- a/cpu/arm7_common/Makefile.dep
+++ b/cpu/arm7_common/Makefile.dep
@@ -1,4 +1,12 @@
 # use common ARM7 periph code
 USEMODULE += arm7_common_periph
-# use the nano-specs of Newlib when available
-USEMODULE += newlib_nano
+
+ifeq (1,$(PICOLIBC))
+  # Use Picolibc when explicitly selected
+  USEMODULE += picolibc
+else
+  # all cortex MCU's use newlib as libc
+  USEMODULE += newlib
+  # use the nano-specs of Newlib when available
+  USEMODULE += newlib_nano
+endif

--- a/cpu/lpc23xx/Makefile.dep
+++ b/cpu/lpc23xx/Makefile.dep
@@ -1,6 +1,5 @@
 USEMODULE += arm7_common
 USEMODULE += bitfield
-USEMODULE += newlib
 USEMODULE += periph
 USEMODULE += pm_layered
 

--- a/cpu/lpc23xx/ldscripts/lpc23xx.ld
+++ b/cpu/lpc23xx/ldscripts/lpc23xx.ld
@@ -70,6 +70,42 @@ SECTIONS
         _efixed = .;            /* End of text section */
     } > rom
 
+    /*
+     * TLS relocations are offsets relative to the address
+     * of the first TLS symbol. That means we just need to
+     * allocate them all together so that the TLS region
+     * is compact when allocated for each thread.
+     */
+
+    /*
+     * TLS initialization data is loaded into ROM so that
+     * each thread can get its values initialized from there
+     * at startup
+     */
+    .tdata :
+    {
+         __tdata_start = .;
+        *(.tdata .tdata.* .gnu.linkonce.td.*)
+        __tdata_end = .;
+    } > rom
+    __tdata_source = LOADADDR(.tdata);
+    __tdata_size = SIZEOF(.tdata);
+
+    /*
+     * TLS zeroed data is relocated as if it immediately followed
+     * the tdata values. However, the linker 'magically' erases the
+     * memory allocation so that no ROM is consumed by this
+     * section
+     */
+    .tbss :
+    {
+        *(.tbss .tbss.* .gnu.linkonce.tb.*)
+        *(.tcommon)
+        __tbss_end = .;
+    } > rom
+    __tls_size = __tbss_end - __tdata_start;
+    __tbss_size = __tls_size - __tdata_size;
+
     /* .ARM.exidx is sorted, so has to go in its own output section.  */
     PROVIDE_HIDDEN (__exidx_start = .);
     .ARM.exidx :


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`lpc23xx` works with the same ARM targeted picolibc as our Cortex-M targets. The linker script also looks almost the same, so adding support for TLS is just copy & paste.

So all that's left to do is enable support for picolibc in the build system.

### Testing procedure

Only tried `tests/thread_cooperation`, `examples/default` and `tests/malloc`. All worked, but `tests/malloc` would only use the first heap segment as multi-heap support is not implemented yet in the picolibc support code.

- **tests/thread_cooperation:**

#### newlibc

```
   text	   data	    bss	    dec	    hex	filename
  19068	    152	  19268	  38488	   9658	/home/benpicco/dev/RIOT/tests/thread_cooperation/bin/mcb2388/tests_thread_cooperation.elf
```

#### picolibc

```
   text	   data	    bss	    dec	    hex	filename
   9680	     52	  19336	  29068	   718c	/home/benpicco/dev/RIOT/tests/thread_cooperation/bin/mcb2388/tests_thread_cooperation.elf
```

- **examples/default:**

#### newlibc

```
  text	   data	    bss	    dec	    hex	filename
  33776	    148	   7152	  41076	   a074	/home/benpicco/dev/RIOT/examples/default/bin/mcb2388/default.elf
```

#### picolibc

```
   text	   data	    bss	    dec	    hex	filename
  21432	     48	   7224	  28704	   7020	/home/benpicco/dev/RIOT/examples/default/bin/mcb2388/default.elf
```

### Issues/PRs references

depends on #14827
