### PR TITLE
cpu/stm32/periph/adc: remove MAX_ADC_SPEED from implementations where it is not used

### DIFF
--- a/cpu/stm32/periph/adc_f0.c
+++ b/cpu/stm32/periph/adc_f0.c
@@ -24,11 +24,6 @@
 #include "periph/adc.h"
 
 /**
- * @brief   Maximum allowed ADC clock speed
- */
-#define MAX_ADC_SPEED           (12000000U)
-
-/**
  * @brief   Load the ADC configuration
  */
 static const adc_conf_t adc_config[] = ADC_CONFIG;
@@ -61,7 +56,7 @@ int adc_init(adc_t line)
 
     /* lock and power on the device */
     prep();
-    /*configure the pin */
+    /* configure the pin */
     gpio_init_analog(adc_config[line].pin);
     /* reset configuration */
     ADC1->CFGR2 = 0;

--- a/cpu/stm32/periph/adc_l0.c
+++ b/cpu/stm32/periph/adc_l0.c
@@ -24,11 +24,6 @@
 #include "periph/adc.h"
 
 /**
- * @brief   Maximum allowed ADC clock speed
- */
-#define MAX_ADC_SPEED           (12000000U)
-
-/**
  * @brief   Load the ADC configuration
  */
 static const adc_conf_t adc_config[] = ADC_CONFIG;

--- a/cpu/stm32/periph/adc_l1.c
+++ b/cpu/stm32/periph/adc_l1.c
@@ -26,11 +26,6 @@
 #include "periph/adc.h"
 
 /**
- * @brief   Maximum allowed ADC clock speed
- */
-#define MAX_ADC_SPEED           (12000000U)
-
-/**
  * @brief   ADC clock settings
  *
  * NB: with ADC_CLOCK_HIGH, Vdda should be 2.4V min


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
All in the title.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
