### PR TITLE
boards: add Adafruit Itsy Bitsy

### DIFF
--- a/boards/adafruit-itsybitsy-nrf52/Kconfig
+++ b/boards/adafruit-itsybitsy-nrf52/Kconfig
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+config BOARD
+    default "adafruit-itsybitsy-nrf52" if BOARD_ADAFRUIT_ITSYBITSY_NRF52
+
+config BOARD_ADAFRUIT_ITSYBITSY_NRF52
+    bool
+    default y
+    select BOARD_COMMON_NRF52
+    select CPU_MODEL_NRF52840XXAA
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_UART
+    select HAS_PERIPH_USBDEV
+    select HAS_RADIO_NRF802154
+    select HAS_BOOTLOADER_NRFUTIL
+
+source "$(RIOTBOARD)/common/nrf52/Kconfig"

--- a/boards/adafruit-itsybitsy-nrf52/Makefile
+++ b/boards/adafruit-itsybitsy-nrf52/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/adafruit-itsybitsy-nrf52/Makefile.dep
+++ b/boards/adafruit-itsybitsy-nrf52/Makefile.dep
@@ -1,0 +1,16 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+ifeq (,$(filter-out stdio_cdc_acm,$(filter stdio_% slipdev_stdio,$(USEMODULE))))
+  # Use stdio_cdc_acm only if no other stdio is requested explicitly.
+  USEMODULE += stdio_cdc_acm
+endif
+
+# enable bootloader reset over USB, requires USB bootloader to be used
+ifneq (,$(filter stdio_cdc_acm,$(USEMODULE)))
+  FEATURES_REQUIRED += bootloader_nrfutil
+  USEMODULE += usb_board_reset
+endif
+
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/adafruit-itsybitsy-nrf52/Makefile.features
+++ b/boards/adafruit-itsybitsy-nrf52/Makefile.features
@@ -1,0 +1,13 @@
+CPU_MODEL = nrf52840xxaa
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += radio_nrf802154
+FEATURES_PROVIDED += bootloader_nrfutil
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/adafruit-itsybitsy-nrf52/Makefile.include
+++ b/boards/adafruit-itsybitsy-nrf52/Makefile.include
@@ -1,0 +1,30 @@
+# This board uses the vendor's serial bootloader
+
+PROGRAMMER ?= nrfutil
+
+ifeq (nrfutil,$(PROGRAMMER))
+
+  # For this board it is required to use Adafruit's implementation of nrfutil.
+  # https://github.com/adafruit/Adafruit_nRF52_nrfutil
+  #
+  # This boards comes with Adafruit's bootloader:
+  # https://github.com/adafruit/Adafruit_nRF52_Bootloader
+  # In order to burn the application in the correct location, a offset of
+  # 0x26000 is required
+
+  ROM_OFFSET = 0x26000
+  ROM_LEN = 0xda000
+
+  FLASHFILE = $(HEXFILE)
+  FLASHDEPS += $(HEXFILE).zip
+  FLASHER = adafruit-nrfutil
+  FFLAGS = --verbose dfu serial -p ${PORT} -b 115200 --singlebank --package=$(HEXFILE).zip
+
+  include $(RIOTMAKE)/tools/usb_board_reset.mk
+endif
+
+%.hex.zip: %.hex
+	$(call check_cmd,$(FLASHER),Flash program and preparation tool)
+	$(FLASHER) dfu genpkg --dev-type 0x0052 --sd-req 0x00B6 --application $< $@
+
+include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/adafruit-itsybitsy-nrf52/board.c
+++ b/boards/adafruit-itsybitsy-nrf52/board.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Bruno Chianca <brunobcf@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-itsybitsy-nrf52
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the Adafruit ItsyBitsy nRF52840
+ *
+ * @author      Bruno Chianca <brunobcf@gmail.com>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the board's single LED */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_set(LED0_PIN);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/adafruit-itsybitsy-nrf52/doc.txt
+++ b/boards/adafruit-itsybitsy-nrf52/doc.txt
@@ -1,0 +1,50 @@
+/**
+@defgroup    boards_adafruit-itsybitsy-nrf52 Adafruit-Itsybitsy-nRF52
+@ingroup     boards
+@brief       Support for the Adafruit-Itsybitsy-nRF52
+
+### General information
+
+This is a small formfactor (only 1.4" long by 0.7" wide) nRF52840 board made by Adafruit.
+
+The board features one LED (LD1: blue), a user (SW1) and a
+reset button as well as 21 configurable external pins(6 of which can be analog in).
+
+### Links
+
+- [Overview](https://learn.adafruit.com/adafruit-itsybitsy-nrf52840-express?view=all)
+- [Pinouts](https://learn.adafruit.com/adafruit-itsybitsy-nrf52840-express/pinouts)
+
+### Flash the board
+
+The board is flashed using its on-board [boot loader](https://github.com/adafruit/Adafruit_nRF52_Bootloader).
+Adafruit has a special version of the [nrfutil](https://github.com/adafruit/Adafruit_nRF52_nrfutil) that program needs to
+be installed. It can turn the binary into a suitable zip file and send it to the DFU
+bootloader.
+
+The process is automated in the usual `make flash` target.
+
+If RIOT is already running on the board, it will automatically reset the CPU and enter
+the bootloader.
+If some other firmware is running or RIOT crashed, you need to enter the bootloader
+manually by double tapping the board's reset button.
+
+Readiness of the bootloader is indicated by LD1 pulsing in blue.
+
+Important to note that Adafruit's nrfutil is not compatible with Nordic's nrfutil.
+
+#### nrfutil installation
+
+On systems with Python 3, a recent version of pip is required to install all dependencies;
+you may need to run `pip3 install --upgrade pip3` before being able to run `pip3 install adafruit-nrfutil` successfully.
+
+### Accessing STDIO
+
+The usual way to obtain a console on this board is using an emulated USB serial port.
+
+
+### Todo
+
+Add support for the mini DotStar RGB LED
+
+ */

