### PR TITLE
tests/driver_netdev_common: add netdev_default

### DIFF
--- a/cpu/atmega128rfa1/Makefile.dep
+++ b/cpu/atmega128rfa1/Makefile.dep
@@ -3,7 +3,7 @@ ifneq (,$(filter atmega_pcint,$(USEMODULE)))
   USEMODULE += atmega_pcint1
 endif
 
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += at86rfa1
 endif
 

--- a/cpu/atmega256rfr2/Makefile.dep
+++ b/cpu/atmega256rfr2/Makefile.dep
@@ -3,7 +3,7 @@ ifneq (,$(filter atmega_pcint,$(USEMODULE)))
   USEMODULE += atmega_pcint1
 endif
 
-ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   USEMODULE += at86rfr2
 endif
 

--- a/cpu/esp32/doc.txt
+++ b/cpu/esp32/doc.txt
@@ -1145,7 +1145,7 @@ The RIOT port for ESP32 realizes with module ```esp_eth``` a ```netdev``` driver
 
 If the board has one of the supported PHY layer chips connected to the ESP32, the ```esp_eth``` module should be enabled by default in board's ```Makefile.dep``` when module ```netdev_default``` is used.
 ```
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
     USEMODULE += esp_eth
 endif
 ```

--- a/cpu/esp32/esp-eth/doc.txt
+++ b/cpu/esp32/esp-eth/doc.txt
@@ -22,7 +22,7 @@ The RIOT port for ESP32 realizes with module ```esp_eth``` a ```netdev``` driver
 
 If the board has one of the supported PHY layer chips connected to the ESP32, the ```esp_eth``` module should be enabled by default in board's ```Makefile.dep``` when module ```netdev_default``` is used.
 ```
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
     USEMODULE += esp_eth
 endif
 ```

--- a/cpu/esp_common/Makefile.dep
+++ b/cpu/esp_common/Makefile.dep
@@ -25,7 +25,7 @@ ifneq (,$(filter esp_wifi_enterprise,$(USEMODULE)))
   USEMODULE += esp_wifi
 endif
 
-ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
+ifneq (,$(filter netdev_default,$(USEMODULE)))
   ifneq (,$(filter lwip,$(USEMODULE)))
     # for lwip, use esp_wifi as default netdev if no other netdev is enabled
     ifeq (,$(filter esp_eth,$(USEMODULE)))

--- a/tests/driver_at86rf215/Makefile
+++ b/tests/driver_at86rf215/Makefile
@@ -3,4 +3,4 @@ BOARD ?= openmote-b
 # the radio driver to test
 USEMODULE += at86rf215
 
-include ../driver_netdev_common/Makefile
+include ../driver_netdev_common/Makefile.netdev.mk

--- a/tests/driver_atwinc15x0/Makefile
+++ b/tests/driver_atwinc15x0/Makefile
@@ -4,4 +4,4 @@ USEMODULE = atwinc15x0
 # msp430-gcc doesn't support -Wno-discarded-qualifiers
 FEATURES_BLACKLIST += arch_msp430
 
-include ../driver_netdev_common/Makefile
+include ../driver_netdev_common/Makefile.netdev.mk

--- a/tests/driver_dose/Makefile
+++ b/tests/driver_dose/Makefile
@@ -1,4 +1,4 @@
 # the driver to test
 USEMODULE = dose
 
-include ../driver_netdev_common/Makefile
+include ../driver_netdev_common/Makefile.netdev.mk

--- a/tests/driver_mrf24j40/Makefile
+++ b/tests/driver_mrf24j40/Makefile
@@ -1,4 +1,4 @@
 # the radio driver to test
 USEMODULE = mrf24j40md
 
-include ../driver_netdev_common/Makefile
+include ../driver_netdev_common/Makefile.netdev.mk

--- a/tests/driver_netdev_common/Makefile
+++ b/tests/driver_netdev_common/Makefile
@@ -1,4 +1,4 @@
 # use the default network interface for the board
