### PR TITLE
drivers/Kconfig: add periph timer config menu 

### DIFF
--- a/cpu/efm32/periph/Kconfig.timer
+++ b/cpu/efm32/periph/Kconfig.timer
@@ -1,0 +1,12 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config EFM32_XTIMER_USE_LETIMER
+    bool "Xtimer uses letimer"
+    depends on CPU_COMMON_EFM32 && USEMODULE_XTIMER
+    default n
+    help
+        Xtimer will use EFM32 Low Energy Timer as its low level timer.

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -15,7 +15,10 @@ rsource "at/Kconfig"
 endmenu # Miscellaneous Device Drivers
 
 rsource "Kconfig.net"
+
+menu "Peripherals drivers"
 rsource "periph_common/Kconfig"
+endmenu # Peripherals drivers
 
 menu "Sensor Device Drivers"
 rsource "ads101x/Kconfig"

--- a/drivers/periph_common/Kconfig
+++ b/drivers/periph_common/Kconfig
@@ -4,6 +4,14 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
+menuconfig KCONFIG_USEMODULE_PERIPH_TIMER
+    bool "Configure timer peripheral"
+    depends on USEMODULE_PERIPH_TIMER
+    help
+        Configure Timer peripheral using Kconfig.
+
+orsource "$(RIOTCPU)/$(CPU)/periph/Kconfig"
+
 menuconfig KCONFIG_USEMODULE_PERIPH_WDT
     bool "Configure Watchdog peripheral"
     depends on USEMODULE_PERIPH_WDT

--- a/drivers/periph_common/Kconfig
+++ b/drivers/periph_common/Kconfig
@@ -4,37 +4,7 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-menuconfig KCONFIG_USEMODULE_PERIPH_TIMER
-    bool "Configure timer peripheral"
-    depends on USEMODULE_PERIPH_TIMER
-    help
-        Configure Timer peripheral using Kconfig.
-
-orsource "$(RIOTCPU)/$(CPU)/periph/Kconfig"
-
-menuconfig KCONFIG_USEMODULE_PERIPH_WDT
-    bool "Configure Watchdog peripheral"
-    depends on USEMODULE_PERIPH_WDT
-    help
-        Configure Watchdog peripheral using Kconfig.
-
-if KCONFIG_USEMODULE_PERIPH_WDT
-
-config WDT_WARNING_PERIOD
-    int "Warning period (in ms)"
-    depends on HAS_PERIPH_WDT_WARNING_PERIOD
-    help
-        Period in ms before reboot where wdt_cb() is executed.
-
-endif # KCONFIG_USEMODULE_PERIPH_WDT
-
-config HAS_PERIPH_WDT_WARNING_PERIOD
-    bool
-    help
-        Indicates that a CPU provides a warning period configuration option.
-
-menu "Peripheral drivers"
-    depends on TEST_KCONFIG
+if TEST_KCONFIG
 
 config MODULE_PERIPH_COMMON
     bool
@@ -167,8 +137,6 @@ config MODULE_PERIPH_INIT_RTT
 
 rsource "Kconfig.spi"
 
-rsource "Kconfig.timer"
-
 rsource "Kconfig.uart"
 
 config MODULE_PERIPH_USBDEV
@@ -181,14 +149,7 @@ config MODULE_PERIPH_INIT_USBDEV
     default y if MODULE_PERIPH_INIT
     depends on MODULE_PERIPH_USBDEV
 
-menuconfig MODULE_PERIPH_WDT
-    bool "Watchdog Timer peripheral driver"
-    depends on HAS_PERIPH_WDT
-    select MODULE_PERIPH_COMMON
+endif # TEST_KCONFIG
 
-config MODULE_PERIPH_INIT_WDT
-    bool "Auto initialize the Watchdog Timer peripheral"
-    default y if MODULE_PERIPH_INIT
-    depends on MODULE_PERIPH_WDT
-
-endmenu # Peripheral drivers
+rsource "Kconfig.timer"
+rsource "Kconfig.wdt"

--- a/drivers/periph_common/Kconfig.timer
+++ b/drivers/periph_common/Kconfig.timer
@@ -3,10 +3,11 @@
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
-#
+
+if TEST_KCONFIG
 
 menuconfig MODULE_PERIPH_TIMER
