### PR TITLE
cpu/sam0_common: flashpage: attempts at bugfixing

### DIFF
--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -29,6 +29,7 @@
 #include <assert.h>
 
 #include "cpu.h"
+#include "mutex.h"
 #include "periph/flashpage.h"
 
 #define ENABLE_DEBUG    (0)
@@ -43,6 +44,29 @@
 #define _NVMCTRL NVMCTRL_SEC
 #else
 #define _NVMCTRL NVMCTRL
+#endif
+
+#ifdef CPU_COMMON_SAMD5X
+/* INTFLAGS >= 0x100 are on NVMCTRL_1_IRQn */
+#define NVM_ISR  isr_nvmctrl0
+#define NVM_IRQ  NVMCTRL_0_IRQn
+#else
+#define NVM_ISR  isr_nvmctrl
+#define NVM_IRQ  NVMCTRL_IRQn
+#endif
+
+#ifdef NVMCTRL_INTFLAG_DONE
+static mutex_t lock = MUTEX_INIT_LOCKED;
+
+static inline void wait_for_cmd(void)
+{
+    mutex_lock(&lock);
+}
+#else
+static inline void wait_for_cmd(void)
+{
+    /* no-op */
+}
 #endif
 
 static inline void wait_nvm_is_ready(void)
@@ -100,6 +124,8 @@ static void _cmd_clear_page_buffer(void)
 #else
     _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_PBC);
 #endif
+
+    wait_for_cmd();
 }
 
 static void _cmd_erase_row(void)
@@ -112,6 +138,8 @@ static void _cmd_erase_row(void)
 #else
     _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_ER);
 #endif
+
+    wait_for_cmd();
 }
 
 static void _cmd_write_page(void)
@@ -124,6 +152,8 @@ static void _cmd_write_page(void)
 #else
     _NVMCTRL->CTRLA.reg = (NVMCTRL_CTRLA_CMDEX_KEY | NVMCTRL_CTRLA_CMD_WP);
 #endif
+
+    wait_for_cmd();
 }
 
 static void _write_page(void* dst, const void *data, size_t len, void (*cmd_write)(void))
@@ -281,3 +311,20 @@ void flashpage_rwwee_write(int page, const void *data)
                _cmd_write_page_rwwee);
 }
 #endif /* FLASHPAGE_RWWEE_NUMOF */
+
+#ifdef NVMCTRL_INTFLAG_DONE
+void flashpage_init(void)
+{
+    NVIC_EnableIRQ(NVM_IRQ);
+
+    _NVMCTRL->INTENSET.reg = NVMCTRL_INTFLAG_DONE;
+}
+
+void NVM_ISR(void)
+{
+    _NVMCTRL->INTFLAG.reg = 0xff;
+    mutex_unlock(&lock);
+
+    cortexm_isr_end();
+}
+#endif

--- a/cpu/samd5x/cpu.c
+++ b/cpu/samd5x/cpu.c
@@ -297,6 +297,8 @@ void cpu_pm_cb_leave(int deep)
     }
 }
 
+void flashpage_init(void);
+
 /**
  * @brief Initialize the CPU, set IRQ priorities, clocks
  */
@@ -382,6 +384,10 @@ void cpu_init(void)
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
     stdio_init();
+
+#ifdef MODULE_PERIPH_FLASHPAGE
+    flashpage_init();
+#endif
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/saml1x/cpu.c
+++ b/cpu/saml1x/cpu.c
@@ -111,6 +111,8 @@ void cpu_pm_cb_leave(int deep)
     /* will be called after wake-up */
 }
 
+void flashpage_init(void);
+
 /**
  * @brief Initialize the CPU, set IRQ priorities, clocks
  */
@@ -173,6 +175,10 @@ void cpu_init(void)
 
     /* initialize stdio prior to periph_init() to allow use of DEBUG() there */
     stdio_init();
+
+#ifdef MODULE_PERIPH_FLASHPAGE
+    flashpage_init();
+#endif
 
     /* trigger static peripheral initialization */
     periph_init();


### PR DESCRIPTION

### Contribution description

This 'fixes' what I thought would be the cause for #14929 

 - wait for commands to be done before proceeding
 - disable cache to avoid triggering *NVM Read Corruption* [errata](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-D5X-E5X-Family-Silicon-Errata-and-Data-Sheet-Clarification-80000748F.pdf)

But this just happens to push the issue away temporariely.
If you replace the interrupt based `wait_for_cmd()` with a polling

```C
static inline void wait_for_cmd(void)
{
   while (_NVMCTRL->INTFLAG.reg == 0) {}
    _NVMCTRL->INTFLAG.reg = 0xff;
}
```

or use a different C library or compiler, the bug is back again.

### Testing procedure

Flash `tests/mtd_flashpage` on `same54-xpro`.
The test will now succeed.
But this is a fluke: try again with `PICOLIBC=1` and it will again fail.
(The test would succeed on `master` with `PICOLIBC=1`, but fail with newlib. The C library is entirely unrelated to the test.)


### Issues/PRs references

attempts to fix #14929 (but no sucess so far) 
