### PR TITLE
tools/tapsetup: fix typo in function name

### DIFF
--- a/dist/tools/tapsetup/tapsetup
+++ b/dist/tools/tapsetup/tapsetup
@@ -28,7 +28,7 @@ usage() {
     echo "   -h, --help:                   Prints this text" >&2
 }
 
-unsupported_plattform() {
+unsupported_platform() {
     echo "unsupported platform" >&2
     echo "(currently supported \`uname -s\` 'Darvin', 'FreeBSD', and 'Linux')" >&2
 }
@@ -234,7 +234,7 @@ case "$(uname -s)" in
     Linux)
         PLATFORM="Linux" ;;
     *)
-        unsupported_plattform
+        unsupported_platform
         exit 1 ;;
 esac
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a typo in one of the function names of the tapsetup script: `unsupported_plattform` -> `unsupported_platform`

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run tapsetup on an unsupported platform: the "unsupported platform" error message should still be displayed.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Saw that while looking at #14881 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
