### PR TITLE
cpu/util: add dummy CPU for native utilities

### DIFF
--- a/boards/util/Kconfig
+++ b/boards/util/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "util" if BOARD_UTIL
+
+config BOARD_UTIL
+    bool
+    default y
+    select CPU_ARCH_UTIL

--- a/boards/util/Makefile
+++ b/boards/util/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/util/Makefile.features
+++ b/boards/util/Makefile.features
@@ -1,0 +1,1 @@
+CPU = util

--- a/boards/util/Makefile.include
+++ b/boards/util/Makefile.include
@@ -1,0 +1,21 @@
+# basic cflags:
+CFLAGS += -Os
+CFLAGS += -Wall -Wextra -pedantic $(CFLAGS_DBG)
+CFLAGS_DBG ?= -g3
+
+# default std set to gnu99 of not overwritten by user
+ifeq (,$(filter -std=%, $(CFLAGS)))
+  CFLAGS += -std=gnu11
+endif
+
+# clean up unused functions
+CFLAGS += -ffunction-sections -fdata-sections
+ifeq ($(OS),Darwin)
+  LINKFLAGS += -Wl,-dead_strip
+else
+  LINKFLAGS += -Wl,--gc-sections
+endif
+LINKFLAGS += -ffunction-sections
+
+FLASHFILE ?= $(ELFFILE)
+TERMPROG  ?= $(ELFFILE)

--- a/boards/util/doc.txt
+++ b/boards/util/doc.txt
@@ -1,0 +1,18 @@
+/**
+@defgroup    boards_util Dummy board
+@ingroup     boards
+@brief       Support for using the RIOT build system to build native utilities
+
+# Overview
+
+While the @ref boards_native is aimed at simulating hardware and using as
+much of RIOT as possible, the `util` dummy board does the opposite.
+
+It attempts to use as little RIOT code as possible to build a native application,
+just leveraging the RIOT build system to build utilities that make use
+of RIOT libaries or packages.
+
+There is no attempt made to simulate any hardware.
+All libraries of the host operating system are available.
+
+ */

--- a/boards/util/include/board.h
+++ b/boards/util/include/board.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_util
+ *
+ * @{
+ *
+ * @file
+ * @brief       Dummy file
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */

--- a/cpu/util/Kconfig
+++ b/cpu/util/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config CPU_ARCH_UTIL
+    bool
+    select HAS_CPU_UTIL
+
+## Declaration of specific features
+config HAS_CPU_UTIL
+    bool
+    help
+        Indicates that the dummy 'util' architecture is used.
+
+## CPU Common symbols
+config CPU
+    default "util" if CPU_ARCH_UTIL

--- a/cpu/util/Makefile
+++ b/cpu/util/Makefile
@@ -1,0 +1,3 @@
+MODULE = cpu
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/util/Makefile.features
+++ b/cpu/util/Makefile.features
@@ -1,0 +1,1 @@
+# util dummy CPU has no features

--- a/cpu/util/Makefile.include
+++ b/cpu/util/Makefile.include
@@ -1,0 +1,1 @@
+# configuration happens in boards/util

--- a/cpu/util/dummy.c
+++ b/cpu/util/dummy.c
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * Util 'cpu' dummy functions
+ *
+ * @ingroup cpu_util
+ * @{
+ * @file
+ * @author  Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#include <fcntl.h>
+#include <linux/limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* cmdline args are 0 separated */
+static unsigned _get_argc(const char *args, const char *end)
+{
+    unsigned count = 0;
+    while (args != end) {
+        if (*args++ == 0) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+void pm_reboot(void)
+{
+    /* get command line from procfs */
+    char cmdline[ARG_MAX];
+    int fd = open("/proc/self/cmdline", O_RDONLY);
+    int n_bytes = read(fd, cmdline, sizeof(cmdline));
+    close(fd);
+
+    char *end = cmdline + n_bytes;
+    char *argv[_get_argc(cmdline, cmdline + n_bytes)];
+
+    /* fill the argv array */
+    unsigned i = 0;
+    for (char *arg = cmdline; arg < end; ) {
+        argv[i++] = arg;
+        arg += strlen(arg) + 1;
+    }
+    argv[i] = 0;
+
+    execve("/proc/self/exe", argv, NULL);
+}
+
+void pm_off(void)
+{
+    exit(0);
+}
+
+void irq_restore(unsigned state)
+{
+    (void) state;
+}
+
+unsigned irq_disable(void)
+{
+    return 0;
+}
+
+/** @} */

--- a/cpu/util/include/cpu.h
+++ b/cpu/util/include/cpu.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu
+ * @defgroup    cpu_util    Dummy/No-op CPU implementation for native utilities
+ * @details     The util CPU allows to use the RIOT build system for native
+ *              application without attempting to simulate hardware.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Dummy file
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#ifndef CPU_H
+#define CPU_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline void cpu_print_last_instruction(void)
+{
+    /* no-op */
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CPU_H */

--- a/cpu/util/include/cpu_conf.h
+++ b/cpu/util/include/cpu_conf.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_util
+ *
+ * @{
+ *
+ * @file
+ * @brief       Dummy file
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#ifndef CPU_CONF_H
+#define CPU_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Dummy stack sizes
+ *          These are not used, but can't be 0 / undefined.
+ *
+ * @{
+ */
+#define THREAD_STACKSIZE_DEFAULT        (1024)
+#define THREAD_STACKSIZE_IDLE           (1024)
+#define THREAD_EXTRA_STACKSIZE_PRINTF   (1024)
+/** @} */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CPU_CONF_H */

--- a/cpu/util/include/periph_conf.h
+++ b/cpu/util/include/periph_conf.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_util
+ *
+ * @{
+ *
+ * @file
+ * @brief       Dummy file
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/cpu/util/include/periph_cpu.h
+++ b/cpu/util/include/periph_cpu.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_util
+ *
+ * @{
+ *
+ * @file
+ * @brief       Dummy file
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#ifndef PERIPH_CPU_H
+#define PERIPH_CPU_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CPU_H */

--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -38,7 +38,7 @@ extern "C" {
  * Instead terminate RIOT, which is also the behavior a user would
  * expect from a CLI application.
  */
-#  ifdef CPU_NATIVE
+#  if defined(CPU_NATIVE) || defined(CPU_UTIL)
 #    define CONFIG_SHELL_SHUTDOWN_ON_EXIT 1
 #  endif
 #endif

--- a/tests/heap_cmd/main.c
+++ b/tests/heap_cmd/main.c
@@ -42,7 +42,7 @@ static int free_cmd(int argc, char **argv)
         return 1;
     }
 
-    unsigned int p = strtoul(argv[1], NULL, 16);
+    uintptr_t p = strtoul(argv[1], NULL, 16);
     void *ptr = (void *)p;
     free(ptr);
     printf("freed %p\n", ptr);


### PR DESCRIPTION
### Contribution description

Sometimes I want to build a native utility, but reference code or variables from RIOT modules or packages.
(e.g. a server and a client should both use the same header file with shared defines from a module)

So far this has always been somewhat messy with hard-coded paths to the RIOT module header locations (e.g. see `dist/tools/uhcpd`).

Using `native` is not an option either as it will route all syscalls to RIOT first instead of just using the operating system C library.
This is of course the desired behavior for testing / simulations, but not for native utilities that just happen to share some code with RIOT.

### Testing procedure

Converting `uhcpd` still requires some cleanups.

You can run 

    make -C examples/default BOARD=util all term

A more practical example would be

    make -C tests/pkg_nanocbor BOARD=util all term

as this can be used to generate `.cbor` files using normal file I/O functions.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
