### PR TITLE
Declare adc_config[] like others peripherals configuration arrays

### DIFF
--- a/boards/airfy-beacon/include/periph_conf.h
+++ b/boards/airfy-beacon/include/periph_conf.h
@@ -86,8 +86,9 @@ static const i2c_conf_t i2c_config[] = {
  * The configuration consists simply of a list of channels that should be used
  * @{
  */
-#define ADC_CONFIG          {3, 4, 5, 6}
-#define ADC_NUMOF           (4)
+static const adc_conf_t adc_config[] = {3, 4, 5, 6};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/common/blxxxpill/include/periph_conf.h
+++ b/boards/common/blxxxpill/include/periph_conf.h
@@ -73,18 +73,18 @@ extern "C" {
  * @{
  */
 static const adc_conf_t adc_config[] = {
-    { .dev = 0, .pin = GPIO_PIN(PORT_A, 0), .chan = 0 },
-    { .dev = 0, .pin = GPIO_PIN(PORT_A, 1), .chan = 1 },
-    { .dev = 0, .pin = GPIO_PIN(PORT_A, 4), .chan = 4 },
-    { .dev = 0, .pin = GPIO_PIN(PORT_A, 5), .chan = 5 },
-    { .dev = 0, .pin = GPIO_PIN(PORT_A, 6), .chan = 6 },
-    { .dev = 0, .pin = GPIO_PIN(PORT_A, 7), .chan = 7 },
-    { .dev = 0, .pin = GPIO_PIN(PORT_B, 0), .chan = 8 },
-    { .dev = 0, .pin = GPIO_PIN(PORT_B, 1), .chan = 9 },
+    { .pin = GPIO_PIN(PORT_A, 0), .dev = 0, .chan = 0 },
+    { .pin = GPIO_PIN(PORT_A, 1), .dev = 0, .chan = 1 },
+    { .pin = GPIO_PIN(PORT_A, 4), .dev = 0, .chan = 4 },
+    { .pin = GPIO_PIN(PORT_A, 5), .dev = 0, .chan = 5 },
+    { .pin = GPIO_PIN(PORT_A, 6), .dev = 0, .chan = 6 },
+    { .pin = GPIO_PIN(PORT_A, 7), .dev = 0, .chan = 7 },
+    { .pin = GPIO_PIN(PORT_B, 0), .dev = 0, .chan = 8 },
+    { .pin = GPIO_PIN(PORT_B, 1), .dev = 0, .chan = 9 },
     /* ADC Temperature channel */
-    { .dev = 0, .pin = GPIO_UNDEF, .chan = 16 },
+    { .pin = GPIO_UNDEF, .dev = 0, .chan = 16 },
     /* ADC VREF channel */
-    { .dev = 0, .pin = GPIO_UNDEF, .chan = 17 },
+    { .pin = GPIO_UNDEF, .dev = 0, .chan = 17 },
 };
 
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)

--- a/boards/common/blxxxpill/include/periph_conf.h
+++ b/boards/common/blxxxpill/include/periph_conf.h
@@ -72,22 +72,22 @@ extern "C" {
  * @name    ADC configuration
  * @{
  */
-#define ADC_CONFIG {                                     \
-    { .dev = 0, .pin = GPIO_PIN(PORT_A, 0), .chan = 0 }, \
-    { .dev = 0, .pin = GPIO_PIN(PORT_A, 1), .chan = 1 }, \
-    { .dev = 0, .pin = GPIO_PIN(PORT_A, 4), .chan = 4 }, \
-    { .dev = 0, .pin = GPIO_PIN(PORT_A, 5), .chan = 5 }, \
-    { .dev = 0, .pin = GPIO_PIN(PORT_A, 6), .chan = 6 }, \
-    { .dev = 0, .pin = GPIO_PIN(PORT_A, 7), .chan = 7 }, \
-    { .dev = 0, .pin = GPIO_PIN(PORT_B, 0), .chan = 8 }, \
-    { .dev = 0, .pin = GPIO_PIN(PORT_B, 1), .chan = 9 }, \
-    /* ADC Temperature channel */                        \
-    { .dev = 0, .pin = GPIO_UNDEF, .chan = 16 },         \
-    /* ADC VREF channel */                               \
-    { .dev = 0, .pin = GPIO_UNDEF, .chan = 17 },         \
-}
+static const adc_conf_t adc_config[] = {
+    { .dev = 0, .pin = GPIO_PIN(PORT_A, 0), .chan = 0 },
+    { .dev = 0, .pin = GPIO_PIN(PORT_A, 1), .chan = 1 },
+    { .dev = 0, .pin = GPIO_PIN(PORT_A, 4), .chan = 4 },
+    { .dev = 0, .pin = GPIO_PIN(PORT_A, 5), .chan = 5 },
+    { .dev = 0, .pin = GPIO_PIN(PORT_A, 6), .chan = 6 },
+    { .dev = 0, .pin = GPIO_PIN(PORT_A, 7), .chan = 7 },
+    { .dev = 0, .pin = GPIO_PIN(PORT_B, 0), .chan = 8 },
+    { .dev = 0, .pin = GPIO_PIN(PORT_B, 1), .chan = 9 },
+    /* ADC Temperature channel */
+    { .dev = 0, .pin = GPIO_UNDEF, .chan = 16 },
+    /* ADC VREF channel */
+    { .dev = 0, .pin = GPIO_UNDEF, .chan = 17 },
+};
 
-#define ADC_NUMOF           10
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 /**

--- a/boards/common/iotlab/include/periph_conf_common.h
+++ b/boards/common/iotlab/include/periph_conf_common.h
@@ -60,12 +60,13 @@ extern "C" {
  * @name    ADC configuration
  * @{
  */
-#define ADC_CONFIG          {       \
-    { GPIO_PIN(PORT_A,3), 0, 3  },  \
-    { GPIO_UNDEF        , 0, 16 },  \
-    { GPIO_UNDEF        , 0, 17 } }
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_A,3), 0, 3  },
+    { GPIO_UNDEF        , 0, 16 },
+    { GPIO_UNDEF        , 0, 17 }
+};
 
