### PR TITLE
drivers/mrf24j40: register with netdev

### DIFF
--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -224,11 +224,10 @@ void mrf24j40_set_addr_short(mrf24j40_t *dev, uint16_t addr);
 /**
  * @brief   Get the configured long address of the given device
  *
- * @param[in] dev           device to read from
- *
- * @return                  the currently set (8-byte) long address
+ * @param[in]  dev          device to read from
+ * @param[out] addr         the currently set (8-byte) long address
  */
-uint64_t mrf24j40_get_addr_long(mrf24j40_t *dev);
+void mrf24j40_get_addr_long(mrf24j40_t *dev, uint8_t *addr);
 
 /**
  * @brief   Set the long address of the given device
@@ -236,7 +235,7 @@ uint64_t mrf24j40_get_addr_long(mrf24j40_t *dev);
  * @param[in] dev           device to write to
  * @param[in] addr          (8-byte) long address to set
  */
-void mrf24j40_set_addr_long(mrf24j40_t *dev, uint64_t addr);
+void mrf24j40_set_addr_long(mrf24j40_t *dev, const uint8_t *addr);
 
 /**
  * @brief   Get the configured channel number of the given device

--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -179,8 +179,10 @@ typedef struct {
  *
  * @param[out] dev          device descriptor
  * @param[in]  params       parameters for device initialization
+ * @param[in]  index        index of @p params in a global parameter struct array.
+ *                          If initialized manually, pass a unique identifier instead.
  */
-void mrf24j40_setup(mrf24j40_t *dev, const mrf24j40_params_t *params);
+void mrf24j40_setup(mrf24j40_t *dev, const mrf24j40_params_t *params, uint8_t index);
 
 /**
  * @brief   Trigger a hardware reset and configure radio with default values

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -282,6 +282,7 @@ typedef enum {
     NETDEV_AT86RF2XX,
     NETDEV_CC2538,
     NETDEV_DOSE,
+    NETDEV_MRF24J40,
     NETDEV_NRF802154,
     /* add more if needed */
 } netdev_type_t;

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -55,7 +55,7 @@ int mrf24j40_reset(mrf24j40_t *dev)
     netdev_ieee802154_setup(&dev->netdev);
 
     /* set short and long address */
-    mrf24j40_set_addr_long(dev, unaligned_get_u64(dev->netdev.long_addr));
+    mrf24j40_set_addr_long(dev, dev->netdev.long_addr);
     mrf24j40_set_addr_short(dev, unaligned_get_u16(dev->netdev.short_addr));
 
     mrf24j40_set_chan(dev, CONFIG_IEEE802154_DEFAULT_CHANNEL);

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -20,7 +20,6 @@
  * @}
  */
 
-#include "luid.h"
 #include "byteorder.h"
 #include "net/gnrc.h"
 #include "mrf24j40_registers.h"
@@ -31,19 +30,19 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-void mrf24j40_setup(mrf24j40_t *dev, const mrf24j40_params_t *params)
+void mrf24j40_setup(mrf24j40_t *dev, const mrf24j40_params_t *params, uint8_t index)
 {
     netdev_t *netdev = (netdev_t *)dev;
 
     netdev->driver = &mrf24j40_driver;
     /* initialize device descriptor */
     dev->params = *params;
+
+    netdev_register(netdev, NETDEV_MRF24J40, index);
 }
 
 int mrf24j40_reset(mrf24j40_t *dev)
 {
-    eui64_t addr_long;
-
     int res = mrf24j40_init(dev);
 
     if (res < 0) {
@@ -52,13 +51,12 @@ int mrf24j40_reset(mrf24j40_t *dev)
 
     netdev_ieee802154_reset(&dev->netdev);
 
-    /* get an 8-byte unique ID to use as hardware address */
-    luid_get(addr_long.uint8, IEEE802154_LONG_ADDRESS_LEN);
-    addr_long.uint8[0] &= ~(0x01);
-    addr_long.uint8[0] |=  (0x02);
+    /* set device address */
+    netdev_ieee802154_setup(&dev->netdev);
+
     /* set short and long address */
-    mrf24j40_set_addr_long(dev, ntohll(addr_long.uint64.u64));
-    mrf24j40_set_addr_short(dev, ntohs(addr_long.uint16[0].u16));
+    mrf24j40_set_addr_long(dev, unaligned_get_u64(dev->netdev.long_addr));
+    mrf24j40_set_addr_short(dev, unaligned_get_u16(dev->netdev.short_addr));
 
     mrf24j40_set_chan(dev, CONFIG_IEEE802154_DEFAULT_CHANNEL);
 

--- a/drivers/mrf24j40/mrf24j40_getset.c
+++ b/drivers/mrf24j40/mrf24j40_getset.c
@@ -157,24 +157,17 @@ void mrf24j40_set_addr_short(mrf24j40_t *dev, uint16_t addr)
                              naddr.u8[0]);
 }
 
