### PR TITLE
drivers/at86rf2xx: fix assert

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -498,12 +498,12 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 
     switch (opt) {
         case NETOPT_ADDRESS:
-            assert(len >= sizeof(network_uint16_t));
+            assert(len <= sizeof(network_uint16_t));
             at86rf2xx_set_addr_short(dev, val);
             /* don't set res to set netdev_ieee802154_t::short_addr */
             break;
         case NETOPT_ADDRESS_LONG:
-            assert(len >= sizeof(eui64_t));
+            assert(len <= sizeof(eui64_t));
             at86rf2xx_set_addr_long(dev, val);
             /* don't set res to set netdev_ieee802154_t::long_addr */
             break;


### PR DESCRIPTION




<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The assert is reversed. It must check if the config value does not exceed the maximum address length, not the other way round.


### Testing procedure

Try setting the `short_addr` on a `samr21-xpro`.
Previously this would lead to a crash when setting a short address:

```
2020-08-23 13:59:56,080 #  ifconfig 7 set addr_short 2
2020-08-23 13:59:56,081 # 0xdcad
2020-08-23 13:59:56,083 # *** RIOT kernel panic:
2020-08-23 13:59:56,085 # FAILED ASSERTION.
```

With this it works as expected

```
2020-08-23 14:05:07,988 #  ifconfig 7 set addr_short 2
2020-08-23 14:05:07,992 # success: set (short) address on interface 7 to 2
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
