### PR TITLE
drivers/dose: use EUI provider

### DIFF
--- a/boards/same54-xpro/Makefile.dep
+++ b/boards/same54-xpro/Makefile.dep
@@ -1,3 +1,7 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+ifneq (,$(filter eui_provider,$(USEMODULE)))
+  USEMODULE += at24mac
+endif

--- a/boards/same54-xpro/include/board.h
+++ b/boards/same54-xpro/include/board.h
@@ -21,6 +21,7 @@
 #define BOARD_H
 
 #include "cpu.h"
+#include "at24mac.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,6 +42,22 @@ extern "C" {
  * @{
  */
 #define ATCA_PARAM_I2C           I2C_DEV(1)
+/** @} */
+
+/**
+ * @brief    AT24Mac provides a EUI-48
+ */
+static inline int _at24mac_get_eui48(const void *arg, eui48_t *addr)
+{
+    return at24mac_get_eui48((uintptr_t)arg, addr);
+}
+
+/**
+ * @name    EUI-48 sources on the board
+ *          AT24Mac is present on the board
+ * @{
+ */
+#define EUI48_PROVIDER_FUNC   _at24mac_get_eui48
 /** @} */
 
 /**

--- a/drivers/dose/Makefile.dep
+++ b/drivers/dose/Makefile.dep
@@ -1,6 +1,8 @@
+FEATURES_REQUIRED += periph_gpio_irq
 FEATURES_REQUIRED += periph_uart
+
+USEMODULE += eui_provider
 USEMODULE += iolist
 USEMODULE += netdev_eth
 USEMODULE += random
 USEMODULE += xtimer
-FEATURES_REQUIRED += periph_gpio_irq

--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -21,12 +21,11 @@
 #include <string.h>
 
 #include "dose.h"
-#include "luid.h"
 #include "random.h"
 #include "irq.h"
 
+#include "net/eui_provider.h"
 #include "net/netdev/eth.h"
-#include "net/eui64.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -559,7 +558,7 @@ void dose_setup(dose_t *ctx, const dose_params_t *params, uint8_t index)
     netdev_register(&ctx->netdev, NETDEV_DOSE, index);
 
     assert(sizeof(ctx->mac_addr.uint8) == ETHERNET_ADDR_LEN);
-    luid_get_eui48(&ctx->mac_addr);
+    netdev_eui48_get(&ctx->netdev, &ctx->mac_addr);
     DEBUG("dose dose_setup(): mac addr %02x:%02x:%02x:%02x:%02x:%02x\n",
           ctx->mac_addr.uint8[0], ctx->mac_addr.uint8[1], ctx->mac_addr.uint8[2],
           ctx->mac_addr.uint8[3], ctx->mac_addr.uint8[4], ctx->mac_addr.uint8[5]

--- a/drivers/dose/include/dose_params.h
+++ b/drivers/dose/include/dose_params.h
@@ -30,7 +30,7 @@ extern "C" {
  * @{
  */
 #ifndef DOSE_PARAM_UART
-#define DOSE_PARAM_UART         (UART_DEV(0))
+#define DOSE_PARAM_UART         (UART_DEV(1))
 #endif
 #ifndef DOSE_PARAM_BAUDRATE
 #define DOSE_PARAM_BAUDRATE     (115200)


### PR DESCRIPTION
### Contribution description

The DOSE driver is already registered with netdev, so we can just use `netdev_eui48_get()` to get an address instead of calling luid directly.

I also added a commit to configure the AT24MAC on the `same54-xpro` as an EUI-48 provider, so we can directly test the functionality.


### Testing procedure

Run `tests/driver_dose` on e.g. `same54-xpro`:

#### master

```
2020-09-03 20:07:03,578 #  ifconfig
2020-09-03 20:07:03,581 # Iface  3  HWaddr: 2E:B7:9E:B1:32:51 
2020-09-03 20:07:03,585 #           L2-PDU:1500  Source address length: 6
```

#### this PR

```
2020-09-03 20:11:26,372 #  ifconfig
2020-09-03 20:11:26,397 # Iface  3  HWaddr: FC:C2:3D:0D:2D:1F <- MAC from AT24MAC
2020-09-03 20:11:26,398 #           L2-PDU:1500  Source address length: 6
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
