### PR TITLE
cpu/stm32gx: cleanup clock initialization

### DIFF
--- a/boards/common/stm32/Kconfig.g0
+++ b/boards/common/stm32/Kconfig.g0
@@ -24,28 +24,25 @@ config USE_CLOCK_HSI
 
 endchoice
 
-if USE_CLOCK_PLL
 config CLOCK_PLL_M
-    int "M: PLLIN division factor"
+    int "M: PLLIN division factor" if USE_CLOCK_PLL
     default 1
     range 1 8
 
 config CLOCK_PLL_N
-    int "N: PLLIN multiply factor"
+    int "N: PLLIN multiply factor" if USE_CLOCK_PLL
     default 20
     range 8 86
 
 config CLOCK_PLL_R
-    int "Q: VCO division factor"
+    int "Q: VCO division factor" if USE_CLOCK_PLL
     default 6 if BOARD_HAS_HSE
-    default 5 if !BOARD_HAS_HSE
+    default 5
     range 2 8
-endif
 
 choice
-bool "HSISYS division factor"
+bool "HSISYS division factor" if USE_CLOCK_HSI
 default CLOCK_HSISYS_DIV_1
-depends on USE_CLOCK_HSI
 
 config CLOCK_HSISYS_DIV_1
     bool "Divide HSISYS by 1"
@@ -75,7 +72,7 @@ endchoice
 
 config CLOCK_HSISYS_DIV
     int
-    default 1 if CLOCK_HSISYS_DIV_1
+    default 1
     default 2 if CLOCK_HSISYS_DIV_2
     default 4 if CLOCK_HSISYS_DIV_4
     default 8 if CLOCK_HSISYS_DIV_8

--- a/boards/common/stm32/Kconfig.g4
+++ b/boards/common/stm32/Kconfig.g4
@@ -24,20 +24,19 @@ config USE_CLOCK_HSI
 
 endchoice
 
-if USE_CLOCK_PLL
 config CLOCK_PLL_M
-    int "M: Division factor for the main PLL input clock"
+    int "M: Division factor for the main PLL input clock" if USE_CLOCK_PLL
     default 6 if BOARD_HAS_HSE
-    default 4 if !BOARD_HAS_HSE
+    default 4
     range 1 16
 
 config CLOCK_PLL_N
-    int "N: Multiply factor for the VCO"
+    int "N: Multiply factor for the VCO" if USE_CLOCK_PLL
     default 40
     range 8 127
 
 choice
-bool "R: Main PLL division factor for PLL 'R' clock (system clock)"
+bool "R: Main PLL division factor for PLL 'R' clock (system clock)" if USE_CLOCK_PLL
 default PLL_R_DIV_2
 
 config PLL_R_DIV_2
@@ -60,7 +59,6 @@ config CLOCK_PLL_R
     default 4 if PLL_R_DIV_4
     default 6 if PLL_R_DIV_6
     default 8 if PLL_R_DIV_8
-endif
 
 choice
 bool "APB1 prescaler (division factor of HCLK to produce PCLK1)"

