### PR TITLE
gnrc_ipv6_nib: don't pull in RDNSS support with sock_dns

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -418,9 +418,6 @@ ifneq (,$(filter gnrc_ipv6_nib,$(USEMODULE)))
   USEMODULE += gnrc_netif
   USEMODULE += ipv6_addr
   USEMODULE += random
-  ifneq (,$(filter sock_dns,$(USEMODULE)))
-    USEMODULE += gnrc_ipv6_nib_dns
-  endif
 endif
 
 ifneq (,$(filter gnrc_udp,$(USEMODULE)))

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -39,7 +39,8 @@ USEMODULE += ps
 # Optionally include DNS support. This includes resolution of names at an
 # upstream DNS server and the handling of RDNSS options in Router Advertisements
 # to auto-configure that upstream DNS server.
-#USEMODULE += sock_dns
+#USEMODULE += sock_dns              # include DNS client
+#USEMODULE += gnrc_ipv6_nib_dns     # include RDNSS option handling
 
 # When using a WiFi uplink we should use DHCPv6
 ifeq (wifi,$(UPLINK))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Just because a user pulls in the DNS client (`sock_dns`) doesn't mean they want to pull in RDNSS option support as well. Besides, since `gnrc_ipv6_nib_dns` depends on `gnrc_ipv6_nib`, this forms a circular dependency that really isn't necessary.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
All applications using `sock_dns` should still work:

```
$ git grep "sock_dns" -- examples/*/Makefile fuzzing/*/Makefile tests/*/Makefile
examples/gnrc_border_router/Makefile:#USEMODULE += sock_dns              # include DNS client
tests/gnrc_ipv6_nib_dns/Makefile:USEMODULE += sock_dns
tests/gnrc_sock_dns/Makefile:USEMODULE += sock_dns
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Aiming to remove circular dependencies in GNRC, so related to Kconfig migration, phase 2.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
