### PR TITLE
periph/gpio: use inline functions to test for valid and equal GPIOs

### DIFF
--- a/drivers/adcxx1c/adcxx1c.c
+++ b/drivers/adcxx1c/adcxx1c.c
@@ -103,7 +103,7 @@ int adcxx1c_enable_alert(adcxx1c_t *dev, adcxx1c_cb_t cb, void *arg)
 
     i2c_acquire(DEV);
     i2c_read_reg(DEV, ADDR, ADCXX1C_CONF_ADDR, &reg, 0);
-    reg |= (dev->params.alert_pin != GPIO_UNDEF ? ADCXX1C_CONF_ALERT_PIN_EN : 0)
+    reg |= (gpio_is_valid(dev->params.alert_pin) ? ADCXX1C_CONF_ALERT_PIN_EN : 0)
             | ADCXX1C_CONF_ALERT_FLAG_EN;
     status = i2c_write_reg(DEV, ADDR, ADCXX1C_CONF_ADDR, reg, 0);
     i2c_release(DEV);
@@ -113,7 +113,7 @@ int adcxx1c_enable_alert(adcxx1c_t *dev, adcxx1c_cb_t cb, void *arg)
         return ADCXX1C_NOI2C;
     }
 
-    if (dev->params.alert_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.alert_pin)) {
         dev->cb = cb;
         dev->arg = arg;
         /* alert active low */

--- a/drivers/ads101x/ads101x.c
+++ b/drivers/ads101x/ads101x.c
@@ -159,7 +159,7 @@ int ads101x_enable_alert(ads101x_alert_t *dev,
 {
     uint8_t regs[2];
 
-    if (dev->params.alert_pin == GPIO_UNDEF) {
+    if (!gpio_is_valid(dev->params.alert_pin)) {
         return ADS101X_OK;
     }
 

--- a/drivers/apds99xx/apds99xx.c
+++ b/drivers/apds99xx/apds99xx.c
@@ -355,7 +355,7 @@ int apds99xx_int_config(apds99xx_t *dev, apds99xx_int_config_t* cfg,
 {
     assert(dev != NULL);
     assert(cfg != NULL);
-    assert(dev->params.int_pin != GPIO_UNDEF);
+    assert(gpio_is_valid(dev->params.int_pin));
     assert(cfg->als_pers <= 15);
     assert(cfg->prx_pers <= 15);
 

--- a/drivers/at24cxxx/at24cxxx.c
+++ b/drivers/at24cxxx/at24cxxx.c
@@ -189,7 +189,7 @@ int at24cxxx_init(at24cxxx_t *dev, const at24cxxx_params_t *params)
         return -EINVAL;
     }
     dev->params = *params;
-    if (DEV_PIN_WP != GPIO_UNDEF) {
+    if (gpio_is_valid(DEV_PIN_WP)) {
         gpio_init(DEV_PIN_WP, GPIO_OUT);
         at24cxxx_disable_write_protect(dev);
     }
@@ -303,7 +303,7 @@ int at24cxxx_erase(const at24cxxx_t *dev)
 
 int at24cxxx_enable_write_protect(const at24cxxx_t *dev)
 {
-    if (DEV_PIN_WP == GPIO_UNDEF) {
+    if (!gpio_is_valid(DEV_PIN_WP)) {
         return -ENOTSUP;
     }
     gpio_set(DEV_PIN_WP);
@@ -312,7 +312,7 @@ int at24cxxx_enable_write_protect(const at24cxxx_t *dev)
 
 int at24cxxx_disable_write_protect(const at24cxxx_t *dev)
 {
-    if (DEV_PIN_WP == GPIO_UNDEF) {
+    if (!gpio_is_valid(DEV_PIN_WP)) {
         return -ENOTSUP;
     }
     gpio_clear(DEV_PIN_WP);

--- a/drivers/at25xxx/at25xxx.c
+++ b/drivers/at25xxx/at25xxx.c
@@ -243,12 +243,12 @@ int at25xxx_init(at25xxx_t *dev, const at25xxx_params_t *params)
     dev->params = *params;
     spi_init_cs(dev->params.spi, dev->params.cs_pin);
 
-    if (dev->params.wp_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.wp_pin)) {
         gpio_init(dev->params.wp_pin, GPIO_OUT);
         gpio_set(dev->params.wp_pin);
     }
 
-    if (dev->params.hold_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.hold_pin)) {
         gpio_init(dev->params.hold_pin, GPIO_OUT);
         gpio_set(dev->params.hold_pin);
     }

--- a/drivers/atwinc15x0/atwinc15x0_bsp.c
+++ b/drivers/atwinc15x0/atwinc15x0_bsp.c
@@ -38,8 +38,8 @@ void atwinc15x0_isr(void *arg)
 sint8 nm_bsp_init(void)
 {
     assert(atwinc15x0);
-    assert(atwinc15x0->params.reset_pin != GPIO_UNDEF);
-    assert(atwinc15x0->params.irq_pin != GPIO_UNDEF);
+    assert(gpio_is_valid(atwinc15x0->params.reset_pin));
+    assert(gpio_is_valid(atwinc15x0->params.irq_pin));
 
     gpio_init(atwinc15x0->params.reset_pin, GPIO_OUT);
     gpio_set(atwinc15x0->params.reset_pin);
@@ -47,12 +47,12 @@ sint8 nm_bsp_init(void)
     gpio_init_int(atwinc15x0->params.irq_pin, GPIO_IN_PU, GPIO_FALLING,
                   atwinc15x0_isr, NULL);
 
-    if (atwinc15x0->params.chip_en_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(atwinc15x0->params.chip_en_pin)) {
         gpio_init(atwinc15x0->params.chip_en_pin, GPIO_OUT);
         gpio_set(atwinc15x0->params.chip_en_pin);
     }
 
-    if (atwinc15x0->params.wake_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(atwinc15x0->params.wake_pin)) {
         gpio_init(atwinc15x0->params.wake_pin, GPIO_OUT);
         gpio_set(atwinc15x0->params.wake_pin);
     }

--- a/drivers/atwinc15x0/atwinc15x0_bus.c
+++ b/drivers/atwinc15x0/atwinc15x0_bus.c
@@ -36,7 +36,7 @@ sint8 nm_bus_init(void *arg)
     (void)arg;
 
     assert(atwinc15x0);
-    assert(atwinc15x0->params.ssn_pin != GPIO_UNDEF);
+    assert(gpio_is_valid(atwinc15x0->params.ssn_pin));
 
     gpio_init(atwinc15x0->params.ssn_pin, GPIO_OUT);
     gpio_set(atwinc15x0->params.ssn_pin);

--- a/drivers/ccs811/ccs811.c
+++ b/drivers/ccs811/ccs811.c
@@ -75,7 +75,7 @@ int ccs811_init(ccs811_t *dev, const ccs811_params_t *params)
 
     int res = CCS811_OK;
 
-    if (dev->params.reset_pin != GPIO_UNDEF &&
+    if (gpio_is_valid(dev->params.reset_pin) &&
         gpio_init(dev->params.reset_pin, GPIO_OUT) == 0) {
         DEBUG_DEV("nRESET pin configured", dev);
         /* enable low active reset signal */
@@ -88,7 +88,7 @@ int ccs811_init(ccs811_t *dev, const ccs811_params_t *params)
         xtimer_usleep(1000);
     }
 
-    if (dev->params.wake_pin != GPIO_UNDEF &&
+    if (gpio_is_valid(dev->params.wake_pin) &&
         gpio_init(dev->params.wake_pin, GPIO_OUT) == 0) {
         gpio_clear(dev->params.wake_pin);
         DEBUG_DEV("nWAKE pin configured", dev);
@@ -208,7 +208,7 @@ int ccs811_set_int_mode(ccs811_t *dev, ccs811_int_mode_t mode)
 {
     ASSERT_PARAM(dev != NULL);
 
-    if (dev->params.int_pin == GPIO_UNDEF) {
+    if (!gpio_is_valid(dev->params.int_pin)) {
         DEBUG_DEV("nINT pin not configured", dev);
         return CCS811_ERROR_NO_INT_PIN;
     }
@@ -365,7 +365,7 @@ int ccs811_power_down (ccs811_t *dev)
     int res = ccs811_set_mode(dev, CCS811_MODE_IDLE);
     dev->params.mode = tmp_mode;
 
-    if (dev->params.wake_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.wake_pin)) {
         DEBUG_DEV("Setting nWAKE pin high", dev);
         gpio_set(dev->params.wake_pin);
     }
@@ -377,7 +377,7 @@ int ccs811_power_up (ccs811_t *dev)
 {
     ASSERT_PARAM(dev != NULL);
 
-    if (dev->params.wake_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.wake_pin)) {
         DEBUG_DEV("Setting nWAKE pin low", dev);
         gpio_clear(dev->params.wake_pin);
     }
@@ -490,7 +490,7 @@ static int _reg_read(const ccs811_t *dev, uint8_t reg, uint8_t *data, uint32_t l
     }
 
 #if MODULE_CCS811_FULL
-    if (dev->params.wake_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.wake_pin)) {
         /* wake the sensor with low active WAKE signal */
         gpio_clear(dev->params.wake_pin);
         /* t_WAKE is 50 us */
@@ -502,7 +502,7 @@ static int _reg_read(const ccs811_t *dev, uint8_t reg, uint8_t *data, uint32_t l
     i2c_release(dev->params.i2c_dev);
 
 #if MODULE_CCS811_FULL
-    if (dev->params.wake_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.wake_pin)) {
         /* let the sensor enter to sleep mode */
         gpio_set(dev->params.wake_pin);
         /* minimum t_DWAKE is 20 us */
@@ -551,7 +551,7 @@ static int _reg_write(const ccs811_t *dev, uint8_t reg, uint8_t *data, uint32_t 
     }
 
 #if MODULE_CCS811_FULL
-    if (dev->params.wake_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.wake_pin)) {
         /* wake the sensor with low active WAKE signal */
         gpio_clear(dev->params.wake_pin);
         /* t_WAKE is 50 us */
@@ -568,7 +568,7 @@ static int _reg_write(const ccs811_t *dev, uint8_t reg, uint8_t *data, uint32_t 
     i2c_release(dev->params.i2c_dev);
 
 #if MODULE_CCS811_FULL
-    if (dev->params.wake_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.wake_pin)) {
         /* let the sensor enter to sleep mode */
         gpio_set(dev->params.wake_pin);
         /* minimum t_DWAKE is 20 us */

--- a/drivers/dfplayer/dfplayer.c
+++ b/drivers/dfplayer/dfplayer.c
@@ -47,7 +47,7 @@ int dfplayer_init(dfplayer_t *dev, const dfplayer_params_t *params)
     mutex_init(&dev->mutex);
     dev->sync = locked;
 
-    if (dev->busy_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->busy_pin)) {
         if (gpio_init(dev->busy_pin, GPIO_IN)) {
             DEBUG("[dfplayer] Initializing busy pin failed\n");
             return -EIO;
@@ -101,7 +101,7 @@ int dfplayer_get_state(dfplayer_t *dev, dfplayer_state_t *state)
         return -EINVAL;
     }
 
-    if (dev->busy_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->busy_pin)) {
         if (!gpio_read(dev->busy_pin)) {
             *state = DFPLAYER_STATE_PLAYING;
             return 0;

--- a/drivers/dfplayer/dfplayer_internal.c
+++ b/drivers/dfplayer/dfplayer_internal.c
@@ -415,7 +415,7 @@ int dfplayer_file_cmd(dfplayer_t *dev, uint8_t cmd, uint8_t p1, uint8_t p2)
          *
          * We just check if the DFPlayer is actually playing
          */
-        if (dev->busy_pin != GPIO_UNDEF) {
+        if (gpio_is_valid(dev->busy_pin)) {
             /* Using BUSY pin to check if device is playing */
             if (gpio_read(dev->busy_pin)) {
                 /* Device not playing, file does not exist */

--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -73,7 +73,7 @@ static dose_signal_t state_transit_blocked(dose_t *ctx, dose_signal_t signal)
         netdev_trigger_event_isr((netdev_t *) ctx);
     }
 
-    if (ctx->sense_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(ctx->sense_pin)) {
         /* Enable GPIO interrupt for start bit sensing */
         gpio_irq_enable(ctx->sense_pin);
     }
@@ -107,7 +107,7 @@ static dose_signal_t state_transit_recv(dose_t *ctx, dose_signal_t signal)
 {
     dose_signal_t rc = DOSE_SIGNAL_NONE;
 
-    if (ctx->state != DOSE_STATE_RECV && ctx->sense_pin != GPIO_UNDEF) {
+    if (ctx->state != DOSE_STATE_RECV && gpio_is_valid(ctx->sense_pin)) {
         /* We freshly entered this state. Thus, no start bit sensing is required
          * anymore. Disable GPIO IRQs during the transmission. */
         gpio_irq_disable(ctx->sense_pin);
@@ -149,7 +149,7 @@ static dose_signal_t state_transit_send(dose_t *ctx, dose_signal_t signal)
 {
     (void) signal;
 
-    if (ctx->state != DOSE_STATE_SEND && ctx->sense_pin != GPIO_UNDEF) {
+    if (ctx->state != DOSE_STATE_SEND && gpio_is_valid(ctx->sense_pin)) {
         /* Disable GPIO IRQs during the transmission. */
         gpio_irq_disable(ctx->sense_pin);
     }
@@ -551,7 +551,7 @@ void dose_setup(dose_t *ctx, const dose_params_t *params, uint8_t index)
     uart_init(ctx->uart, params->baudrate, _isr_uart, (void *) ctx);
 
     ctx->sense_pin = params->sense_pin;
-    if (ctx->sense_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(ctx->sense_pin)) {
         gpio_init_int(ctx->sense_pin, GPIO_IN, GPIO_FALLING, _isr_gpio, (void *) ctx);
         gpio_irq_disable(ctx->sense_pin);
     }

--- a/drivers/hd44780/hd44780.c
+++ b/drivers/hd44780/hd44780.c
@@ -72,7 +72,7 @@ static void _send(const hd44780_t *dev, uint8_t value, hd44780_state_t state)
 {
     (state == HD44780_ON) ? gpio_set(dev->p.rs) : gpio_clear(dev->p.rs);
     /* if RW pin is available, set it to LOW */
-    if (dev->p.rw != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->p.rw)) {
         gpio_clear(dev->p.rw);
     }
     /* write data in 8Bit or 4Bit mode */
@@ -110,7 +110,7 @@ int hd44780_init(hd44780_t *dev, const hd44780_params_t *params)
     }
     dev->flag = 0;
     /* set mode depending on configured pins */
-    if (dev->p.data[4] != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->p.data[4])) {
         dev->flag |= HD44780_8BITMODE;
     }
     else {
@@ -133,7 +133,7 @@ int hd44780_init(hd44780_t *dev, const hd44780_params_t *params)
 
     gpio_init(dev->p.rs, GPIO_OUT);
     /* RW (read/write) of LCD not required, set it to GPIO_UNDEF */
-    if (dev->p.rw != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->p.rw)) {
         gpio_init(dev->p.rw, GPIO_OUT);
     }
     gpio_init(dev->p.enable, GPIO_OUT);
@@ -145,7 +145,7 @@ int hd44780_init(hd44780_t *dev, const hd44780_params_t *params)
     xtimer_usleep(HD44780_INIT_WAIT_XXL);
     gpio_clear(dev->p.rs);
     gpio_clear(dev->p.enable);
-    if (dev->p.rw != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->p.rw)) {
         gpio_clear(dev->p.rw);
     }
     /* put the LCD into 4 bit or 8 bit mode */

--- a/drivers/hmc5883l/hmc5883l.c
+++ b/drivers/hmc5883l/hmc5883l.c
@@ -101,7 +101,7 @@ int hmc5883l_init(hmc5883l_t *dev, const hmc5883l_params_t *params)
 int hmc5883l_init_int(hmc5883l_t *dev, hmc5883l_drdy_int_cb_t cb, void *arg)
 {
     assert(dev != NULL);
-    assert(dev->int_pin != GPIO_UNDEF);
+    assert(gpio_is_valid(dev->int_pin));
     DEBUG_DEV("", dev);
 
     if (gpio_init_int(dev->int_pin, GPIO_IN, GPIO_FALLING, cb, arg)) {

--- a/drivers/ili9341/ili9341.c
+++ b/drivers/ili9341/ili9341.c
@@ -96,7 +96,7 @@ int ili9341_init(ili9341_t *dev, const ili9341_params_t *params)
         return -1;
     }
 
-    if (dev->params->rst_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params->rst_pin)) {
         gpio_init(dev->params->rst_pin, GPIO_OUT);
         gpio_clear(dev->params->rst_pin);
         xtimer_usleep(120 * US_PER_MS);

--- a/drivers/ina3221/alerts.c
+++ b/drivers/ina3221/alerts.c
@@ -29,7 +29,7 @@ int _ina3221_enable_alert(ina3221_t *dev, ina3221_alert_t alert,
     if (alert >= INA3221_NUM_ALERTS) {
         return -ERANGE;
     }
-    if (dev->params.upins.apins.alert_pins[alert] == GPIO_UNDEF) {
+    if (!gpio_is_valid(dev->params.upins.apins.alert_pins[alert])) {
         return -ENOTSUP;
     }
     dev->alert_callbacks[alert] = cb;
@@ -49,7 +49,7 @@ int _ina3221_disable_alert(ina3221_t *dev, ina3221_alert_t alert)
     if (alert >= INA3221_NUM_ALERTS) {
         return -ERANGE;
     }
-    if (dev->params.upins.apins.alert_pins[alert] == GPIO_UNDEF) {
+    if (!gpio_is_valid(dev->params.upins.apins.alert_pins[alert])) {
         return -ENOTSUP;
     }
     gpio_irq_disable(dev->params.upins.apins.alert_pins[alert]);

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -43,6 +43,11 @@
  * definitions in `RIOT/boards/ * /include/periph_conf.h` will define the selected
  * GPIO pin.
  *
+ * @warning The scalar GPIO pin type `gpio_t` is deprecated and will be
+ * replaced by a structured GPIO pin type in a future GPIO API. Therefore,
+ * don't use the direct comparison of GPIO pins anymore. Instead, use the
+ * inline comparison functions @ref gpio_is_equal and @ref gpio_is_valid.
+ *
  * # (Low-) Power Implications
  *
  * On almost all platforms, we can only control the peripheral power state of
@@ -252,6 +257,27 @@ void gpio_toggle(gpio_t pin);
  * @param[in] value     value to set the pin to, 0 for LOW, HIGH otherwise
  */
 void gpio_write(gpio_t pin, int value);
+
+/**
+ * @brief   Test if a GPIO pin is equal to another GPIO pin
+ *
+ * @param[in] gpio1 First GPIO pin to check
+ * @param[in] gpio2 Second GPIO pin to check
+ */
+static inline int gpio_is_equal(gpio_t gpio1, gpio_t gpio2)
+{
+    return (gpio1 == gpio2);
+}
+
+/**
+ * @brief   Test if a GPIO pin is a valid pin and not declared as undefined.
+ *
+ * @param[in] gpio GPIO pin to check
+ */
+static inline int gpio_is_valid(gpio_t gpio)
+{
+    return (gpio != GPIO_UNDEF);
+}
 
 #ifdef __cplusplus
 }

--- a/drivers/itg320x/itg320x.c
+++ b/drivers/itg320x/itg320x.c
@@ -97,7 +97,7 @@ int itg320x_init(itg320x_t *dev, const itg320x_params_t *params)
 int itg320x_init_int(const itg320x_t *dev, itg320x_drdy_int_cb_t cb, void *arg)
 {
     assert(dev != NULL);
-    assert(dev->params.int_pin != GPIO_UNDEF);
+    assert(gpio_is_valid(dev->params.int_pin));
 
     DEBUG_DEV("cb=%p, arg=%p", dev, cb, arg);
 

--- a/drivers/lis2dh12/lis2dh12.c
+++ b/drivers/lis2dh12/lis2dh12.c
@@ -210,7 +210,7 @@ int lis2dh12_set_int(const lis2dh12_t *dev, const lis2dh12_int_params_t *params,
         /* first interrupt line (INT1) */
         case LIS2DH12_INT1:
             pin = dev->p->int1_pin;
-            assert (pin != GPIO_UNDEF);
+            assert (gpio_is_valid(pin));
 
             if (gpio_init_int(pin, GPIO_IN, GPIO_RISING, params->cb, params->arg)) {
                 return LIS2DH12_NOINT;
@@ -224,7 +224,7 @@ int lis2dh12_set_int(const lis2dh12_t *dev, const lis2dh12_int_params_t *params,
         /* second interrupt line (INT2) */
         case LIS2DH12_INT2:
             pin = dev->p->int2_pin;
-            assert (pin != GPIO_UNDEF);
+            assert (gpio_is_valid(pin));
 
             if (gpio_init_int(pin, GPIO_IN, GPIO_RISING, params->cb, params->arg)) {
                 return LIS2DH12_NOINT;

--- a/drivers/ltc4150/ltc4150.c
+++ b/drivers/ltc4150/ltc4150.c
@@ -33,7 +33,7 @@ static void pulse_cb(void *_dev)
     ltc4150_dir_t dir;
     ltc4150_dev_t *dev = _dev;
 
-    if ((dev->params.polarity == GPIO_UNDEF) ||
+    if ((!gpio_is_valid(dev->params.polarity)) ||
         (!gpio_read(dev->params.polarity))
         ) {
         dev->discharged++;
@@ -66,7 +66,7 @@ int ltc4150_init(ltc4150_dev_t *dev, const ltc4150_params_t *params)
     memset(dev, 0, sizeof(ltc4150_dev_t));
     dev->params = *params;
 
-    if (dev->params.shutdown != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.shutdown)) {
         /* Activate LTC4150 */
         if (gpio_init(dev->params.shutdown, GPIO_OUT)) {
             DEBUG("[ltc4150] Failed to initialize shutdown pin");
@@ -75,7 +75,7 @@ int ltc4150_init(ltc4150_dev_t *dev, const ltc4150_params_t *params)
         gpio_set(dev->params.shutdown);
     }
 
-    if (dev->params.polarity != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.polarity)) {
         gpio_mode_t mode = (dev->params.flags & LTC4150_POL_EXT_PULL_UP) ?
                            GPIO_IN : GPIO_IN_PU;
         if (gpio_init(dev->params.polarity, mode)) {
@@ -132,7 +132,7 @@ int ltc4150_shutdown(ltc4150_dev_t *dev)
 
     gpio_irq_disable(dev->params.interrupt);
 
-    if (dev->params.shutdown != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.shutdown)) {
         gpio_clear(dev->params.shutdown);
     }
 

--- a/drivers/ltc4150/ltc4150_saul.c
+++ b/drivers/ltc4150/ltc4150_saul.c
@@ -35,7 +35,7 @@ static int read_charge(const void *_dev, phydat_t *res)
         res->scale = -3;
         res->unit = UNIT_COULOMB;
         temp[0] = temp[2] - temp[1];
-        int dim = (dev->params.polarity != GPIO_UNDEF) ? 3 : 1;
+        int dim = (gpio_is_valid(dev->params.polarity)) ? 3 : 1;
         phydat_fit(res, temp, (unsigned)dim);
         return dim;
     }

--- a/drivers/motor_driver/motor_driver.c
+++ b/drivers/motor_driver/motor_driver.c
@@ -51,21 +51,21 @@ int motor_driver_init(motor_driver_t motor_driver)
     }
 
     for (uint8_t i = 0; i < motor_driver_conf->nb_motors; i++) {
-        if ((motor_driver_conf->motors[i].gpio_dir0 != GPIO_UNDEF)
+        if (gpio_is_valid(motor_driver_conf->motors[i].gpio_dir0)
             && (gpio_init(motor_driver_conf->motors[i].gpio_dir0,
                           GPIO_OUT))) {
             err = EIO;
             LOG_ERROR("gpio_dir0 init failed\n");
             goto motor_init_err;
         }
-        if ((motor_driver_conf->motors[i].gpio_dir1_or_brake != GPIO_UNDEF)
+        if (gpio_is_valid(motor_driver_conf->motors[i].gpio_dir1_or_brake)
             && (gpio_init(motor_driver_conf->motors[i].gpio_dir1_or_brake,
                           GPIO_OUT))) {
             err = EIO;
             LOG_ERROR("gpio_dir1_or_brake init failed\n");
             goto motor_init_err;
         }
-        if (motor_driver_conf->motors[i].gpio_enable != GPIO_UNDEF) {
+        if (gpio_is_valid(motor_driver_conf->motors[i].gpio_enable)) {
             if (gpio_init(motor_driver_conf->motors[i].gpio_enable,
                           GPIO_OUT)) {
                 err = EIO;
@@ -105,8 +105,8 @@ int motor_set(const motor_driver_t motor_driver, uint8_t motor_id, \
 
     /* Two direction GPIO, handling brake */
     if (motor_driver_conf->mode == MOTOR_DRIVER_2_DIRS) {
-        if ((dev->gpio_dir0 == GPIO_UNDEF) || \
-            (dev->gpio_dir1_or_brake == GPIO_UNDEF)) {
+        if (!gpio_is_valid(dev->gpio_dir0) || \
+            !gpio_is_valid(dev->gpio_dir1_or_brake)) {
             err = ENODEV;
             goto motor_set_err;
         }
@@ -124,7 +124,7 @@ int motor_set(const motor_driver_t motor_driver, uint8_t motor_id, \
     }
     /* Single direction GPIO */
     else if (motor_driver_conf->mode == MOTOR_DRIVER_1_DIR) {
-        if (dev->gpio_dir0 == GPIO_UNDEF) {
+        if (!gpio_is_valid(dev->gpio_dir0)) {
             err = ENODEV;
             goto motor_set_err;
         }
@@ -141,8 +141,8 @@ int motor_set(const motor_driver_t motor_driver, uint8_t motor_id, \
     }
     /* Single direction GPIO and brake GPIO */
     else if (motor_driver_conf->mode == MOTOR_DRIVER_1_DIR_BRAKE) {
-        if ((dev->gpio_dir0 == GPIO_UNDEF) || \
-            (dev->gpio_dir1_or_brake == GPIO_UNDEF)) {
+        if (!gpio_is_valid(dev->gpio_dir0) || \
+            !gpio_is_valid(dev->gpio_dir1_or_brake)) {
             err = ENODEV;
             goto motor_set_err;
         }
@@ -204,8 +204,8 @@ int motor_brake(const motor_driver_t motor_driver, uint8_t motor_id)
 
     /* Two direction GPIO, handling brake */
     if (motor_driver_conf->mode == MOTOR_DRIVER_2_DIRS) {
-        if ((dev->gpio_dir0 == GPIO_UNDEF) || \
-            (dev->gpio_dir1_or_brake == GPIO_UNDEF)) {
+        if (!gpio_is_valid(dev->gpio_dir0) || \
+            !gpio_is_valid(dev->gpio_dir1_or_brake)) {
             err = ENODEV;
             goto motor_brake_err;
         }
@@ -221,7 +221,7 @@ int motor_brake(const motor_driver_t motor_driver, uint8_t motor_id)
     }
     /* Single direction GPIO and brake GPIO */
     else if (motor_driver_conf->mode == MOTOR_DRIVER_1_DIR_BRAKE) {
-        if (dev->gpio_dir1_or_brake == GPIO_UNDEF) {
+        if (!gpio_is_valid(dev->gpio_dir1_or_brake)) {
             err = ENODEV;
             goto motor_brake_err;
         }
@@ -256,7 +256,7 @@ void motor_enable(const motor_driver_t motor_driver, uint8_t motor_id)
 
     const motor_t *dev = &motor_driver_conf->motors[motor_id];
 
-    assert(dev->gpio_enable != GPIO_UNDEF);
+    assert(gpio_is_valid(dev->gpio_enable));
 
     gpio_write(dev->gpio_enable, 1 ^ dev->gpio_enable_invert);
 }
@@ -272,7 +272,7 @@ void motor_disable(const motor_driver_t motor_driver, uint8_t motor_id)
 
     const motor_t *dev = &motor_driver_conf->motors[motor_id];
 
-    assert(dev->gpio_enable != GPIO_UNDEF);
+    assert(gpio_is_valid(dev->gpio_enable));
 
     gpio_write(dev->gpio_enable, dev->gpio_enable_invert);
 }

--- a/drivers/pca9685/pca9685.c
+++ b/drivers/pca9685/pca9685.c
@@ -104,7 +104,7 @@ int pca9685_init(pca9685_t *dev, const pca9685_params_t *params)
 
     DEBUG_DEV("params=%p", dev, params);
 
-    if (dev->params.oe_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.oe_pin)) {
         /* init the pin an disable outputs first */
         gpio_init(dev->params.oe_pin, GPIO_OUT);
         gpio_set(dev->params.oe_pin);
@@ -232,7 +232,7 @@ void pca9685_pwm_poweron(pca9685_t *dev)
         EXEC(_update(dev, PCA9685_REG_MODE1, PCA9685_MODE1_RESTART, 1));
     }
 
-    if (dev->params.oe_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.oe_pin)) {
         gpio_clear(dev->params.oe_pin);
     }
 
@@ -244,7 +244,7 @@ void pca9685_pwm_poweroff(pca9685_t *dev)
     ASSERT_PARAM(dev != NULL);
     DEBUG_DEV("", dev);
 
-    if (dev->params.oe_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.oe_pin)) {
         gpio_set(dev->params.oe_pin);
     }
 

--- a/drivers/periph_common/spi.c
+++ b/drivers/periph_common/spi.c
@@ -33,7 +33,7 @@ int spi_init_cs(spi_t bus, spi_cs_t cs)
     if (bus >= SPI_NUMOF) {
         return SPI_NODEV;
     }
-    if ((cs == SPI_CS_UNDEF) || (cs == GPIO_UNDEF)) {
+    if (gpio_is_equal(cs, SPI_CS_UNDEF) || !gpio_is_valid(cs)) {
         return SPI_NOCS;
     }
 

--- a/drivers/ph_oem/ph_oem.c
+++ b/drivers/ph_oem/ph_oem.c
@@ -181,7 +181,7 @@ static int _set_interrupt_pin(const ph_oem_t *dev)
 int ph_oem_enable_interrupt(ph_oem_t *dev, ph_oem_interrupt_pin_cb_t cb,
                             void *arg)
 {
-    if (dev->params.interrupt_pin == GPIO_UNDEF) {
+    if (!gpio_is_valid(dev->params.interrupt_pin)) {
         return PH_OEM_INTERRUPT_GPIO_UNDEF;
     }
 
@@ -292,7 +292,7 @@ int ph_oem_start_new_reading(const ph_oem_t *dev)
 
     /* if interrupt pin is undefined, poll till new reading was taken and stop
      * device form taking further readings */
-    if (dev->params.interrupt_pin == GPIO_UNDEF) {
+    if (!gpio_is_valid(dev->params.interrupt_pin)) {
         int result = _new_reading_available(dev);
         if (result < 0) {
             return result;

--- a/drivers/ph_oem/ph_oem_saul.c
+++ b/drivers/ph_oem/ph_oem_saul.c
@@ -30,7 +30,7 @@ static int read_ph(const void *dev, phydat_t *res)
     const ph_oem_t *mydev = dev;
     uint16_t ph_reading;
 
-    if (mydev->params.interrupt_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(mydev->params.interrupt_pin)) {
         puts("interrupt pin not supported with SAUL yet");
         return -ENOTSUP;
     }

--- a/drivers/qmc5883l/qmc5883l.c
+++ b/drivers/qmc5883l/qmc5883l.c
@@ -178,7 +178,7 @@ int qmc5883l_init_int(const qmc5883l_t *dev, gpio_cb_t cb, void *arg)
     assert(dev);
     assert(cb);
 
-    if (dev->pin_drdy == GPIO_UNDEF) {
+    if (!gpio_is_valid(dev->pin_drdy)) {
         return QMC5883L_NOCFG;
     }
     if (gpio_init_int(dev->pin_drdy, GPIO_IN, GPIO_RISING, cb, arg) != 0) {

--- a/drivers/rn2xx3/rn2xx3.c
+++ b/drivers/rn2xx3/rn2xx3.c
@@ -140,7 +140,7 @@ void rn2xx3_setup(rn2xx3_t *dev, const rn2xx3_params_t *params)
     dev->p = *params;
 
     /* initialize pins and perform hardware reset */
-    if (dev->p.pin_reset != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->p.pin_reset)) {
         gpio_init(dev->p.pin_reset, GPIO_OUT);
         gpio_set(dev->p.pin_reset);
     }
@@ -162,7 +162,7 @@ int rn2xx3_init(rn2xx3_t *dev)
     }
 
     /* if reset pin is connected, do a hardware reset */
-    if (dev->p.pin_reset != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->p.pin_reset)) {
         gpio_clear(dev->p.pin_reset);
         xtimer_usleep(RESET_DELAY);
         gpio_set(dev->p.pin_reset);

--- a/drivers/sdcard_spi/sdcard_spi.c
+++ b/drivers/sdcard_spi/sdcard_spi.c
@@ -97,7 +97,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
                 (gpio_init(card->params.clk,  GPIO_OUT) == 0) &&
                 (gpio_init(card->params.cs,   GPIO_OUT) == 0) &&
                 (gpio_init(card->params.miso, GPIO_IN_PU) == 0) &&
-                ( (card->params.power == GPIO_UNDEF) ||
+                ( (!gpio_is_valid(card->params.power)) ||
                   (gpio_init(card->params.power, GPIO_OUT) == 0)) ) {
 
                 DEBUG("gpio_init(): [OK]\n");
@@ -110,7 +110,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(sdcard_spi_t *card, sd_init_fsm_sta
         case SD_INIT_SPI_POWER_SEQ:
             DEBUG("SD_INIT_SPI_POWER_SEQ\n");
 
-            if (card->params.power != GPIO_UNDEF) {
+            if (gpio_is_valid(card->params.power)) {
                 gpio_write(card->params.power, card->params.power_act_high);
                 xtimer_usleep(SD_CARD_WAIT_AFTER_POWER_UP_US);
             }

--- a/drivers/sds011/sds011.c
+++ b/drivers/sds011/sds011.c
@@ -192,7 +192,7 @@ int sds011_init(sds011_t *dev, const sds011_params_t *params)
 {
     assert((dev != NULL) && (params != NULL) && (params->uart < UART_NUMOF));
 
-    if ((params->pwr_pin != GPIO_UNDEF) &&
+    if ((gpio_is_valid(params->pwr_pin)) &&
         (gpio_init(params->pwr_pin, GPIO_OUT) != 0)) {
         return SDS011_ERROR;
     }
@@ -230,7 +230,7 @@ int sds011_register_callback(sds011_t *dev, sds011_callback_t cb, void *ctx)
 void sds011_power_on(const sds011_t *dev)
 {
     assert(dev != NULL);
-    if(dev->params.pwr_pin != GPIO_UNDEF) {
+    if(gpio_is_valid(dev->params.pwr_pin)) {
         gpio_write(dev->params.pwr_pin, dev->params.pwr_ah);
     }
 }
@@ -238,7 +238,7 @@ void sds011_power_on(const sds011_t *dev)
 void sds011_power_off(const sds011_t *dev)
 {
     assert(dev != NULL);
-    if(dev->params.pwr_pin != GPIO_UNDEF) {
+    if(gpio_is_valid(dev->params.pwr_pin)) {
         gpio_write(dev->params.pwr_pin, !dev->params.pwr_ah);
     }
 }

--- a/drivers/soft_spi/soft_spi.c
+++ b/drivers/soft_spi/soft_spi.c
@@ -63,21 +63,22 @@ void soft_spi_init_pins(soft_spi_t bus)
     assert(soft_spi_bus_is_valid(bus));
 
     /* check that miso is not mosi is not clk*/
-    assert(soft_spi_config[bus].mosi_pin != soft_spi_config[bus].miso_pin);
-    assert(soft_spi_config[bus].mosi_pin != soft_spi_config[bus].clk_pin);
-    assert(soft_spi_config[bus].miso_pin != soft_spi_config[bus].clk_pin);
+    assert(!gpio_is_equal(soft_spi_config[bus].mosi_pin, soft_spi_config[bus].miso_pin));
+    assert(!gpio_is_equal(soft_spi_config[bus].mosi_pin, soft_spi_config[bus].clk_pin));
+    assert(!gpio_is_equal(soft_spi_config[bus].miso_pin, soft_spi_config[bus].clk_pin));
     /* mandatory pins */
-    assert((GPIO_UNDEF != soft_spi_config[bus].mosi_pin) || (GPIO_UNDEF != soft_spi_config[bus].miso_pin));
-    assert(GPIO_UNDEF != soft_spi_config[bus].clk_pin);
+    assert(gpio_is_valid(soft_spi_config[bus].mosi_pin) ||
+           gpio_is_valid(soft_spi_config[bus].miso_pin));
+    assert(gpio_is_valid(soft_spi_config[bus].clk_pin));
 
     /* initialize clock pin */
     gpio_init(soft_spi_config[bus].clk_pin, GPIO_OUT);
     /* initialize optional pins */
-    if (GPIO_UNDEF != soft_spi_config[bus].mosi_pin) {
+    if (gpio_is_valid(soft_spi_config[bus].mosi_pin)) {
         gpio_init(soft_spi_config[bus].mosi_pin, GPIO_OUT);
         gpio_clear(soft_spi_config[bus].mosi_pin);
     }
-    if (GPIO_UNDEF != soft_spi_config[bus].miso_pin) {
+    if (gpio_is_valid(soft_spi_config[bus].miso_pin)) {
         gpio_init(soft_spi_config[bus].mosi_pin, GPIO_IN);
     }
 }
@@ -90,7 +91,7 @@ int soft_spi_init_cs(soft_spi_t bus, soft_spi_cs_t cs)
         return SOFT_SPI_NODEV;
     }
 
-    if ((cs != GPIO_UNDEF) && (cs != SOFT_SPI_CS_UNDEF)) {
+    if (gpio_is_valid(cs) && !gpio_is_equal(cs, SOFT_SPI_CS_UNDEF)) {
         DEBUG("Soft SPI set user CS line\n");
         gpio_init(cs, GPIO_OUT);
         gpio_set(cs);
@@ -174,14 +175,14 @@ uint8_t soft_spi_transfer_byte(soft_spi_t bus, soft_spi_cs_t cs, bool cont, uint
     uint8_t retval = 0;
 
     /* activate the given chip select line */
-    if ((cs != GPIO_UNDEF) && (cs != SOFT_SPI_CS_UNDEF)) {
+    if (gpio_is_valid(cs) && !gpio_is_equal(cs, SOFT_SPI_CS_UNDEF)) {
         gpio_clear((gpio_t)cs);
     }
 
     retval = _transfer_one_byte(bus, out);
 
     if (!cont) {
-        if ((cs != GPIO_UNDEF) && (cs != SOFT_SPI_CS_UNDEF)) {
+        if (gpio_is_valid(cs) && !gpio_is_equal(cs, SOFT_SPI_CS_UNDEF)) {
             gpio_set((gpio_t)cs);
         }
     }

--- a/drivers/soft_uart/soft_uart.c
+++ b/drivers/soft_uart/soft_uart.c
@@ -151,7 +151,7 @@ int soft_uart_init(soft_uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void
         return UART_NOBAUD;
     }
 
-    if (cfg->rx_pin == GPIO_UNDEF) {
+    if (!gpio_is_valid(cfg->rx_pin)) {
         rx_cb = NULL;
     }
 
@@ -166,7 +166,7 @@ int soft_uart_init(soft_uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void
 
     ctx->state_rx = STATE_RX_IDLE;
 
-    if (cfg->tx_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(cfg->tx_pin)) {
         timer_init(cfg->tx_timer, cfg->timer_freq, _tx_timer_cb, (void *)uart);
         gpio_write(cfg->tx_pin, !(cfg->flags & SOFT_UART_FLAG_INVERT_TX));
         gpio_init(cfg->tx_pin, GPIO_OUT);

--- a/drivers/stmpe811/stmpe811.c
+++ b/drivers/stmpe811/stmpe811.c
@@ -160,7 +160,7 @@ int stmpe811_init(stmpe811_t *dev, const stmpe811_params_t * params, touch_event
     /* clear interrupt status */
     _clear_interrupt_status(dev);
 
-    if ((dev->params.int_pin != GPIO_UNDEF) && cb) {
+    if (gpio_is_valid(dev->params.int_pin) && cb) {
         DEBUG("[stmpe811] init: configuring touchscreen interrupt\n");
         gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_FALLING, cb, arg);
 

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -105,7 +105,7 @@ int sx127x_reset(const sx127x_t *dev)
      * 2. Set NReset in Hi-Z state
      * 3. Wait at least 5 milliseconds
      */
-    if (dev->params.reset_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.reset_pin)) {
         gpio_init(dev->params.reset_pin, GPIO_OUT);
 
         /* set reset pin to the state that triggers manual reset */
@@ -138,7 +138,7 @@ int sx127x_init(sx127x_t *dev)
 
     _init_timers(dev);
 
-    if (dev->params.reset_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.reset_pin)) {
         /* reset pin should be left floating during POR */
         gpio_init(dev->params.reset_pin, GPIO_IN);
 
@@ -257,7 +257,7 @@ static int _init_gpios(sx127x_t *dev)
     int res;
 
     /* Check if DIO0 pin is defined */
-    if (dev->params.dio0_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.dio0_pin)) {
         res = gpio_init_int(dev->params.dio0_pin, SX127X_DIO_PULL_MODE,
                             GPIO_RISING, sx127x_on_dio0_isr, dev);
         if (res < 0) {
@@ -272,7 +272,7 @@ static int _init_gpios(sx127x_t *dev)
     }
 
     /* Check if DIO1 pin is defined */
-    if (dev->params.dio1_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.dio1_pin)) {
         res = gpio_init_int(dev->params.dio1_pin, SX127X_DIO_PULL_MODE,
                             GPIO_RISING, sx127x_on_dio1_isr, dev);
         if (res < 0) {
@@ -282,7 +282,7 @@ static int _init_gpios(sx127x_t *dev)
     }
 
     /* check if DIO2 pin is defined */
-    if (dev->params.dio2_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.dio2_pin)) {
         res = gpio_init_int(dev->params.dio2_pin, SX127X_DIO_PULL_MODE,
                             GPIO_RISING, sx127x_on_dio2_isr, dev);
         if (res < 0) {
@@ -296,7 +296,7 @@ static int _init_gpios(sx127x_t *dev)
     }
 
     /* check if DIO3 pin is defined */
-    if (dev->params.dio3_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.dio3_pin)) {
         res = gpio_init_int(dev->params.dio3_pin, SX127X_DIO_PULL_MODE,
                             GPIO_RISING, sx127x_on_dio3_isr, dev);
         if (res < 0) {

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -203,7 +203,7 @@ void sx127x_start_cad(sx127x_t *dev)
                              /* | SX127X_RF_LORA_IRQFLAGS_CADDETECTED*/
                              );
 
-            if (dev->params.dio3_pin != GPIO_UNDEF) {
+            if (gpio_is_valid(dev->params.dio3_pin)) {
                 /* DIO3 = CADDone */
                 sx127x_reg_write(dev, SX127X_REG_DIOMAPPING1,
                                  (sx127x_reg_read(dev, SX127X_REG_DIOMAPPING1) &

--- a/drivers/tps6274x/tps6274x.c
+++ b/drivers/tps6274x/tps6274x.c
@@ -31,14 +31,14 @@ int tps6274x_init(tps6274x_t *dev, const tps6274x_params_t *params)
 
     dev->params = *params;
     for (uint8_t i = 0; i < 4; i++) {
-        if (dev->params.vsel[i] != GPIO_UNDEF) {
+        if (gpio_is_valid(dev->params.vsel[i])) {
             ret = gpio_init(dev->params.vsel[i], GPIO_OUT);
             if(ret < 0) {
                 return TPS6274X_ERR_INIT;
             }
         }
     }
-    if (dev->params.ctrl_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.ctrl_pin)) {
         ret = gpio_init(dev->params.ctrl_pin, GPIO_OUT);
         if(ret < 0) {
             return TPS6274X_ERR_INIT;
@@ -58,7 +58,7 @@ uint16_t tps6274x_switch_voltage(tps6274x_t *dev, uint16_t voltage)
     uint8_t vsel = (voltage - 1800) / 100;
     uint8_t vsel_set = 0;
     for (uint8_t i = 0; i < 4; i++) {
-        if (dev->params.vsel[i] != GPIO_UNDEF) {
+        if (gpio_is_valid(dev->params.vsel[i])) {
             gpio_write(dev->params.vsel[i], (vsel & (0x01 << i)));
             /* mark pins that could and had to be set */
             vsel_set |= vsel & (1 << i);
@@ -75,7 +75,7 @@ uint16_t tps6274x_switch_voltage(tps6274x_t *dev, uint16_t voltage)
 
 void tps6274x_load_ctrl(tps6274x_t *dev, int status)
 {
-    if (dev->params.ctrl_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->params.ctrl_pin)) {
         gpio_write(dev->params.ctrl_pin, status);
     }
 #if ENABLE_DEBUG

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -484,11 +484,11 @@ void xbee_setup(xbee_t *dev, const xbee_params_t *params)
     dev->p = *params;
 
     /* initialize pins */
-    if (dev->p.pin_reset != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->p.pin_reset)) {
         gpio_init(dev->p.pin_reset, GPIO_OUT);
         gpio_set(dev->p.pin_reset);
     }
-    if (dev->p.pin_sleep != GPIO_UNDEF) {
+    if (gpio_is_valid(dev->p.pin_sleep)) {
         gpio_init(dev->p.pin_sleep, GPIO_OUT);
         gpio_clear(dev->p.pin_sleep);
     }
@@ -586,7 +586,7 @@ int xbee_init(netdev_t *dev)
         return -ENXIO;
     }
     /* if reset pin is connected, do a hardware reset */
-    if (xbee->p.pin_reset != GPIO_UNDEF) {
+    if (gpio_is_valid(xbee->p.pin_reset)) {
         gpio_clear(xbee->p.pin_reset);
         xtimer_usleep(RESET_DELAY);
         gpio_set(xbee->p.pin_reset);

--- a/pkg/openwsn/contrib/debugpins.c
+++ b/pkg/openwsn/contrib/debugpins.c
@@ -39,7 +39,7 @@ static debugpins_config_t _configuration = {
 static void _set_checked(gpio_t pin)
 {
     if (IS_USED(MODULE_OPENWSN_DEBUGPINS)) {
-        if (pin != GPIO_UNDEF){
+        if (gpio_is_valid(pin)){
             gpio_set(pin);
         }
     }
@@ -48,7 +48,7 @@ static void _set_checked(gpio_t pin)
 static void _clear_checked(gpio_t pin)
 {
     if (IS_USED(MODULE_OPENWSN_DEBUGPINS)) {
-        if (pin != GPIO_UNDEF){
+        if (gpio_is_valid(pin)){
             gpio_clear(pin);
         }
     }
@@ -57,7 +57,7 @@ static void _clear_checked(gpio_t pin)
 static void _toggle_checked(gpio_t pin)
 {
     if (IS_USED(MODULE_OPENWSN_DEBUGPINS)) {
-        if (pin != GPIO_UNDEF){
+        if (gpio_is_valid(pin)){
             gpio_toggle(pin);
         }
     }
@@ -66,7 +66,7 @@ static void _toggle_checked(gpio_t pin)
 static void _init_checked(gpio_t pin)
 {
     if (IS_USED(MODULE_OPENWSN_DEBUGPINS)) {
-        if (pin != GPIO_UNDEF){
+        if (gpio_is_valid(pin)){
             gpio_init(pin, GPIO_OUT);
         }
     }

--- a/pkg/openwsn/contrib/leds.c
+++ b/pkg/openwsn/contrib/leds.c
@@ -41,7 +41,7 @@ static leds_config_t _configuration = {
 static void _toggle_checked(gpio_t pin)
 {
     if (IS_USED(MODULE_OPENWSN_LEDS)) {
-        if (pin != GPIO_UNDEF) {
+        if (gpio_is_valid(pin)) {
             gpio_toggle(pin);
         }
     }
@@ -50,7 +50,7 @@ static void _toggle_checked(gpio_t pin)
 static void _init_checked(gpio_t pin)
 {
     if (IS_USED(MODULE_OPENWSN_LEDS)) {
-        if (pin != GPIO_UNDEF) {
+        if (gpio_is_valid(pin)) {
             gpio_init(pin, GPIO_OUT);
         }
     }
@@ -59,7 +59,7 @@ static void _init_checked(gpio_t pin)
 static void _write_checked(gpio_t pin, uint8_t on_state)
 {
     if (IS_USED(MODULE_OPENWSN_LEDS)) {
-        if (pin != GPIO_UNDEF) {
+        if (gpio_is_valid(pin)) {
             gpio_write(pin, on_state);
         }
     }
@@ -70,7 +70,7 @@ static uint8_t _is_on_checked(gpio_t pin)
     if (IS_USED(MODULE_OPENWSN_LEDS)) {
         uint8_t ret = 0;
 
-        if (pin != GPIO_UNDEF) {
+        if (gpio_is_valid(pin)) {
             ret = gpio_read(pin);
         }
         return ret;

--- a/pkg/u8g2/contrib/u8x8_riotos.c
+++ b/pkg/u8g2/contrib/u8x8_riotos.c
@@ -70,15 +70,15 @@ static void _enable_pins(const u8x8_riotos_t *u8x8_riot_ptr)
         return;
     }
 
-    if (u8x8_riot_ptr->pin_cs != GPIO_UNDEF) {
+    if (gpio_is_valid(u8x8_riot_ptr->pin_cs)) {
         gpio_init(u8x8_riot_ptr->pin_cs, GPIO_OUT);
     }
 
-    if (u8x8_riot_ptr->pin_dc != GPIO_UNDEF) {
+    if (gpio_is_valid(u8x8_riot_ptr->pin_dc)) {
         gpio_init(u8x8_riot_ptr->pin_dc, GPIO_OUT);
     }
 
-    if (u8x8_riot_ptr->pin_reset != GPIO_UNDEF) {
+    if (gpio_is_valid(u8x8_riot_ptr->pin_reset)) {
         gpio_init(u8x8_riot_ptr->pin_reset, GPIO_OUT);
     }
 }
@@ -106,17 +106,17 @@ uint8_t u8x8_gpio_and_delay_riotos(u8x8_t *u8g2, uint8_t msg, uint8_t arg_int, v
             xtimer_nanosleep(arg_int * 100);
             break;
         case U8X8_MSG_GPIO_CS:
-            if (u8x8_riot_ptr != NULL && u8x8_riot_ptr->pin_cs != GPIO_UNDEF) {
+            if (u8x8_riot_ptr != NULL && gpio_is_valid(u8x8_riot_ptr->pin_cs)) {
                 gpio_write(u8x8_riot_ptr->pin_cs, arg_int);
             }
             break;
         case U8X8_MSG_GPIO_DC:
-            if (u8x8_riot_ptr != NULL && u8x8_riot_ptr->pin_dc != GPIO_UNDEF) {
+            if (u8x8_riot_ptr != NULL && gpio_is_valid(u8x8_riot_ptr->pin_dc)) {
                 gpio_write(u8x8_riot_ptr->pin_dc, arg_int);
             }
             break;
         case U8X8_MSG_GPIO_RESET:
-            if (u8x8_riot_ptr != NULL &&  u8x8_riot_ptr->pin_reset != GPIO_UNDEF) {
+            if (u8x8_riot_ptr != NULL && gpio_is_valid(u8x8_riot_ptr->pin_reset)) {
                 gpio_write(u8x8_riot_ptr->pin_reset, arg_int);
             }
             break;

--- a/pkg/ucglib/contrib/ucg_riotos.c
+++ b/pkg/ucglib/contrib/ucg_riotos.c
@@ -59,15 +59,15 @@ static void _enable_pins(const ucg_riotos_t *ucg_riot_ptr)
         return;
     }
 
-    if (ucg_riot_ptr->pin_cs != GPIO_UNDEF) {
+    if (gpio_is_valid(ucg_riot_ptr->pin_cs)) {
         gpio_init(ucg_riot_ptr->pin_cs, GPIO_OUT);
     }
 
-    if (ucg_riot_ptr->pin_cd != GPIO_UNDEF) {
+    if (gpio_is_valid(ucg_riot_ptr->pin_cd)) {
         gpio_init(ucg_riot_ptr->pin_cd, GPIO_OUT);
     }
 
-    if (ucg_riot_ptr->pin_reset != GPIO_UNDEF) {
+    if (gpio_is_valid(ucg_riot_ptr->pin_reset)) {
         gpio_init(ucg_riot_ptr->pin_reset, GPIO_OUT);
     }
 }
@@ -100,17 +100,17 @@ int16_t ucg_com_hw_spi_riotos(ucg_t *ucg, int16_t msg, uint16_t arg, uint8_t *da
             xtimer_usleep(arg);
             break;
         case UCG_COM_MSG_CHANGE_RESET_LINE:
-            if (ucg_riot_ptr != NULL &&  ucg_riot_ptr->pin_reset != GPIO_UNDEF) {
+            if (ucg_riot_ptr != NULL && gpio_is_valid(ucg_riot_ptr->pin_reset)) {
                 gpio_write(ucg_riot_ptr->pin_reset, arg);
             }
             break;
         case UCG_COM_MSG_CHANGE_CS_LINE:
-            if (ucg_riot_ptr != NULL &&  ucg_riot_ptr->pin_cs != GPIO_UNDEF) {
+            if (ucg_riot_ptr != NULL && gpio_is_valid(ucg_riot_ptr->pin_cs)) {
                 gpio_write(ucg_riot_ptr->pin_cs, arg);
             }
             break;
         case UCG_COM_MSG_CHANGE_CD_LINE:
-            if (ucg_riot_ptr != NULL &&  ucg_riot_ptr->pin_cd != GPIO_UNDEF) {
+            if (ucg_riot_ptr != NULL && gpio_is_valid(ucg_riot_ptr->pin_cd)) {
                 gpio_write(ucg_riot_ptr->pin_cd, arg);
             }
             break;

--- a/tests/driver_lis2dh12/main.c
+++ b/tests/driver_lis2dh12/main.c
@@ -107,7 +107,7 @@ int main(void)
 
 #ifdef MODULE_LIS2DH12_INT
     /* enable interrupt Pins */
-    if (lis2dh12_params[0].int1_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(lis2dh12_params[0].int1_pin)) {
         /* create and set the interrupt params */
         lis2dh12_int_params_t params_int1 = {
             .int_type = LIS2DH12_INT_TYPE_I1_IA1,
@@ -121,7 +121,7 @@ int main(void)
     }
 
     /* create and set the interrupt params */
-    if (lis2dh12_params[0].int2_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(lis2dh12_params[0].int2_pin)) {
         lis2dh12_int_params_t params_int2 = {
             .int_type = LIS2DH12_INT_TYPE_I2_IA2,
             .int_config = LIS2DH12_INT_CFG_YLIE,

--- a/tests/driver_ph_oem/main.c
+++ b/tests/driver_ph_oem/main.c
@@ -224,7 +224,7 @@ int main(void)
         }
     }
 
-    if (dev.params.interrupt_pin != GPIO_UNDEF) {
+    if (gpio_is_valid(dev.params.interrupt_pin)) {
         /* Setting up and enabling the interrupt pin of the pH OEM */
         printf("Enabling interrupt pin... ");
         if (ph_oem_enable_interrupt(&dev, interrupt_pin_callback,
@@ -259,7 +259,7 @@ int main(void)
         /* blocking for ~420ms till reading is done if no interrupt pin defined */
         ph_oem_start_new_reading(&dev);
 
-        if (dev.params.interrupt_pin != GPIO_UNDEF) {
+        if (gpio_is_valid(dev.params.interrupt_pin)) {
             /* when interrupt is defined, wait for the IRQ to fire and
              * the event to be posted, so the "reading_available_event_callback"
              * can be executed after */
@@ -267,7 +267,7 @@ int main(void)
             ev->handler(ev);
         }
 
-        if (dev.params.interrupt_pin == GPIO_UNDEF) {
+        if (!gpio_is_valid(dev.params.interrupt_pin)) {
 
             if (ph_oem_read_ph(&dev, &data) == PH_OEM_OK) {
                 printf("pH value raw: %d\n", data);

--- a/tests/driver_qmc5883l/main.c
+++ b/tests/driver_qmc5883l/main.c
@@ -97,7 +97,7 @@ int main(void)
     }
 #ifdef MODULE_QMC5883L_INT
     printf("Mode:             ");
-    if (qmc5883l_params[0].pin_drdy != GPIO_UNDEF) {
+    if (gpio_is_valid(qmc5883l_params[0].pin_drdy)) {
         puts("interrupt driven");
     }
     else {
@@ -121,7 +121,7 @@ int main(void)
 
 #ifdef MODULE_QMC5883L_INT
     /* safe a reference to the main thread TCB so we can wait for flags */
-    if (qmc5883l_params[0].pin_drdy != GPIO_UNDEF) {
+    if (gpio_is_valid(qmc5883l_params[0].pin_drdy)) {
         _tmain = thread_get_active();
 
         if (qmc5883l_init_int(&_dev, _on_drdy, NULL) != QMC5883L_OK) {


### PR DESCRIPTION
### Contribution description

The expandable GPIO API in PR #14602 requires the comparison of structured GPIO types. This means that inline functions have be used instead of direct comparisons. For the migration process, drivers, packages and tests must first be changed so that they use these inline comparison functions.

This PR is a split-off from PR #14602 and required by PR #14602.

### Testing procedure

Compilation should success. Since many sensor and actuator drivers are affected, a tests of all changes seem to be impractical. Therefore a very careful review of the changes should be done.

### Issues/PRs references

Required by PR #14602.