### PR TITLE
cpu: boards: stm32gx: improve and add Kconfig clock configuration

### DIFF
--- a/boards/common/stm32/Kconfig
+++ b/boards/common/stm32/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD_HAS_HSE
+    bool
+    help
+        Indicates that the board is providing an HSE oscillator
+
+config BOARD_HAS_LSE
+    bool
+    help
+        Indicates that the board is providing an LSE oscillator

--- a/boards/common/stm32/Kconfig.g0
+++ b/boards/common/stm32/Kconfig.g0
@@ -1,0 +1,118 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+menu "STM32 G0 clock configuration"
+    depends on CPU_FAM_G0
+
+choice
+bool "Clock source selection"
+default USE_CLOCK_PLL
+
+config USE_CLOCK_PLL
+    bool "PLL"
+
+config USE_CLOCK_HSE
+    bool "Direct High frequency external oscillator (HSE)"
+    depends on BOARD_HAS_HSE
+
+config USE_CLOCK_HSI
+    bool "Direct High frequency internal oscillator (HSI16)"
+
+endchoice
+
+if USE_CLOCK_PLL
+config CLOCK_PLL_M
+    int "M: PLLIN division factor"
+    default 1
+    range 1 8
+
+config CLOCK_PLL_N
+    int "N: PLLIN multiply factor"
+    default 20
+    range 8 86
+
+config CLOCK_PLL_R
+    int "Q: VCO division factor"
+    default 6 if BOARD_HAS_HSE
+    default 5 if !BOARD_HAS_HSE
+    range 2 8
+endif
+
+choice
+bool "HSISYS division factor"
+default CLOCK_HSISYS_DIV_1
+depends on USE_CLOCK_HSI
+
+config CLOCK_HSISYS_DIV_1
+    bool "Divide HSISYS by 1"
+
+config CLOCK_HSISYS_DIV_2
+    bool "Divide HSISYS by 2"
+
+config CLOCK_HSISYS_DIV_4
+    bool "Divide HSISYS by 4"
+
+config CLOCK_HSISYS_DIV_8
+    bool "Divide HSISYS by 8"
+
+config CLOCK_HSISYS_DIV_16
+    bool "Divide HSISYS by 16"
+
+config CLOCK_HSISYS_DIV_32
+    bool "Divide HSISYS by 32"
+
+config CLOCK_HSISYS_DIV_64
+    bool "Divide HSISYS by 64"
+
+config CLOCK_HSISYS_DIV_128
+    bool "Divide HSISYS by 128"
+
+endchoice
+
+config CLOCK_HSISYS_DIV
+    int
+    default 1 if CLOCK_HSISYS_DIV_1
+    default 2 if CLOCK_HSISYS_DIV_2
+    default 4 if CLOCK_HSISYS_DIV_4
+    default 8 if CLOCK_HSISYS_DIV_8
+    default 16 if CLOCK_HSISYS_DIV_16
+    default 32 if CLOCK_HSISYS_DIV_32
+    default 64 if CLOCK_HSISYS_DIV_64
+    default 128 if CLOCK_HSISYS_DIV_128
+
+choice
+bool "APB prescaler (division factor of HCLK to produce PCLK)"
+default CLOCK_APB1_DIV_1
+
+config CLOCK_APB1_DIV_1
+    bool "Divide HCLK by 1"
+
+config CLOCK_APB1_DIV_2
+    bool "Divide HCLK by 2"
+
+config CLOCK_APB1_DIV_4
+    bool "Divide HCLK by 4"
+
+config CLOCK_APB1_DIV_8
+    bool "Divide HCLK by 8"
+
+config CLOCK_APB1_DIV_16
+    bool "Divide HCLK by 16"
+
+endchoice
+
+config CLOCK_APB1_DIV
+    int
+    default 1 if CLOCK_APB1_DIV_1
+    default 2 if CLOCK_APB1_DIV_2
+    default 4 if CLOCK_APB1_DIV_4
+    default 8 if CLOCK_APB1_DIV_8
+    default 16 if CLOCK_APB1_DIV_16
+
+endmenu
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/common/stm32/Kconfig.g4
+++ b/boards/common/stm32/Kconfig.g4
@@ -1,0 +1,125 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+menu "STM32 G4 clock configuration"
+    depends on CPU_FAM_G4
+
+choice
+bool "Clock source selection"
+default USE_CLOCK_PLL
+
+config USE_CLOCK_PLL
+    bool "PLL"
+
+config USE_CLOCK_HSE
+    bool "Direct High frequency external oscillator (HSE)"
+    depends on BOARD_HAS_HSE
+
+config USE_CLOCK_HSI
+    bool "Direct High frequency internal oscillator (HSI16)"
+
+endchoice
+
+if USE_CLOCK_PLL
+config CLOCK_PLL_M
+    int "M: Division factor for the main PLL input clock"
+    default 6 if BOARD_HAS_HSE
+    default 4 if !BOARD_HAS_HSE
+    range 1 16
+
+config CLOCK_PLL_N
+    int "N: Multiply factor for the VCO"
+    default 40
+    range 8 127
+
+choice
+bool "R: Main PLL division factor for PLL 'R' clock (system clock)"
+default PLL_R_DIV_2
+
+config PLL_R_DIV_2
+    bool "Divide by 2"
+
+config PLL_R_DIV_4
+    bool "Divide by 4"
+
+config PLL_R_DIV_6
+    bool "Divide by 6"
+
+config PLL_R_DIV_8
+    bool "Divide by 8"
+
+endchoice
+
+config CLOCK_PLL_R
+    int
+    default 2 if PLL_R_DIV_2
+    default 4 if PLL_R_DIV_4
+    default 6 if PLL_R_DIV_6
+    default 8 if PLL_R_DIV_8
+endif
+
+choice
+bool "APB1 prescaler (division factor of HCLK to produce PCLK1)"
+default CLOCK_APB1_DIV_1
+
+config CLOCK_APB1_DIV_1
+    bool "Divide HCLK by 1"
+
+config CLOCK_APB1_DIV_2
+    bool "Divide HCLK by 2"
+
+config CLOCK_APB1_DIV_4
+    bool "Divide HCLK by 4"
+
+config CLOCK_APB1_DIV_8
+    bool "Divide HCLK by 8"
+
+config CLOCK_APB1_DIV_16
+    bool "Divide HCLK by 16"
+
+endchoice
+
+config CLOCK_APB1_DIV
+    int
+    default 1 if CLOCK_APB1_DIV_1
+    default 2 if CLOCK_APB1_DIV_2
+    default 4 if CLOCK_APB1_DIV_4
+    default 8 if CLOCK_APB1_DIV_8
+    default 16 if CLOCK_APB1_DIV_16
+
+choice
+bool "APB2 prescaler (division factor of HCLK to produce PCLK2)"
+default CLOCK_APB2_DIV_1
+
+config CLOCK_APB2_DIV_1
+    bool "Divide HCLK by 1"
+
+config CLOCK_APB2_DIV_2
+    bool "Divide HCLK by 2"
+
+config CLOCK_APB2_DIV_4
+    bool "Divide HCLK by 4"
+
+config CLOCK_APB2_DIV_8
+    bool "Divide HCLK by 8"
+
+config CLOCK_APB2_DIV_16
+    bool "Divide HCLK by 16"
+
+endchoice
+
+config CLOCK_APB2_DIV
+    int
+    default 1 if CLOCK_APB2_DIV_1
+    default 2 if CLOCK_APB2_DIV_2
+    default 4 if CLOCK_APB2_DIV_4
+    default 8 if CLOCK_APB2_DIV_8
+    default 16 if CLOCK_APB2_DIV_16
+
+endmenu
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/common/stm32/include/g4/cfg_clock_default.h
+++ b/boards/common/stm32/include/g4/cfg_clock_default.h
@@ -29,44 +29,100 @@ extern "C" {
  * @name    Clock settings
  * @{
  */
-#define CLOCK_USE_HSI       (0)
-#define CLOCK_USE_HSE       (0)
-#define CLOCK_USE_PLL       (1)
+#ifndef CONFIG_USE_CLOCK_PLL
+#if IS_ACTIVE(CONFIG_USE_CLOCK_HSE) || IS_ACTIVE(CONFIG_USE_CLOCK_HSI)
+#define CONFIG_USE_CLOCK_PLL            (0)
+#else
+#define CONFIG_USE_CLOCK_PLL            (1)     /* Use PLL by default */
+#endif
+#endif /* CONFIG_USE_CLOCK_PLL */
 
-#define CLOCK_HSI           (16000000U)
+#ifndef CONFIG_USE_CLOCK_HSE
+#define CONFIG_USE_CLOCK_HSE            (0)
+#endif /* CONFIG_USE_CLOCK_HSE */
+
+#ifndef CONFIG_USE_CLOCK_HSI
+#define CONFIG_USE_CLOCK_HSI            (0)
+#endif /* CONFIG_USE_CLOCK_HSI */
+
+#if CONFIG_USE_CLOCK_PLL && \
+    (CONFIG_USE_CLOCK_HSE || CONFIG_USE_CLOCK_HSI)
+#error "Cannot use PLL as clock source with other clock configurations"
+#endif
+
+#if CONFIG_USE_CLOCK_HSE && \
+    (CONFIG_USE_CLOCK_PLL || CONFIG_USE_CLOCK_HSI)
+#error "Cannot use HSE as clock source with other clock configurations"
+#endif
+
+#if CONFIG_USE_CLOCK_HSI && \
+    (CONFIG_USE_CLOCK_PLL || CONFIG_USE_CLOCK_HSE)
+#error "Cannot use HSI as clock source with other clock configurations"
+#endif
+
+#ifndef CONFIG_BOARD_HAS_HSE
+#define CONFIG_BOARD_HAS_HSE            (0)
+#endif
 #ifndef CLOCK_HSE
-#define CLOCK_HSE           (24000000U)
+#define CLOCK_HSE                       MHZ(24)
 #endif
-#ifndef CLOCK_LSE
-#define CLOCK_LSE           (1U)
+#if CONFIG_BOARD_HAS_HSE && (CLOCK_HSE < MHZ(4) || CLOCK_HSE > MHZ(48))
+#error "HSE clock frequency must be between 4MHz and 48MHz"
 #endif
 
-#if CLOCK_USE_HSI
-#define CLOCK_CORECLOCK     (CLOCK_HSI)
+#ifndef CONFIG_BOARD_HAS_LSE
+#define CONFIG_BOARD_HAS_LSE            (0)
+#endif
+#if CONFIG_BOARD_HAS_LSE
+#define CLOCK_LSE                       (1)
+#else
+#define CLOCK_LSE                       (0)
+#endif
 
-#elif CLOCK_USE_HSE
-#define CLOCK_CORECLOCK     (CLOCK_HSE)
+#define CLOCK_HSI                       MHZ(16)
 
-#elif CLOCK_USE_PLL
-/* The following parameters configure a 170MHz system clock with HSE as input clock */
-#define CLOCK_PLL_M          (6)
-#define CLOCK_PLL_N          (85)
-#define CLOCK_PLL_R          (2)
-#if CLOCK_HSE
-#define CLOCK_PLL_SRC       (CLOCK_HSE)
+#if CONFIG_USE_CLOCK_HSI
+#define CLOCK_CORECLOCK                 (CLOCK_HSI)
+
+#elif CONFIG_USE_CLOCK_HSE
+#if CONFIG_BOARD_HAS_HSE == 0
+#error "The board doesn't provide an HSE oscillator"
+#endif
+#define CLOCK_CORECLOCK                 (CLOCK_HSE)
+
+#elif CONFIG_USE_CLOCK_PLL
+/* The following parameters configure a 170MHz system clock with HSI16 as input clock */
+#ifndef CONFIG_CLOCK_PLL_M
+#define CONFIG_CLOCK_PLL_M              (4)
+#endif
+#ifndef CONFIG_CLOCK_PLL_N
+#define CONFIG_CLOCK_PLL_N              (85)
+#endif
+#ifndef CONFIG_CLOCK_PLL_R
+#define CONFIG_CLOCK_PLL_R              (2)
+#endif
+#if CONFIG_BOARD_HAS_HSE
+#define CLOCK_PLL_SRC                   (CLOCK_HSE)
 #else /* CLOCK_HSI */
-#define CLOCK_PLL_SRC       (CLOCK_HSI)
+#define CLOCK_PLL_SRC                   (CLOCK_HSI)
 #endif
-#define CLOCK_CORECLOCK     ((CLOCK_PLL_SRC / CLOCK_PLL_M) * CLOCK_PLL_N) / CLOCK_PLL_R
+#define CLOCK_CORECLOCK                 \
+        ((CLOCK_PLL_SRC / CONFIG_CLOCK_PLL_M) * CONFIG_CLOCK_PLL_N) / CONFIG_CLOCK_PLL_R
+#if CLOCK_CORECLOCK > MHZ(170)
+#error "SYSCLK cannot exceed 170MHz"
 #endif
+#endif /* CONFIG_USE_CLOCK_PLL */
 
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)   /* max 170MHz */
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV1
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 1)   /* max 170MHz */
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)   /* max 170MHz */
-/** @} */
+#define CLOCK_AHB                       CLOCK_CORECLOCK /* max: 170MHz */
+
+#ifndef CONFIG_CLOCK_APB1_DIV
+#define CONFIG_CLOCK_APB1_DIV           (1)
+#endif
+#define CLOCK_APB1                      (CLOCK_CORECLOCK / CONFIG_CLOCK_APB1_DIV)   /* max: 170MHz */
+#ifndef CONFIG_CLOCK_APB2_DIV
+#define CONFIG_CLOCK_APB2_DIV           (1)
+#endif
+#define CLOCK_APB2                      (CLOCK_CORECLOCK / CONFIG_CLOCK_APB2_DIV)   /* max: 170MHz */
 
 #ifdef __cplusplus
 }