-    bool "Timer peripheral driver"
+    bool "Configure timer peripheral driver"
     depends on HAS_PERIPH_TIMER
     select MODULE_PERIPH_COMMON
 
@@ -30,3 +31,16 @@ config MODULE_PERIPH_INIT_TIMER_PERIODIC
     default y if MODULE_PERIPH_INIT
 
 endif # MODULE_PERIPH_TIMER
+
+endif # TEST_KCONFIG
+
+menuconfig KCONFIG_USEMODULE_PERIPH_TIMER
+    bool "Configure timer peripheral driver"
+    depends on USEMODULE_PERIPH_TIMER
+    help
+        Configure Timer peripheral using Kconfig.
+
+# Include CPU specific configurations
+if KCONFIG_USEMODULE_PERIPH_TIMER
+osource "$(RIOTCPU)/$(CPU)/periph/Kconfig.timer"
+endif

--- a/drivers/periph_common/Kconfig.wdt
+++ b/drivers/periph_common/Kconfig.wdt
@@ -1,0 +1,40 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+if TEST_KCONFIG
+
+menuconfig MODULE_PERIPH_WDT
+    bool "Watchdog Timer peripheral driver"
+    depends on HAS_PERIPH_WDT
+    select MODULE_PERIPH_COMMON
+
+config MODULE_PERIPH_INIT_WDT
+    bool "Auto initialize the Watchdog Timer peripheral"
+    default y if MODULE_PERIPH_INIT
+    depends on MODULE_PERIPH_WDT
+
+endif # TEST_KCONFIG
+
+menuconfig KCONFIG_USEMODULE_PERIPH_WDT
+    bool "Configure Watchdog peripheral"
+    depends on USEMODULE_PERIPH_WDT
+    help
+        Configure Watchdog peripheral using Kconfig.
+
+if KCONFIG_USEMODULE_PERIPH_WDT
+
+config WDT_WARNING_PERIOD
+    int "Warning period (in ms)"
+    depends on HAS_PERIPH_WDT_WARNING_PERIOD
+    help
+        Period in ms before reboot where wdt_cb() is executed.
+
+endif # KCONFIG_USEMODULE_PERIPH_WDT
+
+config HAS_PERIPH_WDT_WARNING_PERIOD
+    bool
+    help
+        Indicates that a CPU provides a warning period configuration option.


### PR DESCRIPTION
## Contribution description

This PR adds peripheral drivers config menu and timer configuration options for `efm32`.

### Testing procedure

Run an `xtimer` test with one of the different configurations for `efm32`:

- default `BOARD=slstk3402a make -C tests/xtimer_usleep/ flash test `

```
main(): This is RIOT! (Version: 2020.10-devel-709-g247c3-pr_periph_timer_config)
Running test 5 times with 7 distinct sleep times
Slept for 10028 us (expected: 10000 us) Offset: 28 us
Slept for 50028 us (expected: 50000 us) Offset: 28 us
Slept for 10261 us (expected: 10234 us) Offset: 27 us
Slept for 56808 us (expected: 56780 us) Offset: 28 us
Slept for 12149 us (expected: 12122 us) Offset: 27 us
Slept for 98793 us (expected: 98765 us) Offset: 28 us
Slept for 75027 us (expected: 75000 us) Offset: 27 us
Slept for 10027 us (expected: 10000 us) Offset: 27 us
Slept for 50028 us (expected: 50000 us) Offset: 28 us
Slept for 10261 us (expected: 10234 us) Offset: 27 us
Slept for 56808 us (expected: 56780 us) Offset: 28 us
Slept for 12149 us (expected: 12122 us) Offset: 27 us
Slept for 98793 us (expected: 98765 us) Offset: 28 us
Slept for 75027 us (expected: 75000 us) Offset: 27 us
Slept for 10027 us (expected: 10000 us) Offset: 27 us
Slept for 50028 us (expected: 50000 us) Offset: 28 us
Slept for 10261 us (expected: 10234 us) Offset: 27 us
Slept for 56808 us (expected: 56780 us) Offset: 28 us
Slept for 12149 us (expected: 12122 us) Offset: 27 us
Slept for 98793 us (expected: 98765 us) Offset: 28 us
Slept for 75027 us (expected: 75000 us) Offset: 27 us
Slept for 10027 us (expected: 10000 us) Offset: 27 us
Slept for 50028 us (expected: 50000 us) Offset: 28 us
Slept for 10261 us (expected: 10234 us) Offset: 27 us
Slept for 56808 us (expected: 56780 us) Offset: 28 us
Slept for 12149 us (expected: 12122 us) Offset: 27 us
Slept for 98793 us (expected: 98765 us) Offset: 28 us
Slept for 75027 us (expected: 75000 us) Offset: 27 us
Slept for 10027 us (expected: 10000 us) Offset: 27 us
Slept for 50028 us (expected: 50000 us) Offset: 28 us
Slept for 10261 us (expected: 10234 us) Offset: 27 us
Slept for 56808 us (expected: 56780 us) Offset: 28 us
Slept for 12149 us (expected: 12122 us) Offset: 27 us
Slept for 98793 us (expected: 98765 us) Offset: 28 us
Slept for 75027 us (expected: 75000 us) Offset: 27 us
Test ran for 1734049 us
```

