### PR TITLE
dist/tools/compile_and_test_for_board: script to compile test for all boards

### DIFF
--- a/dist/tools/compile_test/compile_for_all_boards.sh
+++ b/dist/tools/compile_test/compile_for_all_boards.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Compile an an application for all boards.
+# Store the boards where it failed in `failed.txt`.
+
+if [ -z $1 ]; then
+    echo "Usage: $0 <app_dir>"
+    exit 1
+fi
+
+OUT=$1/failed.txt
+rm -f $OUT
+
+BOARDS=$(make --no-print-directory -C $1 info-boards-supported)
+
+for i in $BOARDS; do
+    if make -C $1 BOARD=$i -j > /dev/null ; then
+        echo $i ok
+    else
+        echo $i >> $OUT;
+    fi
+done
+
+if [ -f $OUT ]; then
+    echo "Failed on:"
+    cat $OUT
+fi


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Sometimes I want to compile a test for all boards that it is supposed to be working on and see where it fails.

This simple script does just that, maybe it's useful for others as well.

### Testing procedure

Run e.g. `dist/tools/compile_test/compile_for_all_boards.sh tests/periph_dac`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
