### PR TITLE
board/cc2538dk: Restore renode config

### DIFF
--- a/boards/cc2538dk/dist/board.resc
+++ b/boards/cc2538dk/dist/board.resc
@@ -1,0 +1,30 @@
+mach create
+using sysbus
+machine LoadPlatformDescription @platforms/cpus/cc2538.repl
+
+machine PyDevFromFile @scripts/pydev/rolling-bit.py 0x400D2004 0x4 True "sysctrl"
+
+# show the UART output
+showAnalyzer uart0
+
+# get an id value starting with 1
+$id = `next_value 1`
+
+macro reset
+"""
+    # set node address based on the $id variable. 0x00 0x12 0x4B is TI OUI
+    sysbus WriteByte 0x00280028 $id
+    sysbus WriteByte 0x0028002C 0x00
+    sysbus WriteByte 0x00280030 0xAB
+    sysbus WriteByte 0x00280034 0x89
+    sysbus WriteByte 0x00280038 0x00
+    sysbus WriteByte 0x0028003C 0x4B
+    sysbus WriteByte 0x00280040 0x12
+    sysbus WriteByte 0x00280044 0x00
+    sysbus LoadBinary @http://antmicro.com/projects/renode/cc2538_rom_dump.bin-s_524288-0c196cdc21b5397f82e0ff42b206d1cc4b6d7522 0x0
+    sysbus LoadELF $image_file
+    cpu VectorTableOffset 0x200000
+"""
+
+runMacro $reset
+start


### PR DESCRIPTION
### Contribution description

Restores the board.resc config file for the cc2538.

### Testing procedure

If you have renode installed just use:

`BOARD=cc2538dk make all emulate -C tests/shell`


### Issues/PRs references
accidentally removed in #14724
