### PR TITLE
tests: Cleanup access to internal variables

### DIFF
--- a/tests/bench_runtime_coreapis/main.c
+++ b/tests/bench_runtime_coreapis/main.c
@@ -62,7 +62,7 @@ int main(void)
 {
     puts("Runtime of Selected Core API functions\n");
 
-    t = (thread_t *)sched_active_thread;
+    t = thread_get_active();
 
     BENCHMARK_FUNC("nop loop", BENCH_RUNS, __asm__ volatile ("nop"));
     puts("");

--- a/tests/bench_thread_flags_pingpong/main.c
+++ b/tests/bench_thread_flags_pingpong/main.c
@@ -62,7 +62,7 @@ int main(void)
                                        NULL,
                                        "second_thread");
 
-    thread_t *tcb = (thread_t *)sched_threads[other];
+    thread_t *tcb = thread_get(other);
 
     xtimer_t timer;
     timer.callback = _timer_callback;

--- a/tests/cond_order/main.c
+++ b/tests/cond_order/main.c
@@ -28,8 +28,6 @@
 #define THREAD_NUMOF            (5U)
 #define THREAD_FIRSTGROUP_NUMOF (3U)
 
-extern volatile thread_t *sched_active_thread;
-
 static char stacks[THREAD_NUMOF][THREAD_STACKSIZE_MAIN];
 
 static const char prios[THREAD_NUMOF] = {THREAD_PRIORITY_MAIN - 1, 4, 0, 2, 1};
