### PR TITLE
sock: cleanup dependencies

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -143,18 +143,12 @@ ifneq (,$(filter gnrc_sock_%,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_sock_async,$(USEMODULE)))
-  USEMODULE += sock_async
   USEMODULE += gnrc_netapi_callbacks
-endif
-
-ifneq (,$(filter gnrc_sock_ip,$(USEMODULE)))
-  USEMODULE += sock_ip
 endif
 
 ifneq (,$(filter gnrc_sock_udp,$(USEMODULE)))
   USEMODULE += gnrc_udp
   USEMODULE += random     # to generate random ports
-  USEMODULE += sock_udp
 endif
 
 ifneq (,$(filter gnrc_sock,$(USEMODULE)))
@@ -557,17 +551,14 @@ endif
 
 ifneq (,$(filter lwip_sock_ip,$(USEMODULE)))
   USEMODULE += lwip_raw
-  USEMODULE += sock_ip
 endif
 
 ifneq (,$(filter lwip_sock_tcp,$(USEMODULE)))
   USEMODULE += lwip_tcp
-  USEMODULE += sock_tcp
 endif
 
 ifneq (,$(filter lwip_sock_udp,$(USEMODULE)))
   USEMODULE += lwip_udp
-  USEMODULE += sock_udp
 endif
 
 ifneq (,$(filter lwip_%,$(USEMODULE)))
@@ -1024,7 +1015,6 @@ endif
 
 ifneq (,$(filter tinydtls_sock_dtls, $(USEMODULE)))
     USEPKG += tinydtls
-    USEMODULE += sock_dtls
 endif
 
 ifneq (,$(filter sock_dtls, $(USEMODULE)))

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -645,6 +645,12 @@ ifneq (,$(filter gnrc,$(USEMODULE)))
   USEMODULE += gnrc_netif
   USEMODULE += gnrc_netif_hdr
   USEMODULE += gnrc_pktbuf
+  ifneq (,$(filter sock_async, $(USEMODULE)))
+    USEMODULE += gnrc_sock_async
+  endif
+  ifneq (,$(filter sock_ip, $(USEMODULE)))
+    USEMODULE += gnrc_sock_ip
+  endif
   ifneq (,$(filter sock_udp, $(USEMODULE)))
     USEMODULE += gnrc_sock_udp
   endif

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -903,7 +903,7 @@ endif
 
 ifneq (,$(filter gcoap,$(USEMODULE)))
   USEMODULE += nanocoap
-  USEMODULE += gnrc_sock_async
+  USEMODULE += sock_async
   USEMODULE += sock_async_event
   USEMODULE += sock_util
   USEMODULE += event_callback

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -850,6 +850,7 @@ ifneq (,$(filter sock_async_event,$(USEMODULE)))
 endif
 
 ifneq (,$(filter sock_dns,$(USEMODULE)))
+  USEMODULE += sock_udp
   USEMODULE += sock_util
   USEMODULE += posix_headers
 endif
@@ -857,7 +858,6 @@ endif
 ifneq (,$(filter sock_util,$(USEMODULE)))
   USEMODULE += posix_inet
   USEMODULE += fmt
-  USEMODULE += sock_udp
 endif
 
 ifneq (,$(filter event_%,$(USEMODULE)))
@@ -905,6 +905,7 @@ ifneq (,$(filter gcoap,$(USEMODULE)))
   USEMODULE += nanocoap
   USEMODULE += sock_async
   USEMODULE += sock_async_event
+  USEMODULE += sock_udp
   USEMODULE += sock_util
   USEMODULE += event_callback
   USEMODULE += event_timeout

--- a/examples/asymcute_mqttsn/Makefile
+++ b/examples/asymcute_mqttsn/Makefile
@@ -12,7 +12,6 @@ RIOTBASE ?= $(CURDIR)/../..
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_sock_udp
 USEMODULE += gnrc_ipv6_default
 # Include MQTT-SN
 USEMODULE += asymcute

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -13,7 +13,7 @@ USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for IPv6 and UDP
 USEMODULE += gnrc_ipv6_default
-USEMODULE += gnrc_sock_udp
+USEMODULE += sock_udp
 
 # Add also the shell, some shell commands
 USEMODULE += shell

--- a/examples/dtls-sock/Makefile
+++ b/examples/dtls-sock/Makefile
@@ -16,10 +16,13 @@ USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for IPv6 and UDP
 USEMODULE += gnrc_ipv6_default
-USEMODULE += gnrc_sock_udp
 
