### PR TITLE
gnrc_ipv6_nib: don't add non-link-local to NC without ARSM 

### DIFF
--- a/sys/include/net/gnrc/ipv6/nib/nc.h
+++ b/sys/include/net/gnrc/ipv6/nib/nc.h
@@ -222,10 +222,13 @@ static inline unsigned gnrc_ipv6_nib_nc_get_ar_state(const gnrc_ipv6_nib_nc_t *e
  * If an entry pointing to the same IPv6 address as @p ipv6 exists already it
  * will be overwritten and marked as unmanaged.
  *
- * If @ref CONFIG_GNRC_IPV6_NIB_ARSM != 0 @p l2addr and @p l2addr_len won't be set.
+ * If @ref CONFIG_GNRC_IPV6_NIB_ARSM == 0 @p l2addr and @p l2addr_len won't be
+ * set and @p ipv6 must be a link-local address.
  *
  * @return  0 on success.
  * @return  -ENOMEM, if no space is left in neighbor cache.
+ * @return  -EINVAL, if @p ipv6 is invalid (i.e.
+ *          @ref CONFIG_GNRC_IPV6_NIB_ARSM == 0 and @p ipv6 is not link-local).
  */
 int gnrc_ipv6_nib_nc_set(const ipv6_addr_t *ipv6, unsigned iface,
                          const uint8_t *l2addr, size_t l2addr_len);

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -237,7 +237,10 @@ int gnrc_ipv6_nib_get_next_hop_l2addr(const ipv6_addr_t *dst,
                       "search neighbor cache\n",
                       ipv6_addr_to_str(addr_str, dst, sizeof(addr_str)));
 
-                if (res == 0) {
+                if ((res == 0) &&
+                    /* If ARSM is not active only use link-local as next hop */
+                    (IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_ARSM) ||
+                     ipv6_addr_is_link_local(dst))) {
                     DEBUG("nib: prefix list entry => taking dst as next hop\n");
                     memcpy(&route.next_hop, dst, sizeof(route.next_hop));
                 }

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_nc.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_nc.c
@@ -46,6 +46,9 @@ int gnrc_ipv6_nib_nc_set(const ipv6_addr_t *ipv6, unsigned iface,
 #else
     (void)l2addr;
     (void)l2addr_len;
+    if (!ipv6_addr_is_link_local(ipv6)) {
+        return -EINVAL;
+    }
 #endif
     node->info &= ~(GNRC_IPV6_NIB_NC_INFO_AR_STATE_MASK |
                     GNRC_IPV6_NIB_NC_INFO_NUD_STATE_MASK);

--- a/sys/shell/commands/sc_gnrc_ipv6_nib.c
+++ b/sys/shell/commands/sc_gnrc_ipv6_nib.c
@@ -136,7 +136,10 @@ static int _nib_neigh(int argc, char **argv)
             _usage_nib_neigh(argv);
             return 1;
         }
-        gnrc_ipv6_nib_nc_set(&ipv6_addr, iface, l2addr, l2addr_len);
+        if (gnrc_ipv6_nib_nc_set(&ipv6_addr, iface, l2addr, l2addr_len) < 0) {
+            printf("Unable to add %s%%%u to neighbor cache\n",
+                   argv[4], iface);
+        }
     }
     else if ((argc > 3) && (strcmp(argv[2], "del") == 0)) {
         ipv6_addr_t ipv6_addr;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This fixes https://github.com/RIOT-OS/RIOT/issues/9709. When there is no address resolution state-machine (ARSM), address resolution is restricted to reverse translations of the interface identifier (IID) of link-local addresses as defined in [RFC 6775](https://tools.ietf.org/html/rfc6775#section-5.6). As such, the function to fetch the next-hop data from the NIB-internals, asserts that the address of the next-hop is a link-local address, when the ARSM is deactivated.

https://github.com/RIOT-OS/RIOT/blob/d2369a2651400cd7f1ae1011332210654fdc4f04/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c#L333-L338

However, there are functions that add to the neighbor cache without checking if the address is a link-local address or not. This PR aims to fix that.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The steps to reproduce in https://github.com/RIOT-OS/RIOT/issues/9709#issuecomment-653298937 should succeed now and also the one described in OP.

`examples/gnrc_networking` should still work on `native` when using global addresses:

<details>

```
$ make -C examples/gnrc_networking -j flash term
[…]
main(): This is RIOT! (Version: 2020.10-devel-1136-gc5b63)
RIOT network stack example application
All up, running the shell now
> ifconfig 6 add affe::2
ifconfig 6 add affe::2
success: added affe::2/64 to interface 6
```

```
$ PORT=tap1 make -C examples/gnrc_networking term
[…]
main(): This is RIOT! (Version: 2020.10-devel-1136-gc5b63)
RIOT network stack example application
All up, running the shell now
> ifconfig
ifconfig
Iface  6  HWaddr: E2:BC:7D:CB:F5:50 
          L2-PDU:1500  MTU:1500  HL:64  RTR  
          RTR_ADV  
          Source address length: 6
          Link type: wired
          inet6 addr: fe80::e0bc:7dff:fecb:f550  scope: link  VAL
          inet6 addr: affe::e0bc:7dff:fecb:f550  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ffcb:f550
          
          Statistics for Layer 2
            RX packets 90  bytes 8276
            TX packets 64 (Multicast: 13)  bytes 5824
            TX succeeded 64 errors 0
          Statistics for IPv6
            RX packets 90  bytes 7016
            TX packets 64 (Multicast: 13)  bytes 4928
            TX succeeded 64 errors 0

> ping6 affe::2
ping6 affe::2
12 bytes from affe::2: icmp_seq=0 ttl=64 time=3.056 ms
12 bytes from affe::2: icmp_seq=1 ttl=64 time=1.293 ms
12 bytes from affe::2: icmp_seq=2 ttl=64 time=1.294 ms

--- affe::2 PING statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 1.293/1.881/3.056 ms
```

</details>
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Fixes https://github.com/RIOT-OS/RIOT/issues/9709
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
