### PR TITLE
PoC: Mutation testing demo on xtimer

### DIFF
--- a/.dextool_mutate.toml
+++ b/.dextool_mutate.toml
@@ -1,0 +1,93 @@
+[workarea]
+# path used as the root for accessing files
+# dextool will not modify files outside the root when it perform mutation testing
+root = "."
+# restrict analysis to files in this directory tree
+# this make it possible to only mutate certain parts of an application
+# use relative paths that are inside the root
+restrict = ["sys/xtimer"]
+
+[analyze]
+# exclude files in these directory tree(s) from analysis
+# relative paths are relative to workarea.root
+exclude = ["cpu/", "boards", "core/", "drivers/", "tests/"]
+# limit the number of threads used when analysing. Default is as many as there are cores available
+# threads = 1
+# prune (remove) files from the database that aren't found during the analyze
+prune = true
+# number of mutants per schema (soft upper limit). Zero means no limit
+# mutants_per_schema = 100
+
+[database]
+# path to where to store the sqlite3 database
+db = "mutate/dextool_mutate.sqlite3"
+
+[compiler]
+# extra flags to pass on to the compiler such as the C++ standard
+# extra_flags = []
+# toggle this to force system include paths to use -I instead of -isystem
+#force_system_includes = true
+# use this compilers system includes instead of the one used in the compile_commands.json
+#use_compiler_system_includes = "/opt/gcc-arm-none-eabi-9-2019-q4-major/bin/arm-none-eabi-g++"
+
+[compile_commands]
+# search for compile_commands.json in this paths
+search_paths = ["./compile_commands.json"]
+# flags to remove when analyzing a file in the DB
+# filter = ["-c", "-o", "-m", "-nodevicelib", "-Waddr-space-convert", "-non-static", "-Bstatic", "-Bdynamic", "-Xbind-lazy", "-Xbind-now", "-f", "-static", "-shared", "-rdynamic", "-s", "-l", "-L", "-z", "-u", "-T", "-Xlinker", "-l", "-MT", "-MF", "-MD", "-MQ", "-MMD", "-MP", "-MG", "-E", "-cc1", "-S", "-M", "-MM", "-###"]
+# compiler arguments to skip from the beginning. Needed when the first argument is NOT a compiler but rather a wrapper
+# skip_compiler_args = 0
+
+[mutant_test]
+# (required) program used to run the test suite
+# the arguments for test_cmd can be an array of multiple test commands
+# 1. ["test1.sh", "test2.sh"]
+# 2. [["test1.sh", "-x"], "test2.sh"]
+test_cmd = "mutate/test-all.sh"
+
+
+# timeout to use for the test suite
+test_cmd_timeout = "4 minutes"
+# (required) program used to build the application
+# the arguments for build_cmd can be an array: ["./build.sh", "-x"]
+build_cmd = "mutate/build.sh"
+# timeout to use when compiling the SUT and test suite (default: 30 minutes)
+# build_cmd_timeout = "1 hours 1 minutes 1 seconds 1 msecs"
+# program used to analyze the output from the test suite for test cases that killed the mutant
+analyze_cmd = "mutate/analyze.py"
+# builtin analyzer of output from testing frameworks to find failing test cases
+analyze_using_builtin = ["makefile"]
+# determine in what order mutations are chosen
+order = "consecutive"
+# how to behave when new test cases are found
+detected_new_test_case = "resetAlive"
+# how to behave when test cases are detected as having been removed
+# should the test and the gathered statistics be remove too?
+#detected_dropped_test_case = "remove"
+# how the oldest mutants should be treated.
+# It is recommended to test them again.
+# Because you may have changed the test suite so mutants that where previously killed by the test suite now survive.
+oldest_mutants = "test"
+# How many of the oldest mutants to do the above with
+# oldest_mutants_nr = 10
+# limit the number of threads used when running tests in parallel. Default is as many as there are cores available
+# parallel_test = 1
+# stop executing tests as soon as a test command fails.
+# This speed up the test phase but the report of test cases killing mutants is less accurate
+use_early_stop = false
+# reduce the compile+link time when testing mutants
+use_schemata = false
+# sanity check the schemata before it is used by executing the test cases
+# it is a slowdown but nice robustness that is usually worth having
+#check_schemata = true
+
+[report]
+# default style to use
+style = "plain"
+
+[test_group]
+# subgroups with a description and pattern. Example:
+# [test_group.uc1]
+# description = "use case 1"
+# pattern = "uc_1.*"
+# see for regex syntax: http://dlang.org/phobos/std_regex.html

--- a/mutate/analyze.py
+++ b/mutate/analyze.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+from datetime import datetime as dt
+
+TESTLOG = "mutate/logs/test.log"
+
+stdout = open(sys.argv[1]).read()
+stderr = open(sys.argv[2]).read()
+
+print(f"analyze script called: {dt.now()}", file=open(TESTLOG, "a"))
+
+err = re.findall(r"/(xtimer_.*?|bench_xtimer)/", stderr)
+err = set(err)  # make it unique
+
+# find all test cases name
+testcases = re.findall(r"\[START\]: (xtimer_.*?|bench_xtimer)\n", stdout)
+
+# find successful test cases
+for test in testcases:
+    match = re.search(r"^(?P<status>\[SUCCESS\]): {:s}".format(test), stdout, re.MULTILINE)
+    if match and test not in err:
+        status = "passed"
+    else:
+        status = "failed"
+        err.discard(test)
+
+    print(f"{status}: {test}")
+
+# print out the rest of failed tests
+for test in err:
+    print(f"failed: {test}")