-USEMODULE += netdev_default
+USEMODULE += gnrc_netdev_default
 
 include Makefile.netdev.mk

--- a/tests/driver_netdev_common/Makefile
+++ b/tests/driver_netdev_common/Makefile
@@ -1,28 +1,4 @@
-include ../Makefile.tests_common
+# use the default network interface for the board
+USEMODULE += netdev_default
 
-# Modules to include:
-USEMODULE += shell
-USEMODULE += shell_commands
-USEMODULE += ps
-
-# allow to use a smaller packet buffer in low-PDU drivers
-ifdef GNRC_PKTBUF_SIZE
-  CFLAGS += -DCONFIG_GNRC_PKTBUF_SIZE=$(GNRC_PKTBUF_SIZE)
-endif
-
-# gnrc is a meta module including all required, basic gnrc networking modules
-USEMODULE += gnrc
-
-# automatically initialize the network interface
-USEMODULE += auto_init_gnrc_netif
-
-# shell command to send L2 packets with a simple string
-USEMODULE += gnrc_txtsnd
-
-# the application dumps received packets to stdout
-USEMODULE += gnrc_pktdump
-
-include $(RIOTBASE)/Makefile.include
-
-# Set a custom channel if needed
-include $(RIOTMAKE)/default-radio-settings.inc.mk
+include Makefile.netdev.mk

--- a/tests/driver_netdev_common/Makefile.netdev.mk
+++ b/tests/driver_netdev_common/Makefile.netdev.mk
@@ -1,0 +1,28 @@
+include ../Makefile.tests_common
+
+# Modules to include:
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+# allow to use a smaller packet buffer in low-PDU drivers
+ifdef GNRC_PKTBUF_SIZE
+  CFLAGS += -DCONFIG_GNRC_PKTBUF_SIZE=$(GNRC_PKTBUF_SIZE)
+endif
+
+# gnrc is a meta module including all required, basic gnrc networking modules
+USEMODULE += gnrc
+
+# automatically initialize the network interface
+USEMODULE += auto_init_gnrc_netif
+
+# shell command to send L2 packets with a simple string
+USEMODULE += gnrc_txtsnd
+
+# the application dumps received packets to stdout
+USEMODULE += gnrc_pktdump
+
+include $(RIOTBASE)/Makefile.include
+
+# Set a custom channel if needed
+include $(RIOTMAKE)/default-radio-settings.inc.mk

--- a/tests/driver_w5100/Makefile
+++ b/tests/driver_w5100/Makefile
@@ -1,4 +1,4 @@
 # the driver to test
 USEMODULE = w5100
 
-include ../driver_netdev_common/Makefile
+include ../driver_netdev_common/Makefile.netdev.mk

--- a/tests/driver_xbee/Makefile
+++ b/tests/driver_xbee/Makefile
@@ -3,4 +3,4 @@ USEMODULE += xbee
 # No need of big buffer for this test
 GNRC_PKTBUF_SIZE=512
 
-include ../driver_netdev_common/Makefile
+include ../driver_netdev_common/Makefile.netdev.mk


### PR DESCRIPTION
### Contribution description

The test was missing `netdev_default` so there was no `ifconfig`:

### Testing procedure

`BOARD=samr21-xpro make -C tests/driver_netdev_common/ flash term -j3`

- master

```
> ifconfig
2020-08-25 14:44:00,431 #  ifconfig
> 
```

- pr

```
ifconfig
2020-08-25 14:43:06,354 # ifconfig
2020-08-25 14:43:06,361 # Iface  4  HWaddr: 0F:F4  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2020-08-25 14:43:06,362 #           
2020-08-25 14:43:06,366 #           Long HWaddr: 96:8D:13:13:55:32:7E:78 
2020-08-25 14:43:06,373 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-08-25 14:43:06,380 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  Source address length: 2
2020-08-25 14:43:06,381 #  
```

