### PR TITLE
tests/periph_rtt_min: force RIOT_TERMINAL socat

### DIFF
--- a/tests/periph_rtt_min/Makefile
+++ b/tests/periph_rtt_min/Makefile
@@ -6,15 +6,22 @@ USEMODULE += xtimer
 FEATURES_REQUIRED += periph_rtt
 DISABLE_MODULE += periph_init_rtt
 
-SAMPLES ?= 1024
-CFLAGS += -DSAMPLES=$(SAMPLES)
+RIOT_TERMINAL ?= socat
 
 include $(RIOTBASE)/Makefile.include
-
-$(call target-export-variables, test, SAMPLES)
 
 # use highest possible RTT_FREQUENCY for boards that allow it
 ifneq (,$(filter stm32 nrf5%,$(CPU)))
   RTT_FREQUENCY ?= RTT_MAX_FREQUENCY
   CFLAGS += -DRTT_FREQUENCY=$(RTT_FREQUENCY)
 endif
+
+# kinetis rtt runs at 1Hz, reduce samples to speed up the test
+ifneq (,$(filter kinetis,$(CPU)))
+  SAMPLES ?= 64
+else
+  SAMPLES ?= 1024
+endif
+CFLAGS += -DSAMPLES=$(SAMPLES)
+
+$(call target-export-variables, test, SAMPLES)


### PR DESCRIPTION
### Contribution description

pyterm only echoes after a \n is received, so use socat instead so '.' are printed as they are generated. This has an impact when running on slow rtt, e.g.: kinetis which runs at 1Hz.

To speed up the test for these boards (so it doesn't last 17min, the sample size is reduced).

### Testing procedure

With this PR the test now passes for kinetis `BOARD`s (and takes a reasonable time)

```
main(): This is RIOT! (Version: 2020.10-devel-1181-g4874d-pr_rtt_min_socat)
Evaluate RTT_MIN_OFFSET over 64 samples
................................................................
RTT_MIN_OFFSET for pba-d-01-kw2x: 1
```


### Issues/PRs references