-uint64_t mrf24j40_get_addr_long(mrf24j40_t *dev)
+void mrf24j40_get_addr_long(mrf24j40_t *dev, uint8_t *addr)
 {
-    network_uint64_t naddr;
-
     for (int i = 0; i < 8; i++) {
-        naddr.u8[7 - i] = mrf24j40_reg_read_short(dev, (MRF24J40_REG_EADR0 + i));
+        addr[7 - i] = mrf24j40_reg_read_short(dev, MRF24J40_REG_EADR0 + i);
     }
-    return naddr.u64;
 }
 
-void mrf24j40_set_addr_long(mrf24j40_t *dev, uint64_t addr)
+void mrf24j40_set_addr_long(mrf24j40_t *dev, const uint8_t *addr)
 {
-    network_uint64_t naddr;
-    naddr.u64 = addr;
-
     for (int i = 0; i < 8; i++) {
-        mrf24j40_reg_write_short(dev, (MRF24J40_REG_EADR0 + i),
-                                 (naddr.u8[7 - i]));
+        mrf24j40_reg_write_short(dev, MRF24J40_REG_EADR0 + i, addr[7 - i]);
     }
 }
 

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -184,7 +184,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
                 res = -EOVERFLOW;
             }
             else {
-                *(uint64_t*)val = mrf24j40_get_addr_long(dev);
+                mrf24j40_get_addr_long(dev, val);
                 res = sizeof(uint64_t);
             }
             break;
@@ -400,7 +400,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
                 res = -EOVERFLOW;
             }
             else {
-                mrf24j40_set_addr_long(dev, *((const uint64_t *)val));
+                mrf24j40_set_addr_long(dev, val);
                 res = sizeof(uint64_t);
             }
             break;

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -191,7 +191,7 @@ void lwip_bootstrap(void)
     }
 #elif defined(MODULE_MRF24J40)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
-        mrf24j40_setup(&mrf24j40_devs[i], &mrf24j40_params[i]);
+        mrf24j40_setup(&mrf24j40_devs[i], &mrf24j40_params[i], i);
         if (netif_add(&netif[i], &mrf24j40_devs[i], lwip_netdev_init,
                       tcpip_6lowpan_input) == NULL) {
             DEBUG("Could not add mrf24j40 device\n");

--- a/sys/net/gnrc/netif/init_devs/auto_init_mrf24j40.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_mrf24j40.c
@@ -46,7 +46,7 @@ void auto_init_mrf24j40(void)
     for (unsigned i = 0; i < MRF24J40_NUM; i++) {
         LOG_DEBUG("[auto_init_netif] initializing mrf24j40 #%u\n", i);
 
-        mrf24j40_setup(&mrf24j40_devs[i], &mrf24j40_params[i]);
+        mrf24j40_setup(&mrf24j40_devs[i], &mrf24j40_params[i], i);
         gnrc_netif_ieee802154_create(&_netif[i], _mrf24j40_stacks[i],
                                      MRF24J40_MAC_STACKSIZE, MRF24J40_MAC_PRIO,
                                      "mrf24j40",


### PR DESCRIPTION
### Contribution description

Register `mrf24j40` with netdev so we don't have to generate a EUI inside the driver but can make use of an EUI provider if available.

### Testing procedure

A board with a `mrf24j40` radio still gets an address and is reachable by other nodes

```
Iface  5  HWaddr: 1F:8F  Channel: 26  Page: 0  NID: 0x23  PHY: O-QPSK 
          
          Long HWaddr: 5E:D0:02:E4:02:51:1F:8F 
           TX-Power: 0dBm  State: IDLE  max. Retrans.: 3  CSMA Retries: 4 
          ACK_REQ  CSMA  L2-PDU:102  MTU:1280  HL:64  RTR  
          RTR_ADV  6LO  IPHC  
          Source address length: 8
          Link type: wireless
          inet6 addr: fe80::5cd0:2e4:251:1f8f  scope: link  VAL
          inet6 addr: 2001:db8::5cd0:2e4:251:1f8f  scope: global  VAL
          inet6 group: ff02::2
          inet6 group: ff02::1
          inet6 group: ff02::1:ff51:1f8f
          
> ping6 ff02::1
12 bytes from fe80::e9ec:1820:ed85:a84b: icmp_seq=0 ttl=64 time=9.630 ms
12 bytes from fe80::e9ec:1820:ed85:a84b: icmp_seq=1 ttl=64 time=9.880 ms
12 bytes from fe80::5077:c931:e1b:1b8e%5: icmp_seq=1 ttl=64 rssi=-53 dBm time=16.728 ms (DUP!)
12 bytes from fe80::e9ec:1820:ed85:a84b: icmp_seq=2 ttl=64 time=9.874 ms

--- ff02::1 PING statistics ---
3 packets transmitted, 3 packets received, 1 duplicates, 0% packet loss
round-trip min/avg/max = 9.630/11.528/16.728 ms
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
