### PR TITLE
gh-actions: initial import of a label-checker workflow

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,0 +1,15 @@
+name: check-labels
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled]
+  pull_request_review:
+    types: [submitted, dismissed]
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: RIOT-OS/check-labels-action@v1.0.0
+      with:
+        access_token: ${{ secrets.GITHUB_TOKEN }}
+        unset_labels: 'CI: needs squashing,State: waiting for other PR'
+        cond_labels: '(Process: needs >1 ACK,review.approvals>1),(Area: RDM,review.approvals>2)'


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This adds a label checker that checks if certain labels are set, not set or if some are set, enough reviews were provided. The idea is to make this a required check, once merged.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Let GitHub do it's thing I would say ;-) (see https://github.com/RIOT-OS/RIOT/pull/14850#issuecomment-680217585). You can run the tests yourself by running `pytest` over at https://github.com/RIOT-OS/check-labels-action.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
