### PR TITLE
xtimer: add rtt as xtimer low-level source

### DIFF
--- a/boards/nucleo-f413zh/include/periph_conf.h
+++ b/boards/nucleo-f413zh/include/periph_conf.h
@@ -194,12 +194,17 @@ static const adc_conf_t adc_config[] = {
 #define ADC_NUMOF           ARRAY_SIZE(adc_config)
 /** @} */
 
+#ifdef MODULE_XTIMER_ON_RTT
+#define XTIMER_HZ           (32768ul)
+#define XTIMER_WIDTH        16
+#endif
+
 /**
  * @name    RTT configuration
  * @{
  */
 #ifndef RTT_FREQUENCY
-#define RTT_FREQUENCY       (4096)
+#define RTT_FREQUENCY       (32768)
 #endif
 /** @} */
 

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -140,7 +140,7 @@ PSEUDOMODULES += suit_storage_%
 PSEUDOMODULES += sys_bus_%
 PSEUDOMODULES += wakaama_objects_%
 PSEUDOMODULES += wifi_enterprise
-PSEUDOMODULES += xtimer_on_ztimer
+PSEUDOMODULES += xtimer_on_%
 PSEUDOMODULES += zptr
 PSEUDOMODULES += ztimer%
 

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -1051,9 +1051,12 @@ ifneq (,$(filter xtimer,$(USEMODULE)))
     # xtimer is used, ztimer xtimer wrapper is not
     DEFAULT_MODULE += auto_init_xtimer
     USEMODULE += div
-    ifeq (,$(filter xtimer_on_ztimer,$(USEMODULE)))
+    ifeq (,$(filter xtimer_on_rtt xtimer_on_ztimer,$(USEMODULE)))
       # ztimer is not used, so use *periph_timer as low-level timer*.
       FEATURES_REQUIRED += periph_timer
+    else ifneq (,$(filter xtimer_on_rtt,$(USEMODULE)))
+      # will use *RTT as low-level timer*
+      FEATURES_REQUIRED += periph_rtt
     else
       # will use *ztimer_usec as low-level timer*
     endif

--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -29,6 +29,8 @@
 
 #ifdef MODULE_XTIMER_ON_ZTIMER
 #include "ztimer.h"
+#elif defined(MODULE_XTIMER_ON_RTT)
+#include "periph/rtt.h"
 #else
 #include "periph/timer.h"
 #endif
@@ -52,12 +54,13 @@ extern volatile uint64_t _xtimer_current_time;
  */
 static inline uint32_t _xtimer_lltimer_now(void)
 {
-#ifndef MODULE_XTIMER_ON_ZTIMER
-    return timer_read(XTIMER_DEV);
-#else
+#if defined(MODULE_XTIMER_ON_ZTIMER)
     return ztimer_now(ZTIMER_USEC);
+#elif defined(MODULE_XTIMER_ON_RTT)
+    return rtt_get_counter();
+#else
+    return timer_read(XTIMER_DEV);
 #endif
-
 }
 
 /**


### PR DESCRIPTION

### Contribution description

This PR adds periph_rtt as xtimer low-level source.

### Testing procedure

- configure your board's rtt to run at least at 32.768 kHz
- use `xtimer_on_rtt` module
- configure xtimer to match your rtt frequency
- check that xtimer still works properly