--- a/boards/nucleo-g070rb/Kconfig
+++ b/boards/nucleo-g070rb/Kconfig
@@ -23,4 +23,8 @@ config BOARD_NUCLEO_G070RB
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
+    # Clock configuration
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig.g0"
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-g070rb/include/periph_conf.h
+++ b/boards/nucleo-g070rb/include/periph_conf.h
@@ -20,6 +20,12 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+
+/* Add specific clock configuration (HSE, LSE) for this board here */
+#ifndef CONFIG_BOARD_HAS_LSE
+#define CONFIG_BOARD_HAS_LSE            (1)
+#endif
+
 #include "g0/cfg_clock_default.h"
 #include "cfg_i2c1_pb8_pb9.h"
 #include "cfg_rtt_default.h"

--- a/boards/nucleo-g474re/Kconfig
+++ b/boards/nucleo-g474re/Kconfig
@@ -26,4 +26,9 @@ config BOARD_NUCLEO_G474RE
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig.g4"
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-g474re/include/periph_conf.h
+++ b/boards/nucleo-g474re/include/periph_conf.h
@@ -19,6 +19,19 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* Add specific clock configuration (HSE, LSE) for this board here */
+#ifndef CONFIG_BOARD_HAS_LSE
+#define CONFIG_BOARD_HAS_LSE            (1)
+#endif
+/* This board provides a 24MHz HSE oscillator */
+#ifndef CONFIG_BOARD_HAS_HSE
+#define CONFIG_BOARD_HAS_HSE            (1)
+#endif
+/* By default, configure a 80MHz SYSCLK with PLL using HSE as input clock */
+#ifndef CONFIG_CLOCK_PLL_M
+#define CONFIG_CLOCK_PLL_M              (6)
+#endif
+
 #include "periph_cpu.h"
 #include "g4/cfg_clock_default.h"
 #include "cfg_i2c1_pb8_pb9.h"

