### PR TITLE
net/gnrc/rpl: fix default route lifetime

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -66,6 +66,15 @@ static void _rpl_trickle_send_dio(void *args)
           ipv6_addr_to_str(addr_str,&dodag->dodag_id, sizeof(addr_str)));
 }
 
+/* The lifetime of the default route should exceed the parent timeout interval
+ * by the time we allow the node to probe its parent */
+static uint16_t _dflt_route_lifetime_sec(gnrc_rpl_dodag_t *dodag)
+{
+    return (dodag->default_lifetime * dodag->lifetime_unit) +
+           (GNRC_RPL_PARENT_TIMEOUT *
+            (GNRC_RPL_PARENT_PROBE_INTERVAL / MS_PER_SEC));
+}
+
 bool gnrc_rpl_instance_add(uint8_t instance_id, gnrc_rpl_instance_t **inst)
 {
     *inst = NULL;
@@ -235,9 +244,8 @@ bool gnrc_rpl_parent_remove(gnrc_rpl_parent_t *parent)
 
         /* set the default route to the next parent for now */
         if (parent->next) {
-            gnrc_ipv6_nib_ft_add(NULL, 0,
-                                 &parent->next->addr, dodag->iface,
-                                 dodag->default_lifetime * dodag->lifetime_unit * MS_PER_SEC);
+            gnrc_ipv6_nib_ft_add(NULL, 0, &parent->next->addr, dodag->iface,
+                                 _dflt_route_lifetime_sec(dodag));
         }
     }
     LL_DELETE(dodag->parents, parent);
@@ -278,7 +286,7 @@ void gnrc_rpl_parent_update(gnrc_rpl_dodag_t *dodag, gnrc_rpl_parent_t *parent)
     if ((parent != NULL) && (parent->state != GNRC_RPL_PARENT_UNUSED)) {
         parent->state = GNRC_RPL_PARENT_ACTIVE;
         evtimer_del((evtimer_t *)(&gnrc_rpl_evtimer), (evtimer_event_t *)&parent->timeout_event);
-        ((evtimer_event_t *)&(parent->timeout_event))->offset = dodag->default_lifetime * dodag->lifetime_unit * MS_PER_SEC;
+        ((evtimer_event_t *)&(parent->timeout_event))->offset = (dodag->default_lifetime - 1) * dodag->lifetime_unit * MS_PER_SEC;
         parent->timeout_event.msg.type = GNRC_RPL_MSG_TYPE_PARENT_TIMEOUT;
         evtimer_add_msg(&gnrc_rpl_evtimer, &parent->timeout_event, gnrc_rpl_pid);
 #ifdef MODULE_GNRC_RPL_P2P
@@ -287,7 +295,7 @@ void gnrc_rpl_parent_update(gnrc_rpl_dodag_t *dodag, gnrc_rpl_parent_t *parent)
         if (parent == dodag->parents) {
             gnrc_ipv6_nib_ft_del(NULL, 0);
             gnrc_ipv6_nib_ft_add(NULL, 0, &parent->addr, dodag->iface,
-                                 dodag->default_lifetime * dodag->lifetime_unit);
+                                 _dflt_route_lifetime_sec(dodag));
         }
 #ifdef MODULE_GNRC_RPL_P2P
         }


### PR DESCRIPTION
### Contribution description
Running some IP-over-BLE experiments using RPL, I stumbled over some packet loss which at first I could not explain. On random basis, every now an then a node started dropping IP packets for a short amount of time (~4-5s), although there was no packet loss on the link layer. 

After some digging, I found this was caused by be default route being removed for a short amount of time. If a node tried to send an IP packet to its parent node exactly in that time frame, where the default route entry was gone, this packet was dropped. However, since there was no packet loss on the link layer, the default route should never be removed in the first place....

After some more digging I was able to find the reason for this: when a node receives a DIO message from its parent, it sets a PARENT_TIMEOUT timer and updates the forwarding table (FT) entry of the default route with a given lifetime. The problem at hand is, that the current implementation uses exactly the same value (default is 300s) for both the PARENT_TIMEOUT timer AND the FT entry lifetime. Once this time runs up, the default route is removed from the FT and the PARENT_TIMEOUT event are is triggered at the same time. But to refresh the default route, RPL needs to probe the parent (by sending a DIS) and await and parse the response (DIO). 

So while waiting for the DIO to arrive, the default route is not set, leading to the faulty behavior described on top. Keeping in mind, that DIS or DIO messages might as well be lost on lossy links, the time span without a valid default route is even prolonged, increasing the potential packet loss...

The solution is quite simple: when setting the default route's lifetime, we simply need to add the time it takes the RPL node to probe its parent to the default lifetime. In particular, the probing may take a maximum of `GNRC_RPL_PARENT_TIMEOUT * GNRC_RPL_PARENT_PROBE_INTERVAL (-> 5 * 2000)`us. So this PR adds that time on top of the default lifetime of `CONFIG_GNRC_RPL_DEFAULT_LIFETIME * CONFIG_GNRC_RPL_DEFAULT_LIFETIME (5 * 60)`s.

Bonus: this PR also fixes a time scale conversion bug in `gnrc_rpl_parent_remove()`: `gnrc_ipv6_nib_ft_add()` takes the lifetime in seconds, but in `gnrc_rpl_parent_remove()` it was given in `us`. Seems this code was never tested :-)


### Testing procedure
Probably build test + release tests for RPL.

On top, here are the before and after packet delivery rates from my IP-over-BLE experiment:
Master:
[em7_uni_statconn-rpl_1s1h59b_20200824-100524_pdr.pdf](https://github.com/RIOT-OS/RIOT/files/5118588/em7_uni_statconn-rpl_1s1h59b_20200824-100524_pdr.pdf)


With this fix:
[em7_uni_statconn-rpl_1s1h59b_20200824-143116_pdr.pdf](https://github.com/RIOT-OS/RIOT/files/5118586/em7_uni_statconn-rpl_1s1h59b_20200824-143116_pdr.pdf)

### Issues/PRs references
none