### PR TITLE
stm32/can: add option to enable deep-sleep per device

### DIFF
--- a/cpu/stm32/include/can_params.h
+++ b/cpu/stm32/include/can_params.h
@@ -65,6 +65,7 @@ static const can_conf_t candev_conf[] = {
         .rx1_irqn = CAN1_RX1_IRQn,
         .sce_irqn = CAN1_SCE_IRQn,
 #endif
+        .en_deep_sleep_wake_up = true,
         .ttcm = 0,
         .abom = 1,
         .awum = 1,
@@ -85,6 +86,7 @@ static const can_conf_t candev_conf[] = {
 #ifndef CPU_FAM_STM32F1
         .af = GPIO_AF9,
 #endif
+        .en_deep_sleep_wake_up = true,
         .tx_irqn = CAN2_TX_IRQn,
         .rx0_irqn = CAN2_RX0_IRQn,
         .rx1_irqn = CAN2_RX1_IRQn,
@@ -108,6 +110,7 @@ static const can_conf_t candev_conf[] = {
         .rx_pin = GPIO_PIN(PORT_B, 3),
         .tx_pin = GPIO_PIN(PORT_B, 4),
         .af = GPIO_AF11,
+        .en_deep_sleep_wake_up = true,
         .tx_irqn = CAN3_TX_IRQn,
         .rx0_irqn = CAN3_RX0_IRQn,
         .rx1_irqn = CAN3_RX1_IRQn,

--- a/cpu/stm32/include/candev_stm32.h
+++ b/cpu/stm32/include/candev_stm32.h
@@ -100,6 +100,7 @@ typedef struct {
 #ifndef CPU_FAM_STM32F1
     gpio_af_t af;               /**< Alternate pin function to use */
 #endif
+    bool en_deep_sleep_wake_up; /**< Enable deep-sleep wake-up interrupt */
 #if CANDEV_STM32_CHAN_NUMOF > 1 || defined(DOXYGEN)
     CAN_TypeDef *can_master;    /**< Master CAN device */
     uint32_t master_rcc_mask;   /**< Master device RCC mask */


### PR DESCRIPTION

### Contribution description

Deep-sleep was based on using rx pin as external interrupt to be able to
wake up from stop mode. If rx pin cannot be used as interrupt or user
does not need to wake up from stop from the CAN, an option is now
present. If en_deep_sleep_wake_up is set to false, setting the device to
sleep simply unblocks stop mode. Otherwise the behavior is unchanged.
