### PR TITLE
murdock: disable CC color output

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -6,6 +6,7 @@
 : ${TEST_KCONFIG_samr21_xpro:="examples/hello-world"}
 
 export RIOT_CI_BUILD=1
+export CC_NOCOLOR=1
 export STATIC_TESTS=${STATIC_TESTS:-1}
 export CFLAGS_DBG=""
 export DLCACHE_DIR=${DLCACHE_DIR:-~/.dlcache}


### PR DESCRIPTION
### Contribution description
[Outputs](https://ci.riot-os.org/RIOT-OS/RIOT/14846/692f99989a779ae4a3c6df5825d4523808a5dc98/output/compile/examples/ndn-ping/yunjia-nrf51822:gnu.txt) on the CI are sometimes hard to read, because of the ANSI colors on the compiler diagnostic messages. We can disable this when building for the CI to improve readability.

### Testing procedure
Locally you can force a compiler error and then run `/bin/bash -c "source .murdock; JOBS=4 compile examples/hello-world samr21-xpro:gcc &> out.txt"`. The txt should not have any color codes.

### Issues/PRs references
None