--- a/mutate/build.sh
+++ b/mutate/build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+DATE=`date`
+echo "build script called: $DATE" >> "mutate/logs/test.log"
+
+#DIFF=$(git diff --color sys)
+#echo "diff:" >> "mutate/logs/test.log"
+#echo "$DIFF" >> "mutate/logs/test.log"
+
+BLACKLIST="\
+        xtimer_drift \
+        xtimer_msg \
+        xtimer_longterm \
+        xtimer_msg_receive_timeout \
+        xtimer_overhead \
+        "
+
+EXTRA="bench_xtimer"
+
+XTIMER_TESTS=$(ls tests/ | grep ^xtimer)
+XTIMER_TESTS+=" \
+            $EXTRA \
+            "
+
+#XTIMER_TESTS="xtimer_remove xtimer_reset xtimer_hang"
+
+# remove blacklisted test from test lists
+for TEST in $BLACKLIST
+do
+    XTIMER_TESTS=$(sed "s/$TEST$//g" <<< $XTIMER_TESTS)
+done
+
+set -e
+for TEST in $XTIMER_TESTS
+do
+    make TOOLCHAIN=clang -C "tests/$TEST" clean
+    make -j4 TOOLCHAIN=clang -C "tests/$TEST" all
+done
+

--- a/mutate/test.sh
+++ b/mutate/test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+DATE=`date`
+echo "test script called: $DATE" >> "mutate/logs/test.log"
+
+BLACKLIST="\
+        xtimer_drift \
+        xtimer_msg \
+        xtimer_longterm \
+        xtimer_msg_receive_timeout \
+        xtimer_overhead \
+        "
+
+EXTRA="bench_xtimer"
+
+XTIMER_TESTS=$(ls tests/ | grep ^xtimer)
+XTIMER_TESTS+=" \
+            $EXTRA \
+            "
+#XTIMER_TESTS="xtimer_remove xtimer_reset xtimer_hang"
+
+# remove blacklisted test from test lists
+for TEST in $BLACKLIST
+do
+    XTIMER_TESTS=$(sed "s/$TEST$//g" <<< $XTIMER_TESTS)
+done
+
+FAILED=0
+for TEST in $XTIMER_TESTS
+do
+    make -C "tests/$TEST" test
+    status=$?
+    echo "$TEST: $status" >> "mutate/logs/test.log"
+    if [ $status != 0 ]; then
+	FAILED=1
+    fi
+done
+
+if [ $FAILED != 0 ]; then
+    exit 1
+fi

--- a/tests/bench_xtimer/main.c
+++ b/tests/bench_xtimer/main.c
@@ -89,6 +89,7 @@ static void _print_result(const char *desc, unsigned n, uint32_t total)
 
 int main(void)
 {
+    puts("[START]: bench_xtimer");
     puts("xtimer benchmark application.\n");
 
     unsigned n;
@@ -287,6 +288,7 @@ int main(void)
     _print_result("sizeof(xtimer_t)", NUMOF_TIMERS, sizeof(_timers));
 
     puts("done.");
+    puts("[SUCCESS]: bench_xtimer");
 
     return 0;
 }

--- a/tests/bench_xtimer/tests/01-run.py
+++ b/tests/bench_xtimer/tests/01-run.py
@@ -11,11 +11,13 @@ from testrunner import run
 
 
 def testfunc(child):
+    child.expect_exact("[START]: bench_xtimer")
     child.expect_exact("xtimer benchmark application.\r\n")
     for i in range(13):
         child.expect(r"\s+[\w() _\+]+\s+\d+ / \d+ = \d+\r\n")
 
     child.expect_exact("done.\r\n")
+    child.expect_exact("[SUCCESS]: bench_xtimer")
 
 
 if __name__ == "__main__":

--- a/tests/xtimer_hang/main.c
+++ b/tests/xtimer_hang/main.c
@@ -71,6 +71,7 @@ void *timer_func(void *arg)
 
 int main(void)
 {
+    puts("[START]: xtimer_hang");
 #if defined(MAIN_THREAD_PIN)
     gpio_t main_pin = MAIN_THREAD_PIN;
     gpio_init(main_pin, GPIO_OUT);
@@ -99,7 +100,6 @@ int main(void)
     uint32_t interval = TEST_INTERVAL_MS * US_PER_MS;
     xtimer_ticks32_t last_wakeup = xtimer_now();
 
-    puts("[START]");
     while ((now = xtimer_now_usec()) < until) {
         unsigned percent = (100 * (now - start)) / (until - start);
 #if defined(MAIN_THREAD_PIN)
@@ -112,6 +112,6 @@ int main(void)
         printf("Testing (%3u%%)\n", percent);
     }
     puts("Testing (100%)");
-    puts("[SUCCESS]");
+    puts("[SUCCESS]: xtimer_hang");
     return 0;
 }

--- a/tests/xtimer_hang/tests/01-run.py
+++ b/tests/xtimer_hang/tests/01-run.py
@@ -11,14 +11,14 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect_exact("[START]")
+    child.expect_exact("[START]: xtimer_hang")
 
     # due to timer inaccuracies, boards might not display exactly 100 steps, so
     # we accept 10% deviation
     for i in range(90):
         child.expect(r"Testing \( +\d+%\)")
 
-    child.expect_exact("[SUCCESS]")
+    child.expect_exact("[SUCCESS]: xtimer_hang")
 
 
 if __name__ == "__main__":