-#define ADC_NUMOF           (3)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 /**

--- a/boards/im880b/include/periph_conf.h
+++ b/boards/im880b/include/periph_conf.h
@@ -161,17 +161,17 @@ static const i2c_conf_t i2c_config[] = {
  * @name    ADC configuration
  * @{
  */
-#define ADC_CONFIG {              \
-    { GPIO_PIN(PORT_A, 0), 0 }, /* P14 */ \
-    { GPIO_PIN(PORT_A, 1), 1 }, /* P15 */ \
-    { GPIO_PIN(PORT_A, 3), 3 }, /* P17 */ \
-    /* ADC Temperature channel */ \
-    { GPIO_UNDEF,          16 },  \
-    /* ADC VREF channel */        \
-    { GPIO_UNDEF,          17 },  \
-}
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_A, 0), 0 }, /* P14 */
+    { GPIO_PIN(PORT_A, 1), 1 }, /* P15 */
+    { GPIO_PIN(PORT_A, 3), 3 }, /* P17 */
+    /* ADC Temperature channel */
+    { GPIO_UNDEF,          16 },
+    /* ADC VREF channel */
+    { GPIO_UNDEF,          17 },
+};
 
-#define ADC_NUMOF           (5)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/msbiot/include/periph_conf.h
+++ b/boards/msbiot/include/periph_conf.h
@@ -95,12 +95,12 @@ static const pwm_conf_t pwm_config[] = {
  * PIN, device (ADCx), channel
  * @{
  */
-#define ADC_CONFIG {             \
-    {GPIO_PIN(PORT_B, 0), 0, 8}, \
-    {GPIO_PIN(PORT_B, 1), 0, 9}  \
-}
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_B, 0), 0, 8},
+    {GPIO_PIN(PORT_B, 1), 0, 9}
+};
 
-#define ADC_NUMOF           (2)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f030r8/include/periph_conf.h
+++ b/boards/nucleo-f030r8/include/periph_conf.h
@@ -177,16 +177,16 @@ static const spi_conf_t spi_config[] = {
  * @name   ADC configuration
  * @{
  */
-#define ADC_CONFIG {            \
-    { GPIO_PIN(PORT_A, 0), 0 }, \
-    { GPIO_PIN(PORT_A, 1), 1 }, \
-    { GPIO_PIN(PORT_A, 4), 4 }, \
-    { GPIO_PIN(PORT_B, 0), 8 }, \
-    { GPIO_PIN(PORT_C, 1), 11 },\
-    { GPIO_PIN(PORT_C, 0), 10 } \
-}
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_A, 0), 0 },
+    { GPIO_PIN(PORT_A, 1), 1 },
+    { GPIO_PIN(PORT_A, 4), 4 },
+    { GPIO_PIN(PORT_B, 0), 8 },
+    { GPIO_PIN(PORT_C, 1), 11 },
+    { GPIO_PIN(PORT_C, 0), 10 }
+};
 
-#define ADC_NUMOF           (6)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f031k6/include/periph_conf.h
+++ b/boards/nucleo-f031k6/include/periph_conf.h
@@ -144,15 +144,15 @@ static const spi_conf_t spi_config[] = {
  * @name   ADC configuration
  * @{
  */
-#define ADC_CONFIG {            \
-    { GPIO_PIN(PORT_A, 0), 0 }, \
-    { GPIO_PIN(PORT_A, 1), 1 }, \
-    { GPIO_PIN(PORT_A, 3), 3 }, \
-    { GPIO_PIN(PORT_A, 4), 4 }, \
-    { GPIO_PIN(PORT_A, 7), 7 }  \
-}
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_A, 0), 0 },
+    { GPIO_PIN(PORT_A, 1), 1 },
+    { GPIO_PIN(PORT_A, 3), 3 },
+    { GPIO_PIN(PORT_A, 4), 4 },
+    { GPIO_PIN(PORT_A, 7), 7 }
+};
 
