### PR TITLE
thread: Add THREAD_NAMES make flag

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -243,6 +243,12 @@ ifeq ($(DEVELHELP),1)
   CFLAGS += -DDEVELHELP
 endif
 
+# Set this to 1 to enable thread names
+THREAD_NAMES ?= 0
+ifeq ($(THREAD_NAMES),1)
+  CFLAGS += -DCONFIG_THREAD_NAMES
+endif
+
 # Override LOG_LEVEL if variable is set and if CFLAGS doesn't already contain
 # a LOG_LEVEL config
 ifdef LOG_LEVEL

--- a/core/Kconfig
+++ b/core/Kconfig
@@ -46,3 +46,19 @@ config MODULE_CORE_THREAD_FLAGS
     bool "Thread flags"
 
 endif # MODULE_CORE
+
+menuconfig KCONFIG_USEMODULE_CORE
+    bool "Configure RIOT Core"
+    depends on USEMODULE_CORE
+    help
+        Configure RIOT Core using Kconfig.
+
+if KCONFIG_USEMODULE_CORE
+
+config THREAD_NAMES
+    bool "Store thread name strings"
+    help
+        By default, thread names are not stored if DEVELHELP is not used.
+        Use this parameter to store them for non-devel builds.
+
+endif # KCONFIG_USEMODULE_CORE

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -133,6 +133,16 @@
 extern "C" {
 #endif
 
+#if defined(DEVELHELP) && !defined(CONFIG_THREAD_NAMES)
+/**
+ * @brief   This global macro enable storage of thread names to help developers.
+ *
+ *          To activate it set environment variable `THREAD_NAMES=1`, or use Kconfig.
+ *          It is automatically enabled if `DEVELHELP` is.
+ */
+#define CONFIG_THREAD_NAMES
+#endif
+
 /**
  * @brief Prototype for a thread entry function
  */
@@ -172,8 +182,10 @@ struct _thread {
     || defined(MODULE_MPU_STACK_GUARD) || defined(DOXYGEN)
     char *stack_start;              /**< thread's stack start address   */
 #endif
-#if defined(DEVELHELP) || defined(DOXYGEN)
+#if defined(CONFIG_THREAD_NAMES) || defined(DOXYGEN)
     const char *name;               /**< thread's name                  */
+#endif
+#if defined(DEVELHELP) || defined(DOXYGEN)
     int stack_size;                 /**< thread's stack size            */
 #endif
 /* enable TLS only when Picolibc is compiled with TLS enabled */

--- a/core/thread.c
+++ b/core/thread.c
@@ -42,7 +42,7 @@ thread_status_t thread_getstatus(kernel_pid_t pid)
 
 const char *thread_getname(kernel_pid_t pid)
 {
-#ifdef DEVELHELP
+#ifdef CONFIG_THREAD_NAMES
     thread_t *thread = thread_get(pid);
     return thread ? thread->name : NULL;
 #else
@@ -194,8 +194,9 @@ kernel_pid_t thread_create(char *stack, int stacksize, uint8_t priority,
 
 #ifdef DEVELHELP
     int total_stacksize = stacksize;
-#else
-    (void)name;
+#endif
+#ifndef CONFIG_THREAD_NAMES
+    (void) name;
 #endif
 
     /* align the stack on a 16/32bit boundary */
@@ -271,6 +272,8 @@ kernel_pid_t thread_create(char *stack, int stacksize, uint8_t priority,
 
 #ifdef DEVELHELP
     thread->stack_size = total_stacksize;
+#endif
+#ifdef CONFIG_THREAD_NAMES
     thread->name = name;
 #endif
 

--- a/doc.txt
+++ b/doc.txt
@@ -37,6 +37,17 @@
 #endif
 
 /**
+ * @def CONFIG_THREAD_NAMES
+ * @brief   This global macro enable storage of thread names to help developers.
+ *
+ *          To activate it set environment variable `THREAD_NAMES=1`, or use Kconfig.
+ *          It is automatically enabled if `DEVELHELP` is.
+ */
+#if DOXYGEN
+#   define CONFIG_THREAD_NAMES
+#endif
+
+/**
  * @def TEST_SUITES
  * @brief   This global macro activates functionality that is needed for
  *          automated testing but not needed otherwise.

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -82,7 +82,7 @@ void ps(void)
 #endif
 
     printf("\tpid | "
-#ifdef DEVELHELP
+#ifdef CONFIG_THREAD_NAMES
             "%-21s| "
 #endif
             "%-9sQ | pri "
@@ -93,7 +93,7 @@ void ps(void)
            "| runtime  | switches"
 #endif
            "\n",
-#ifdef DEVELHELP
+#ifdef CONFIG_THREAD_NAMES
            "name",
 #endif
            "state");
@@ -144,7 +144,7 @@ void ps(void)
             unsigned switches = sched_pidlist[i].schedules;
 #endif
             printf("\t%3" PRIkernel_pid
-#ifdef DEVELHELP
+#ifdef CONFIG_THREAD_NAMES
                    " | %-20s"
 #endif
                    " | %-8s %.1s | %3i"
@@ -156,7 +156,7 @@ void ps(void)
 #endif
                    "\n",
                    p->pid,
-#ifdef DEVELHELP
+#ifdef CONFIG_THREAD_NAMES
                    p->name,
 #endif
                    sname, queued, p->priority


### PR DESCRIPTION

### Contribution description

Separate thread names from DEVELHELP so thread names can be
enabled in non-development/debug builds when required/desired.
THREAD_NAMES will be enabled by default when DEVELHELP is set to 1.