### PR TITLE
gh-actions: annotate failures in GitHub action

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -69,7 +69,8 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox junit2html
+        python -m pip install tox junit2html \
+          pytest-github-actions-annotate-failures
     - name: Pull riotbuild docker image
       run: |
         DOCKER_VERSION="${{ github.event.inputs.docker_version }}"
@@ -81,6 +82,8 @@ jobs:
       run: |
         sudo RIOT/dist/tools/tapsetup/tapsetup -c 11
     - name: Run release tests
+      env:
+        PYTEST_PLUGINS: pytest_github_actions_annotate_failures
       timeout-minutes: 350
       run: |
         RIOTBASE="$GITHUB_WORKSPACE/RIOT"
@@ -150,7 +153,8 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install tox junit2html
+        python -m pip install tox junit2html \
+          pytest-github-actions-annotate-failures
     - name: Pull riotbuild docker image
       run: |
         DOCKER_VERSION="${{ github.event.inputs.docker_version }}"
@@ -171,6 +175,8 @@ jobs:
         ssh -oStrictHostKeyChecking=accept-new \
           ${IOTLAB_USER}@saclay.iot-lab.info exit
     - name: Run release tests
+      env:
+        PYTEST_PLUGINS: pytest_github_actions_annotate_failures
       timeout-minutes: 350
       run: |
         # definition in env does not work since $GITHUB_WORKSPACE seems not to


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While wondering if there is a way to improve skimming through the release test results, I found [this](https://pypi.org/project/pytest-github-actions-annotate-failures/). It's quite new, but it just requires you to install it and then hooks into pytest, so quite straight forward.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
We can start an action, if required. Otherwise, there is not much code included, so we basically have to trust the included package's testing.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
