### PR TITLE
sys/ztimer: allow compensation of ztimer_sleep() overhead

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -295,7 +295,9 @@ struct ztimer_clock {
     ztimer_base_t list;             /**< list of active timers              */
     const ztimer_ops_t *ops;        /**< pointer to methods structure       */
     ztimer_base_t *last;            /**< last timer in queue, for _is_set() */
-    uint32_t adjust;                /**< will be subtracted on every set()  */
+    uint16_t adjust_set;            /**< will be subtracted on every set()  */
+    uint16_t adjust_sleep;          /**< will be subtracted on every sleep(),
+                                         in addition to adjust_set          */
 #if MODULE_ZTIMER_EXTEND || MODULE_ZTIMER_NOW64 || DOXYGEN
     /* values used for checkpointed intervals and 32bit extension */
     uint32_t max_value;             /**< maximum relative timer value       */

--- a/sys/ztimer/auto_init.c
+++ b/sys/ztimer/auto_init.c
@@ -125,10 +125,15 @@ void ztimer_init(void)
                              FREQ_1MHZ, CONFIG_ZTIMER_USEC_BASE_FREQ);
 #    endif
 #  endif
-#  ifdef CONFIG_ZTIMER_USEC_ADJUST
-    LOG_DEBUG("ztimer_init(): ZTIMER_USEC setting adjust value to %i\n",
-              CONFIG_ZTIMER_USEC_ADJUST);
-    ZTIMER_USEC->adjust = CONFIG_ZTIMER_USEC_ADJUST;
+#  ifdef CONFIG_ZTIMER_USEC_ADJUST_SET
+    LOG_DEBUG("ztimer_init(): ZTIMER_USEC setting adjust_set value to %i\n",
+              CONFIG_ZTIMER_USEC_ADJUST_SET );
+    ZTIMER_USEC->adjust_set = CONFIG_ZTIMER_USEC_ADJUST_SET;
+#  endif
+#  ifdef CONFIG_ZTIMER_USEC_ADJUST_SLEEP
+    LOG_DEBUG("ztimer_init(): ZTIMER_USEC setting adjust_sleep value to %i\n",
+              CONFIG_ZTIMER_USEC_ADJUST_SLEEP );
+    ZTIMER_USEC->adjust_sleep = CONFIG_ZTIMER_USEC_ADJUST_SLEEP;
 #  endif
 #  ifdef MODULE_PM_LAYERED
     LOG_DEBUG("ztimer_init(): ZTIMER_USEC setting required_pm_mode to %i\n",

--- a/sys/ztimer/core.c
+++ b/sys/ztimer/core.c
@@ -84,8 +84,8 @@ void ztimer_set(ztimer_clock_t *clock, ztimer_t *timer, uint32_t val)
     }
 
     /* optionally subtract a configurable adjustment value */
-    if (val > clock->adjust) {
-        val -= clock->adjust;
+    if (val > clock->adjust_set) {
+        val -= clock->adjust_set;
     }
     else {
         val = 0;

--- a/sys/ztimer/util.c
+++ b/sys/ztimer/util.c
@@ -51,6 +51,14 @@ void ztimer_sleep(ztimer_clock_t *clock, uint32_t duration)
         .arg = (void *)&mutex,
     };
 
+    /* correct board / MCU specific overhead */
+    if (duration > clock->adjust_sleep) {
+        duration -= clock->adjust_sleep;
+    }
+    else {
+        duration = 0;
+    }
+
     ztimer_set(clock, &timer, duration);
     mutex_lock(&mutex);
 }

--- a/tests/xtimer_usleep/tests/01-run.py
+++ b/tests/xtimer_usleep/tests/01-run.py
@@ -35,7 +35,7 @@ def testfunc(child):
                 sleep_time = int(child.match.group(1))
                 exp = int(child.match.group(2))
                 upper_bound = exp + (exp * INTERNAL_JITTER)
-                if not (exp < sleep_time < upper_bound):
+                if not (exp <= sleep_time < upper_bound):
                     delta = (upper_bound-exp)
                     error = min(upper_bound-sleep_time, sleep_time-exp)
                     raise InvalidTimeout("Invalid timeout %d, expected %d < timeout < %d"

--- a/tests/ztimer_overhead/main.c
+++ b/tests/ztimer_overhead/main.c
@@ -37,8 +37,8 @@ int main(void)
     int32_t max = INT32_MIN;
 
     /* unset configured adjustment */
-    /* ZTIMER_USEC->adjust = 0; */
-    printf("ZTIMER_USEC->adjust = %" PRIu32 "\n", ZTIMER_USEC->adjust);
+    /* ZTIMER_USEC->adjust_set = 0; */
+    printf("ZTIMER_USEC->adjust_set = %" PRIu16 "\n", ZTIMER_USEC->adjust_set);
 
     unsigned n = SAMPLES;
     while (n--) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

```ztimer_sleep()``` can take considerable overhead.

This PR introduces a per-clock field ```adjust_sleep``` that allows compensating this overhead.
It can be configured for ztimer_usec by setting CONFIG_ZTIMER_USEC_ADJUST_SLEEP.

For consistency reasons, the corresponding adjust value field for "ztimer_set()" has been renamed from just "adjust" to "adjust_set", the config option CONFIG_ZTIMER_USEC_ADJUST_SET.

The sleep value is used *in addition to the set value*.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- run tests/ztimer_overhead, not down "min" value, recompile with ```CFLAGS += -DCONFIG_ZTIMER_USEC_ADJUST_SET=<min>```

- run tests/xtimer_usleep compiled with ```CFLAGS += -DCONFIG_ZTIMER_USEC_ADJUST_SET=<min>``` and ```USEMODULE+=ztimer_xtimer_compat```, note offset value

- re-run tests/xtimer_usleep compiled with ```CFLAGS += -DCONFIG_ZTIMER_USEC_ADJUST_SET=<min>``` and ```USEMODULE+=ztimer_xtimer_compat```, and ```CFLAGS += -DCONFIG_ZTIMER_USEC_ADJUST_SLEEP=<offset>```

The offset should now be closer to zero.



<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
