### PR TITLE
drivers/periph_common: RTC: fix doxygen

### DIFF
--- a/drivers/include/periph/rtc.h
+++ b/drivers/include/periph/rtc.h
@@ -52,7 +52,7 @@ extern "C" {
  *
  * 01.01.$RIOT_EPOCH will be the reset value of the RTC if supported.
  *
- * Internal RTC helper functions such as @see rtc_mktime and @see rtc_localtime
+ * Internal RTC helper functions such as @ref rtc_mktime and @ref rtc_localtime
  * will not work on dates earlier than that.
  */
 #define RIOT_EPOCH (2020)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The doxygen used `@see` instead of `@ref` which results in [this](https://doc.riot-os.org/group__drivers__periph__rtc.html#gae6d6a8215f604e1907b4df059179ea1c) output:


![image](https://user-images.githubusercontent.com/1301112/91718981-be61f780-eb94-11ea-986b-cefa0e851ff3.png)

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
