### PR TITLE
STM32F3 familly ADC implementation

### DIFF
--- a/cpu/stm32/include/periph/f3/periph_cpu.h
+++ b/cpu/stm32/include/periph/f3/periph_cpu.h
@@ -23,6 +23,24 @@
 extern "C" {
 #endif
 
+/**
+ * @brief   Available number of ADC devices
+ */
+#if defined(ADC4)
+#define ADC_DEVS            (4U)
+#elif defined(ADC3)
+#define ADC_DEVS            (3U)
+#elif defined(ADC2)
+#define ADC_DEVS            (2U)
+#elif defined(ADC1)
+#define ADC_DEVS            (1U)
+#endif
+
+/**
+ * @brief   ADC voltage regulator start-up time [us]
+ */
+#define ADC_T_ADCVREG_STUP_US (10)
+
 #ifndef DOXYGEN
 
 /**
@@ -31,6 +49,20 @@ extern "C" {
  */
 #define STM32_BOOTLOADER_ADDR   (0x1FFFD800)
 
+/**
+ * @brief   Override ADC resolution values
+ * @{
+ */
+#define HAVE_ADC_RES_T
+typedef enum {
+    ADC_RES_6BIT  = (ADC_CFGR_RES),   /**< ADC resolution: 6 bit */
+    ADC_RES_8BIT  = (ADC_CFGR_RES_1), /**< ADC resolution: 8 bit */
+    ADC_RES_10BIT = (ADC_CFGR_RES_0), /**< ADC resolution: 10 bit */
+    ADC_RES_12BIT = (0x0),            /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = (0x1),            /**< not applicable */
+    ADC_RES_16BIT = (0x2)             /**< not applicable */
+} adc_res_t;
+/** @} */
 #endif /* ndef DOXYGEN */
 
 #ifdef __cplusplus

--- a/cpu/stm32/periph/adc_f3.c
+++ b/cpu/stm32/periph/adc_f3.c
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2020 LAAS-CNRS
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_stm32
+ * @ingroup     drivers_periph_adc
+ * @{
+ *
+ * @file
+ * @brief       Low-level ADC driver implementation
+ *
+ * @author      Hugues Larrive <hugues.larrive@laas.fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "mutex.h"
+#include "periph/adc.h"
+#include "periph_conf.h"
+#include "xtimer.h"
+
+#define SMP_SLOW    (0x2) /*< Sampling time for slow channels
+                                (0x2 = 4.5 ADC clock cycles) */
+
+/**
+ * @brief   Allocate locks for all available ADC devices
+ */
+static mutex_t locks[ADC_DEVS];
+
+static inline ADC_TypeDef *dev(adc_t line)
+{
+    return (ADC_TypeDef *)(ADC1_BASE + (adc_config[line].dev << 8));
+}
+
+static inline void prep(adc_t line)
+{
+    mutex_lock(&locks[adc_config[line].dev]);
+/* Enable the clock here only if it will be disabled by done, else just
+ * enable it once in adc_init() */
+#if defined(RCC_AHBENR_ADC1EN)
+    periph_clk_en(AHB, (RCC_AHBENR_ADC1EN << adc_config[line].dev));
+#endif
+}
+
+static inline void done(adc_t line)
+{
+/* On some STM32F3 ADC are grouped by paire (ADC12EN or ADC34EN) so
+ * don't disable the clock as the other device may still use it. */
+#if defined(RCC_AHBENR_ADC1EN)
+    periph_clk_dis(AHB, (RCC_AHBENR_ADC1EN << adc_config[line].dev));
+#endif
+    mutex_unlock(&locks[adc_config[line].dev]);
+}
+
+int adc_init(adc_t line)
+{
+    /* Check if the line is valid */
+    if (line >= ADC_NUMOF) {
+        return -1;
+    }
+
+    /* Lock device and enable its peripheral clock */
+    prep(line);
+/* On some STM32F3 ADC are grouped by paire (ADC12EN or ADC34EN) so
+ * enable the clock only once here. */
+#if !defined(RCC_AHBENR_ADC1EN)
+    periph_clk_en(AHB, (RCC_AHBENR_ADC12EN << adc_config[line].dev));
+#endif
+
+    /* Setting ADC clock to HCLK/1 is only allowed if AHB clock
+     * prescaler is 1 */
+    if (!(RCC->CFGR & RCC_CFGR_HPRE_3)) {
+        /* set ADC clock to HCLK/1 */
+        ADC12_COMMON->CCR |= ADC_CCR_CKMODE_0;
+    }
+    else {
+        /* set ADC clock to HCLK/2 otherwise */
+        ADC12_COMMON->CCR |= ADC_CCR_CKMODE_1;
+    }
+
+    /* Configure the pin */
+    gpio_init_analog(adc_config[line].pin);
+
+    /* Init ADC line only if it wasn't already initialized */
+    if (!(dev(line)->CR & ADC_CR_ADEN)) {
+        /* Enable ADC internal voltage regulator and wait for startup period */
+        dev(line)->CR |= ADC_CR_ADVREGEN;
+        xtimer_usleep(ADC_T_ADCVREG_STUP_US);
+
+        /* Configure calibration for single ended input */
+        dev(line)->CR &= ~ADC_CR_ADCALDIF;
+
+        /* Start automatic calibration and wait for it to complete */
+        dev(line)->CR |= ADC_CR_ADCAL;
+        while (dev(line)->CR  & ADC_CR_ADCAL) {}
+
+        /* Clear ADRDY by writing it */
+        dev(line)->ISR |= ADC_ISR_ADRDY;
+
+        /* Enable ADC and wait for it to be ready */
+        dev(line)->CR |= ADC_CR_ADEN;
+        while ((dev(line)->ISR & ADC_ISR_ADRDY) == 0) {}
+
+        /* Set sequence length to 1 conversion */
+        dev(line)->SQR1 |= (0 & ADC_SQR1_L);
+    }
+
+    /* Configure sampling time for the given channel (6 to 18) */
+    dev(line)->SMPR1 = (SMP_SLOW << ADC_SMPR1_SMP6_Pos)
+                        | (SMP_SLOW << ADC_SMPR1_SMP7_Pos)
+                        | (SMP_SLOW << ADC_SMPR1_SMP8_Pos)
+                        | (SMP_SLOW << ADC_SMPR1_SMP9_Pos);
+    dev(line)->SMPR2 = (SMP_SLOW << ADC_SMPR2_SMP10_Pos)
+                        | (SMP_SLOW << ADC_SMPR2_SMP11_Pos)
+                        | (SMP_SLOW << ADC_SMPR2_SMP12_Pos)
+                        | (SMP_SLOW << ADC_SMPR2_SMP13_Pos)
+                        | (SMP_SLOW << ADC_SMPR2_SMP14_Pos)
+                        | (SMP_SLOW << ADC_SMPR2_SMP15_Pos)
+                        | (SMP_SLOW << ADC_SMPR2_SMP16_Pos)
+                        | (SMP_SLOW << ADC_SMPR2_SMP17_Pos)
+                        | (SMP_SLOW << ADC_SMPR2_SMP18_Pos);
+
+    /* Power off and unlock device again */
+    done(line);
+
+    return 0;
+}
+
+int32_t adc_sample(adc_t line, adc_res_t res)
+{
+    int sample;
+
+    /* Check if resolution is applicable */
+    if (res & 0x3) {
+        return -1;
+    }
+
+    /* Lock and power on the ADC device */
+    prep(line);
+
+    /* Set resolution */
+    dev(line)->CFGR &= ~ADC_CFGR_RES;
+    dev(line)->CFGR |= res;
+
+    /* Specify channel for regular conversion */
+    dev(line)->SQR1 = adc_config[line].chan << ADC_SQR1_SQ1_Pos;
+
+    /* Start conversion and wait for it to complete */
+    dev(line)->CR |= ADC_CR_ADSTART;
+    while (!(dev(line)->ISR & ADC_ISR_EOC)) {}
+
+    /* Read the sample */
+    sample = (int)dev(line)->DR;
+
+    /* Power off and unlock device again */
+    done(line);
+
+    return sample;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
A quick implementation that only support external channels for the nucleo arduino header pins.

We need differential channels in our project so I now plane to use the adc_ng api from #13247 and don't spend more time on that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
See PR #14861.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
