### PR TITLE
pkg/{lwip,ubasic}: call submake with '+'

### DIFF
--- a/pkg/lwip/Makefile
+++ b/pkg/lwip/Makefile
@@ -15,7 +15,7 @@ LWIP_MODULE_MAKEFILE = $(RIOTBASE)/Makefile.base
 
 CFLAGS += -Wno-address
 
-make_module = "$(MAKE)" -C $(2) -f $(LWIP_MODULE_MAKEFILE) MODULE=$(1)
+make_module = +"$(MAKE)" -C $(2) -f $(LWIP_MODULE_MAKEFILE) MODULE=$(1)
 
 all: lwip
 

--- a/pkg/ubasic/Makefile
+++ b/pkg/ubasic/Makefile
@@ -12,7 +12,7 @@ UBASIC_USEMODULE = $(filter $(UBASIC_MODULES),$(USEMODULE))
 
 all: ubasic
 
-make_module = "$(MAKE)" -f $(RIOTPKG)/ubasic/$(1).mk -C $(2)
+make_module = +"$(MAKE)" -f $(RIOTPKG)/ubasic/$(1).mk -C $(2)
 
 ubasic: $(UBASIC_USEMODULE)
 	$(call make_module,$@,$(PKG_SOURCE_DIR))


### PR DESCRIPTION
### Contribution description
When calling `make` recursively (via `$(MAKE)`) make will pass some information to the child process, but only when make can ensure that the child process is `make`. This was not happening on some packages, as the recipe was being expanded from a function call, which is one of the exceptions mentioned [here](https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html#MAKE-Variable). Simply adding `+` will tell make to pass this information to the subprocess, and build in parallel. 

### Testing procedure
On master building these packages with multiple jobs, returns a warning `make -C tests/lwip -j8`:

```
"make" -C /home/leandro/Work/RIOT/build/pkg/lwip/src/netif -f /home/leandro/Work/RIOT/Makefile.base MODULE=lwip_netif
make[2]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[2]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[2]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
make[2]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
```
With this PR it should be gone.

### Issues/PRs references
None
