### PR TITLE
tests/ztimer_usleep: add sleep test for ztimer

### DIFF
--- a/tests/ztimer_usleep/Makefile
+++ b/tests/ztimer_usleep/Makefile
@@ -1,0 +1,11 @@
+include ../Makefile.tests_common
+
+USEMODULE += ztimer_usec
+
+# Port and pin configuration for probing with oscilloscope
+# Port number should be found in port enum e.g in cpu/include/periph_cpu.h
+#FEATURES_REQUIRED += periph_gpio
+#CFLAGS += -DSLEEP_PIN=7
+#CFLAGS += -DSLEEP_PORT=PORT_F
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/ztimer_usleep/README.md
+++ b/tests/ztimer_usleep/README.md
@@ -1,0 +1,103 @@
+# ztimer_usleep test application
+
+This test tests `ztimer_usleep()` against the timings of `ztimer_now_usec()`
+and by comparing the incoming values with the test hosts time.
+
+The sleep times can be probed with a oscilloscope at a pin if `SLEEP_PIN` is set
+and the respective gpio `SLEEP_PORT` is defined in the makefile, the port
+information can be found in the enum in `cpu/include/periph_cpu.h`.
+
+```
+FEATURES_REQUIRED += periph_gpio
+CFLAGS += -DSLEEP_PIN=7
+CFLAGS += -DSLEEP_PORT=PORT_F
+```
+
+## Usage
+Executed from the project directory
+```
+make BOARD=<Board Name> flash test
+```
+
+### Expected result running
+```
+XXX-XX-XX XX:XX:XX,XXX - INFO # Connect to serial port /dev/ttyACM0
+Welcome to pyterm!
+Type '/exit' to exit.
+XXXX-XX-XX XX:XX:XX,XXX - INFO # main(): This is RIOT! (Version: XXX )
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Running test 5 times with 7 distinct sleep times
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Please hit any key and then ENTER to continue
+a
+a
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10232 us (expected: 10000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 50232 us (expected: 50000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10464 us (expected: 10234 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 57008 us (expected: 56780 us) Offset: 228 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 12352 us (expected: 12122 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 98992 us (expected: 98765 us) Offset: 227 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 75232 us (expected: 75000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10232 us (expected: 10000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 50224 us (expected: 50000 us) Offset: 224 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10464 us (expected: 10234 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 57008 us (expected: 56780 us) Offset: 228 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 12352 us (expected: 12122 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 98992 us (expected: 98765 us) Offset: 227 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 75232 us (expected: 75000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10232 us (expected: 10000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 50232 us (expected: 50000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10456 us (expected: 10234 us) Offset: 222 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 57008 us (expected: 56780 us) Offset: 228 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 12352 us (expected: 12122 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 98992 us (expected: 98765 us) Offset: 227 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 75232 us (expected: 75000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10232 us (expected: 10000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 50232 us (expected: 50000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10456 us (expected: 10234 us) Offset: 222 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 57008 us (expected: 56780 us) Offset: 228 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 12352 us (expected: 12122 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 98992 us (expected: 98765 us) Offset: 227 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 75232 us (expected: 75000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10232 us (expected: 10000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 50232 us (expected: 50000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10464 us (expected: 10234 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 57008 us (expected: 56780 us) Offset: 228 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 12352 us (expected: 12122 us) Offset: 230 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 98992 us (expected: 98765 us) Offset: 227 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 75224 us (expected: 75000 us) Offset: 224 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Test ran for 2056976 us
+```
+
+### On Error with pyterm
+```
+XXX-XX-XX XX:XX:XX,XXX - INFO # Connect to serial port /dev/ttyACM0
+Welcome to pyterm!
+Type '/exit' to exit.
+XXXX-XX-XX XX:XX:XX,XXX - INFO # main(): This is RIOT! (XXX)
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Running test 5 times with 7 distinct sleep times
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Please hit any key and then ENTER to continue
+a
+a
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 10224 us (expected: 10000 us) Offset: 224 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 50232 us (expected: 50000 us) Offset: 232 us
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 1464 us (expected: 1234 us) Offset: 230 us
+Invalid timeout 1464 ,expected 1172 < 1234 < 1295
+Host max error  61
+error           291
+```
+
+Test also fails with negative offset as ztimer_usleep must sleep for at least
+the expected time.
+
+```
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Connect to serial port /dev/ttyACM0
+Welcome to pyterm!
+Type '/exit' to exit.
+XXXX-XX-XX XX:XX:XX,XXX - INFO # main(): This is RIOT! (XXX)
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Running test 5 times with 7 distinct sleep times
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Please hit any key and then ENTER to continue
+a
+XXXX-XX-XX XX:XX:XX,XXX - INFO # Slept for 9979 us (expected: 10000 us) Offset: -21 us
+Invalid timeout 9979 ,expected 10000 < 10500
+Host max error  500
+error           -21
+```

