### PR TITLE
mtd_spi_nor | littlefs: 

### DIFF
--- a/drivers/include/mtd_spi_nor.h
+++ b/drivers/include/mtd_spi_nor.h
@@ -36,6 +36,24 @@ extern "C"
 {
 #endif
 
+#define STATUS_WIP  0x01u
+#define STATUS_WEL  0x02u
+#define STATUS_BP0  0x04u
+#define STATUS_BP1  0x08u
+#define STATUS_BP2  0x10u
+#define STATUS_BP3  0x20u
+#define STATUS_QE   0x40u
+#define STATUS_SRWD 0x80u
+
+#define SECURITY_SOTP 0x01u
+#define SECURITY_LDSO 0x02u
+#define SECURITY_PSB  0x04u
+#define SECURITY_ESB  0x08u
+#define SECURITY_XXXXX 0x10u
+#define SECURITY_PFAIL 0x20u
+#define SECURITY_EFAIL 0x40u
+#define SECURITY_WPSEL 0x80u
+
 /**
  * @brief   SPI NOR flash opcode table
  */
@@ -53,7 +71,7 @@ typedef struct {
     uint8_t chip_erase;      /**< Chip erase */
     uint8_t sleep;           /**< Deep power down */
     uint8_t wake;            /**< Release from deep power down */
-    /* TODO: enter 4 byte address mode for large memories */
+    uint8_t rdscur;          /**< Read security register */
 } mtd_spi_nor_opcode_t;
 
 /**

--- a/drivers/mtd_spi_nor/mtd_spi_nor.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor.c
@@ -317,6 +317,34 @@ static uint32_t mtd_spi_nor_get_size(const mtd_jedec_id_t *id)
     return 1 << id->device[1];
 }
 
+static inline void wait_for_write_enable_cleared(const mtd_spi_nor_t *dev)
+{
+    do {
+        uint8_t status;
+        mtd_spi_cmd_read(dev, dev->params->opcode->rdsr, &status, sizeof(status));
+
+        TRACE("mtd_spi_nor: wait device status = 0x%02x, waiting !WEL\n", (unsigned int)status);
+        if ((status & STATUS_WEL) == 0) {
+            break;
+        }
+        thread_yield();
+    } while (1);
+}
+
+static inline void wait_for_write_enable_set(const mtd_spi_nor_t *dev)
+{
+    do {
+        uint8_t status;
+        mtd_spi_cmd_read(dev, dev->params->opcode->rdsr, &status, sizeof(status));
+
+        TRACE("mtd_spi_nor: wait device status = 0x%02x, waiting WEL\n", (unsigned int)status);
+        if (status & STATUS_WEL) {
+            break;
+        }
+        thread_yield();
+    } while (1);
+}
+
 static inline void wait_for_write_complete(const mtd_spi_nor_t *dev, uint32_t us)
 {
     unsigned i = 0, j = 0;
@@ -328,8 +356,8 @@ static inline void wait_for_write_complete(const mtd_spi_nor_t *dev, uint32_t us
         uint8_t status;
         mtd_spi_cmd_read(dev, dev->params->opcode->rdsr, &status, sizeof(status));
 
-        TRACE("mtd_spi_nor: wait device status = 0x%02x\n", (unsigned int)status);
-        if ((status & 1) == 0) { /* TODO magic number */
+        TRACE("mtd_spi_nor: wait device status = 0x%02x, waiting !WIP\n", (unsigned int)status);
+        if ((status & STATUS_WIP) == 0) {
             break;
         }
         i++;
@@ -479,6 +507,7 @@ static int mtd_spi_nor_read(mtd_dev_t *mtd, void *dest, uint32_t addr, uint32_t 
 
 static int mtd_spi_nor_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uint32_t size)
 {
+    int ret = 0;
     uint32_t total_size = mtd->page_size * mtd->pages_per_sector * mtd->sector_count;
 
     DEBUG("mtd_spi_nor_write: %p, %p, 0x%" PRIx32 ", 0x%" PRIx32 "\n",
@@ -505,14 +534,29 @@ static int mtd_spi_nor_write(mtd_dev_t *mtd, const void *src, uint32_t addr, uin
     /* write enable */
     mtd_spi_cmd(dev, dev->params->opcode->wren);
 
+    /* Wait for WEL to be set */
+    wait_for_write_enable_set(dev);
+
     /* Page program */
     mtd_spi_cmd_addr_write(dev, dev->params->opcode->page_program, addr_be, src, size);
 
     /* waiting for the command to complete before returning */
     wait_for_write_complete(dev, 0);
 
+    /* Wait for WEL to be cleared */
+    wait_for_write_enable_cleared(dev);
+
+    /* Read security register */
+    uint8_t rdscur;
+    mtd_spi_cmd_read(dev, dev->params->opcode->rdscur, &rdscur, sizeof(rdscur));
+    if (rdscur & SECURITY_PFAIL) {
+        DEBUG("mtd_spi_nor_write: ERR: page program failed!\n");
+        ret = -EIO;
+    }
+
     mtd_spi_release(dev);
-    return 0;
+
+    return ret;
 }
 
 static int mtd_spi_nor_write_page(mtd_dev_t *mtd, const void *src, uint32_t page, uint32_t offset,
@@ -525,6 +569,7 @@ static int mtd_spi_nor_write_page(mtd_dev_t *mtd, const void *src, uint32_t page
 
     uint32_t remaining = mtd->page_size - offset;
     size = MIN(remaining, size);
+    int ret = size;
 
     be_uint32_t addr_be = byteorder_htonl(page * mtd->page_size + offset);
 
@@ -533,19 +578,34 @@ static int mtd_spi_nor_write_page(mtd_dev_t *mtd, const void *src, uint32_t page
     /* write enable */
     mtd_spi_cmd(dev, dev->params->opcode->wren);
 
+    /* Wait for WEL to be set */
+    wait_for_write_enable_set(dev);
+
     /* Page program */
     mtd_spi_cmd_addr_write(dev, dev->params->opcode->page_program, addr_be, src, size);
 
     /* waiting for the command to complete before returning */
     wait_for_write_complete(dev, 0);
 
+    /* Wait for WEL to be cleared */
+    wait_for_write_enable_cleared(dev);
+
+    /* Read security register */
+    uint8_t rdscur;
+    mtd_spi_cmd_read(dev, dev->params->opcode->rdscur, &rdscur, sizeof(rdscur));
+    if (rdscur & SECURITY_PFAIL) {
+        DEBUG("mtd_spi_nor_write: ERR: page program failed!\n");
+        ret = -EIO;
+    }
+
     mtd_spi_release(dev);
 
-    return size;
+    return ret;
 }
 
 static int mtd_spi_nor_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size)
 {
+    int ret = 0;
     DEBUG("mtd_spi_nor_erase: %p, 0x%" PRIx32 ", 0x%" PRIx32 "\n",
           (void *)mtd, addr, size);
     mtd_spi_nor_t *dev = (mtd_spi_nor_t *)mtd;
@@ -574,6 +634,9 @@ static int mtd_spi_nor_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size)
         be_uint32_t addr_be = byteorder_htonl(addr);
         /* write enable */
         mtd_spi_cmd(dev, dev->params->opcode->wren);
+
+        /* Wait for WEL to be set */
+        wait_for_write_enable_set(dev);
 
         if (size == total_size) {
             mtd_spi_cmd(dev, dev->params->opcode->chip_erase);
@@ -605,10 +668,21 @@ static int mtd_spi_nor_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size)
 
         /* waiting for the command to complete before continuing */
         wait_for_write_complete(dev, us);
+
+        /* Wait for WEL to be cleared */
+        wait_for_write_enable_cleared(dev);
+
+        /* Read security register */
+        uint8_t rdscur;
+        mtd_spi_cmd_read(dev, dev->params->opcode->rdscur, &rdscur, sizeof(rdscur));
+        if (rdscur & SECURITY_EFAIL) {
+            DEBUG("mtd_spi_nor_erase: ERR: erase failed!\n");
+            ret = -EIO;
+        }
     }
     mtd_spi_release(dev);
 
-    return 0;
+    return ret;
 }
 
 static int mtd_spi_nor_power(mtd_dev_t *mtd, enum mtd_power_state power)

--- a/drivers/mtd_spi_nor/mtd_spi_nor_configs.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor_configs.c
@@ -40,6 +40,7 @@ const mtd_spi_nor_opcode_t mtd_spi_nor_opcode_default = {
     .chip_erase      = 0xc7,
     .sleep           = 0xb9,
     .wake            = 0xab,
+    .rdscur          = 0x2b,
 };
 
 const mtd_spi_nor_opcode_t mtd_spi_nor_opcode_default_4bytes = {
@@ -56,6 +57,7 @@ const mtd_spi_nor_opcode_t mtd_spi_nor_opcode_default_4bytes = {
     .chip_erase      = 0xc7,
     .sleep           = 0xb9,
     .wake            = 0xab,
+    .rdscur          = 0x2b,
 };
 
 /** @} */

--- a/pkg/littlefs/fs/littlefs_fs.c
+++ b/pkg/littlefs/fs/littlefs_fs.c
@@ -85,8 +85,12 @@ static int _dev_write(const struct lfs_config *c, lfs_block_t block,
     DEBUG("lfs_write: c=%p, block=%" PRIu32 ", off=%" PRIu32 ", buf=%p, size=%" PRIu32 "\n",
           (void *)c, block, off, buffer, size);
 
-    return mtd_write_page(mtd, buffer, (fs->base_addr + block) * mtd->pages_per_sector,
-                          off, size);
+    int ret = mtd_write_page(mtd, buffer, (fs->base_addr + block) * mtd->pages_per_sector,
+                             off, size);
+    if (ret == -EIO) {
+        ret = LFS_ERR_CORRUPT;
+    }
+    return ret;
 }
 
 static int _dev_erase(const struct lfs_config *c, lfs_block_t block)
@@ -96,7 +100,11 @@ static int _dev_erase(const struct lfs_config *c, lfs_block_t block)
 
     DEBUG("lfs_erase: c=%p, block=%" PRIu32 "\n", (void *)c, block);
 
-    return mtd_erase_sector(mtd, fs->base_addr + block, 1);
+    int ret = mtd_erase_sector(mtd, fs->base_addr + block, 1);
+    if (ret == -EIO) {
+        ret = LFS_ERR_CORRUPT;
+    }
+    return ret;
 }
 
 static int _dev_sync(const struct lfs_config *c)

--- a/pkg/littlefs2/fs/littlefs2_fs.c
+++ b/pkg/littlefs2/fs/littlefs2_fs.c
@@ -85,8 +85,12 @@ static int _dev_write(const struct lfs_config *c, lfs_block_t block,
     DEBUG("lfs_write: c=%p, block=%" PRIu32 ", off=%" PRIu32 ", buf=%p, size=%" PRIu32 "\n",
           (void *)c, block, off, buffer, size);
 
-    return mtd_write_page(mtd, buffer, (fs->base_addr + block) * mtd->pages_per_sector,
-                          off, size);
+    int ret = mtd_write_page(mtd, buffer, (fs->base_addr + block) * mtd->pages_per_sector,
+                             off, size);
+    if (ret == -EIO) {
+        ret = LFS_ERR_CORRUPT;
+    }
+    return ret;
 }
 
 static int _dev_erase(const struct lfs_config *c, lfs_block_t block)
@@ -96,7 +100,11 @@ static int _dev_erase(const struct lfs_config *c, lfs_block_t block)
 
     DEBUG("lfs_erase: c=%p, block=%" PRIu32 "\n", (void *)c, block);
 
-    return mtd_erase_sector(mtd, fs->base_addr + block, 1);
+    int ret = mtd_erase_sector(mtd, fs->base_addr + block, 1);
+    if (ret == -EIO) {
+        ret = LFS_ERR_CORRUPT;
+    }
+    return ret;
 }
 
 static int _dev_sync(const struct lfs_config *c)


### PR DESCRIPTION

### Contribution description

This PR improves the reliability of `mtd_spi_nor` and `littlefs`:
- `mtd_spi_nor`: properly checks for `WEL` enabling/disabling, check for errors when writing/erasing and return a dedicated error code (`-EIO`).
- `littlefs`: catch `-EIO` and translate it into `LFS_ERR_CORRUPT` that is internally used to realloc sectors if needed

### Testing procedure

Check that littlefs(2) still works (`examples/filesystem`).
This has been tested with flash that had dead sectors. littlefs could detect them and recover.

