### PR TITLE
gnrc_ipv6_nib: check return value of gnrc_netif_ipv6_addr_idx()

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6lr.c
@@ -69,6 +69,21 @@ uint8_t _reg_addr_upstream(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
                 _handle_sl2ao(netif, ipv6, icmpv6, sl2ao);
                 /* re-get NCE in case it was updated */
                 nce = _nib_onl_get(&ipv6->src, netif->pid);
+                /* and re-check EUI-64 in case nce was not an NC before */
+                if ((memcmp(&nce->eui64, &aro->eui64,
+                            sizeof(aro->eui64)) != 0) &&
+                    (_get_ar_state(nce) != GNRC_IPV6_NIB_NC_INFO_AR_STATE_GC)) {
+                    /* ignore address registration requests from upstream */
+                    DEBUG("nib: Could not register %s, duplicate entry with "
+                          "EUI-64 %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x\n",
+                          ipv6_addr_to_str(addr_str, &ipv6->src,
+                                           sizeof(addr_str)),
+                          nce->eui64.uint8[0], nce->eui64.uint8[1],
+                          nce->eui64.uint8[2], nce->eui64.uint8[3],
+                          nce->eui64.uint8[4], nce->eui64.uint8[5],
+                          nce->eui64.uint8[6], nce->eui64.uint8[7]);
+                    return SIXLOWPAN_ND_STATUS_DUP;
+                }
                 return _update_nce_ar_state(aro, nce);
             }
             else if (nce != NULL) {

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -916,21 +916,33 @@ static void _handle_nbr_sol(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
     gnrc_netif_t *tgt_netif = gnrc_netif_get_by_ipv6_addr(&nbr_sol->tgt);
 
     if (tgt_netif != NULL) {
-        int idx = gnrc_netif_ipv6_addr_idx(tgt_netif, &nbr_sol->tgt);
+        int idx;
 
-        if (gnrc_netif_ipv6_addr_dad_trans(tgt_netif, idx)) {
+        gnrc_netif_acquire(tgt_netif);
+        idx = gnrc_netif_ipv6_addr_idx(tgt_netif, &nbr_sol->tgt);
+        /* if idx < 0:
+         * nbr_sol->tgt was removed between getting tgt_netif by nbr_sol->tgt
+         * and gnrc_netif_acquire(tgt_netif). This is like `tgt_netif` would
+         * have been NULL in the first place so just continue as if it would
+         * have. */
+        if ((idx >= 0) && gnrc_netif_ipv6_addr_dad_trans(tgt_netif, idx)) {
             if (!ipv6_addr_is_unspecified(&ipv6->src)) {
                 /* (see https://tools.ietf.org/html/rfc4862#section-5.4.3) */
                 DEBUG("nib: Neighbor is performing AR, but target address is "
                       "still TENTATIVE for us => Ignoring NS\n");
+                gnrc_netif_release(tgt_netif);
                 return;
             }
             /* cancel validation timer */
             evtimer_del(&_nib_evtimer,
                         &tgt_netif->ipv6.addrs_timers[idx].event);
+            /* _remove_tentative_addr() context switches to `tgt_netif->pid` so
+             * release `tgt_netif`. We are done here anyway. */
+            gnrc_netif_release(tgt_netif);
             _remove_tentative_addr(tgt_netif, &nbr_sol->tgt);
             return;
         }
+        gnrc_netif_release(tgt_netif);
     }
 #endif  /* CONFIG_GNRC_IPV6_NIB_SLAAC */
     if (ipv6_addr_is_unspecified(&ipv6->src)) {
@@ -1048,19 +1060,30 @@ static void _handle_nbr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
     gnrc_netif_t *tgt_netif = gnrc_netif_get_by_ipv6_addr(&nbr_adv->tgt);
 
     if (tgt_netif != NULL) {
-        int idx = gnrc_netif_ipv6_addr_idx(tgt_netif, &nbr_adv->tgt);
+        int idx;
 
-        if (gnrc_netif_ipv6_addr_dad_trans(tgt_netif, idx)) {
+        gnrc_netif_acquire(tgt_netif);
+        idx = gnrc_netif_ipv6_addr_idx(tgt_netif, &nbr_adv->tgt);
+        /* if idx < 0:
+         * nbr_sol->tgt was removed between getting tgt_netif by nbr_sol->tgt
+         * and gnrc_netif_acquire(tgt_netif). This is like `tgt_netif` would
+         * have been NULL in the first place so just continue as if it would
+         * have. */
+        if ((idx >= 0) && gnrc_netif_ipv6_addr_dad_trans(tgt_netif, idx)) {
             DEBUG("nib: duplicate address detected, removing target address "
                   "from this interface\n");
             /* cancel validation timer */
             evtimer_del(&_nib_evtimer,
                         &tgt_netif->ipv6.addrs_timers[idx].event);
+            /* _remove_tentative_addr() context switches to `tgt_netif->pid` so
+             * release `tgt_netif`. We are done here anyway. */
+            gnrc_netif_release(tgt_netif);
             _remove_tentative_addr(tgt_netif, &nbr_adv->tgt);
             return;
         }
         /* else case beyond scope of RFC4862:
          * https://tools.ietf.org/html/rfc4862#section-5.4.4 */
+        gnrc_netif_release(tgt_netif);
     }
 #endif  /* CONFIG_GNRC_IPV6_NIB_SLAAC */
     if (((nce = _nib_onl_get(&nbr_adv->tgt, netif->pid)) != NULL) &&


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
... and acquire exclusive network interface access when necessar

See https://github.com/RIOT-OS/RIOT/issues/14752#issuecomment-682440377

I also found a bug in the address registration of 6Lo-ND while testing this, which I piggy-backed so the tests work. If desired, I can split them out in a separate PR.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
There are two functionalities affected by this change: the duplicate address detection (DAD) of classic IPv6 stateless address auto-configuration (SLAAC) and address registration in 6Lo-ND. For the first, just starting two native instances and checking if the addresses are `VAL` should be enough (I also pinged between them to be absolutely sure), even if the addresses are the same (DAD assigns a new MAC to the interface if it causes duplicates). For the latter, starting a border router and a `gnrc_networking` node should lead to a `VAL` address on the `gnrc_networking` node. Change `CONFIG_GNRC_SIXLOWPAN_ND_AR_LTIME` to decrease the lifetime.

<details><summary>Test negative DAD (no duplicate addresses)</summary>

```
$ sudo dist/tools/tapsetup/tapsetup
creating tapbr0
creating tap0
creating tap1
$ PORT=tap0 make -C examples/gnrc_networking -j flash term
[...]
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking'
/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking/bin/native/gnrc_networking.elf tap0 
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-1091-g7eed33)
RIOT network stack example application
All up, running the shell now
> ifconfig
ifconfig
Iface  6  HWaddr: E2:BC:7D:CB:F5:50 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          RTR_ADV  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::e0bc:7dff:fecb:f550  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffcb:f550
          
          Statistics for Layer 2
            RX packets 38  bytes 3468
            TX packets 13 (Multicast: 5)  bytes 1078
            TX succeeded 13 errors 0
          Statistics for IPv6
            RX packets 38  bytes 2936
            TX packets 13 (Multicast: 5)  bytes 896
            TX succeeded 13 errors 0

> ping6 fe80::d827:1dff:fea8:6424
ping6 fe80::d827:1dff:fea8:6424
12 bytes from fe80::d827:1dff:fea8:6424%6: icmp_seq=0 ttl=64 time=2.508 ms
12 bytes from fe80::d827:1dff:fea8:6424%6: icmp_seq=1 ttl=64 time=0.989 ms
12 bytes from fe80::d827:1dff:fea8:6424%6: icmp_seq=2 ttl=64 time=1.128 ms

--- fe80::d827:1dff:fea8:6424 PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 0.989/1.541/2.508 ms
```

```
PORT=tap1 make -C examples/gnrc_networking term
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking'
/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking/bin/native/gnrc_networking.elf tap1 
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-1091-g7eed33)
RIOT network stack example application
All up, running the shell now
> ifconfig
ifconfig
Iface  6  HWaddr: DA:27:1D:A8:64:24 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          RTR_ADV  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::d827:1dff:fea8:6424  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffa8:6424
          
          Statistics for Layer 2
            RX packets 6  bytes 512
            TX packets 2 (Multicast: 1)  bytes 156
            TX succeeded 2 errors 0
          Statistics for IPv6
            RX packets 6  bytes 428
            TX packets 2 (Multicast: 1)  bytes 128
            TX succeeded 2 errors 0

> ^C
native: exiting
```
</details>

<details><summary>Test positive DAD (the addresses on both TAPs are the same)</summary>

We make use of the fact, that a `native` instance's `netdev_tap` device's address [is based on the TAP's MAC address on Linux](https://github.com/RIOT-OS/RIOT/blob/master/cpu/native/netdev_tap/netdev_tap.c#L363-L378):

```
$ ip link show tap0
5: tap0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel master tapbr0 state DOWN mode DEFAULT group default qlen 1000
    link/ether e2:bc:7d:cb:f5:4f brd ff:ff:ff:ff:ff:ff
$ sudo ip link set dev tap1 down
$ sudo ip link set dev tap1 address e2:bc:7d:cb:f5:4f
$ sudo ip link set dev tap1 up
$ ip link show tap1
6: tap1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel master tapbr0 state DOWN mode DEFAULT group default qlen 1000
    link/ether e2:bc:7d:cb:f5:4f brd ff:ff:ff:ff:ff:ff
```

Then repeat test for negative DAD. On both nodes `ifconfig` should work, the address on the second node started should be different

```
$ PORT=tap0 make -C examples/gnrc_networking term
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking'
/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking/bin/native/gnrc_networking.elf tap0 
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-1092-gad81e-gnrc_ipv6_nib/fix/ipv6_addr_idx-check)
RIOT network stack example application
All up, running the shell now
> ifconfig
ifconfig
Iface  6  HWaddr: E2:BC:7D:CB:F5:50 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          RTR_ADV  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::e0bc:7dff:fecb:f550  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffcb:f550
          
          Statistics for Layer 2
            RX packets 7  bytes 642
            TX packets 2 (Multicast: 2)  bytes 164
            TX succeeded 2 errors 0
          Statistics for IPv6
            RX packets 7  bytes 544
            TX packets 2 (Multicast: 2)  bytes 136
            TX succeeded 2 errors 0

> ^C
native: exiting
```

```
$ PORT=tap1 make -C examples/gnrc_networking term
make: Entering directory '/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking'
/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_networking/bin/native/gnrc_networking.elf tap1 
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-1092-gad81e-gnrc_ipv6_nib/fix/ipv6_addr_idx-check)
RIOT network stack example application
All up, running the shell now
> ifconfig
ifconfig
Iface  6  HWaddr: 14:6C:23:23:14:6C 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          RTR_ADV  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::166c:23ff:fe23:146c  scope: link  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff23:146c
          
          Statistics for Layer 2
            RX packets 3  bytes 266
            TX packets 2 (Multicast: 2)  bytes 156
            TX succeeded 2 errors 0
          Statistics for IPv6
            RX packets 3  bytes 224
            TX packets 2 (Multicast: 2)  bytes 128
            TX succeeded 2 errors 0

> ^C
native: exiting

```

</details>

Clean host state before the next steps:

```sh
sudo dist/tools/tapsetup/tapsetup -d
```

For the positive node you need two IEEE 802.15.4 capable nodes, for the negative 3. I used 3 `samr21-xpro`s. I configured `CONFIG_GNRC_SIXLOWPAN_ND_AR_LTIME` to 1 minute in both cases, so I have to wait a minute between re-registrations (in fact shorter, because re-registration happens _before_ the lifetime ends ;-)).

<details><summary>Test positive address registration (no duplicate addresses in network)</summary>

```
$ CFLAGS="-DCONFIG_GNRC_SIXLOWPAN_ND_AR_LTIME=1" BOARD=samr21-xpro SERIAL=ATML2127031800004989 make -C examples/gnrc_border_router/ -j flash term
[...]
sudo sh /home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/ethos/start_network.sh  /dev/ttyACM0 tap0 2001:db8::/64 115200 
net.ipv6.conf.tap0.forwarding = 1
net.ipv6.conf.tap0.accept_ra = 0
----> ethos: sending hello.
----> ethos: activating serial pass through.
----> ethos: hello received
gnrc_uhcpc: Using 7 as border interface and 6 as wireless interface.
uhcp_client(): sending REQ...
udp_sendto(): sendto(): Cannot assign requested address
main(): This is RIOT! (Version: 2020.10-devel-1092-gad81e-gnrc_ipv6_nib/fix/ipv6_addr_idx-check)
RIOT border router example application
All up, running the shell now
> reboot
reboot
----> ethos: hello received
gnrc_uhcpc: Using 7 as border interface and 6 as wireless interface.
uhcp_client(): sending REQ...
main(): This is RIOT! (Version: 2020.10-devel-1092-gad81e-gnrc_ipv6_nib/fix/ipv6_addr_idx-check)
RIOT border router example application
All up, running the shell now
gogot packet from fe80::e0bc:7dff:fecb:f54f port 34318
uhcp: push from fe80::e0bc:7dff:fecb:f54f:34318 prefix=2001:db8::/64
gnrc_uhcpc: uhcp_handle_prefix(): add compression context 0 for prefix 2001:db8::589d:9386:2208:6779/64
gnrc_uhcpc: uhcp_handle_prefix(): configured new prefix 2001:db8::589d:9386:2208:6779/64
uhcp_client(): sending REQ...
got packet from fe80::e0bc:7dff:fecb:f54f port 39920
uhcp: push from fe80::e0bc:7dff:fecb:f54f:39920 prefix=2001:db8::/64
gnrc_uhcpc: uhcp_handle_prefix(): got same prefix again
gnrc_uhcpc: uhcp_handle_prefix(): add compression context 0 for prefix 2001:db8::589d:9386:2208:6779/64
uhcp_client(): sending REQ...
got packet from fe80::e0bc:7dff:fecb:f54f port 56752
uhcp: push from fe80::e0bc:7dff:fecb:f54f:56752 prefix=2001:db8::/64
gnrc_uhcpc: uhcp_handle_prefix(): got same prefix again
gnrc_uhcpc: uhcp_handle_prefix(): add compression context 0 for prefix 2001:db8::589d:9386:2208:6779/64
nib neigh
nib neigh
fe80::1 dev #7 lladdr E2:BC:7D:CB:F5:4F  REACHABLE GC
fe80::e0bc:7dff:fecb:f54f dev #7 lladdr E2:BC:7D:CB:F5:4F  STALE GC
2001:db8::28ab:dc15:5401:6679 dev #6 lladdr 2A:AB:DC:15:54:01:66:79  REACHABLE REGISTERED
^CCleaning up...
make: *** [/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_border_router/../../Makefile.include:741: term] Error 130
```

```
$ CFLAGS="-DCONFIG_GNRC_SIXLOWPAN_ND_AR_LTIME=1" BOARD=samr21-xpro SERIAL=ATML2127031800008319 make -C examples/gnrc_networking -j flash term
[...]
/home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM1" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-08-28 13:14:20,598 # Connect to serial port /dev/ttyACM1
Welcome to pyterm!
Type '/exit' to exit.
ifconfig
2020-08-28 13:14:26,500 # ifconfig
2020-08-28 13:14:26,507 # Iface  7  HWaddr: 67:E4  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2020-08-28 13:14:26,508 #           
2020-08-28 13:14:26,513 #           Long HWaddr: 2A:AB:DC:15:54:01:66:79 
2020-08-28 13:14:26,520 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-08-28 13:14:26,527 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2020-08-28 13:14:26,530 #           RTR_ADV  6LO  IPHC  
2020-08-28 13:14:26,533 #           Source address length: 8
2020-08-28 13:14:26,535 #           Link type: wireless
2020-08-28 13:14:26,541 #           inet6 addr: fe80::28ab:dc15:5401:6679  scope: link  VAL
2020-08-28 13:14:26,548 #           inet6 addr: 2001:db8::28ab:dc15:5401:6679  scope: global  VAL
2020-08-28 13:14:26,550 #           inet6 group: ff02::2
2020-08-28 13:14:26,553 #           inet6 group: ff02::1
2020-08-28 13:14:26,557 #           inet6 group: ff02::1:ff01:6679
2020-08-28 13:14:26,558 #           
2020-08-28 13:14:26,561 #           Statistics for Layer 2
2020-08-28 13:14:26,564 #             RX packets 4  bytes 286
2020-08-28 13:14:26,569 #             TX packets 3 (Multicast: 1)  bytes 171
2020-08-28 13:14:26,572 #             TX succeeded 3 errors 0
2020-08-28 13:14:26,574 #           Statistics for IPv6
2020-08-28 13:14:26,578 #             RX packets 3  bytes 304
2020-08-28 13:14:26,582 #             TX packets 3 (Multicast: 1)  bytes 224
2020-08-28 13:14:26,585 #             TX succeeded 3 errors 0
2020-08-28 13:14:26,586 # 
> waiting a minute
2020-08-28 13:14:51,259 #  waiting a minute
2020-08-28 13:14:51,262 # shell: command not found: waiting
ifconfig
2020-08-28 13:16:17,139 #  ifconfig
2020-08-28 13:16:17,145 # Iface  7  HWaddr: 67:E4  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2020-08-28 13:16:17,147 #           
2020-08-28 13:16:17,151 #           Long HWaddr: 2A:AB:DC:15:54:01:66:79 
2020-08-28 13:16:17,158 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-08-28 13:16:17,165 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2020-08-28 13:16:17,168 #           RTR_ADV  6LO  IPHC  
2020-08-28 13:16:17,171 #           Source address length: 8
2020-08-28 13:16:17,174 #           Link type: wireless
2020-08-28 13:16:17,180 #           inet6 addr: fe80::28ab:dc15:5401:6679  scope: link  VAL
2020-08-28 13:16:17,186 #           inet6 addr: 2001:db8::28ab:dc15:5401:6679  scope: global  VAL
2020-08-28 13:16:17,189 #           inet6 group: ff02::2
2020-08-28 13:16:17,192 #           inet6 group: ff02::1
2020-08-28 13:16:17,195 #           inet6 group: ff02::1:ff01:6679
2020-08-28 13:16:17,196 #           
2020-08-28 13:16:17,199 #           Statistics for Layer 2
2020-08-28 13:16:17,202 #             RX packets 8  bytes 542
2020-08-28 13:16:17,207 #             TX packets 7 (Multicast: 1)  bytes 459
2020-08-28 13:16:17,210 #             TX succeeded 7 errors 0
2020-08-28 13:16:17,213 #           Statistics for IPv6
2020-08-28 13:16:17,216 #             RX packets 7  bytes 624
2020-08-28 13:16:17,221 #             TX packets 7 (Multicast: 1)  bytes 576
2020-08-28 13:16:17,224 #             TX succeeded 7 errors 0
2020-08-28 13:16:17,224 # 
> 2020-08-28 13:16:34,269 # Exiting Pyterm
```

</details>

<details><summary>Test negative address registration (no duplicate addresses in network)</summary>

I patched the address auto-configuration to generate duplicate global addresses (link-local addresses need to be based on a unique EUI-64 for 6Lo-ND to work):

```diff
diff --git a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
index 3a977edba0..e2a0a6927d 100644
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -55,7 +55,12 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 #if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN)
     bool new_address = false;
 #endif  /* CONFIG_GNRC_IPV6_NIB_6LN */
-    gnrc_netif_ipv6_get_iid(netif, (eui64_t *)&addr.u64[1]);
+    if (ipv6_addr_is_link_local(pfx)) {
+        gnrc_netif_ipv6_get_iid(netif, (eui64_t *)&addr.u64[1]);
+    }
+    else {
+        addr.u64[1].u64 = 42U;
+    }
     ipv6_addr_init_prefix(&addr, pfx, pfx_len);
     if ((idx = gnrc_netif_ipv6_addr_idx(netif, &addr)) < 0) {
         if ((idx = gnrc_netif_ipv6_addr_add_internal(netif, &addr, pfx_len,
```

Then I used one border router (BR) and 2 `gnrc_networking` nodes. The second node to register should not get a global address and the BR should only contain one global neighbor cache entry (check with `nib neigh`; the one that managed to register). Sometimes the non-BRs try to register with each other in which case the test won't work (check if `nib neigh` on each node contains no global address). Just reset both nodes in that case. Both nodes need to try to register with the border router for this to work (or Multihop-DAD from RFC6775 which is not implemented yet):

##### `gnrc_border_router`
```
$ CFLAGS="-DCONFIG_GNRC_SIXLOWPAN_ND_AR_LTIME=1" BOARD=samr21-xpro SERIAL=ATML2127031800004989 make -C examples/gnrc_border_router/ -j flash term
sudo sh /home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/ethos/start_network.sh  /dev/ttyACM0 tap0 2001:db8::/64 115200 
[sudo] password for mlenders: 
net.ipv6.conf.tap0.forwarding = 1
net.ipv6.conf.tap0.accept_ra = 0
----> ethos: sending hello.
----> ethos: activating serial pass through.
----> ethos: hello reply received
----> ethos: hello received
gnrc_uhcpc: Using 7 as border interface and 6 as wireless interface.
uhcp_client(): sending REQ...
main(): This is RIOT! (Version: 2020.10-devel-1093-g9775c-gnrc_ipv6_nib/fix/ipv6_addr_idx-check)
RIOT border router example application
All up, running the shell now
gogot packet from fe80::e0bc:7dff:fecb:f54f port 57969
uhcp: push from fe80::e0bc:7dff:fecb:f54f:57969 prefix=2001:db8::/64
gnrc_uhcpc: uhcp_handle_prefix(): add compression context 0 for prefix 2001:db8::589d:9386:2208:6779/64
gnrc_uhcpc: uhcp_handle_prefix(): configured new prefix 2001:db8::589d:9386:2208:6779/64
uhcp_client(): sending REQ...
got packet from fe80::e0bc:7dff:fecb:f54f port 38006
uhcp: push from fe80::e0bc:7dff:fecb:f54f:38006 prefix=2001:db8::/64
gnrc_uhcpc: uhcp_handle_prefix(): got same prefix again
gnrc_uhcpc: uhcp_handle_prefix(): add compression context 0 for prefix 2001:db8::589d:9386:2208:6779/64
nib neigh
nib neigh
fe80::1 dev #7 lladdr E2:BC:7D:CB:F5:4F  REACHABLE GC
fe80::e0bc:7dff:fecb:f54f dev #7 lladdr E2:BC:7D:CB:F5:4F  STALE GC
2001:db8:0:0:2a00:: dev #6 lladdr 2A:AB:DC:15:54:01:66:79  REACHABLE REGISTERED
> ^CCleaning up...
make: *** [/home/mlenders/Repositories/RIOT-OS/RIOT/examples/gnrc_border_router/../../Makefile.include:741: term] Error 130
```

`gnrc_networking`
```
/home/mlenders/Repositories/RIOT-OS/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM2" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-08-28 14:02:18,591 # Connect to serial port /dev/ttyACM2
Welcome to pyterm!
Type '/exit' to exit.
nib neigh
2020-08-28 14:02:35,901 # nib neigh
2020-08-28 14:02:35,909 # fe80::589d:9386:2208:6779 dev #7 lladdr 5A:9D:93:86:22:08:67:79 router REACHABLE GC
> ifconfig
2020-08-28 14:02:43,723 #  ifconfig
2020-08-28 14:02:43,729 # Iface  7  HWaddr: 67:E4  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2020-08-28 14:02:43,730 #           
2020-08-28 14:02:43,734 #           Long HWaddr: 2A:AB:DC:15:54:01:66:79 
2020-08-28 14:02:43,741 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-08-28 14:02:43,748 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2020-08-28 14:02:43,751 #           RTR_ADV  6LO  IPHC  
2020-08-28 14:02:43,754 #           Source address length: 8
2020-08-28 14:02:43,757 #           Link type: wireless
2020-08-28 14:02:43,763 #           inet6 addr: fe80::28ab:dc15:5401:6679  scope: link  VAL
2020-08-28 14:02:43,769 #           inet6 addr: 2001:db8:0:0:2a00::  scope: global  VAL
2020-08-28 14:02:43,772 #           inet6 group: ff02::2
2020-08-28 14:02:43,774 #           inet6 group: ff02::1
2020-08-28 14:02:43,778 #           inet6 group: ff02::1:ff01:6679
2020-08-28 14:02:43,781 #           inet6 group: ff02::1:ff00:0
2020-08-28 14:02:43,782 #           
2020-08-28 14:02:43,785 #           Statistics for Layer 2
2020-08-28 14:02:43,789 #             RX packets 6  bytes 460
2020-08-28 14:02:43,793 #             TX packets 3 (Multicast: 1)  bytes 187
2020-08-28 14:02:43,796 #             TX succeeded 3 errors 0
2020-08-28 14:02:43,799 #           Statistics for IPv6
2020-08-28 14:02:43,802 #             RX packets 4  bytes 448
2020-08-28 14:02:43,807 #             TX packets 3 (Multicast: 1)  bytes 224
2020-08-28 14:02:43,810 #             TX succeeded 3 errors 0
2020-08-28 14:02:43,810 # 
> ifconfig
2020-08-28 14:03:45,979 #  ifconfig
2020-08-28 14:03:45,986 # Iface  7  HWaddr: 67:E4  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2020-08-28 14:03:45,987 #           
2020-08-28 14:03:45,991 #           Long HWaddr: 2A:AB:DC:15:54:01:66:79 
2020-08-28 14:03:45,998 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-08-28 14:03:46,006 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2020-08-28 14:03:46,008 #           RTR_ADV  6LO  IPHC  
2020-08-28 14:03:46,011 #           Source address length: 8
2020-08-28 14:03:46,014 #           Link type: wireless
2020-08-28 14:03:46,020 #           inet6 addr: fe80::28ab:dc15:5401:6679  scope: link  VAL
2020-08-28 14:03:46,025 #           inet6 addr: 2001:db8:0:0:2a00::  scope: global  VAL
2020-08-28 14:03:46,028 #           inet6 group: ff02::2
2020-08-28 14:03:46,031 #           inet6 group: ff02::1
2020-08-28 14:03:46,035 #           inet6 group: ff02::1:ff01:6679
2020-08-28 14:03:46,038 #           inet6 group: ff02::1:ff00:0
2020-08-28 14:03:46,039 #           
2020-08-28 14:03:46,042 #           Statistics for Layer 2
2020-08-28 14:03:46,045 #             RX packets 9  bytes 676
2020-08-28 14:03:46,050 #             TX packets 6 (Multicast: 1)  bytes 419
2020-08-28 14:03:46,053 #             TX succeeded 6 errors 0
2020-08-28 14:03:46,056 #           Statistics for IPv6
2020-08-28 14:03:46,059 #             RX packets 7  bytes 688
2020-08-28 14:03:46,063 #             TX packets 6 (Multicast: 1)  bytes 480
2020-08-28 14:03:46,067 #             TX succeeded 6 errors 0
2020-08-28 14:03:46,067 # 
2020-08-28 14:04:40,338 # Exiting Pyterm
```

```
nib neigh
2020-08-28 14:02:40,038 # nib neigh
2020-08-28 14:02:40,045 # fe80::589d:9386:2208:6779 dev #7 lladdr 5A:9D:93:86:22:08:67:79 router STALE GC
> ifconfig
2020-08-28 14:02:41,764 #  ifconfig
2020-08-28 14:02:41,771 # Iface  7  HWaddr: 10:88  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2020-08-28 14:02:41,772 #           
2020-08-28 14:02:41,776 #           Long HWaddr: 86:0C:77:EC:23:33:60:79 
2020-08-28 14:02:41,783 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-08-28 14:02:41,790 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2020-08-28 14:02:41,793 #           RTR_ADV  6LO  IPHC  
2020-08-28 14:02:41,796 #           Source address length: 8
2020-08-28 14:02:41,799 #           Link type: wireless
2020-08-28 14:02:41,805 #           inet6 addr: fe80::840c:77ec:2333:6079  scope: link  VAL
2020-08-28 14:02:41,808 #           inet6 group: ff02::2
2020-08-28 14:02:41,810 #           inet6 group: ff02::1
2020-08-28 14:02:41,814 #           inet6 group: ff02::1:ff33:6079
2020-08-28 14:02:41,815 #           
2020-08-28 14:02:41,818 #           Statistics for Layer 2
2020-08-28 14:02:41,821 #             RX packets 4  bytes 273
2020-08-28 14:02:41,826 #             TX packets 4 (Multicast: 1)  bytes 289
2020-08-28 14:02:41,829 #             TX succeeded 4 errors 0
2020-08-28 14:02:41,832 #           Statistics for IPv6
2020-08-28 14:02:41,835 #             RX packets 3  bytes 288
2020-08-28 14:02:41,839 #             TX packets 3 (Multicast: 1)  bytes 304
2020-08-28 14:02:41,843 #             TX succeeded 3 errors 0
2020-08-28 14:02:41,843 # 
> ifconfig
2020-08-28 14:03:50,256 #  ifconfig
2020-08-28 14:03:50,262 # Iface  7  HWaddr: 10:88  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
2020-08-28 14:03:50,271 #           
2020-08-28 14:03:50,271 #           Long HWaddr: 86:0C:77:EC:23:33:60:79 
2020-08-28 14:03:50,275 #            TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
2020-08-28 14:03:50,282 #           AUTOACK  ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
2020-08-28 14:03:50,285 #           RTR_ADV  6LO  IPHC  
2020-08-28 14:03:50,288 #           Source address length: 8
2020-08-28 14:03:50,290 #           Link type: wireless
2020-08-28 14:03:50,296 #           inet6 addr: fe80::840c:77ec:2333:6079  scope: link  VAL
2020-08-28 14:03:50,299 #           inet6 group: ff02::2
2020-08-28 14:03:50,302 #           inet6 group: ff02::1
2020-08-28 14:03:50,306 #           inet6 group: ff02::1:ff33:6079
2020-08-28 14:03:50,306 #           
2020-08-28 14:03:50,310 #           Statistics for Layer 2
2020-08-28 14:03:50,313 #             RX packets 4  bytes 273
2020-08-28 14:03:50,317 #             TX packets 4 (Multicast: 1)  bytes 289
2020-08-28 14:03:50,321 #             TX succeeded 4 errors 0
2020-08-28 14:03:50,323 #           Statistics for IPv6
2020-08-28 14:03:50,326 #             RX packets 3  bytes 288
2020-08-28 14:03:50,331 #             TX packets 3 (Multicast: 1)  bytes 304
2020-08-28 14:03:50,334 #             TX succeeded 3 errors 0
2020-08-28 14:03:50,334 # 
2020-08-28 14:06:10,133 # Exiting Pyterm
```

</details>


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes https://github.com/RIOT-OS/RIOT/issues/14752
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
