### PR TITLE
drivers/adcxx1c: add clear alert function

### DIFF
--- a/drivers/adcxx1c/adcxx1c.c
+++ b/drivers/adcxx1c/adcxx1c.c
@@ -168,3 +168,29 @@ int adcxx1c_set_alert_parameters(const adcxx1c_t *dev, int16_t low_limit,
 
     return ADCXX1C_OK;
 }
+
+int adcxx1c_get_and_clear_alert(const adcxx1c_t *dev)
+{
+    int status;
+    uint8_t alert;
+
+    i2c_acquire(DEV);
+
+    status = i2c_read_reg(DEV, ADDR, ADCXX1C_ALERT_STATUS_ADDR, &alert, 0);
+    if (status < 0) {
+        i2c_release(DEV);
+        DEBUG("[adcxx1c] get_and_clear_alert - error: unable to read reg (%d)\n", status);
+        return ADCXX1C_NOI2C;
+    }
+
+    status = i2c_write_reg(DEV, ADDR, ADCXX1C_ALERT_STATUS_ADDR, alert, 0);
+    if (status < 0) {
+        i2c_release(DEV);
+        DEBUG("[adcxx1c] get_and_clear_alert - error: unable to write reg (%d)\n", status);
+        return ADCXX1C_NOI2C;
+    }
+
+    i2c_release(DEV);
+
+    return alert;
+}

--- a/drivers/include/adcxx1c.h
+++ b/drivers/include/adcxx1c.h
@@ -88,6 +88,14 @@ enum {
 };
 
 /**
+ * @brief   Alert values
+ */
+enum {
+    ADCXX1C_ALERT_UNDER_RANGE   = 1,    /**< Measured voltage fell below Vlow */
+    ADCXX1C_ALERT_OVER_RANGE    = 2,    /**< Measured voltage exceeded Vhigh */
+};
+
+/**
  * @brief   ADCxx1C params
  */
 typedef struct adcxx1c_params {
@@ -158,6 +166,16 @@ int adcxx1c_enable_alert(adcxx1c_t *dev, adcxx1c_cb_t cb, void *arg);
  */
 int adcxx1c_set_alert_parameters(const adcxx1c_t *dev, int16_t low_limit,
                                  int16_t high_limit, int16_t hysteresis);
+
+/**
+ * @brief   Get alert source and clear it
+ *
+ * @param[in,out]   dev       device descriptor
+ *
+ * @return a combination of ADCXX1C_ALERT_OVER_RANGE and ADCXX1C_ALERT_UNDER_RANGE on success
+ * @return negative error code on error
+ */
+int adcxx1c_get_and_clear_alert(const adcxx1c_t *dev);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION

### Contribution description

Adds a function to get and clear alert.

It was already possible to enable and configure an alert with `adcxx1c_enable_alert()` and `adcxx1c_set_alert_parameters()`. With this addition, one can read the alert reason (over / under) and clear it.

### Testing procedure

- configure and enable alert
- trigger an alert
- read the alert reason

