### PR TITLE
drivers/at: improve URC handling

### DIFF
--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -237,6 +237,7 @@ ssize_t at_send_cmd_get_resp(at_dev_t *dev, const char *command,
 {
     ssize_t res;
 
+    xtimer_usleep(AT_CMD_DELAY);
     at_drain(dev);
 
     res = at_send_cmd(dev, command, timeout);
@@ -264,6 +265,7 @@ ssize_t at_send_cmd_get_lines(at_dev_t *dev, const char *command,
     size_t bytes_left = len - 1;
     char *pos = resp_buf;
 
+    xtimer_usleep(AT_CMD_DELAY);
     at_drain(dev);
 
     res = at_send_cmd(dev, command, timeout);
@@ -329,6 +331,7 @@ int at_send_cmd_wait_prompt(at_dev_t *dev, const char *command, uint32_t timeout
 {
     unsigned cmdlen = strlen(command);
 
+    xtimer_usleep(AT_CMD_DELAY);
     at_drain(dev);
 
     uart_write(dev->uart, (const uint8_t *)command, cmdlen);

--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -81,6 +81,17 @@ int at_expect_bytes(at_dev_t *dev, const char *bytes, uint32_t timeout)
     dev->awaiting_response = true;
 #endif
 
+#ifdef MODULE_AT_URC
+    /* Check for emitted URC */
+    if (bytes) {
+        char c;
+        if (!isrpipe_peek_one(&dev->isrpipe, (uint8_t *)&c)) {
+            if (c != *bytes && c == '+') {
+                return -1;
+            }
+        }
+    }
+#endif
     while (*bytes) {
         char c;
         if ((res = isrpipe_read_timeout(&dev->isrpipe, (uint8_t *)&c, 1, timeout)) == 1) {

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -65,6 +65,7 @@
 #include "kernel_defines.h"
 
 #include "event.h"
+#include "xtimer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -184,6 +185,10 @@ typedef struct {
 
 /** Shortcut for getting send end of line length */
 #define AT_SEND_EOL_LEN  (sizeof(CONFIG_AT_SEND_EOL) - 1)
+#ifndef AT_CMD_DELAY
+/** Delay to be introduced before starting a new AT command operation */
+#define AT_CMD_DELAY    (20U * US_PER_MS)
+#endif
 
 /**
  * @brief AT device structure

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -163,6 +163,11 @@ extern "C" {
 #define AT_BUF_SIZE   (1 << CONFIG_AT_BUF_SIZE_EXP)
 #endif
 
+#ifndef AT_URC_FIRST_CHAR
+/** Beginning character of an unsolicited result code */
+#define AT_URC_FIRST_CHAR '+'
+#endif
+
 /**
  * @brief   Unsolicited result code callback
  *

--- a/sys/include/isrpipe.h
+++ b/sys/include/isrpipe.h
@@ -76,6 +76,17 @@ int isrpipe_write_one(isrpipe_t *isrpipe, uint8_t c);
  */
 int isrpipe_read(isrpipe_t *isrpipe, uint8_t *buf, size_t count);
 
+/**
+ * @brief   Peek one byte from isrpipe
+ *
+ * @param[in]   isrpipe    isrpipe object to operate on
+ * @param[in]   buf        buffer to write to
+ *
+ * @returns     0 on success
+ * @returns     < 0 on error
+ */
+int isrpipe_peek_one(isrpipe_t *isrpipe, uint8_t *buf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/isrpipe/read_timeout.h
+++ b/sys/include/isrpipe/read_timeout.h
@@ -47,6 +47,18 @@ extern "C" {
 int isrpipe_read_timeout(isrpipe_t *isrpipe, uint8_t *buf, size_t count, uint32_t timeout);
 
 /**
+ * @brief   Peek one byte from isrpipe (with timeout, blocking)
+ *
+ * @param[in]   isrpipe    isrpipe object to operate on
+ * @param[in]   buf        buffer to write to
+ * @param[in]   timeout    timeout in microseconds
+ *
+ * @returns     0 on success
+ * @returns     -ETIMEDOUT on timeout
+ */
+int isrpipe_peek_one_timeout(isrpipe_t *isrpipe, uint8_t *buffer, uint32_t timeout);
+
+/**
  * @brief   Read data from isrpipe (with timeout, blocking, wait until all read)
  *
  * This function is like @ref isrpipe_read_timeout, but will only return on

--- a/sys/include/tsrb.h
+++ b/sys/include/tsrb.h
@@ -112,6 +112,15 @@ static inline unsigned int tsrb_free(const tsrb_t *rb)
 }
 
 /**
+ * @brief       Peeks a byte from ringbuffer
+ * @param[in]   rb  Ringbuffer to operate on
+ * @param[out]  dst buffer to write to
+ * @return      0 on success
+ * @return      -1  if no byte available
+ */
+int tsrb_peek_one(tsrb_t *rb, uint8_t *dst);
+
+/**
  * @brief       Get a byte from ringbuffer
  * @param[in]   rb  Ringbuffer to operate on
  * @return      >=0 byte that has been read

--- a/sys/isrpipe/isrpipe.c
+++ b/sys/isrpipe/isrpipe.c
@@ -46,3 +46,9 @@ int isrpipe_read(isrpipe_t *isrpipe, uint8_t *buffer, size_t count)
     }
     return res;
 }
+
+int isrpipe_peek_one(isrpipe_t *isrpipe, uint8_t *buffer)
+{
+    return tsrb_peek_one(&isrpipe->tsrb, buffer);
+}
+

--- a/sys/tsrb/tsrb.c
+++ b/sys/tsrb/tsrb.c
@@ -29,6 +29,22 @@ static uint8_t _pop(tsrb_t *rb)
     return rb->buf[rb->reads++ & (rb->size - 1)];
 }
 
+static uint8_t _peek(tsrb_t *rb)
+{
+    return rb->buf[rb->reads & (rb->size - 1)];
+}
+
+int tsrb_peek_one(tsrb_t *rb, uint8_t *dst)
+{
+    if (!tsrb_empty(rb)) {
+        *dst = _peek(rb);
+        return 0;
+    }
+    else {
+        return -1;
+    }
+}
+
 int tsrb_get_one(tsrb_t *rb)
 {
     if (!tsrb_empty(rb)) {


### PR DESCRIPTION

### Contribution description

Those changes improved our situation regarding URC with our modem.
main changes:
- check for URC during `at_drain()`
- check for URC in `at_expect()`
Rationale: a URC can be emitted while a command is being sent before the echo is received.

The credit (and hopefully the support for this PR ;p ) goes to @aaltuntas 