### PR TITLE
cpu/lpc23xx: add MTD wrapper for MCI driver

### DIFF
--- a/boards/mcb2388/Makefile.dep
+++ b/boards/mcb2388/Makefile.dep
@@ -2,3 +2,10 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_adc
   USEMODULE += saul_gpio
 endif
+
+# default to mtd_mci if no other MTD backend is selected
+ifneq (,$(filter mtd,$(USEMODULE)))
+  ifeq (,$(filter mtd_%,$(USEMODULE)))
+    USEMODULE += mtd_mci
+  endif
+endif

--- a/boards/mcb2388/board_init.c
+++ b/boards/mcb2388/board_init.c
@@ -22,8 +22,15 @@
 
 #include "board.h"
 #include "cpu.h"
+#include "mtd.h"
 #include "periph/init.h"
 #include "stdio_base.h"
+
+#ifdef MODULE_MTD_MCI
+extern const mtd_desc_t mtd_mci_driver;
+static mtd_dev_t _mtd_mci = { .driver = &mtd_mci_driver };
+mtd_dev_t *mtd0 = &_mtd_mci;
+#endif
 
 void board_init(void)
 {

--- a/boards/mcb2388/include/board.h
+++ b/boards/mcb2388/include/board.h
@@ -20,6 +20,7 @@
 #define BOARD_H
 
 #include "lpc23xx.h"
+#include "mtd.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -102,6 +103,16 @@ extern "C" {
                                             GPIO_PIN(1,26), GPIO_PIN(1,27), \
                                             GPIO_UNDEF,     GPIO_UNDEF,     \
                                             GPIO_UNDEF,     GPIO_UNDEF      }
+/** @} */
+
+/**
+ * @name MTD configuration
+ * @{
+ */
+#ifdef MODULE_MTD_MCI
+extern mtd_dev_t *mtd0;
+#define MTD_0 mtd0
+#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/msba2/Makefile.dep
+++ b/boards/msba2/Makefile.dep
@@ -6,3 +6,10 @@ ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += ltc4150
   USEMODULE += sht11
 endif
+
+# default to mtd_mci if no other MTD backend is selected
+ifneq (,$(filter mtd,$(USEMODULE)))
+  ifeq (,$(filter mtd_%,$(USEMODULE)))
+    USEMODULE += mtd_mci
+  endif
+endif

--- a/boards/msba2/board_init.c
+++ b/boards/msba2/board_init.c
@@ -26,8 +26,15 @@
 
 #include "board.h"
 #include "cpu.h"
+#include "mtd.h"
 #include "periph/init.h"
 #include "stdio_base.h"
