### PR TITLE
sys/fmt: use fwrite with picolibc

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -24,7 +24,8 @@
 #include <unistd.h>
 #include <string.h>
 
-#if defined(__WITH_AVRLIBC__) || defined(__mips__)
+#if defined(__WITH_AVRLIBC__) || defined(__mips__) || defined(MODULE_PICOLIBC)
+#define USE_FWRITE
 #include <stdio.h>  /* for fwrite() */
 #else
 /* work around broken sys/posix/unistd.h */
@@ -503,7 +504,7 @@ uint32_t scn_u32_hex(const char *str, size_t n)
 
 void print(const char *s, size_t n)
 {
-#ifdef __WITH_AVRLIBC__
+#ifdef USE_FWRITE
     /* AVR's libc doesn't offer write(), so use fwrite() instead */
     fwrite(s, n, 1, stdout);
 #else
@@ -515,7 +516,7 @@ void print(const char *s, size_t n)
         n -= written;
         s += written;
     }
-#endif /* __WITH_AVRLIBC__ */
+#endif /* USE_FWRITE */
 }
 
 void print_u32_dec(uint32_t val)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Use `fwrite()` instead of `write()` to fix linking with picolibc.

(Why even keep the separate `write` codepath?)

### Testing procedure

    make -C examples/gnrc_networking BOARD=samr21-xpro PICOLIBC=1 -j

should be working now.


### Issues/PRs references

follow-up to #14827
#14843 offers a more comprehensive solution. 