-#define ADC_NUMOF           (5)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f042k6/include/periph_conf.h
+++ b/boards/nucleo-f042k6/include/periph_conf.h
@@ -154,15 +154,15 @@ static const spi_conf_t spi_config[] = {
  * @name   ADC configuration
  * @{
  */
-#define ADC_CONFIG {            \
-    { GPIO_PIN(PORT_A, 0), 0 }, \
-    { GPIO_PIN(PORT_A, 1), 1 }, \
-    { GPIO_PIN(PORT_A, 3), 3 }, \
-    { GPIO_PIN(PORT_A, 4), 4 }, \
-    { GPIO_PIN(PORT_A, 7), 7 }  \
-}
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_A, 0), 0 },
+    { GPIO_PIN(PORT_A, 1), 1 },
+    { GPIO_PIN(PORT_A, 3), 3 },
+    { GPIO_PIN(PORT_A, 4), 4 },
+    { GPIO_PIN(PORT_A, 7), 7 }
+};
 
-#define ADC_NUMOF          (5)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f070rb/include/periph_conf.h
+++ b/boards/nucleo-f070rb/include/periph_conf.h
@@ -154,16 +154,16 @@ static const pwm_conf_t pwm_config[] = {
  * @name   ADC configuration
  * @{
  */
-#define ADC_CONFIG {            \
-    { GPIO_PIN(PORT_A, 0), 0 },\
-    { GPIO_PIN(PORT_A, 1), 1 },\
-    { GPIO_PIN(PORT_A, 4), 4 },\
-    { GPIO_PIN(PORT_B, 0), 8 },\
-    { GPIO_PIN(PORT_C, 1), 11 },\
-    { GPIO_PIN(PORT_C, 0), 10 } \
-}
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_A, 0), 0 },
+    { GPIO_PIN(PORT_A, 1), 1 },
+    { GPIO_PIN(PORT_A, 4), 4 },
+    { GPIO_PIN(PORT_B, 0), 8 },
+    { GPIO_PIN(PORT_C, 1), 11 },
+    { GPIO_PIN(PORT_C, 0), 10 }
+};
 
-#define ADC_NUMOF           (6)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f072rb/include/periph_conf.h
+++ b/boards/nucleo-f072rb/include/periph_conf.h
@@ -198,16 +198,16 @@ static const spi_conf_t spi_config[] = {
  * @name   ADC configuration
  * @{
  */
-#define ADC_CONFIG {            \
-    { GPIO_PIN(PORT_A, 0), 0 }, \
-    { GPIO_PIN(PORT_A, 1), 1 }, \
-    { GPIO_PIN(PORT_A, 4), 4 }, \
-    { GPIO_PIN(PORT_B, 0), 8 }, \
-    { GPIO_PIN(PORT_C, 1), 11 },\
-    { GPIO_PIN(PORT_C, 0), 10 } \
-}
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_A, 0), 0 },
+    { GPIO_PIN(PORT_A, 1), 1 },
+    { GPIO_PIN(PORT_A, 4), 4 },
+    { GPIO_PIN(PORT_B, 0), 8 },
+    { GPIO_PIN(PORT_C, 1), 11 },
+    { GPIO_PIN(PORT_C, 0), 10 }
+};
 
-#define ADC_NUMOF           (6)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f091rc/include/periph_conf.h
+++ b/boards/nucleo-f091rc/include/periph_conf.h
@@ -208,16 +208,16 @@ static const pwm_conf_t pwm_config[] = {
  * @name   ADC configuration
  * @{
  */
-#define ADC_CONFIG {            \
-    { GPIO_PIN(PORT_A, 0), 0 },\
-    { GPIO_PIN(PORT_A, 1), 1 },\
-    { GPIO_PIN(PORT_A, 4), 4 },\
-    { GPIO_PIN(PORT_B, 0), 8 },\
-    { GPIO_PIN(PORT_C, 1), 11 },\
-    { GPIO_PIN(PORT_C, 0), 10 } \
-}
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_A, 0), 0 },
+    { GPIO_PIN(PORT_A, 1), 1 },
+    { GPIO_PIN(PORT_A, 4), 4 },
+    { GPIO_PIN(PORT_B, 0), 8 },
+    { GPIO_PIN(PORT_C, 1), 11 },
+    { GPIO_PIN(PORT_C, 0), 10 }
+};
 
