### PR TITLE
gnrc_ipv6_nib: 6ln: send neighbor solicitation if node is unreachable

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -233,7 +233,7 @@ void _handle_snd_ns(_nib_onl_entry_t *nbr)
             }
             /* intentionally falls through */
         case GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNREACHABLE:
-            _probe_nbr(nbr, false);
+            _snd_uc_ns(nbr, true);
             break;
         default:
             break;


### PR DESCRIPTION
### Contribution description
On `master` if a node is unreachable once it gets stuck in a loop:
`_handle_snd_ns()` will call `_probe_nbr()` which schedules an `GNRC_IPV6_NIB_SND_MC_NS` event.

This event is handled by `gnrc_ipv6_nib_handle_timer_event()` which in turn calls `_handle_snd_ns()`, starting the whole process all over again.

The result is that only periodic `GNRC_IPV6_NIB_SND_MC_NS` events are generated without ever sending a neighbor solicitation.

The result is that the previously unreachable node is stuck in the TNT[3] state forever.

As a quick fix, just send out the neighbor solicitation instead of scheduling the event.


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Follow the process outlined in #14735

Basically, have a node that is offline for a while and then tries to re-join the border router.

The [sleepy_node](https://github.com/benpicco/sleepy_node) application will do just that. There is no need to run the CoAP server for this test. Just run a `gnrc_border_router` and this app.

You will find that on `master` after a few cycles, the node will always get a "border router timeout".
With this patch you should instead always get a "get time failed", or if you run the CoAP server as described, the current time.

### Issues/PRs references

This fixes #14735

