### PR TITLE
cpu/cc2538/radio: only build required files

### DIFF
--- a/cpu/cc2538/radio/Makefile
+++ b/cpu/cc2538/radio/Makefile
@@ -1,3 +1,15 @@
 MODULE = cc2538_rf
 
+SRC = \
+    cc2538_rf.c \
+    cc2538_rf_getset.c \
+    cc2538_rf_internal.c \
+    #
+
+ifneq (,$(filter ieee802154_radio_hal,$(USEMODULE)))
+  SRC += cc2538_rf_radio_ops.c
+else
+  SRC += cc2538_rf_netdev.c
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -31,8 +31,6 @@
 #define ENABLE_DEBUG        (0)
 #include "debug.h"
 
-#if !IS_USED(MODULE_IEEE802154_RADIO_HAL)
-
 /* Reference pointer for the IRQ handler */
 static netdev_t *_dev;
 
@@ -422,6 +420,3 @@ const netdev_driver_t cc2538_rf_driver = {
     .isr  = _isr,
     .init = _init,
 };
-#else
-int dont_be_pedantic;
-#endif /* MODULE_IEEE802154_RADIO_HAL */

--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -8,7 +8,6 @@
 
 #include "net/ieee802154/radio.h"
 
-#if IS_USED(MODULE_IEEE802154_RADIO_HAL)
 static const ieee802154_radio_ops_t cc2538_rf_ops;
 
 ieee802154_dev_t cc2538_rf_dev = {
@@ -487,6 +486,3 @@ static const ieee802154_radio_ops_t cc2538_rf_ops = {
     .set_csma_params = _set_csma_params,
     .set_rx_mode = _set_rx_mode,
 };
-#else
-int dont_be_pedantic;
-#endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR extends a bit the Makefile of the cc2538 radio module to only build required files depending on the module used:
- if the `ieee802154_radio_hal` module is used, use `cc2538_rf_radio_ops.c`
- use `cc2538_rf_netdev.c` otherwise

The other C files are always built.

This allows to remove the need to exclude the whole content of the C files using preprocessor conditionals and the `int dont_be_pedantic;` else case which I find much nicer.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Initially spotted this #14802 for nrf but too late for cc2538 that was just merged.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