-#define ADC_NUMOF           (6)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f207zg/include/periph_conf.h
+++ b/boards/nucleo-f207zg/include/periph_conf.h
@@ -223,11 +223,12 @@ static const spi_conf_t spi_config[] = {
  * PIN, device (ADCx), channel
  * @{
  */
-#define ADC_CONFIG {              \
-    {GPIO_PIN(PORT_A, 3), 0, 3},  \
-    {GPIO_PIN(PORT_C, 0), 1, 0}  \
-}
-#define ADC_NUMOF          (2)
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 3), 0, 3},
+    {GPIO_PIN(PORT_C, 0), 1, 0}
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f401re/include/periph_conf.h
+++ b/boards/nucleo-f401re/include/periph_conf.h
@@ -237,15 +237,16 @@ static const spi_conf_t spi_config[] = {
  *
  * @{
  */
-#define ADC_NUMOF          (6U)
-#define ADC_CONFIG {             \
-    {GPIO_PIN(PORT_A, 0), 0, 0}, \
-    {GPIO_PIN(PORT_A, 1), 0, 1}, \
-    {GPIO_PIN(PORT_A, 4), 0, 4}, \
-    {GPIO_PIN(PORT_B, 0), 0, 8}, \
-    {GPIO_PIN(PORT_C, 1), 0, 11}, \
-    {GPIO_PIN(PORT_C, 0), 0, 10}, \
-}
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 0), 0, 0},
+    {GPIO_PIN(PORT_A, 1), 0, 1},
+    {GPIO_PIN(PORT_A, 4), 0, 4},
+    {GPIO_PIN(PORT_B, 0), 0, 8},
+    {GPIO_PIN(PORT_C, 1), 0, 11},
+    {GPIO_PIN(PORT_C, 0), 0, 10},
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f410rb/include/periph_conf.h
+++ b/boards/nucleo-f410rb/include/periph_conf.h
@@ -140,15 +140,16 @@ static const spi_conf_t spi_config[] = {
  *
  * @{
  */
-#define ADC_NUMOF          (6U)
-#define ADC_CONFIG {             \
-    {GPIO_PIN(PORT_A, 0), 0, 0}, \
-    {GPIO_PIN(PORT_A, 1), 0, 1}, \
-    {GPIO_PIN(PORT_A, 4), 0, 4}, \
-    {GPIO_PIN(PORT_B, 0), 0, 8}, \
-    {GPIO_PIN(PORT_C, 1), 0, 11}, \
-    {GPIO_PIN(PORT_C, 0), 0, 10}, \
-}
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 0), 0, 0},
+    {GPIO_PIN(PORT_A, 1), 0, 1},
+    {GPIO_PIN(PORT_A, 4), 0, 4},
+    {GPIO_PIN(PORT_B, 0), 0, 8},
+    {GPIO_PIN(PORT_C, 1), 0, 11},
+    {GPIO_PIN(PORT_C, 0), 0, 10},
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f411re/include/periph_conf.h
+++ b/boards/nucleo-f411re/include/periph_conf.h
@@ -169,15 +169,16 @@ static const spi_conf_t spi_config[] = {
  *
  * @{
  */
-#define ADC_NUMOF          (6U)
-#define ADC_CONFIG {             \
-    {GPIO_PIN(PORT_A, 0), 0, 0}, \
-    {GPIO_PIN(PORT_A, 1), 0, 1}, \
-    {GPIO_PIN(PORT_A, 4), 0, 4}, \
-    {GPIO_PIN(PORT_B, 0), 0, 8}, \
-    {GPIO_PIN(PORT_C, 1), 0, 11}, \
-    {GPIO_PIN(PORT_C, 0), 0, 10}, \
-}
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 0), 0, 0},
+    {GPIO_PIN(PORT_A, 1), 0, 1},
+    {GPIO_PIN(PORT_A, 4), 0, 4},
+    {GPIO_PIN(PORT_B, 0), 0, 8},
+    {GPIO_PIN(PORT_C, 1), 0, 11},
+    {GPIO_PIN(PORT_C, 0), 0, 10},
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f412zg/include/periph_conf.h
+++ b/boards/nucleo-f412zg/include/periph_conf.h
@@ -171,15 +171,16 @@ static const spi_conf_t spi_config[] = {
  *
  * @{
  */
-#define ADC_NUMOF          (6U)
-#define ADC_CONFIG {              \
-    {GPIO_PIN(PORT_A, 3), 0, 3},  \
-    {GPIO_PIN(PORT_C, 0), 0, 10}, \
-    {GPIO_PIN(PORT_C, 3), 0, 13}, \
-    {GPIO_PIN(PORT_C, 1), 0, 11}, \
-    {GPIO_PIN(PORT_C, 4), 0, 14}, \
-    {GPIO_PIN(PORT_C, 5), 0, 15}, \
-}
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 3), 0, 3},
+    {GPIO_PIN(PORT_C, 0), 0, 10},
+    {GPIO_PIN(PORT_C, 3), 0, 13},
+    {GPIO_PIN(PORT_C, 1), 0, 11},
+    {GPIO_PIN(PORT_C, 4), 0, 14},
+    {GPIO_PIN(PORT_C, 5), 0, 15},
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f413zh/include/periph_conf.h
+++ b/boards/nucleo-f413zh/include/periph_conf.h
@@ -172,15 +172,16 @@ static const spi_conf_t spi_config[] = {
  *
  * @{
  */
-#define ADC_NUMOF          (6U)
-#define ADC_CONFIG {              \
-    {GPIO_PIN(PORT_A, 3), 0, 3},  \
-    {GPIO_PIN(PORT_C, 0), 0, 10}, \
-    {GPIO_PIN(PORT_C, 3), 0, 13}, \
-    {GPIO_PIN(PORT_C, 1), 0, 11}, \
-    {GPIO_PIN(PORT_C, 4), 0, 14}, \
-    {GPIO_PIN(PORT_C, 5), 0, 15}, \
-}
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 3), 0, 3},
+    {GPIO_PIN(PORT_C, 0), 0, 10},
+    {GPIO_PIN(PORT_C, 3), 0, 13},
+    {GPIO_PIN(PORT_C, 1), 0, 11},
+    {GPIO_PIN(PORT_C, 4), 0, 14},
+    {GPIO_PIN(PORT_C, 5), 0, 15},
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 /**

--- a/boards/nucleo-f429zi/include/periph_conf.h
+++ b/boards/nucleo-f429zi/include/periph_conf.h
@@ -169,15 +169,16 @@ static const spi_conf_t spi_config[] = {
  *
  * @{
  */