--- a/boards/common/stm32/include/g0/cfg_clock_default.h
+++ b/boards/common/stm32/include/g0/cfg_clock_default.h
@@ -88,10 +88,11 @@ extern "C" {
 
 #define CLOCK_HSI                       MHZ(16)
 
-#if CONFIG_USE_CLOCK_HSI
 #ifndef CONFIG_CLOCK_HSISYS_DIV
 #define CONFIG_CLOCK_HSISYS_DIV         (1)
 #endif
+
+#if CONFIG_USE_CLOCK_HSI
 #define CLOCK_CORECLOCK                 (CLOCK_HSI / CONFIG_CLOCK_HSISYS_DIV)
 
 #elif CONFIG_USE_CLOCK_HSE

--- a/boards/common/stm32/include/g0/cfg_clock_default.h
+++ b/boards/common/stm32/include/g0/cfg_clock_default.h
@@ -37,50 +37,50 @@ extern "C" {
 /* Select the desired system clock source between PLL, HSE or HSI */
 #ifndef CONFIG_USE_CLOCK_PLL
 #if IS_ACTIVE(CONFIG_USE_CLOCK_HSE) || IS_ACTIVE(CONFIG_USE_CLOCK_HSI)
-#define CONFIG_USE_CLOCK_PLL            (0)
+#define CONFIG_USE_CLOCK_PLL            0
 #else
-#define CONFIG_USE_CLOCK_PLL            (1)     /* Use PLL by default */
+#define CONFIG_USE_CLOCK_PLL            1       /* Use PLL by default */
 #endif
 #endif /* CONFIG_USE_CLOCK_PLL */
 
 #ifndef CONFIG_USE_CLOCK_HSE
-#define CONFIG_USE_CLOCK_HSE            (0)
+#define CONFIG_USE_CLOCK_HSE            0
 #endif /* CONFIG_USE_CLOCK_HSE */
 
 #ifndef CONFIG_USE_CLOCK_HSI
-#define CONFIG_USE_CLOCK_HSI            (0)
+#define CONFIG_USE_CLOCK_HSI            0
 #endif /* CONFIG_USE_CLOCK_HSI */
 
-#if CONFIG_USE_CLOCK_PLL && \
-    (CONFIG_USE_CLOCK_HSE || CONFIG_USE_CLOCK_HSI)
+#if IS_ACTIVE(CONFIG_USE_CLOCK_PLL) && \
+    (IS_ACTIVE(CONFIG_USE_CLOCK_HSE) || IS_ACTIVE(CONFIG_USE_CLOCK_HSI))
 #error "Cannot use PLL as clock source with other clock configurations"
 #endif
 
-#if CONFIG_USE_CLOCK_HSE && \
-    (CONFIG_USE_CLOCK_PLL || CONFIG_USE_CLOCK_HSI)
+#if IS_ACTIVE(CONFIG_USE_CLOCK_HSE) && \
+    (IS_ACTIVE(CONFIG_USE_CLOCK_PLL) || IS_ACTIVE(CONFIG_USE_CLOCK_HSI))
 #error "Cannot use HSE as clock source with other clock configurations"
 #endif
 
-#if CONFIG_USE_CLOCK_HSI && \
-    (CONFIG_USE_CLOCK_PLL || CONFIG_USE_CLOCK_HSE)
+#if IS_ACTIVE(CONFIG_USE_CLOCK_HSI) && \
+    (IS_ACTIVE(CONFIG_USE_CLOCK_PLL) || IS_ACTIVE(CONFIG_USE_CLOCK_HSE))
 #error "Cannot use HSI as clock source with other clock configurations"
 #endif
 
 #ifndef CONFIG_BOARD_HAS_HSE
-#define CONFIG_BOARD_HAS_HSE            (0)
+#define CONFIG_BOARD_HAS_HSE            0
 #endif
 
 #ifndef CLOCK_HSE
 #define CLOCK_HSE                       MHZ(24)
 #endif
-#if CONFIG_BOARD_HAS_HSE && (CLOCK_HSE < MHZ(4) || CLOCK_HSE > MHZ(48))
+#if IS_ACTIVE(CONFIG_BOARD_HAS_HSE) && (CLOCK_HSE < MHZ(4) || CLOCK_HSE > MHZ(48))
 #error "HSE clock frequency must be between 4MHz and 48MHz"
 #endif
 
 #ifndef CONFIG_BOARD_HAS_LSE
-#define CONFIG_BOARD_HAS_LSE            (0)
+#define CONFIG_BOARD_HAS_LSE            0
 #endif
-#if CONFIG_BOARD_HAS_LSE
+#if IS_ACTIVE(CONFIG_BOARD_HAS_LSE)
 #define CLOCK_LSE                       (1)
 #else
 #define CLOCK_LSE                       (0)
@@ -92,16 +92,12 @@ extern "C" {
 #define CONFIG_CLOCK_HSISYS_DIV         (1)
 #endif
 
-#if CONFIG_USE_CLOCK_HSI
-#define CLOCK_CORECLOCK                 (CLOCK_HSI / CONFIG_CLOCK_HSISYS_DIV)
-
-#elif CONFIG_USE_CLOCK_HSE
-#if CONFIG_BOARD_HAS_HSE == 0
-#error "The board doesn't provide an HSE oscillator"
+#if IS_ACTIVE(CONFIG_BOARD_HAS_HSE)
+#define CLOCK_PLL_SRC                   (CLOCK_HSE)
+#else /* CLOCK_HSI */
+#define CLOCK_PLL_SRC                   (CLOCK_HSI)
 #endif
-#define CLOCK_CORECLOCK                 (CLOCK_HSE)
 
-#elif CONFIG_USE_CLOCK_PLL
 /* The following parameters configure a 64MHz system clock with HSI as input clock */
 #ifndef CONFIG_CLOCK_PLL_M
 #define CONFIG_CLOCK_PLL_M              (1)
@@ -112,11 +108,17 @@ extern "C" {
 #ifndef CONFIG_CLOCK_PLL_R
 #define CONFIG_CLOCK_PLL_R              (5)
 #endif
-#if CONFIG_BOARD_HAS_HSE
-#define CLOCK_PLL_SRC                   (CLOCK_HSE)
-#else /* CLOCK_HSI */
-#define CLOCK_PLL_SRC                   (CLOCK_HSI)
+
+#if IS_ACTIVE(CONFIG_USE_CLOCK_HSI)
+#define CLOCK_CORECLOCK                 (CLOCK_HSI / CONFIG_CLOCK_HSISYS_DIV)
+
+#elif IS_ACTIVE(CONFIG_USE_CLOCK_HSE)
+#if !IS_ACTIVE(CONFIG_BOARD_HAS_HSE)
+#error "The board doesn't provide an HSE oscillator"
 #endif
+#define CLOCK_CORECLOCK                 (CLOCK_HSE)
+
+#elif IS_ACTIVE(CONFIG_USE_CLOCK_PLL)
 #define CLOCK_CORECLOCK                 \
         ((CLOCK_PLL_SRC / CONFIG_CLOCK_PLL_M) * CONFIG_CLOCK_PLL_N) / CONFIG_CLOCK_PLL_R
 #if CLOCK_CORECLOCK > MHZ(64)

--- a/boards/common/stm32/include/g4/cfg_clock_default.h
+++ b/boards/common/stm32/include/g4/cfg_clock_default.h
@@ -31,49 +31,49 @@ extern "C" {
  */
 #ifndef CONFIG_USE_CLOCK_PLL
 #if IS_ACTIVE(CONFIG_USE_CLOCK_HSE) || IS_ACTIVE(CONFIG_USE_CLOCK_HSI)
-#define CONFIG_USE_CLOCK_PLL            (0)
+#define CONFIG_USE_CLOCK_PLL            0
 #else
-#define CONFIG_USE_CLOCK_PLL            (1)     /* Use PLL by default */
+#define CONFIG_USE_CLOCK_PLL            1       /* Use PLL by default */
 #endif
 #endif /* CONFIG_USE_CLOCK_PLL */
 
 #ifndef CONFIG_USE_CLOCK_HSE
-#define CONFIG_USE_CLOCK_HSE            (0)
+#define CONFIG_USE_CLOCK_HSE            0
 #endif /* CONFIG_USE_CLOCK_HSE */
 
 #ifndef CONFIG_USE_CLOCK_HSI
-#define CONFIG_USE_CLOCK_HSI            (0)
+#define CONFIG_USE_CLOCK_HSI            0
 #endif /* CONFIG_USE_CLOCK_HSI */
 
-#if CONFIG_USE_CLOCK_PLL && \
-    (CONFIG_USE_CLOCK_HSE || CONFIG_USE_CLOCK_HSI)
+#if IS_ACTIVE(CONFIG_USE_CLOCK_PLL) && \
+    (IS_ACTIVE(CONFIG_USE_CLOCK_HSE) || IS_ACTIVE(CONFIG_USE_CLOCK_HSI))
 #error "Cannot use PLL as clock source with other clock configurations"
 #endif
 
-#if CONFIG_USE_CLOCK_HSE && \
-    (CONFIG_USE_CLOCK_PLL || CONFIG_USE_CLOCK_HSI)
+#if IS_ACTIVE(CONFIG_USE_CLOCK_HSE) && \
+    (IS_ACTIVE(CONFIG_USE_CLOCK_PLL) || IS_ACTIVE(CONFIG_USE_CLOCK_HSI))
 #error "Cannot use HSE as clock source with other clock configurations"
 #endif
 
-#if CONFIG_USE_CLOCK_HSI && \
-    (CONFIG_USE_CLOCK_PLL || CONFIG_USE_CLOCK_HSE)
+#if IS_ACTIVE(CONFIG_USE_CLOCK_HSI) && \
+    (IS_ACTIVE(CONFIG_USE_CLOCK_PLL) || IS_ACTIVE(CONFIG_USE_CLOCK_HSE))
 #error "Cannot use HSI as clock source with other clock configurations"
 #endif
 
 #ifndef CONFIG_BOARD_HAS_HSE
-#define CONFIG_BOARD_HAS_HSE            (0)
+#define CONFIG_BOARD_HAS_HSE            0
 #endif
 #ifndef CLOCK_HSE
 #define CLOCK_HSE                       MHZ(24)
 #endif
-#if CONFIG_BOARD_HAS_HSE && (CLOCK_HSE < MHZ(4) || CLOCK_HSE > MHZ(48))
+#if IS_ACTIVE(CONFIG_BOARD_HAS_HSE) && (CLOCK_HSE < MHZ(4) || CLOCK_HSE > MHZ(48))
 #error "HSE clock frequency must be between 4MHz and 48MHz"
 #endif
 
 #ifndef CONFIG_BOARD_HAS_LSE
-#define CONFIG_BOARD_HAS_LSE            (0)
+#define CONFIG_BOARD_HAS_LSE            0
 #endif
-#if CONFIG_BOARD_HAS_LSE
+#if IS_ACTIVE(CONFIG_BOARD_HAS_LSE)
 #define CLOCK_LSE                       (1)
 #else
 #define CLOCK_LSE                       (0)
@@ -81,16 +81,12 @@ extern "C" {
 
 #define CLOCK_HSI                       MHZ(16)
 
-#if CONFIG_USE_CLOCK_HSI
-#define CLOCK_CORECLOCK                 (CLOCK_HSI)
-
-#elif CONFIG_USE_CLOCK_HSE
-#if CONFIG_BOARD_HAS_HSE == 0
-#error "The board doesn't provide an HSE oscillator"
+#if IS_ACTIVE(CONFIG_BOARD_HAS_HSE)
+#define CLOCK_PLL_SRC                   (CLOCK_HSE)
+#else /* CLOCK_HSI */
+#define CLOCK_PLL_SRC                   (CLOCK_HSI)
 #endif
-#define CLOCK_CORECLOCK                 (CLOCK_HSE)
 
-#elif CONFIG_USE_CLOCK_PLL
 /* The following parameters configure a 170MHz system clock with HSI16 as input clock */
 #ifndef CONFIG_CLOCK_PLL_M
 #define CONFIG_CLOCK_PLL_M              (4)
@@ -101,11 +97,17 @@ extern "C" {
 #ifndef CONFIG_CLOCK_PLL_R
 #define CONFIG_CLOCK_PLL_R              (2)
 #endif
-#if CONFIG_BOARD_HAS_HSE
-#define CLOCK_PLL_SRC                   (CLOCK_HSE)
-#else /* CLOCK_HSI */
-#define CLOCK_PLL_SRC                   (CLOCK_HSI)
+
+#if IS_ACTIVE(CONFIG_USE_CLOCK_HSI)
+#define CLOCK_CORECLOCK                 (CLOCK_HSI)
+
+#elif IS_ACTIVE(CONFIG_USE_CLOCK_HSE)
+#if !IS_ACTIVE(CONFIG_BOARD_HAS_HSE)
+#error "The board doesn't provide an HSE oscillator"
 #endif
+#define CLOCK_CORECLOCK                 (CLOCK_HSE)
+
+#elif IS_ACTIVE(CONFIG_USE_CLOCK_PLL)
 #define CLOCK_CORECLOCK                 \
         ((CLOCK_PLL_SRC / CONFIG_CLOCK_PLL_M) * CONFIG_CLOCK_PLL_N) / CONFIG_CLOCK_PLL_R
 #if CLOCK_CORECLOCK > MHZ(170)

--- a/boards/common/stm32/include/g4/cfg_clock_default.h
+++ b/boards/common/stm32/include/g4/cfg_clock_default.h
@@ -120,11 +120,11 @@ extern "C" {
 #ifndef CONFIG_CLOCK_APB1_DIV
 #define CONFIG_CLOCK_APB1_DIV           (1)
 #endif
-#define CLOCK_APB1                      (CLOCK_CORECLOCK / CONFIG_CLOCK_APB1_DIV)   /* max: 170MHz */
+#define CLOCK_APB1                      (CLOCK_AHB / CONFIG_CLOCK_APB1_DIV)     /* max: 170MHz */
 #ifndef CONFIG_CLOCK_APB2_DIV
 #define CONFIG_CLOCK_APB2_DIV           (1)
 #endif
-#define CLOCK_APB2                      (CLOCK_CORECLOCK / CONFIG_CLOCK_APB2_DIV)   /* max: 170MHz */
+#define CLOCK_APB2                      (CLOCK_AHB / CONFIG_CLOCK_APB2_DIV)     /* max: 170MHz */
 
 #ifdef __cplusplus
 }

--- a/boards/nucleo-g070rb/include/periph_conf.h
+++ b/boards/nucleo-g070rb/include/periph_conf.h
@@ -23,7 +23,7 @@
 
 /* Add specific clock configuration (HSE, LSE) for this board here */
 #ifndef CONFIG_BOARD_HAS_LSE
-#define CONFIG_BOARD_HAS_LSE            (1)
+#define CONFIG_BOARD_HAS_LSE            1
 #endif
 
 #include "g0/cfg_clock_default.h"

--- a/boards/nucleo-g071rb/include/periph_conf.h
+++ b/boards/nucleo-g071rb/include/periph_conf.h
@@ -21,7 +21,7 @@
 
 /* Add specific clock configuration (HSE, LSE) for this board here */
 #ifndef CONFIG_BOARD_HAS_LSE
-#define CONFIG_BOARD_HAS_LSE            (1)
+#define CONFIG_BOARD_HAS_LSE            1
 #endif
 
 #include "g0/cfg_clock_default.h"

--- a/boards/nucleo-g431rb/include/periph_conf.h
+++ b/boards/nucleo-g431rb/include/periph_conf.h
@@ -21,11 +21,11 @@
 
 /* Add specific clock configuration (HSE, LSE) for this board here */
 #ifndef CONFIG_BOARD_HAS_LSE
-#define CONFIG_BOARD_HAS_LSE            (1)
+#define CONFIG_BOARD_HAS_LSE            1
 #endif
 /* This board provides a 24MHz HSE oscillator */
 #ifndef CONFIG_BOARD_HAS_HSE
-#define CONFIG_BOARD_HAS_HSE            (1)
+#define CONFIG_BOARD_HAS_HSE            1
 #endif
 /* By default, configure a 170MHz SYSCLK with PLL using HSE as input clock */
 #ifndef CONFIG_CLOCK_PLL_M

--- a/boards/nucleo-g474re/include/periph_conf.h
+++ b/boards/nucleo-g474re/include/periph_conf.h
@@ -21,11 +21,11 @@
 
 /* Add specific clock configuration (HSE, LSE) for this board here */
 #ifndef CONFIG_BOARD_HAS_LSE
-#define CONFIG_BOARD_HAS_LSE            (1)
+#define CONFIG_BOARD_HAS_LSE            1
 #endif
 /* This board provides a 24MHz HSE oscillator */
 #ifndef CONFIG_BOARD_HAS_HSE
-#define CONFIG_BOARD_HAS_HSE            (1)
+#define CONFIG_BOARD_HAS_HSE            1
 #endif
 /* By default, configure a 80MHz SYSCLK with PLL using HSE as input clock */
 #ifndef CONFIG_CLOCK_PLL_M

--- a/cpu/stm32/stmclk/stmclk_gx.c
+++ b/cpu/stm32/stmclk/stmclk_gx.c
@@ -186,10 +186,6 @@ void stmclk_init_sysclk(void)
     /* disable all active clocks except HSI -> resets the clk configuration */
     RCC->CR = RCC_CR_HSION;
 
-#if CLOCK_LSE
-    stmclk_enable_lfclk();
-#endif
-
 #if defined(CPU_FAM_STM32G0)
     if (CONFIG_USE_CLOCK_HSI && CONFIG_CLOCK_HSISYS_DIV != 1) {
         /* configure HSISYS divider, only available on G0 */

--- a/cpu/stm32/stmclk/stmclk_gx.c
+++ b/cpu/stm32/stmclk/stmclk_gx.c
@@ -239,8 +239,11 @@ void stmclk_init_sysclk(void)
 #endif
     }
 
-    stmclk_disable_hsi();
-    irq_restore(is);
+    if (!IS_ACTIVE(CONFIG_USE_CLOCK_HSI) ||
+        (IS_ACTIVE(CONFIG_USE_CLOCK_PLL) && IS_ACTIVE(CONFIG_BOARD_HAS_HSE))) {
+        /* Disable HSI only if not used */
+        stmclk_disable_hsi();
+    }
 
 #if defined(CPU_FAM_STM32G4)
     if (IS_USED(MODULE_PERIPH_HWRNG)) {
@@ -260,4 +263,6 @@ void stmclk_init_sysclk(void)
         }
     }
 #endif
+
+    irq_restore(is);
 }

--- a/cpu/stm32/stmclk/stmclk_gx.c
+++ b/cpu/stm32/stmclk/stmclk_gx.c
@@ -57,7 +57,7 @@
 #define PLL_R                       (((CONFIG_CLOCK_PLL_R >> 1) - 1) << RCC_PLLCFGR_PLLR_Pos)
 #endif
 
-#if CONFIG_BOARD_HAS_HSE
+#if IS_ACTIVE(CONFIG_BOARD_HAS_HSE)
 #define PLL_IN                      CLOCK_HSE
 #define PLL_SRC                     RCC_PLLCFGR_PLLSRC_HSE
 #else
@@ -187,14 +187,14 @@ void stmclk_init_sysclk(void)
     RCC->CR = RCC_CR_HSION;
 
 #if defined(CPU_FAM_STM32G0)
-    if (CONFIG_USE_CLOCK_HSI && CONFIG_CLOCK_HSISYS_DIV != 1) {
+    if (IS_ACTIVE(CONFIG_USE_CLOCK_HSI) && CONFIG_CLOCK_HSISYS_DIV != 1) {
         /* configure HSISYS divider, only available on G0 */
         RCC->CR |= CLOCK_HSI_DIV;
         while (!(RCC->CR & RCC_CR_HSIRDY)) {}
     }
 #endif
 
-    if (CONFIG_USE_CLOCK_HSE) {
+    if (IS_ACTIVE(CONFIG_USE_CLOCK_HSE)) {
         /* if configured, we need to enable the HSE clock now */
         RCC->CR |= RCC_CR_HSEON;
         while (!(RCC->CR & RCC_CR_HSERDY)) {}
@@ -206,8 +206,8 @@ void stmclk_init_sysclk(void)
 #endif
         while ((RCC->CFGR & RCC_CFGR_SWS) != RCC_CFGR_SWS_HSE) {}
     }
-    else if (CONFIG_USE_CLOCK_PLL) {
-        if (CONFIG_BOARD_HAS_HSE) {
+    else if (IS_ACTIVE(CONFIG_USE_CLOCK_PLL)) {
+        if (IS_ACTIVE(CONFIG_BOARD_HAS_HSE)) {
             /* if configured, we need to enable the HSE clock now */
             RCC->CR |= RCC_CR_HSEON;
             while (!(RCC->CR & RCC_CR_HSERDY)) {}
@@ -252,7 +252,7 @@ void stmclk_init_sysclk(void)
     if (IS_USED(MODULE_PERIPH_RTT)) {
         /* Ensure LPTIM1 clock source (LSI or LSE) is correctly reset when initializing
            the clock, this is particularly useful after waking up from deep sleep */
-        if (CONFIG_BOARD_HAS_LSE) {
+        if (IS_ACTIVE(CONFIG_BOARD_HAS_LSE)) {
             RCC->CCIPR |= RCC_CCIPR_LPTIM1SEL_0 | RCC_CCIPR_LPTIM1SEL_1;
         }
         else {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a cleanup of the clock initialization of stm32g0/g4 families:
- to select the clock modes, preprocessor conditionals are replaced by regular C `if`. This way all modes are built even if they are unused and the compiler optimizes the unused parts anyway. So code size is unchanged.
- the initialization of the LSE is not needed during initialization so it's removed

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Test the different clock modes on nucleo-g070rb and nucleo-g474re, they should still work as in master

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up cleanup PR of #14837 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
