### PR TITLE
gnrc: remove circular module dependencies

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -236,7 +236,6 @@ ifneq (,$(filter gnrc_sixlowpan_default,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_sixlowpan_router_default,$(USEMODULE)))
-  USEMODULE += gnrc_ipv6_router_default
   USEMODULE += gnrc_ipv6_nib_6lr
   USEMODULE += gnrc_sixlowpan_frag
   USEMODULE += gnrc_sixlowpan_iphc

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -422,6 +422,7 @@ ifneq (,$(filter gnrc_ipv6_nib,$(USEMODULE)))
   USEMODULE += evtimer
   USEMODULE += gnrc_ndp
   USEMODULE += gnrc_netif
+  USEMODULE += gnrc_netif_ipv6
   USEMODULE += ipv6_addr
   USEMODULE += random
   ifneq (,$(filter sock_dns,$(USEMODULE)))

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -217,9 +217,6 @@ ifneq (,$(filter ieee802154 nrfmin esp_now cc110x gnrc_sixloenc,$(USEMODULE)))
   ifneq (,$(filter gnrc_ipv6, $(USEMODULE)))
     USEMODULE += gnrc_sixlowpan
   endif
-  ifneq (,$(filter gnrc_ipv6_router, $(USEMODULE)))
-    USEMODULE += gnrc_sixlowpan_router
-  endif
   ifneq (,$(filter gnrc_ipv6_default, $(USEMODULE)))
     USEMODULE += gnrc_sixlowpan_default
   endif
@@ -232,7 +229,6 @@ ifneq (,$(filter ieee802154 nrfmin esp_now cc110x gnrc_sixloenc,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_sixlowpan_default,$(USEMODULE)))
-  USEMODULE += gnrc_ipv6_default
   USEMODULE += gnrc_ipv6_nib_6ln
   USEMODULE += gnrc_sixlowpan
   USEMODULE += gnrc_sixlowpan_frag
@@ -242,7 +238,6 @@ endif
 ifneq (,$(filter gnrc_sixlowpan_router_default,$(USEMODULE)))
   USEMODULE += gnrc_ipv6_router_default
   USEMODULE += gnrc_ipv6_nib_6lr
-  USEMODULE += gnrc_sixlowpan_router
   USEMODULE += gnrc_sixlowpan_frag
   USEMODULE += gnrc_sixlowpan_iphc
 endif
@@ -250,13 +245,8 @@ endif
 ifneq (,$(filter gnrc_sixlowpan_border_router_default,$(USEMODULE)))
   USEMODULE += gnrc_ipv6_nib_6lbr
   USEMODULE += gnrc_ipv6_router_default
-  USEMODULE += gnrc_sixlowpan_router
   USEMODULE += gnrc_sixlowpan_frag
   USEMODULE += gnrc_sixlowpan_iphc
-endif
-
-ifneq (,$(filter gnrc_sixlowpan_router,$(USEMODULE)))
-  USEMODULE += gnrc_ipv6_router
 endif
 
 ifneq (,$(filter gnrc_sixlowpan_frag,$(USEMODULE)))

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -311,21 +311,27 @@ endif
 
 ifneq (,$(filter gnrc_ndp,$(USEMODULE)))
   USEMODULE += gnrc_icmpv6
+  USEMODULE += gnrc_ipv6_hdr
   USEMODULE += gnrc_netif
 endif
 
 ifneq (,$(filter gnrc_icmpv6_echo,$(USEMODULE)))
   USEMODULE += gnrc_icmpv6
+  USEMODULE += gnrc_ipv6_hdr
+  USEMODULE += gnrc_netif_hdr
 endif
 
 ifneq (,$(filter gnrc_icmpv6_error,$(USEMODULE)))
   USEMODULE += gnrc_icmpv6
+  USEMODULE += gnrc_ipv6_hdr
+  USEMODULE += gnrc_netif_hdr
 endif
 
 ifneq (,$(filter gnrc_icmpv6,$(USEMODULE)))
   USEMODULE += inet_csum
-  USEMODULE += gnrc_ipv6
+  USEMODULE += ipv6_hdr
   USEMODULE += gnrc_nettype_icmpv6
+  USEMODULE += gnrc_nettype_ipv6
   USEMODULE += icmpv6
 endif
 
