### PR TITLE
boards/stm32l1: introduce shared clock configuration header

### DIFF
--- a/boards/common/stm32/include/l1/cfg_clock_default.h
+++ b/boards/common/stm32/include/l1/cfg_clock_default.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @{
+ *
+ * @file
+ * @brief       Default clock configuration for the STM32L1
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef L1_CFG_CLOCK_DEFAULT_H
+#define L1_CFG_CLOCK_DEFAULT_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock system configuration
+ * @{
+ */
+#define CLOCK_HSI           (16000000U)         /* internal oscillator */
+#define CLOCK_CORECLOCK     (32000000U)         /* desired core clock frequency */
+
+#ifndef CLOCK_LSE
+#define CLOCK_LSE           (0)                 /* disable low speed external oscillator */
+#endif
+
+/* configuration of PLL prescaler and multiply values */
+/* CORECLOCK := HSI / CLOCK_PLL_DIV * CLOCK_PLL_MUL */
+#define CLOCK_PLL_DIV       RCC_CFGR_PLLDIV2
+#define CLOCK_PLL_MUL       RCC_CFGR_PLLMUL4
+/* configuration of peripheral bus clock prescalers */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1      /* AHB clock -> 32MHz */
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* APB2 clock -> 32MHz */
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV1     /* APB1 clock -> 32MHz */
+/* configuration of flash access cycles */
+#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY
+
+/* bus clocks for simplified peripheral initialization, UPDATE MANUALLY! */
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 1)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* L1_CFG_CLOCK_DEFAULT_H */
+/** @} */

--- a/boards/im880b/Makefile.include
+++ b/boards/im880b/Makefile.include
@@ -1,3 +1,6 @@
+# this board uses shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/im880b/include/periph_conf.h
+++ b/boards/im880b/include/periph_conf.h
@@ -19,42 +19,19 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
-#include "periph_cpu.h"
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/**
- * @name    Clock system configuration
- * @{
- **/
-#define CLOCK_HSE           (16000000U)         /* external oscillator */
-#define CLOCK_CORECLOCK     (32000000U)         /* desired core clock frequency */
-
 /*
- * 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz)
+ * This board provides an LSE, so enable it before including the default clock config
  */
 #ifndef CLOCK_LSE
 #define CLOCK_LSE           (1)
 #endif
-/* configuration of PLL prescaler and multiply values */
-/* CORECLOCK := HSE / CLOCK_PLL_DIV * CLOCK_PLL_MUL */
-#define CLOCK_PLL_DIV       RCC_CFGR_PLLDIV2
-#define CLOCK_PLL_MUL       RCC_CFGR_PLLMUL4
-/* configuration of peripheral bus clock prescalers */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1      /* AHB clock -> 32MHz */
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* APB2 clock -> 32MHz */
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV1     /* APB1 clock -> 32MHz */
-/* configuration of flash access cycles */
-#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY
 
-/* bus clocks for simplified peripheral initialization, UPDATE MANUALLY! */
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-/** @} */
+#include "periph_cpu.h"
+#include "l1/cfg_clock_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @name    Timer configuration

--- a/boards/limifrog-v1/Makefile.include
+++ b/boards/limifrog-v1/Makefile.include
@@ -1,3 +1,6 @@
+# this board uses shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/limifrog-v1/include/periph_conf.h
+++ b/boards/limifrog-v1/include/periph_conf.h
@@ -20,34 +20,11 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "l1/cfg_clock_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock system configuration
- * @{
- **/
-#define CLOCK_HSI           (16000000U)         /* internal oscillator */
-#define CLOCK_CORECLOCK     (32000000U)         /* desired core clock frequency */
-
-/* configuration of PLL prescaler and multiply values */
-/* CORECLOCK := HSI / CLOCK_PLL_DIV * CLOCK_PLL_MUL */
-#define CLOCK_PLL_DIV       RCC_CFGR_PLLDIV2
-#define CLOCK_PLL_MUL       RCC_CFGR_PLLMUL4
-/* configuration of peripheral bus clock prescalers */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1      /* AHB clock -> 32MHz */
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* APB2 clock -> 32MHz */
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV1     /* APB1 clock -> 32MHz */
-/* configuration of flash access cycles */
-#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY
-
-/* bus clocks for simplified peripheral initialization, UPDATE MANUALLY! */
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 1)
-/** @} */
 
 /**
  * @name    Timer configuration

--- a/boards/lobaro-lorabox/include/periph_conf.h
+++ b/boards/lobaro-lorabox/include/periph_conf.h
@@ -24,42 +24,20 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/*
+ * This board provides an LSE, so enable it before including the default clock config
+ */
+#ifndef CLOCK_LSE
+#define CLOCK_LSE           (1)
+#endif
+
 #include "periph_cpu.h"
+#include "l1/cfg_clock_default.h"
 #include "cfg_timer_tim2.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name Clock system configuration
- * @{
- **/
-#define CLOCK_HSI           (16000000U)             /* frequency of internal oscillator */
-#define CLOCK_CORECLOCK     (32000000U)             /* targeted core clock frequency */
-/*
- * 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz)
- */
-#ifndef CLOCK_LSE
-#define CLOCK_LSE           (1)
-#endif
-/* configuration of PLL prescaler and multiply values */
-/* CORECLOCK := HSI / CLOCK_PLL_DIV * CLOCK_PLL_MUL */
-#define CLOCK_PLL_DIV       RCC_CFGR_PLLDIV2
-#define CLOCK_PLL_MUL       RCC_CFGR_PLLMUL4
-/* configuration of peripheral bus clock prescalers */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1      /* AHB clock -> 32MHz */
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* APB2 clock -> 32MHz */
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV1     /* APB1 clock -> 32MHz */
-/* configuration of flash access cycles */
-#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY
-
-/* bus clocks for simplified peripheral initialization, UPDATE MANUALLY! */
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 1)
-/** @} */
 
 /**
  * @name   UART configuration

--- a/boards/nucleo-l152re/include/periph_conf.h
+++ b/boards/nucleo-l152re/include/periph_conf.h
@@ -21,45 +21,12 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "l1/cfg_clock_default.h"
 #include "cfg_timer_tim5.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name Clock system configuration
- * @{
- **/
-#define CLOCK_HSI           (16000000U)             /* frequency of internal oscillator */
-#define CLOCK_CORECLOCK     (32000000U)             /* targeted core clock frequency */
-/*
- * 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz)
- *
- * LSE might not be available by default in early (C-01) Nucleo boards.
- * For newer revisions, an LSE crystal is present and CLOCK_LSE can be set to 1
- * if one wants to use it.
- */
-#ifndef CLOCK_LSE
-#define CLOCK_LSE           (0)
-#endif
-/* configuration of PLL prescaler and multiply values */
-/* CORECLOCK := HSI / CLOCK_PLL_DIV * CLOCK_PLL_MUL */
-#define CLOCK_PLL_DIV       RCC_CFGR_PLLDIV2
-#define CLOCK_PLL_MUL       RCC_CFGR_PLLMUL4
-/* configuration of peripheral bus clock prescalers */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1      /* AHB clock -> 32MHz */
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* APB2 clock -> 32MHz */
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV1     /* APB1 clock -> 32MHz */
-/* configuration of flash access cycles */
-#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY
-
-/* bus clocks for simplified peripheral initialization, UPDATE MANUALLY! */
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 1)
-/** @} */
 
 /**
  * @name    DMA streams configuration

--- a/boards/nz32-sc151/include/periph_conf.h
+++ b/boards/nz32-sc151/include/periph_conf.h
@@ -20,35 +20,12 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "l1/cfg_clock_default.h"
 #include "cfg_timer_tim5.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock system configuration
- * @{
- **/
-#define CLOCK_HSI           (16000000U)         /* internal oscillator */
-#define CLOCK_CORECLOCK     (32000000U)         /* desired core clock frequency */
-
-/* configuration of PLL prescaler and multiply values */
-/* CORECLOCK := HSI / CLOCK_PLL_DIV * CLOCK_PLL_MUL */
-#define CLOCK_PLL_DIV       RCC_CFGR_PLLDIV2
-#define CLOCK_PLL_MUL       RCC_CFGR_PLLMUL4
-/* configuration of peripheral bus clock prescalers */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1      /* AHB clock -> 32MHz */
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* APB2 clock -> 32MHz */
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV1     /* APB1 clock -> 32MHz */
-/* configuration of flash access cycles */
-#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY
-
-/* bus clocks for simplified peripheral initialization, UPDATE MANUALLY! */
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-/** @} */
 
 /**
  * @name    UART configuration


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Similar to other stm32 families, this PR introduces a shared clock configuration for the stm32l1 family of boards. Related boards are adapted to make use.
The `CLOCK_LSE` constant is set to 0 by default (some boards like nz32-sc151 and limifrog-v1 were not defining it) and boards which provide one are setting it ot 1 in their periph_conf.h file, before including the shared header.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- One can check that the code remains unchanged for affected boards.

Example with nz32-sc151:
<details><summary>this PR</summary>

```
BUILD_IN_DOCKER=1 RIOT_VERSION=test make BOARD=nz32-sc151 -C tests/periph_rtc --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nz32-sc151' -e 'RIOT_VERSION=test'  -w '/data/riotbuild/riotbase/tests/periph_rtc/' 'riot/riotbuild:latest' make 'BOARD=nz32-sc151'    
Building application "tests_periph_rtc" for "nz32-sc151" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/pkg/stm32cmsis
"make" -C /data/riotbuild/riotbase/boards/nz32-sc151
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/bootloader
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  12016	    132	   2432	  14580	   38f4	/data/riotbuild/riotbase/tests/periph_rtc/bin/nz32-sc151/tests_periph_rtc.elf
```

</details>

<details><summary>master</summary>

```
BUILD_IN_DOCKER=1 RIOT_VERSION=test make BOARD=nz32-sc151 -C tests/periph_rtc --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nz32-sc151' -e 'RIOT_VERSION=test'  -w '/data/riotbuild/riotbase/tests/periph_rtc/' 'riot/riotbuild:latest' make 'BOARD=nz32-sc151'    
Building application "tests_periph_rtc" for "nz32-sc151" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/pkg/stm32cmsis
"make" -C /data/riotbuild/riotbase/boards/nz32-sc151
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/bootloader
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  12016	    132	   2432	  14580	   38f4	/data/riotbuild/riotbase/tests/periph_rtc/bin/nz32-sc151/tests_periph_rtc.elf
```

</details>

- run `examples/hello-world` on nucleo-l152re:


<details>

```
BUILD_IN_DOCKER=1 RIOT_VERSION=test make BOARD=nucleo-l152re -C examples/hello-world flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-l152re' -e 'RIOT_VERSION=test'  -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make 'BOARD=nucleo-l152re'    
Building application "hello-world" for "nucleo-l152re" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/pkg/stm32cmsis
"make" -C /data/riotbuild/riotbase/boards/nucleo-l152re
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/bootloader
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8520	    112	   2324	  10956	   2acc	/data/riotbuild/riotbase/examples/hello-world/bin/nucleo-l152re/hello-world.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/examples/hello-world/bin/nucleo-l152re/hello-world.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01383-gd46f28c2e-dirty (2020-08-20-10:53)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
WARNING: interface/stlink-v2-1.cfg is deprecated, please switch to interface/stlink.cfg
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 300 kHz
Info : STLINK V2J25M14 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.262228
Info : stm32l1.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32l1.cpu on 0
Info : Listening on port 34271 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32l1.cpu        hla_target little stm32l1.cpu        reset

Info : Unable to match requested speed 300 kHz, using 240 kHz
Info : Unable to match requested speed 300 kHz, using 240 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08000594 msp: 0x20000200
Info : Device: STM32L1xx (Cat.5/Cat.6)
Info : STM32L flash has dual banks. Bank (0) size is 256kb, base address is 0x8000000
auto erase enabled
wrote 12288 bytes from file /work/riot/RIOT/examples/hello-world/bin/nucleo-l152re/hello-world.elf in 1.616144s (7.425 KiB/s)

verified 8632 bytes in 0.584199s (14.429 KiB/s)

Info : Unable to match requested speed 300 kHz, using 240 kHz
Info : Unable to match requested speed 300 kHz, using 240 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-08-27 16:15:26,351 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2020-08-27 16:15:30,105 # main(): This is RIOT! (Version: test)
2020-08-27 16:15:30,106 # Hello World!
2020-08-27 16:15:30,111 # You are running RIOT on a(n) nucleo-l152re board.
2020-08-27 16:15:30,117 # This board features a(n) stm32 MCU.
2020-08-27 16:15:31,269 # Exiting Pyterm
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Will be required for the PR I'm planning to open and that rework/improve the clock configuration for l0/l1.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