--- a/cpu/stm32/stmclk/stmclk_gx.c
+++ b/cpu/stm32/stmclk/stmclk_gx.c
@@ -21,10 +21,6 @@
 #include "stmclk.h"
 #include "periph_conf.h"
 
-#if CLOCK_USE_HSE && CLOCK_HSE == 0
-#error "HSE is selected as input clock source but CLOCK_HSE is not set"
-#endif
-
 #if defined(CPU_FAM_STM32G0)
 #define PLL_M_MIN                   (1)
 #define PLL_M_MAX                   (8)
@@ -41,28 +37,28 @@
 #define PLL_R_MAX                   (8)
 #endif
 
-#if CLOCK_USE_PLL
-#if (CLOCK_PLL_M < PLL_M_MIN || CLOCK_PLL_M > PLL_M_MAX)
+#if CONFIG_USE_CLOCK_PLL
+#if (CONFIG_CLOCK_PLL_M < PLL_M_MIN || CONFIG_CLOCK_PLL_M > PLL_M_MAX)
 #error "PLL configuration: PLL M value is out of range"
 #endif
-#define PLL_M                       ((CLOCK_PLL_M - 1) << RCC_PLLCFGR_PLLM_Pos)
+#define PLL_M                       ((CONFIG_CLOCK_PLL_M - 1) << RCC_PLLCFGR_PLLM_Pos)
 
