### PR TITLE
boards/stm32f0: introduce default shared clock configuration header

### DIFF
--- a/boards/common/stm32/include/f0/cfg_clock_default.h
+++ b/boards/common/stm32/include/f0/cfg_clock_default.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @{
+ *
+ * @file
+ * @brief       Default clock configuration for STM32F0
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      José Ignacio Alamos <jialamos@uc.cl>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef F0_CFG_CLOCK_DEFAULT_H
+#define F0_CFG_CLOCK_DEFAULT_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock settings
+ * @{
+ */
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 48MHz */
+#define CLOCK_CORECLOCK         MHZ(48)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#ifndef CLOCK_HSE
+#define CLOCK_HSE               MHZ(8)
+#endif
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#ifndef CLOCK_LSE
+#define CLOCK_LSE               (0)
+#endif
+/* peripheral clock setup */
+#define CLOCK_AHB_DIV           RCC_CFGR_HPRE_DIV1
+#define CLOCK_AHB               (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1_DIV          RCC_CFGR_PPRE_DIV1      /* max 48MHz */
+#define CLOCK_APB1              (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB2              (CLOCK_APB1)
+
+/* PLL factors */
+#ifndef CLOCK_PLL_PREDIV
+#define CLOCK_PLL_PREDIV        (1)
+#endif
+#ifndef CLOCK_PLL_MUL
+#define CLOCK_PLL_MUL           (6)
+#endif
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F0_CFG_CLOCK_DEFAULT_H */
+/** @} */

--- a/boards/nucleo-f030r8/include/periph_conf.h
+++ b/boards/nucleo-f030r8/include/periph_conf.h
@@ -21,39 +21,15 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* This board provides an LSE */
+#define CLOCK_LSE           (1)
+
 #include "periph_cpu.h"
+#include "f0/cfg_clock_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 48MHz */
- #define CLOCK_CORECLOCK      (48000000U)
- /* 0: no external high speed crystal available
-  * else: actual crystal frequency [in Hz] */
- #define CLOCK_HSE            (8000000U)
- /* 0: no external low speed crystal available,
-  * 1: external crystal available (always 32.768kHz) */
- #define CLOCK_LSE            (1)
- /* peripheral clock setup */
- #define CLOCK_AHB_DIV        RCC_CFGR_HPRE_DIV1
- #define CLOCK_AHB            (CLOCK_CORECLOCK / 1)
- #define CLOCK_APB1_DIV       RCC_CFGR_PPRE_DIV1      /* max 48MHz */
- #define CLOCK_APB1           (CLOCK_CORECLOCK / 1)
- #define CLOCK_APB2           (CLOCK_APB1)
-
- /* PLL factors */
- #define CLOCK_PLL_PREDIV     (1)
- #define CLOCK_PLL_MUL        (6)
- /** @} */
 
 /**
  * @name   Timer configuration

--- a/boards/nucleo-f031k6/include/periph_conf.h
+++ b/boards/nucleo-f031k6/include/periph_conf.h
@@ -20,40 +20,20 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* No HSE available on this board */
+#define CLOCK_HSE            (0U)
+
+/* Adjust PLL factors when PLL is clocked by HSI */
+#define CLOCK_PLL_PREDIV     (2)
+#define CLOCK_PLL_MUL        (12)
+
 #include "periph_cpu.h"
+#include "f0/cfg_clock_default.h"
 #include "cfg_timer_tim2.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 48MHz */
-#define CLOCK_CORECLOCK      (48000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE            (0U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE            (0)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV        RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB            (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV       RCC_CFGR_PPRE_DIV1      /* max 48MHz */
-#define CLOCK_APB1           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB2           (CLOCK_APB1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (2)
-#define CLOCK_PLL_MUL        (12)
-/** @} */
 
 /**
  * @name UART configuration

--- a/boards/nucleo-f042k6/include/periph_conf.h
+++ b/boards/nucleo-f042k6/include/periph_conf.h
@@ -19,40 +19,20 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* No HSE available on this board */
+#define CLOCK_HSE            (0U)
+
+/* Adjust PLL factors when PLL is clocked by HSI */
+#define CLOCK_PLL_PREDIV     (2)
+#define CLOCK_PLL_MUL        (12)
+
 #include "periph_cpu.h"
+#include "f0/cfg_clock_default.h"
 #include "cfg_timer_tim2.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 48MHz */
-#define CLOCK_CORECLOCK     (48000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (0U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (0)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE_DIV1      /* max 48MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB2          (CLOCK_APB1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (2)
-#define CLOCK_PLL_MUL        (12)
-/** @} */
 
 /**
  * @name   UART configuration

--- a/boards/nucleo-f070rb/include/periph_conf.h
+++ b/boards/nucleo-f070rb/include/periph_conf.h
@@ -21,40 +21,16 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* This board provides an LSE */
+#define CLOCK_LSE           (1)
+
 #include "periph_cpu.h"
+#include "f0/cfg_clock_default.h"
 #include "cfg_i2c1_pb8_pb9.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 48MHz */
- #define CLOCK_CORECLOCK      (48000000U)
- /* 0: no external high speed crystal available
-  * else: actual crystal frequency [in Hz] */
- #define CLOCK_HSE            (8000000U)
- /* 0: no external low speed crystal available,
-  * 1: external crystal available (always 32.768kHz) */
- #define CLOCK_LSE            (1)
- /* peripheral clock setup */
- #define CLOCK_AHB_DIV        RCC_CFGR_HPRE_DIV1
- #define CLOCK_AHB            (CLOCK_CORECLOCK / 1)
- #define CLOCK_APB1_DIV       RCC_CFGR_PPRE_DIV1      /* max 48MHz */
- #define CLOCK_APB1           (CLOCK_CORECLOCK / 1)
- #define CLOCK_APB2           (CLOCK_APB1)
-
- /* PLL factors */
- #define CLOCK_PLL_PREDIV     (1)
- #define CLOCK_PLL_MUL        (6)
- /** @} */
 
 /**
  * @name   Timer configuration

--- a/boards/nucleo-f072rb/include/periph_conf.h
+++ b/boards/nucleo-f072rb/include/periph_conf.h
@@ -20,40 +20,16 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* This board provides an LSE */
+#define CLOCK_LSE           (1)
+
 #include "periph_cpu.h"
+#include "f0/cfg_clock_default.h"
 #include "cfg_i2c1_pb8_pb9.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 48MHz */
- #define CLOCK_CORECLOCK      (48000000U)
- /* 0: no external high speed crystal available
-  * else: actual crystal frequency [in Hz] */
- #define CLOCK_HSE            (8000000U)
- /* 0: no external low speed crystal available,
-  * 1: external crystal available (always 32.768kHz) */
- #define CLOCK_LSE            (1)
- /* peripheral clock setup */
- #define CLOCK_AHB_DIV        RCC_CFGR_HPRE_DIV1
- #define CLOCK_AHB            (CLOCK_CORECLOCK / 1)
- #define CLOCK_APB1_DIV       RCC_CFGR_PPRE_DIV1      /* max 48MHz */
- #define CLOCK_APB1           (CLOCK_CORECLOCK / 1)
- #define CLOCK_APB2           (CLOCK_APB1)
-
- /* PLL factors */
- #define CLOCK_PLL_PREDIV     (1)
- #define CLOCK_PLL_MUL        (6)
- /** @} */
 
 /**
  * @name   Timer configuration

--- a/boards/nucleo-f091rc/include/periph_conf.h
+++ b/boards/nucleo-f091rc/include/periph_conf.h
@@ -19,40 +19,16 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* This board provides an LSE */
+#define CLOCK_LSE           (1)
+
 #include "periph_cpu.h"
+#include "f0/cfg_clock_default.h"
 #include "cfg_i2c1_pb8_pb9.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 48MHz */
-#define CLOCK_CORECLOCK      (48000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE            (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE            (1)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV        RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB            (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV       RCC_CFGR_PPRE_DIV1      /* max 48MHz */
-#define CLOCK_APB1           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB2           (CLOCK_APB1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (1)
-#define CLOCK_PLL_MUL        (6)
-/** @} */
 
 /**
  * @name    DMA streams configuration

--- a/boards/stm32f030f4-demo/include/periph_conf.h
+++ b/boards/stm32f030f4-demo/include/periph_conf.h
@@ -23,38 +23,11 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f0/cfg_clock_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 48MHz */
- #define CLOCK_CORECLOCK      (48000000U)
- /* 0: no external high speed crystal available
-  * else: actual crystal frequency [in Hz] */
- #define CLOCK_HSE            (8000000U)
- /* 0: no external low speed crystal available,
-  * 1: external crystal available (always 32.768kHz) */
- #define CLOCK_LSE            (0)
- /* peripheral clock setup */
- #define CLOCK_AHB_DIV        RCC_CFGR_HPRE_DIV1
- #define CLOCK_AHB            (CLOCK_CORECLOCK / 1)
- #define CLOCK_APB1_DIV       RCC_CFGR_PPRE_DIV1      /* max 48MHz */
- #define CLOCK_APB1           (CLOCK_CORECLOCK / 1)
- #define CLOCK_APB2           (CLOCK_APB1)
-
- /* PLL factors */
- #define CLOCK_PLL_PREDIV     (1)
- #define CLOCK_PLL_MUL        (6)
- /** @} */
 
 /**
  * @name   Timer configuration

--- a/boards/stm32f0discovery/Makefile.include
+++ b/boards/stm32f0discovery/Makefile.include
@@ -1,3 +1,6 @@
+# we use shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBASE)/boards/common/stm32/include
+
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/stm32f0discovery/include/periph_conf.h
+++ b/boards/stm32f0discovery/include/periph_conf.h
@@ -20,38 +20,11 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f0/cfg_clock_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 48MHz */
-#define CLOCK_CORECLOCK      (48000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE            (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE            (0)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV        RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB            (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV       RCC_CFGR_PPRE_DIV1      /* max 48MHz */
-#define CLOCK_APB1           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB2           (CLOCK_APB1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (1)
-#define CLOCK_PLL_MUL        (6)
-/** @} */
 
 /**
  * @name   Timer configuration


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is similar to #stm32l1 but applied to the stm32f0 family. In master, all stm32f0 based boards are configured the same way, except the nucleo-f030 and nucleo-f042. There are also some boards that provide an LSE and some not, some having an HSE and others not.
To take this into account, the default configuration has good defaults (HSE set to 8MHz, no LSE and PLL prescalers used in the majority of boards. All theses parameters can be overridden by the boards themselves depending on their configuration.
Doing this removes a bit of code duplication between the boards configurations.

The idea of this PR is first to prepare the migration toward a fully configurable clock like it's done for stm32gx (and stm32l4/wb in #14866), without changing the current situation. Having a common and default configuration file will make things easier (to refactor and to review).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Verify that the boards are still functional

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