-#define ADC_NUMOF          (6U)
-#define ADC_CONFIG {              \
-    {GPIO_PIN(PORT_A, 3), 2, 3},  \
-    {GPIO_PIN(PORT_C, 0), 2, 10}, \
-    {GPIO_PIN(PORT_C, 3), 2, 13}, \
-    {GPIO_PIN(PORT_F, 3), 2, 9},  \
-    {GPIO_PIN(PORT_F, 5), 2, 15}, \
-    {GPIO_PIN(PORT_F, 10), 2, 8}, \
-}
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 3), 2, 3},
+    {GPIO_PIN(PORT_C, 0), 2, 10},
+    {GPIO_PIN(PORT_C, 3), 2, 13},
+    {GPIO_PIN(PORT_F, 3), 2, 9},
+    {GPIO_PIN(PORT_F, 5), 2, 15},
+    {GPIO_PIN(PORT_F, 10), 2, 8},
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-f446re/include/periph_conf.h
+++ b/boards/nucleo-f446re/include/periph_conf.h
@@ -247,15 +247,16 @@ static const spi_conf_t spi_config[] = {
  *
  * @{
  */
-#define ADC_NUMOF          (6U)
-#define ADC_CONFIG {             \
-    {GPIO_PIN(PORT_A, 0), 0, 0}, \
-    {GPIO_PIN(PORT_A, 1), 0, 1}, \
-    {GPIO_PIN(PORT_A, 4), 0, 4}, \
-    {GPIO_PIN(PORT_B, 0), 0, 8}, \
-    {GPIO_PIN(PORT_C, 1), 0, 11}, \
-    {GPIO_PIN(PORT_C, 0), 0, 10}, \
-}
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 0), 0, 0},
+    {GPIO_PIN(PORT_A, 1), 0, 1},
+    {GPIO_PIN(PORT_A, 4), 0, 4},
+    {GPIO_PIN(PORT_B, 0), 0, 8},
+    {GPIO_PIN(PORT_C, 1), 0, 11},
+    {GPIO_PIN(PORT_C, 0), 0, 10},
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-l031k6/include/periph_conf.h
+++ b/boards/nucleo-l031k6/include/periph_conf.h
@@ -102,16 +102,17 @@ static const spi_conf_t spi_config[] = {
  * @name    ADC configuration
  * @{
  */
-#define ADC_CONFIG {                           \
-    { GPIO_PIN(PORT_A, 0), 0 },  /* Pin A0 */  \
-    { GPIO_PIN(PORT_A, 1), 1 },  /* Pin A1 */  \
-    { GPIO_PIN(PORT_A, 3), 3 },  /* Pin A2 */  \
-    { GPIO_PIN(PORT_A, 4), 4 },  /* Pin A3 */  \
-    { GPIO_PIN(PORT_A, 5), 5 },  /* Pin A4 */  \
-    { GPIO_PIN(PORT_A, 6), 6 },  /* Pin A5 */  \
-    { GPIO_PIN(PORT_A, 7), 7 },  /* Pin A6 */  \
-}
-#define ADC_NUMOF           (7U)
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_A, 0), 0 },  /* Pin A0 */
+    { GPIO_PIN(PORT_A, 1), 1 },  /* Pin A1 */
+    { GPIO_PIN(PORT_A, 3), 3 },  /* Pin A2 */
+    { GPIO_PIN(PORT_A, 4), 4 },  /* Pin A3 */
+    { GPIO_PIN(PORT_A, 5), 5 },  /* Pin A4 */
+    { GPIO_PIN(PORT_A, 6), 6 },  /* Pin A5 */
+    { GPIO_PIN(PORT_A, 7), 7 },  /* Pin A6 */
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nucleo-l073rz/include/periph_conf.h
+++ b/boards/nucleo-l073rz/include/periph_conf.h
@@ -132,16 +132,16 @@ static const spi_conf_t spi_config[] = {
  * @name    ADC configuration
  * @{
  */
-#define ADC_CONFIG {            \
-    { GPIO_PIN(PORT_A, 0), 0 }, \
-    { GPIO_PIN(PORT_A, 1), 1 }, \
-    { GPIO_PIN(PORT_A, 4), 4 }, \
-    { GPIO_PIN(PORT_B, 0), 8 }, \
-    { GPIO_PIN(PORT_C, 1), 11 },\
-    { GPIO_PIN(PORT_C, 0), 10 } \
-}
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_A, 0), 0 },
+    { GPIO_PIN(PORT_A, 1), 1 },
+    { GPIO_PIN(PORT_A, 4), 4 },
+    { GPIO_PIN(PORT_B, 0), 8 },
+    { GPIO_PIN(PORT_C, 1), 11 },
+    { GPIO_PIN(PORT_C, 0), 10 }
+};
 