-#if (CLOCK_PLL_N < PLL_N_MIN || CLOCK_PLL_N > PLL_N_MAX)
+#if (CONFIG_CLOCK_PLL_N < PLL_N_MIN || CONFIG_CLOCK_PLL_N > PLL_N_MAX)
 #error "PLL configuration: PLL N value is out of range"
 #endif
-#define PLL_N                       (CLOCK_PLL_N << RCC_PLLCFGR_PLLN_Pos)
+#define PLL_N                       (CONFIG_CLOCK_PLL_N << RCC_PLLCFGR_PLLN_Pos)
 
-#if (CLOCK_PLL_R < PLL_R_MIN || CLOCK_PLL_R > PLL_R_MAX)
+#if (CONFIG_CLOCK_PLL_R < PLL_R_MIN || CONFIG_CLOCK_PLL_R > PLL_R_MAX)
 #error "PLL configuration: PLL R value is out of range"
 #endif
 
 #if defined(CPU_FAM_STM32G0)
-#define PLL_R                       ((CLOCK_PLL_R - 1) << RCC_PLLCFGR_PLLR_Pos)
+#define PLL_R                       ((CONFIG_CLOCK_PLL_R - 1) << RCC_PLLCFGR_PLLR_Pos)
 #else /* CPU_FAM_STM32G4 */
