### PR TITLE
Updated stlink makefile to use OpenOCD's single configuration file.

### DIFF
--- a/dist/tools/openocd/adapters/stlink.cfg
+++ b/dist/tools/openocd/adapters/stlink.cfg
@@ -1,0 +1,12 @@
+# OpenOCD currently uses a single configuration file for all ST-Link
+# adapters. However not all supported distributions use the latest
+# OpenOCD.
+# If the default script isn't available then use the old method via
+# specifying the correct version.
+try {
+    source [find interface/stlink.cfg]
+} on error {} {
+    puts "WARNING: using old version of OpenOCD"
+    puts "Using STLINK_VERSION $stlink_version"
+    source [find interface/stlink-v${stlink_version}.cfg]
+}

--- a/makefiles/tools/openocd-adapters/stlink.inc.mk
+++ b/makefiles/tools/openocd-adapters/stlink.inc.mk
@@ -1,9 +1,11 @@
 # ST-Link debug adapter
-# Use st-link v2-1 by default
+
+# Set the default version for the old OpenOCD versions
 STLINK_VERSION ?= 2-1
 
-# Use STLINK_VERSION to select which stlink version is used
-OPENOCD_ADAPTER_INIT ?= -c 'source [find interface/stlink-v$(STLINK_VERSION).cfg]'
+# Determine which configuration file to use for OpenOCD.
+# Also pass the correct version of the ST-Link adapter to the script.
+OPENOCD_ADAPTER_INIT ?= -c 'set stlink_version $(STLINK_VERSION);source $(RIOTBASE)/dist/tools/openocd/adapters/stlink.cfg'
 
 # If swd / jtag is selected by the board, prefix it with hla_
 ifneq (,$(filter swd jtag,$(OPENOCD_TRANSPORT)))


### PR DESCRIPTION

### Contribution description
OpenOCD has been using a single configuration file for all ST-link adapters. RIOT still used a specific version. Which leads to a warning when flashing a board. This patch makes RIOT use the generic stlink.cfg which OpenOCD has been using since 2017.

### Testing procedure
Flash firmware to a board via an ST-Link adapter using OpenOCD. I tested this with a Bluepill board. 

### Issues/PRs references
This Fixes #14855