-# Use tinydtls for sock_dtls
-USEMODULE += tinydtls_sock_dtls
+# Specify DTLS implementation
+USEPKG += tinydtls
+
+# Pull in sock APIs
+USEMODULE += sock_dtls
+USEMODULE += sock_udp
 
 # tinydtls needs crypto secure PRNG
 USEMODULE += prng_sha1prng

--- a/examples/dtls-wolfssl/Makefile
+++ b/examples/dtls-wolfssl/Makefile
@@ -13,7 +13,7 @@ USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for IPv6 and UDP
 USEMODULE += gnrc_ipv6_default
-USEMODULE += gnrc_sock_udp
+USEMODULE += sock_udp
 
 # Add also the shell, some shell commands
 USEMODULE += shell

--- a/examples/emcute_mqttsn/Makefile
+++ b/examples/emcute_mqttsn/Makefile
@@ -11,8 +11,7 @@ RIOTBASE ?= $(CURDIR)/../..
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
-# Specify the mandatory networking modules for IPv6 and UDP
-USEMODULE += gnrc_sock_udp
+# Specify the mandatory networking modules for IPv6
 USEMODULE += gnrc_ipv6_default
 # Include MQTT-SN
 USEMODULE += emcute

--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -13,8 +13,7 @@ USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for IPv6 and UDP
 USEMODULE += gnrc_ipv6_default
-USEMODULE += gnrc_udp
-USEMODULE += gnrc_sock_udp
+USEMODULE += sock_udp
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
 

--- a/examples/paho-mqtt/Makefile
+++ b/examples/paho-mqtt/Makefile
@@ -31,7 +31,6 @@ ifneq (0, $(LWIP_IPV4))
   USEMODULE += lwip_arp
   USEMODULE += lwip_ipv4
   USEMODULE += lwip_dhcp_auto
-  USEMODULE += lwip_sock_udp
   CFLAGS += -DETHARP_SUPPORT_STATIC_ENTRIES=1
   LWIP_IPV6 ?= 0
 else
@@ -44,11 +43,13 @@ ifneq (0, $(LWIP_IPV6))
 endif
 
 USEMODULE += lwip_netdev
-USEMODULE += lwip lwip_sock_ip
-USEMODULE += lwip_tcp lwip_sock_tcp
-USEMODULE += lwip_sock_async
+USEMODULE += lwip
 
 USEMODULE += sock_async_event
+USEMODULE += sock_ip
+USEMODULE += sock_udp
+USEMODULE += sock_tcp
+
 ####
 
 include $(RIOTBASE)/Makefile.include

--- a/examples/posix_select/Makefile
+++ b/examples/posix_select/Makefile
@@ -14,8 +14,7 @@ USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for socket communication via UDP
 USEMODULE += gnrc_ipv6_default
 # Add stack-specific implementations of sock modules
-USEMODULE += gnrc_sock_async
-USEMODULE += gnrc_sock_udp
+USEMODULE += sock_udp
 # Add POSIX modules
 USEMODULE += posix_select
 USEMODULE += posix_sockets

--- a/examples/posix_sockets/Makefile
+++ b/examples/posix_sockets/Makefile
@@ -13,8 +13,7 @@ USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for socket communication via UDP
 USEMODULE += gnrc_ipv6_default
-USEMODULE += gnrc_udp
-USEMODULE += gnrc_sock_udp
+USEMODULE += sock_udp
 USEMODULE += posix_sockets
 USEMODULE += posix_time
 USEMODULE += posix_inet

--- a/examples/suit_update/Makefile
+++ b/examples/suit_update/Makefile
@@ -25,8 +25,7 @@ endif
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for IPv6 and UDP
 USEMODULE += gnrc_ipv6_router_default
-USEMODULE += gnrc_udp
-USEMODULE += gnrc_sock_udp
+USEMODULE += sock_udp
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
 

--- a/examples/wakaama/Makefile
+++ b/examples/wakaama/Makefile
@@ -15,7 +15,7 @@ USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules
 USEMODULE += gnrc_ipv6_router_default
-USEMODULE += gnrc_sock_udp
+USEMODULE += sock_udp
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
 # Add also the shell, some shell commands

--- a/pkg/lwip/Makefile.dep
+++ b/pkg/lwip/Makefile.dep
@@ -4,6 +4,15 @@ FEATURES_REQUIRED += arch_32bit
 
 DEFAULT_MODULE += auto_init_lwip
 
