### PR TITLE
boards/yarm: support debugging via openocd

### DIFF
--- a/boards/yarm/dist/openocd.cfg
+++ b/boards/yarm/dist/openocd.cfg
@@ -1,0 +1,2 @@
+source [find target/at91samdXX.cfg]
+$_TARGETNAME configure -rtos auto


### PR DESCRIPTION
Added dist/openocd.cfg file to boards/yarm, to allow _make debug_ via openocd.