### PR TITLE
boards/stm32f1: stm32f3: use shared default clock configuration header

### DIFF
--- a/boards/common/blxxxpill/Makefile.include
+++ b/boards/common/blxxxpill/Makefile.include
@@ -1,3 +1,4 @@
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 INCLUDES += -I$(RIOTBOARD)/common/blxxxpill/include
 
 ifeq (dfu-util,$(PROGRAMMER))

--- a/boards/common/blxxxpill/include/periph_conf.h
+++ b/boards/common/blxxxpill/include/periph_conf.h
@@ -24,40 +24,15 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* blxxxpill boards provide an LSE */
+#define CLOCK_LSE            (1)
+
 #include "periph_cpu.h"
+#include "f1f3/cfg_clock_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 72MHz */
-#define CLOCK_CORECLOCK     (72000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1U)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (1)
-#define CLOCK_PLL_MUL        (9)
-/** @} */
 
 /**
  * @name    Real time counter configuration

--- a/boards/common/iotlab/Makefile.include
+++ b/boards/common/iotlab/Makefile.include
@@ -17,4 +17,5 @@ OPENOCD_CONFIG ?= $(RIOTBOARD)/common/iotlab/dist/openocd.cfg
 include $(RIOTMAKE)/tools/openocd.inc.mk
 
 # add the common header files to the include path
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
 INCLUDES += -I$(RIOTBOARD)/common/iotlab/include

--- a/boards/common/iotlab/include/periph_conf_common.h
+++ b/boards/common/iotlab/include/periph_conf_common.h
@@ -20,41 +20,21 @@
 #ifndef PERIPH_CONF_COMMON_H
 #define PERIPH_CONF_COMMON_H
 
+/* iotlab boards provide an LSE */
+#define CLOCK_LSE            (1)
+
+/* HSE is clocked at 16MHz */
+#define CLOCK_HSE            MHZ(16)
+
+/* Adjust PLL predevider to reach 72MHz sysclock */
+#define CLOCK_PLL_PREDIV     (2)
+
 #include "periph_cpu.h"
+#include "f1f3/cfg_clock_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 72MHz */
- #define CLOCK_CORECLOCK      (72000000U)
- /* 0: no external high speed crystal available
-  * else: actual crystal frequency [in Hz] */
- #define CLOCK_HSE            (16000000U)
- /* 0: no external low speed crystal available,
-  * 1: external crystal available (always 32.768kHz) */
- #define CLOCK_LSE            (1)
- /* peripheral clock setup */
- #define CLOCK_AHB_DIV        RCC_CFGR_HPRE_DIV1
- #define CLOCK_AHB            (CLOCK_CORECLOCK / 1)
- #define CLOCK_APB1_DIV       RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
- #define CLOCK_APB1           (CLOCK_CORECLOCK / 2)
- #define CLOCK_APB2_DIV       RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
- #define CLOCK_APB2           (CLOCK_CORECLOCK / 1)
-
- /* PLL factors */
- #define CLOCK_PLL_PREDIV     (2)
- #define CLOCK_PLL_MUL        (9)
- /** @} */
 
 /**
  * @name    ADC configuration

--- a/boards/common/stm32/include/f1f3/cfg_clock_default.h
+++ b/boards/common/stm32/include/f1f3/cfg_clock_default.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 TriaGnoSys GmbH
+ *               2017 Alexander Kurth, Sören Tempel, Tristan Bruns
+ *               2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_stm32
+ * @{
+ *
+ * @file
+ * @brief       Default clock configuration for STM32F1/F3
+ *
+ * @author      Víctor Ariño <victor.arino@triagnosys.com>
+ * @author      Sören Tempel <tempel@uni-bremen.de>
+ * @author      Tristan Bruns <tbruns@uni-bremen.de>
+ * @author      Alexander Kurth <kurth1@uni-bremen.de>
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#ifndef F1F3_CFG_CLOCK_DEFAULT_H
+#define F1F3_CFG_CLOCK_DEFAULT_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock settings
+ * @{
+ */
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 72MHz */
+#define CLOCK_CORECLOCK     MHZ(72)
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#ifndef CLOCK_HSE
+#define CLOCK_HSE           MHZ(8)
+#endif
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#ifndef CLOCK_LSE
+#define CLOCK_LSE           (0)
+#endif
+/* peripheral clock setup */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
+
+/* PLL factors */
+#ifndef CLOCK_PLL_PREDIV
+#define CLOCK_PLL_PREDIV     (1)
+#endif
+#ifndef CLOCK_PLL_MUL
+#define CLOCK_PLL_MUL        (9)
+#endif
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* F1F3_CFG_CLOCK_DEFAULT_H */
+/** @} */

--- a/boards/fox/Makefile.include
+++ b/boards/fox/Makefile.include
@@ -1,3 +1,6 @@
+# Include shared STM32 headers
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyUSB1
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*)))

