### PR TITLE
tools/genconfig: add empty recipes in dependency file

### DIFF
--- a/dist/tools/kconfiglib/genconfig.py
+++ b/dist/tools/kconfiglib/genconfig.py
@@ -159,8 +159,13 @@ only supported for backwards compatibility).
         logging.debug("Kconfig dependencies written to '{}'".format(args.file_list))
         with open(args.file_list, "w", encoding="utf-8") as f:
             f.write("{}: \\\n".format(args.config_out))
+            # add dependencies
             for path in kconf.kconfig_filenames:
                 f.write("    {} \\\n".format(os.path.abspath(path)))
+            # add empty recipes for dependencies
+            f.write("\n\n")
+            for path in kconf.kconfig_filenames:
+                f.write("{}:\n\n".format(os.path.abspath(path)))
 
     if args.env_list is not None:
         logging.debug("Kconfig environmental variables written to '{}'".format(args.env_list))


### PR DESCRIPTION
### Contribution description
The file `out.config.d` in `bin/<board>/generated` is similar to the dependency files generated by the compiler for the object files. It contains a list of files that should be watched by Make to decide if `out.config` should be regenerated (e.g. because of the change of a default value or dependencies). When one of the used Kconfig files is removed after the configuration file has been generated for the first time, Make raises an error as it tries to generate the file and does not know how. This is fixed adding empty recipes for these files.

### Testing procedure
- Kconfig should still work as usual. Configurations can be changed multiple times.
- To reproduce the case described above you can try:
   - Run kconfig once on some example (either by compiling with `SHOULD_RUN_KCONFIG` or calling `make menuconfig` saving and compiling)
   - Remove some Kconfig that is always added (e.g. some file from sys - don't forget to remove the inclusion in the parent file)
   - Try to trigger Kconfig again -> Make would complain in master. With this PR that should not happen.

### Issues/PRs references
None