-#define ADC_NUMOF           (6U)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 /**

--- a/boards/nucleo-l152re/include/periph_conf.h
+++ b/boards/nucleo-l152re/include/periph_conf.h
@@ -236,16 +236,16 @@ static const i2c_conf_t i2c_config[] = {
  * @name   ADC configuration
  * @{
  */
-#define ADC_CONFIG {             \
-    { GPIO_PIN(PORT_A, 0), 0 },  \
-    { GPIO_PIN(PORT_A, 1), 1 },  \
-    { GPIO_PIN(PORT_A, 4), 4 },  \
-    { GPIO_PIN(PORT_B, 0), 8 },  \
-    { GPIO_PIN(PORT_C, 1), 11 }, \
-    { GPIO_PIN(PORT_C, 0), 10 }, \
-}
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_A, 0), 0 },
+    { GPIO_PIN(PORT_A, 1), 1 },
+    { GPIO_PIN(PORT_A, 4), 4 },
+    { GPIO_PIN(PORT_B, 0), 8 },
+    { GPIO_PIN(PORT_C, 1), 11 },
+    { GPIO_PIN(PORT_C, 0), 10 },
+};
 
-#define ADC_NUMOF           (6U)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 /**

--- a/boards/nucleo-l476rg/include/periph_conf.h
+++ b/boards/nucleo-l476rg/include/periph_conf.h
@@ -209,15 +209,16 @@ static const spi_conf_t spi_config[] = {
  *
  * @{
  */
-#define ADC_NUMOF           (6U)
-#define ADC_CONFIG {             \
-    {GPIO_PIN(PORT_A, 0), 0, 5},  /*< ADC12_IN5 */   \
-    {GPIO_PIN(PORT_A, 1), 0, 6},  /*< ADC12_IN6 */   \
-    {GPIO_PIN(PORT_A, 4), 1, 9},  /*< ADC12_IN9 */   \
-    {GPIO_PIN(PORT_B, 0), 1, 15}, /*< ADC12_IN15 */  \
-    {GPIO_PIN(PORT_C, 1), 2, 2},  /*< ADC123_IN_2 */ \
-    {GPIO_PIN(PORT_C, 0), 2, 1},  /*< ADC123_IN_1 */ \
-}
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 0), 0, 5},  /*< ADC12_IN5 */
+    {GPIO_PIN(PORT_A, 1), 0, 6},  /*< ADC12_IN6 */
+    {GPIO_PIN(PORT_A, 4), 1, 9},  /*< ADC12_IN9 */
+    {GPIO_PIN(PORT_B, 0), 1, 15}, /*< ADC12_IN15 */
+    {GPIO_PIN(PORT_C, 1), 2, 2},  /*< ADC123_IN_2 */
+    {GPIO_PIN(PORT_C, 0), 2, 1},  /*< ADC123_IN_1 */
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nz32-sc151/include/periph_conf.h
+++ b/boards/nz32-sc151/include/periph_conf.h
@@ -191,17 +191,17 @@ static const i2c_conf_t i2c_config[] = {
  * @name    ADC configuration
  * @{
  */
-#define ADC_CONFIG {              \
-    { GPIO_PIN(PORT_C, 0), 10 },  \
-    { GPIO_PIN(PORT_C, 1), 11 },  \
-    { GPIO_PIN(PORT_C, 2), 12 },  \
-    /* ADC Temperature channel */ \
-    { GPIO_UNDEF,          16 },  \
-    /* ADC VREF channel */        \
-    { GPIO_UNDEF,          17 },  \
-}
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_C, 0), 10 },
+    { GPIO_PIN(PORT_C, 1), 11 },
+    { GPIO_PIN(PORT_C, 2), 12 },
+    /* ADC Temperature channel */
+    { GPIO_UNDEF,          16 },
+    /* ADC VREF channel */
+    { GPIO_UNDEF,          17 },
+};
 
-#define ADC_NUMOF           (5)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 /**

