### PR TITLE
drivers/periph: Remove UART from device_enums.h

### DIFF
--- a/boards/ek-lm4f120xl/include/periph_conf.h
+++ b/boards/ek-lm4f120xl/include/periph_conf.h
@@ -73,10 +73,9 @@ extern "C" {
  * @{
  */
 #define UART_NUMOF          (1U)
-#define UART_0_EN           1
-#define UART_1_EN           0
 #define UART_IRQ_PRIO       1
-#define UART_CLK            ROM_SysCtlClockGet()  /* UART clock runs with 40MHz */
+/* UART clock runs with 40MHz */
+#define UART_CLK            ROM_SysCtlClockGet()
 /* UART 0 device configuration */
 #define UART_0_DEV          UART0_BASE
 #define UART_0_CLK          (40000000)
@@ -86,12 +85,6 @@ extern "C" {
 #define UART_0_PORT         GPIOA
 #define UART_0_TX_PIN       UART_PA1_U0TX
 #define UART_0_RX_PIN       UART_PA0_U0RX
-
-/* UART 1 device configuration */
-#define UART_1_DEV          UART1_BASE
-#define UART_1_CLK          (40000000)
-#define UART_1_IRQ_CHAN     UART1_IRQn
-#define UART_1_ISR          isr_uart1
 /** @} */
 
 /**

--- a/boards/mbed_lpc1768/include/periph_conf.h
+++ b/boards/mbed_lpc1768/include/periph_conf.h
@@ -19,6 +19,8 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+#include "periph_cpu.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,42 +49,29 @@ extern "C" {
  * @name    UART configuration
  * @{
  */
-#define UART_NUMOF          (2U)
-#define UART_0_EN           1
-#define UART_1_EN           1
+static const uart_conf_t uart_config[] = {
+    {
+        .dev = (LPC_UART_TypeDef*)LPC_UART0,
+        .irq_rx = UART0_IRQn,
+        .pinsel = 0,
+        .pinsel_shift = 2,
+        .pinsel_af = 1,
+    },
+    {
+        .dev = (LPC_UART_TypeDef*)LPC_UART2,
+        .irq_rx = UART2_IRQn,
+        .pinsel = 0,
+        .pinsel_shift = 20,
+        .pinsel_af = 1,
+    }
+};
+
 #define UART_IRQ_PRIO       1
 
-/* UART 0 device configuration */
-#define UART_0_DEV          LPC_UART0
-#define UART_0_CLKSEL()     (LPC_SC->PCLKSEL0 &= ~(0x3 << 6))       /* PCLK := CCLK / 4 */
-#define UART_0_CLKEN()      (LPC_SC->PCONP |= (1 << 3))
-#define UART_0_CLKDIS()     (LPC_SC->PCONP &= ~(1 << 3))
-#define UART_0_IRQ          UART0_IRQn
 #define UART_0_ISR          isr_uart0
-/* UART 0 pin configuration */
-#define UART_0_TX_PINSEL    (LPC_PINCON->PINSEL0)
-#define UART_0_RX_PINSEL    (LPC_PINCON->PINSEL0)
-#define UART_0_TX_PINMODE   (LPC_PINCON->PINMODE0)
-#define UART_0_RX_PINMODE   (LPC_PINCON->PINMODE0)
-#define UART_0_TX_PIN       (3)
-#define UART_0_RX_PIN       (2)
-#define UART_0_AF           (1)
+#define UART_1_ISR          isr_uart2
 
-/* UART 1 device configuration */
-#define UART_1_DEV          LPC_UART3
-#define UART_1_CLKSEL()     (LPC_SC->PCLKSEL1 &= ~(0x3 << 18))      /* PCLK := CCLK / 4 */
-#define UART_1_CLKEN()      (LPC_SC->PCONP |= (1 << 25))
-#define UART_1_CLKDIS()     (LPC_SC->PCONP &= ~(1 << 25))
-#define UART_1_IRQ          UART3_IRQn
-#define UART_1_ISR          isr_uart3
-/* UART 1 pin configuration */
-#define UART_1_TX_PINSEL    (LPC_PINCON->PINSEL0)
-#define UART_1_RX_PINSEL    (LPC_PINCON->PINSEL0)
-#define UART_1_TX_PINMODE   (LPC_PINCON->PINMODE0)
-#define UART_1_RX_PINMODE   (LPC_PINCON->PINMODE0)
-#define UART_1_RX_PIN       (0)
-#define UART_1_TX_PIN       (1)
-#define UART_1_AF           (2)
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/msb-430/include/periph_conf.h
+++ b/boards/msb-430/include/periph_conf.h
@@ -51,7 +51,6 @@ extern "C" {
  * @{
  */
 #define UART_NUMOF          (1U)
-#define UART_0_EN           (1U)
 
 #define UART_BASE           (USART_1)
 #define UART_IE             (SFR->IE2)
@@ -81,9 +80,9 @@ extern "C" {
 #define SPI_IE_TX_BIT       (1 << 7)
 #define SPI_ME              (SFR->ME1)
 #define SPI_ME_BIT          (1 << 6)
-#define SPI_PIN_MISO        GPIO_PIN(P5,2)
-#define SPI_PIN_MOSI        GPIO_PIN(P5,1)
-#define SPI_PIN_CLK         GPIO_PIN(P5,3)
+#define SPI_PIN_MISO        GPIO_PIN(P5, 2)
+#define SPI_PIN_MOSI        GPIO_PIN(P5, 1)
+#define SPI_PIN_CLK         GPIO_PIN(P5, 3)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/msb-430h/include/periph_conf.h
+++ b/boards/msb-430h/include/periph_conf.h
@@ -53,7 +53,6 @@ extern "C" {
  * @{
  */
 #define UART_NUMOF          (1U)
-#define UART_0_EN           (1U)
 
 #define UART_BASE           (USART_1)
 #define UART_IE             (SFR->IE2)
@@ -83,9 +82,9 @@ extern "C" {
 #define SPI_IE_TX_BIT       (1 << 7)
 #define SPI_ME              (SFR->ME1)
 #define SPI_ME_BIT          (1 << 6)
-#define SPI_PIN_MISO        GPIO_PIN(P3,2)
-#define SPI_PIN_MOSI        GPIO_PIN(P3,1)
-#define SPI_PIN_CLK         GPIO_PIN(P3,3)
+#define SPI_PIN_MISO        GPIO_PIN(P3, 2)
+#define SPI_PIN_MOSI        GPIO_PIN(P3, 1)
+#define SPI_PIN_CLK         GPIO_PIN(P3, 3)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nrf6310/include/periph_conf.h
+++ b/boards/nrf6310/include/periph_conf.h
@@ -36,7 +36,6 @@ extern "C" {
  * @{
  */
 #define UART_NUMOF          (1U)
-#define UART_0_EN           1
 #define UART_IRQ_PRIO       1
 
 /* UART pin configuration */

--- a/boards/seeeduino_arch-pro/include/periph_conf.h
+++ b/boards/seeeduino_arch-pro/include/periph_conf.h
@@ -20,6 +20,8 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
+#include "periph_cpu.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -48,42 +50,30 @@ extern "C" {
  * @name    UART configuration
  * @{
  */
-#define UART_NUMOF          (2U)
-#define UART_0_EN           1
-#define UART_1_EN           1
+static const uart_conf_t uart_config[] = {
+    {
+        .dev = (LPC_UART_TypeDef*)LPC_UART0,
+        .irq_rx = UART0_IRQn,
+        .pinsel = 0,
+        .pinsel_shift = 2,
+        .pinsel_af = 1,
+    },
+    {
+        .dev = (LPC_UART_TypeDef*)LPC_UART3,
+        .irq_rx = UART3_IRQn,
+        .pinsel = 0,
+        .pinsel_shift = 0,
+        .pinsel_af = 2
+    }
+};
+
 #define UART_IRQ_PRIO       1
 
-/* UART 0 device configuration */
-#define UART_0_DEV          LPC_UART0
-#define UART_0_CLKSEL()     (LPC_SC->PCLKSEL0 &= ~(0x3 << 6))       /* PCLK := CCLK / 4 */
-#define UART_0_CLKEN()      (LPC_SC->PCONP |= (1 << 3))
-#define UART_0_CLKDIS()     (LPC_SC->PCONP &= ~(1 << 3))
-#define UART_0_IRQ          UART0_IRQn
 #define UART_0_ISR          isr_uart0
-/* UART 0 pin configuration */
-#define UART_0_TX_PINSEL    (LPC_PINCON->PINSEL0)
-#define UART_0_RX_PINSEL    (LPC_PINCON->PINSEL0)
-#define UART_0_TX_PINMODE   (LPC_PINCON->PINMODE0)
-#define UART_0_RX_PINMODE   (LPC_PINCON->PINMODE0)
-#define UART_0_TX_PIN       (3)
-#define UART_0_RX_PIN       (2)
-#define UART_0_AF           (1)
-
-/* UART 1 device configuration */
-#define UART_1_DEV          LPC_UART3
-#define UART_1_CLKSEL()     (LPC_SC->PCLKSEL1 &= ~(0x3 << 18))      /* PCLK := CCLK / 4 */
-#define UART_1_CLKEN()      (LPC_SC->PCONP |= (1 << 25))
-#define UART_1_CLKDIS()     (LPC_SC->PCONP &= ~(1 << 25))
-#define UART_1_IRQ          UART3_IRQn
 #define UART_1_ISR          isr_uart3
-/* UART 1 pin configuration */
-#define UART_1_TX_PINSEL    (LPC_PINCON->PINSEL0)
-#define UART_1_RX_PINSEL    (LPC_PINCON->PINSEL0)
-#define UART_1_TX_PINMODE   (LPC_PINCON->PINMODE0)
-#define UART_1_RX_PINMODE   (LPC_PINCON->PINMODE0)
-#define UART_1_RX_PIN       (0)
-#define UART_1_TX_PIN       (1)
-#define UART_1_AF           (2)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/telosb/include/periph_conf.h
+++ b/boards/telosb/include/periph_conf.h
@@ -51,7 +51,6 @@ extern "C" {
  * @{
  */
 #define UART_NUMOF          (1U)
-#define UART_0_EN           (1U)
 
 #define UART_BASE           (USART_1)
 #define UART_IE             (SFR->IE2)
@@ -81,9 +80,9 @@ extern "C" {
 #define SPI_IE_TX_BIT       (1 << 7)
 #define SPI_ME              (SFR->ME1)
 #define SPI_ME_BIT          (1 << 6)
-#define SPI_PIN_MISO        GPIO_PIN(P3,2)
-#define SPI_PIN_MOSI        GPIO_PIN(P3,1)
-#define SPI_PIN_CLK         GPIO_PIN(P3,3)
+#define SPI_PIN_MISO        GPIO_PIN(P3, 2)
+#define SPI_PIN_MOSI        GPIO_PIN(P3, 1)
+#define SPI_PIN_CLK         GPIO_PIN(P3, 3)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/z1/include/periph_conf.h
+++ b/boards/z1/include/periph_conf.h
@@ -51,7 +51,6 @@ extern "C" {
  * @{
  */
 #define UART_NUMOF          (1U)
-#define UART_0_EN           (1U)
 
 #define UART_USE_USCI
 #define UART_BASE           (USCI_0)
@@ -80,9 +79,9 @@ extern "C" {
 #define SPI_IF              (SFR->IFG2)
 #define SPI_IE_RX_BIT       (1 << 2)
 #define SPI_IE_TX_BIT       (1 << 3)
-#define SPI_PIN_MISO        GPIO_PIN(P3,2)
-#define SPI_PIN_MOSI        GPIO_PIN(P3,1)
-#define SPI_PIN_CLK         GPIO_PIN(P3,3)
+#define SPI_PIN_MISO        GPIO_PIN(P3, 2)
+#define SPI_PIN_MOSI        GPIO_PIN(P3, 1)
+#define SPI_PIN_CLK         GPIO_PIN(P3, 3)
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/lm4f120/periph/uart.c
+++ b/cpu/lm4f120/periph/uart.c
@@ -26,6 +26,9 @@
 #include "periph/uart.h"
 #include "periph_conf.h"
 
+/* The only implemented UART device number for this cpu. */
+#define _UART_DEV_NUM   0
+
 /**
  * @brief UART device configurations
  */
@@ -39,14 +42,16 @@ static int init_base(uart_t uart, uint32_t baudrate);
 int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 {
     /* Check the arguments */
-    assert(uart == 0);
+    /* Only one UART is supported, assert that is what is used. */
+    assert(uart == _UART_DEV_NUM);
+    (void) uart;
     /* Check to make sure the UART peripheral is present */
-    if(!ROM_SysCtlPeripheralPresent(SYSCTL_PERIPH_UART0)){
+    if (!ROM_SysCtlPeripheralPresent(SYSCTL_PERIPH_UART0)) {
         return UART_NODEV;
     }
 
     int res = init_base(uart, baudrate);
-    if(res != UART_OK){
+    if (res != UART_OK) {
         return res;
     }
 
@@ -54,35 +59,21 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     config[uart].rx_cb = rx_cb;
     config[uart].arg = arg;
 
-/*  ulBase = g_ulUARTBase[uart]; */
-    switch (uart){
-#if UART_0_EN
-        case UART_0:
-            ROM_UARTTxIntModeSet(UART0_BASE, UART_TXINT_MODE_EOT);
-            ROM_UARTFIFOLevelSet(UART0_BASE, UART_FIFO_TX4_8, UART_FIFO_RX4_8);
-            ROM_UARTFIFOEnable(UART0_BASE);
+    ROM_UARTTxIntModeSet(UART0_BASE, UART_TXINT_MODE_EOT);
+    ROM_UARTFIFOLevelSet(UART0_BASE, UART_FIFO_TX4_8, UART_FIFO_RX4_8);
+    ROM_UARTFIFOEnable(UART0_BASE);
 
-            /* Enable the UART interrupt */
-            NVIC_EnableIRQ(UART_0_IRQ_CHAN);
-            /* Enable RX interrupt */
-            UART0_IM_R = UART_IM_RXIM | UART_IM_RTIM;
-            break;
-#endif
-#if UART_1_EN
-        case UART_1:
-            /* Enable the UART interrupt */
-            NVIC_EnableIRQ(UART_1_IRQ_CHAN);
-            break;
-#endif
-    }
+    /* Enable the UART interrupt */
+    NVIC_EnableIRQ(UART_0_IRQ_CHAN);
+    /* Enable RX interrupt */
+    UART0_IM_R = UART_IM_RXIM | UART_IM_RTIM;
     return UART_OK;
 }
 
 static int init_base(uart_t uart, uint32_t baudrate)
 {
-    switch(uart){
-#if UART_0_EN
-        case UART_0:
+    switch (uart) {
+        case _UART_DEV_NUM:
             ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_UART0);
             ROM_SysCtlPeripheralEnable(SYSCTL_PERIPH_GPIOA);
             ROM_GPIOPinConfigure(GPIO_PA0_U0RX);
@@ -93,11 +84,8 @@ static int init_base(uart_t uart, uint32_t baudrate)
             ROM_UARTConfigSetExpClk(UART0_BASE,ROM_SysCtlClockGet(), baudrate,
                     (UART_CONFIG_PAR_NONE | UART_CONFIG_STOP_ONE |
                      UART_CONFIG_WLEN_8));
-
-
             ROM_UARTEnable(UART0_BASE);
             break;
-#endif
         default:
             return UART_NODEV;
         }
@@ -106,8 +94,9 @@ static int init_base(uart_t uart, uint32_t baudrate)
 
 void uart_write(uart_t uart, const uint8_t *data, size_t len)
 {
+    /* Only one UART is supported, assert that is what is used. */
+    assert(uart == _UART_DEV_NUM);
     (void) uart;
-
     for (size_t i = 0; i < len; i++) {
         ROM_UARTCharPut(UART0_BASE, (char)data[i]);
     }
@@ -115,15 +104,17 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
 
 void uart_poweron(uart_t uart)
 {
+    /* Only one UART is supported, assert that is what is used. */
+    assert(uart == _UART_DEV_NUM);
     (void) uart;
-
     ROM_UARTEnable(UART0_BASE);
 }
 
 void uart_poweroff(uart_t uart)
 {
+    /* Only one UART is supported, assert that is what is used. */
+    assert(uart == _UART_DEV_NUM);
     (void) uart;
-
     ROM_UARTDisable(UART0_BASE);
 }
 
@@ -138,12 +129,11 @@ void isr_uart0(void)
     ROM_UARTIntClear(UART0_BASE, ulStatus);
 
     /* Are we interrupted due to a received character */
-    if(ulStatus & (UART_INT_RX | UART_INT_RT))
-    {
-        while(ROM_UARTCharsAvail(UART0_BASE))
-        {
+    if (ulStatus & (UART_INT_RX | UART_INT_RT)) {
+        while (ROM_UARTCharsAvail(UART0_BASE)) {
             long lchar = ROM_UARTCharGetNonBlocking(UART0_BASE);
-            config[UART_0].rx_cb(config[UART_0].arg, (uint8_t)lchar);
+            config[_UART_DEV_NUM].rx_cb(config[_UART_DEV_NUM].arg,
+                    (uint8_t)lchar);
         }
     }
     cortexm_isr_end();

--- a/cpu/lpc1768/include/periph_cpu.h
+++ b/cpu/lpc1768/include/periph_cpu.h
@@ -75,6 +75,17 @@ typedef enum {
  */
 #define PM_NUM_MODES    (2U)
 
+/**
+ * @brief   UART device configuration
+ */
+typedef struct {
+    LPC_UART_TypeDef *dev;  /**< pointer to the UART device */
+    uint8_t irq_rx;         /**< RX IRQ number */
+    uint8_t pinsel;         /**< PINSEL# of the RX and TX pin */
+    uint8_t pinsel_shift;   /**< TX/RX bitshift of the PINSEL# register */
+    uint8_t pinsel_af;      /**< Alternate function of the PINSEL# register */
+} uart_conf_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/lpc1768/periph/uart.c
+++ b/cpu/lpc1768/periph/uart.c
@@ -24,197 +24,153 @@
 #include "periph/uart.h"
 #include "periph_conf.h"
 
+/* For the clock modules we can take advantage of the offsets in the
+ * register map to find the bitshifting that is needed.
+ */
+#define _DEV_ADDR(uart)     ((uint32_t)(uart_config[uart].dev))
+#define _DEV_OFFSET(uart)   ((_DEV_ADDR(uart) - LPC_APB0_BASE) / 0x4000)
+
 /**
  * @brief UART device configurations
  */
 static uart_isr_ctx_t config[UART_NUMOF];
 
-static int init_base(uart_t uart, uint32_t baudrate);
+static inline void init_base(uart_t uart, uint32_t baudrate);
+
+/**
+ * @brief   Get the GPT register base for a timer
+ *
+ * @param[in] tim   index of the timer
+ *
+ * @return          base address
+ */
+static inline LPC_UART_TypeDef *dev(uart_t uart)
+{
+    assert(uart < UART_NUMOF);
+
+    return ((LPC_UART_TypeDef *)uart_config[uart].dev);
+}
 
 int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 {
-    int res = init_base(uart, baudrate);
-    if (res != UART_OK) {
-        return res;
-    }
+    assert(uart < UART_NUMOF);
+    init_base(uart, baudrate);
 
     /* save callbacks */
     config[uart].rx_cb = rx_cb;
     config[uart].arg = arg;
 
-    switch (uart) {
-#if UART_0_EN
-        case UART_0:
-        /* configure and enable global device interrupts */
-        NVIC_SetPriority(UART_0_IRQ, UART_IRQ_PRIO);
-        NVIC_EnableIRQ(UART_0_IRQ);
-        /* enable RX interrupt */
-        UART_0_DEV->IER |= (1 << 0);
-            break;
-#endif
-#if UART_1_EN
-        case UART_1:
-        /* configure and enable global device interrupts */
-        NVIC_SetPriority(UART_1_IRQ, UART_IRQ_PRIO);
-        NVIC_EnableIRQ(UART_1_IRQ);
-        /* enable RX interrupt */
-        UART_1_DEV->IER |= (1 << 0);
-            break;
-#endif
-    }
+    /* configure and enable global device interrupts */
+    NVIC_SetPriority(uart_config[uart].irq_rx, UART_IRQ_PRIO);
+    NVIC_EnableIRQ(uart_config[uart].irq_rx);
+    /* enable RX interrupt */
+    dev(uart)->IER |= (1 << 0);
 
     return UART_OK;
 }
 
-static int init_base(uart_t uart, uint32_t baudrate)
+static inline void init_base(uart_t uart, uint32_t baudrate)
 {
-    switch (uart) {
-#if UART_0_EN
-        case UART_0:
-            /* this implementation only supports 115200 baud */
-            if (baudrate != 115200) {
-                return UART_NOBAUD;
-            }
+    /* Fixed baud rate. */
+    assert(baudrate == 115200);
+    assert(uart < UART_NUMOF);
+    (void) baudrate;
+    const uart_conf_t *cfg = &uart_config[uart];
+    /* The RX/TX must be together */
+    assert(cfg->pinsel_shift <= 27);
 
-            /* power on UART device and select peripheral clock */
-            UART_0_CLKEN();
-            UART_0_CLKSEL();
-            /* set mode to 8N1 and enable access to divisor latch */
-            UART_0_DEV->LCR = ((0x3 << 0) | (1 << 7));
-            /* set baud rate registers (fixed for now) */
-            UART_0_DEV->DLM = 0;
-            UART_0_DEV->DLL = 13;
-            /* enable FIFOs */
-            UART_0_DEV->FCR = 1;
-            /* select and configure the pin for RX */
-            UART_0_RX_PINSEL &= ~(0x3 << (UART_0_RX_PIN * 2));
-            UART_0_RX_PINSEL |= (UART_0_AF << (UART_0_RX_PIN * 2));
-            UART_0_RX_PINMODE &= ~(0x3 << (UART_0_RX_PIN * 2));
-            UART_0_RX_PINMODE |= (0x2 << (UART_0_RX_PIN * 2));
-            /* select and configure the pin for TX */
-            UART_0_TX_PINSEL &= ~(0x3 << (UART_0_TX_PIN * 2));
-            UART_0_TX_PINSEL |= (UART_0_AF << (UART_0_TX_PIN * 2));
-            UART_0_TX_PINMODE &= ~(0x3 << (UART_0_TX_PIN * 2));
-            UART_0_TX_PINMODE |= (0x2 << (UART_0_TX_PIN * 2));
-            /* disable access to divisor latch */
-            UART_0_DEV->LCR &= ~(1 << 7);
-            break;
-#endif
-#if UART_1_EN
-        case UART_1:
-            /* this implementation only supports 115200 baud */
-            if (baudrate != 115200) {
-                return UART_NOBAUD;
-            }
-
-            /* power on UART device and select peripheral clock */
-            UART_1_CLKEN();
-            UART_1_CLKSEL();
-            /* set mode to 8N1 and enable access to divisor latch */
-            UART_1_DEV->LCR = ((0x3 << 0) | (1 << 7));
-            /* set baud rate registers (fixed for now) */
-            UART_1_DEV->DLM = 0;
-            UART_1_DEV->DLL = 13;
-            /* enable FIFOs */
-            UART_1_DEV->FCR = 1;
-            /* select and configure the pin for RX */
-            UART_1_RX_PINSEL &= ~(0x3 << (UART_1_RX_PIN * 2));
-            UART_1_RX_PINSEL |= (UART_1_AF << (UART_1_RX_PIN * 2));
-            UART_1_RX_PINMODE &= ~(0x3 << (UART_1_RX_PIN * 2));
-            UART_1_RX_PINMODE |= (0x2 << (UART_1_RX_PIN * 2));
-            /* select and configure the pin for TX */
-            UART_1_TX_PINSEL &= ~(0x3 << (UART_1_TX_PIN * 2));
-            UART_1_TX_PINSEL |= (UART_1_AF << (UART_1_TX_PIN * 2));
-            UART_1_TX_PINMODE &= ~(0x3 << (UART_1_TX_PIN * 2));
-            UART_1_TX_PINMODE |= (0x2 << (UART_1_TX_PIN * 2));
-            /* disable access to divisor latch */
-            UART_1_DEV->LCR &= ~(1 << 7);
-            break;
-#endif
-        default:
-            return UART_NODEV;
+    /* power on UART device and select peripheral clock */
+    LPC_SC->PCONP |= (1 << _DEV_OFFSET(uart));
+    if (_DEV_OFFSET(uart) >= 16) {
+        LPC_SC->PCLKSEL1 &= ~(0x3 << ((_DEV_OFFSET(uart) * 2) - 32));
     }
+    else {
+        LPC_SC->PCLKSEL0 &= ~(0x3 << (_DEV_OFFSET(uart) * 2));
+    }
+    /* set mode to 8N1 and enable access to divisor latch */
+    dev(uart)->LCR = ((0x3 << 0) | (1 << 7));
+    /* set baud rate registers (fixed for now) */
+    dev(uart)->DLM = 0;
+    dev(uart)->DLL = 13;
+    /* enable FIFOs */
+    dev(uart)->FCR = 1;
 
-    return UART_OK;
+    /* Clear register for mux selection */
+    *(&LPC_PINCON->PINSEL0 + cfg->pinsel) &= ~(0xF << (cfg->pinsel_shift));
+    /* Select uart TX mux */
+    *(&LPC_PINCON->PINSEL0 + cfg->pinsel) |=
+            (cfg->pinsel_af << (cfg->pinsel_shift));
+    /* Select uart RX mux */
+    *(&LPC_PINCON->PINSEL0 + cfg->pinsel) |=
+            (cfg->pinsel_af << (cfg->pinsel_shift + 2));
+
+    /* Clear modes for RX and TX pins */
+    *(&LPC_PINCON->PINMODE0 + cfg->pinsel) &= ~(0xF << (cfg->pinsel_shift));
+    /* Set TX mode */
+    *(&LPC_PINCON->PINMODE0 + cfg->pinsel) |= (0x2 << (cfg->pinsel_shift));
+    /* Set RX mode */
+    *(&LPC_PINCON->PINMODE0 + cfg->pinsel) |= (0x2 << (cfg->pinsel_shift + 2));
+
+    /* disable access to divisor latch */
+    dev(uart)->LCR &= ~(1 << 7);
 }
 
 void uart_write(uart_t uart, const uint8_t *data, size_t len)
 {
-    LPC_UART_TypeDef *dev = NULL;
-
-    switch (uart) {
-#if UART_0_EN
-        case UART_0:
-            dev = (LPC_UART_TypeDef *)UART_0_DEV;
-            break;
-#endif
-#if UART_1_EN
-        case UART_1:
-            dev = (LPC_UART_TypeDef *)UART_1_DEV;
-            break;
-#endif
-        default:
-            return;
-    }
-
-    if (dev) {
-        for (size_t i = 0; i < len; i++) {
-            while (!(dev->LSR & (1 << 5))) {}  /* wait for THRE bit to be set */
-            dev->THR = data[i];
-        }
+    assert(uart < UART_NUMOF);
+    for (size_t i = 0; i < len; i++) {
+        /* wait for THRE bit to be set */
+        while (!(dev(uart)->LSR & (1 << 5))) {}
+        dev(uart)->THR = data[i];
     }
 }
 
 void uart_poweron(uart_t uart)
 {
-    switch (uart) {
-#if UART_0_EN
-        case UART_0:
-            UART_0_CLKEN();
-            break;
-#endif
-#if UART_1_EN
-        case UART_1:
-            UART_1_CLKEN();
-            break;
-#endif
-    }
+    assert(uart < UART_NUMOF);
+    LPC_SC->PCONP |= (1 << _DEV_OFFSET(uart));
 }
 
 void uart_poweroff(uart_t uart)
 {
-    switch (uart) {
-#if UART_0_EN
-        case UART_0:
-            UART_0_CLKDIS();
-            break;
-#endif
-#if UART_1_EN
-        case UART_1:
-            UART_1_CLKDIS();
-            break;
-#endif
-    }
+    assert(uart < UART_NUMOF);
+    LPC_SC->PCONP &= ~(1 << _DEV_OFFSET(uart));
 }
 
-#if UART_0_EN
+static void irq_handler(uart_t uart)
+{
+    assert(uart < UART_NUMOF);
+    if (dev(uart)->LSR & (1 << 0)) {
+        uint8_t data = (uint8_t)dev(uart)->RBR;
+        config[uart].rx_cb(config[uart].arg, data);
+    }
+    cortexm_isr_end();
+}
+
+#ifdef UART_0_ISR
 void UART_0_ISR(void)
 {
-    if (UART_0_DEV->LSR & (1 << 0)) {       /* is RDR flag set? */
-        uint8_t data = (uint8_t)UART_0_DEV->RBR;
-        config[UART_0].rx_cb(config[UART_0].arg, data);
-    }
-    cortexm_isr_end();
+    irq_handler(UART_DEV(0));
 }
 #endif
 
-#if UART_1_EN
+#ifdef UART_1_ISR
 void UART_1_ISR(void)
 {
-    if (UART_1_DEV->LSR & (1 << 0)) {       /* is RDR flag set? */
-        uint8_t data = (uint8_t)UART_1_DEV->RBR;
-        config[UART_1].rx_cb(config[UART_1].arg, data);
-    }
-    cortexm_isr_end();
+    irq_handler(UART_DEV(1));
+}
+#endif
+
+#ifdef UART_2_ISR
+void UART_2_ISR(void)
+{
+    irq_handler(UART_DEV(2));
+}
+#endif
+
+#ifdef UART_3_ISR
+void UART_3_ISR(void)
+{
+    irq_handler(UART_DEV(3));
 }
 #endif

--- a/drivers/include/periph/dev_enums.h
+++ b/drivers/include/periph/dev_enums.h
@@ -67,34 +67,6 @@ enum {
     I2C_UNDEFINED           /**< Deprecated symbol, use I2C_UNDEF instead */
 };
 
-/**
- * @brief   Legacy definition of UART devices
- */
-enum {
-#if UART_0_EN
-    UART_0 = 0,             /**< UART 0 */
-#endif
-#if UART_1_EN
-    UART_1,                 /**< UART 1 */
-#endif
-#if UART_2_EN
-    UART_2,                 /**< UART 2 */
-#endif
-#if UART_3_EN
-    UART_3,                 /**< UART 3 */
-#endif
-#if UART_4_EN
-    UART_4,                 /**< UART 4 */
-#endif
-#if UART_5_EN
-    UART_5,                 /**< UART 5 */
-#endif
-#if UART_6_EN
-    UART_6,                 /**< UART 6 */
-#endif
-    UART_UNDEFINED          /**< Deprecated symbol, use UART_UNDEF instead */
-};
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

In order to remove the need for the legacy device_enums and clean things up all boards using  UART definitions from device_enums have been updated.

This includes:
`ek-lm4f120xl` - Since only UART0 was implemented, asserts ensure only that uart is implemented.
`mbed_lpc1768` - Implementation for all uarts are added assuming pins are together, periph conf was updated for uart 1 to be on p9 and p10 since they were previously inaccessable
`msb-430` - Implementation does not require device_enums.h
`msb-430h` - Implementation does not require device_enums.h
`nrf6310` - Implementation does not require device_enums.h
`seeeduino_arch-pro` - Implementation for all uarts are added assuming pins are together
`telosb` - Implementation does not require device_enums.h
`z1` - Implementation does not require device_enums.h

Some generic cleanup also applied to files as new static checks have shown warnings.

### Testing procedure

Use `tests/periph_uart` to ensure communication (stdio uart) and any additional uarts.

The `lpc1768` cpu change was verified with the `mbed_lpc1768` by enabling uart 1 and reading loopback messages.

### Issues/PRs references

Step forward with #7941
