### PR TITLE
net/sock/dtls :  Expose configuration to Kconfig

### DIFF
--- a/sys/include/net/sock/dtls.h
+++ b/sys/include/net/sock/dtls.h
@@ -491,13 +491,35 @@
 extern "C" {
 #endif
 
+/**
+ * @defgroup net_sock_dtls_conf    SOCK DTLS compile configuration
+ * @ingroup  net_sock_conf
+ * @{
+ */
+/**
+ * @brief   Default buffer size for DTLS handshake (as exponent of 2^n)
+ *
+ * As the buffer size ALWAYS needs to be power of two, this option represents
+ * the exponent of 2^n, which will be used as the size of the buffer
+ * ( @ref DTLS_HANDSHAKE_BUFSIZE ).
+ *
+ */
+#ifndef CONFIG_DTLS_HANDSHAKE_BUFSIZE_EXP
+#define CONFIG_DTLS_HANDSHAKE_BUFSIZE_EXP  8
+#endif
+/** @} */
+
+/**
+ * @brief   Size buffer used in handshake to hold credentials
+ */
 #ifndef DTLS_HANDSHAKE_BUFSIZE
-#define DTLS_HANDSHAKE_BUFSIZE  (256)   /**< Size buffer used in handshake to
-                                             hold credentials */
+#define DTLS_HANDSHAKE_BUFSIZE  (1 << CONFIG_DTLS_HANDSHAKE_BUFSIZE_EXP)
 #endif
 
-#define SOCK_DTLS_HANDSHAKE     (EXDEV) /**< Return value for a successful
-                                             handshake */
+/**
+ * @brief   Return value for a successful handshake
+ */
+#define SOCK_DTLS_HANDSHAKE     (EXDEV)
 
 /**
  * @brief DTLS version number

--- a/sys/include/net/sock/util.h
+++ b/sys/include/net/sock/util.h
@@ -206,11 +206,9 @@ static inline bool sock_udp_ep_equal(const sock_udp_ep_t *a,
 
 /**
  * @defgroup    net_sock_util_conf SOCK utility functions compile configurations
- * @ingroup     net_sock_util
- * @ingroup     config
+ * @ingroup     net_sock_conf
  * @{
  */
-
 /**
  * @brief maximum length of the scheme part for sock_urlsplit.
  *
@@ -233,7 +231,6 @@ static inline bool sock_udp_ep_equal(const sock_udp_ep_t *a,
 #ifndef CONFIG_SOCK_URLPATH_MAXLEN
 #define CONFIG_SOCK_URLPATH_MAXLEN     (64U)
 #endif
-
 /** @} */
 
 #ifdef __cplusplus

--- a/sys/net/sock/Kconfig
+++ b/sys/net/sock/Kconfig
@@ -29,3 +29,19 @@ config SOCK_URLPATH_MAXLEN
         This value is used in sock_urlsplit().
 
 endif # KCONFIG_USEMODULE_SOCK_UTIL
+
+menuconfig KCONFIG_USEMODULE_SOCK_DTLS
+    bool "Configure SOCK DTLS"
+    depends on USEMODULE_SOCK_DTLS
+
+if KCONFIG_USEMODULE_SOCK_DTLS
+
+config DTLS_HANDSHAKE_BUFSIZE_EXP
+    int "Exponent for the DTLS buffer size (resulting in the buffer size 2^n)"
+    default 8
+    help
+        As the buffer size ALWAYS needs to be power of two, this option
+        represents the exponent of 2^n, which will be used as the size of the
+        buffer. The buffer is used to hold credentials during DTLS handshakes.
+
+endif # KCONFIG_USEMODULE_SOCK_DTLS

--- a/sys/net/sock/doc.txt
+++ b/sys/net/sock/doc.txt
@@ -1,0 +1,11 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+/**
+ * @defgroup    net_sock_conf SOCK compile configurations
+ * @ingroup     config
+ * @brief       Group of compile time configurations related to SOCK
+ */


### PR DESCRIPTION
### Contribution description

This PR exposes compile configurations in **net/sock/dtls** to Kconfig.

### Testing procedure

1. New documentation was built using Doxygen 

   The build works fine.

  2. Test files were added to tests/gnrc_sock_dtls/

      The test branch can be found [here](https://github.com/akshaim/RIOT/tree/Kconfig_dtls_tests)

      Compiled binaries for native

#### Default State:

##### Firmware Output

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-1161-g37ad3-Kconfig_dtls_tests)
CONFIG_DTLS_HANDSHAKE_BUFSIZE_EXP=8
DTLS_HANDSHAKE_BUFSIZE=(1 << 8)

```
#### Usage with CFLAGS :
```
CFLAGS += -DCONFIG_DTLS_HANDSHAKE_BUFSIZE_EXP=10
```

##### Firmware Output

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-1161-g37ad3-Kconfig_dtls_tests)
CONFIG_DTLS_HANDSHAKE_BUFSIZE_EXP=10
DTLS_HANDSHAKE_BUFSIZE=(1 << 10)
```

#### Usage with menuconfig :


`make menuconfig`

#### Default values

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-1161-g37ad3-Kconfig_dtls_tests)
CONFIG_DTLS_HANDSHAKE_BUFSIZE_EXP=8
DTLS_HANDSHAKE_BUFSIZE=(1 << 8)
```
##### Macros Configured output

```
RIOT native interrupts/signals initialized.
LED_RED_OFF
LED_GREEN_ON
RIOT native board initialized.
RIOT native hardware initialization complete.

main(): This is RIOT! (Version: 2020.10-devel-1161-g37ad3-Kconfig_dtls_tests)
CONFIG_DTLS_HANDSHAKE_BUFSIZE_EXP=6
DTLS_HANDSHAKE_BUFSIZE=(1 << 6)
```


**MACROS were successfully configured.**

### Issues/PRs references

#12888 