--- a/tests/ztimer_usleep/main.c
+++ b/tests/ztimer_usleep/main.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2017 Inria
+ *               2017 Freie Universität Berlin
+ *               2018 Josua Arndt
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       xtimer_usleep test application
+ *
+ * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @}
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "ztimer.h"
+#include "timex.h"
+
+#define RUNS                (5U)
+#define SLEEP_TIMES_NUMOF   ARRAY_SIZE(sleep_times)
+
+static const uint32_t sleep_times[] = { 40, 20, 1, 10000, 50000, 10234, 56780,
+                                        12122, 98765, 75000, 1000000 };
+
+#define ERROR_US 70
+
+/*
+ * To use a pin to probe the sleep times enable the gpio module and define
+ * SLEEP_PORT and SLEEP_PIN in the makefile, the port information can be found
+ * in the enum in `cpu/include/periph_cpu.h`.
+ *
+ * FEATURES_REQUIRED += periph_gpio
+ * CFLAGS += -DSLEEP_PIN=7
+ * CFLAGS += -DSLEEP_PORT=PORT_F
+ * */
+#ifdef SLEEP_PIN
+#include "board.h"
+#include "periph/gpio.h"
+#endif
+
+int main(void)
+{
+    uint32_t start_test, testtime;
+
+#ifdef SLEEP_PIN
+    printf("Debug port 0x%02x pin %d\n", SLEEP_PORT, SLEEP_PIN);
+    gpio_t sleep_pin = GPIO_PIN(SLEEP_PORT, SLEEP_PIN);
+    gpio_init(sleep_pin, GPIO_OUT);
+#endif
+
+    printf("Running test %u times with %u distinct sleep times\n", RUNS,
+           (unsigned)SLEEP_TIMES_NUMOF);
+    start_test = ztimer_now(ZTIMER_USEC);
+    for (unsigned m = 0; m < RUNS; m++) {
+        for (unsigned n = 0;
+             n < ARRAY_SIZE(sleep_times);
+             n++) {
+
+            uint32_t start_sleep, diff;
+            int32_t err;
+
+            start_sleep = ztimer_now(ZTIMER_USEC);
+
+#ifdef SLEEP_PIN
+            gpio_set(sleep_pin);
+#endif
+            ztimer_sleep(ZTIMER_USEC, sleep_times[n]);
+#ifdef SLEEP_PIN
+            gpio_clear(sleep_pin);
+#endif
+
+            diff = ztimer_now(ZTIMER_USEC) - start_sleep;
+
+            err = diff - sleep_times[n];
+
+            printf("Slept for %" PRIu32 " us (expected: %" PRIu32 " us) "
+                   "Offset: %" PRIi32 " us\n", diff, sleep_times[n], err);
+        }
+    }
+    testtime = ztimer_now(ZTIMER_USEC) - start_test;
+    printf("Test ran for %" PRIu32 " us\n", testtime);
+
+    return 0;
+}

--- a/tests/ztimer_usleep/tests/01-run.py
+++ b/tests/ztimer_usleep/tests/01-run.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+
+# Copyright (C) 2017 Francisco Acosta <francisco.acosta@inria.fr>
+#               2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+import time
+from testrunner import run
+
+
+US_PER_SEC = 1000000
+INTERNAL_JITTER = 0.05
+EXTERNAL_JITTER = 0.15
+
+
+class InvalidTimeout(Exception):
+    pass
+
+
+def testfunc(child):
+    child.expect(u"Running test (\\d+) times with (\\d+) distinct sleep times")
+    RUNS = int(child.match.group(1))
+    SLEEP_TIMES_NUMOF = int(child.match.group(2))
+    try:
+        start_test = time.time()
+        for m in range(RUNS):
+            for n in range(SLEEP_TIMES_NUMOF):
+                child.expect(u"Slept for (\\d+) us \\(expected: (\\d+) us\\) Offset: (-?\\d+) us")
+                sleep_time = int(child.match.group(1))
+                exp = int(child.match.group(2))
+                upper_bound = exp + (exp * INTERNAL_JITTER)
+                if not (exp < sleep_time < upper_bound):
+                    delta = (upper_bound-exp)
+                    error = min(upper_bound-sleep_time, sleep_time-exp)
+                    raise InvalidTimeout("Invalid timeout %d, expected %d < timeout < %d"
+                                         "\nHost max error\t%d\nerror\t\t%d" %
+                                         (sleep_time, exp, upper_bound,
+                                          delta, error))
+        testtime = (time.time() - start_test) * US_PER_SEC
+        child.expect(u"Test ran for (\\d+) us")
+        exp = int(child.match.group(1))
+        lower_bound = exp - (exp * EXTERNAL_JITTER)
+        upper_bound = exp + (exp * EXTERNAL_JITTER)
+        if not (lower_bound < testtime < upper_bound):
+            raise InvalidTimeout("Host timer measured %d us (client measured %d us)" %
+                                 (testtime, exp))
+    except InvalidTimeout as e:
+        print(e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description
When trying to get #14897 running on a slower board (`arify-beacon` -> nrf51 @ 16MHz) I stumbled upon the behavior already described in #10073: `xtimer` experiences a constant offset when setting it, in my case `81µs +- 2µs`. I obtained this value using logic analyzer with the driver code from #14897, but I get the same value running `tests/xtimer_usleep`. My hope was to mitigate this problem by simply using `ztimer`, but here I run into the same problem...

To raise awareness for this, I think it is a good idea to apply the `xtimer_usleep` PR to `ztimer`. So this PR more or less copies the existing `xtimer` test and simply uses `ztimer` instead. To also get a feeling on the overhead in conjunction with spinning, I added some shorter sleep values as well.

From my two quick tests I got the following offsets:
`airfy-beacon` (Cortex-M0, 16MHz):
- xtimer: 81-82µs
- ztimer: 100-101µs
`nrf52840dk` (Cortex-M4f, 64MHz):
- xtimer: 31-32µs
- ztimer: 27-28µs

IMO these would be ok for very coarse timings, but for any timeout > 100µs there should not be such kind of imprecision, right?!

Or did I miss something in terms of configuration options etc, that would allow to compensate for this offset?

### Testing procedure
Run with any boards at your disposal, you should see the same output as running `tests/xtimer_usleep` - the same except the offset values that should be slightly different for `ztimer`.

### Issues/PRs references
show cases that #10073 also holds for `ztimer`