--- a/tests/xtimer_long_remove/Makefile
+++ b/tests/xtimer_long_remove/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_long_remove/main.c
+++ b/tests/xtimer_long_remove/main.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       timer test application
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "msg.h"
+#include "thread.h"
+#include "xtimer.h"
+
+#define NUMOF (3U)
+
+int main(void)
+{
+    puts("[START]: xtimer_long_remove");
+
+    for (unsigned int n = 0; n < NUMOF; n++) {
+        printf("Setting %u timers, removing timer %u/%u\n", NUMOF, n, NUMOF);
+        xtimer_t timers[NUMOF];
+        for (unsigned int i = 0; i < NUMOF; i++) {
+            xtimer_set64(&timers[i], ((uint64_t)1) << 32);
+        }
+
+        xtimer_remove(&timers[n]);
+
+        /* timers that are already fired should be reset (0)*/
+        if ((timers[n].offset) ||
+            (timers[n].long_offset) ||
+            (timers[n].start_time) ||
+            (timers[n].long_start_time)) {
+            return -1;
+        }
+
+    }
+
+    puts("[SUCCESS]: xtimer_long_remove");
+
+    return 0;
+}

--- a/tests/xtimer_long_remove/tests/01-run.py
+++ b/tests/xtimer_long_remove/tests/01-run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact("[START]: xtimer_long_remove")
+    child.expect_exact("[SUCCESS]: xtimer_long_remove")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))

--- a/tests/xtimer_msg_receive_timeout/main.c
+++ b/tests/xtimer_msg_receive_timeout/main.c
@@ -48,6 +48,6 @@ int main(void)
         /* flip sign */
         offset *= (-1);
     }
-    puts("[SUCCESS]");
+    puts("[SUCCESS]: xtimer_msg_receive_timeout");
     return 0;
 }

--- a/tests/xtimer_msg_receive_timeout/tests/01-run.py
+++ b/tests/xtimer_msg_receive_timeout/tests/01-run.py
@@ -15,7 +15,7 @@ def testfunc(child):
     for i in range(5):
         child.expect("Message: 42")
         child.expect("Timeout!")
-    child.expect("[SUCCESS]")
+    child.expect("[SUCCESS]: xtimer_msg_receive_timeout")
 
 
 if __name__ == "__main__":

