### PR TITLE
drivers: add generic 1-Wire bus driver

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -97,6 +97,10 @@ ifneq (,$(filter nrfmin,$(USEMODULE)))
   USEMODULE += netif
 endif
 
+ifneq (,$(fitler onewire_%,$(USEMODULE)))
+  USEMODULE += onewire
+endif
+
 ifneq (,$(filter qmc5883l_%,$(USEMODULE)))
   USEMODULE += qmc5883l
 endif

--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -15,9 +15,31 @@
  * This is generic soft driver to interface devices connected via the 1-Wire
  * bus specified by Dallas Semiconductor Corp, today Maxim Integrated.
  *
+ * @see         https://www.maximintegrated.com/en/design/technical-documents/app-notes/1/126.html
  * @see         https://www.maximintegrated.com/en/design/technical-documents/app-notes/7/74.html
  * @see         https://pdfserv.maximintegrated.com/en/an/AN937.pdf
  * @see         https://www.ti.com/lit/an/spma057c/spma057c.pdf?ts=1598599201996
+ *
+ * # Thread Safety and Preemtion (onewire_safe)
+ * In the vanilla form this driver is not thread safe and will not work reliable
+ * if the thread running the driver is interrupted during data transfer. This is
+ * because the driver depends on an active spin loop to produce the needed
+ * timings. If that loop is interrupted, the timings will be off target and
+ * therefore the ongoing data transfer will be invalid.
+ *
+ * To achieve reliable data transfers you have two choices:
+ * 1. Run the driver in a high priority thread that will not be interrupted.
+ *    Furthermore it needs to run in an environment, where at most very short
+ *    interrupts may be triggered.
+ * 2. Run the driver in safe mode by selecting the `onewire_safe` module. In
+ *    this mode all data transfers are run in a critical section by disabling
+ *    ALL interrupts for that period of time. Precisely, the interrupts will be
+ *    disabled for one block of 960us and 1-to-N blocks of 70us for each
+ *    reset->read/write sequence.
+ *
+ * @warning     Using the drivers safe mode (`onewire_safe`) will impact the
+ *              real-time capabilities of the overall system as interrupts will
+ *              be disabled for periods of time (blocks of 960us and 70us)
  *
  * @{
  * @file

--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -81,7 +81,7 @@ enum {
     ONEWIRE_OK          =  0,   /**< everything fine */
     ONEWIRE_NODEV       = -1,   /**< no device connected to the bus */
     ONEWIRE_ERR_PINCFG  = -2,   /**< unable to initialize pin as open-drain */
-    ONEWIRE_ERR_ROMSTR  = -3    /**< invalid ROM string given */
+    ONEWIRE_ERR_ROMSTR  = -3,   /**< invalid ROM string given */
 };
 
 /**
@@ -92,7 +92,7 @@ enum {
     ONEWIRE_ROM_READ    = 0x33, /**< read ROM code in single device config */
     ONEWIRE_ROM_MATCH   = 0x55, /**< address a specific slave */
     ONEWIRE_ROM_SKIP    = 0xcc, /**< broadcast commands to all connected devs */
-    ONEWIRE_ROM_ALARM   = 0xec  /**< search for devices with active alarm */
+    ONEWIRE_ROM_ALARM   = 0xec, /**< search for devices with active alarm */
 };
 
 /**

--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -38,7 +38,12 @@ extern "C" {
 #endif
 
 /**
- * @brief   String length of a hex encoded 1-wire ROM code (including \0)
+ * @brief   Length of 1-Wire ROM code in bytes
+ */
+#define ONEWIRE_ROM_LEN         (8U)
+
+/**
+ * @brief   String length of a hex encoded 1-Wire ROM code (including \0)
  */
 #define ONEWIRE_ROM_STR_LEN     (17U)
 