@@ -347,7 +353,7 @@ ifneq (,$(filter gnrc_ipv6_ext_rh,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_ipv6_ext,$(USEMODULE)))
-  USEMODULE += gnrc_ipv6
+  USEMODULE += gnrc_nettype_ipv6
   USEMODULE += gnrc_nettype_ipv6_ext
 endif
 

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -52,7 +52,6 @@ PSEUDOMODULES += gnrc_sixlowpan_default
 PSEUDOMODULES += gnrc_sixlowpan_frag_hint
 PSEUDOMODULES += gnrc_sixlowpan_iphc_nhc
 PSEUDOMODULES += gnrc_sixlowpan_nd_border_router
-PSEUDOMODULES += gnrc_sixlowpan_router
 PSEUDOMODULES += gnrc_sixlowpan_router_default
 PSEUDOMODULES += gnrc_sock_async
 PSEUDOMODULES += gnrc_sock_check_reuse

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -588,8 +588,9 @@ int gnrc_netif_ipv6_addr_add_internal(gnrc_netif_t *netif,
 
         gnrc_netif_ipv6_bus_post(netif, GNRC_IPV6_EVENT_ADDR_VALID, &netif->ipv6.addrs[idx]);
     }
-#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC)
-    else if (!gnrc_netif_is_6ln(netif)) {
+    else if (IS_USED(MODULE_GNRC_IPV6) &&
+             IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_SLAAC) &&
+             !gnrc_netif_is_6ln(netif)) {
         /* cast to remove const qualifier (will still be used NIB internally as
          * const) */
         msg_t msg = { .type = GNRC_IPV6_NIB_DAD,
@@ -597,7 +598,6 @@ int gnrc_netif_ipv6_addr_add_internal(gnrc_netif_t *netif,
 
         msg_send(&msg, gnrc_ipv6_pid);
     }
-#endif
 #else
     (void)pfx_len;
 #endif

--- a/sys/net/gnrc/network_layer/ipv6/hdr/gnrc_ipv6_hdr.c
+++ b/sys/net/gnrc/network_layer/ipv6/hdr/gnrc_ipv6_hdr.c
@@ -26,7 +26,7 @@ static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 #endif
 
 /* For independent testing */
-#ifdef MODULE_GNRC_IPV6
+#ifdef MODULE_GNRC_NETTYPE_IPV6
 #define HDR_NETTYPE (GNRC_NETTYPE_IPV6)
 #else
 #define HDR_NETTYPE (GNRC_NETTYPE_UNDEF)

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.h
@@ -28,6 +28,7 @@
 #include "net/gnrc/netif.h"
 #include "net/ndp.h"
 #include "net/icmpv6.h"
+#include "net/ipv6/hdr.h"
 
 #include "_nib-internal.h"
 

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -18,6 +18,7 @@
 
 #include "log.h"
 #include "luid.h"
+#include "net/gnrc/ipv6/nib.h"
 #include "net/gnrc/netif/internal.h"
 
 #include "_nib-6ln.h"

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_ft.c
@@ -18,6 +18,7 @@
 
 #include "_nib-internal.h"
 
+#include "net/gnrc/ipv6/nib.h"
 #include "net/gnrc/ipv6/nib/ft.h"
 
 int gnrc_ipv6_nib_ft_get(const ipv6_addr_t *dst, gnrc_pktsnip_t *pkt,

--- a/tests/gnrc_ndp/Makefile
+++ b/tests/gnrc_ndp/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 USEMODULE += gnrc_ipv6_nib_router
 USEMODULE += gnrc_ndp
 USEMODULE += gnrc_netif
+USEMODULE += gnrc_nettype_ipv6
 USEMODULE += embunit
 USEMODULE += netdev_ieee802154
 USEMODULE += netdev_test

--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -6,6 +6,8 @@ USEMODULE += netdev_ieee802154
 USEMODULE += netdev_test
 # 6LoWPAN and its extensions
 USEMODULE += gnrc_sixlowpan_default
+# IPv6 host support
+USEMODULE += gnrc_ipv6_default
 # UDP
 USEMODULE += gnrc_udp
 # Dumps packets


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
According to my analysis (which might be incomplete :sweat_smile:) this removes all circles within GNRC's module dependencies.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/gnrc_upd` should still work as expected, including when sending fragmented IPv6 packets (see release specs). The modules of which the dependencies were changed should still compile when isolated:

```
USEMDODULE=gnrc_icmpv6 make -C examples/hello-world
USEMDODULE=gnrc_ipv6_ext make -C examples/hello-world
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Finalizes the hunt for circular dependencies in GNRC, so related to Kconfig migration, phase 2.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
