### PR TITLE
picolibc: fix build for fe310

### DIFF
--- a/sys/picolibc_syscalls_default/syscalls.c
+++ b/sys/picolibc_syscalls_default/syscalls.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <sys/times.h>
 
+#include "irq.h"
 #include "log.h"
 #include "periph/pm.h"
 #include "stdio_base.h"


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

We need to include `irq.h` for `irq_disable()`.

### Testing procedure

    make BOARD=hifive1 PICOLIBC=1 -C examples/hello-world


### Issues/PRs references

split off #14878
