### PR TITLE
sifive_e: Initial include of Qemu sifive_e target

### DIFF
--- a/boards/hifive1/include/periph_conf.h
+++ b/boards/hifive1/include/periph_conf.h
@@ -32,6 +32,7 @@ extern "C" {
  *
  * @{
  */
+#define CLOCK_TIMERCLOCK            (RTC_FREQ)
 #define TIMER_NUMOF                 (1)
 /** @} */
 

--- a/boards/hifive1b/include/periph_conf.h
+++ b/boards/hifive1b/include/periph_conf.h
@@ -33,6 +33,7 @@ extern "C" {
  *
  * @{
  */
+#define CLOCK_TIMERCLOCK            (RTC_FREQ)
 #define TIMER_NUMOF                 (1)
 /** @} */
 

--- a/boards/sifive_e/Kconfig
+++ b/boards/sifive_e/Kconfig
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 Koen Zandberg <koen@bergzand.net>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "sifive_e" if BOARD_SIFIVE_E
+
+config BOARD_SIFIVE_E
+    bool
+    default y
+    select CPU_MODEL_FE310_G000
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART

--- a/boards/sifive_e/Makefile
+++ b/boards/sifive_e/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/sifive_e/Makefile.features
+++ b/boards/sifive_e/Makefile.features
@@ -1,0 +1,6 @@
+CPU = fe310
+CPU_MODEL = fe310_g000
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart

--- a/boards/sifive_e/Makefile.include
+++ b/boards/sifive_e/Makefile.include
@@ -1,0 +1,10 @@
+FLASHER = true
+FLASHFILE ?= $(ELFFILE)
+EMULATOR = qemu-system-riscv32
+EMULATOR_FLAGS = -machine sifive_e -kernel $(ELFFILE) \
+                 -serial stdio \
+                 -monitor telnet::45454,server,nowait \
+                 -nographic
+
+TERMPROG ?= $(EMULATOR)
+TERMFLAGS ?= $(EMULATOR_FLAGS)

--- a/boards/sifive_e/board.c
+++ b/boards/sifive_e/board.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_sifive_e
+ * @{
+ *
+ * @file
+ * @brief       Support for the Qemu sifive_e RISC-V board
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+
+void board_init(void)
+{
+    cpu_init();
+}

--- a/boards/sifive_e/doc.txt
+++ b/boards/sifive_e/doc.txt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_sifive_e Qemu siFive_e RISC-V board
+ * @ingroup     boards
+ * @brief       Support for the QEmu sifive_e RISC-V board
+ * @author      Koen Zandberg <koen@bergzand.net>
+
+The Qemu sifive_e 'board' is an emulated RISC-V machine supported by Qemu from
+release v2.12.0. Supported is UART stdio and the RISC-V core internal timer.
+
+Binaries for the hifive1 board are mostly compatible. The exception is the
+timer. On sifive_e it runs at 10 MHz.
+
+## Usage
+
+Compile as usual:
+```
+make -C examples/hello-world BOARD=sifive_e
+```
+
+Start and run with Qemu with the `emulate` target:
+
+```
+make -C examples/hello-world BOARD=sifive_e emulate
+```
+
+## Known issues
+
+A Qemu-supplied warning noting that time_lo and time_hi are not implemented
+can appear when using the hardware timer:
+
+```
+qemu-system-riscv32: clint: time_lo write not implemented
+qemu-system-riscv32: clint: time_hi write not implemented
+```
+
+RIOT resets the mtime register when initializing the timer. Qemu however
+doesn't implement writes to this register and throws a warning instead. This
+doesn't negatively impact RIOT as long as the firmware doesn't rely on an
+absolute value returned by `timer_read()`.
+ */

--- a/boards/sifive_e/include/board.h
+++ b/boards/sifive_e/include/board.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sifive_e
+ * @brief       Board specific definitions for the Qemu sifive_e RISC-V board
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Qemu sifive_e RISC-V board
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "macros/units.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_HZ                   (MHZ(10))
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/sifive_e/include/periph_conf.h
+++ b/boards/sifive_e/include/periph_conf.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg <koen@bergzand.net>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_sifive_e
+ * @{
+ *
+ * @file
+ * @brief       Peripheral specific definitions for the Qemu sifive_e RISC-V
+ *              board
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "macros/units.h"
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Core Clock configuration
+ *
+ * Contains the absolute minimum to make the clock code happy. Intentionally
+ * doesn't define CLOCK_CORECLOCK. Qemu doesn't pretend to run at a specific
+ * clock frequency.
+ * @{
+ */
+#define CONFIG_USE_CLOCK_HFXOSC_PLL         (0)
+#define CONFIG_USE_CLOCK_HFXOSC             (0)
+#define CONFIG_CLOCK_HFROSC_DIV             (1)
+#define CONFIG_CLOCK_HFROSC_TRIM            (6)
+/** @} */
+
+/**
+ * @name    Timer configuration
+ *
+ * @{
+ */
+#define CLOCK_TIMERCLOCK            (MHZ(10))
+#define TIMER_NUMOF                 (1)
+/** @} */
+
+/**
+ * @name   UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .addr       = UART0_CTRL_ADDR,
+        .rx         = GPIO_PIN(0, 16),
+        .tx         = GPIO_PIN(0, 17),
+        .isr_num    = INT_UART0_BASE,
+    },
+    {
+        .addr       = UART1_CTRL_ADDR,
+        .rx         = GPIO_PIN(0, 18),
+        .tx         = GPIO_PIN(0, 23),
+        .isr_num    = INT_UART1_BASE,
+    },
+};
+
+#define UART_NUMOF                  ARRAY_SIZE(uart_config)
+/** @} */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */
+

--- a/cpu/fe310/periph/timer.c
+++ b/cpu/fe310/periph/timer.c
@@ -45,7 +45,7 @@ int timer_init(tim_t dev, uint32_t freq, timer_cb_t cb, void *arg)
     }
 
     /* Built in timer for FE310 is 32KHz */
-    if (freq != RTC_FREQ) {
+    if (freq != CLOCK_TIMERCLOCK) {
         return -1;
     }
 

--- a/examples/asymcute_mqttsn/Makefile.ci
+++ b/examples/asymcute_mqttsn/Makefile.ci
@@ -33,6 +33,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/examples/cord_ep/Makefile.ci
+++ b/examples/cord_ep/Makefile.ci
@@ -24,6 +24,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l031k6 \
     nucleo-l053r8 \
     samd10-xmini \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/examples/cord_epsim/Makefile.ci
+++ b/examples/cord_epsim/Makefile.ci
@@ -21,6 +21,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l031k6 \
     nucleo-l053r8 \
     samd10-xmini \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/examples/cord_lc/Makefile.ci
+++ b/examples/cord_lc/Makefile.ci
@@ -25,6 +25,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l031k6 \
     nucleo-l053r8 \
     samd10-xmini \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/examples/dtls-echo/Makefile.ci
+++ b/examples/dtls-echo/Makefile.ci
@@ -33,6 +33,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/examples/dtls-sock/Makefile.ci
+++ b/examples/dtls-sock/Makefile.ci
@@ -37,6 +37,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/examples/dtls-wolfssl/Makefile.ci
+++ b/examples/dtls-wolfssl/Makefile.ci
@@ -32,6 +32,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     saml11-xpro \
     slstk3400a \
     spark-core \
+    sifive_e \
     stk3200 \
     stm32f030f4-demo \
     stm32f0discovery \

--- a/examples/emcute_mqttsn/Makefile.ci
+++ b/examples/emcute_mqttsn/Makefile.ci
@@ -27,6 +27,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l031k6 \
     nucleo-l053r8 \
     samd10-xmini \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/examples/gnrc_border_router/Makefile.ci
+++ b/examples/gnrc_border_router/Makefile.ci
@@ -48,6 +48,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/examples/gnrc_networking/Makefile.ci
+++ b/examples/gnrc_networking/Makefile.ci
@@ -34,6 +34,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/examples/javascript/Makefile.ci
+++ b/examples/javascript/Makefile.ci
@@ -44,6 +44,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/examples/paho-mqtt/Makefile.ci
+++ b/examples/paho-mqtt/Makefile.ci
@@ -24,6 +24,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/examples/wakaama/Makefile.ci
+++ b/examples/wakaama/Makefile.ci
@@ -30,6 +30,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -32,6 +32,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include "timex.h"
+#include "macros/units.h"
 #ifdef MODULE_CORE_MSG
 #include "msg.h"
 #endif /* MODULE_CORE_MSG */
@@ -605,7 +606,7 @@ static inline int xtimer_msg_receive_timeout64(msg_t *msg, uint64_t timeout);
 #endif
 
 #if !defined(XTIMER_SHIFT) && !defined(MODULE_XTIMER_ON_ZTIMER)
-#if (XTIMER_HZ == 32768ul)
+#if (XTIMER_HZ == 32768ul) || (XTIMER_HZ == MHZ(10))
 /* No shift necessary, the conversion is not a power of two and is handled by
  * functions in tick_conversion.h */
 #define XTIMER_SHIFT (0)

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -23,6 +23,7 @@
 #endif
 
 #include "div.h"
+#include "macros/units.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -120,6 +121,24 @@ static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
     /* return (usec * 15625) / 512; */
     uint64_t usec = (uint64_t)ticks * 15625ul;
     return (usec >> 9); /* equivalent to (usec / 512) */
+}
+
+#elif XTIMER_HZ == MHZ(10)
+
+static inline uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
+    return usec * 10;
+}
+
+static inline uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
+    return usec * 10;
+}
+
+static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
+    return ticks / 10;
+}
+
+static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
+    return ticks / 10;
 }
 
 #else

--- a/tests/bench_xtimer/Makefile
+++ b/tests/bench_xtimer/Makefile
@@ -55,6 +55,7 @@ LOW_MEMORY_BOARDS += \
   saml10-xpro \
   saml11-xpro \
   serpente \
+  sifive_e \
   sodaq-autonomo \
   sodaq-explorer \
   sodaq-one \

--- a/tests/conn_can/Makefile.ci
+++ b/tests/conn_can/Makefile.ci
@@ -29,6 +29,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l053r8 \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     stm32f0discovery \
     stm32f030f4-demo \
     stm32l0538-disco \

--- a/tests/driver_cc110x/Makefile.ci
+++ b/tests/driver_cc110x/Makefile.ci
@@ -29,6 +29,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/emcute/Makefile.ci
+++ b/tests/emcute/Makefile.ci
@@ -45,6 +45,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/tests/gnrc_dhcpv6_client/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client/Makefile.ci
@@ -28,6 +28,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
+++ b/tests/gnrc_dhcpv6_client_6lbr/Makefile.ci
@@ -49,6 +49,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/tests/gnrc_ipv6_ext/Makefile.ci
+++ b/tests/gnrc_ipv6_ext/Makefile.ci
@@ -28,6 +28,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/gnrc_ipv6_ext_frag/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_frag/Makefile.ci
@@ -31,6 +31,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/gnrc_netif/Makefile.ci
+++ b/tests/gnrc_netif/Makefile.ci
@@ -50,6 +50,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/tests/gnrc_rpl_srh/Makefile.ci
+++ b/tests/gnrc_rpl_srh/Makefile.ci
@@ -28,6 +28,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/gnrc_sixlowpan/Makefile.ci
+++ b/tests/gnrc_sixlowpan/Makefile.ci
@@ -24,6 +24,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/gnrc_sixlowpan_frag_sfr/Makefile.ci
+++ b/tests/gnrc_sixlowpan_frag_sfr/Makefile.ci
@@ -31,6 +31,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/gnrc_sock_dns/Makefile.ci
+++ b/tests/gnrc_sock_dns/Makefile.ci
@@ -22,6 +22,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-l031k6 \
     nucleo-l053r8 \
     samd10-xmini \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/gnrc_tcp/Makefile.ci
+++ b/tests/gnrc_tcp/Makefile.ci
@@ -28,6 +28,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/gnrc_udp/Makefile.ci
+++ b/tests/gnrc_udp/Makefile.ci
@@ -37,6 +37,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/tests/lwip/Makefile.ci
+++ b/tests/lwip/Makefile.ci
@@ -18,6 +18,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     stk3200 \
     stm32f030f4-demo \

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -30,6 +30,10 @@ BOARDS_TIMER_32kHz := \
     stk3700 \
     #
 
+BOARDS_TIMER_10MHz := \
+  sifive_e \
+  #
+
 BOARDS_TIMER_CLOCK_CORECLOCK := \
   cc2538dk \
   openmote-b \
@@ -39,10 +43,13 @@ BOARDS_TIMER_CLOCK_CORECLOCK := \
   waspmote-pro \
   #
 
+
 ifneq (,$(filter $(BOARDS_TIMER_250kHz),$(BOARD)))
   TIMER_SPEED ?= 250000
 else ifneq (,$(filter $(BOARDS_TIMER_32kHz),$(BOARD)))
   TIMER_SPEED ?= 32768
+else ifneq (,$(filter $(BOARDS_TIMER_10MHz),$(BOARD)))
+  TIMER_SPEED ?= 10000000
 else ifneq (,$(filter $(BOARDS_TIMER_CLOCK_CORECLOCK),$(BOARD)))
   TIMER_SPEED ?= CLOCK_CORECLOCK
 endif

--- a/tests/pkg_relic/Makefile
+++ b/tests/pkg_relic/Makefile
@@ -19,6 +19,7 @@ BOARD_BLACKLIST :=  arduino-duemilanove \
                     msb-430h \
                     msbiot \
                     redbee-econotag \
+		    sifive_e \
                     stm32f0discovery \
                     stm32f3discovery \
                     telosb \

--- a/tests/pkg_tinydtls_sock_async/Makefile.ci
+++ b/tests/pkg_tinydtls_sock_async/Makefile.ci
@@ -37,6 +37,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samd10-xmini \
     saml10-xpro \
     saml11-xpro \
+    sifive_e \
     slstk3400a \
     spark-core \
     stk3200 \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -90,6 +90,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     samr30-xpro \
     samr34-xpro \
     sensebox_samd21 \
+    sifive_e \
     slstk3400a \
     slstk3401a \
     sltb001a \


### PR DESCRIPTION
### Contribution description

Qemu supports the RISCV sifive_e machine. This machine closely matches the hifive1 board, emulating most of the hardware of the fe310 core. One notable difference is that the clock for the mtime is running at 10 MHz.

This commit adds the sifive_e target as a separate board. It can be used by compiling for this board and starting qemu with `make emulate`.

See also: https://www.sifive.com/blog/risc-v-qemu-part-2-the-risc-v-qemu-port-is-upstream

### Testing procedure

TODO :innocent: 

### Issues/PRs references

None