### PR TITLE
pkg/lwip: start dhcp also for stm32_eth

### DIFF
--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -269,7 +269,8 @@ void lwip_bootstrap(void)
 #endif
     /* also allow for external interface definition */
     tcpip_init(NULL, NULL);
-#if IS_USED(MODULE_LWIP_DHCP_AUTO) && IS_USED(MODULE_NETDEV_TAP)
+#if IS_USED(MODULE_LWIP_DHCP_AUTO) && \
+    (IS_USED(MODULE_NETDEV_TAP) || IS_USED(MODULE_STM32_ETH))
     /* XXX: Hack to get DHCP with IPv4 with `netdev_tap`, as it does
      * not emit a `NETDEV_EVENT_LINK_UP` event. Remove, once it does
      * at an appropriate point.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the issue reported in #14816. It also start the dhcp when auto dhcp is enabled and stm32_eth is loaded.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Connect an stm32 board with an ethernet interface to a network with a DHCP server
- Configure LWIP as shown in #14816
- The board should automatically configure an IPv4 address

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fix proposed that solved #14816

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