--- a/boards/fox/include/periph_conf.h
+++ b/boards/fox/include/periph_conf.h
@@ -19,40 +19,21 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* iotlab boards provide an LSE */
+#define CLOCK_LSE            (1)
+
+/* HSE is clocked at 16MHz */
+#define CLOCK_HSE            MHZ(16)
+
+/* Adjust PLL predevider to reach 72MHz sysclock */
+#define CLOCK_PLL_PREDIV     (2)
+
 #include "periph_cpu.h"
+#include "f1f3/cfg_clock_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 72MHz */
-#define CLOCK_CORECLOCK     (72000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (16000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1U)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (2)
-#define CLOCK_PLL_MUL        (9)
-/** @} */
 
 /**
  * @name    Timer configuration

--- a/boards/maple-mini/Makefile.include
+++ b/boards/maple-mini/Makefile.include
@@ -1,3 +1,6 @@
+# Include shared STM32 headers
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/maple-mini/include/periph_conf.h
+++ b/boards/maple-mini/include/periph_conf.h
@@ -20,39 +20,11 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f1f3/cfg_clock_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 72MHz */
-#define CLOCK_CORECLOCK     (72000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (0U)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (1)
-#define CLOCK_PLL_MUL        (9)
-/** @} */
 
 /**
  * @name   Timer configuration

--- a/boards/nucleo-f103rb/include/periph_conf.h
+++ b/boards/nucleo-f103rb/include/periph_conf.h
@@ -19,40 +19,15 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* This board provides an LSE */
+#define CLOCK_LSE            (1)
+
 #include "periph_cpu.h"
+#include "f1f3/cfg_clock_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 72MHz */
-#define CLOCK_CORECLOCK      (72000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE            (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE            (1)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV        RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB            (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV       RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
-#define CLOCK_APB1           (CLOCK_CORECLOCK / 2)
-#define CLOCK_APB2_DIV       RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
-#define CLOCK_APB2           (CLOCK_CORECLOCK / 1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (1)
-#define CLOCK_PLL_MUL        (9)
-/** @} */
 
 /**
  * @name   Timer configuration

--- a/boards/nucleo-f302r8/include/periph_conf.h
+++ b/boards/nucleo-f302r8/include/periph_conf.h
@@ -23,41 +23,16 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* This board provides an LSE */
+#define CLOCK_LSE            (1)
+
 #include "periph_cpu.h"
+#include "f1f3/cfg_clock_default.h"
 #include "cfg_timer_tim2.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 72MHz */
-#define CLOCK_CORECLOCK     (72000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (1)
-#define CLOCK_PLL_MUL        (9)
-/** @} */
 
 /**
  * @name   UART configuration

--- a/boards/nucleo-f303k8/include/periph_conf.h
+++ b/boards/nucleo-f303k8/include/periph_conf.h
@@ -19,41 +19,20 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* No HSE available for this board */
+#define CLOCK_HSE           (0U)
+
+/* Adjust PLL prescalers to reach 72MHz sysclock */
+#define CLOCK_PLL_PREDIV    (2)
+#define CLOCK_PLL_MUL       (16)
+
 #include "periph_cpu.h"
+#include "f1f3/cfg_clock_default.h"
 #include "cfg_timer_tim2.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 72MHz */
-#define CLOCK_CORECLOCK     (64000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (0U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (0)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (2)
-#define CLOCK_PLL_MUL        (16)
-/** @} */
 
 /**
  * @name    DMA streams configuration

--- a/boards/nucleo-f303re/include/periph_conf.h
+++ b/boards/nucleo-f303re/include/periph_conf.h
@@ -21,41 +21,16 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* This board provides an LSE */
+#define CLOCK_LSE            (1)
+
 #include "periph_cpu.h"
+#include "f1f3/cfg_clock_default.h"
 #include "cfg_timer_tim2.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 72MHz */
-#define CLOCK_CORECLOCK     (72000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (1)
-#define CLOCK_PLL_MUL        (9)
-/** @} */
 
 /**
  * @name   UART configuration

--- a/boards/nucleo-f303ze/include/periph_conf.h
+++ b/boards/nucleo-f303ze/include/periph_conf.h
@@ -19,41 +19,16 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* This board provides an LSE */
+#define CLOCK_LSE            (1)
+
 #include "periph_cpu.h"
+#include "f1f3/cfg_clock_default.h"
 #include "cfg_timer_tim2.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 72MHz */
-#define CLOCK_CORECLOCK     (72000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (1)
-#define CLOCK_PLL_MUL        (9)
-/** @} */
 
 /**
  * @name    UART configuration

--- a/boards/nucleo-f334r8/include/periph_conf.h
+++ b/boards/nucleo-f334r8/include/periph_conf.h
@@ -20,41 +20,16 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* This board provides an LSE */
+#define CLOCK_LSE            (1)
+
 #include "periph_cpu.h"