--- a/boards/olimexino-stm32/include/periph_conf.h
+++ b/boards/olimexino-stm32/include/periph_conf.h
@@ -58,16 +58,16 @@ extern "C" {
  * @name   ADC configuration
  * @{
  */
-#define ADC_CONFIG {                \
-        { GPIO_PIN(PORT_C, 0), 0, 10 }, \
-        { GPIO_PIN(PORT_C, 1), 0, 11 }, \
-        { GPIO_PIN(PORT_C, 2), 0, 12 }, \
-        { GPIO_PIN(PORT_C, 3), 0, 13 }, \
-        { GPIO_PIN(PORT_C, 4), 0, 14 }, \
-        { GPIO_PIN(PORT_C, 5), 0, 15 }  \
-}
+static const adc_conf_t adc_config[] = {
+        { GPIO_PIN(PORT_C, 0), 0, 10 },
+        { GPIO_PIN(PORT_C, 1), 0, 11 },
+        { GPIO_PIN(PORT_C, 2), 0, 12 },
+        { GPIO_PIN(PORT_C, 3), 0, 13 },
+        { GPIO_PIN(PORT_C, 4), 0, 14 },
+        { GPIO_PIN(PORT_C, 5), 0, 15 }
+};
 
-#define ADC_NUMOF           (6)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 /**

--- a/boards/stm32f030f4-demo/include/periph_conf.h
+++ b/boards/stm32f030f4-demo/include/periph_conf.h
@@ -152,16 +152,16 @@ static const spi_conf_t spi_config[] = {
  * @name   ADC configuration
  * @{
  */
-#define ADC_CONFIG {            \
-    { GPIO_PIN(PORT_A, 0), 0 }, \
-    { GPIO_PIN(PORT_A, 1), 1 }, \
-    { GPIO_PIN(PORT_A, 2), 2 }, \
-    { GPIO_PIN(PORT_A, 3), 3 }, \
-    { GPIO_PIN(PORT_A, 4), 4 },\
-    { GPIO_PIN(PORT_A, 5), 5 } \
-}
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_A, 0), 0 },
+    { GPIO_PIN(PORT_A, 1), 1 },
+    { GPIO_PIN(PORT_A, 2), 2 },
+    { GPIO_PIN(PORT_A, 3), 3 },
+    { GPIO_PIN(PORT_A, 4), 4 },
+    { GPIO_PIN(PORT_A, 5), 5 }
+};
 
-#define ADC_NUMOF           (6)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/stm32f0discovery/include/periph_conf.h
+++ b/boards/stm32f0discovery/include/periph_conf.h
@@ -112,16 +112,16 @@ static const uart_conf_t uart_config[] = {
  * [ pin, channel ]
  * @{
  */
-#define ADC_CONFIG {            \
-    { GPIO_PIN(PORT_C, 0), 10 },\
-    { GPIO_PIN(PORT_C, 1), 11 },\
-    { GPIO_PIN(PORT_C, 2), 12 },\
-    { GPIO_PIN(PORT_C, 3), 13 },\
-    { GPIO_PIN(PORT_C, 4), 14 },\
-    { GPIO_PIN(PORT_C, 5), 15 } \
-}
+static const adc_conf_t adc_config[] = {
+    { GPIO_PIN(PORT_C, 0), 10 },
+    { GPIO_PIN(PORT_C, 1), 11 },
+    { GPIO_PIN(PORT_C, 2), 12 },
+    { GPIO_PIN(PORT_C, 3), 13 },
+    { GPIO_PIN(PORT_C, 4), 14 },
+    { GPIO_PIN(PORT_C, 5), 15 }
+};
 
-#define ADC_NUMOF           (6)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 /**

--- a/boards/stm32f4discovery/include/periph_conf.h
+++ b/boards/stm32f4discovery/include/periph_conf.h
@@ -122,14 +122,14 @@ static const uart_conf_t uart_config[] = {
  * PIN, device (ADCx), channel
  * @{
  */
-#define ADC_CONFIG {              \
-    {GPIO_PIN(PORT_A, 1), 0, 1},  \
-    {GPIO_PIN(PORT_A, 4), 0, 4},  \
-    {GPIO_PIN(PORT_C, 1), 1, 11}, \
-    {GPIO_PIN(PORT_C, 2), 1, 12}  \
-}
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 1), 0, 1},
+    {GPIO_PIN(PORT_A, 4), 0, 4},
+    {GPIO_PIN(PORT_C, 1), 1, 11},
+    {GPIO_PIN(PORT_C, 2), 1, 12}
+};
 
-#define ADC_NUMOF           (4)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 /**

