### PR TITLE
features_modules: include puf_sram if used

### DIFF
--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -21,6 +21,9 @@ endif
 # select cpu_check_address pseudomodule if the corresponding feature is used
 USEMODULE += $(filter cpu_check_address, $(FEATURES_USED))
 
+# include puf_sram if used
+USEMODULE += $(filter puf_sram, $(FEATURES_USED))
+
 # include periph_common if any periph_* driver is used
 ifneq (,$(filter periph_%, $(USEMODULE)))
   USEMODULE += periph_common

--- a/tests/puf_sram/Makefile
+++ b/tests/puf_sram/Makefile
@@ -2,7 +2,7 @@ BOARD ?= nucleo-f411re
 
 include ../Makefile.tests_common
 
-USEMODULE += puf_sram
+FEATURES_REQUIRED += puf_sram
 DISABLE_MODULE += test_utils_interactive_sync
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`puf_sram` is advertised as a CPU feature, but it can only be used as a module.

### Testing procedure

Run `FEATURES_REQUIRED=puf_sram make BOARD=samr21-xpro -C examples/gnrc_networking -j flash`

`puf_sram` should now be used.
On `master` the `FEATURES_REQUIRED` is simply ignored and no `puf_sram` is used, nor is an error raised.


### Issues/PRs references

suggested by @fjmolinas in https://github.com/RIOT-OS/RIOT/issues/14939#issuecomment-686932347
fixes #14939