### PR TITLE
boards/nucleo-f334r8: add ADC feature

### DIFF
--- a/boards/nucleo-f334r8/Kconfig
+++ b/boards/nucleo-f334r8/Kconfig
@@ -15,6 +15,7 @@ config BOARD_NUCLEO_F334R8
     select CPU_MODEL_STM32F334R8
 
     # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_ADC
     select HAS_PERIPH_DMA
     select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC

--- a/boards/nucleo-f334r8/Makefile.features
+++ b/boards/nucleo-f334r8/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32f334r8
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f334r8/include/periph_conf.h
+++ b/boards/nucleo-f334r8/include/periph_conf.h
@@ -32,6 +32,28 @@ extern "C" {
 #endif
 
 /**
+ * @name    ADC configuration
+ *
+ * Note that we do not configure all ADC channels,
+ * and not in the STM32F334 order.  Instead, we
+ * just define 6 ADC channels, for the Nucleo
+ * Arduino header pins A0-A5
+ *
+ * @{
+ */
+static const adc_conf_t adc_config[] = {
+    { .pin = GPIO_PIN(PORT_A, 0), .dev = 0, .chan =  1 }, /* ADC1_IN1,  fast */
+    { .pin = GPIO_PIN(PORT_A, 1), .dev = 0, .chan =  2 }, /* ADC1_IN2,  fast */
+    { .pin = GPIO_PIN(PORT_A, 4), .dev = 1, .chan =  1 }, /* ADC2_IN1,  fast */
+    { .pin = GPIO_PIN(PORT_B, 0), .dev = 0, .chan = 11 }, /* ADC1_IN11, slow */
+    { .pin = GPIO_PIN(PORT_C, 1), .dev = 1, .chan =  7 }, /* ADC12_IN7, slow */
+    { .pin = GPIO_PIN(PORT_C, 0), .dev = 1, .chan =  6 }, /* ADC12_IN6, slow */
+};
+
+#define ADC_NUMOF           ARRAY_SIZE(adc_config)
+/** @} */
+
+/**
  * @name    DMA streams configuration
  * @{
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Add ADC feature.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Tested using tests/periph_adc:
- set RES to 12bits and DELAY to 1s
- grounded each header A0 to A5 one after the other and saw the corresponding value go to zero.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on PR #14860.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
