### PR TITLE
drivers: add driver for DS18B20 temperature sensors

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -97,6 +97,10 @@ ifneq (,$(filter nrfmin,$(USEMODULE)))
   USEMODULE += netif
 endif
 
+ifneq (,$(fitler onewire_%,$(USEMODULE)))
+  USEMODULE += onewire
+endif
+
 ifneq (,$(filter qmc5883l_%,$(USEMODULE)))
   USEMODULE += qmc5883l
 endif

--- a/drivers/ds18b20/Makefile
+++ b/drivers/ds18b20/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/ds18b20/Makefile.dep
+++ b/drivers/ds18b20/Makefile.dep
@@ -1,0 +1,2 @@
+USEMODULE += onewire
+USEMODULE += xtimer

--- a/drivers/ds18b20/ds18b20.c
+++ b/drivers/ds18b20/ds18b20.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2016-2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_ds18b20
+ * @{
+ *
+ * @file
+ * @brief       DS18B20 driver implementation
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "log.h"
+#include "xtimer.h"
+#include "onewire.h"
+
+#include "ds18b20.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+#define CMD_CONVERT         (0x44)
+#define CMD_READ            (0xbe)
+#define CMD_WRITE           (0x4e)
+#define CMD_COPY            (0x48)
+#define CMD_RECALL          (0xB8)
+#define CMD_READ_PWR        (0xb4)
+
+#define RSIZE               (9U)
+#define WSIZE               (3U)
+
+#define SP_RESERVED5        (0xff)
+#define SP_RESERVED7        (0x10)
+#define CFGBASE             (0x1f)
+#define RES_SHIFT           (5U)
+#define RES_NUM             (4U)
+#define TEMP_SCALE          (625)
+
+/* scratch pad memory layout */
+enum {
+    R_TEMP_L = 0,
+    R_TEMP_H,
+    R_USER_H,
+    R_USER_L,
+    R_CONF,
+    R_RESERVED5,
+    R_RESERVED6,
+    R_RESERVED7,
+    R_CRC,
+};
+
+/* conversion times */
+static const uint32_t _conv_time_us[RES_NUM] = {
+    [DS18B20_RES_9BIT] = 93750U,    /**< conversion for 9 bit resolution */
+    [DS18B20_RES_10BIT] = 187500U,  /**< conversion for 10 bit resolution */
+    [DS18B20_RES_11BIT] = 375000U,  /**< conversion for 11 bit resolution */
+    [DS18B20_RES_12BIT] = 750000U,  /**< conversion for 12 bit resolution */
+};
+
+static int _read_scratchpad(const ds18b20_t *dev, uint8_t *buf)
+{
+    if (onewire_reset(dev->bus, &dev->rom) != ONEWIRE_OK) {
+        return DS18B20_NODEV;
+    }
+    onewire_write_byte(dev->bus, CMD_READ);
+    onewire_read(dev->bus, buf, RSIZE);
+
+    if (buf[R_CRC] != onewire_crc8(buf, (RSIZE - 1))) {
+        return DS18B20_ERR_CRC;
+    }
+
+    return DS18B20_OK;
+}
+
+int ds18b20_init(ds18b20_t *dev, onewire_t *owi, const ds18b20_params_t *params)
+{
+    assert(dev);
+    assert(owi);
+    assert(params);
+    assert(params->res < RES_NUM);
+
+    dev->bus = owi;
+    memcpy(&dev->rom, &params->rom, sizeof(onewire_rom_t));
+    dev->res = params->res;
+
+    /* do a dry read of the scratchpad memory and compare constant bytes */
+    uint8_t mem[RSIZE];
+    int res = _read_scratchpad(dev, mem);
+    if (res != DS18B20_OK) {
+        DEBUG("[ds18b20] init: error reading scratchpad from device\n");
+        return res;
+    }
+
+    if ((mem[R_RESERVED5] != SP_RESERVED5) ||
+        (mem[R_RESERVED7] != SP_RESERVED7)) {
+        DEBUG("[ds18b20] _init: invalid data in scratchpad memory\n");
+        return DS18B20_NODEV;
+    }
+
+    /* configure resolution (write high+low user + config registers) */
+    memset(mem, 0, 2);
+    mem[2] = (CFGBASE | (params->res << RES_SHIFT));
+
+    if (onewire_reset(dev->bus, &dev->rom) != ONEWIRE_OK) {
+        return DS18B20_NODEV;
+    }
+    onewire_write_byte(dev->bus, CMD_WRITE);
+    onewire_write(dev->bus, mem, WSIZE);
+    return DS18B20_OK;
+}
+
+uint32_t ds18b20_get_conv_time_us(const ds18b20_t *dev)
+{
+    assert(dev);
+
+    return _conv_time_us[(int)dev->res];
+}
+
+int ds18b20_trigger(const ds18b20_t *dev)
+{
+    assert(dev);
+
+    /* start conversion */
+    if (onewire_reset(dev->bus, &dev->rom) != ONEWIRE_OK) {
+        return DS18B20_NODEV;
+    }
+    onewire_write_byte(dev->bus, CMD_CONVERT);
+    return ONEWIRE_OK;
+}
+
+int ds18b20_trigger_all(const ds18b20_t *dev)
+{
+    assert(dev);
+
+    if (onewire_reset(dev->bus, NULL) != ONEWIRE_OK) {
+        return DS18B20_NODEV;
+    }
+    onewire_write_byte(dev->bus, ONEWIRE_ROM_SKIP);
+    onewire_write_byte(dev->bus, CMD_CONVERT);
+    return DS18B20_OK;
+}
+
+int ds18b20_read(const ds18b20_t *dev, int16_t *temp)
+{
+    assert(dev);
+    assert(temp);
+    uint8_t mem[RSIZE];
+
+    /* read scratchpad memory */
+    int res = _read_scratchpad(dev, mem);
+    if (res != DS18B20_OK) {
+        return res;
+    }
+
+    int32_t tmp = ((int32_t)(mem[R_TEMP_H] << 8 | mem[R_TEMP_L]) * TEMP_SCALE);
+    *temp = (int16_t)(tmp / 100);
+    return DS18B20_OK;
+}
+
+int ds18b20_get_temp(const ds18b20_t *dev, int16_t *temp)
+{
+    int res = ds18b20_trigger(dev);
+    if (res != DS18B20_OK) {
+        return res;
+    }
+    xtimer_usleep(_conv_time_us[(int)dev->res]);
+    return ds18b20_read(dev, temp);
+}

--- a/drivers/include/ds18b20.h
+++ b/drivers/include/ds18b20.h
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2016-2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_ds18b20 DS18B20 temperature sensor driver
+ * @ingroup     drivers_sensors
+ * @brief       Driver for DS18B20 temperature sensors
+ *
+ * @{
+ * @file
+ * @brief       DS18B20 driver interface
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef DS18B20_H
+#define DS18B20_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "onewire.h"
+
+/**
+ * @brief   1-Wire family code identifying DS18B20 sensors (LSB in ROM)
+ */
+#define DS18B20_FAMILY_CODE         0x28
+
+/**
+ * @brief   Return codes used by this driver
+ */
+enum {
+    DS18B20_OK          =  0,       /**< all good */
+    DS18B20_NODEV       = -1,       /**< no device detected */
+    DS18B20_ERR_CRC     = -2,       /**< checksum error */
+};
+
+/**
+ * @brief   Available resolution values
+ */
+typedef enum {
+    DS18B20_RES_9BIT =  0,          /**< conversion time ~93.75ms */
+    DS18B20_RES_10BIT = 1,          /**< conversion time ~187.5ms */
+    DS18B20_RES_11BIT = 2,          /**< conversion time ~375ms */
+    DS18B20_RES_12BIT = 3,          /**< conversion time ~750ms */
+} ds18b20_res_t;
+
+/**
+ * @brief   Static device configuration values
+ */
+typedef struct {
+    onewire_rom_t rom;              /**< Onewire bus address */
+    ds18b20_res_t res;              /**< sampling resolution */
+} ds18b20_params_t;
+
+/**
+ * @brief   DS18B20 device descriptor
+ */
+typedef struct {
+    onewire_t *bus;                 /**< reference to the used Onewire bus */
+    onewire_rom_t rom;              /**< Onewire bus address */
+    ds18b20_res_t res;              /**< conversion time */
+} ds18b20_t;
+
+/**
+ * @brief   Initialize a DS18B20 sensor
+ *
+ * @param[out] dev      device descriptor
+ * @param[in] owi       pointer a pre-initialized Onewire bus descriptor
+ * @param[in] params    device configuration options
+ *
+ * @return  DS18B20_OK on success
+ * @return  DS18B20_NODEV if device did not respond
+ * @return  DS18B20_ERR_CRC on checksum error when transferring data from device
+ */
+int ds18b20_init(ds18b20_t *dev, onewire_t *owi, const ds18b20_params_t *params);
+
+/**
+ * @brief   Test if the given ROM code identifies a DS18B20 device
+ *
+ * @param[in] rom       ROM code to check
+ *
+ * @return  DS18B20_OK if given ROM belongs to a DS18B20 device
+ * @return  DS18B20_NODEV if ROM does not belong to a DS18B20 device
+ */
+static inline int ds18b20_id(const onewire_rom_t *rom)
+{
+    return (rom->u8[0] == DS18B20_FAMILY_CODE) ? DS18B20_OK : DS18B20_NODEV;
+}
+
+/**
+ * @brief   Get the appropriate conversion time [in us]
+ *
+ * @param[in] dev       device descriptor
+ *
+ * @return  appropriate conversion time [in us]
+ */
+uint32_t ds18b20_get_conv_time_us(const ds18b20_t *dev);
+
+/**
+ * @brief   Trigger a new temperature data conversion
+ *
+ * To get the sampled temperature data one has to wait for the sampling time
+ * according to the configured resolution before reading the sampled data.
+ *
+ * @param[in] dev       device to trigger
+ *
+ * @return  DS18B20_OK on success
+ * @return  DS18B20_NODEV if device did not respond
+ */
+int ds18b20_trigger(const ds18b20_t *dev);
+
+/**
+ * @brief   Trigger a new temperature data conversion for ALL devices connected
+ *          to the same bus
+ *
+ * @param[in] dev       device descriptor, only the Onewire interface is used
+ *
+ * @return  DS18B20_OK on success
+ * @return  DS18B20_NODEV if no device responded
+ */
+int ds18b20_trigger_all(const ds18b20_t *dev);
+
+/**
+ * @brief   Read the sampled temperature data from the given device
+ *
+ * Before reading the temperature data, a conversion has to be triggered using
+ * the ds18b20_trigger() or ds18b20_trigger_all() functions. After triggering
+ * the conversion, the conversion time corresponding to the configure resolution
+ * has to be awaited before reading the temperature data.
+ *
+ * @param[in] dev       device descriptor
+ * @param[out] temp     sampled temperature data
+ *
+ * @return  DS18B20_OK on success
+ * @return  DS18B20_NODEV if device did not respond
+ * @return  DS18B20_ERR_CRC on checksum error when transferring data from device
+ */
+int ds18b20_read(const ds18b20_t *dev, int16_t *temp);
+
+/**
+ * @brief   Trigger a reading, wait, and read the sampled temperature data
+ *
+ * This is a convenience function which combines calls to ds18b20_trigger() and
+ * ds18b20_read() with a wait period of the conversion time fitting the
+ * configured resolution.
+ *
+ * @note    This function will block from 93ms to 750ms, depending on the
+ *          configured resolution.
+ *
+ * @param[in] dev       device to read from
+ * @param[out] temp     sampled temperature data
+ *
+ * @return  DS18B20_OK on success
+ * @return  DS18B20_NODEV if device did not respond
+ * @return  DS18B20_ERR_CRC on checksum error when transferring data from device
+ */
+int ds18b20_get_temp(const ds18b20_t *dev, int16_t *temp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DS18B20_H */
+/** @} */

--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -15,9 +15,31 @@
  * This is generic soft driver to interface devices connected via the 1-Wire
  * bus specified by Dallas Semiconductor Corp, today Maxim Integrated.
  *
+ * @see         https://www.maximintegrated.com/en/design/technical-documents/app-notes/1/126.html
  * @see         https://www.maximintegrated.com/en/design/technical-documents/app-notes/7/74.html
  * @see         https://pdfserv.maximintegrated.com/en/an/AN937.pdf
  * @see         https://www.ti.com/lit/an/spma057c/spma057c.pdf?ts=1598599201996
+ *
+ * # Thread Safety and Preemtion (onewire_safe)
+ * In the vanilla form this driver is not thread safe and will not work reliable
+ * if the thread running the driver is interrupted during data transfer. This is
+ * because the driver depends on an active spin loop to produce the needed
+ * timings. If that loop is interrupted, the timings will be off target and
+ * therefore the ongoing data transfer will be invalid.
+ *
+ * To achieve reliable data transfers you have two choices:
+ * 1. Run the driver in a high priority thread that will not be interrupted.
+ *    Furthermore it needs to run in an environment, where at most very short
+ *    interrupts may be triggered.
+ * 2. Run the driver in safe mode by selecting the `onewire_safe` module. In
+ *    this mode all data transfers are run in a critical section by disabling
+ *    ALL interrupts for that period of time. Precisely, the interrupts will be
+ *    disabled for one block of 960us and 1-to-N blocks of 70us for each
+ *    reset->read/write sequence.
+ *
+ * @warning     Using the drivers safe mode (`onewire_safe`) will impact the
+ *              real-time capabilities of the overall system as interrupts will
+ *              be disabled for periods of time (blocks of 960us and 70us)
  *
  * @{
  * @file

--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -81,7 +81,7 @@ enum {
     ONEWIRE_OK          =  0,   /**< everything fine */
     ONEWIRE_NODEV       = -1,   /**< no device connected to the bus */
     ONEWIRE_ERR_PINCFG  = -2,   /**< unable to initialize pin as open-drain */
-    ONEWIRE_ERR_ROMSTR  = -3    /**< invalid ROM string given */
+    ONEWIRE_ERR_ROMSTR  = -3,   /**< invalid ROM string given */
 };
 
 /**
@@ -92,7 +92,7 @@ enum {
     ONEWIRE_ROM_READ    = 0x33, /**< read ROM code in single device config */
     ONEWIRE_ROM_MATCH   = 0x55, /**< address a specific slave */
     ONEWIRE_ROM_SKIP    = 0xcc, /**< broadcast commands to all connected devs */
-    ONEWIRE_ROM_ALARM   = 0xec  /**< search for devices with active alarm */
+    ONEWIRE_ROM_ALARM   = 0xec, /**< search for devices with active alarm */
 };
 
 /**

--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -38,7 +38,12 @@ extern "C" {
 #endif
 
 /**
- * @brief   String length of a hex encoded 1-wire ROM code (including \0)
+ * @brief   Length of 1-Wire ROM code in bytes
+ */
+#define ONEWIRE_ROM_LEN         (8U)
+
+/**
+ * @brief   String length of a hex encoded 1-Wire ROM code (including \0)
  */
 #define ONEWIRE_ROM_STR_LEN     (17U)
 
@@ -48,7 +53,7 @@ extern "C" {
 #define ONEWIRE_SEARCH_FIRST    (0)
 
 /**
- * @brief   Return codes used by the 1-wire driver
+ * @brief   Return codes used by the 1-Wire driver
  */
 enum {
     ONEWIRE_OK          =  0,   /**< everything fine */
@@ -89,12 +94,12 @@ typedef struct {
  * @brief   1-Wire ROM code (device address) representation
  */
 typedef struct {
-    uint8_t u8[8];              /**< byte-wise access to address bytes */
+    uint8_t u8[ONEWIRE_ROM_LEN];    /**< byte-wise access to address bytes */
 } onewire_rom_t;
 
 
 /**
- * @brief   Initialize a 1-wire bus on the given GPIO pin
+ * @brief   Initialize a 1-Wire bus on the given GPIO pin
  *
  * This tries to configure the pin as open-drain output and will fail, if the
  * platform does not support this GPIO mode.
@@ -163,7 +168,14 @@ uint8_t onewire_crc8(const uint8_t *data, size_t len);
 /**
  * @brief   Search for devices on the given 1-Wire bus
  *
- * TODO
+ * @see     https://pdfserv.maximintegrated.com/en/an/AN937.pdf page 51+52
+ *
+ * Use this function to discover devices connected to the given 1-Wire bus. To
+ * carry out a full device discovery, this function has to be called multiple
+ * times. For each iteration, the return value of the previous call as well as
+ * the previous discovered ROM code have to be given as @p rom and @p ld
+ * parameters to the subsequent call. One the function returns 0, the last
+ * device has been found and there are no further devices to be discovered.
  *
  * @param[in] owi       1-Wire bus
  * @param[in,out] rom   next discovery ROM code, needs to hold previous value

--- a/drivers/include/onewire.h
+++ b/drivers/include/onewire.h
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2016-2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_onewire 1-Wire Bus Driver
+ * @ingroup     drivers_misc
+ * @brief       Generic driver for 1-Wire bus
+ *
+ * # About
+ * This is generic soft driver to interface devices connected via the 1-Wire
+ * bus specified by Dallas Semiconductor Corp, today Maxim Integrated.
+ *
+ * @see         https://www.maximintegrated.com/en/design/technical-documents/app-notes/7/74.html
+ * @see         https://pdfserv.maximintegrated.com/en/an/AN937.pdf
+ * @see         https://www.ti.com/lit/an/spma057c/spma057c.pdf?ts=1598599201996
+ *
+ * @{
+ * @file
+ * @brief       1-Wire driver interface
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef ONEWIRE_H
+#define ONEWIRE_H
+
+#include <stdint.h>
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   String length of a hex encoded 1-wire ROM code (including \0)
+ */
+#define ONEWIRE_ROM_STR_LEN     (17U)
+
+/**
+ * @brief   Custom value used to start a device search
+ */
+#define ONEWIRE_SEARCH_FIRST    (0)
+
+/**
+ * @brief   Return codes used by the 1-wire driver
+ */
+enum {
+    ONEWIRE_OK          =  0,   /**< everything fine */
+    ONEWIRE_NODEV       = -1,   /**< no device connected to the bus */
+    ONEWIRE_ERR_PINCFG  = -2,   /**< unable to initialize pin as open-drain */
+    ONEWIRE_ERR_ROMSTR  = -3    /**< invalid ROM string given */
+};
+
+/**
+ * @brief   1-Wire ROM commands
+ */
+enum {
+    ONEWIRE_ROM_SEARCH  = 0xf0, /**< search for devices */
+    ONEWIRE_ROM_READ    = 0x33, /**< read ROM code in single device config */
+    ONEWIRE_ROM_MATCH   = 0x55, /**< address a specific slave */
+    ONEWIRE_ROM_SKIP    = 0xcc, /**< broadcast commands to all connected devs */
+    ONEWIRE_ROM_ALARM   = 0xec  /**< search for devices with active alarm */
+};
+
+/**
+ * @brief   1-Wire configuration parameters
+ */
+typedef struct {
+    gpio_t pin;                 /**< GPIO pin the bus is connected to */
+    gpio_mode_t pin_mode;       /**< GPIO pin output mode */
+} onewire_params_t;
+
+/**
+ * @brief   1-Wire bus device descriptor
+ */
+typedef struct {
+    gpio_t pin;                 /**< GPIO pin */
+    gpio_mode_t omode;          /**< GPIO pin output mode */
+    gpio_mode_t imode;          /**< GPIO pin input mode, deducted from omode */
+} onewire_t;
+
+/**
+ * @brief   1-Wire ROM code (device address) representation
+ */
+typedef struct {
+    uint8_t u8[8];              /**< byte-wise access to address bytes */
+} onewire_rom_t;
+
+
+/**
+ * @brief   Initialize a 1-wire bus on the given GPIO pin
+ *
+ * This tries to configure the pin as open-drain output and will fail, if the
+ * platform does not support this GPIO mode.
+ *
+ * @param[out] owi      1-Wire bus device descriptor
+ * @param[in] params    configuration parameters
+ *
+ * @return  ONEWIRE_OK on success
+ * @return  ONEWIRE_ERR_PINCFG if open-drain mode unsupported
+ */
+int onewire_init(onewire_t *owi, const onewire_params_t *params);
+
+/**
+ * @brief   Generate a bus reset sequence and look for connected devices
+ *
+ * Every bus transaction must be started with this reset sequence. During this
+ * sequence it is detected, if there are any slaves connected to the bus.
+ *
+ * @param[in] owi       1-Wire bus device descriptor
+ * @param[in] rom       1-Wire ROM code of target device
+ *
+ * @return  ONEWIRE_OK if slave(s) were found
+ * @return  ONEWIRE_NODEV if no slave answered the reset sequence
+ */
+int onewire_reset(const onewire_t *owi, const onewire_rom_t *rom);
+
+/**
+ * @brief   Read data from the bus
+ *
+ * @param[in] owi       1-Wire bus device descriptor
+ * @param[out] data     buffer to write received bytes into
+ * @param[in] len       number of bytes to read from the bus
+ */
+void onewire_read(const onewire_t *owi, void *data, size_t len);
+
+/**
+ * @brief   Write data to the bus
+ *
+ * @param[in] owi       1-Wire bus device descriptor
+ * @param[in] data      buffer holding the data that is written to the bus
+ * @param[in] len       number of bytes to write to the bus
+ */
+void onewire_write(const onewire_t *owi, const void *data, size_t len);
+
+/**
+ * @brief   Convenience function for writing a single byte to the bus
+ *
+ * @param[in] owi       1-Wire bus device descriptor
+ * @param[in] data      data byte to write to the bus
+ */
+static inline void onewire_write_byte(const onewire_t *owi, uint8_t data)
+{
+    onewire_write(owi, &data, 1);
+}
+
+/**
+ * @brief   Calculate a 8-bit CRC using the 1-Wire specific polynomial
+ *
+ * @param[in] data      input data
+ * @param[in] len       len of @p data in bytes
+ *
+ * @return  calculate 8-bit CRC
+ */
+uint8_t onewire_crc8(const uint8_t *data, size_t len);
+
+/**
+ * @brief   Search for devices on the given 1-Wire bus
+ *
+ * TODO
+ *
+ * @param[in] owi       1-Wire bus
+ * @param[in,out] rom   next discovery ROM code, needs to hold previous value
+ *                      when function is called multiple times
+ * @param[in] ld        position of last discrepancy or ONEWIRE_SEARCH_FIRST for
+ *                      initial call
+ *
+ * @return  bit position of last discrepancy
+ * @return  0 if discovered device was the last
+ * @return ONEWIRE_NODEV of no device was found
+ */
+int onewire_search(const onewire_t *owi, onewire_rom_t *rom, int ld);
+
+/**
+ * @brief   Read 1-Wire ROM code from string
+ *
+ * @param[out] rom      ROM code is parsed into this location
+ * @param[in] str       String representation of a ROM code
+ *
+ * @return  ONEWIRE_OK on success
+ * @return  ONEWIRE_ERR_ROMSTR on parsing error
+ */
+int onewire_rom_from_str(onewire_rom_t *rom, const char *str);
+
+/**
+ * @brief   Write a 1-Wire ROM code to a string
+ *
+ * @param[out] str      Output string, must be able to hold ONEWIRE_ROM_STR_LEN
+ *                      characters
+ * @param[in] rom       1-Wire ROM code to read
+ */
+void onewire_rom_to_str(char *str, const onewire_rom_t *rom);
+
+/**
+ * @brief   Print a 1-Wire ROM code to STDIO
+ *
+ * @param[in] rom       1-Wire ROM code
+ */
+void onewire_rom_print(const onewire_rom_t *rom);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ONEWIRE_H */
+/** @} */

--- a/drivers/onewire/Makefile
+++ b/drivers/onewire/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/onewire/Makefile.dep
+++ b/drivers/onewire/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += xtimer
+USEMODULE += fmt
+FEATURES_REQUIRED += periph_gpio

--- a/drivers/onewire/onewire.c
+++ b/drivers/onewire/onewire.c
@@ -73,21 +73,21 @@ static int _read_bit(const onewire_t *owi, uint32_t *t_ref)
 {
     int in;
 
-    CRIT_IN;
+    CRIT_IN
     _pull(owi);
     _spin_us(t_ref, T_RW_START_US);
     _release(owi);
     _spin_us(t_ref, T_R_WAIT_US);
     in = (gpio_read(owi->pin)) ? 1 : 0;
     _spin_us(t_ref, T_R_END_US);
-    CRIT_OUT;
+    CRIT_OUT
 
     return in;
 }
 
 static void _write_bit(const onewire_t *owi, uint32_t *t_ref, int out)
 {
-    CRIT_IN;
+    CRIT_IN
     _pull(owi);
     if (out) {
         _spin_us(t_ref, T_RW_START_US);
@@ -123,7 +123,7 @@ int onewire_reset(const onewire_t *owi, const onewire_rom_t *rom)
 {
     int res = ONEWIRE_OK;
 
-    CRIT_IN;
+    CRIT_IN
     uint32_t t_ref = xtimer_now_usec();
     _pull(owi);
     _spin_us(&t_ref, T_RESET_HOLD_US);
@@ -133,7 +133,7 @@ int onewire_reset(const onewire_t *owi, const onewire_rom_t *rom)
         res = ONEWIRE_NODEV;
     }
     _spin_us(&t_ref, (T_RESET_HOLD_US - T_RESET_SAMPLE_US));
-    CRIT_OUT;
+    CRIT_OUT
 
     if ((res == ONEWIRE_OK) && (rom != NULL)) {
         onewire_write_byte(owi, ONEWIRE_ROM_MATCH);
@@ -191,6 +191,7 @@ int onewire_search(const onewire_t *owi, onewire_rom_t *rom, int ld)
     int marker = 0;
     int pos = 1;
     for (unsigned b = 0; b < sizeof(onewire_rom_t); b++) {
+        CRIT_IN
         for (int i = 0; i < 8; i++) {
             int bit1 = _read_bit(owi, &t_ref);
             int bit2 = _read_bit(owi, &t_ref);
@@ -216,6 +217,7 @@ int onewire_search(const onewire_t *owi, onewire_rom_t *rom, int ld)
             _write_bit(owi, &t_ref, bit1);
             pos++;
         }
+        CRIT_OUT
     }
 
     return marker;

--- a/drivers/onewire/onewire.c
+++ b/drivers/onewire/onewire.c
@@ -37,7 +37,7 @@
 #define T_R_SAMPLE_US       (7)
 #define T_R_RECOVER_US      (55)
 
-static inline int _read_bit(const onewire_t *owi)
+static int _read_bit(const onewire_t *owi)
 {
     gpio_clear(owi->pin);
     xtimer_usleep(T_RW_PULSE_US);
@@ -51,7 +51,7 @@ static inline int _read_bit(const onewire_t *owi)
     return in;
 }
 
-static inline void _write_bit(const onewire_t *owi, int out)
+static void _write_bit(const onewire_t *owi, int out)
 {
     gpio_clear(owi->pin);
     if (out) {
@@ -112,7 +112,7 @@ void onewire_read(const onewire_t *owi, void *data, size_t len)
 {
     uint8_t *buf = (uint8_t *)data;
 
-    for (size_t pos = 0; pos < (size_t)len; pos++) {
+    for (size_t pos = 0; pos < len; pos++) {
         /* read the next byte from the bus */
         uint8_t tmp = 0;
         for (int i = 0; i < 8; i++) {
@@ -126,7 +126,7 @@ void onewire_write(const onewire_t *owi, const void *data, size_t len)
 {
     const uint8_t *buf = (uint8_t *)data;
 
-    for (size_t pos = 0; pos < (size_t)len; pos ++) {
+    for (size_t pos = 0; pos < len; pos ++) {
 
         for (int i = 0; i < 8; i++) {
             _write_bit(owi, (buf[pos] & (1 << i)));

--- a/drivers/onewire/onewire.c
+++ b/drivers/onewire/onewire.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2016-2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_onewire
+ * @{
+ *
+ * @file
+ * @brief       1-Wire bus driver implementation
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "assert.h"
+#include "xtimer.h"
+#include "onewire.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+#define T_RESET_HOLD        (480)
+#define T_RESET_SAMPLE      (70)
+
+#define T_RW_PULSE          (3)
+#define T_W_HOLD            (57)
+#define T_W_RECOVER         (10)
+#define T_R_SAMPLE          (7)
+#define T_R_RECOVER         (55)
+
+static inline int _read_bit(const onewire_t *owi)
+{
+    gpio_clear(owi->pin);
+    xtimer_usleep(T_RW_PULSE);
+    gpio_init(owi->pin, owi->imode);
+    xtimer_usleep(T_R_SAMPLE);
+    int in = (gpio_read(owi->pin)) ? 1 : 0;
+    xtimer_usleep(T_R_RECOVER);
+    gpio_init(owi->pin, owi->omode);
+    gpio_set(owi->pin);
+
+    return in;
+}
+
+static inline void _write_bit(const onewire_t *owi, int out)
+{
+    gpio_clear(owi->pin);
+    if (out) {
+        /* shift out a `1` */
+        xtimer_usleep(T_RW_PULSE);
+        gpio_set(owi->pin);
+        xtimer_usleep(T_W_HOLD);
+    }
+    else {
+        /* shift out a `0` */
+        xtimer_usleep(T_RW_PULSE + T_W_HOLD);
+        gpio_set(owi->pin);
+    }
+    xtimer_usleep(T_W_RECOVER);
+}
+
+int onewire_init(onewire_t *owi, const onewire_params_t *params)
+{
+    owi->pin = params->pin;
+
+    owi->omode = params->pin_mode;
+    owi->imode = (owi->omode == GPIO_OD_PU) ? GPIO_IN_PU : GPIO_IN;
+
+    if (gpio_init(owi->pin, owi->omode) != 0) {
+        return ONEWIRE_ERR_PINCFG;
+    }
+    gpio_set(owi->pin);
+    return ONEWIRE_OK;
+}
+
+int onewire_reset(const onewire_t *owi, const onewire_rom_t *rom)
+{
+    int res = ONEWIRE_OK;
+
+    gpio_clear(owi->pin);
+    xtimer_usleep(T_RESET_HOLD);
+    gpio_set(owi->pin);
+
+    xtimer_usleep(T_RESET_SAMPLE);
+    gpio_init(owi->pin, owi->imode);
+    if (gpio_read(owi->pin)) {
+        res = ONEWIRE_NODEV;
+    }
+
+    xtimer_usleep(T_RESET_HOLD - T_RESET_SAMPLE);
+    gpio_init(owi->pin, owi->omode);
+    gpio_set(owi->pin);
+
+    if ((res == ONEWIRE_OK) && (rom != NULL)) {
+        onewire_write_byte(owi, ONEWIRE_ROM_MATCH);
+        onewire_write(owi, rom->u8, sizeof(onewire_rom_t));
+    }
+
+    return res;
+}
+
+void onewire_read(const onewire_t *owi, void *data, size_t len)
+{
+    uint8_t *buf = (uint8_t *)data;
+
+    for (unsigned pos = 0; pos < (unsigned)len; pos++) {
+        /* read the next byte from the bus */
+        uint8_t tmp = 0;
+        for (int i = 0; i < 8; i++) {
+            tmp |= (_read_bit(owi) << i);
+        }
+        buf[pos] = tmp;
+    }
+}
+
+void onewire_write(const onewire_t *owi, const void *data, size_t len)
+{
+    uint8_t *buf = (uint8_t *)data;
+
+    for (unsigned pos = 0; pos < (unsigned)len; pos ++) {
+
+        for (int i = 0; i < 8; i++) {
+            _write_bit(owi, (buf[pos] & (1 << i)));
+        }
+    }
+}
+
+int onewire_search(const onewire_t *owi, onewire_rom_t *rom, int ld)
+{
+    /* initialize the search state */
+    if (ld == ONEWIRE_SEARCH_FIRST) {
+        memset(rom, 0, sizeof(onewire_rom_t));
+    }
+
+    /* send reset condition and issue search ROM command */
+    if (onewire_reset(owi, NULL) != ONEWIRE_OK) {
+        return ONEWIRE_NODEV;
+    }
+    onewire_write_byte(owi, ONEWIRE_ROM_SEARCH);
+
+    /* start search */
+    int marker = 0;
+    int pos = 1;
+    for (unsigned b = 0; b < sizeof(onewire_rom_t); b++) {
+        for (int i = 0; i < 8; i++) {
+            int bit1 = _read_bit(owi);
+            int bit2 = _read_bit(owi);
+
+            if (bit1 == bit2) {
+                if (pos < ld) {
+                    bit1 = (rom->u8[b] & (1 << i)) ? 1 : 0;
+                    if (bit1 == 0) {
+                        marker = pos;
+                    }
+                }
+                else if (pos == ld) {
+                    bit1 = 1;
+                }
+                else {
+                    marker = pos;
+                    bit1 = 0;
+                }
+            }
+
+            rom->u8[b] &= ~(1 << i);
+            rom->u8[b] |= (bit1 << i);
+            _write_bit(owi, bit1);
+            pos++;
+        }
+    }
+
+    return marker;
+}

--- a/drivers/onewire/onewire_crc.c
+++ b/drivers/onewire/onewire_crc.c
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 1992-2017 Arjen Lentz
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS”
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @ingroup     drivers_ds18b20
+ * @{
+ *
+ * @file
+ * @brief       Lookup table based OneWire CRC implementation
+ *
+ * @see         https://lentz.com.au/blog/calculating-crc-with-a-tiny-32-entry-lookup-table
+ *
+ * @author      Arjen Lentz
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @}
+ */
+
+#include <stdint.h>
+
+/**
+ * @brief   Dow-CRC using polynomial X^8 + X^5 + X^4 + X^0
+ */
+static const uint8_t dscrc_table[] = {
+    0x00, 0x5E, 0xBC, 0xE2, 0x61, 0x3F, 0xDD, 0x83,
+    0xC2, 0x9C, 0x7E, 0x20, 0xA3, 0xFD, 0x1F, 0x41,
+    0x00, 0x9D, 0x23, 0xBE, 0x46, 0xDB, 0x65, 0xF8,
+    0x8C, 0x11, 0xAF, 0x32, 0xCA, 0x57, 0xE9, 0x74
+};
+
+/**
+ * @brief   Compute a Dallas Semiconductor 8 bit CRC. These show up in the ROM
+ *          and the registers.
+ */
+uint8_t onewire_crc8(const uint8_t *addr, uint8_t len)
+{
+    uint8_t crc = 0;
+
+    while (len--) {
+        crc = *addr++ ^ crc;    /* just re-using crc as intermediate */
+        crc = dscrc_table[crc & 0x0f] ^
+              dscrc_table[16 + ((crc >> 4) & 0x0f)];
+    }
+
+    return crc;
+}

--- a/drivers/onewire/onewire_crc.c
+++ b/drivers/onewire/onewire_crc.c
@@ -21,7 +21,7 @@
  */
 
 /**
- * @ingroup     drivers_ds18b20
+ * @ingroup     drivers_onewire
  * @{
  *
  * @file

--- a/drivers/onewire/onewire_str.c
+++ b/drivers/onewire/onewire_str.c
@@ -24,21 +24,6 @@
 #include "assert.h"
 #include "onewire.h"
 
-static int _hex2int(char c) {
-    if ('0' <= c && c <= '9') {
-        return c - '0';
-    }
-    else if ('a' <= c && c <= 'f') {
-        return c - 'a' + 10;
-    }
-    else if ('A' <= c && c <= 'F') {
-        return c - 'A' + 10;
-    }
-    else {
-        return -1;
-    }
-}
-
 int onewire_rom_from_str(onewire_rom_t *rom, const char *str)
 {
     assert(rom);
@@ -47,17 +32,7 @@ int onewire_rom_from_str(onewire_rom_t *rom, const char *str)
     if (strlen(str) != (ONEWIRE_ROM_STR_LEN - 1)) {
         return ONEWIRE_ERR_ROMSTR;
     }
-
-    memset(rom->u8, 0, sizeof(onewire_rom_t));
-    for (int i = 0; i < 8; i++) {
-        for (int j = 0; j < 2; j++) {
-            int digit = _hex2int(str[(i * 2) + j]);
-            if (digit < 0) {
-                return ONEWIRE_ERR_ROMSTR;
-            }
-            rom->u8[i] |= (digit << ((1 - j) * 4));
-        }
-    }
+    fmt_hex_bytes(rom->u8, str);
 
     return ONEWIRE_OK;
 }

--- a/drivers/onewire/onewire_str.c
+++ b/drivers/onewire/onewire_str.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2016-2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_onewire
+ * @{
+ *
+ * @file
+ * @brief       1-Wire address (ROM) string helper functions
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "fmt.h"
+#include "assert.h"
+#include "onewire.h"
+
+static int _hex2int(char c) {
+    if ('0' <= c && c <= '9') {
+        return c - '0';
+    }
+    else if ('a' <= c && c <= 'f') {
+        return c - 'a' + 10;
+    }
+    else if ('A' <= c && c <= 'F') {
+        return c - 'A' + 10;
+    }
+    else {
+        return -1;
+    }
+}
+
+int onewire_rom_from_str(onewire_rom_t *rom, const char *str)
+{
+    assert(rom);
+    assert(str);
+
+    if (strlen(str) != (ONEWIRE_ROM_STR_LEN - 1)) {
+        return ONEWIRE_ERR_ROMSTR;
+    }
+
+    memset(rom->u8, 0, sizeof(onewire_rom_t));
+    for (int i = 0; i < 8; i++) {
+        for (int j = 0; j < 2; j++) {
+            int digit = _hex2int(str[(i * 2) + j]);
+            if (digit < 0) {
+                return ONEWIRE_ERR_ROMSTR;
+            }
+            rom->u8[i] |= (digit << ((1 - j) * 4));
+        }
+    }
+
+    return ONEWIRE_OK;
+}
+
+void onewire_rom_to_str(char *str, const onewire_rom_t *rom)
+{
+    assert(rom);
+    assert(str);
+
+    size_t pos = fmt_bytes_hex(str, rom->u8, sizeof(onewire_rom_t));
+    str[pos] = '\0';
+}
+
+void onewire_rom_print(const onewire_rom_t *rom)
+{
+    assert(rom);
+
+    char str[ONEWIRE_ROM_STR_LEN];
+    onewire_rom_to_str(str, rom);
+    print(str, (ONEWIRE_ROM_STR_LEN - 1));
+}

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -84,6 +84,7 @@ PSEUDOMODULES += nimble_autoconn_%
 PSEUDOMODULES += newlib
 PSEUDOMODULES += newlib_gnu_source
 PSEUDOMODULES += newlib_nano
+PSEUDOMODULES += onewire_%
 PSEUDOMODULES += openthread
 PSEUDOMODULES += picolibc
 PSEUDOMODULES += pktqueue

--- a/tests/driver_ds18b20/Makefile
+++ b/tests/driver_ds18b20/Makefile
@@ -1,0 +1,9 @@
+APPLICATION = driver_ds18b20
+include ../Makefile.tests_common
+
+USEMODULE += ds18b20
+USEMODULE += xtimer
+USEMODULE += shell
+USEMODULE += fmt
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_ds18b20/main.c
+++ b/tests/driver_ds18b20/main.c
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2016 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       xtimer_msg test application
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @}
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "fmt.h"
+#include "shell.h"
+#include "xtimer.h"
+
+#include "ds18b20.h"
+
+#define DEVICE_LIMIT        (10U)
+#define INIT_FAIL           (0xff)
+
+static onewire_t owi = { GPIO_UNDEF, GPIO_OD_PU, GPIO_IN_PU };
+static ds18b20_params_t _dslist[DEVICE_LIMIT];
+static ds18b20_t _devlist[DEVICE_LIMIT];
+static unsigned _cnt = 0;
+
+
+static int _cmd_init(int argc, char **argv)
+{
+    int portsel, pinsel, modesel, res;
+    onewire_params_t params;
+    uint8_t dsres = DS18B20_RES_12BIT;
+
+    if (argc < 3) {
+        printf("usage: %s <port num> <pin num> [mode] [res]\n", argv[0]);
+        puts("\tmode: 0: open drain with pull-up (default)");
+        puts("\t      1: open-drain without pull resistor");
+        puts("\t      2: push pull output (external transistor needed)");
+        puts("\t res: 9, 10, 11, or 12-bit resolution, default is 12-bit");
+        return 1;
+    }
+
+    portsel = atoi(argv[1]);
+    pinsel = atoi(argv[2]);
+    params.pin = GPIO_PIN(portsel, pinsel);
+    params.pin_mode = GPIO_OD_PU;
+
+    if (argc >= 4) {
+        modesel = atoi(argv[3]);
+        switch (modesel) {
+            case 0: break;
+            case 1: params.pin_mode = GPIO_OD;      break;
+            case 2: params.pin_mode = GPIO_OUT;     break;
+            default:
+                puts("err: unable to parse 1-Wire pin mode");
+                return 1;
+        }
+    }
+
+    if (argc >= 5) {
+        res = atoi(argv[4]);
+        if (res < 9 || res > 12) {
+            puts("err: resolution must be 9, 10, 11, or 12");
+            return 1;
+        }
+        dsres = res - 9;
+    }
+
+    /* initialize the one wire bus */
+    printf("initializing 1-Wire bus on GPIO_PIN(%i, %i)...\n", portsel, pinsel);
+    if (onewire_init(&owi, &params) != ONEWIRE_OK) {
+        puts("err: open-drain pin mode not applicable\n");
+        owi.pin = GPIO_UNDEF;
+        return 1;
+    }
+    puts("-> 1-Wire Bus initialized\n");
+
+    /* reset device list */
+    memset(_dslist, 0xff, sizeof(_dslist));
+
+    /* search for devices */
+    puts("discovering DS18B20 devices...");
+    _cnt = 0;
+    onewire_rom_t tmp;
+    res = ONEWIRE_SEARCH_FIRST;
+    do {
+        res = onewire_search(&owi, &tmp, res);
+        if ((res >= 0) && (ds18b20_id(&tmp) == DS18B20_OK)) {
+            memcpy(&_dslist[_cnt].rom, &tmp, sizeof(onewire_rom_t));
+            _dslist[_cnt].res = dsres;
+            ++_cnt;
+        }
+    } while ((res > 0) && (_cnt < DEVICE_LIMIT));
+
+    printf("discovered %u devices:\n", _cnt);
+    for (unsigned i = 0; i < _cnt; i++) {
+        char rom_str[ONEWIRE_ROM_STR_LEN];
+        onewire_rom_to_str(rom_str, &_dslist[i].rom);
+        printf("[%2u] ROM code: %s\n", i, rom_str);
+    }
+
+    /* initialize all discovered devices */
+    puts("\ninitializing DS18B20 sensors...");
+    for (unsigned i = 0; i < _cnt; i++) {
+        char rom_str[ONEWIRE_ROM_STR_LEN];
+        onewire_rom_to_str(rom_str, &_dslist[i].rom);
+
+        res = ds18b20_init(&_devlist[i], &owi, &_dslist[i]);
+        if (res == DS18B20_OK) {
+            printf("[%2u] %s: OK\n", i, rom_str);
+        }
+        else {
+            _dslist[i].res = INIT_FAIL;  /* mark as invalid */
+            printf("[%2u] %s: err - initialization failed\n", i, rom_str);
+        }
+    }
+
+    return 0;
+}
+
+static void _print_res(unsigned num, int state, uint16_t temp)
+{
+    char rom_str[ONEWIRE_ROM_STR_LEN];
+    onewire_rom_to_str(rom_str, &_dslist[num].rom);
+
+    if (state == DS18B20_OK) {
+        char temp_str[20];
+        size_t pos = fmt_s16_dfp(temp_str, temp, -2);
+        temp_str[pos] = '\0';
+        printf("[%2u] %s: %s°C\n", num, rom_str, temp_str);
+    }
+    else {
+        printf("[%2u] %s: err - unable to acquire temperature\n", num, rom_str);
+    }
+}
+
+static int _cmd_read(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    if (_cnt == 0) {
+        puts("err: no device detected");
+        return 1;
+    }
+
+    /* trigger a new sample on all devices connected to the bus */
+    puts("triggering a new sample for all devices on the bus...");
+    ds18b20_trigger_all(&_devlist[0]);
+
+    /* wait for the conversion to finish */
+    puts("wait for conversion time to pass...");
+    xtimer_usleep(ds18b20_get_conv_time_us(&_devlist[0]));
+
+    /* read temperature data from each device */
+    puts("reading results...");
+    for (unsigned i = 0; i < _cnt; i++) {
+        if (_dslist[i].res != INIT_FAIL) {
+            int16_t temp;
+            int res = ds18b20_read(&_devlist[i], &temp);
+            _print_res(i, res, temp);
+        }
+    }
+
+    return 0;
+}
+
+static int _cmd_read_seq(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    if (_cnt == 0) {
+        puts("err: no device detected");
+        return 1;
+    }
+
+    for (unsigned i = 0; i < _cnt; i++) {
+        if (_dslist[i].res != INIT_FAIL) {
+            int16_t temp;
+            int res = ds18b20_get_temp(&_devlist[i], &temp);
+            _print_res(i, res, temp);
+        }
+    }
+
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "init", "initialize 1-Wire driver with given pin", _cmd_init },
+    { "read", "read temperature data from all sensors", _cmd_read },
+    { "read_seq", "read all sensors sequential", _cmd_read_seq },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("DS18B20 driver test application\n");
+
+    /* run the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/driver_onewire/Makefile
+++ b/tests/driver_onewire/Makefile
@@ -1,10 +1,6 @@
-APPLICATION = driver_onewire
 include ../Makefile.tests_common
 
 USEMODULE += onewire
 USEMODULE += shell
-
-BUS_PIN ?= GPIO_PIN\(0,0\)
-CFLAGS += -DBUS_PIN=${BUS_PIN}
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_onewire/Makefile
+++ b/tests/driver_onewire/Makefile
@@ -1,0 +1,10 @@
+APPLICATION = driver_onewire
+include ../Makefile.tests_common
+
+USEMODULE += onewire
+USEMODULE += shell
+
+BUS_PIN ?= GPIO_PIN\(0,0\)
+CFLAGS += -DBUS_PIN=${BUS_PIN}
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_onewire/main.c
+++ b/tests/driver_onewire/main.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2016-2020 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the 1-Wire (onewire) bus driver
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @}
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "fmt.h"
+#include "shell.h"
+#include "xtimer.h"
+
+#include "onewire.h"
+
+#define DEVICE_LIMIT        (10U)
+
+static int _noinit = 1;
+static onewire_t _owi = { GPIO_UNDEF, GPIO_OD_PU, GPIO_IN_PU };
+static onewire_rom_t _devlist[DEVICE_LIMIT];
+
+static int _cmd_init(int argc, char **argv)
+{
+    int portsel;
+    int pinsel;
+    onewire_params_t params;
+
+    if (argc < 3) {
+        printf("usage: %s <port num> <pin num> [mode]\n", argv[0]);
+        puts("\tmode: 0: open drain with pull-up (default)");
+        puts("\t      1: open-drain without pull resistor");
+        puts("\t      2: push pull output (external pull-up needed)");
+        return 1;
+    }
+
+    portsel = atoi(argv[1]);
+    pinsel = atoi(argv[2]);
+    params.pin = GPIO_PIN(portsel, pinsel);
+    params.pin_mode = GPIO_OD_PU;
+    if (argc > 3) {
+        switch (atoi(argv[3])) {
+            case 0:
+                break;
+            case 1:
+                params.pin_mode = GPIO_OD;
+                break;
+            case 2:
+                params.pin_mode = GPIO_OUT;
+                break;
+            default:
+                puts("unable to parse mode");
+                return 1;
+        }
+    }
+
+    printf("Initializing 1-Wire bus at GPIO_PIN(%i, %i)\n", portsel, pinsel);
+
+    /* initialize the one wire bus */
+    if (onewire_init(&_owi, &params) == ONEWIRE_OK) {
+        _noinit = 0;
+        puts("1-Wire bus successfully initialized");
+    }
+    else {
+        puts("Error: pin initialization failed: pin mode not supported\n");
+        _noinit = 1;
+    }
+
+    return _noinit;
+}
+
+static int _cmd_discover(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    if (_noinit) {
+        puts("Error: 1-Wire bus is not initialized");
+        return 1;
+    }
+
+    /* reset device list and detect all connected devices */
+    int ld = ONEWIRE_SEARCH_FIRST;
+    unsigned cnt = 0;
+    onewire_rom_t tmp;
+
+    memset(_devlist, 0, ARRAY_SIZE(_devlist));
+    do {
+        ld = onewire_search(&_owi, &tmp, ld);
+        if (ld >= 0) {
+            memcpy(&_devlist[cnt++], &tmp, sizeof(onewire_rom_t));
+        }
+    } while ((ld > 0) && (cnt < DEVICE_LIMIT));
+
+    printf("Discovery finished, found %u devices:\n", cnt);
+    puts("Dev # - ROM code");
+    for (unsigned i = 0; i < cnt; i++) {
+        char rom_str[ONEWIRE_ROM_STR_LEN];
+        onewire_rom_to_str(rom_str, &_devlist[i]);
+        printf("[%2i]    %s\n", i, rom_str);
+    }
+
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "init", "initialize OneWire interface on given pin", _cmd_init },
+    { "discover", "list all connected devices", _cmd_discover },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("1-Wire bus driver test application\n");
+
+    /* run the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/driver_onewire/main.c
+++ b/tests/driver_onewire/main.c
@@ -110,7 +110,7 @@ static int _cmd_discover(int argc, char **argv)
     for (unsigned i = 0; i < cnt; i++) {
         char rom_str[ONEWIRE_ROM_STR_LEN];
         onewire_rom_to_str(rom_str, &_devlist[i]);
-        printf("[%2i]    %s\n", i, rom_str);
+        printf("[%2u]    %s\n", i, rom_str);
     }
 
     return 0;


### PR DESCRIPTION
### Contribution description
This PR adds a new device driver for `ds18b20` temperature sensors. It is build on top of the generic 1-Wire bus driver (PRed in #14897) and supports any number of sensors connected to the same bus.

I PRed it separately of the existing `ds18` driver, as it enables users to chose whichever version suits their application best...

### Testing procedure
Connect any number of `ds18b20` sensors to a board of your choice, flash the included test application, and use the `init`, `read`, and `read_seq` shell commands to sample the connected sensors.

### Issues/PRs references
rebased on #14897