### PR TITLE
boards/hifive*: improve clock configuration and initialization

### DIFF
--- a/boards/hifive1/include/periph_conf.h
+++ b/boards/hifive1/include/periph_conf.h
@@ -71,7 +71,6 @@ extern "C" {
 #error "Cannot use HFROSC with other clock configurations"
 #endif
 
-#if CONFIG_USE_CLOCK_HFXOSC_PLL
 #define CONFIG_CLOCK_PLL_R                  (1)     /* Divide input clock by 2, mandatory with HFXOSC */
 #ifndef CONFIG_CLOCK_PLL_F
 #define CONFIG_CLOCK_PLL_F                  (39)    /* Multiply REFR by 80, e.g 2 * (39 + 1) */
@@ -79,6 +78,8 @@ extern "C" {
 #ifndef CONFIG_CLOCK_PLL_Q
 #define CONFIG_CLOCK_PLL_Q                  (1)     /* Divide VCO by 2, e.g 2^1 */
 #endif
+
+#if CONFIG_USE_CLOCK_HFXOSC_PLL
 #define CLOCK_PLL_INPUT_CLOCK               (16000000UL)
 #define CLOCK_PLL_REFR                      (CLOCK_PLL_INPUT_CLOCK / (CONFIG_CLOCK_PLL_R + 1))
 #define CLOCK_PLL_VCO                       (CLOCK_PLL_REFR * (2 * (CONFIG_CLOCK_PLL_F + 1)))
@@ -98,26 +99,21 @@ extern "C" {
 
 #elif CONFIG_USE_CLOCK_HFXOSC
 #define CLOCK_CORECLOCK                     (16000000UL)
+#endif
 
 /*
   When using HFROSC input clock, the core clock cannot be computed from settings,
   call cpu_freq() to get the configured CPU frequency.
 */
-#elif CONFIG_USE_CLOCK_HFROSC_PLL
 #ifndef CONFIG_CLOCK_DESIRED_FREQUENCY
 #define CONFIG_CLOCK_DESIRED_FREQUENCY     (320000000UL)
 #endif
 
-#elif CONFIG_USE_CLOCK_HFROSC
 #ifndef CONFIG_CLOCK_HFROSC_TRIM
 #define CONFIG_CLOCK_HFROSC_TRIM           (6)      /* ~72000000Hz input freq */
 #endif
 #ifndef CONFIG_CLOCK_HFROSC_DIV
 #define CONFIG_CLOCK_HFROSC_DIV            (1)      /* Divide by 2 */
-#endif
-
-#else
-#error "Invalid clock configuration"
 #endif
 /** @} */
 

--- a/boards/hifive1/include/periph_conf.h
+++ b/boards/hifive1/include/periph_conf.h
@@ -33,22 +33,22 @@ extern "C" {
 #ifndef CONFIG_USE_CLOCK_HFXOSC_PLL
 #if IS_ACTIVE(CONFIG_USE_CLOCK_HFXOSC) || IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC_PLL) || \
     IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC)
-#define CONFIG_USE_CLOCK_HFXOSC_PLL         (0)
+#define CONFIG_USE_CLOCK_HFXOSC_PLL         0
 #else
-#define CONFIG_USE_CLOCK_HFXOSC_PLL         (1)     /* Use PLL clocked by HFXOSC by default */
+#define CONFIG_USE_CLOCK_HFXOSC_PLL         1       /* Use PLL clocked by HFXOSC by default */
 #endif
 #endif /* CONFIG_USE_CLOCK_HFXOSC_PLL */
 
 #ifndef CONFIG_USE_CLOCK_HFXOSC
-#define CONFIG_USE_CLOCK_HFXOSC             (0)
+#define CONFIG_USE_CLOCK_HFXOSC             0
 #endif /* CONFIG_USE_CLOCK_HFXOSC */
 
 #ifndef CONFIG_USE_CLOCK_HFROSC_PLL
-#define CONFIG_USE_CLOCK_HFROSC_PLL         (0)
+#define CONFIG_USE_CLOCK_HFROSC_PLL         0
 #endif /* CONFIG_USE_CLOCK_HFROSC_PLL */
 
 #ifndef CONFIG_USE_CLOCK_HFROSC
-#define CONFIG_USE_CLOCK_HFROSC             (0)
+#define CONFIG_USE_CLOCK_HFROSC             0
 #endif /* CONFIG_USE_CLOCK_HFROSC */
 
 #if CONFIG_USE_CLOCK_HFXOSC_PLL && \

--- a/boards/hifive1/include/periph_conf.h
+++ b/boards/hifive1/include/periph_conf.h
@@ -80,25 +80,25 @@ extern "C" {
 #endif
 
 #if CONFIG_USE_CLOCK_HFXOSC_PLL
-#define CLOCK_PLL_INPUT_CLOCK               (16000000UL)
+#define CLOCK_PLL_INPUT_CLOCK               MHZ(16)
 #define CLOCK_PLL_REFR                      (CLOCK_PLL_INPUT_CLOCK / (CONFIG_CLOCK_PLL_R + 1))
 #define CLOCK_PLL_VCO                       (CLOCK_PLL_REFR * (2 * (CONFIG_CLOCK_PLL_F + 1)))
 #define CLOCK_PLL_OUT                       (CLOCK_PLL_VCO / (1 << CONFIG_CLOCK_PLL_Q))
 #define CLOCK_CORECLOCK                     (CLOCK_PLL_OUT) /* 320000000Hz with the values used above */
 
 /* Check PLL settings */
-#if CLOCK_PLL_REFR != 8000000
+#if CLOCK_PLL_REFR != MHZ(8)
 #error "Only R=2 can be used when using HFXOSC"
 #endif
-#if (CLOCK_PLL_VCO < 384000000) || (CLOCK_PLL_VCO > 768000000)
+#if (CLOCK_PLL_VCO < MHZ(384)) || (CLOCK_PLL_VCO > MHZ(768))
 #error "VCO frequency must be in the range [384MHz - 768MHz], check the CLOCK_PLL_F value"
 #endif
-#if (CLOCK_PLL_OUT < 48000000) || (CLOCK_PLL_OUT > 384000000)
+#if (CLOCK_PLL_OUT < MHZ(48)) || (CLOCK_PLL_OUT > MHZ(384))
 #error "PLL output frequency must be in the range [48MHz - 384MHz], check the CLOCK_PLL_Q value"
 #endif
 
 #elif CONFIG_USE_CLOCK_HFXOSC
-#define CLOCK_CORECLOCK                     (16000000UL)
+#define CLOCK_CORECLOCK                     MHZ(16)
 #endif
 
 /*
@@ -106,7 +106,7 @@ extern "C" {
   call cpu_freq() to get the configured CPU frequency.
 */
 #ifndef CONFIG_CLOCK_DESIRED_FREQUENCY
-#define CONFIG_CLOCK_DESIRED_FREQUENCY     (320000000UL)
+#define CONFIG_CLOCK_DESIRED_FREQUENCY     MHZ(320)
 #endif
 
 #ifndef CONFIG_CLOCK_HFROSC_TRIM

--- a/boards/hifive1b/include/periph_conf.h
+++ b/boards/hifive1b/include/periph_conf.h
@@ -81,25 +81,25 @@ extern "C" {
 #endif
 
 #if CONFIG_USE_CLOCK_HFXOSC_PLL
-#define CLOCK_PLL_INPUT_CLOCK               (16000000UL)
+#define CLOCK_PLL_INPUT_CLOCK               MHZ(16)
 #define CLOCK_PLL_REFR                      (CLOCK_PLL_INPUT_CLOCK / (CONFIG_CLOCK_PLL_R + 1))
 #define CLOCK_PLL_VCO                       (CLOCK_PLL_REFR * (2 * (CONFIG_CLOCK_PLL_F + 1)))
 #define CLOCK_PLL_OUT                       (CLOCK_PLL_VCO / (1 << CONFIG_CLOCK_PLL_Q))
 #define CLOCK_CORECLOCK                     (CLOCK_PLL_OUT) /* 320000000Hz with the values used above */
 
 /* Check PLL settings */
-#if CLOCK_PLL_REFR != 8000000
+#if CLOCK_PLL_REFR != MHZ(8)
 #error "Only R=2 can be used when using HFXOSC"
 #endif
-#if (CLOCK_PLL_VCO < 384000000) || (CLOCK_PLL_VCO > 768000000)
+#if (CLOCK_PLL_VCO < MHZ(384)) || (CLOCK_PLL_VCO > MHZ(768))
 #error "VCO frequency must be in the range [384MHz - 768MHz], check the CLOCK_PLL_F value"
 #endif
-#if (CLOCK_PLL_OUT < 48000000) || (CLOCK_PLL_OUT > 384000000)
+#if (CLOCK_PLL_OUT < MHZ(48)) || (CLOCK_PLL_OUT > MHZ(384))
 #error "PLL output frequency must be in the range [48MHz - 384MHz], check the CLOCK_PLL_Q value"
 #endif
 
 #elif CONFIG_USE_CLOCK_HFXOSC
-#define CLOCK_CORECLOCK                     (16000000UL)
+#define CLOCK_CORECLOCK                     MHZ(16)
 #endif
 
 /*
@@ -107,7 +107,7 @@ extern "C" {
   call cpu_freq() to get the configured CPU frequency.
 */
 #ifndef CONFIG_CLOCK_DESIRED_FREQUENCY
-#define CONFIG_CLOCK_DESIRED_FREQUENCY     (320000000UL)
+#define CONFIG_CLOCK_DESIRED_FREQUENCY     MHZ(320)
 #endif
 
 #ifndef CONFIG_CLOCK_HFROSC_TRIM

--- a/boards/hifive1b/include/periph_conf.h
+++ b/boards/hifive1b/include/periph_conf.h
@@ -72,7 +72,6 @@ extern "C" {
 #error "Cannot use HFROSC with other clock configurations"
 #endif
 
-#if CONFIG_USE_CLOCK_HFXOSC_PLL
 #define CONFIG_CLOCK_PLL_R                  (1)     /* Divide input clock by 2, mandatory with HFXOSC */
 #ifndef CONFIG_CLOCK_PLL_F
 #define CONFIG_CLOCK_PLL_F                  (39)    /* Multiply REFR by 80, e.g 2 * (39 + 1) */
@@ -80,6 +79,8 @@ extern "C" {
 #ifndef CONFIG_CLOCK_PLL_Q
 #define CONFIG_CLOCK_PLL_Q                  (1)     /* Divide VCO by 2, e.g 2^1 */
 #endif
+
+#if CONFIG_USE_CLOCK_HFXOSC_PLL
 #define CLOCK_PLL_INPUT_CLOCK               (16000000UL)
 #define CLOCK_PLL_REFR                      (CLOCK_PLL_INPUT_CLOCK / (CONFIG_CLOCK_PLL_R + 1))
 #define CLOCK_PLL_VCO                       (CLOCK_PLL_REFR * (2 * (CONFIG_CLOCK_PLL_F + 1)))
@@ -99,26 +100,21 @@ extern "C" {
 
 #elif CONFIG_USE_CLOCK_HFXOSC
 #define CLOCK_CORECLOCK                     (16000000UL)
+#endif
 
 /*
   When using HFROSC input clock, the core clock cannot be computed from settings,
   call cpu_freq() to get the configured CPU frequency.
 */
-#elif CONFIG_USE_CLOCK_HFROSC_PLL
 #ifndef CONFIG_CLOCK_DESIRED_FREQUENCY
 #define CONFIG_CLOCK_DESIRED_FREQUENCY     (320000000UL)
 #endif
 
-#elif CONFIG_USE_CLOCK_HFROSC
 #ifndef CONFIG_CLOCK_HFROSC_TRIM
 #define CONFIG_CLOCK_HFROSC_TRIM           (6)      /* ~72000000Hz input freq */
 #endif
 #ifndef CONFIG_CLOCK_HFROSC_DIV
 #define CONFIG_CLOCK_HFROSC_DIV            (1)      /* Divide by 2 */
-#endif
-
-#else
-#error "Invalid clock configuration"
 #endif
 /** @} */
 

--- a/boards/hifive1b/include/periph_conf.h
+++ b/boards/hifive1b/include/periph_conf.h
@@ -34,22 +34,22 @@ extern "C" {
 #ifndef CONFIG_USE_CLOCK_HFXOSC_PLL
 #if IS_ACTIVE(CONFIG_USE_CLOCK_HFXOSC) || IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC_PLL) || \
     IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC)
-#define CONFIG_USE_CLOCK_HFXOSC_PLL         (0)
+#define CONFIG_USE_CLOCK_HFXOSC_PLL         0
 #else
-#define CONFIG_USE_CLOCK_HFXOSC_PLL         (1)     /* Use PLL clocked by HFXOSC by default */
+#define CONFIG_USE_CLOCK_HFXOSC_PLL         1       /* Use PLL clocked by HFXOSC by default */
 #endif
 #endif /* CONFIG_USE_CLOCK_HFXOSC_PLL */
 
 #ifndef CONFIG_USE_CLOCK_HFXOSC
-#define CONFIG_USE_CLOCK_HFXOSC             (0)
+#define CONFIG_USE_CLOCK_HFXOSC             0
 #endif /* CONFIG_USE_CLOCK_HFXOSC */
 
 #ifndef CONFIG_USE_CLOCK_HFROSC_PLL
-#define CONFIG_USE_CLOCK_HFROSC_PLL         (0)
+#define CONFIG_USE_CLOCK_HFROSC_PLL         0
 #endif /* CONFIG_USE_CLOCK_HFROSC_PLL */
 
 #ifndef CONFIG_USE_CLOCK_HFROSC
-#define CONFIG_USE_CLOCK_HFROSC             (0)
+#define CONFIG_USE_CLOCK_HFROSC             0
 #endif /* CONFIG_USE_CLOCK_HFROSC */
 
 #if CONFIG_USE_CLOCK_HFXOSC_PLL && \

--- a/cpu/fe310/clock.c
+++ b/cpu/fe310/clock.c
@@ -22,7 +22,7 @@
 
 #include "vendor/prci_driver.h"
 
-#if CONFIG_USE_CLOCK_HFROSC || CONFIG_USE_CLOCK_HFROSC_PLL
+#if IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC) || IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC_PLL)
 static uint32_t _cpu_frequency = 0;
 #endif
 
@@ -41,7 +41,7 @@ void clock_init(void)
         PRCI_REG(PRCI_PLLCFG) &= ~PLL_SEL(PLL_SEL_PLL);
     }
 
-    if (CONFIG_USE_CLOCK_HFXOSC || CONFIG_USE_CLOCK_HFXOSC_PLL) {
+    if (IS_ACTIVE(CONFIG_USE_CLOCK_HFXOSC) || IS_ACTIVE(CONFIG_USE_CLOCK_HFXOSC_PLL)) {
         /* Ensure HFXOSC is enabled */
         PRCI_REG(PRCI_HFXOSCCFG) = XOSC_EN(1);
 
@@ -51,7 +51,7 @@ void clock_init(void)
         /* Select HFXOSC as reference frequency and bypass PLL */
         PRCI_REG(PRCI_PLLCFG) = PLL_REFSEL(PLL_REFSEL_HFXOSC) | PLL_BYPASS(1);
 
-        if (CONFIG_USE_CLOCK_HFXOSC_PLL) {
+        if (IS_ACTIVE(CONFIG_USE_CLOCK_HFXOSC_PLL)) {
             /* Divide final output frequency by 1 */
             PRCI_REG(PRCI_PLLDIV) = (PLL_FINAL_DIV_BY_1(1) | PLL_FINAL_DIV(0));
 
@@ -71,7 +71,7 @@ void clock_init(void)
         /* Turn off the HFROSC */
         PRCI_REG(PRCI_HFROSCCFG) &= ~ROSC_EN(1);
     }
-    else if (CONFIG_USE_CLOCK_HFROSC_PLL) {
+    else if (IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC_PLL)) {
         PRCI_set_hfrosctrim_for_f_cpu(CONFIG_CLOCK_DESIRED_FREQUENCY, PRCI_FREQ_UNDERSHOOT);
     }
     else { /* Clock HFROSC */
@@ -91,7 +91,7 @@ void clock_init(void)
 
 uint32_t cpu_freq(void)
 {
-#if CONFIG_USE_CLOCK_HFROSC || CONFIG_USE_CLOCK_HFROSC_PLL
+#if IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC) || IS_ACTIVE(CONFIG_USE_CLOCK_HFROSC_PLL)
     /* Clock frequency with HFROSC cannot be determined precisely from
        settings */
     /* If not done already, estimate the CPU frequency */

--- a/cpu/fe310/clock.c
+++ b/cpu/fe310/clock.c
@@ -22,7 +22,7 @@
 
 #include "vendor/prci_driver.h"
 
-#if !(CONFIG_USE_CLOCK_HFXOSC || CONFIG_USE_CLOCK_HFXOSC_PLL)
+#if CONFIG_USE_CLOCK_HFROSC || CONFIG_USE_CLOCK_HFROSC_PLL
 static uint32_t _cpu_frequency = 0;
 #endif
 
@@ -41,58 +41,59 @@ void clock_init(void)
         PRCI_REG(PRCI_PLLCFG) &= ~PLL_SEL(PLL_SEL_PLL);
     }
 
-#if CONFIG_USE_CLOCK_HFXOSC || CONFIG_USE_CLOCK_HFXOSC_PLL
-    /* Ensure HFXOSC is enabled */
-    PRCI_REG(PRCI_HFXOSCCFG) = XOSC_EN(1);
+    if (CONFIG_USE_CLOCK_HFXOSC || CONFIG_USE_CLOCK_HFXOSC_PLL) {
+        /* Ensure HFXOSC is enabled */
+        PRCI_REG(PRCI_HFXOSCCFG) = XOSC_EN(1);
 
-    /* Wait for HFXOSC to become ready */
-    while ((PRCI_REG(PRCI_HFXOSCCFG) & XOSC_RDY(1)) == 0);
+        /* Wait for HFXOSC to become ready */
+        while ((PRCI_REG(PRCI_HFXOSCCFG) & XOSC_RDY(1)) == 0);
 
-    /* Select HFXOSC as reference frequency and bypass PLL */
-    PRCI_REG(PRCI_PLLCFG) = PLL_REFSEL(PLL_REFSEL_HFXOSC) | PLL_BYPASS(1);
+        /* Select HFXOSC as reference frequency and bypass PLL */
+        PRCI_REG(PRCI_PLLCFG) = PLL_REFSEL(PLL_REFSEL_HFXOSC) | PLL_BYPASS(1);
 
-#if CONFIG_USE_CLOCK_HFXOSC_PLL
-    /* Divide final output frequency by 1 */
-    PRCI_REG(PRCI_PLLDIV) = (PLL_FINAL_DIV_BY_1(1) | PLL_FINAL_DIV(0));
+        if (CONFIG_USE_CLOCK_HFXOSC_PLL) {
+            /* Divide final output frequency by 1 */
+            PRCI_REG(PRCI_PLLDIV) = (PLL_FINAL_DIV_BY_1(1) | PLL_FINAL_DIV(0));
 
-    /* Configure PLL */
-    PRCI_REG(PRCI_PLLCFG) |= PLL_R(CONFIG_CLOCK_PLL_R) | PLL_F(CONFIG_CLOCK_PLL_F) | PLL_Q(CONFIG_CLOCK_PLL_Q);
+            /* Configure PLL */
+            PRCI_REG(PRCI_PLLCFG) |= PLL_R(CONFIG_CLOCK_PLL_R) | PLL_F(CONFIG_CLOCK_PLL_F) | PLL_Q(CONFIG_CLOCK_PLL_Q);
 
-    /* Disable PLL Bypass */
-    PRCI_REG(PRCI_PLLCFG) &= ~PLL_BYPASS(1);
+            /* Disable PLL Bypass */
+            PRCI_REG(PRCI_PLLCFG) &= ~PLL_BYPASS(1);
 
-    /* Now it is safe to check for PLL Lock */
-    while ((PRCI_REG(PRCI_PLLCFG) & PLL_LOCK(1)) == 0);
-#endif
+            /* Now it is safe to check for PLL Lock */
+            while ((PRCI_REG(PRCI_PLLCFG) & PLL_LOCK(1)) == 0);
+        }
 
-    /* Switch over to PLL Clock source */
-    PRCI_REG(PRCI_PLLCFG) |= PLL_SEL(PLL_SEL_PLL);
+        /* Switch over to PLL Clock source */
+        PRCI_REG(PRCI_PLLCFG) |= PLL_SEL(PLL_SEL_PLL);
 
-    /* Turn off the HFROSC */
-    PRCI_REG(PRCI_HFROSCCFG) &= ~ROSC_EN(1);
-#elif CONFIG_USE_CLOCK_HFROSC_PLL
-    PRCI_set_hfrosctrim_for_f_cpu(CONFIG_CLOCK_DESIRED_FREQUENCY, PRCI_FREQ_UNDERSHOOT);
-#else /* Clock HFROSC */
-    /* Disable Bypass */
-    PRCI_REG(PRCI_PLLCFG) &= ~PLL_BYPASS(1);
+        /* Turn off the HFROSC */
+        PRCI_REG(PRCI_HFROSCCFG) &= ~ROSC_EN(1);
+    }
+    else if (CONFIG_USE_CLOCK_HFROSC_PLL) {
+        PRCI_set_hfrosctrim_for_f_cpu(CONFIG_CLOCK_DESIRED_FREQUENCY, PRCI_FREQ_UNDERSHOOT);
+    }
+    else { /* Clock HFROSC */
+        /* Disable Bypass */
+        PRCI_REG(PRCI_PLLCFG) &= ~PLL_BYPASS(1);
 
-    /* Configure trim and divider values of HFROSC */
-    PRCI_REG(PRCI_HFROSCCFG) = (ROSC_DIV(CONFIG_CLOCK_HFROSC_DIV) | ROSC_TRIM(CONFIG_CLOCK_HFROSC_TRIM) | ROSC_EN(1));
+        /* Configure trim and divider values of HFROSC */
+        PRCI_REG(PRCI_HFROSCCFG) = (ROSC_DIV(CONFIG_CLOCK_HFROSC_DIV) | ROSC_TRIM(CONFIG_CLOCK_HFROSC_TRIM) | ROSC_EN(1));
 
-    /* Wait for HFROSC to be ready */
-    while ((PRCI_REG(PRCI_HFROSCCFG) & ROSC_RDY(1)) == 0);
+        /* Wait for HFROSC to be ready */
+        while ((PRCI_REG(PRCI_HFROSCCFG) & ROSC_RDY(1)) == 0);
 
-    /* Don't use PLL clock source */
-    PRCI_REG(PRCI_PLLCFG) &= ~PLL_SEL(PLL_SEL_PLL);
-#endif
+        /* Don't use PLL clock source */
+        PRCI_REG(PRCI_PLLCFG) &= ~PLL_SEL(PLL_SEL_PLL);
+    }
 }
 
 uint32_t cpu_freq(void)
 {
-#if CONFIG_USE_CLOCK_HFXOSC || CONFIG_USE_CLOCK_HFXOSC_PLL
-    return CLOCK_CORECLOCK;
-#else /* Clock frequency with HFROSC cannot be determined precisely from
-         settings */
+#if CONFIG_USE_CLOCK_HFROSC || CONFIG_USE_CLOCK_HFROSC_PLL
+    /* Clock frequency with HFROSC cannot be determined precisely from
+       settings */
     /* If not done already, estimate the CPU frequency */
     if (_cpu_frequency == 0) {
         /* Ignore the first run (for icache reasons) */
@@ -100,5 +101,7 @@ uint32_t cpu_freq(void)
         _cpu_frequency = PRCI_measure_mcycle_freq(3000, RTC_FREQ);
     }
     return _cpu_frequency;
+#else
+    return CLOCK_CORECLOCK;
 #endif
 }

--- a/cpu/fe310/include/cpu.h
+++ b/cpu/fe310/include/cpu.h
@@ -26,6 +26,7 @@
 #define CPU_H
 
 #include "thread.h"
+#include "macros/units.h"
 
 #include "vendor/platform.h"
 #include "vendor/plic_driver.h"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR improves a bit the clock configuration/initialization of the fe310 based boards:
- in the clock initialization sequence, instead of only relying on macro conditionals, it uses regular C conditionals and relies on compiler optimization to drop the always false blocks. This ensures all clock modes are built by the CI even if not configured by default. The firmware size is unchanged compared to master.
- in also makes use of the MHZ utility macro

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Configure the different clock modes and ensure the application is still functional (or also follow the testing procedure already described in #14614)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up PR of #14614

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