--- a/boards/ublox-c030-u201/include/periph_conf.h
+++ b/boards/ublox-c030-u201/include/periph_conf.h
@@ -243,15 +243,16 @@ static const i2c_conf_t i2c_config[] = {
  *
  * @{
  */
-#define ADC_NUMOF          (6U)
-#define ADC_CONFIG {             \
-    {GPIO_PIN(PORT_A, 3), 0, 3}, \
-    {GPIO_PIN(PORT_C, 0), 0, 10}, \
-    {GPIO_PIN(PORT_C, 3), 0, 4}, \
-    {GPIO_PIN(PORT_A, 4), 0, 14}, \
-    {GPIO_PIN(PORT_B, 7), 0, 7}, \
-    {GPIO_PIN(PORT_B, 6), 0, 6}, \
-}
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 3), 0, 3},
+    {GPIO_PIN(PORT_C, 0), 0, 10},
+    {GPIO_PIN(PORT_C, 3), 0, 4},
+    {GPIO_PIN(PORT_A, 4), 0, 14},
+    {GPIO_PIN(PORT_B, 7), 0, 7},
+    {GPIO_PIN(PORT_B, 6), 0, 6},
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/weact-f411ce/include/periph_conf.h
+++ b/boards/weact-f411ce/include/periph_conf.h
@@ -162,15 +162,14 @@ static const spi_conf_t spi_config[] = {
  *
  * @{
  */
+static const adc_conf_t adc_config[] = {
+    {GPIO_PIN(PORT_A, 0), 0, 0},
+    {GPIO_PIN(PORT_A, 1), 0, 1},
+    {GPIO_PIN(PORT_A, 4), 0, 4},
+    {GPIO_PIN(PORT_B, 0), 0, 8},
+};
 
-#define ADC_CONFIG {             \
-    {GPIO_PIN(PORT_A, 0), 0, 0}, \
-    {GPIO_PIN(PORT_A, 1), 0, 1}, \
-    {GPIO_PIN(PORT_A, 4), 0, 4}, \
-    {GPIO_PIN(PORT_B, 0), 0, 8}, \
-}
-
-#define ADC_NUMOF           (4)
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/yunjia-nrf51822/include/periph_conf.h
+++ b/boards/yunjia-nrf51822/include/periph_conf.h
@@ -83,8 +83,9 @@ static const i2c_conf_t i2c_config[] = {
  * The configuration consists simply of a list of channels that should be used
  * @{
  */
-#define ADC_CONFIG          {4, 5, 6, 7}
-#define ADC_NUMOF           (4)
+static const adc_conf_t adc_config[] = {4, 5, 6, 7};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/nrf51/include/periph_cpu.h
+++ b/cpu/nrf51/include/periph_cpu.h
@@ -84,6 +84,11 @@ typedef enum {
 #endif /* ndef DOXYGEN */
 
 /**
+ * @brief ADC configuration wrapper
+ */
+typedef gpio_t adc_conf_t;
+
+/**
  * @brief   I2C (TWI) configuration options
  */
 typedef struct {

--- a/cpu/nrf51/periph/adc.c
+++ b/cpu/nrf51/periph/adc.c
@@ -24,11 +24,6 @@
 #include "periph_conf.h"
 
 /**
- * @brief   Load the ADC configuration
- */
-static const uint8_t adc_config[] = ADC_CONFIG;
-
-/**
  * @brief   Lock to prevent concurrency issues when used from different threads
  */
 static mutex_t lock;

--- a/cpu/stm32/periph/adc_f0.c
+++ b/cpu/stm32/periph/adc_f0.c
@@ -24,11 +24,6 @@
 #include "periph/adc.h"
 
 /**
- * @brief   Load the ADC configuration
- */
-static const adc_conf_t adc_config[] = ADC_CONFIG;
-
-/**
  * @brief   Allocate locks for all three available ADC device
  *
  * All STM32F0 CPUs we support so far only come with a single ADC device.

--- a/cpu/stm32/periph/adc_f1.c
+++ b/cpu/stm32/periph/adc_f1.c
@@ -31,11 +31,6 @@
 #define MAX_ADC_SPEED           (14000000U)
 
 /**
- * @brief   Load the ADC configuration
- */
-static const adc_conf_t adc_config[] = ADC_CONFIG;
-
-/**
  * @brief   Allocate locks for all three available ADC devices
  */
 static mutex_t locks[] = {

--- a/cpu/stm32/periph/adc_f2.c
+++ b/cpu/stm32/periph/adc_f2.c
@@ -31,16 +31,6 @@
 #define MAX_ADC_SPEED           (12000000U)
 
 /**
- * @brief   Load the ADC configuration
- * @{
- */
-#ifdef ADC_CONFIG
-static const adc_conf_t adc_config[] = ADC_CONFIG;
-#else
-static const adc_conf_t adc_config[] = {};
-#endif
-
-/**
  * @brief   Allocate locks for all three available ADC devices
  */
 static mutex_t locks[] = {

--- a/cpu/stm32/periph/adc_f4.c
+++ b/cpu/stm32/periph/adc_f4.c
@@ -30,11 +30,6 @@
 #define MAX_ADC_SPEED           (12000000U)
 
 /**
- * @brief   Load the ADC configuration
- */
-static const adc_conf_t adc_config[] = ADC_CONFIG;
-
-/**
  * @brief   Allocate locks for all three available ADC devices
  */
 static mutex_t locks[] = {

--- a/cpu/stm32/periph/adc_l0.c
+++ b/cpu/stm32/periph/adc_l0.c
@@ -24,11 +24,6 @@
 #include "periph/adc.h"
 
 /**
- * @brief   Load the ADC configuration
- */
-static const adc_conf_t adc_config[] = ADC_CONFIG;
-
-/**
  * @brief   Allocate locks for all three available ADC device
  *
  * All STM32L0 CPUs we support so far only come with a single ADC device.

--- a/cpu/stm32/periph/adc_l1.c
+++ b/cpu/stm32/periph/adc_l1.c
@@ -48,11 +48,6 @@
 #define ADC_SAMPLE_TIME_384C  (7)
 
 /**
- * @brief   Load the ADC configuration
- */
-static const adc_conf_t adc_config[] = ADC_CONFIG;
-
-/**
  * @brief   Allocate locks for all three available ADC device
  *
  * All STM32l1 CPU's have single ADC device

--- a/cpu/stm32/periph/adc_l4.c
+++ b/cpu/stm32/periph/adc_l4.c
@@ -56,11 +56,6 @@
 #endif
 
 /**
- * @brief   Load the ADC configuration
- */
-static const adc_conf_t adc_config[] = ADC_CONFIG;
-
-/**
  * @brief   Allocate locks for all three available ADC devices
  */
 static mutex_t locks[ADC_DEVS];


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
I don't see why it was done this way.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