+#include "f1f3/cfg_clock_default.h"
 #include "cfg_timer_tim2.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 72MHz */
-#define CLOCK_CORECLOCK     (72000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (1)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (1)
-#define CLOCK_PLL_MUL        (9)
-/** @} */
 
 /**
  * @name    DMA streams configuration

--- a/boards/olimexino-stm32/include/periph_conf.h
+++ b/boards/olimexino-stm32/include/periph_conf.h
@@ -19,40 +19,15 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+/* This board provides an LSE */
+#define CLOCK_LSE            (1)
+
 #include "periph_cpu.h"
+#include "f1f3/cfg_clock_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 72MHz */
-#define CLOCK_CORECLOCK      (72000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE            (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE            (1)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV        RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB            (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV       RCC_CFGR_PPRE1_DIV2        /* max 36MHz */
-#define CLOCK_APB1           (CLOCK_CORECLOCK / 2)
-#define CLOCK_APB2_DIV       RCC_CFGR_PPRE2_DIV1        /* max 72MHz */
-#define CLOCK_APB2           (CLOCK_CORECLOCK / 1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (1)
-#define CLOCK_PLL_MUL        (9)
-/** @} */
 
 /**
  * @name   ADC configuration

--- a/boards/opencm904/Makefile.include
+++ b/boards/opencm904/Makefile.include
@@ -1,3 +1,6 @@
+# Include shared STM32 headers
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))

--- a/boards/opencm904/include/periph_conf.h
+++ b/boards/opencm904/include/periph_conf.h
@@ -20,39 +20,11 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f1f3/cfg_clock_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 72MHz */
-#define CLOCK_CORECLOCK     (72000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (0U)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (1)
-#define CLOCK_PLL_MUL        (9)
-/** @} */
 
 /**
  * @name   Timer configuration

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -1,3 +1,6 @@
+# Include shared STM32 headers
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -20,39 +20,11 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f1f3/cfg_clock_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
- /**
-  * @name    Clock settings
-  *
-  * @note    This is auto-generated from
-  *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
-  * @{
-  */
- /* give the target core clock (HCLK) frequency [in Hz],
-  * maximum: 72MHz */
- #define CLOCK_CORECLOCK     (72000000U)
- /* 0: no external high speed crystal available
-  * else: actual crystal frequency [in Hz] */
- #define CLOCK_HSE           (8000000U)
- /* 0: no external low speed crystal available,
-  * 1: external crystal available (always 32.768kHz) */
- #define CLOCK_LSE           (0U)
- /* peripheral clock setup */
- #define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
- #define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
- #define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
- #define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
- #define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
- #define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-
- /* PLL factors */
- #define CLOCK_PLL_PREDIV     (1)
- #define CLOCK_PLL_MUL        (9)
- /** @} */
 
 /**
  * @name   Timer configuration

--- a/boards/stm32f3discovery/Makefile.include
+++ b/boards/stm32f3discovery/Makefile.include
@@ -1,3 +1,6 @@
+# add the common header files to the include path
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
 # define the default port depending on the host OS
 PORT_LINUX ?= /dev/ttyUSB0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))

--- a/boards/stm32f3discovery/include/periph_conf.h
+++ b/boards/stm32f3discovery/include/periph_conf.h
@@ -20,39 +20,11 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "f1f3/cfg_clock_default.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock settings
- *
- * @note    This is auto-generated from
- *          `cpu/stm32_common/dist/clk_conf/clk_conf.c`
- * @{
- */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 72MHz */
-#define CLOCK_CORECLOCK     (72000000U)
-/* 0: no external high speed crystal available
- * else: actual crystal frequency [in Hz] */
-#define CLOCK_HSE           (8000000U)
-/* 0: no external low speed crystal available,
- * 1: external crystal available (always 32.768kHz) */
-#define CLOCK_LSE           (0)
-/* peripheral clock setup */
-#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
-#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
-#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV2     /* max 36MHz */
-#define CLOCK_APB1          (CLOCK_CORECLOCK / 2)
-#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* max 72MHz */
-#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
-
-/* PLL factors */
-#define CLOCK_PLL_PREDIV     (1)
-#define CLOCK_PLL_MUL        (9)
-/** @} */
 
 /**
  * @name   DAC configuration


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is the same as #14891 and #14870 but applied to stm32f1 and stm32f3 boards. I noticed that all f1 and f3 are more or less configured the same way (same sysclock of 72MHz, same PLL prescalers, etc).
So this PR introduce a shared header containing default clock configuration for all f1/f3 based boards. Boards that require specific parameters (LSE present, specific HSE clock and PLL prescalers) can override these values from the own configuration.

This PR is an intermediate step toward fully configurable clock configuration via Kconfig and CFLAGS (like it's already done with stm32gx and stm32l4/wb in #14866).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Affected boards are still functional

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Similar to #14891 and #14870 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