-ifneq (,$(filter lwip_sock_async,$(USEMODULE)))
-  USEMODULE += sock_async
+ifneq (,$(filter sock_async,$(USEMODULE)))
+  USEMODULE += lwip_sock_async
+endif
+ifneq (,$(filter sock_ip,$(USEMODULE)))
+  USEMODULE += lwip_sock_ip
+endif
+ifneq (,$(filter sock_tcp,$(USEMODULE)))
+  USEMODULE += lwip_sock_tcp
+endif
+ifneq (,$(filter sock_udp,$(USEMODULE)))
+  USEMODULE += lwip_sock_udp
 endif

--- a/pkg/tinydtls/Makefile.dep
+++ b/pkg/tinydtls/Makefile.dep
@@ -8,3 +8,7 @@ USEMODULE += tinydtls_ecc
 
 # TinyDTLS only has support for 32-bit architectures ATM
 FEATURES_REQUIRED += arch_32bit
+
+ifneq (,$(filter sock_dtls,$(USEMODULE)))
+  USEMODULE += tinydtls_sock_dtls
+endif

--- a/tests/emcute/Makefile
+++ b/tests/emcute/Makefile
@@ -16,7 +16,7 @@ else
 endif
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_ipv6_default
-USEMODULE += gnrc_sock_udp
+USEMODULE += sock_udp
 USEMODULE += gnrc_netif_single          # Only one interface used and it makes
                                         # shell commands easier
 USEMODULE += emcute

--- a/tests/gnrc_ipv6_nib_dns/Makefile
+++ b/tests/gnrc_ipv6_nib_dns/Makefile
@@ -5,7 +5,7 @@ RIOTBASE ?= $(CURDIR)/../..
 export TAP ?= tap0
 
 USEMODULE += sock_dns
-USEMODULE += gnrc_sock_udp
+
 USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_ipv6_nib_dns
 # use Ethernet as link-layer protocol

--- a/tests/gnrc_sock_async_event/Makefile
+++ b/tests/gnrc_sock_async_event/Makefile
@@ -3,10 +3,9 @@ include ../Makefile.tests_common
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_ipv6_hdr
 USEMODULE += gnrc_pktdump
-USEMODULE += gnrc_sock_async
-USEMODULE += gnrc_sock_ip
-USEMODULE += gnrc_sock_udp
 USEMODULE += sock_async_event
+USEMODULE += sock_ip
+USEMODULE += sock_udp
 USEMODULE += od
 USEMODULE += xtimer
 

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -5,7 +5,6 @@ RIOTBASE ?= $(CURDIR)/../..
 export TAP ?= tap0
 
 USEMODULE += sock_dns
-USEMODULE += gnrc_sock_udp
 USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_ipv6_nib_dns
 USEMODULE += gnrc_netif_single          # Only one interface used and it makes

--- a/tests/gnrc_sock_ip/Makefile
+++ b/tests/gnrc_sock_ip/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-USEMODULE += gnrc_sock_ip
+USEMODULE += sock_ip
 USEMODULE += gnrc_ipv6
 USEMODULE += ps
 

--- a/tests/gnrc_sock_neterr/Makefile
+++ b/tests/gnrc_sock_neterr/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_neterr
-USEMODULE += gnrc_sock_udp
+USEMODULE += sock_udp
 USEMODULE += od
 USEMODULE += xtimer
 

--- a/tests/gnrc_sock_udp/Makefile
+++ b/tests/gnrc_sock_udp/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
 USEMODULE += gnrc_sock_check_reuse
-USEMODULE += gnrc_sock_udp
+USEMODULE += sock_udp
 USEMODULE += gnrc_ipv6
 USEMODULE += ps
 

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -21,11 +21,13 @@ ifneq (0, $(LWIP_IPV6))
 endif
 
 # including lwip_ipv6_mld would currently break this test on at86rf2xx radios
-USEMODULE += lwip lwip_sock_ip lwip_netdev
-USEMODULE += lwip_udp lwip_sock_udp
-USEMODULE += lwip_tcp lwip_sock_tcp
-USEMODULE += lwip_sock_async
+USEMODULE += lwip lwip_netdev
+USEMODULE += lwip_udp
+USEMODULE += lwip_tcp
 USEMODULE += sock_async_event
+USEMODULE += sock_ip
+USEMODULE += sock_tcp
+USEMODULE += sock_udp
 USEMODULE += sock_util
 USEMODULE += shell
 USEMODULE += shell_commands

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -20,10 +20,10 @@ endif
 USEMODULE += inet_csum
 USEMODULE += l2util
 USEMODULE += lwip_netdev
-USEMODULE += lwip_sock_ip
 USEMODULE += netdev_eth
 USEMODULE += netdev_test
 USEMODULE += ps
