### PR TITLE
net/ieee802154_hal: add const qualifiers and set pan_id with pointer

### DIFF
--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -635,14 +635,15 @@ struct ieee802154_radio_ops {
      *            address is not altered..
      * @param[in] ext_addr the IEEE802.15.4 extended address (Network Byte Order).
      *            If NULL, the extended address is not altered.
-     * @param[in] pan_id the IEEE802.15.4 PAN ID
+     * @param[in] pan_id the IEEE802.15.4 PAN ID. If NULL, the PAN ID is not altered.
      *
      * @return 0 on success
      * @return negative errno on error
      */
     int (*set_hw_addr_filter)(ieee802154_dev_t *dev,
                               const network_uint16_t *short_addr,
-                              const eui64_t *ext_addr, uint16_t pan_id);
+                              const eui64_t *ext_addr,
+                              const uint16_t *pan_id);
 
     /**
      * @brief Set number of frame retransmissions
@@ -826,16 +827,18 @@ static inline int ieee802154_radio_off(ieee802154_dev_t *dev)
  * @pre the device is on
  *
  * @param[in] dev IEEE802.15.4 device descriptor
- * @param[in] short_addr the IEEE802.15.4 short address
- * @param[in] ext_addr the IEEE802.15.4 extended address (Network Byte Order)
- * @param[in] pan_id IEEE802.15.4 PAN ID
+ * @param[in] short_addr the IEEE802.15.4 short address. If NULL, the short
+ *            address is not altered..
+ * @param[in] ext_addr the IEEE802.15.4 extended address (Network Byte Order).
+ *            If NULL, the extended address is not altered.
+ * @param[in] pan_id the IEEE802.15.4 PAN ID. If NULL, the PAN ID is not altered.
  *
  * @return result of @ref ieee802154_radio_ops::set_hw_addr_filter
  */
 static inline int ieee802154_radio_set_hw_addr_filter(ieee802154_dev_t *dev,
                                                       const network_uint16_t *short_addr,
                                                       const eui64_t *ext_addr,
-                                                      uint16_t pan_id)
+                                                      const uint16_t *pan_id)
 {
     return dev->driver->set_hw_addr_filter(dev, short_addr, ext_addr, pan_id);
 }

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -363,7 +363,7 @@ struct ieee802154_radio_ops {
      * @return 0 on success
      * @return negative errno on error
      */
-    int (*write)(ieee802154_dev_t *dev, iolist_t *psdu);
+    int (*write)(ieee802154_dev_t *dev, const iolist_t *psdu);
 
     /**
      * @brief Request the transmission of a preloaded frame
@@ -641,8 +641,8 @@ struct ieee802154_radio_ops {
      * @return negative errno on error
      */
     int (*set_hw_addr_filter)(ieee802154_dev_t *dev,
-                              network_uint16_t *short_addr,
-                              eui64_t *ext_addr, uint16_t pan_id);
+                              const network_uint16_t *short_addr,
+                              const eui64_t *ext_addr, uint16_t pan_id);
 
     /**
      * @brief Set number of frame retransmissions
@@ -701,7 +701,7 @@ struct ieee802154_radio_ops {
  *
  * @return result of @ref ieee802154_radio_ops::write
  */
-static inline int ieee802154_radio_write(ieee802154_dev_t *dev, iolist_t *psdu)
+static inline int ieee802154_radio_write(ieee802154_dev_t *dev, const iolist_t *psdu)
 {
     return dev->driver->write(dev, psdu);
 }
@@ -833,8 +833,8 @@ static inline int ieee802154_radio_off(ieee802154_dev_t *dev)
  * @return result of @ref ieee802154_radio_ops::set_hw_addr_filter
  */
 static inline int ieee802154_radio_set_hw_addr_filter(ieee802154_dev_t *dev,
-                                                      network_uint16_t *short_addr,
-                                                      eui64_t *ext_addr,
+                                                      const network_uint16_t *short_addr,
+                                                      const eui64_t *ext_addr,
                                                       uint16_t pan_id)
 {
     return dev->driver->set_hw_addr_filter(dev, short_addr, ext_addr, pan_id);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR:
- Add `const` qualifiers in read only arguments
- As discussed in https://github.com/RIOT-OS/RIOT/pull/13943#issuecomment-685573941, now the `panid` argument of `ieee802154_radio_set_hw_addr_filter` is a pointer. It's now possible to pass NULL if there's no interest in updating the PAN ID.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
This is alrady used by #14655 . Compiling that one should be enough.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#13943 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
