### PR TITLE
picolibc: only enable stdout buffering for CDC ACM, ethos, semihosting & SLIP

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -86,6 +86,7 @@ PSEUDOMODULES += newlib_gnu_source
 PSEUDOMODULES += newlib_nano
 PSEUDOMODULES += openthread
 PSEUDOMODULES += picolibc
+PSEUDOMODULES += picolibc_stdout_buffered
 PSEUDOMODULES += pktqueue
 PSEUDOMODULES += posix_headers
 PSEUDOMODULES += printf_float

--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -55,3 +55,10 @@ ifneq (,$(filter stdio_semihosting,$(USEMODULE)))
   USEMODULE += xtimer
   FEATURES_REQUIRED += cpu_core_cortexm
 endif
+
+# enable stdout buffering for modules that benefit from sending out buffers in larger chunks
+ifneq (,$(filter picolibc,$(USEMODULE)))
+  ifneq (,$(filter stdio_cdc_acm stdio_ethos slipdev_stdio stdio_semihosting,$(USEMODULE)))
+    USEMODULE += picolibc_stdout_buffered
+  endif
+endif

--- a/sys/picolibc_syscalls_default/syscalls.c
+++ b/sys/picolibc_syscalls_default/syscalls.c
@@ -63,10 +63,12 @@ int kill(pid_t pid, int sig)
 
 #include "mutex.h"
 
-static mutex_t picolibc_put_mutex = MUTEX_INIT;
-
+#ifndef PICOLIBC_STDOUT_BUFSIZE
 #define PICOLIBC_STDOUT_BUFSIZE 64
+#endif
 
+#ifdef MODULE_PICOLIBC_STDOUT_BUFFERED
+static mutex_t picolibc_put_mutex = MUTEX_INIT;
 static char picolibc_stdout[PICOLIBC_STDOUT_BUFSIZE];
 static int picolibc_stdout_queued;
 
@@ -81,10 +83,14 @@ static void _picolibc_flush(void)
 static int picolibc_put(char c, FILE *file)
 {
     (void)file;
+
     mutex_lock(&picolibc_put_mutex);
     picolibc_stdout[picolibc_stdout_queued++] = c;
-    if (picolibc_stdout_queued == PICOLIBC_STDOUT_BUFSIZE || c == '\n')
+
+    if (picolibc_stdout_queued == PICOLIBC_STDOUT_BUFSIZE || c == '\n') {
         _picolibc_flush();
+    }
+
     mutex_unlock(&picolibc_put_mutex);
     return 1;
 }
@@ -97,6 +103,22 @@ static int picolibc_flush(FILE *file)
     mutex_unlock(&picolibc_put_mutex);
     return 0;
 }
+
+#else
+int picolibc_put(char c, FILE *file)
+{
+    (void)file;
+    stdio_write(&c, 1);
+    return 1;
+}
+
+static int picolibc_flush(FILE *file)
+{
+    (void)file;
+    return 0;
+}
+
+#endif
 
 static int picolibc_get(FILE *file)
 {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

CDC ACM, ethos, Semihosting and SLIP all benefit from sending data out in larger chunks and will benefit from stdout buffering.

`stdio_rtt` does have an internal TX buffer, so we don't need to do any buffering on top.

With plain UART there was a slight advantage *without* buffering when testing with `tests/periph_uart_nonblocking` (with the non-blocking feature disabled).

Since the removal of the buffering saves us some RAM and ROM, disable it by default there.

This will be different with DMA enabled UARTs.


### Testing procedure

Run e.g. `tests/periph_uart_nonblocking` with `PICOLIBC=1` and disable the `periph_uart_nonblocking` feature in the `Makefile`.

This will print a lot of text and measure the time it took.

For UART on `samr21-xpro` I see

#### with buffering

```
   text	   data	    bss	    dec	    hex	filename
   8832	     44	   2728	  11604	   2d54	/home/benpicco/dev/RIOT/tests/periph_uart_nonblocking/bin/samr21-xpro/tests_periph_uart_nonblocking.elf

…
2020-08-24 18:54:47,990 # == printed in 2155228/2100000 µs ==
```

#### without buffering

```
   text	   data	    bss	    dec	    hex	filename
   8736	     44	   2656	  11436	   2cac	/home/benpicco/dev/RIOT/tests/periph_uart_nonblocking/bin/samr21-xpro/tests_periph_uart_nonblocking.elf

…
2020-08-24 18:54:15,423 # == printed in 2154940/2100000 µs ==
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
