### PR TITLE
cpu/stm32g4: add transition phase when raising +80MHz clock

### DIFF
--- a/boards/common/stm32/include/g4/cfg_clock_default.h
+++ b/boards/common/stm32/include/g4/cfg_clock_default.h
@@ -48,15 +48,10 @@ extern "C" {
 #define CLOCK_CORECLOCK     (CLOCK_HSE)
 
 #elif CLOCK_USE_PLL
-/* The following parameters configure a 80MHz system clock with HSE as input clock */
-#define CLOCK_PLL_M         (6)
-#define CLOCK_PLL_N         (40)
-#define CLOCK_PLL_R         (2)
-/* Use the following to reach 170MHz
+/* The following parameters configure a 170MHz system clock with HSE as input clock */
 #define CLOCK_PLL_M          (6)
 #define CLOCK_PLL_N          (85)
 #define CLOCK_PLL_R          (2)
-*/
 #if CLOCK_HSE
 #define CLOCK_PLL_SRC       (CLOCK_HSE)
 #else /* CLOCK_HSI */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR implement the missing transition phase that is ~required~ recommended when a core clock > 80MHz is configured via PLL.
This transition phase is described in the [stm32g4 reference manual (RM0440)](https://www.st.com/resource/en/reference_manual/dm00355726-stm32g4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf), paragraph 7.2.7, page 282:

```
To switch from low speed to high speed or from high speed to low speed system clock, it is recommended to use a transition state with medium speed clock, for at least 1 μs.

Clock source switching conditions:
• Switching from HSE or HSI16 to PLL with AHB frequency (HCLK) higher than 80 MHz
• Switching from PLL with HCLK higher than 80 MHz to HSE or HSI16

Transition state:
• Set the AHB prescaler HPRE[3:0] bits to divide the system frequency by 2
• Switch system clock to PLL
• Wait for at least 1 μs and then reconfigure AHB prescaler bits to the needed HCLK frequency
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Applications are still working on nucleo-g474re with the default clock (80MHz)
- Apply the following patch (to configure a 170MHz clock) and verify that applications are still functional:

```diff
diff --git a/boards/common/stm32/include/g4/cfg_clock_default.h b/boards/common/stm32/include/g4/cfg_clock_default.h
index 19615da177..abd07272cf 100644
--- a/boards/common/stm32/include/g4/cfg_clock_default.h
+++ b/boards/common/stm32/include/g4/cfg_clock_default.h
@@ -49,14 +49,13 @@ extern "C" {
 
 #elif CLOCK_USE_PLL
 /* The following parameters configure a 80MHz system clock with HSE as input clock */
-#define CLOCK_PLL_M         (6)
-#define CLOCK_PLL_N         (40)
-#define CLOCK_PLL_R         (2)
-/* Use the following to reach 170MHz
+// #define CLOCK_PLL_M         (6)
+// #define CLOCK_PLL_N         (40)
+// #define CLOCK_PLL_R         (2)
+/* Use the following to reach 170MHz */
 #define CLOCK_PLL_M          (6)
 #define CLOCK_PLL_N          (85)
 #define CLOCK_PLL_R          (2)
-*/
 #if CLOCK_HSE
 #define CLOCK_PLL_SRC       (CLOCK_HSE)
 #else /* CLOCK_HSI */
diff --git a/examples/hello-world/main.c b/examples/hello-world/main.c
index f51bf8c0a0..e5b1a1d80e 100644
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -21,6 +21,8 @@
 
 #include <stdio.h>
 
+#include "board.h"
+
 int main(void)
 {
     puts("Hello World!");
@@ -28,5 +30,13 @@ int main(void)
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);
 
+    printf("Clock coreclock: %u\n", CLOCK_CORECLOCK);
+    printf("AHB clock: %u\n", CLOCK_AHB);
+    printf("APB1 clock: %u\n", CLOCK_APB1);
+#ifdef CLOCK_APB2
+    printf("APB2 clock: %u\n", CLOCK_APB2);
+
+#endif
+
     return 0;
 }
```

Hello-world is modified to print the different clock values.

<details><summary>With 170MHz core clock:</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=nucleo-g474re -C examples/hello-world flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-g474re'  -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make 'BOARD=nucleo-g474re'    
Building application "hello-world" for "nucleo-g474re" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/pkg/stm32cmsis
"make" -C /data/riotbuild/riotbase/boards/nucleo-g474re
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/bootloader
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   9804	    112	   2312	  12228	   2fc4	/data/riotbuild/riotbase/examples/hello-world/bin/nucleo-g474re/hello-world.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/examples/hello-world/bin/nucleo-g474re/hello-world.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01383-gd46f28c2e-dirty (2020-08-20-10:53)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 2000 kHz
Info : STLINK V3J7M2 (API v3) VID:PID 0483:374E
Info : Target voltage: 3.285220
Info : stm32g4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32g4x.cpu on 0
Info : Listening on port 36587 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32g4x.cpu       hla_target little stm32g4x.cpu       reset

Info : Unable to match requested speed 2000 kHz, using 1000 kHz
Info : Unable to match requested speed 2000 kHz, using 1000 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x080005b0 msp: 0x20000200
Info : device idcode = 0x20016469 (STM32G47/G48xx - Rev: Z)
Info : flash size = 512kbytes
Info : flash mode : dual-bank
Info : Padding image section 1 at 0x080026bc with 4 bytes (bank write end alignment)
Warn : Adding extra erase range, 0x080026c0 .. 0x080027ff
auto erase enabled
wrote 9920 bytes from file /work/riot/RIOT/examples/hello-world/bin/nucleo-g474re/hello-world.elf in 0.399773s (24.233 KiB/s)

verified 9916 bytes in 0.165111s (58.649 KiB/s)

Info : Unable to match requested speed 2000 kHz, using 1000 kHz
Info : Unable to match requested speed 2000 kHz, using 1000 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-08-24 14:31:24,701 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2020-08-24 14:31:25,854 # main(): This is RIOT! (Version: 2020.10-devel-917-gc00d6-pr/cpu/stm32g4_full_speed)
2020-08-24 14:31:25,855 # Hello World!
2020-08-24 14:31:25,860 # You are running RIOT on a(n) nucleo-g474re board.
2020-08-24 14:31:25,863 # This board features a(n) stm32 MCU.
2020-08-24 14:31:25,865 # Clock coreclock: 170000000
2020-08-24 14:31:25,867 # AHB clock: 170000000
2020-08-24 14:31:25,869 # APB1 clock: 170000000
2020-08-24 14:31:25,871 # APB2 clock: 170000000
2020-08-24 14:31:26,841 # Exiting Pyterm
```

</details>

<details><summary>With 80MHz core clock:</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=nucleo-g474re -C examples/hello-world flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-g474re'  -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make 'BOARD=nucleo-g474re'    
Building application "hello-world" for "nucleo-g474re" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/pkg/stm32cmsis
"make" -C /data/riotbuild/riotbase/boards/nucleo-g474re
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/bootloader
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   9788	    112	   2312	  12212	   2fb4	/data/riotbuild/riotbase/examples/hello-world/bin/nucleo-g474re/hello-world.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/examples/hello-world/bin/nucleo-g474re/hello-world.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01383-gd46f28c2e-dirty (2020-08-20-10:53)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 2000 kHz
Info : STLINK V3J7M2 (API v3) VID:PID 0483:374E
Info : Target voltage: 3.283622
Info : stm32g4x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32g4x.cpu on 0
Info : Listening on port 34039 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32g4x.cpu       hla_target little stm32g4x.cpu       reset

Info : Unable to match requested speed 2000 kHz, using 1000 kHz
Info : Unable to match requested speed 2000 kHz, using 1000 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x080005b0 msp: 0x20000200
Info : device idcode = 0x20016469 (STM32G47/G48xx - Rev: Z)
Info : flash size = 512kbytes
Info : flash mode : dual-bank
Info : Padding image section 1 at 0x080026ac with 4 bytes (bank write end alignment)
Warn : Adding extra erase range, 0x080026b0 .. 0x080027ff
auto erase enabled
wrote 9904 bytes from file /work/riot/RIOT/examples/hello-world/bin/nucleo-g474re/hello-world.elf in 0.402463s (24.032 KiB/s)

verified 9900 bytes in 0.168856s (57.256 KiB/s)

Info : Unable to match requested speed 2000 kHz, using 1000 kHz
Info : Unable to match requested speed 2000 kHz, using 1000 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-08-24 14:30:43,281 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2020-08-24 14:30:45,368 # main(): This is RIOT! (Version: 2020.10-devel-917-gc00d6-pr/cpu/stm32g4_full_speed)
2020-08-24 14:30:45,369 # Hello World!
2020-08-24 14:30:45,373 # You are running RIOT on a(n) nucleo-g474re board.
2020-08-24 14:30:45,376 # This board features a(n) stm32 MCU.
2020-08-24 14:30:45,378 # Clock coreclock: 80000000
2020-08-24 14:30:45,380 # AHB clock: 80000000
2020-08-24 14:30:45,382 # APB1 clock: 80000000
2020-08-24 14:30:45,384 # APB2 clock: 80000000
2020-08-24 14:30:46,493 # Exiting Pyterm
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