@@ -48,7 +53,7 @@ extern "C" {
 #define ONEWIRE_SEARCH_FIRST    (0)
 
 /**
- * @brief   Return codes used by the 1-wire driver
+ * @brief   Return codes used by the 1-Wire driver
  */
 enum {
     ONEWIRE_OK          =  0,   /**< everything fine */
@@ -89,12 +94,12 @@ typedef struct {
  * @brief   1-Wire ROM code (device address) representation
  */
 typedef struct {
-    uint8_t u8[8];              /**< byte-wise access to address bytes */
+    uint8_t u8[ONEWIRE_ROM_LEN];    /**< byte-wise access to address bytes */
 } onewire_rom_t;
 
 
 /**
- * @brief   Initialize a 1-wire bus on the given GPIO pin
+ * @brief   Initialize a 1-Wire bus on the given GPIO pin
  *
  * This tries to configure the pin as open-drain output and will fail, if the
  * platform does not support this GPIO mode.
@@ -163,7 +168,14 @@ uint8_t onewire_crc8(const uint8_t *data, size_t len);
 /**
  * @brief   Search for devices on the given 1-Wire bus
  *
- * TODO
+ * @see     https://pdfserv.maximintegrated.com/en/an/AN937.pdf page 51+52
+ *
+ * Use this function to discover devices connected to the given 1-Wire bus. To
+ * carry out a full device discovery, this function has to be called multiple
+ * times. For each iteration, the return value of the previous call as well as
+ * the previous discovered ROM code have to be given as @p rom and @p ld
+ * parameters to the subsequent call. One the function returns 0, the last
+ * device has been found and there are no further devices to be discovered.
  *
  * @param[in] owi       1-Wire bus
  * @param[in,out] rom   next discovery ROM code, needs to hold previous value

--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2016-2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_onewire 1-Wire Bus Driver
+ * @ingroup     drivers_misc
+ * @brief       Generic driver for 1-Wire bus
+ *
+ * # About
+ * This is generic soft driver to interface devices connected via the 1-Wire
+ * bus specified by Dallas Semiconductor Corp, today Maxim Integrated.
+ *
+ * @see         https://www.maximintegrated.com/en/design/technical-documents/app-notes/7/74.html
+ * @see         https://pdfserv.maximintegrated.com/en/an/AN937.pdf
+ * @see         https://www.ti.com/lit/an/spma057c/spma057c.pdf?ts=1598599201996
+ *
+ * @{
+ * @file
+ * @brief       1-Wire driver interface
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef ONEWIRE_H
+#define ONEWIRE_H
+
+#include <stdint.h>
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   String length of a hex encoded 1-wire ROM code (including \0)
+ */
+#define ONEWIRE_ROM_STR_LEN     (17U)
+
+/**
+ * @brief   Custom value used to start a device search
+ */
+#define ONEWIRE_SEARCH_FIRST    (0)
+
+/**
+ * @brief   Return codes used by the 1-wire driver
+ */
+enum {
+    ONEWIRE_OK          =  0,   /**< everything fine */
+    ONEWIRE_NODEV       = -1,   /**< no device connected to the bus */
+    ONEWIRE_ERR_PINCFG  = -2,   /**< unable to initialize pin as open-drain */
+    ONEWIRE_ERR_ROMSTR  = -3    /**< invalid ROM string given */
+};
+
+/**
+ * @brief   1-Wire ROM commands
+ */
+enum {
+    ONEWIRE_ROM_SEARCH  = 0xf0, /**< search for devices */
+    ONEWIRE_ROM_READ    = 0x33, /**< read ROM code in single device config */
+    ONEWIRE_ROM_MATCH   = 0x55, /**< address a specific slave */
+    ONEWIRE_ROM_SKIP    = 0xcc, /**< broadcast commands to all connected devs */
+    ONEWIRE_ROM_ALARM   = 0xec  /**< search for devices with active alarm */
+};
+
+/**
+ * @brief   1-Wire configuration parameters
+ */
+typedef struct {
+    gpio_t pin;                 /**< GPIO pin the bus is connected to */
+    gpio_mode_t pin_mode;       /**< GPIO pin output mode */
+} onewire_params_t;
+
+/**
+ * @brief   1-Wire bus device descriptor
+ */
+typedef struct {
+    gpio_t pin;                 /**< GPIO pin */
+    gpio_mode_t omode;          /**< GPIO pin output mode */
+    gpio_mode_t imode;          /**< GPIO pin input mode, deducted from omode */
+} onewire_t;
+
+/**
+ * @brief   1-Wire ROM code (device address) representation
+ */
+typedef struct {
+    uint8_t u8[8];              /**< byte-wise access to address bytes */
+} onewire_rom_t;
+
+
+/**
+ * @brief   Initialize a 1-wire bus on the given GPIO pin
+ *
+ * This tries to configure the pin as open-drain output and will fail, if the
+ * platform does not support this GPIO mode.
+ *
+ * @param[out] owi      1-Wire bus device descriptor
+ * @param[in] params    configuration parameters
+ *
+ * @return  ONEWIRE_OK on success
+ * @return  ONEWIRE_ERR_PINCFG if open-drain mode unsupported
+ */
+int onewire_init(onewire_t *owi, const onewire_params_t *params);
+
+/**
+ * @brief   Generate a bus reset sequence and look for connected devices
+ *
+ * Every bus transaction must be started with this reset sequence. During this
+ * sequence it is detected, if there are any slaves connected to the bus.
+ *
+ * @param[in] owi       1-Wire bus device descriptor
+ * @param[in] rom       1-Wire ROM code of target device
+ *
+ * @return  ONEWIRE_OK if slave(s) were found
+ * @return  ONEWIRE_NODEV if no slave answered the reset sequence
+ */
+int onewire_reset(const onewire_t *owi, const onewire_rom_t *rom);
+
+/**
+ * @brief   Read data from the bus
+ *
+ * @param[in] owi       1-Wire bus device descriptor
+ * @param[out] data     buffer to write received bytes into
+ * @param[in] len       number of bytes to read from the bus
+ */
+void onewire_read(const onewire_t *owi, void *data, size_t len);
+
+/**
+ * @brief   Write data to the bus
+ *
+ * @param[in] owi       1-Wire bus device descriptor
+ * @param[in] data      buffer holding the data that is written to the bus
+ * @param[in] len       number of bytes to write to the bus
+ */
+void onewire_write(const onewire_t *owi, const void *data, size_t len);
+
+/**
+ * @brief   Convenience function for writing a single byte to the bus
+ *
+ * @param[in] owi       1-Wire bus device descriptor
+ * @param[in] data      data byte to write to the bus
+ */
+static inline void onewire_write_byte(const onewire_t *owi, uint8_t data)
+{
+    onewire_write(owi, &data, 1);
+}
+
+/**
+ * @brief   Calculate a 8-bit CRC using the 1-Wire specific polynomial
+ *
+ * @param[in] data      input data
+ * @param[in] len       len of @p data in bytes
+ *
+ * @return  calculate 8-bit CRC
+ */
+uint8_t onewire_crc8(const uint8_t *data, size_t len);
+
+/**
+ * @brief   Search for devices on the given 1-Wire bus
+ *
+ * TODO
+ *
+ * @param[in] owi       1-Wire bus
+ * @param[in,out] rom   next discovery ROM code, needs to hold previous value
+ *                      when function is called multiple times
+ * @param[in] ld        position of last discrepancy or ONEWIRE_SEARCH_FIRST for
+ *                      initial call
+ *
+ * @return  bit position of last discrepancy
+ * @return  0 if discovered device was the last
+ * @return ONEWIRE_NODEV of no device was found
+ */
+int onewire_search(const onewire_t *owi, onewire_rom_t *rom, int ld);
+
+/**
+ * @brief   Read 1-Wire ROM code from string
+ *
+ * @param[out] rom      ROM code is parsed into this location
+ * @param[in] str       String representation of a ROM code
+ *
+ * @return  ONEWIRE_OK on success
+ * @return  ONEWIRE_ERR_ROMSTR on parsing error
+ */
+int onewire_rom_from_str(onewire_rom_t *rom, const char *str);
+
+/**
+ * @brief   Write a 1-Wire ROM code to a string
+ *
+ * @param[out] str      Output string, must be able to hold ONEWIRE_ROM_STR_LEN
+ *                      characters
+ * @param[in] rom       1-Wire ROM code to read
+ */
+void onewire_rom_to_str(char *str, const onewire_rom_t *rom);
+
+/**
+ * @brief   Print a 1-Wire ROM code to STDIO
+ *
+ * @param[in] rom       1-Wire ROM code
+ */
+void onewire_rom_print(const onewire_rom_t *rom);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ONEWIRE_H */
+/** @} */

--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -53,6 +53,7 @@
 
 #include <stdint.h>
 
+#include "fmt.h"
 #include "periph/gpio.h"
 
 #ifdef __cplusplus
@@ -236,7 +237,12 @@ void onewire_rom_to_str(char *str, const onewire_rom_t *rom);
  *
  * @param[in] rom       1-Wire ROM code
  */
-void onewire_rom_print(const onewire_rom_t *rom);
+static inline void onewire_rom_print(const onewire_rom_t *rom)
+{
+    char str[ONEWIRE_ROM_STR_LEN];
+    onewire_rom_to_str(str, rom);
+    print(str, (ONEWIRE_ROM_STR_LEN - 1));
+}
 
 #ifdef __cplusplus
 }

--- a/drivers/onewire/Makefile
+++ b/drivers/onewire/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/onewire/Makefile.dep
+++ b/drivers/onewire/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += xtimer
+USEMODULE += fmt
+FEATURES_REQUIRED += periph_gpio

--- a/drivers/onewire/onewire.c
+++ b/drivers/onewire/onewire.c
@@ -73,21 +73,21 @@ static int _read_bit(const onewire_t *owi, uint32_t *t_ref)
 {
     int in;
 
-    CRIT_IN;
+    CRIT_IN
     _pull(owi);
     _spin_us(t_ref, T_RW_START_US);
     _release(owi);
     _spin_us(t_ref, T_R_WAIT_US);
     in = (gpio_read(owi->pin)) ? 1 : 0;
     _spin_us(t_ref, T_R_END_US);
-    CRIT_OUT;
+    CRIT_OUT
 
     return in;
 }
 
 static void _write_bit(const onewire_t *owi, uint32_t *t_ref, int out)
 {
-    CRIT_IN;
+    CRIT_IN
     _pull(owi);
     if (out) {
         _spin_us(t_ref, T_RW_START_US);
@@ -123,7 +123,7 @@ int onewire_reset(const onewire_t *owi, const onewire_rom_t *rom)
 {
     int res = ONEWIRE_OK;
 
-    CRIT_IN;
+    CRIT_IN
     uint32_t t_ref = xtimer_now_usec();
     _pull(owi);
     _spin_us(&t_ref, T_RESET_HOLD_US);
@@ -133,7 +133,7 @@ int onewire_reset(const onewire_t *owi, const onewire_rom_t *rom)
         res = ONEWIRE_NODEV;
     }
     _spin_us(&t_ref, (T_RESET_HOLD_US - T_RESET_SAMPLE_US));
-    CRIT_OUT;
+    CRIT_OUT
 
     if ((res == ONEWIRE_OK) && (rom != NULL)) {
         onewire_write_byte(owi, ONEWIRE_ROM_MATCH);
@@ -191,6 +191,7 @@ int onewire_search(const onewire_t *owi, onewire_rom_t *rom, int ld)
     int marker = 0;
     int pos = 1;
     for (unsigned b = 0; b < sizeof(onewire_rom_t); b++) {
+        CRIT_IN
         for (int i = 0; i < 8; i++) {
             int bit1 = _read_bit(owi, &t_ref);
             int bit2 = _read_bit(owi, &t_ref);
@@ -216,6 +217,7 @@ int onewire_search(const onewire_t *owi, onewire_rom_t *rom, int ld)
             _write_bit(owi, &t_ref, bit1);
             pos++;
         }
+        CRIT_OUT
     }
 
     return marker;

--- a/drivers/onewire/onewire.c
+++ b/drivers/onewire/onewire.c
@@ -37,7 +37,7 @@
 #define T_R_SAMPLE_US       (7)
 #define T_R_RECOVER_US      (55)
 
-static inline int _read_bit(const onewire_t *owi)
+static int _read_bit(const onewire_t *owi)
 {
     gpio_clear(owi->pin);
     xtimer_usleep(T_RW_PULSE_US);
@@ -51,7 +51,7 @@ static inline int _read_bit(const onewire_t *owi)
     return in;
 }
 
-static inline void _write_bit(const onewire_t *owi, int out)
+static void _write_bit(const onewire_t *owi, int out)
 {
     gpio_clear(owi->pin);
     if (out) {
@@ -112,7 +112,7 @@ void onewire_read(const onewire_t *owi, void *data, size_t len)
 {
     uint8_t *buf = (uint8_t *)data;
 
-    for (size_t pos = 0; pos < (size_t)len; pos++) {
+    for (size_t pos = 0; pos < len; pos++) {
         /* read the next byte from the bus */
         uint8_t tmp = 0;
         for (int i = 0; i < 8; i++) {
@@ -126,7 +126,7 @@ void onewire_write(const onewire_t *owi, const void *data, size_t len)
 {
     const uint8_t *buf = (uint8_t *)data;
 
-    for (size_t pos = 0; pos < (size_t)len; pos ++) {
+    for (size_t pos = 0; pos < len; pos ++) {
 
         for (int i = 0; i < 8; i++) {
             _write_bit(owi, (buf[pos] & (1 << i)));

--- a/drivers/onewire/onewire.c
+++ b/drivers/onewire/onewire.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2016-2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_onewire
+ * @{
+ *
+ * @file
+ * @brief       1-Wire bus driver implementation
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "assert.h"
+#include "xtimer.h"
+#include "onewire.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+#define T_RESET_HOLD        (480)
+#define T_RESET_SAMPLE      (70)
+
+#define T_RW_PULSE          (3)
+#define T_W_HOLD            (57)
+#define T_W_RECOVER         (10)
+#define T_R_SAMPLE          (7)
+#define T_R_RECOVER         (55)
+
+static inline int _read_bit(const onewire_t *owi)
+{
+    gpio_clear(owi->pin);
+    xtimer_usleep(T_RW_PULSE);
+    gpio_init(owi->pin, owi->imode);
+    xtimer_usleep(T_R_SAMPLE);
+    int in = (gpio_read(owi->pin)) ? 1 : 0;
+    xtimer_usleep(T_R_RECOVER);
+    gpio_init(owi->pin, owi->omode);
+    gpio_set(owi->pin);
+
+    return in;
+}
+
+static inline void _write_bit(const onewire_t *owi, int out)
+{
+    gpio_clear(owi->pin);
+    if (out) {
+        /* shift out a `1` */
+        xtimer_usleep(T_RW_PULSE);
+        gpio_set(owi->pin);
+        xtimer_usleep(T_W_HOLD);
+    }
+    else {
+        /* shift out a `0` */
+        xtimer_usleep(T_RW_PULSE + T_W_HOLD);
+        gpio_set(owi->pin);
+    }
+    xtimer_usleep(T_W_RECOVER);
+}
+
+int onewire_init(onewire_t *owi, const onewire_params_t *params)
+{
+    owi->pin = params->pin;
+
+    owi->omode = params->pin_mode;
+    owi->imode = (owi->omode == GPIO_OD_PU) ? GPIO_IN_PU : GPIO_IN;
+
+    if (gpio_init(owi->pin, owi->omode) != 0) {
+        return ONEWIRE_ERR_PINCFG;
+    }
+    gpio_set(owi->pin);
+    return ONEWIRE_OK;
+}
+
+int onewire_reset(const onewire_t *owi, const onewire_rom_t *rom)
+{
+    int res = ONEWIRE_OK;
+
+    gpio_clear(owi->pin);
+    xtimer_usleep(T_RESET_HOLD);
+    gpio_set(owi->pin);
+
+    xtimer_usleep(T_RESET_SAMPLE);
+    gpio_init(owi->pin, owi->imode);
+    if (gpio_read(owi->pin)) {
+        res = ONEWIRE_NODEV;
+    }
+
+    xtimer_usleep(T_RESET_HOLD - T_RESET_SAMPLE);
+    gpio_init(owi->pin, owi->omode);
+    gpio_set(owi->pin);
+
+    if ((res == ONEWIRE_OK) && (rom != NULL)) {
+        onewire_write_byte(owi, ONEWIRE_ROM_MATCH);
+        onewire_write(owi, rom->u8, sizeof(onewire_rom_t));
+    }
+
+    return res;
+}
+
+void onewire_read(const onewire_t *owi, void *data, size_t len)
+{
+    uint8_t *buf = (uint8_t *)data;
+
+    for (unsigned pos = 0; pos < (unsigned)len; pos++) {
+        /* read the next byte from the bus */
+        uint8_t tmp = 0;
+        for (int i = 0; i < 8; i++) {
+            tmp |= (_read_bit(owi) << i);
+        }
+        buf[pos] = tmp;
+    }
+}
+
+void onewire_write(const onewire_t *owi, const void *data, size_t len)
+{
+    uint8_t *buf = (uint8_t *)data;
+
+    for (unsigned pos = 0; pos < (unsigned)len; pos ++) {
+
+        for (int i = 0; i < 8; i++) {
+            _write_bit(owi, (buf[pos] & (1 << i)));
+        }
+    }
+}
+
+int onewire_search(const onewire_t *owi, onewire_rom_t *rom, int ld)
+{
+    /* initialize the search state */
+    if (ld == ONEWIRE_SEARCH_FIRST) {
+        memset(rom, 0, sizeof(onewire_rom_t));
+    }
+
+    /* send reset condition and issue search ROM command */
+    if (onewire_reset(owi, NULL) != ONEWIRE_OK) {
+        return ONEWIRE_NODEV;
+    }
+    onewire_write_byte(owi, ONEWIRE_ROM_SEARCH);
+
+    /* start search */
+    int marker = 0;
+    int pos = 1;
+    for (unsigned b = 0; b < sizeof(onewire_rom_t); b++) {
+        for (int i = 0; i < 8; i++) {
+            int bit1 = _read_bit(owi);
+            int bit2 = _read_bit(owi);
+
+            if (bit1 == bit2) {
+                if (pos < ld) {
+                    bit1 = (rom->u8[b] & (1 << i)) ? 1 : 0;
+                    if (bit1 == 0) {
+                        marker = pos;
+                    }
+                }
+                else if (pos == ld) {
+                    bit1 = 1;
+                }
+                else {
+                    marker = pos;
+                    bit1 = 0;
+                }
+            }
+
+            rom->u8[b] &= ~(1 << i);
+            rom->u8[b] |= (bit1 << i);
+            _write_bit(owi, bit1);
+            pos++;
+        }
+    }
+
+    return marker;
+}

--- a/drivers/onewire/onewire.c
+++ b/drivers/onewire/onewire.c
@@ -43,8 +43,8 @@
  * https://www.maximintegrated.com/en/design/technical-documents/app-notes/1/126.html
  * all in microseconds
  */
-#define T_RESET_HOLD_US     (480)
-#define T_RESET_SAMPLE_US   (70)
+#define T_RESET_HOLD_US     (480U)
+#define T_RESET_SAMPLE_US   (70U)
 #define T_RW_START_US       (6U)
 #define T_W_0_HOLD_US       (60U)
 #define T_W_0_END_US        (10U)
@@ -147,7 +147,7 @@ int onewire_reset(const onewire_t *owi, const onewire_rom_t *rom)
 
 void onewire_read(const onewire_t *owi, void *data, size_t len)
 {
-    uint8_t *buf = (uint8_t *)data;
+    uint8_t *buf = data;
     uint32_t t_ref = xtimer_now_usec();
 
     for (size_t pos = 0; pos < len; pos++) {
@@ -162,7 +162,7 @@ void onewire_read(const onewire_t *owi, void *data, size_t len)
 
 void onewire_write(const onewire_t *owi, const void *data, size_t len)
 {
-    const uint8_t *buf = (uint8_t *)data;
+    const uint8_t *buf = data;
     uint32_t t_ref = xtimer_now_usec();
 
     for (size_t pos = 0; pos < len; pos ++) {

--- a/drivers/onewire/onewire.c
+++ b/drivers/onewire/onewire.c
@@ -65,8 +65,10 @@ static void _release(const onewire_t *owi)
 
 static void _spin_us(uint32_t *t_ref, uint32_t delay_us)
 {
-    *t_ref = *t_ref + delay_us;
-    while (xtimer_now_usec() < *t_ref) {}
+    /* we know, that t_ref is always less then xtimer_now_usec(). So the
+     * following does also work for t_ref + delay_us overflowing */
+    while ((xtimer_now_usec() - *t_ref) < delay_us) {}
+    *t_ref += delay_us;
 }
 
 static int _read_bit(const onewire_t *owi, uint32_t *t_ref)

--- a/drivers/onewire/onewire_crc.c
+++ b/drivers/onewire/onewire_crc.c
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 1992-2017 Arjen Lentz
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @ingroup     drivers_ds18b20
+ * @{
+ *
+ * @file
+ * @brief       Lookup table based OneWire CRC implementation
+ *
+ * @see         https://lentz.com.au/blog/calculating-crc-with-a-tiny-32-entry-lookup-table
+ *
+ * @author      Arjen Lentz
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @}
+ */
+
+#include <stdint.h>
+
+/**
+ * @brief   Dow-CRC using polynomial X^8 + X^5 + X^4 + X^0
+ */
+static const uint8_t dscrc_table[] = {
+    0x00, 0x5E, 0xBC, 0xE2, 0x61, 0x3F, 0xDD, 0x83,
+    0xC2, 0x9C, 0x7E, 0x20, 0xA3, 0xFD, 0x1F, 0x41,
+    0x00, 0x9D, 0x23, 0xBE, 0x46, 0xDB, 0x65, 0xF8,
+    0x8C, 0x11, 0xAF, 0x32, 0xCA, 0x57, 0xE9, 0x74
+};
+
+/**
+ * @brief   Compute a Dallas Semiconductor 8 bit CRC. These show up in the ROM
+ *          and the registers.
+ */
+uint8_t onewire_crc8(const uint8_t *addr, uint8_t len)
+{
+    uint8_t crc = 0;
+
+    while (len--) {
+        crc = *addr++ ^ crc;    /* just re-using crc as intermediate */
+        crc = dscrc_table[crc & 0x0f] ^
+              dscrc_table[16 + ((crc >> 4) & 0x0f)];
+    }
+
+    return crc;
+}

--- a/drivers/onewire/onewire_crc.c
+++ b/drivers/onewire/onewire_crc.c
@@ -21,7 +21,7 @@
  */
 
 /**
- * @ingroup     drivers_ds18b20
+ * @ingroup     drivers_onewire
  * @{
  *
  * @file

--- a/drivers/onewire/onewire_str.c
+++ b/drivers/onewire/onewire_str.c
@@ -24,21 +24,6 @@
 #include "assert.h"
 #include "onewire.h"
 
-static int _hex2int(char c) {
-    if ('0' <= c && c <= '9') {
-        return c - '0';
-    }
-    else if ('a' <= c && c <= 'f') {
-        return c - 'a' + 10;
-    }
-    else if ('A' <= c && c <= 'F') {
-        return c - 'A' + 10;
-    }
-    else {
-        return -1;
-    }
-}
-
 int onewire_rom_from_str(onewire_rom_t *rom, const char *str)
 {
     assert(rom);
@@ -47,17 +32,7 @@ int onewire_rom_from_str(onewire_rom_t *rom, const char *str)
     if (strlen(str) != (ONEWIRE_ROM_STR_LEN - 1)) {
         return ONEWIRE_ERR_ROMSTR;
     }
-
-    memset(rom->u8, 0, sizeof(onewire_rom_t));
-    for (int i = 0; i < 8; i++) {
-        for (int j = 0; j < 2; j++) {
-            int digit = _hex2int(str[(i * 2) + j]);
-            if (digit < 0) {
-                return ONEWIRE_ERR_ROMSTR;
-            }
-            rom->u8[i] |= (digit << ((1 - j) * 4));
-        }
-    }
+    fmt_hex_bytes(rom->u8, str);
 
     return ONEWIRE_OK;
 }

--- a/drivers/onewire/onewire_str.c
+++ b/drivers/onewire/onewire_str.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2016-2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_onewire
+ * @{
+ *
+ * @file
+ * @brief       1-Wire address (ROM) string helper functions
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "fmt.h"
+#include "assert.h"
+#include "onewire.h"
+
+static int _hex2int(char c) {
+    if ('0' <= c && c <= '9') {
+        return c - '0';
+    }
+    else if ('a' <= c && c <= 'f') {
+        return c - 'a' + 10;
+    }
+    else if ('A' <= c && c <= 'F') {
+        return c - 'A' + 10;
+    }
+    else {
+        return -1;
+    }
+}
+
+int onewire_rom_from_str(onewire_rom_t *rom, const char *str)
+{
+    assert(rom);
+    assert(str);
+
+    if (strlen(str) != (ONEWIRE_ROM_STR_LEN - 1)) {
+        return ONEWIRE_ERR_ROMSTR;
+    }
+
+    memset(rom->u8, 0, sizeof(onewire_rom_t));
+    for (int i = 0; i < 8; i++) {
+        for (int j = 0; j < 2; j++) {
+            int digit = _hex2int(str[(i * 2) + j]);
+            if (digit < 0) {
+                return ONEWIRE_ERR_ROMSTR;
+            }
+            rom->u8[i] |= (digit << ((1 - j) * 4));
+        }
+    }
+
+    return ONEWIRE_OK;
+}
+
+void onewire_rom_to_str(char *str, const onewire_rom_t *rom)
+{
+    assert(rom);
+    assert(str);
+
+    size_t pos = fmt_bytes_hex(str, rom->u8, sizeof(onewire_rom_t));
+    str[pos] = '\0';
+}
+
+void onewire_rom_print(const onewire_rom_t *rom)
+{
+    assert(rom);
+
+    char str[ONEWIRE_ROM_STR_LEN];
+    onewire_rom_to_str(str, rom);
+    print(str, (ONEWIRE_ROM_STR_LEN - 1));
+}

--- a/drivers/onewire/onewire_str.c
+++ b/drivers/onewire/onewire_str.c
@@ -46,10 +46,8 @@ void onewire_rom_to_str(char *str, const onewire_rom_t *rom)
     str[pos] = '\0';
 }
 
-void onewire_rom_print(const onewire_rom_t *rom)
+static inline void onewire_rom_print(const onewire_rom_t *rom)
 {
-    assert(rom);
-
     char str[ONEWIRE_ROM_STR_LEN];
     onewire_rom_to_str(str, rom);
     print(str, (ONEWIRE_ROM_STR_LEN - 1));

--- a/drivers/onewire/onewire_str.c
+++ b/drivers/onewire/onewire_str.c
@@ -45,10 +45,3 @@ void onewire_rom_to_str(char *str, const onewire_rom_t *rom)
     size_t pos = fmt_bytes_hex(str, rom->u8, sizeof(onewire_rom_t));
     str[pos] = '\0';
 }
-
-static inline void onewire_rom_print(const onewire_rom_t *rom)
-{
-    char str[ONEWIRE_ROM_STR_LEN];
-    onewire_rom_to_str(str, rom);
-    print(str, (ONEWIRE_ROM_STR_LEN - 1));
-}

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -84,6 +84,7 @@ PSEUDOMODULES += nimble_autoconn_%
 PSEUDOMODULES += newlib
 PSEUDOMODULES += newlib_gnu_source
 PSEUDOMODULES += newlib_nano
+PSEUDOMODULES += onewire_%
 PSEUDOMODULES += openthread
 PSEUDOMODULES += picolibc
 PSEUDOMODULES += pktqueue

--- a/tests/driver_onewire/Makefile
+++ b/tests/driver_onewire/Makefile
@@ -1,10 +1,6 @@
-APPLICATION = driver_onewire
 include ../Makefile.tests_common
 
 USEMODULE += onewire
 USEMODULE += shell
-
-BUS_PIN ?= GPIO_PIN\(0,0\)
-CFLAGS += -DBUS_PIN=${BUS_PIN}
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_onewire/Makefile
+++ b/tests/driver_onewire/Makefile
@@ -1,0 +1,10 @@
+APPLICATION = driver_onewire
+include ../Makefile.tests_common
+
+USEMODULE += onewire
+USEMODULE += shell
+
+BUS_PIN ?= GPIO_PIN\(0,0\)
+CFLAGS += -DBUS_PIN=${BUS_PIN}
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_onewire/main.c
+++ b/tests/driver_onewire/main.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2016-2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the 1-Wire (onewire) bus driver
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @}
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "fmt.h"
+#include "shell.h"
+#include "xtimer.h"
+
+#include "onewire.h"
+
+#define DEVICE_LIMIT        (10U)
+
+static int _noinit = 1;
+static onewire_t _owi = { GPIO_UNDEF, GPIO_OD_PU, GPIO_IN_PU };
+static onewire_rom_t _devlist[DEVICE_LIMIT];
+
+static int _cmd_init(int argc, char **argv)
+{
+    int portsel;
+    int pinsel;
+    onewire_params_t params;
+
+    if (argc < 3) {
+        printf("usage: %s <port num> <pin num> [mode]\n", argv[0]);
+        puts("\tmode: 0: open drain with pull-up (default)");
+        puts("\t      1: open-drain without pull resistor");
+        puts("\t      2: push pull output (external pull-up needed)");
+        return 1;
+    }
+
+    portsel = atoi(argv[1]);
+    pinsel = atoi(argv[2]);
+    params.pin = GPIO_PIN(portsel, pinsel);
+    params.pin_mode = GPIO_OD_PU;
+    if (argc > 3) {
+        switch (atoi(argv[3])) {
+            case 0:
+                break;
+            case 1:
+                params.pin_mode = GPIO_OD;
+                break;
+            case 2:
+                params.pin_mode = GPIO_OUT;
+                break;
+            default:
+                puts("unable to parse mode");
+                return 1;
+        }
+    }
+
+    printf("Initializing 1-Wire bus at GPIO_PIN(%i, %i)\n", portsel, pinsel);
+
+    /* initialize the one wire bus */
+    if (onewire_init(&_owi, &params) == ONEWIRE_OK) {
+        _noinit = 0;
+        puts("1-Wire bus successfully initialized");
+    }
+    else {
+        puts("Error: pin initialization failed: pin mode not supported\n");
+        _noinit = 1;
+    }
+
+    return _noinit;
+}
+
+static int _cmd_discover(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    if (_noinit) {
+        puts("Error: 1-Wire bus is not initialized");
+        return 1;
+    }
+
+    /* reset device list and detect all connected devices */
+    int ld = ONEWIRE_SEARCH_FIRST;
+    unsigned cnt = 0;
+    onewire_rom_t tmp;
+
+    memset(_devlist, 0, ARRAY_SIZE(_devlist));
+    do {
+        ld = onewire_search(&_owi, &tmp, ld);
+        if (ld >= 0) {
+            memcpy(&_devlist[cnt++], &tmp, sizeof(onewire_rom_t));
+        }
+    } while ((ld > 0) && (cnt < DEVICE_LIMIT));
+
+    printf("Discovery finished, found %u devices:\n", cnt);
+    puts("Dev # - ROM code");
+    for (unsigned i = 0; i < cnt; i++) {
+        char rom_str[ONEWIRE_ROM_STR_LEN];
+        onewire_rom_to_str(rom_str, &_devlist[i]);
+        printf("[%2i]    %s\n", i, rom_str);
+    }
+
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "init", "initialize OneWire interface on given pin", _cmd_init },
+    { "discover", "list all connected devices", _cmd_discover },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("1-Wire bus driver test application\n");
+
+    /* run the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/driver_onewire/main.c
+++ b/tests/driver_onewire/main.c
@@ -110,7 +110,7 @@ static int _cmd_discover(int argc, char **argv)
     for (unsigned i = 0; i < cnt; i++) {
         char rom_str[ONEWIRE_ROM_STR_LEN];
         onewire_rom_to_str(rom_str, &_devlist[i]);
-        printf("[%2i]    %s\n", i, rom_str);
+        printf("[%2u]    %s\n", i, rom_str);
     }
 
     return 0;


### PR DESCRIPTION
### Contribution description
This PR adds a generic driver for interfacing with devices that use the Dallas Integrated 1-Wire bus (e.g. the `ds18b20` temperature sensors). It allows to read/write specific devices, as well as scanning the bus for connected devices and to discover their ROM codes (addresses).

I had this code laying around for some years now and finally found some time to clean it up...

A PR for a `ds18b20` device driver based on this PR will be opened separately.


### Testing procedure
Connect one or more 1-Wire devices (e.g. `ds18b20` sensors) to a board of your choice, flash the included test application (`tests/driver_onewire`), and run the `init` and `discover` shell commands.


### Issues/PRs references
none