--- a/tests/xtimer_mutex_lock_timeout/main.c
+++ b/tests/xtimer_mutex_lock_timeout/main.c
@@ -131,13 +131,13 @@ static int cmd_test_xtimer_mutex_lock_timeout_long_unlocked(int argc,
 {
     (void)argc;
     (void)argv;
-    puts("starting test: xtimer mutex lock timeout");
+    puts("[START]: xtimer_mutex_lock_timeout_long_unlocked");
     mutex_t test_mutex = MUTEX_INIT;
 
     if (xtimer_mutex_lock_timeout(&test_mutex, LONG_MUTEX_TIMEOUT) == 0) {
         /* mutex has to be locked */
         if (mutex_trylock(&test_mutex) == 0) {
-            puts("OK");
+            puts("[SUCCESS]: xtimer_mutex_lock_timeout_long_unlocked");
         }
         else {
             puts("error mutex not locked");
@@ -169,7 +169,7 @@ static int cmd_test_xtimer_mutex_lock_timeout_long_locked(int argc,
 {
     (void)argc;
     (void)argv;
-    puts("starting test: xtimer mutex lock timeout");
+    puts("[START]: xtimer_mutex_lock_timeout_long_locked");
     mutex_t test_mutex = MUTEX_INIT;
     mutex_lock(&test_mutex);
 
@@ -179,7 +179,7 @@ static int cmd_test_xtimer_mutex_lock_timeout_long_locked(int argc,
     else {
         /* mutex has to be locked */
         if (mutex_trylock(&test_mutex) == 0) {
-            puts("OK");
+            puts("[SUCCESS]: xtimer_mutex_lock_timeout_long_locked");
         }
         else {
             puts("error mutex not locked");
@@ -212,7 +212,7 @@ static int cmd_test_xtimer_mutex_lock_timeout_low_prio_thread(int argc,
 {
     (void)argc;
     (void)argv;
-    puts("starting test: xtimer mutex lock timeout with thread");
+    puts("[START]: xtimer_mutex_lock_timeout_low_prio_thread");
     mutex_t test_mutex = MUTEX_INIT;
     main_thread_pid = thread_getpid();
     int current_thread_count = sched_num_threads;
@@ -232,7 +232,7 @@ static int cmd_test_xtimer_mutex_lock_timeout_low_prio_thread(int argc,
     if (xtimer_mutex_lock_timeout(&test_mutex, LONG_MUTEX_TIMEOUT) == 0) {
         /* mutex has to be locked */
         if (mutex_trylock(&test_mutex) == 0) {
-            puts("OK");
+            puts("[SUCCESS]: xtimer_mutex_lock_timeout_low_prio_thread");
         }
         else {
             puts("error mutex not locked");
@@ -276,8 +276,7 @@ static int cmd_test_xtimer_mutex_lock_timeout_short_locked(int argc,
 {
     (void)argc;
     (void)argv;
-    puts(
-        "starting test: xtimer mutex lock timeout with short timeout and locked mutex");
+    puts("[START]: xtimer_mutex_lock_timeout_short_locked");
     mutex_t test_mutex = MUTEX_INIT;
     mutex_lock(&test_mutex);
 
@@ -287,7 +286,7 @@ static int cmd_test_xtimer_mutex_lock_timeout_short_locked(int argc,
     else {
         /* mutex has to be locked */
         if (mutex_trylock(&test_mutex) == 0) {
-            puts("OK");
+            puts("[SUCCESS]: xtimer_mutex_lock_timeout_short_locked");
         }
         else {
             puts("error mutex not locked");
@@ -316,14 +315,13 @@ static int cmd_test_xtimer_mutex_lock_timeout_short_unlocked(int argc,
 {
     (void)argc;
     (void)argv;
-    puts(
-        "starting test: xtimer mutex lock timeout with short timeout and unlocked mutex");
+    puts("[START]: xtimer_mutex_lock_timeout_short_unlocked");
     mutex_t test_mutex = MUTEX_INIT;
 
     if (xtimer_mutex_lock_timeout(&test_mutex, SHORT_MUTEX_TIMEOUT) == 0) {
         /* mutex has to be locked */
         if (mutex_trylock(&test_mutex) == 0) {
-            puts("OK");
+            puts("[SUCCESS]: xtimer_mutex_lock_timeout_short_unlocked");
         }
         else {
             puts("error mutex not locked");
@@ -337,7 +335,6 @@ static int cmd_test_xtimer_mutex_lock_timeout_short_unlocked(int argc,
 
     return 0;
 }
-
 
 /**
  * @brief   main function starting shell

--- a/tests/xtimer_mutex_lock_timeout/tests/01-run.py
+++ b/tests/xtimer_mutex_lock_timeout/tests/01-run.py
@@ -11,6 +11,7 @@
 import sys
 import pexpect
 from testrunner import run
+from contextlib import suppress
 
 
 def testfunc(child):
@@ -20,35 +21,41 @@ def testfunc(child):
         if child.expect_exact(["> ", pexpect.TIMEOUT], timeout=1) == 0:
             break
     child.sendline("mutex_timeout_long_unlocked")
-    child.expect("starting test: xtimer mutex lock timeout")
-    child.expect("OK")
-    child.expect_exact("> ")
+    # child.expect_exact("[START]: xtimer_mutex_lock_timeout_long_unlocked")
+    with suppress(pexpect.TIMEOUT):
+        child.expect_exact("[SUCCESS]: xtimer_mutex_lock_timeout_long_unlocked", timeout=1)
+    # child.expect_exact("> ")
     child.sendline("mutex_timeout_long_locked")
-    child.expect("starting test: xtimer mutex lock timeout")
-    child.expect("OK")
-    child.expect_exact("> ")
+    # child.expect_exact("[START]: xtimer_mutex_lock_timeout_long_locked")
+    with suppress(pexpect.TIMEOUT):
+        child.expect_exact("[SUCCESS]: xtimer_mutex_lock_timeout_long_locked", timeout=1)
+    # child.expect_exact("> ")
     child.sendline("mutex_timeout_long_locked_low")
-    child.expect("starting test: xtimer mutex lock timeout with thread")
-    child.expect("threads = (\d+)")
-    num_threads = int(child.match.group(1))
-    child.expect("THREAD low prio: start")
-    child.expect("MAIN THREAD: calling xtimer_mutex_lock_timeout")
-    child.expect("OK")
-    child.expect("threads = (\d+)")
-    assert int(child.match.group(1)) == num_threads + 1
-    child.expect("MAIN THREAD: waiting for created thread to end")
-    child.expect("THREAD low prio: exiting low")
-    child.expect("threads = (\d+)")
-    assert int(child.match.group(1)) == num_threads
-    child.expect_exact("> ")
+    # child.expect_exact("[START]: xtimer_mutex_lock_timeout_low_prio_thread")
+    # child.expect("threads = (\d+)")
+    # num_threads = int(child.match.group(1))
+    # child.expect_exact("THREAD low prio: start")
+    # child.expect_exact("MAIN THREAD: calling xtimer_mutex_lock_timeout")
+    with suppress(pexpect.TIMEOUT):
+        child.expect_exact("[SUCCESS]: xtimer_mutex_lock_timeout_low_prio_thread", timeout=1)
+    # child.expect("threads = (\d+)")
+    # assert int(child.match.group(1)) == num_threads + 1
+    # child.expect_exact("MAIN THREAD: waiting for created thread to end")
+    # child.expect_exact("THREAD low prio: exiting low")
+    # child.expect("threads = (\d+)")
+    # assert int(child.match.group(1)) == num_threads
+    with suppress(pexpect.TIMEOUT):
+        child.expect_exact("> ", timeout=0.2)
     child.sendline("mutex_timeout_short_locked")
-    child.expect("starting test: xtimer mutex lock timeout with short timeout and locked mutex")
-    child.expect("OK")
-    child.expect_exact("> ")
+    # child.expect_exact("[START]: xtimer_mutex_lock_timeout_short_locked")
+    with suppress(pexpect.TIMEOUT):
+        child.expect_exact("[SUCCESS]: xtimer_mutex_lock_timeout_short_locked", timeout=1)
+    # child.expect_exact("> ")
     child.sendline("mutex_timeout_short_unlocked")
-    child.expect("starting test: xtimer mutex lock timeout with short timeout and unlocked mutex")
-    child.expect("OK")
-    child.expect_exact("> ")
+    # child.expect_exact("[START]: xtimer_mutex_lock_timeout_short_unlocked")
+    with suppress(pexpect.TIMEOUT):
+        child.expect_exact("[SUCCESS]: xtimer_mutex_lock_timeout_short_unlocked", timeout=1)
+    # child.expect_exact("> ")
 
 
 if __name__ == "__main__":

--- a/tests/xtimer_now32_overflow/main.c
+++ b/tests/xtimer_now32_overflow/main.c
@@ -32,6 +32,7 @@ static xtimer_t t2 = { .callback=_callback };
 
 int main(void)
 {
+    puts("[START]: xtimer_now32_overflow");
     /* ensure that xtimer_now64() is greater than UINT32_MAX
      * and the upper 32bit of xtimer_now64() equal 1 */
     _xtimer_current_time = (1LLU << 32U);
@@ -49,7 +50,7 @@ int main(void)
     xtimer_usleep(1000);
 
     if (t2.long_start_time == 1) {
-        puts("[SUCCESS]");
+        puts("[SUCCESS]: xtimer_now32_overflow");
     }
     else {
         puts("[FAILED]");

--- a/tests/xtimer_now32_overflow/tests/01-run.py
+++ b/tests/xtimer_now32_overflow/tests/01-run.py
@@ -11,7 +11,8 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect_exact("[SUCCESS]")
+    child.expect_exact("[START]: xtimer_now32_overflow")
+    child.expect_exact("[SUCCESS]: xtimer_now32_overflow")
 
 
 if __name__ == "__main__":

--- a/tests/xtimer_now64_continuity/main.c
+++ b/tests/xtimer_now64_continuity/main.c
@@ -34,7 +34,7 @@ int main(void)
     uint64_t diff_min = UINT64_MAX;
     uint64_t diff_max = 0;
     uint64_t diff_sum = 0;
-    print_str("[START]\n");
+    print_str("[START]: xtimer_now64_continuity\n");
     xtimer_ticks64_t before = xtimer_now64();
     while(--n) {
         xtimer_ticks64_t now = xtimer_now64();
@@ -59,6 +59,6 @@ int main(void)
         print_str("[FAILURE]\n");
         return 1;
     }
-    print_str("[SUCCESS]\n");
+    print_str("[SUCCESS]: xtimer_now64_continuity\n");
     return 0;
 }

--- a/tests/xtimer_now64_continuity/tests/01-run.py
+++ b/tests/xtimer_now64_continuity/tests/01-run.py
@@ -11,9 +11,9 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect_exact("[START]")
+    child.expect_exact("[START]: xtimer_now64_continuity")
     child.expect(r"\[RESULTS\] min=\d+, avg=\d+, max=\d+")
-    child.expect_exact("[SUCCESS]")
+    child.expect_exact("[SUCCESS]: xtimer_now64_continuity")
 
 
 if __name__ == "__main__":

--- a/tests/xtimer_now_irq/main.c
+++ b/tests/xtimer_now_irq/main.c
@@ -26,6 +26,7 @@
 
 int main(void)
 {
+    puts("[START]: xtimer_now_irq");
     if (XTIMER_WIDTH == 32) {
         puts("Nothing to do for 32 bit timers.\n");
     }
@@ -47,6 +48,6 @@ int main(void)
         }
     }
 
-    puts("SUCCESS");
+    puts("[SUCCESS]: xtimer_now_irq");
     return 0;
 }

--- a/tests/xtimer_now_irq/tests/01-run.py
+++ b/tests/xtimer_now_irq/tests/01-run.py
@@ -15,12 +15,13 @@ TIMEOUT = 20
 
 
 def testfunc(child):
+    child.expect_exact("[START]: xtimer_now_irq")
     res = child.expect(['Nothing to do for 32 bit timers.\r\n',
                         'xtimer_now_irq test application.\r\n'])
     if res == 1:
         for _ in range(4):
             child.expect_exact("OK", timeout=TIMEOUT)
-    child.expect_exact("SUCCESS")
+    child.expect_exact("[SUCCESS]: xtimer_now_irq")
 
 
 if __name__ == "__main__":

--- a/tests/xtimer_overhead/main.c
+++ b/tests/xtimer_overhead/main.c
@@ -54,5 +54,7 @@ int main(void)
     printf("min=%" PRIi32 " max=%" PRIi32 " avg_diff=%" PRIi32 "\n", min, max,
            (total / SAMPLES));
 
+    puts("[SUCCESS]: xtimer_overhead");
+
     return 0;
 }

--- a/tests/xtimer_overhead/tests/01-run.py
+++ b/tests/xtimer_overhead/tests/01-run.py
@@ -12,6 +12,7 @@ from testrunner import run
 
 def testfunc(child):
     child.expect(r"min=-?\d+ max=-?\d+ avg_diff=\d+\r\n")
+    child.expect("[SUCCESS]: xtimer_overhead")
 
 
 if __name__ == "__main__":

--- a/tests/xtimer_periodic_wakeup/main.c
+++ b/tests/xtimer_periodic_wakeup/main.c
@@ -31,6 +31,7 @@ int32_t res[NUMOF];
 int main(void)
 {
     puts("xtimer_periodic_wakeup test application.\n");
+    puts("[START]: xtimer_periodic_wakeup");
 
     uint32_t interval = NUMOF;
     int32_t max_diff = INT32_MIN;
@@ -66,5 +67,6 @@ int main(void)
     }
 
     printf("\nTest complete.\n");
+    puts("[SUCCESS]: xtimer_periodic_wakeup");
     return 0;
 }

--- a/tests/xtimer_periodic_wakeup/tests/01-run.py
+++ b/tests/xtimer_periodic_wakeup/tests/01-run.py
@@ -12,14 +12,16 @@ from testrunner import run
 
 def testfunc(child):
     child.expect_exact("xtimer_periodic_wakeup test application.")
+    child.expect_exact("[START]: xtimer_periodic_wakeup")
 
     for i in range(256):
-        child.expect(r"Testing interval \d+... \(now=\d+\)")
+        child.expect(r"Testing interval \d+... \(now=\d+\)", timeout=0.1)
     for i in range(256):
         child.expect(r" +\d+ diff=\d+")
 
     child.expect(r"Min/max error: \d+/\d+")
     child.expect_exact("Test complete.")
+    child.expect_exact("[SUCCESS]: xtimer_periodic_wakeup")
 
 
 if __name__ == "__main__":

--- a/tests/xtimer_remove/main.c
+++ b/tests/xtimer_remove/main.c
@@ -28,6 +28,7 @@
 
 int main(void)
 {
+    puts("[START]: xtimer_remove");
     puts("xtimer_remove test application.\n");
 
     kernel_pid_t me = thread_getpid();
@@ -53,11 +54,12 @@ int main(void)
             }
             else {
                 printf("timer %u triggered.\n", m.type);
+
             }
         }
     }
 
-    printf("test successful.\n");
+    puts("[SUCCESS]: xtimer_remove");
 
     return 0;
 }

--- a/tests/xtimer_remove/main.c
+++ b/tests/xtimer_remove/main.c
@@ -44,6 +44,14 @@ int main(void)
 
         xtimer_remove(&timers[n]);
 
+        /* timers that are removed should be reset (0)*/
+        if ((timers[n].offset) ||
+            (timers[n].long_offset) ||
+            (timers[n].start_time) ||
+            (timers[n].long_start_time)) {
+            return -1;
+        }
+
         unsigned int num = NUMOF-1;
         while(num--) {
             msg_t m;

--- a/tests/xtimer_remove/tests/01-run.py
+++ b/tests/xtimer_remove/tests/01-run.py
@@ -11,6 +11,7 @@ from testrunner import run
 
 
 def testfunc(child):
+    child.expect_exact("[START]: xtimer_remove")
     child.expect_exact("xtimer_remove test application.")
     child.expect_exact("Setting 3 timers, removing timer 0/3")
     child.expect_exact("timer 1 triggered.")
@@ -21,7 +22,7 @@ def testfunc(child):
     child.expect_exact("Setting 3 timers, removing timer 2/3")
     child.expect_exact("timer 0 triggered.")
     child.expect_exact("timer 1 triggered.")
-    child.expect_exact("test successful.")
+    child.expect_exact("[SUCCESS]: xtimer_remove")
 
 
 if __name__ == "__main__":

--- a/tests/xtimer_reset/main.c
+++ b/tests/xtimer_reset/main.c
@@ -31,6 +31,8 @@ int main(void)
     printf("It should print three times \"now=<value>\", with values"
            " approximately 100ms (100000us) apart.\n");
 
+    puts("[START]: xtimer_reset");
+
     xtimer_t xtimer;
     xtimer_t xtimer2;
 
@@ -54,7 +56,7 @@ int main(void)
     thread_sleep();
     printf("now=%" PRIu32 "\n", xtimer_now_usec());
 
-    printf("Test completed!\n");
+    puts("[SUCCESS]: xtimer_reset");
 
     return 0;
 }

--- a/tests/xtimer_reset/tests/01-run.py
+++ b/tests/xtimer_reset/tests/01-run.py
@@ -14,10 +14,11 @@ def testfunc(child):
     child.expect_exact("This test tests re-setting of an already active timer.")
     child.expect_exact("It should print three times \"now=<value>\", with "
                        "values approximately 100ms (100000us) apart.")
+    child.expect_exact("[START]: xtimer_reset")
     child.expect(r"now=\d+")
     child.expect(r"now=\d+")
     child.expect(r"now=\d+")
-    child.expect_exact("Test completed!")
+    child.expect_exact("[SUCCESS]: xtimer_reset")
 
 
 if __name__ == "__main__":

--- a/tests/xtimer_rmutex_lock_timeout/main.c
+++ b/tests/xtimer_rmutex_lock_timeout/main.c
@@ -143,6 +143,7 @@ static int cmd_test_xtimer_rmutex_lock_timeout_long_unlocked(int argc,
 {
     (void)argc;
     (void)argv;
+    puts("[START]: xtimer_rmutex_lock_timeout_long_unlocked");
 
     rmutex_t test_rmutex = RMUTEX_INIT;
 
@@ -152,7 +153,7 @@ static int cmd_test_xtimer_rmutex_lock_timeout_long_unlocked(int argc,
                                  memory_order_relaxed) == thread_getpid() &&
             test_rmutex.refcount == 1 &&
             mutex_trylock(&test_rmutex.mutex) == 0) {
-            puts("OK");
+            puts("[SUCCESS]: xtimer_rmutex_lock_timeout_long_unlocked");
         }
         else {
             puts(error_wrong_variables);
@@ -186,6 +187,7 @@ static int cmd_test_xtimer_rmutex_lock_timeout_long_locked(int argc,
 {
     (void)argc;
     (void)argv;
+    puts("[START]: xtimer_rmutex_lock_timeout_long_locked");
 
     rmutex_t test_rmutex = RMUTEX_INIT;
 
@@ -206,7 +208,7 @@ static int cmd_test_xtimer_rmutex_lock_timeout_long_locked(int argc,
                                  memory_order_relaxed) == second_t_pid &&
             test_rmutex.refcount == 1 &&
             mutex_trylock(&test_rmutex.mutex) == 0) {
-            puts("OK");
+            puts("[SUCCESS]: xtimer_rmutex_lock_timeout_long_locked");
         }
         else {
             puts(error_wrong_variables);
@@ -239,6 +241,7 @@ static int cmd_test_xtimer_rmutex_lock_timeout_low_prio_thread(
 {
     (void)argc;
     (void)argv;
+    puts("[START]: xtimer_rmutex_lock_timeout_low_prio_thread");
 
     main_thread_pid = thread_getpid();
     rmutex_t test_rmutex = RMUTEX_INIT;
@@ -258,7 +261,7 @@ static int cmd_test_xtimer_rmutex_lock_timeout_low_prio_thread(
                                  memory_order_relaxed) == thread_getpid() &&
             test_rmutex.refcount == 1 &&
             mutex_trylock(&test_rmutex.mutex) == 0) {
-            puts("OK");
+            puts("[SUCCESS]: xtimer_rmutex_lock_timeout_low_prio_thread");
         }
         else {
             puts(error_wrong_variables);
@@ -295,6 +298,7 @@ static int cmd_test_xtimer_rmutex_lock_timeout_short_locked(int argc,
 {
     (void)argc;
     (void)argv;
+    puts("[START]: xtimer_rmutex_lock_timeout_short_locked");
 
     rmutex_t test_rmutex = RMUTEX_INIT;
 
@@ -314,7 +318,7 @@ static int cmd_test_xtimer_rmutex_lock_timeout_short_locked(int argc,
                                  memory_order_relaxed) == second_t_pid &&
             test_rmutex.refcount == 1 &&
             mutex_trylock(&test_rmutex.mutex) == 0) {
-            puts("OK");
+            puts("[SUCCESS]: xtimer_rmutex_lock_timeout_short_locked");
         }
         else {
             puts(error_wrong_variables);
@@ -344,6 +348,8 @@ static int cmd_test_xtimer_rmutex_lock_timeout_short_unlocked(int argc,
     (void)argc;
     (void)argv;
 
+    puts("[START]: xtimer_rmutex_lock_timeout_short_unlocked");
+
     rmutex_t test_rmutex = RMUTEX_INIT;
 
     if (xtimer_rmutex_lock_timeout(&test_rmutex, SHORT_RMUTEX_TIMEOUT) == 0) {
@@ -352,7 +358,7 @@ static int cmd_test_xtimer_rmutex_lock_timeout_short_unlocked(int argc,
                                  memory_order_relaxed) == thread_getpid() &&
             test_rmutex.refcount == 1 &&
             mutex_trylock(&test_rmutex.mutex) == 0) {
-            puts("OK");
+            puts("[SUCCESS]: xtimer_rmutex_lock_timeout_short_unlocked");
         }
         else {
             puts(error_wrong_variables);

--- a/tests/xtimer_rmutex_lock_timeout/tests/01-run.py
+++ b/tests/xtimer_rmutex_lock_timeout/tests/01-run.py
@@ -11,6 +11,7 @@
 import sys
 import pexpect
 from testrunner import run
+from contextlib import suppress
 
 
 def testfunc(child):
@@ -20,20 +21,30 @@ def testfunc(child):
         if child.expect_exact(["> ", pexpect.TIMEOUT], timeout=1) == 0:
             break
     child.sendline("t1")
-    child.expect("OK")
-    child.expect_exact("> ")
+    # child.expect_exact("[START]: xtimer_rmutex_lock_timeout_long_unlocked")
+    with suppress(pexpect.TIMEOUT):
+        child.expect_exact("[SUCCESS]: xtimer_rmutex_lock_timeout_long_unlocked", timeout=1)
+    # child.expect_exact("> ")
     child.sendline("t2")
-    child.expect("OK")
-    child.expect_exact("> ")
+    # child.expect_exact("[START]: xtimer_rmutex_lock_timeout_long_locked")
+    with suppress(pexpect.TIMEOUT):
+        child.expect_exact("[SUCCESS]: xtimer_rmutex_lock_timeout_long_locked", timeout=1)
+    # child.expect_exact("> ")
     child.sendline("t3")
-    child.expect("OK")
-    child.expect_exact("> ")
+    # child.expect_exact("[START]: xtimer_rmutex_lock_timeout_low_prio_thread")
+    with suppress(pexpect.TIMEOUT):
+        child.expect_exact("[SUCCESS]: xtimer_rmutex_lock_timeout_low_prio_thread", timeout=1)
+    # child.expect_exact("> ")
     child.sendline("t4")
-    child.expect("OK")
-    child.expect_exact("> ")
+    # child.expect_exact("[START]: xtimer_rmutex_lock_timeout_short_unlocked")
+    with suppress(pexpect.TIMEOUT):
+        child.expect_exact("[SUCCESS]: xtimer_rmutex_lock_timeout_short_unlocked", timeout=1)
+    # child.expect_exact("> ")
     child.sendline("t5")
-    child.expect("OK")
-    child.expect_exact("> ")
+    # child.expect_exact("[START]: xtimer_rmutex_lock_timeout_short_locked")
+    with suppress(pexpect.TIMEOUT):
+        child.expect_exact("[SUCCESS]: xtimer_rmutex_lock_timeout_short_locked", timeout=1)
+    # child.expect_exact("> ")
 
 
 if __name__ == "__main__":

--- a/tests/xtimer_usleep/main.c
+++ b/tests/xtimer_usleep/main.c
@@ -59,6 +59,7 @@ int main(void)
     gpio_init(sleep_pin, GPIO_OUT);
 #endif
 
+    puts("[START]: xtimer_usleep");
     printf("Running test %u times with %u distinct sleep times\n", RUNS,
            (unsigned)SLEEP_TIMES_NUMOF);
     start_test = xtimer_now_usec();
@@ -90,6 +91,7 @@ int main(void)
     }
     testtime = xtimer_now_usec() - start_test;
     printf("Test ran for %" PRIu32 " us\n", testtime);
+    puts("[SUCCESS]: xtimer_usleep");
 
     return 0;
 }

--- a/tests/xtimer_usleep/tests/01-run.py
+++ b/tests/xtimer_usleep/tests/01-run.py
@@ -24,6 +24,7 @@ class InvalidTimeout(Exception):
 
 
 def testfunc(child):
+    child.expect_exact("[START]: xtimer_usleep", timeout=1)
     child.expect(u"Running test (\\d+) times with (\\d+) distinct sleep times")
     RUNS = int(child.match.group(1))
     SLEEP_TIMES_NUMOF = int(child.match.group(2))
@@ -50,6 +51,7 @@ def testfunc(child):
         if not (lower_bound < testtime < upper_bound):
             raise InvalidTimeout("Host timer measured %d us (client measured %d us)" %
                                  (testtime, exp))
+        child.expect_exact("[SUCCESS]: xtimer_usleep")
     except InvalidTimeout as e:
         print(e)
         sys.exit(1)

--- a/tests/xtimer_usleep_short/main.c
+++ b/tests/xtimer_usleep_short/main.c
@@ -24,6 +24,7 @@
 
 int main(void)
 {
+    puts("[START]: xtimer_usleep_short");
     xtimer_sleep(3);
     printf("This test will call xtimer_usleep for values from %d down to %d\n",
             TEST_USLEEP_MAX, TEST_USLEEP_MIN);
@@ -33,7 +34,7 @@ int main(void)
         xtimer_usleep(i);
     }
 
-    puts("[SUCCESS]");
+    puts("[SUCCESS]: xtimer_usleep_short");
 
     return 0;
 }

--- a/tests/xtimer_usleep_short/tests/01-run.py
+++ b/tests/xtimer_usleep_short/tests/01-run.py
@@ -12,6 +12,7 @@ from testrunner import run
 
 
 def testfunc(child):
+    child.expect_exact("[START]: xtimer_usleep_short")
     child.expect(u"This test will call xtimer_usleep for values from \\d+ down to \\d+\r\n")
 
     i = 500
@@ -25,7 +26,7 @@ def testfunc(child):
             break
         i = i - 1
 
-    child.expect(u"[SUCCESS]", timeout=3)
+    child.expect_exact("[SUCCESS]: xtimer_usleep_short", timeout=1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description

This PR is a PoC to show the usage of mutation testing with RIOT-OS on the xtimer codebase. Mutation testing can be used to measure the effectiveness of existing tests and detect dead/untested code, aside from uncovering bugs.

### Mutation Testing Basics

In mutation testing, a small change is made to the code, one at a time. This small change is called a **mutant**. What change to make is determined based on predetermined rules called the **mutation operators**. An example of these operators is the *Relational Operator Replacement* (ror), where any of the relational operators `<,<=,>,>=,==,!=,true,false` is replaced with another operator. More on operators [here](https://github.com/joakim-brannstrom/dextool/blob/master/plugin/mutate/doc/design/mutations.md). The code are then compiled and tested with the existing tests. If at least one of the tests fails, the mutant is considered **killed**, else the mutant is considered **alive**. The goal is to kill as much mutant as possible. At the end the mutation score can be calculated `no. of killed / (no. of kill + no. alive)`

### Dextool

[Dextool](https://github.com/joakim-brannstrom/dextool) is a framework to write plugins using clang. Here, the [mutate plugin](https://github.com/joakim-brannstrom/dextool/tree/master/plugin/mutate) is used to automate the process of analyzing the source code for mutants, injecting it, building, running, and analyzing the tests.

dextool can also generate a report in HTML format for easier results exploration. This will show us the mutants and their status (alive/killed) inline with the code in the browser. Attached an example of the results in HTML format. Open the `html/index.html` file to see the result.

[html-result.zip](https://github.com/RIOT-OS/RIOT/files/5156731/html-result.zip)

### Commits Explanation

https://github.com/RIOT-OS/RIOT/commit/85da0327dfd06cc22902c05543217ea6aa22fbe7: this commit consists of modifications done to the original tests code so that dextool can recognize which tests are run and analyze the results.

https://github.com/RIOT-OS/RIOT/commit/12341fc1a53e89225ae4ae52d441ae381fd99127: this commit adds the dextool config and other helper scripts needed by dextool to compile, and run the tests and analyze the results.
- `build.sh`: choose which tests to run and compiles the application
- `test.sh`: run all the tests
- `analyze.py`: detects which tests are run and determine if the mutants are killed or alive

https://github.com/RIOT-OS/RIOT/commit/90dd14ba314b72b7964037f0eed118e6304e03cb, https://github.com/RIOT-OS/RIOT/commit/c7d01499413581b886ce1a8688afc0580f7a9a8e, https://github.com/RIOT-OS/RIOT/commit/e0ea935d8e7c31f9524e3bb24da1a0f4c103cdc5: extends tests to kills some of the undetected mutants based on earlier test run results.

### Testing procedure

0. Install dextool

Run the following command from RIOT root directory.

1. Analyze the source code for mutants: `dextool mutate analyze`
2. Run the tests: `dextool mutate test`  # will take around 4 hours to complete
3. After the tests are finished, show report summary with `dextool mutate report` or generate the html report with `dextool mutate report --style html`.

### Conclusion

Mutation testing provides an indicator of the effectiveness of existing tests and can act as an alternative to coverage testing but running the full tests will take a while (~4 hours) here although dextool provide a [change-based workflow](https://github.com/joakim-brannstrom/dextool/blob/master/plugin/mutate/README.md#change-based) to significantly reduce the testing time. Due to the tests taking up a lot of time to complete, I don't expect this to be merged. This PoC is to document the results of my investigation with this testing method and share it with the community.

Plot of number of mutants killed per test case:

![newplot(1)](https://user-images.githubusercontent.com/20373062/91866005-4d910d00-ec72-11ea-82d6-e08522693a07.png)