- `BOARD=slstk3402a make -C tests/xtimer_usleep/ flash test` with `CONFIG_EFM32_XTIMER_USE_LETIMER` enabled through `menuconfig`

![image](https://user-images.githubusercontent.com/23060007/91192952-db12b100-e6f6-11ea-9bbe-4d8fd915ceba.png)


```
main(): This is RIOT! (Version: 2020.10-devel-709-g247c3-pr_periph_timer_config)
Running test 5 times with 7 distinct sleep times
Slept for 10010 us (expected: 10000 us) Offset: 10 us
Slept for 50019 us (expected: 50000 us) Offset: 19 us
Slept for 10254 us (expected: 10234 us) Offset: 20 us
Slept for 56793 us (expected: 56780 us) Offset: 13 us
Slept for 12146 us (expected: 12122 us) Offset: 24 us
Slept for 98785 us (expected: 98765 us) Offset: 20 us
Slept for 75012 us (expected: 75000 us) Offset: 12 us
Slept for 10010 us (expected: 10000 us) Offset: 10 us
Slept for 50018 us (expected: 50000 us) Offset: 18 us
Slept for 10254 us (expected: 10234 us) Offset: 20 us
Slept for 56824 us (expected: 56780 us) Offset: 44 us
Slept for 12177 us (expected: 12122 us) Offset: 55 us
Slept for 98785 us (expected: 98765 us) Offset: 20 us
Slept for 75012 us (expected: 75000 us) Offset: 12 us
Slept for 10010 us (expected: 10000 us) Offset: 10 us
Slept for 50019 us (expected: 50000 us) Offset: 19 us
Slept for 10254 us (expected: 10234 us) Offset: 20 us
Slept for 56793 us (expected: 56780 us) Offset: 13 us
Slept for 12146 us (expected: 12122 us) Offset: 24 us
Slept for 98785 us (expected: 98765 us) Offset: 20 us
Slept for 75012 us (expected: 75000 us) Offset: 12 us
Slept for 10010 us (expected: 10000 us) Offset: 10 us
Slept for 50018 us (expected: 50000 us) Offset: 18 us
Slept for 10254 us (expected: 10234 us) Offset: 20 us
Slept for 56794 us (expected: 56780 us) Offset: 14 us
Slept for 12146 us (expected: 12122 us) Offset: 24 us
Slept for 98786 us (expected: 98765 us) Offset: 21 us
Slept for 75013 us (expected: 75000 us) Offset: 13 us
Slept for 10010 us (expected: 10000 us) Offset: 10 us
Slept for 50018 us (expected: 50000 us) Offset: 18 us
Slept for 10254 us (expected: 10234 us) Offset: 20 us
Slept for 56793 us (expected: 56780 us) Offset: 13 us
Slept for 12146 us (expected: 12122 us) Offset: 24 us
Slept for 98786 us (expected: 98765 us) Offset: 21 us
Slept for 75012 us (expected: 75000 us) Offset: 12 us
Test ran for 1733887 us
```

### Issues/PRs references

Depends on #https://github.com/RIOT-OS/RIOT/pull/14780
