### PR TITLE
memarray: Add memarray_calloc

### DIFF
--- a/sys/include/memarray.h
+++ b/sys/include/memarray.h
@@ -54,12 +54,26 @@ void memarray_init(memarray_t *mem, void *data, size_t size, size_t num);
  *
  * @pre `mem != NULL`
  *
+ * @note Allocated structure is not cleared before returned
+ *
  * @param[in,out] mem   memarray pool to allocate block in
  *
  * @return pointer to allocated structure, if enough memory was available
  * @return NULL, on failure
  */
 void *memarray_alloc(memarray_t *mem);
+
+/**
+ * @brief Allocate and clear memory chunk in memarray pool
+ *
+ * @pre `mem != NULL`
+ *
+ * @param[in,out] mem   memarray pool to allocate block in
+ *
+ * @return pointer to allocated structure, if enough memory was available
+ * @return NULL, on failure
+ */
+void *memarray_calloc(memarray_t *mem);
 
 /**
  * @brief Free memory chunk in memarray pool

--- a/sys/memarray/memarray.c
+++ b/sys/memarray/memarray.c
@@ -44,6 +44,15 @@ void *memarray_alloc(memarray_t *mem)
     return free;
 }
 
+void *memarray_calloc(memarray_t *mem)
+{
+    void *new = memarray_alloc(mem);
+    if (new) {
+        memset(new, 0, mem->size);
+    }
+    return new;
+}
+
 void memarray_free(memarray_t *mem, void *ptr)
 {
     assert((mem != NULL) && (ptr != NULL));

--- a/tests/pkg_cn-cbor/main.c
+++ b/tests/pkg_cn-cbor/main.c
@@ -58,12 +58,10 @@ static cn_cbor_context ct =
 static void *cbor_calloc(size_t count, size_t size, void *memblock)
 {
     (void)count;
+    (void)size;
     expect(count == 1); /* Count is always 1 with cn-cbor */
-    void *block = memarray_alloc(memblock);
-    if (block) {
-        memset(block, 0, size);
-    }
-    return block;
+    expect(size == sizeof(cn_cbor));
+    return memarray_calloc(memblock);
 }
 
 static void cbor_free(void *ptr, void *memblock)


### PR DESCRIPTION
### Contribution description

The memarray_alloc can be error prone to use as the block returned can
contain data from previous uses. The memarray_calloc call added in this
commit always zeroes the block before returning it to the user.

### Testing procedure

`tests/memarray` should still compile.

### Issues/PRs references

None