### PR TITLE
tests/candev: remove make error

### DIFF
--- a/tests/candev/Makefile
+++ b/tests/candev/Makefile
@@ -1,4 +1,6 @@
 include ../Makefile.tests_common
+
+# the test currently only works with can_linux, so on "native"
 BOARD_WHITELIST := native
 
 USEMODULE += shell
@@ -7,15 +9,6 @@ USEMODULE += isrpipe
 
 # define the CAN driver you want to use here
 CAN_DRIVER ?= CAN_NATIVE
-
-# prevent using native driver on non-native board
-ifeq ($(CAN_DRIVER), CAN_NATIVE)
-  ifneq ($(BOARD), native)
-    $(error native can driver can only be used on native board!)
-  endif
-endif
-
-
 
 ifeq ($(CAN_DRIVER), PERIPH_CAN)
 # periph_can modules/variables go here


### PR DESCRIPTION
### Contribution description

Based on the discussion in https://github.com/RIOT-OS/RIOT/pull/14828#issuecomment-685915169, this simply removes the make error replying for now only on the whitelist.

### Testing procedure

The following now works.

```
BOARD=nucleo-l152re make -C tests/candev/ info-boards-supported --no-print-directory
native
```