### PR TITLE
cpu/fe310: RTC: use rtc_mktime()

### DIFF
--- a/cpu/fe310/periph/rtc.c
+++ b/cpu/fe310/periph/rtc.c
@@ -17,10 +17,6 @@
  * @}
  */
 
-#include <stdlib.h>
-#include <unistd.h>
-#include <time.h>
-
 #include "cpu.h"
 #include "periph_cpu.h"
 #include "periph_conf.h"
@@ -46,38 +42,38 @@ void rtc_init(void)
 
 int rtc_set_time(struct tm *time)
 {
-    time_t t = mktime(time);
+    uint32_t t = rtc_mktime(time);
 
-    rtt_set_counter((uint32_t)t);
+    rtt_set_counter(t);
 
     return 0;
 }
 
 int rtc_get_time(struct tm *time)
 {
-    time_t t = (time_t)rtt_get_counter();
+    uint32_t t = rtt_get_counter();
 
-    gmtime_r(&t, time);
+    rtc_localtime(t, time);
 
     return 0;
 }
 
 int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
 {
-    time_t t = mktime(time);
+    uint32_t t = rtc_mktime(time);
 
     rtc_callback.cb = cb;
 
-    rtt_set_alarm((uint32_t)t, rtc_cb, arg);
+    rtt_set_alarm(t, rtc_cb, arg);
 
     return 0;
 }
 
 int rtc_get_alarm(struct tm *time)
 {
-    time_t t = (time_t)rtt_get_alarm();
+    uint32_t t = rtt_get_alarm();
 
-    gmtime_r(&t, time);
+    rtc_localtime(t, time);
 
     return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Use RTC helper functions instead of libc functions.
This gives us y2038 safety by the extended epoch and saves a good chunk of memory:

#### picolibc mktime():

```
   text	   data	    bss	    dec	    hex	filename
  15048	    520	   2504	  18072	   4698	tests/periph_rtc/bin/hifive1/tests_periph_rtc.elf
```

#### rtc_mktime():

```
   text	   data	    bss	    dec	    hex	filename
   7632	     40	   2452	  10124	   278c	tests/periph_rtc/bin/hifive1/tests_periph_rtc.elf
```

### Testing procedure

`tests/periph_rtc` should still work.
(untested, I don't have the hardware)

### Issues/PRs references

#13277