@@ -40,7 +38,7 @@ static cond_t testcond;
 static void *lockme(void *arg)
 {
     (void)arg;
-    volatile thread_t *t = sched_active_thread;
+    thread_t *t = thread_get_active();
 
     mutex_lock(&testlock);
     printf("T%i (prio %i): waiting on condition variable now\n",

--- a/tests/driver_ccs811_full/main.c
+++ b/tests/driver_ccs811_full/main.c
@@ -75,7 +75,7 @@ int main(void)
     }
 
     /* save the pid of main thread */
-    p_main = sched_active_pid;
+    p_main = thread_getpid();
 
     printf("\n+--------Starting Measurements--------+\n");
 

--- a/tests/driver_hmc5883l/main.c
+++ b/tests/driver_hmc5883l/main.c
@@ -79,7 +79,7 @@ int main(void)
 {
     hmc5883l_t dev;
 
-    p_main = sched_active_pid;
+    p_main = thread_getpid();
 
     puts("HMC5883L magnetometer driver test application\n");
     puts("Initializing HMC5883L sensor");

--- a/tests/driver_itg320x/main.c
+++ b/tests/driver_itg320x/main.c
@@ -66,7 +66,7 @@ int main(void)
 {
     itg320x_t dev;
 
-    p_main = sched_active_pid;
+    p_main = thread_getpid();
 
     puts("ITG320X gyroscope driver test application\n");
     puts("Initializing ITG320X sensor");

--- a/tests/driver_qmc5883l/main.c
+++ b/tests/driver_qmc5883l/main.c
@@ -122,7 +122,7 @@ int main(void)
 #ifdef MODULE_QMC5883L_INT
     /* safe a reference to the main thread TCB so we can wait for flags */
     if (qmc5883l_params[0].pin_drdy != GPIO_UNDEF) {
-        _tmain = (thread_t *)thread_get(thread_getpid());
+        _tmain = thread_get_active();
 
         if (qmc5883l_init_int(&_dev, _on_drdy, NULL) != QMC5883L_OK) {
             puts("Error: unable to configure interrupt callback");

--- a/tests/event_wait_timeout/main.c
+++ b/tests/event_wait_timeout/main.c
@@ -72,7 +72,7 @@ static void *_cnt_thread(void *arg)
 int main(void)
 {
     /* setup */
-    _thread_main = (thread_t *)thread_get(thread_getpid());
+    _thread_main = thread_get_active();
 
     puts("[START] event_wait_timeout test application.\n");
 

--- a/tests/gnrc_ipv6_nib/mockup_netif.c
+++ b/tests/gnrc_ipv6_nib/mockup_netif.c
@@ -92,7 +92,7 @@ void _tests_init(void)
     _mock_netif->ipv6.addrs_flags[0] &= ~GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_MASK;
     _mock_netif->ipv6.addrs_flags[0] |= GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID;
     gnrc_netreg_entry_init_pid(&dumper, GNRC_NETREG_DEMUX_CTX_ALL,
-                               sched_active_pid);
+                               thread_getpid());
     gnrc_netreg_register(GNRC_NETTYPE_NDP, &dumper);
 }
 

--- a/tests/gnrc_ipv6_nib_6ln/mockup_netif.c
+++ b/tests/gnrc_ipv6_nib_6ln/mockup_netif.c
@@ -108,7 +108,7 @@ void _tests_init(void)
     _mock_netif = &_netif;
     expect(res == 0);
     gnrc_netreg_entry_init_pid(&dumper, GNRC_NETREG_DEMUX_CTX_ALL,
-                               sched_active_pid);
+                               thread_getpid());
     gnrc_netreg_register(GNRC_NETTYPE_NDP, &dumper);
 }
 

--- a/tests/gnrc_ndp/main.c
+++ b/tests/gnrc_ndp/main.c
@@ -1275,7 +1275,7 @@ static void init_pkt_handler(void)
 {
     msg_init_queue(msg_queue_main, MSG_QUEUE_SIZE);
     gnrc_netreg_entry_init_pid(&netreg_entry, GNRC_NETREG_DEMUX_CTX_ALL,
-                               sched_active_pid);
+                               thread_getpid());
     gnrc_netreg_register(GNRC_NETTYPE_NDP, &netreg_entry);
     netdev_test_setup(&dev, NULL);
     netdev_test_set_get_cb(&dev, NETOPT_ADDRESS_LONG,

--- a/tests/gnrc_sixlowpan_frag/main.c
+++ b/tests/gnrc_sixlowpan_frag/main.c
@@ -330,7 +330,7 @@ static void test_rbuf_add__success_complete(void)
     msg_t msg = { .type = 0U };
     gnrc_netreg_entry_t reg = GNRC_NETREG_ENTRY_INIT_PID(
             GNRC_NETREG_DEMUX_CTX_ALL,
-            sched_active_pid
+            thread_getpid()
         );
 
     gnrc_netreg_register(TEST_DATAGRAM_NETTYPE, &reg);

--- a/tests/gnrc_sock_ip/stack.c
+++ b/tests/gnrc_sock_ip/stack.c
@@ -30,7 +30,7 @@ void _net_init(void)
 {
     msg_init_queue(_msg_queue, _MSG_QUEUE_SIZE);
     gnrc_netreg_entry_init_pid(&_ip_handler, GNRC_NETREG_DEMUX_CTX_ALL,
-                               sched_active_pid);
+                               thread_getpid());
 }
 
 void _prepare_send_checks(void)

--- a/tests/gnrc_sock_udp/stack.c
+++ b/tests/gnrc_sock_udp/stack.c
@@ -35,7 +35,7 @@ void _net_init(void)
 {
     msg_init_queue(_msg_queue, _MSG_QUEUE_SIZE);
     gnrc_netreg_entry_init_pid(&_udp_handler, GNRC_NETREG_DEMUX_CTX_ALL,
-                               sched_active_pid);
+                               thread_getpid());
 }
 
 void _prepare_send_checks(void)

--- a/tests/lwip_sock_ip/stack.c
+++ b/tests/lwip_sock_ip/stack.c
@@ -139,7 +139,7 @@ static int _netdev_send(netdev_t *dev, const iolist_t *iolist)
 void _net_init(void)
 {
     msg_init_queue(_msg_queue, _MSG_QUEUE_SIZE);
-    _check_pid = sched_active_pid;
+    _check_pid = thread_getpid();
 
     netdev_test_setup(&netdev, NULL);
     netdev_test_set_get_cb(&netdev, NETOPT_SRC_LEN, _get_src_len);

--- a/tests/lwip_sock_tcp/main.c
+++ b/tests/lwip_sock_tcp/main.c
@@ -1073,7 +1073,7 @@ static void *_server_func(void *arg)
 
     (void)arg;
     msg_init_queue(_server_msg_queue, _MSG_QUEUE_SIZE);
-    _server = sched_active_pid;
+    _server = thread_getpid();
     while (1) {
         msg_t msg;
 
@@ -1139,7 +1139,7 @@ static void *_client_func(void *arg)
 
     (void)arg;
     msg_init_queue(_client_msg_queue, _MSG_QUEUE_SIZE);
-    _client = sched_active_pid;
+    _client = thread_getpid();
     while (1) {
         msg_t msg;
 

--- a/tests/lwip_sock_udp/stack.c
+++ b/tests/lwip_sock_udp/stack.c
@@ -142,7 +142,7 @@ static int _netdev_send(netdev_t *dev, const iolist_t *iolist)
 void _net_init(void)
 {
     msg_init_queue(_msg_queue, _MSG_QUEUE_SIZE);
-    _check_pid = sched_active_pid;
+    _check_pid = thread_getpid();
 
     netdev_test_setup(&netdev, NULL);
     netdev_test_set_get_cb(&netdev, NETOPT_SRC_LEN, _get_src_len);

--- a/tests/mutex_order/main.c
+++ b/tests/mutex_order/main.c
@@ -24,8 +24,6 @@
 
 #define THREAD_NUMOF            (5U)
 
-extern volatile thread_t *sched_active_thread;
-
 static char stacks[THREAD_NUMOF][THREAD_STACKSIZE_MAIN];
 
 static const char prios[THREAD_NUMOF] = {THREAD_PRIORITY_MAIN - 1, 4, 0, 2, 1};
@@ -35,7 +33,7 @@ static mutex_t testlock;
 static void *lockme(void *arg)
 {
     (void)arg;
-    volatile thread_t *t = sched_active_thread;
+    thread_t *t = thread_get_active();
 
     printf("T%i (prio %i): trying to lock mutex now\n",
            (int)t->pid, (int)t->priority);

--- a/tests/netdev_test/main.c
+++ b/tests/netdev_test/main.c
@@ -135,7 +135,7 @@ static int test_receive(void)
     uint8_t *rcv_payload = _tmp + sizeof(ethernet_hdr_t);
     gnrc_pktsnip_t *pkt, *hdr;
     gnrc_netreg_entry_t me = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
-                                                        sched_active_pid);
+                                                        thread_getpid());
     msg_t msg;
 
     if (_dev.netdev.event_callback == NULL) {

--- a/tests/nimble_l2cap/main.c
+++ b/tests/nimble_l2cap/main.c
@@ -312,7 +312,7 @@ int main(void)
     puts("NimBLE L2CAP test application");
 
     /* save context of the main thread */
-    _main = (thread_t *)thread_get(thread_getpid());
+    _main = thread_get_active();
 
     /* initialize buffers and setup the test environment */
     res = os_mempool_init(&_coc_mempool, MBUFCNT, MBUFSIZE, _coc_mem, "appbuf");

--- a/tests/periph_spi/main.c
+++ b/tests/periph_spi/main.c
@@ -82,14 +82,14 @@ static struct {
  */
 static void _sched_statistics_trigger(void)
 {
-    sched_statistics_cb(sched_active_pid, sched_active_pid);
+    sched_statistics_cb(thread_getpid(), thread_getpid());
 }
 
 static xtimer_ticks32_t _sched_ticks(void)
 {
     _sched_statistics_trigger();
     xtimer_ticks32_t runtime_ticks = {
-        .ticks32 = sched_pidlist[sched_active_pid].runtime_ticks
+        .ticks32 = sched_pidlist[thread_getpid()].runtime_ticks
     };
     return runtime_ticks;
 }

--- a/tests/periph_timer_short_relative_set/main.c
+++ b/tests/periph_timer_short_relative_set/main.c
@@ -65,7 +65,7 @@ int main(void)
            "On failure, this test prints an error message.\n\n");
 
     printf("testing periph_timer %u, freq %lu\n", TEST_TIMER_DEV, TEST_TIMER_FREQ);
-    timer_init(TEST_TIMER_DEV, TEST_TIMER_FREQ, cb, (thread_t *)sched_active_thread);
+    timer_init(TEST_TIMER_DEV, TEST_TIMER_FREQ, cb, thread_get_active());
 
     uint32_t interval = 100;
     while (interval--) {

--- a/tests/pthread_rwlock/main.c
+++ b/tests/pthread_rwlock/main.c
@@ -63,8 +63,8 @@ static mutex_t stdout_mutex = MUTEX_INIT;
     do {                                                    \
         mutex_lock(&stdout_mutex);                          \
         printf("%c%" PRIkernel_pid " (prio=%u): " FMT "\n", \
-               __func__[0], sched_active_pid,               \
-               sched_active_thread->priority,               \
+               __func__[0], thread_getpid(),                \
+               thread_get_active()->priority,                \
                (int)__VA_ARGS__);                           \
         mutex_unlock(&stdout_mutex);                        \
     } while (0)

--- a/tests/rmutex/main.c
+++ b/tests/rmutex/main.c
@@ -25,8 +25,6 @@
 
 #define THREAD_NUMOF            (5U)
 
-extern volatile thread_t *sched_active_thread;
-
 static char stacks[THREAD_NUMOF][THREAD_STACKSIZE_MAIN];
 
 static const char prios[THREAD_NUMOF] = {THREAD_PRIORITY_MAIN - 1, 4, 5, 2, 4};
@@ -36,7 +34,7 @@ static rmutex_t testlock;
 
 static void lock_recursive(char n, char depth)
 {
-    volatile thread_t *t = sched_active_thread;
+    thread_t *t = thread_get_active();
 
     printf("T%i (prio %i, depth %i): trying to lock rmutex now\n",
         (int)t->pid, (int)t->priority, (int)n);

--- a/tests/rmutex_cpp/main.cpp
+++ b/tests/rmutex_cpp/main.cpp
@@ -25,8 +25,6 @@
 
 #define THREAD_NUMOF            (5U)
 
-extern volatile thread_t *sched_active_thread;
-
 static char stacks[THREAD_NUMOF][THREAD_STACKSIZE_MAIN];
 
 static const char prios[THREAD_NUMOF] = {THREAD_PRIORITY_MAIN - 1, 4, 5, 2, 4};
@@ -36,7 +34,7 @@ static rmutex_t testlock;
 
 static void lock_recursive(char n, char depth)
 {
-    volatile thread_t *t = sched_active_thread;
+    thread_t *t = thread_get_active();
 
     printf("T%i (prio %i, depth %i): trying to lock rmutex now\n",
         (int)t->pid, (int)t->priority, (int)n);

--- a/tests/socket_zep/main.c
+++ b/tests/socket_zep/main.c
@@ -27,7 +27,9 @@
 #include "sched.h"
 #include "socket_zep.h"
 #include "socket_zep_params.h"
+#include "socket_zep_params.h"
 #include "test_utils/expect.h"
+#include "thread.h"
 #include "msg.h"
 #include "od.h"
 
@@ -106,7 +108,7 @@ int main(void)
 {
     puts("Socket ZEP device driver test");
     msg_init_queue(_msg_queue, MSG_QUEUE_SIZE);
-    _main_pid = sched_active_pid;
+    _main_pid = thread_getpid();
 
     test_init();
     test_send__iolist_NULL();

--- a/tests/thread_flags_xtimer/main.c
+++ b/tests/thread_flags_xtimer/main.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 
 #include "xtimer.h"
+#include "thread.h"
 #include "thread_flags.h"
 
 #define TIMEOUT         (100UL * US_PER_MS)
@@ -29,7 +30,7 @@
 
 static void time_evt(void *arg)
 {
-    thread_flags_set((thread_t *)arg, 0x1);
+    thread_flags_set(arg, 0x1);
 }
 
 int main(void)
@@ -37,7 +38,7 @@ int main(void)
     puts("START");
     xtimer_t timer;
     timer.callback = time_evt;
-    timer.arg = (void *)sched_active_thread;
+    timer.arg = thread_get_active();
     uint32_t last = xtimer_now_usec();
 
     puts("Test setting thread flags from (x)timer callback");

--- a/tests/thread_msg/main.c
+++ b/tests/thread_msg/main.c
@@ -85,7 +85,7 @@ void *thread3(void *arg)
 
 int main(void)
 {
-    p_main = sched_active_pid;
+    p_main = thread_getpid();
     p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
                        THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,
                        thread1, NULL, "nr1");

--- a/tests/thread_msg_block_race/main.c
+++ b/tests/thread_msg_block_race/main.c
@@ -86,7 +86,7 @@ int main(void)
     random_init(timer_read(TIMER_DEV(0)));
     puts("Test is \"successful\" if it runs forever without halting\n"
          "on any of the assertion in this file\n");
-    _pid_main = sched_active_pid;
+    _pid_main = thread_getpid();
 
     puts("I will try to trigger an interrupt at random intervals. When an\n"
          "interrupt is fired while ISR is disable in the thread_yield_higher()\n"

--- a/tests/thread_msg_block_w_queue/main.c
+++ b/tests/thread_msg_block_w_queue/main.c
@@ -55,7 +55,7 @@ void *sender_thread(void *arg)
 int main(void)
 {
     msg_t msg;
-    p_recv = sched_active_pid;
+    p_recv = thread_getpid();
 
     msg_t msg_q[1];
     msg_init_queue(msg_q, 1);

--- a/tests/thread_msg_block_wo_queue/main.c
+++ b/tests/thread_msg_block_wo_queue/main.c
@@ -55,7 +55,7 @@ void *thread1(void *arg)
 int main(void)
 {
     msg_t msg;
-    p_recv = sched_active_pid;
+    p_recv = thread_getpid();
 
     p_send = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
                        THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,

--- a/tests/thread_msg_bus/main.c
+++ b/tests/thread_msg_bus/main.c
@@ -107,7 +107,7 @@ int main(void)
 
     msg_bus_init(&my_bus);
 
-    p_main = sched_active_pid;
+    p_main = thread_getpid();
     p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 3,
                        THREAD_CREATE_STACKTEST, thread1, &my_bus, "nr1");
     p2 = thread_create(t2_stack, sizeof(t2_stack), THREAD_PRIORITY_MAIN - 2,

--- a/tests/thread_msg_seq/main.c
+++ b/tests/thread_msg_seq/main.c
@@ -54,7 +54,7 @@ int main(void)
     puts("START");
     msg_t msg;
 
-    p_main = sched_active_pid;
+    p_main = thread_getpid();
 
     p1 = thread_create(t1_stack, sizeof(t1_stack), THREAD_PRIORITY_MAIN - 1,
                        THREAD_CREATE_STACKTEST, sub_thread, "nr1", "nr1");

--- a/tests/thread_race/main.c
+++ b/tests/thread_race/main.c
@@ -48,7 +48,7 @@ static void _thread_wake_wo_yield(kernel_pid_t pid)
 {
     unsigned old_state = irq_disable();
 
-    thread_t *other_thread = (thread_t *) thread_get(pid);
+    thread_t *other_thread = thread_get(pid);
 
     sched_set_status(other_thread, STATUS_RUNNING);
 

--- a/tests/trickle/main.c
+++ b/tests/trickle/main.c
@@ -68,7 +68,7 @@ int main(void)
 
     msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
 
-    trickle_start(sched_active_pid, &trickle, TRICKLE_MSG, TR_IMIN,
+    trickle_start(thread_getpid(), &trickle, TRICKLE_MSG, TR_IMIN,
                   TR_IDOUBLINGS, TR_REDCONST);
 
     puts("[START]");

--- a/tests/unittests/tests-core/tests-core-ringbuffer.c
+++ b/tests/unittests/tests-core/tests-core-ringbuffer.c
@@ -106,7 +106,7 @@ static void *run_get(void *arg)
 
 static void tests_core_ringbuffer(void)
 {
-    pid_add = sched_active_pid;
+    pid_add = thread_getpid();
     pid_get = thread_create(stack_get, sizeof (stack_get),
                             THREAD_PRIORITY_MAIN,
                             THREAD_CREATE_SLEEPING | THREAD_CREATE_STACKTEST,

--- a/tests/xtimer_msg_receive_timeout/main.c
+++ b/tests/xtimer_msg_receive_timeout/main.c
@@ -37,7 +37,7 @@ int main(void)
     tmsg.type = 42;
     puts("[START]");
     for (unsigned i = 0; i < TEST_COUNT; i++) {
-        xtimer_set_msg(&t, TEST_PERIOD + offset, &tmsg, sched_active_pid);
+        xtimer_set_msg(&t, TEST_PERIOD + offset, &tmsg, thread_getpid());
         if (xtimer_msg_receive_timeout(&m, TEST_PERIOD) < 0) {
             puts("Timeout!");
             msg_receive(&m);


### PR DESCRIPTION
### Contribution description

Replaced direct accesses to `sched_active_thread` and `sched_active_pid` with
the helper functions thread_getpid() and thread_get_active(). This serves
two purposes:

1. It makes accidental writes to those variable from outside core less likely.
2. Casting off the volatile qualifier is now well contained to those two functions

### Testing procedure

Binaries shouldn't change

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/14702