--- a/boards/adafruit-itsybitsy-nrf52/include/board.h
+++ b/boards/adafruit-itsybitsy-nrf52/include/board.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C)  2020 Bruno Chianca <brunobcf@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-itsybitsy-nrf52
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for Adafruit ItsyBitsy nRF52840
+ *
+ * @author      Bruno Chianca <brunobcf@gmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+ /** @brief The LED labelled LD1 */
+#define LED0_PIN            GPIO_PIN(0, 6)
+
+/** @} */
+
+/**
+ * @name    LED access macros
+ * @{
+ */
+
+/** Enable LD1 */
+#define LED0_ON gpio_clear(LED0_PIN)
+/** Disable LD1 */
+#define LED0_OFF gpio_set(LED0_PIN)
+/** Toggle LD1 */
+#define LED0_TOGGLE gpio_toggle(LED0_PIN)
+
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+/** @brief The button labelled SW1 */
+#define BTN0_PIN GPIO_PIN(0, 29)
+/** @brief The GPIO pin mode of the button labelled SW1 */
+#define BTN0_MODE GPIO_IN_PU
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/adafruit-itsybitsy-nrf52/include/gpio_params.h
+++ b/boards/adafruit-itsybitsy-nrf52/include/gpio_params.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020 Bruno Chianca <brunobcf@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-itsybitsy-nrf52
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins for the Adafruit
+ *              ItsyBitsy nRF52840
+ *
+ * @author      Bruno Chianca <brunobcf@gmail.com>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED and button configuration for SAUL
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "LD 1",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
+    },
+    {
+        .name  = "SW 1",
+        .pin   = BTN0_PIN,
+        .mode  = GPIO_IN_PU,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/adafruit-itsybitsy-nrf52/include/periph_conf.h
+++ b/boards/adafruit-itsybitsy-nrf52/include/periph_conf.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2020 Bruno Chianca <brunobcf@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-itsybitsy-nrf52
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the Adafruit ItsyBitsy nRF52840
+ *
+ * @author      Bruno Chianca <brunobcf@gmail.com>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ *
+ * This board does RX and TX defined as pins 0 and 1 on the board.
+ *
+ * @{
+ */
+
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0, 25),
+        .tx_pin     = GPIO_PIN(0, 24),
+#ifdef MODULE_PERIPH_UART_HW_FC
+        .rts_pin    = GPIO_UNDEF,
+        .cts_pin    = GPIO_UNDEF,
+#endif
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+};
+
+#define UART_0_ISR          isr_uart0
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPIM0,
+        .sclk = GPIO_PIN(0, 13),
+        .mosi = GPIO_PIN(0, 15),
+        .miso = GPIO_PIN(0, 20),
+    }
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = NRF_TWIM1,
+        .scl = GPIO_PIN(0, 14),
+        .sda = GPIO_PIN(0, 16),
+        .speed = I2C_SPEED_NORMAL
+    }
+};
+#define I2C_NUMOF           ARRAY_SIZE(i2c_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/boards/adafruit-itsybitsy-nrf52/reset.c
+++ b/boards/adafruit-itsybitsy-nrf52/reset.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C)  2020 Bruno Chianca
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_adafruit-itsybitsy-nrf52
+ * @{
+ * @file
+ * @brief       Allows reboot into bootloader via prompt
+ *
+ * @author      Bruno Chianca
+ *
+ * @}
+ */
+
+#ifdef MODULE_USB_BOARD_RESET
+
+#include "periph/gpio.h"
+#include "usb_board_reset.h"
+
+#define NRF52_DOUBLE_TAP_MAGIC_NUMBER       (0x4e)
+
+void usb_board_reset_in_bootloader(void)
+{
+    NRF_POWER->GPREGRET = NRF52_DOUBLE_TAP_MAGIC_NUMBER;
+
+    usb_board_reset_in_application();
+}
+
+#endif /* MODULE_USB_BOARD_RESET */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Adding the support for a new board: Itsy Bitsy nRF52840 from Adafruit.
In order to test one need to have one board and test compiling any application.

### Testing procedure

- Find a Itsy Bitsy nRF52840 board
- Install adafruit-nrfutil: pip3 install adafruit-nrfutil
- Connect via USB
- Enter bootloader mode: double tap the reset button
- switch to application directory
- make flash BOARD=adafruit-itsybitsy-nrf52

The board should be flashed and the application should work as expected
It is important to remember that adafruit-nrfutil and nrfutil from Nordic are not compatible

For subsequent flashes the board enters bootloader mode automatically

### Issues/PRs references

<!--
-->