-#define PLL_R                       (((CLOCK_PLL_R >> 1) - 1) << RCC_PLLCFGR_PLLR_Pos)
+#define PLL_R                       (((CONFIG_CLOCK_PLL_R >> 1) - 1) << RCC_PLLCFGR_PLLR_Pos)
 #endif
 
-#if CLOCK_HSE
+#if CONFIG_BOARD_HAS_HSE
 #define PLL_IN                      CLOCK_HSE
 #define PLL_SRC                     RCC_PLLCFGR_PLLSRC_HSE
 #else
@@ -70,13 +66,75 @@
 #define PLL_SRC                     RCC_PLLCFGR_PLLSRC_HSI
 #endif
 
-#endif /* CLOCK_USE_PLL */
+#endif /* CONFIG_USE_CLOCK_PLL */
 
 #if defined(CPU_FAM_STM32G0)
 #define RCC_CFGR_SW_HSI             (0)
 #define RCC_CFGR_SW_HSE             (RCC_CFGR_SW_0)
 #define RCC_CFGR_SW_PLL             (RCC_CFGR_SW_1)
+
+#if CONFIG_USE_CLOCK_HSI
+#if CONFIG_CLOCK_HSISYS_DIV == 1
+#define CLOCK_HSI_DIV               (0)
+#elif CONFIG_CLOCK_HSISYS_DIV == 2
+#define CLOCK_HSI_DIV               (RCC_CR_HSIDIV_0)
+#elif CONFIG_CLOCK_HSISYS_DIV == 4
+#define CLOCK_HSI_DIV               (RCC_CR_HSIDIV_1)
+#elif CONFIG_CLOCK_HSISYS_DIV == 8
+#define CLOCK_HSI_DIV               (RCC_CR_HSIDIV_1 | RCC_CR_HSIDIV_0)
+#elif CONFIG_CLOCK_HSISYS_DIV == 16
+#define CLOCK_HSI_DIV               (RCC_CR_HSIDIV_2)
+#elif CONFIG_CLOCK_HSISYS_DIV == 32
+#define CLOCK_HSI_DIV               (RCC_CR_HSIDIV_2 | RCC_CR_HSIDIV_0)
+#elif CONFIG_CLOCK_HSISYS_DIV == 64
+#define CLOCK_HSI_DIV               (RCC_CR_HSIDIV_2 | RCC_CR_HSIDIV_1)
+#elif CONFIG_CLOCK_HSISYS_DIV == 128
+#define CLOCK_HSI_DIV               (RCC_CR_HSIDIV_2 | RCC_CR_HSIDIV_1 | RCC_CR_HSIDIV_0)
 #endif