+USEMODULE += sock_ip
 
 DISABLE_MODULE += auto_init_lwip
 

--- a/tests/lwip_sock_tcp/Makefile
+++ b/tests/lwip_sock_tcp/Makefile
@@ -19,10 +19,10 @@ endif
 
 USEMODULE += inet_csum
 USEMODULE += lwip_netdev
-USEMODULE += lwip_sock_tcp
 USEMODULE += netdev_eth
 USEMODULE += netdev_test
 USEMODULE += ps
+USEMODULE += sock_tcp
 
 DISABLE_MODULE += auto_init_lwip
 

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -20,10 +20,10 @@ endif
 USEMODULE += inet_csum
 USEMODULE += l2util
 USEMODULE += lwip_netdev
-USEMODULE += lwip_sock_udp
 USEMODULE += netdev_eth
 USEMODULE += netdev_test
 USEMODULE += ps
+USEMODULE += sock_udp
 
 DISABLE_MODULE += auto_init_lwip
 

--- a/tests/nanocoap_cli/Makefile
+++ b/tests/nanocoap_cli/Makefile
@@ -6,8 +6,7 @@ USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules
 USEMODULE += gnrc_ipv6_default
-USEMODULE += gnrc_udp
-USEMODULE += gnrc_sock_udp
+USEMODULE += sock_udp
 
 USEMODULE += nanocoap_sock
 

--- a/tests/pkg_libcoap/Makefile
+++ b/tests/pkg_libcoap/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
 USEMODULE += gnrc_ipv6
-USEMODULE += gnrc_sock_udp
+USEMODULE += sock_udp
 USEPKG += libcoap
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_microcoap/Makefile
+++ b/tests/pkg_microcoap/Makefile
@@ -4,14 +4,12 @@ include ../Makefile.tests_common
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
-# Specify the mandatory networking modules for IPv6 and UDP
+# Specify the mandatory networking modules for IPv6
 USEMODULE += gnrc_ipv6_default
-USEMODULE += gnrc_udp
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
 
-#
-USEMODULE += gnrc_sock_udp
+USEMODULE += sock_udp
 
 USEPKG += microcoap
 

--- a/tests/pkg_tinydtls_sock_async/Makefile
+++ b/tests/pkg_tinydtls_sock_async/Makefile
@@ -9,14 +9,14 @@ USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for IPv6 and UDP
 USEMODULE += gnrc_ipv6_default
-USEMODULE += gnrc_sock_async
-USEMODULE += gnrc_sock_udp
 USEMODULE += sock_async_event
+USEMODULE += sock_dtls
+USEMODULE += sock_udp
 USEMODULE += event_thread_medium
 USEMODULE += event_timeout
 
 # Use tinydtls for sock_dtls
-USEMODULE += tinydtls_sock_dtls
+USEPKG += tinydtls
 # tinydtls needs crypto secure PRNG
 USEMODULE += prng_sha1prng
 

--- a/tests/riotboot_flashwrite/Makefile
+++ b/tests/riotboot_flashwrite/Makefile
@@ -9,8 +9,7 @@ USEMODULE += auto_init_gnrc_netif
 # Specify the mandatory networking modules for IPv6 and UDP
 USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_ipv6_router_default
-USEMODULE += gnrc_udp
-USEMODULE += gnrc_sock_udp
+USEMODULE += sock_udp
 # Additional networking modules that can be dropped if not needed
 USEMODULE += gnrc_icmpv6_echo
 

--- a/tests/sntp/Makefile
+++ b/tests/sntp/Makefile
@@ -1,7 +1,6 @@
 include ../Makefile.tests_common
 
 USEMODULE += sntp
-USEMODULE += gnrc_sock_udp
 USEMODULE += gnrc_ipv6_default
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_netdev_default


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
As discussed in https://github.com/RIOT-OS/RIOT/pull/14886#issuecomment-683704224 the logical conclusion of https://github.com/RIOT-OS/RIOT/pull/12931 is that an application should pull in the pseudo-module of a sock API, not its implementation. In addition to making the inclusion of `sock` more clearer, it gives us the possibility to remove a circular dependency in the build system.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
It _should_ just be verifiable by compiling all applications, but it is safer if the various `test/*_sock_*` applications are also run (in all their variations, so `tests/lwip_sock_*` should also be run with `LWIP_IPV4=1` and `LWIP_IPV4=1 LWIP_IPV6=1`).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Follow-up on https://github.com/RIOT-OS/RIOT/pull/12931
Discussed in https://github.com/RIOT-OS/RIOT/pull/14886
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