+
+#ifdef MODULE_MTD_MCI
+extern const mtd_desc_t mtd_mci_driver;
+static mtd_dev_t _mtd_mci = { .driver = &mtd_mci_driver };
+mtd_dev_t *mtd0 = &_mtd_mci;
+#endif
 
 void board_init(void)
 {

--- a/boards/msba2/include/board.h
+++ b/boards/msba2/include/board.h
@@ -20,6 +20,7 @@
 #define BOARD_H
 
 #include "lpc23xx.h"
+#include "mtd.h"
 #include "bitarithm.h"
 
 #ifdef __cplusplus
@@ -43,6 +44,16 @@ extern "C" {
 #define LED1_OFF            (FIO3SET  = LED1_MASK)
 #define LED1_ON             (FIO3CLR  = LED1_MASK)
 #define LED1_TOGGLE         (FIO3PIN ^= LED1_MASK)
+/** @} */
+
+/**
+ * @name MTD configuration
+ * @{
+ */
+#ifdef MODULE_MTD_MCI
+extern mtd_dev_t *mtd0;
+#define MTD_0 mtd0
+#endif
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/lpc23xx/Makefile.dep
+++ b/cpu/lpc23xx/Makefile.dep
@@ -4,4 +4,8 @@ USEMODULE += newlib
 USEMODULE += periph
 USEMODULE += pm_layered
 
+ifneq (,$(filter mci,$(USEMODULE)))
+  USEMODULE += xtimer
+endif
+
 include $(RIOTCPU)/arm7_common/Makefile.dep

--- a/drivers/mtd_mci/Makefile
+++ b/drivers/mtd_mci/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/mtd_mci/Makefile.dep
+++ b/drivers/mtd_mci/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += mci

--- a/drivers/mtd_mci/mtd_mci.c
+++ b/drivers/mtd_mci/mtd_mci.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2020 Beuth Hochschule für Technik Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     drivers_mtd
+ * @{
+ *
+ * @file
+ * @brief       Driver for using lpc23xx-mci via mtd interface
+ *
+ * @author      Benjamin Valentin <benpicco@beuth-hochschule.de>
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include <string.h>
+
+#include "diskio.h"
+#include "mtd.h"
+#include "sdcard_spi.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#define min(a, b) ((a) > (b) ? (b) : (a))
+
+/* MCI driver only suports whole page reads / writes */
+static uint8_t _page_buffer[SD_HC_BLOCK_SIZE];
+
+static int mtd_mci_init(mtd_dev_t *dev)
+{
+    if (mci_initialize()) {
+        return -EIO;
+    }
+
+    if (ENABLE_DEBUG) {
+        uint32_t block_size;
+        mci_ioctl(GET_BLOCK_SIZE, &block_size);
+        DEBUG("block size: %lu\n", block_size);
+    }
+
+    dev->pages_per_sector = 1;
+    dev->page_size = SD_HC_BLOCK_SIZE;
+    mci_ioctl(GET_SECTOR_COUNT, &dev->sector_count);
+
+    DEBUG("sector size: %lu\n", dev->page_size);
+    DEBUG("sector count: %lu\n", dev->sector_count);
+    DEBUG("pages / sector: %lu\n", dev->pages_per_sector);
+
+    return 0;
+}
+
+static int mtd_mci_read_page(mtd_dev_t *dev, void *buff, uint32_t page,
+                             uint32_t offset, uint32_t size)
+{
+    (void)dev;
+    uint8_t pages = size / SD_HC_BLOCK_SIZE;
+
+    DEBUG("%s(%lu, %lu, %lu)\n", __func__, page, offset, size);
+
+    /* emulate unaligned / sub-page read */
+    if (pages == 0 || offset) {
+        size = min(SD_HC_BLOCK_SIZE - offset, size);
+
+        if (mci_read(_page_buffer, page, 1)) {
+            return -EIO;
+        }
+
+        memcpy(buff, _page_buffer + offset, size);
+
+        return size;
+    }
+
+    if (mci_read(buff, page, pages)) {
+        return -EIO;
+    }
+
+    return pages * SD_HC_BLOCK_SIZE;
+}
+
+static int mtd_mci_write_page(mtd_dev_t *dev, const void *buff, uint32_t page,
+                              uint32_t offset, uint32_t size)
+{
+    (void)dev;
+    uint8_t pages = size / SD_HC_BLOCK_SIZE;
+
+    DEBUG("%s(%lu, %lu, %lu)\n", __func__, page, offset, size);
+
+    /* emulate unaligned / sub-page write */
+    if (pages == 0 || offset) {
+        size = min(SD_HC_BLOCK_SIZE - offset, size);
+
+        if (mci_read(_page_buffer, page, 1)) {
+            return -EIO;
+        }
+
+        memcpy(_page_buffer + offset, buff, size);
+
+        buff  = _page_buffer;
+        pages = 1;
+    }
+
+    if (mci_write(buff, page, pages)) {
+        return -EIO;
+    }
+
+    return pages * SD_HC_BLOCK_SIZE;
+}
+
+static int mtd_mci_erase_sector(mtd_dev_t *dev, uint32_t sector, uint32_t count)
+{
+    (void)dev;
+
+    while (count--) {
+        mci_ioctl(CTRL_ERASE_SECTOR, &sector);
+        ++sector;
+    }
+    return 0;
+}
+
+static int mtd_mci_power(mtd_dev_t *dev, enum mtd_power_state power)
+{
+    (void)dev;
+
+    unsigned char on = power == MTD_POWER_UP ? 1 : 0;
+    if (mci_ioctl(CTRL_POWER, &on)) {
+        return -EIO;
+    }
+
+    return 0;
+}
+
+const mtd_desc_t mtd_mci_driver = {
+    .init           = mtd_mci_init,
+    .read_page      = mtd_mci_read_page,
+    .write_page     = mtd_mci_write_page,
+    .erase_sector   = mtd_mci_erase_sector,
+    .power          = mtd_mci_power,
+};

--- a/tests/pkg_fatfs_vfs/main.c
+++ b/tests/pkg_fatfs_vfs/main.c
@@ -25,6 +25,7 @@
 #include "fs/fatfs.h"
 #include "vfs.h"
 #include "mtd.h"
+#include "board.h"
 
 #include "kernel_defines.h"
 
@@ -403,7 +404,7 @@ int main(void)
     }
 #endif
 
-#ifdef MODULE_MTD_NATIVE
+#if defined(MODULE_MTD_NATIVE) || defined(MODULE_MTD_MCI)
     fatfs_mtd_devs[fatfs.vol_idx] = mtd0;
 #else
     fatfs_mtd_devs[fatfs.vol_idx] = mtd1;


### PR DESCRIPTION
### Contribution description

RIOT has a driver for the Memory Card Interface on `lpc23xx`.
It even still works! But it's not integrated into anything.

This adds a MTD wrapper so it can serve as a backend for VFS.

### Testing procedure

Insert a FAT formatted SD card into the SD-Card slot of the `msba2`.

You can run the `examples/filesystem` with

<details><summary>this patch</summary>

```patch
--- a/examples/filesystem/Makefile
+++ b/examples/filesystem/Makefile
@@ -33,9 +33,9 @@ USEMODULE += vfs
 
 # Use a file system
 # USEMODULE += littlefs
-USEMODULE += littlefs2
+# USEMODULE += littlefs2
 # USEMODULE += spiffs
-# USEMODULE += fatfs_vfs
+USEMODULE += fatfs_vfs
 USEMODULE += constfs
 # USEMODULE += devfs
```
</details>

To run `tests/pkg_fatfs_vfs` apply

<details><summary>this patch</summary>

```patch
--- a/tests/pkg_fatfs_vfs/Makefile
+++ b/tests/pkg_fatfs_vfs/Makefile
@@ -19,7 +19,7 @@ ifeq ($(BOARD),native)
   CFLAGS += -DFATFS_IMAGE_FILE_SIZE_MIB=$(FATFS_IMAGE_FILE_SIZE_MIB)
   CFLAGS += -DMTD_SECTOR_NUM=$(MTD_SECTOR_NUM)
 else
-  USEMODULE += mtd_sdcard
+  USEMODULE += mtd
 endif
 ```
</details>

### Issues/PRs references

Sectors / Block numbers might need some work.
It is obvious that the MCI driver was written with fatfs in mind.
`mci_ioctl()` maps directly to `disk_ioctl()`.

However, `fatfs_diskio` then got assumptions about `sdcard_spi` baked in (basically only works with `pages_per_sector = 1`), so don't use this on any SD cards with valuable data.