### PR TITLE
cpu/kinetis: RTC use rtc_mktime()

### DIFF
--- a/cpu/kinetis/periph/rtc.c
+++ b/cpu/kinetis/periph/rtc.c
@@ -20,8 +20,6 @@
  * @}
  */
 
-#include <stdint.h>
-#include <time.h>
 #include "cpu.h"
 #include "periph/rtc.h"
 #include "periph/rtt.h"
@@ -41,7 +39,7 @@ static rtc_state_t rtc_callback;
  *
  * @param[inout] arg    argument passed from the RTT interrupt
  */
-static void rtc_cb(void* arg);
+static void rtc_cb(void *arg);
 
 void rtc_init(void)
 {
@@ -50,38 +48,38 @@ void rtc_init(void)
 
 int rtc_set_time(struct tm *time)
 {
-    time_t t = mktime(time);
+    uint32_t t = rtc_mktime(time);
 
-    rtt_set_counter((uint32_t)t);
+    rtt_set_counter(t);
 
     return 0;
 }
 
 int rtc_get_time(struct tm *time)
 {
-    time_t t = (time_t)rtt_get_counter();
+    uint32_t t = rtt_get_counter();
 
-    gmtime_r(&t, time);
+    rtc_localtime(t, time);
 
     return 0;
 }
 
 int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
 {
-    time_t t = mktime(time);
+    uint32_t t = rtc_mktime(time);
 
     rtc_callback.cb = cb;
 
-    rtt_set_alarm((uint32_t)t, rtc_cb, arg);
+    rtt_set_alarm(t, rtc_cb, arg);
 
     return 0;
 }
 
 int rtc_get_alarm(struct tm *time)
 {
-    time_t t = (time_t)rtt_get_alarm();
+    uint32_t t = rtt_get_alarm();
 
-    gmtime_r(&t, time);
+    rtc_localtime(t, time);
 
     return 0;
 }
@@ -102,7 +100,7 @@ void rtc_poweroff(void)
     rtt_poweroff();
 }
 
-static void rtc_cb(void* arg)
+static void rtc_cb(void *arg)
 {
     if (rtc_callback.cb != NULL) {
         rtc_callback.cb(arg);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Use RTC helper functions instead of libc functions.
This gives us y2038 safety by the extended epoch and saves a good chunk of memory:

#### mktime():

```
   text	   data	    bss	    dec	    hex	filename
  24756	    232	   2736	  27724	   6c4c	testssperiph_rtc/bin/openlabs-kw41z-mini/tests_periph_rtc.elf
```

#### rtc_mktime():

```
   text	   data	    bss	    dec	    hex	filename
  16348	    132	   2696	  19176	   4ae8	tests/periph_rtc/bin/openlabs-kw41z-mini/tests_periph_rtc.elf
```

### Testing procedure

`tests/periph_rtc` should still work.


### Issues/PRs references

#13277