+#endif /* CONFIG_USE_CLOCK_HSI */
+
+#define CLOCK_AHB_DIV               (0)
+
+#if CONFIG_CLOCK_APB1_DIV == 1
+#define CLOCK_APB1_DIV              (0)
+#elif CONFIG_CLOCK_APB1_DIV == 2
+#define CLOCK_APB1_DIV              (RCC_CFGR_PPRE_2)
+#elif CONFIG_CLOCK_APB1_DIV == 4
+#define CLOCK_APB1_DIV              (RCC_CFGR_PPRE_2 | RCC_CFGR_PPRE_0)
+#elif CONFIG_CLOCK_APB1_DIV == 8
+#define CLOCK_APB1_DIV              (RCC_CFGR_PPRE_2 | RCC_CFGR_PPRE_1)
+#elif CONFIG_CLOCK_APB1_DIV == 16
+#define CLOCK_APB1_DIV              (RCC_CFGR_PPRE_2 | RCC_CFGR_PPRE_1 | RCC_CFGR_PPRE_0)
+#endif
+#endif /* CPU_FAM_STM32G0 */
+
+#if defined(CPU_FAM_STM32G4)
+#define CLOCK_AHB_DIV               (RCC_CFGR_HPRE_DIV1)
+
+#if CONFIG_CLOCK_APB1_DIV == 1
+#define CLOCK_APB1_DIV              (RCC_CFGR_PPRE1_DIV1)
+#elif CONFIG_CLOCK_APB1_DIV == 2
+#define CLOCK_APB1_DIV              (RCC_CFGR_PPRE1_DIV2)
+#elif CONFIG_CLOCK_APB1_DIV == 4
+#define CLOCK_APB1_DIV              (RCC_CFGR_PPRE1_DIV4)
+#elif CONFIG_CLOCK_APB1_DIV == 8
+#define CLOCK_APB1_DIV              (RCC_CFGR_PPRE1_DIV8)
+#elif CONFIG_CLOCK_APB1_DIV == 16
+#define CLOCK_APB1_DIV              (RCC_CFGR_PPRE1_DIV16)
+#endif
+
+#if CONFIG_CLOCK_APB2_DIV == 1
+#define CLOCK_APB2_DIV              (RCC_CFGR_PPRE2_DIV1)
+#elif CONFIG_CLOCK_APB2_DIV == 2
+#define CLOCK_APB2_DIV              (RCC_CFGR_PPRE2_DIV2)
+#elif CONFIG_CLOCK_APB2_DIV == 4
+#define CLOCK_APB2_DIV              (RCC_CFGR_PPRE2_DIV4)
+#elif CONFIG_CLOCK_APB2_DIV == 8
+#define CLOCK_APB2_DIV              (RCC_CFGR_PPRE2_DIV8)
+#elif CONFIG_CLOCK_APB2_DIV == 16
+#define CLOCK_APB2_DIV              (RCC_CFGR_PPRE2_DIV16)
+#endif
+#endif /* CPU_FAM_STM32G4 */
 
 /** Determine the required flash wait states from the core clock frequency */
 #if defined(CPU_FAM_STM32G0)
@@ -137,15 +195,25 @@ void stmclk_init_sysclk(void)
     stmclk_enable_lfclk();
 #endif
 
-#if CLOCK_USE_HSE
+#if CONFIG_USE_CLOCK_HSI && defined(CPU_FAM_STM32G0)
+    /* configure HSISYS divider, only available on G0 */
+    RCC->CR |= CLOCK_HSI_DIV;
+    while (!(RCC->CR & RCC_CR_HSIRDY)) {}
+
+#elif CONFIG_USE_CLOCK_HSE
     /* if configured, we need to enable the HSE clock now */
     RCC->CR |= RCC_CR_HSEON;
     while (!(RCC->CR & RCC_CR_HSERDY)) {}
 
+#if defined(CPU_FAM_STM32G0)
+    RCC->CFGR = (RCC_CFGR_SW_HSE | CLOCK_AHB_DIV | CLOCK_APB1_DIV);
+#elif defined(CPU_FAM_STM32G4)
     RCC->CFGR = (RCC_CFGR_SW_HSE | CLOCK_AHB_DIV | CLOCK_APB1_DIV | CLOCK_APB2_DIV);
+#endif
     while ((RCC->CFGR & RCC_CFGR_SWS) != RCC_CFGR_SWS_HSE) {}
-#elif CLOCK_USE_PLL
-#if CLOCK_HSE
+
+#elif CONFIG_USE_CLOCK_PLL
+#if CONFIG_BOARD_HAS_HSE
     /* if configured, we need to enable the HSE clock now */
     RCC->CR |= RCC_CR_HSEON;
     while (!(RCC->CR & RCC_CR_HSERDY)) {}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR reworks the clock configuration of stm32g0 and stm32g4 to make it even more flexible. It also add Kconfig options to easily configure the clock without having to edit RIOT's code:
- the logic is kept in a common header file with good defaults
- it's now possible to choose between several clock source among HSI, HSE and PLL (the default)
- the APBx prescalers can also be configured
- at the board specific level, one can declare if a board provides an LSE or an HSE (and if it's the case, specify the frequency of the HSE)

This PR is very similar to #14614 but applied to STM32Gx. There's still room for improvement but this PR is already a good start IMHO.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Apply the following patch to print the different clock values (sysclock, APBx clocks) using `examples/hello-world`
```diff
diff --git a/examples/hello-world/main.c b/examples/hello-world/main.c
index f51bf8c0a0..9786bc1cdb 100644
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -21,6 +21,8 @@
 
 #include <stdio.h>
 
+#include "board.h"
+
 int main(void)
 {
     puts("Hello World!");
@@ -28,5 +30,14 @@ int main(void)
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);
 
+    printf("Clock coreclock: %u\n", CLOCK_CORECLOCK);
+    printf("AHB clock: %u\n", CLOCK_AHB);
+    printf("APB1 clock: %u\n", CLOCK_APB1);
+    printf("APB1 div: %d\n", CONFIG_CLOCK_APB1_DIV);
+#ifdef CLOCK_APB2
+    printf("APB2 clock: %u\n", CLOCK_APB2);
+    printf("APB2 div: %d\n", CONFIG_CLOCK_APB2_DIV);
+#endif
+
     return 0;
 }
```

- Run `make BOARD=nucleo-g070rb -C examples/hello-world menuconfig` and select different clock source and, depending on the clock source, tweak some parameters. The application will print the following output:

When running `make menuconfig`, there's an entry for configuring the STM32 G0 clock. When selected the G0 clock configuration menu should look like this by default:

![image](https://user-images.githubusercontent.com/1375137/91048025-4dae5e80-e61b-11ea-9e90-aa036d490b3f.png)


<details><summary>Default values (PLL clocked by HSI, M=1, N=20, R=5 => 64MHz):</summary>

```
BUILD_IN_DOCKER=1 make BOARD=nucleo-g070rb -C examples/hello-world clean flash term --no-print-directory 
rm -rf /work/riot/RIOT/examples/hello-world/bin/nucleo-g070rb/pkg-build/stm32cmsis
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-g070rb'  -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make 'BOARD=nucleo-g070rb'    
Building application "hello-world" for "nucleo-g070rb" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/pkg/stm32cmsis
"make" -C /data/riotbuild/riotbase/boards/nucleo-g070rb
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/bootloader
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8488	    112	   2568	  11168	   2ba0	/data/riotbuild/riotbase/examples/hello-world/bin/nucleo-g070rb/hello-world.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/examples/hello-world/bin/nucleo-g070rb/hello-world.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01383-gd46f28c2e-dirty (2020-08-20-10:53)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 2000 kHz
Info : STLINK V2J31M21 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.222947
Info : stm32g0x.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for stm32g0x.cpu on 0
Info : Listening on port 44337 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32g0x.cpu       hla_target little stm32g0x.cpu       reset

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0xf1000000 pc: 0x08000424 msp: 0x20000200
Info : device idcode = 0x20006460 (STM32G07/G08xx - Rev: B)
Info : flash size = 128kbytes
Info : flash mode : single-bank
Warn : Adding extra erase range, 0x08002198 .. 0x080027ff
auto erase enabled
wrote 8600 bytes from file /work/riot/RIOT/examples/hello-world/bin/nucleo-g070rb/hello-world.elf in 0.271347s (30.951 KiB/s)

verified 8600 bytes in 0.070959s (118.356 KiB/s)

Info : Unable to match requested speed 2000 kHz, using 1800 kHz
Info : Unable to match requested speed 2000 kHz, using 1800 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-08-24 14:56:10,045 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2020-08-24 14:56:11,821 # main(): This is RIOT! (Version: 2020.10-devel-921-gc2ef7-pr/boards/stm32gx_clock_kconfig)
2020-08-24 14:56:11,822 # Hello World!
2020-08-24 14:56:11,827 # You are running RIOT on a(n) nucleo-g070rb board.
2020-08-24 14:56:11,830 # This board features a(n) stm32 MCU.
2020-08-24 14:56:11,832 # Clock coreclock: 64000000
2020-08-24 14:56:11,834 # AHB clock: 64000000
2020-08-24 14:56:11,836 # APB1 clock: 64000000
2020-08-24 14:56:11,837 # APB1 div: 1
2020-08-24 14:56:12,909 # Exiting Pyterm
```

</details>


<details><summary>HSI with default HSISYS division factor (expected clock 16MHz):</summary>

![image](https://user-images.githubusercontent.com/1375137/91047814-f3ad9900-e61a-11ea-9d04-e813c98f9970.png)

![image](https://user-images.githubusercontent.com/1375137/91048106-6f0f4a80-e61b-11ea-9418-1eba00de7f38.png)

```
2020-08-24 15:01:25,983 # main(): This is RIOT! (Version: 2020.10-devel-921-gc2ef7-pr/boards/stm32gx_clock_kconfig)
2020-08-24 15:01:25,984 # Hello World!
2020-08-24 15:01:25,988 # You are running RIOT on a(n) nucleo-g070rb board.
2020-08-24 15:01:25,992 # This board features a(n) stm32 MCU.
2020-08-24 15:01:25,994 # Clock coreclock: 16000000
2020-08-24 15:01:25,996 # AHB clock: 16000000
2020-08-24 15:01:25,999 # APB1 clock: 16000000
2020-08-24 15:01:26,000 # APB1 div: 1
```

</details>

<details><summary>HSI with HSISYS division factor 8 (expected clock 2MHz):</summary>

![image](https://user-images.githubusercontent.com/1375137/91048206-9534ea80-e61b-11ea-8611-a7fc47b0403f.png)

![image](https://user-images.githubusercontent.com/1375137/91048246-aa117e00-e61b-11ea-8e66-aa307cada803.png)

```
2020-08-24 15:02:19,898 # main(): This is RIOT! (Version: 2020.10-devel-921-gc2ef7-pr/boards/stm32gx_clock_kconfig)
2020-08-24 15:02:19,900 # Hello World!
2020-08-24 15:02:19,906 # You are running RIOT on a(n) nucleo-g070rb board.
2020-08-24 15:02:19,911 # This board features a(n) stm32 MCU.
2020-08-24 15:02:19,914 # Clock coreclock: 2000000
2020-08-24 15:02:19,917 # AHB clock: 2000000
2020-08-24 15:02:19,920 # APB1 clock: 2000000
2020-08-24 15:02:19,923 # APB1 div: 1
```

</details>

<details><summary>PLL with N=10 (expected clock 32MHz):</summary>

![image](https://user-images.githubusercontent.com/1375137/91048314-c7dee300-e61b-11ea-8d64-e82e87253f13.png)


```
2020-08-24 15:09:46,056 # main(): This is RIOT! (Version: 2020.10-devel-921-gc2ef7-pr/boards/stm32gx_clock_kconfig)
2020-08-24 15:09:46,057 # Hello World!
2020-08-24 15:09:46,062 # You are running RIOT on a(n) nucleo-g070rb board.
2020-08-24 15:09:46,065 # This board features a(n) stm32 MCU.
2020-08-24 15:09:46,067 # Clock coreclock: 32000000
2020-08-24 15:09:46,070 # AHB clock: 32000000
2020-08-24 15:09:46,071 # APB1 clock: 32000000
2020-08-24 15:09:46,072 # APB1 div: 1
```

</details>

<details><summary>Default PLL with APB division factor 8 (expected APB1 clock 8MHz):</summary>

![image](https://user-images.githubusercontent.com/1375137/91048447-fd83cc00-e61b-11ea-89f4-4b36193f83f0.png)

```
2020-08-24 15:11:14,082 # main(): This is RIOT! (Version: 2020.10-devel-921-gc2ef7-pr/boards/stm32gx_clock_kconfig)
2020-08-24 15:11:14,083 # Hello World!
2020-08-24 15:11:14,088 # You are running RIOT on a(n) nucleo-g070rb board.
2020-08-24 15:11:14,091 # This board features a(n) stm32 MCU.
2020-08-24 15:11:14,093 # Clock coreclock: 64000000
2020-08-24 15:11:14,095 # AHB clock: 64000000
2020-08-24 15:11:14,097 # APB1 clock: 8000000
2020-08-24 15:11:14,098 # APB1 div: 8
```

</details>

- On nucleo-g474re the above parameters could also be tested (and adapted). One can also verify that the HSE input clock source is also available (since this board provides and HSE):

![image](https://user-images.githubusercontent.com/1375137/91048744-63705380-e61c-11ea-8066-b0c0b8d8881e.png)

If it's selected, the core clock is running at 24MHz:

```
2020-08-24 15:15:07,464 # main(): This is RIOT! (Version: 2020.10-devel-921-gc2ef7-pr/boards/stm32gx_clock_kconfig)
2020-08-24 15:15:07,465 # Hello World!
2020-08-24 15:15:07,470 # You are running RIOT on a(n) nucleo-g474re board.
2020-08-24 15:15:07,473 # This board features a(n) stm32 MCU.
2020-08-24 15:15:07,475 # Clock coreclock: 24000000
2020-08-24 15:15:07,478 # AHB clock: 24000000
2020-08-24 15:15:07,480 # APB1 clock: 24000000
2020-08-24 15:15:07,481 # APB1 div: 1
2020-08-24 15:15:07,482 # APB2 clock: 24000000
2020-08-24 15:15:07,483 # APB2 div: 1
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
