### PR TITLE
makefiles/cflags.inc.mk: Add -Wcast-align

### DIFF
--- a/boards/common/stm32/include/cfg_usb_otg_fs.h
+++ b/boards/common/stm32/include/cfg_usb_otg_fs.h
@@ -36,7 +36,7 @@ extern "C" {
  */
 static const stm32_usb_otg_fshs_config_t stm32_usb_otg_fshs_config[] = {
     {
-        .periph   = (uint8_t *)USB_OTG_FS_PERIPH_BASE,
+        .periph   = USB_OTG_FS_PERIPH_BASE,
         .rcc_mask = RCC_AHB2ENR_OTGFSEN,
         .phy      = STM32_USB_OTG_PHY_BUILTIN,
         .type     = STM32_USB_OTG_FS,

--- a/boards/common/stm32/include/cfg_usb_otg_hs_fs.h
+++ b/boards/common/stm32/include/cfg_usb_otg_hs_fs.h
@@ -36,7 +36,7 @@ extern "C" {
  */
 static const stm32_usb_otg_fshs_config_t stm32_usb_otg_fshs_config[] = {
     {
-        .periph   = (uint8_t *)USB_OTG_HS_PERIPH_BASE,
+        .periph   = USB_OTG_HS_PERIPH_BASE,
         .rcc_mask = RCC_AHB1ENR_OTGHSEN,
         .phy      = STM32_USB_OTG_PHY_BUILTIN,
         .type     = STM32_USB_OTG_HS,

--- a/boards/p-nucleo-wb55/include/periph_conf.h
+++ b/boards/p-nucleo-wb55/include/periph_conf.h
@@ -109,13 +109,13 @@ static const spi_conf_t spi_config[] = {
  */
 static const stm32_usbdev_fs_config_t stm32_usbdev_fs_config[] = {
     {
-        .base_addr   = (uintptr_t *)USB,
-        .rcc_mask = RCC_APB1ENR1_USBEN | RCC_APB1ENR1_CRSEN,
-        .irqn     = USB_LP_IRQn,
-        .apb      = APB1,
-        .dm       = GPIO_PIN(PORT_A, 11),
-        .dp       = GPIO_PIN(PORT_A, 12),
-        .af       = GPIO_AF10,
+        .base_addr  = (uintptr_t)USB,
+        .rcc_mask   = RCC_APB1ENR1_USBEN | RCC_APB1ENR1_CRSEN,
+        .irqn       = USB_LP_IRQn,
+        .apb        = APB1,
+        .dm         = GPIO_PIN(PORT_A, 11),
+        .dp         = GPIO_PIN(PORT_A, 12),
+        .af         = GPIO_AF10,
     },
 };
 

--- a/core/sched.c
+++ b/core/sched.c
@@ -120,7 +120,11 @@ static void _unschedule(thread_t *active_thread)
     }
 
 #if IS_ACTIVE(SCHED_TEST_STACK)
-    if (*((uintptr_t *)active_thread->stack_start) !=
+    /* All platforms align the stack to word boundaries (possible wasting one
+     * word of RAM), so this access is not unaligned. Using an intermediate
+     * cast to uintptr_t to silence -Wcast-align
+     */
+    if (*((uintptr_t *)(uintptr_t)active_thread->stack_start) !=
         (uintptr_t)active_thread->stack_start) {
         LOG_WARNING(
             "scheduler(): stack overflow detected, pid=%" PRIkernel_pid "\n",

--- a/cpu/esp32/periph/can.c
+++ b/cpu/esp32/periph/can.c
@@ -149,7 +149,7 @@ static const struct can_bittiming_const bittiming_const = {
 
 static void _esp_can_isr(candev_t *candev)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
 
     DEBUG("%s candev=%p\n", __func__, candev);
 
@@ -217,7 +217,7 @@ static void _esp_can_isr(candev_t *candev)
 
 static int _esp_can_init(candev_t *candev)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
 
     DEBUG("%s candev=%p\n", __func__, candev);
 
@@ -234,7 +234,7 @@ static int _esp_can_init(candev_t *candev)
 
 static int _esp_can_send(candev_t *candev, const struct can_frame *frame)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
 
     DEBUG("%s candev=%p frame=%p\n", __func__, candev, frame);
 
@@ -301,7 +301,7 @@ static int _esp_can_send(candev_t *candev, const struct can_frame *frame)
 
 static int _esp_can_set(candev_t *candev, canopt_t opt, void *value, size_t value_len)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
 
     assert(dev);
     assert(value);
@@ -354,7 +354,7 @@ static int _esp_can_set(candev_t *candev, canopt_t opt, void *value, size_t valu
 
 static int _esp_can_get(candev_t *candev, canopt_t opt, void *value, size_t max_len)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
 
     DEBUG("%s\n", __func__);
 
@@ -447,7 +447,7 @@ static int _esp_can_get(candev_t *candev, canopt_t opt, void *value, size_t max_
 
 static int _esp_can_abort(candev_t *candev, const struct can_frame *frame)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
 
     DEBUG("%s candev=%p frame=%p\n", __func__, candev, frame);
 
@@ -465,7 +465,7 @@ static int _esp_can_abort(candev_t *candev, const struct can_frame *frame)
 
 static int _esp_can_set_filter(candev_t *candev, const struct can_filter *filter)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
 
     DEBUG("%s candev=%p filter=%p\n", __func__, candev, filter);
 
@@ -502,7 +502,7 @@ static int _esp_can_set_filter(candev_t *candev, const struct can_filter *filter
 
 static int _esp_can_remove_filter(candev_t *candev, const struct can_filter *filter)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
 
     DEBUG("%s candev=%p filter=%p\n", __func__, candev, filter);
 

--- a/cpu/esp32/vendor/Makefile
+++ b/cpu/esp32/vendor/Makefile
@@ -2,3 +2,6 @@
 DIRS += esp-idf
 
 include $(RIOTBASE)/Makefile.base
+# vendor code contains casts that increase alignment requirements. Let's hope
+# those are false positives.
+CFLAGS += -Wno-cast-align

--- a/cpu/kinetis/periph/flashpage.c
+++ b/cpu/kinetis/periph/flashpage.c
@@ -88,8 +88,11 @@ enum {
     ERASE_ERROR         = -6,
 };
 
-/* Pointer to FCCOB register */
-volatile uint32_t *const FCCOBx = (volatile uint32_t *)&FTFx->FCCOB3;
+/* Pointer to FCCOB register. An intermediate cast is used to silence
+ * -Wcast-align as the address of the h/w register is properly aligned
+ * for 32 bit accesses
+ */
+static volatile uint32_t *const FCCOBx = (volatile uint32_t *)(uintptr_t)&FTFx->FCCOB3;
 
 /* Erasing/Programming flash is not allowed inside the same flash block
    where the program is being read, for _run_command to be executed in

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -821,7 +821,7 @@ typedef enum {
  * @brief stm32 USB OTG configuration
  */
 typedef struct {
-    uint8_t *periph;                /**< USB peripheral base address */
+    uintptr_t periph;               /**< USB peripheral base address */
     uint32_t rcc_mask;              /**< bit in clock enable register */
     stm32_usb_otg_fshs_phy_t phy;   /**< Built-in or ULPI phy */
     stm32_usb_otg_fshs_type_t type; /**< FS or HS type */

--- a/cpu/stm32/include/periph_cpu.h
+++ b/cpu/stm32/include/periph_cpu.h
@@ -836,7 +836,7 @@ typedef struct {
  * @brief stm32 USB device FS configuration
  */
 typedef struct {
-    uintptr_t *base_addr;           /**< USB peripheral base address */
+    uintptr_t base_addr;            /**< USB peripheral base address */
     uint32_t rcc_mask;              /**< bit in clock enable register */
     uint8_t irqn;                   /**< IRQ channel */
     uint8_t apb;                    /**< APB bus */

--- a/cpu/stm32/periph/can.c
+++ b/cpu/stm32/periph/can.c
@@ -268,7 +268,7 @@ void candev_stm32_set_pins(can_t *dev, gpio_t tx_pin, gpio_t rx_pin)
 
 static int _init(candev_t *candev)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
     int res = 0;
 
     _can[get_channel(dev->conf->can)] = dev;
@@ -389,7 +389,7 @@ static inline void set_bit_timing(can_t *dev)
 
 static int _send(candev_t *candev, const struct can_frame *frame)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
     CAN_TypeDef *can = dev->conf->can;
     int mailbox = 0;
 
@@ -430,7 +430,7 @@ static int _send(candev_t *candev, const struct can_frame *frame)
 
 static int _abort(candev_t *candev, const struct can_frame *frame)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
     CAN_TypeDef *can = dev->conf->can;
     int mailbox = 0;
 
@@ -496,7 +496,7 @@ static int read_frame(can_t *dev, struct can_frame *frame, int mailbox)
 
 static void _isr(candev_t *candev)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
 
     if (dev->isr_flags.isr_tx) {
         tx_isr(dev);
@@ -749,7 +749,7 @@ static int _sleep(can_t *dev)
 
 static int _set(candev_t *candev, canopt_t opt, void *value, size_t value_len)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
     CAN_TypeDef *can = dev->conf->can;
     int res = 0;
     can_mode_t mode;
@@ -827,7 +827,7 @@ static int _set(candev_t *candev, canopt_t opt, void *value, size_t value_len)
 
 static int _get(candev_t *candev, canopt_t opt, void *value, size_t max_len)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
     CAN_TypeDef *can = dev->conf->can;
     int res = 0;
 
@@ -916,7 +916,7 @@ static int _get(candev_t *candev, canopt_t opt, void *value, size_t max_len)
 
 static int _set_filter(candev_t *candev, const struct can_filter *filter)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
 
     DEBUG("_set_filter: dev=%p, filter=0x%" PRIx32 "\n", (void *)candev, filter->can_id);
 
@@ -942,7 +942,7 @@ static int _set_filter(candev_t *candev, const struct can_filter *filter)
 
 static int _remove_filter(candev_t *candev, const struct can_filter *filter)
 {
-    can_t *dev = (can_t *)candev;
+    can_t *dev = container_of(candev, can_t, candev);
 
     int first_filter = get_first_filter(dev);
     int last_filter = first_filter + get_nb_filter(dev);

--- a/cpu/stm32/periph/usbdev_fs.c
+++ b/cpu/stm32/periph/usbdev_fs.c
@@ -64,7 +64,7 @@ const usbdev_driver_t driver;
 
 static USB_TypeDef *_global_regs(const stm32_usbdev_fs_config_t *conf)
 {
-    return (USB_TypeDef*)conf->base_addr;
+    return (USB_TypeDef *)conf->base_addr;
 }
 
 /* Endpoint Buffer Descriptor */

--- a/drivers/mcp2515/candev_mcp2515.c
+++ b/drivers/mcp2515/candev_mcp2515.c
@@ -119,7 +119,7 @@ static void _mcp2515_irq_handler(void *arg)
 static int _init(candev_t *candev)
 {
     int res = 0;
-    candev_mcp2515_t *dev = (candev_mcp2515_t *)candev;
+    candev_mcp2515_t *dev = container_of(candev, candev_mcp2515_t, candev);
 
     memset(dev->tx_mailbox, 0, sizeof(dev->tx_mailbox));
 
@@ -151,7 +151,7 @@ static int _init(candev_t *candev)
 
 static int _send(candev_t *candev, const struct can_frame *frame)
 {
-    candev_mcp2515_t *dev = (candev_mcp2515_t *)candev;
+    candev_mcp2515_t *dev = container_of(candev, candev_mcp2515_t, candev);
     int box;
     int ret = 0;
     enum mcp2515_mode mode;
@@ -210,7 +210,7 @@ static int _send(candev_t *candev, const struct can_frame *frame)
 
 static int _abort(candev_t *candev, const struct can_frame *frame)
 {
-    candev_mcp2515_t *dev = (candev_mcp2515_t *)candev;
+    candev_mcp2515_t *dev = container_of(candev, candev_mcp2515_t, candev);
     int box;
 
     DEBUG("Inside mcp2515 abort\n");
@@ -241,7 +241,7 @@ static int _abort(candev_t *candev, const struct can_frame *frame)
 static void _isr(candev_t *candev)
 {
     uint8_t flag;
-    candev_mcp2515_t *dev = (candev_mcp2515_t *)candev;
+    candev_mcp2515_t *dev = container_of(candev, candev_mcp2515_t, candev);
 
     if (mutex_trylock(&_mcp_mutex)) {
         flag = mcp2515_get_irq(dev);
@@ -309,7 +309,7 @@ static void _isr(candev_t *candev)
 
 static int _set(candev_t *candev, canopt_t opt, void *value, size_t value_len)
 {
-    candev_mcp2515_t *dev = (candev_mcp2515_t *)candev;
+    candev_mcp2515_t *dev = container_of(candev, candev_mcp2515_t, candev);
     int res = 0;
 
     DEBUG("Inside mcp2515 set opt=%d\n", opt);
@@ -379,7 +379,7 @@ static int _set(candev_t *candev, canopt_t opt, void *value, size_t value_len)
 
 static int _get(candev_t *candev, canopt_t opt, void *value, size_t max_len)
 {
-    candev_mcp2515_t *dev = (candev_mcp2515_t *)candev;
+    candev_mcp2515_t *dev = container_of(candev, candev_mcp2515_t, candev);
     int res = 0;
 
     DEBUG("Inside mcp2515 get opt=%d\n", opt);
@@ -436,7 +436,7 @@ static int _set_filter(candev_t *dev, const struct can_filter *filter)
     int res = -1;
     enum mcp2515_mode mode;
 
-    candev_mcp2515_t *dev_mcp = (candev_mcp2515_t *)dev;
+    candev_mcp2515_t *dev_mcp = container_of(dev, candev_mcp2515_t, candev);
 
     if (f.can_mask == 0) {
         return -EINVAL; /* invalid mask */
@@ -538,7 +538,7 @@ static int _remove_filter(candev_t *dev, const struct can_filter *filter)
     int res = 0;
     enum mcp2515_mode mode;
 
-    candev_mcp2515_t *dev_mcp = (candev_mcp2515_t *)dev;
+    candev_mcp2515_t *dev_mcp = container_of(dev, candev_mcp2515_t, candev);
 
     if (f.can_mask == 0) {
         return -1; /* invalid mask */

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -70,6 +70,9 @@ OPTIONAL_CFLAGS += -Wformat=2
 OPTIONAL_CFLAGS += -Wformat-overflow
 OPTIONAL_CFLAGS += -Wformat-truncation
 
+# Warn about casts that increase alignment requirements
+OPTIONAL_CFLAGS += -Wcast-align
+
 # Warn if a user-supplied include directory does not exist.
 CFLAGS += -Wmissing-include-dirs
 

--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -17,6 +17,8 @@ endif
 
 TOOLCHAIN_FILE = $(PKG_SOURCE_DIR)/xcompile-toolchain.cmake
 
+CFLAGS += -Wno-cast-align
+
 all: $(BINDIR)/ccn-lite.a
 
 $(BINDIR)/ccn-lite.a: $(PKG_BUILD_DIR)/lib/libccnl-riot.a

--- a/pkg/cmsis-dsp/Makefile
+++ b/pkg/cmsis-dsp/Makefile
@@ -22,6 +22,8 @@ CMSIS_DSP_MODULES =                \
 
 .PHONY: cmsis-dsp_%
 
+CFLAGS += -Wno-cast-align
+
 all: $(CMSIS_DSP_MODULES)
 
 cmsis-dsp_%:

--- a/pkg/cmsis-dsp/patches/0003-Inclue-arm_math.h-silence-Wcast-align.patch
+++ b/pkg/cmsis-dsp/patches/0003-Inclue-arm_math.h-silence-Wcast-align.patch
@@ -1,0 +1,25 @@
+From c9a4e05071aabfcc2dae7e3e5b5772806c28f86c Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Sun, 7 Nov 2021 15:22:12 +0100
+Subject: [PATCH] Inclue/arm_math.h: silence -Wcast-align
+
+---
+ CMSIS/DSP/Include/arm_math.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMSIS/DSP/Include/arm_math.h b/CMSIS/DSP/Include/arm_math.h
+index 6af24bab5..897623e6e 100644
+--- a/CMSIS/DSP/Include/arm_math.h
++++ b/CMSIS/DSP/Include/arm_math.h
+@@ -482,7 +482,7 @@ extern "C"
+ #endif
+ 
+ #define __SIMD32(addr)        (*(__SIMD32_TYPE **) & (addr))
+-#define __SIMD32_CONST(addr)  ((__SIMD32_TYPE *)(addr))
++#define __SIMD32_CONST(addr)  ((__SIMD32_TYPE *)(uintptr_t)(addr))
+ #define _SIMD32_OFFSET(addr)  (*(__SIMD32_TYPE *)  (addr))
+ #define __SIMD64(addr)        (*(int64_t **) & (addr))
+ 
+-- 
+2.33.1
+

--- a/pkg/cmsis-nn/Makefile
+++ b/pkg/cmsis-nn/Makefile
@@ -5,6 +5,8 @@ PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+CFLAGS += -Wno-cast-align
+
 CMSIS_NN_MODULES =                   \
     cmsis-nn_ActivationFunctions     \
     cmsis-nn_ConvolutionFunctions    \

--- a/pkg/cn-cbor/Makefile
+++ b/pkg/cn-cbor/Makefile
@@ -8,6 +8,7 @@ include $(RIOTBASE)/pkg/pkg.mk
 # Enable code forcing aligned reads
 CFLAGS += -DCBOR_ALIGN_READS
 CFLAGS += -Wno-return-local-addr
+CFLAGS += -Wno-cast-align
 
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)

--- a/pkg/cryptoauthlib/Makefile
+++ b/pkg/cryptoauthlib/Makefile
@@ -11,10 +11,18 @@ include $(RIOTBASE)/pkg/pkg.mk
 CMAKE_MINIMAL_VERSION = 3.6.0
 
 CFLAGS += $(INCLUDES)
-CFLAGS += -Wno-missing-field-initializers -Wno-unused-function
-CFLAGS += -Wno-type-limits -Wno-strict-aliasing -Wno-unused-variable -DATCA_HAL_I2C
-CFLAGS += -Wno-unused-parameter -Wno-sign-compare -Wno-overflow -Wno-pointer-to-int-cast
+CFLAGS += -DATCA_HAL_I2C
+CFLAGS += -Wno-cast-align
 CFLAGS += -Wno-char-subscripts
+CFLAGS += -Wno-missing-field-initializers
+CFLAGS += -Wno-overflow
+CFLAGS += -Wno-pointer-to-int-cast
+CFLAGS += -Wno-sign-compare
+CFLAGS += -Wno-strict-aliasing
+CFLAGS += -Wno-type-limits
+CFLAGS += -Wno-unused-function
+CFLAGS += -Wno-unused-parameter
+CFLAGS += -Wno-unused-variable
 
 TOOLCHAIN_FILE=$(PKG_SOURCE_DIR)/xcompile-toolchain.cmake
 

--- a/pkg/elk/Makefile
+++ b/pkg/elk/Makefile
@@ -5,6 +5,7 @@ PKG_LICENSE=GPLv2
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+CFLAGS += -Wno-cast-align
 CFLAGS += -Wno-format-nonliteral
 CFLAGS += -Wno-pedantic
 CFLAGS += -Wno-unused-parameter

--- a/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
+++ b/pkg/fatfs/fatfs_vfs/fatfs_vfs.c
@@ -118,10 +118,17 @@ static int _rename(vfs_mount_t *mountp, const char *from_path,
                                        fatfs_abs_path_to));
 }
 
+static fatfs_file_desc_t * _get_fatfs_file_desc(vfs_file_t *f)
+{
+    /* the private buffer is part of a union that also contains a
+     * void pointer, hence, it is naturally aligned */
+    return (fatfs_file_desc_t *)(uintptr_t)f->private_data.buffer;
+}
+
 static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode,
                  const char *abs_path)
 {
-    fatfs_file_desc_t *fd = (fatfs_file_desc_t *)&filp->private_data.buffer[0];
+    fatfs_file_desc_t *fd = _get_fatfs_file_desc(filp);
     fatfs_desc_t *fs_desc = (fatfs_desc_t *)filp->mp->private_data;
     _build_abs_path(fs_desc, name);
 
@@ -179,7 +186,7 @@ static int _open(vfs_file_t *filp, const char *name, int flags, mode_t mode,
 
 static int _close(vfs_file_t *filp)
 {
-    fatfs_file_desc_t *fd = (fatfs_file_desc_t *)filp->private_data.buffer;
+    fatfs_file_desc_t *fd = _get_fatfs_file_desc(filp);
 
     DEBUG("fatfs_vfs.c: _close: private_data = %p\n", filp->mp->private_data);
 
@@ -197,7 +204,7 @@ static int _close(vfs_file_t *filp)
 
 static ssize_t _write(vfs_file_t *filp, const void *src, size_t nbytes)
 {
-    fatfs_file_desc_t *fd = (fatfs_file_desc_t *)filp->private_data.buffer;
+    fatfs_file_desc_t *fd = _get_fatfs_file_desc(filp);
 
     UINT bw;
 
@@ -212,7 +219,7 @@ static ssize_t _write(vfs_file_t *filp, const void *src, size_t nbytes)
 
 static ssize_t _read(vfs_file_t *filp, void *dest, size_t nbytes)
 {
-    fatfs_file_desc_t *fd = (fatfs_file_desc_t *)filp->private_data.buffer;
+    fatfs_file_desc_t *fd = _get_fatfs_file_desc(filp);
 
     UINT br;
 
@@ -227,7 +234,7 @@ static ssize_t _read(vfs_file_t *filp, void *dest, size_t nbytes)
 
 static off_t _lseek(vfs_file_t *filp, off_t off, int whence)
 {
-    fatfs_file_desc_t *fd = (fatfs_file_desc_t *)filp->private_data.buffer;
+    fatfs_file_desc_t *fd = _get_fatfs_file_desc(filp);
     FRESULT res;
     off_t new_pos = 0;
 
@@ -294,9 +301,16 @@ static int _fstat(vfs_file_t *filp, struct stat *buf)
     return fatfs_err_to_errno(res);
 }
 
+static inline DIR * _get_DIR(vfs_DIR *d)
+{
+    /* the private buffer is part of a union that also contains a
+     * void pointer, hence, it is naturally aligned */
+    return (DIR *)(uintptr_t)d->private_data.buffer;
+}
+
 static int _opendir(vfs_DIR *dirp, const char *dirname, const char *abs_path)
 {
-    DIR *dir = (DIR *)&dirp->private_data.buffer;
+    DIR *dir = _get_DIR(dirp);
     fatfs_desc_t *fs_desc = (fatfs_desc_t *)dirp->mp->private_data;
     (void) abs_path;
 
@@ -307,7 +321,7 @@ static int _opendir(vfs_DIR *dirp, const char *dirname, const char *abs_path)
 
 static int _readdir(vfs_DIR *dirp, vfs_dirent_t *entry)
 {
-    DIR *dir = (DIR *)&dirp->private_data.buffer[0];
+    DIR *dir = _get_DIR(dirp);
     FILINFO fi;
 
     FRESULT res = f_readdir(dir, &fi);
@@ -328,7 +342,7 @@ static int _readdir(vfs_DIR *dirp, vfs_dirent_t *entry)
 
 static int _closedir(vfs_DIR *dirp)
 {
-    DIR *dir = (DIR *)&dirp->private_data.buffer[0];
+    DIR *dir = _get_DIR(dirp);
 
     return fatfs_err_to_errno(f_closedir(dir));
 }

--- a/pkg/flatbuffers/Makefile
+++ b/pkg/flatbuffers/Makefile
@@ -5,5 +5,7 @@ PKG_LICENSE=Apache2.0
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+CFLAGS += -Wno-cast-align
+
 all:
 	@:

--- a/pkg/flatbuffers/patches/0001-Silence-Wcast-align-in-public-headers.patch
+++ b/pkg/flatbuffers/patches/0001-Silence-Wcast-align-in-public-headers.patch
@@ -1,0 +1,126 @@
+From 1f739fa4e49839c63ef2831ed454965746ed104d Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Sat, 13 Nov 2021 09:17:04 +0100
+Subject: [PATCH] Silence -Wcast-align in public headers
+
+---
+ include/flatbuffers/flatbuffers.h | 30 ++++++++++++++++++++++++++++++
+ 1 file changed, 30 insertions(+)
+
+diff --git a/include/flatbuffers/flatbuffers.h b/include/flatbuffers/flatbuffers.h
+index a1a95f00..8c50576e 100644
+--- a/include/flatbuffers/flatbuffers.h
++++ b/include/flatbuffers/flatbuffers.h
+@@ -83,7 +83,10 @@ template<typename T> struct IndirectHelper {
+   typedef T mutable_return_type;
+   static const size_t element_stride = sizeof(T);
+   static return_type Read(const uint8_t *p, uoffset_t i) {
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wcast-align"
+     return EndianScalar((reinterpret_cast<const T *>(p))[i]);
++#pragma GCC diagnostic pop
+   }
+ };
+ template<typename T> struct IndirectHelper<Offset<T>> {
+@@ -92,7 +95,10 @@ template<typename T> struct IndirectHelper<Offset<T>> {
+   static const size_t element_stride = sizeof(uoffset_t);
+   static return_type Read(const uint8_t *p, uoffset_t i) {
+     p += i * sizeof(uoffset_t);
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wcast-align"
+     return reinterpret_cast<return_type>(p + ReadScalar<uoffset_t>(p));
++#pragma GCC diagnostic pop
+   }
+ };
+ template<typename T> struct IndirectHelper<const T *> {
+@@ -807,12 +813,18 @@ class vector_downward {
+   // Specialized version of push() that avoids memcpy call for small data.
+   template<typename T> void push_small(const T &little_endian_t) {
+     make_space(sizeof(T));
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wcast-align"
+     *reinterpret_cast<T *>(cur_) = little_endian_t;
++#pragma GCC diagnostic pop
+   }
+ 
+   template<typename T> void scratch_push_small(const T &t) {
+     ensure_space(sizeof(T));
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wcast-align"
+     *reinterpret_cast<T *>(scratch_) = t;
++#pragma GCC diagnostic pop
+     scratch_ += sizeof(T);
+   }
+ 
+@@ -1217,7 +1229,10 @@ class FlatBufferBuilder {
+     // Write the offsets into the table
+     for (auto it = buf_.scratch_end() - num_field_loc * sizeof(FieldLoc);
+          it < buf_.scratch_end(); it += sizeof(FieldLoc)) {
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wcast-align"
+       auto field_location = reinterpret_cast<FieldLoc *>(it);
++#pragma GCC diagnostic pop
+       auto pos = static_cast<voffset_t>(vtableoffsetloc - field_location->off);
+       // If this asserts, it means you've set a field twice.
+       FLATBUFFERS_ASSERT(
+@@ -1225,7 +1240,10 @@ class FlatBufferBuilder {
+       WriteScalar<voffset_t>(buf_.data() + field_location->id, pos);
+     }
+     ClearOffsets();
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wcast-align"
+     auto vt1 = reinterpret_cast<voffset_t *>(buf_.data());
++#pragma GCC diagnostic pop
+     auto vt1_size = ReadScalar<voffset_t>(vt1);
+     auto vt_use = GetSize();
+     // See if we already have generated a vtable with this exact same
+@@ -1233,8 +1251,11 @@ class FlatBufferBuilder {
+     if (dedup_vtables_) {
+       for (auto it = buf_.scratch_data(); it < buf_.scratch_end();
+            it += sizeof(uoffset_t)) {
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wcast-align"
+         auto vt_offset_ptr = reinterpret_cast<uoffset_t *>(it);
+         auto vt2 = reinterpret_cast<voffset_t *>(buf_.data_at(*vt_offset_ptr));
++#pragma GCC diagnostic pop
+         auto vt2_size = *vt2;
+         if (vt1_size != vt2_size || 0 != memcmp(vt2, vt1, vt1_size)) continue;
+         vt_use = *vt_offset_ptr;
+@@ -1889,8 +1910,11 @@ protected:
+   struct StringOffsetCompare {
+     StringOffsetCompare(const vector_downward &buf) : buf_(&buf) {}
+     bool operator()(const Offset<String> &a, const Offset<String> &b) const {
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wcast-align"
+       auto stra = reinterpret_cast<const String *>(buf_->data_at(a.o));
+       auto strb = reinterpret_cast<const String *>(buf_->data_at(b.o));
++#pragma GCC diagnostic pop
+       return StringLessThan(stra->data(), stra->size(),
+                             strb->data(), strb->size());
+     }
+@@ -2272,8 +2296,11 @@ class Table {
+   template<typename P> P GetPointer(voffset_t field) {
+     auto field_offset = GetOptionalFieldOffset(field);
+     auto p = data_ + field_offset;
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wcast-align"
+     return field_offset ? reinterpret_cast<P>(p + ReadScalar<uoffset_t>(p))
+                         : nullptr;
++#pragma GCC diagnostic pop
+   }
+   template<typename P> P GetPointer(voffset_t field) const {
+     return const_cast<Table *>(this)->GetPointer<P>(field);
+@@ -2282,7 +2309,10 @@ class Table {
+   template<typename P> P GetStruct(voffset_t field) const {
+     auto field_offset = GetOptionalFieldOffset(field);
+     auto p = const_cast<uint8_t *>(data_ + field_offset);
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wcast-align"
+     return field_offset ? reinterpret_cast<P>(p) : nullptr;
++#pragma GCC diagnostic pop
+   }
+ 
+   template<typename T> bool SetField(voffset_t field, T val, T def) {
+-- 
+2.33.1
+

--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -13,5 +13,10 @@ ifneq (llvm,$(TOOLCHAIN))
   CFLAGS += -Wno-int-in-bool-context
 endif
 
+# Disable -Wcast-align for this package, as source contains cast that increase
+# alignment requirements. Let's hope those are false positives and proper
+# alignment is assured.
+CFLAGS += -Wno-cast-align
+
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/dist

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -12,6 +12,7 @@ JERRY_GC_LIMIT ?= 0  # Use default value, e.g. 1/32 of total heap size
 JERRY_GC_MARK_LIMIT ?= 8  # maximum recursion depth during GC mark phase
 
 EXT_CFLAGS := -D__TARGET_RIOT
+CFLAGS += -Wno-cast-align
 
 # disable warnings when compiling with LLVM for board native
 ifeq ($(TOOLCHAIN)_$(BOARD),llvm_native)

--- a/pkg/libb2/Makefile
+++ b/pkg/libb2/Makefile
@@ -5,5 +5,7 @@ PKG_LICENSE = CC0-1.0
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+CFLAGS += -Wno-cast-align
+
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(CURDIR)/Makefile.$(PKG_NAME)

--- a/pkg/libhydrogen/Makefile
+++ b/pkg/libhydrogen/Makefile
@@ -7,6 +7,7 @@ include $(RIOTBASE)/pkg/pkg.mk
 
 # This warning is triggered on non-32bit platforms
 CFLAGS += -Wno-type-limits
+CFLAGS += -Wno-cast-align
 
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/lua/Makefile
+++ b/pkg/lua/Makefile
@@ -6,5 +6,7 @@ PKG_LICENSE=MIT
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+CFLAGS += -Wno-cast-align
+
 all: Makefile.lua
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(CURDIR)/Makefile.lua

--- a/pkg/lua/contrib/binsearch.c
+++ b/pkg/lua/contrib/binsearch.c
@@ -26,7 +26,7 @@ int binsearch_str(const void *start, size_t offset, size_t stride, size_t nmemb,
 
     while (lo < hi) {
         size_t mid = (lo + hi) / 2;
-        const char *target = *((const char *const *)(cstart + mid * stride));
+        const char *target = *((const char *const *)(uintptr_t)(cstart + mid * stride));
         int cmp = strncmp(str, target, n);
 
         if (cmp == 0) {

--- a/pkg/lvgl/Makefile
+++ b/pkg/lvgl/Makefile
@@ -15,6 +15,8 @@ LVGL_MODULES =      \
     lvgl_widgets    \
     #
 
+CFLAGS += -Wno-cast-align
+
 .PHONY: lvgl_%
 
 all: $(LVGL_MODULES)

--- a/pkg/mynewt-core/Makefile
+++ b/pkg/mynewt-core/Makefile
@@ -8,6 +8,7 @@ include $(RIOTBASE)/pkg/pkg.mk
 CFLAGS += -Wno-unused-parameter
 CFLAGS += -Wno-unused-but-set-variable
 CFLAGS += -Wno-sign-compare
+CFLAGS += -Wno-cast-align
 
 MYNEWT_CORE_MODULES := mynewt-core_os \
                        mynewt-core_util \

--- a/pkg/ndn-riot/Makefile
+++ b/pkg/ndn-riot/Makefile
@@ -5,5 +5,7 @@ PKG_LICENSE=LGPLv2.1
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+CFLAGS += -Wno-cast-align
+
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -10,7 +10,7 @@ PDIR = $(PKG_SOURCE_DIR)
 
 # NimBLE is not optimized for building with all (extra) warnings enabled. So for
 # now, we disable a number of selected compiler warnings when building NimBLE.
-CFLAGS += -Wno-extra
+CFLAGS += -Wno-extra -Wno-cast-align
 ifeq (llvm,$(TOOLCHAIN))
 # the static function `ble_ll_adv_active_chanset_is_sec()` in
 # `nimble/controller/src/ble_ll_adv.c` isn't used in our compilation path, so

--- a/pkg/nimble/patches/0001-porting-nimble-silence-Wcast-align.patch
+++ b/pkg/nimble/patches/0001-porting-nimble-silence-Wcast-align.patch
@@ -1,0 +1,31 @@
+From ba0f5ceb2aeaa6c2aab5c20c79597d306d360900 Mon Sep 17 00:00:00 2001
+From: Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+Date: Thu, 4 Nov 2021 15:38:38 +0100
+Subject: [PATCH] porting/nimble: silence -Wcast-align
+
+---
+ porting/nimble/include/os/os_mbuf.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/porting/nimble/include/os/os_mbuf.h b/porting/nimble/include/os/os_mbuf.h
+index 771ea761..e5ca0617 100644
+--- a/porting/nimble/include/os/os_mbuf.h
++++ b/porting/nimble/include/os/os_mbuf.h
+@@ -132,12 +132,12 @@ struct os_mqueue {
+     ((__om)->om_pkthdr_len >= sizeof (struct os_mbuf_pkthdr))
+ 
+ /** Get a packet header pointer given an mbuf pointer */
+-#define OS_MBUF_PKTHDR(__om) ((struct os_mbuf_pkthdr *)     \
++#define OS_MBUF_PKTHDR(__om) ((struct os_mbuf_pkthdr *)(uintptr_t) \
+     ((uint8_t *)&(__om)->om_data + sizeof(struct os_mbuf)))
+ 
+ /** Given a mbuf packet header pointer, return a pointer to the mbuf */
+ #define OS_MBUF_PKTHDR_TO_MBUF(__hdr)   \
+-     (struct os_mbuf *)((uint8_t *)(__hdr) - sizeof(struct os_mbuf))
++     (struct os_mbuf *)(uintptr_t)((uint8_t *)(__hdr) - sizeof(struct os_mbuf))
+ 
+ /**
+  * Gets the length of an entire mbuf chain.  The specified mbuf must have a
+-- 
+2.33.1
+

--- a/pkg/openwsn/Makefile
+++ b/pkg/openwsn/Makefile
@@ -29,6 +29,7 @@ OPENWSN_MODULES := $(filter-out $(IGNORE_MODULES),$(filter openwsn_%,$(USEMODULE
 OPENWSN_LOG_LEVEL ?= LOG_NONE
 
 CFLAGS += -Wno-array-bounds
+CFLAGS += -Wno-cast-align
 CFLAGS += -Wno-implicit-fallthrough
 CFLAGS += -Wno-implicit-function-declaration
 CFLAGS += -Wno-incompatible-pointer-types
@@ -36,8 +37,8 @@ CFLAGS += -Wno-maybe-uninitialized
 CFLAGS += -Wno-old-style-definition
 CFLAGS += -Wno-return-type
 CFLAGS += -Wno-sign-compare
-CFLAGS += -Wno-unused-parameter
 CFLAGS += -Wno-strict-prototypes
+CFLAGS += -Wno-unused-parameter
 CFLAGS += -DLOG_LEVEL=$(OPENWSN_LOG_LEVEL)
 
 OPENWSN_PATH_openstack      = openstack

--- a/pkg/paho-mqtt/Makefile
+++ b/pkg/paho-mqtt/Makefile
@@ -3,6 +3,8 @@ PKG_URL = https://github.com/eclipse/paho.mqtt.embedded-c.git
 PKG_VERSION = 29ab2aa29c5e47794284376d7f8386cfd54c3eed
 PKG_LICENSE = EDL
 
+CFLAGS += -Wno-cast-align
+
 include $(RIOTBASE)/pkg/pkg.mk
 
 all:

--- a/pkg/qdsa/Makefile
+++ b/pkg/qdsa/Makefile
@@ -5,5 +5,7 @@ PKG_LICENSE=PD
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+CFLAGS += -Wno-cast-align
+
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/$(patsubst qdsa_impl_%,%,$(filter qdsa_impl_%,$(USEMODULE)))

--- a/pkg/spiffs/Makefile
+++ b/pkg/spiffs/Makefile
@@ -8,5 +8,7 @@ include $(RIOTBASE)/pkg/pkg.mk
 # Disable 'ISO C99 doesn’t support unnamed structs/unions [-Werror=pedantic]'
 CFLAGS += -Wno-pedantic
 
+CFLAGS += -Wno-cast-align
+
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR)/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)

--- a/pkg/spiffs/fs/spiffs_fs.c
+++ b/pkg/spiffs/fs/spiffs_fs.c
@@ -355,10 +355,17 @@ static int _fstat(vfs_file_t *filp, struct stat *buf)
     return spiffs_err_to_errno(ret);
 }
 
+static spiffs_DIR * _get_spifs_dir(vfs_DIR *dirp)
+{
+    /* the private buffer is part of a union that also contains a
+     * void pointer, hence, it is naturally aligned */
+    return (spiffs_DIR *)(uintptr_t)&dirp->private_data.buffer[0];
+}
+
 static int _opendir(vfs_DIR *dirp, const char *dirname, const char *abs_path)
 {
     spiffs_desc_t *fs_desc = dirp->mp->private_data;
-    spiffs_DIR *d = (spiffs_DIR *)&dirp->private_data.buffer[0];
+    spiffs_DIR *d = _get_spifs_dir(dirp);
     (void) abs_path;
 
     spiffs_DIR *res = SPIFFS_opendir(&fs_desc->fs, dirname, d);
@@ -371,7 +378,7 @@ static int _opendir(vfs_DIR *dirp, const char *dirname, const char *abs_path)
 
 static int _readdir(vfs_DIR *dirp, vfs_dirent_t *entry)
 {
-    spiffs_DIR *d = (spiffs_DIR *)&dirp->private_data.buffer[0];
+    spiffs_DIR *d = _get_spifs_dir(dirp);
     struct spiffs_dirent e;
     struct spiffs_dirent *ret;
 
@@ -396,7 +403,7 @@ static int _readdir(vfs_DIR *dirp, vfs_dirent_t *entry)
 
 static int _closedir(vfs_DIR *dirp)
 {
-    spiffs_DIR *d = (spiffs_DIR *)&dirp->private_data.buffer[0];
+    spiffs_DIR *d = _get_spifs_dir(dirp);
 
     return spiffs_err_to_errno(SPIFFS_closedir(d));
 }

--- a/pkg/tensorflow-lite/Makefile
+++ b/pkg/tensorflow-lite/Makefile
@@ -11,6 +11,7 @@ TF_USEMODULE = $(filter $(TF_MODULES),$(USEMODULE))
 .PHONY: tensorflow-lite tensorflow-lite-%
 
 CFLAGS += -Wno-pedantic
+CFLAGS += -Wno-cast-align
 CFLAGS += -DTF_LITE_STATIC_MEMORY
 CFLAGS += -DTF_LITE_USE_GLOBAL_ROUND
 

--- a/pkg/tlsf/Makefile
+++ b/pkg/tlsf/Makefile
@@ -5,5 +5,7 @@ PKG_LICENSE=BSD
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+CFLAGS += -Wno-cast-align
+
 all:
 	$(QQ)"$(MAKE)" -C $(PKG_SOURCE_DIR) -f $(RIOTBASE)/Makefile.base

--- a/pkg/ucglib/contrib/ucg_riotos.c
+++ b/pkg/ucglib/contrib/ucg_riotos.c
@@ -90,8 +90,11 @@ int16_t ucg_com_hw_spi_riotos(ucg_t *ucg, int16_t msg, uint16_t arg, uint8_t *da
 
             /* setup SPI */
             spi_init_pins(dev);
-            spi_acquire(dev, GPIO_UNDEF, SPI_MODE_0,
-                        ucg_serial_clk_speed_to_spi_speed(((ucg_com_info_t *)data)->serial_clk_speed));
+            /* correct alignment of data can be assumed, as in pkg callers use
+             * ucg_com_info_t to allocate memory */
+            ucg_com_info_t *info = (void *)(uintptr_t)data;
+            spi_clk_t speed = ucg_serial_clk_speed_to_spi_speed(info->serial_clk_speed);
+            spi_acquire(dev, GPIO_UNDEF, SPI_MODE_0, speed);
 
             break;
         case UCG_COM_MSG_POWER_DOWN:

--- a/pkg/uwb-dw1000/Makefile
+++ b/pkg/uwb-dw1000/Makefile
@@ -5,14 +5,15 @@ PKG_LICENSE=Apache-2.0
 
 include $(RIOTBASE)/pkg/pkg.mk
 
-CFLAGS += -Wno-enum-compare
 CFLAGS += -Wno-address-of-packed-member
+CFLAGS += -Wno-cast-align
+CFLAGS += -Wno-enum-compare
 CFLAGS += -Wno-enum-conversion
 CFLAGS += -Wno-maybe-uninitialized
 CFLAGS += -Wno-missing-braces
 CFLAGS += -Wno-missing-declarations
-CFLAGS += -Wno-sign-compare
 CFLAGS += -Wno-return-type
+CFLAGS += -Wno-sign-compare
 CFLAGS += -Wno-unused-but-set-variable
 CFLAGS += -Wno-unused-function
 CFLAGS += -Wno-unused-parameter

--- a/pkg/wakaama/Makefile
+++ b/pkg/wakaama/Makefile
@@ -5,6 +5,8 @@ PKG_LICENSE=EDL-1.0,EPL-1.0
 
 include $(RIOTBASE)/pkg/pkg.mk
 
+CFLAGS += -Wno-cast-align
+
 # some variable seem uninitialized to gcc with -Og but are not
 # https://gcc.gnu.org/bugzilla/buglist.cgi?quicksearch=may%20be%20used%20uninitialized
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=42145

--- a/pkg/wolfssl/Makefile
+++ b/pkg/wolfssl/Makefile
@@ -11,6 +11,12 @@ include $(RIOTBASE)/pkg/pkg.mk
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90710#c1
 CFLAGS += -Wno-maybe-uninitialized
 
+# wolfcrypt uses uint8_t for block buffers, on which fast
+# 32 bit operations are performed. From a quick peek at the
+# code it looks like the buffers are correctly aligned, so
+# this is a false positive.
+CFLAGS += -Wno-cast-align
+
 .PHONY: wolfcrypt%
 
 all: $(filter wolfcrypt wolfcrypt-test wolfcrypt-benchmark,$(USEMODULE))

--- a/sys/include/net/netif.h
+++ b/sys/include/net/netif.h
@@ -84,7 +84,7 @@ typedef struct {
  * @return next network interface.
  * @return NULL, if there is no interface after @p last
  */
-netif_t *netif_iter(netif_t *last);
+netif_t *netif_iter(const netif_t *last);
 
 /**
  * @brief   Gets name of an interface

--- a/sys/net/gnrc/netif/_netif.c
+++ b/sys/net/gnrc/netif/_netif.c
@@ -18,6 +18,7 @@
 #include <string.h>
 
 #include "fmt.h"
+#include "kernel_defines.h"
 #include "net/gnrc/netapi.h"
 #include "net/gnrc/netif/internal.h"
 
@@ -25,7 +26,7 @@
 
 int netif_get_name(netif_t *iface, char *name)
 {
-    gnrc_netif_t *netif = (gnrc_netif_t*) iface;
+    gnrc_netif_t *netif = container_of(iface, gnrc_netif_t, netif);
 
     int res = 0;
     res += fmt_u16_dec(&name[res], netif->pid);
@@ -33,10 +34,10 @@ int netif_get_name(netif_t *iface, char *name)
     return res;
 }
 
-int16_t netif_get_id(const netif_t *netif)
+int16_t netif_get_id(const netif_t *iface)
 {
-    const gnrc_netif_t *iface = (const gnrc_netif_t*)netif;
-    return iface->pid;
+    const gnrc_netif_t *netif = container_of(iface, gnrc_netif_t, netif);
+    return netif->pid;
 }
 
 netif_t *netif_get_by_id(int16_t id)
@@ -44,18 +45,18 @@ netif_t *netif_get_by_id(int16_t id)
     return &gnrc_netif_get_by_pid((kernel_pid_t)id)->netif;
 }
 
-int netif_get_opt(netif_t *netif, netopt_t opt, uint16_t context,
+int netif_get_opt(netif_t *iface, netopt_t opt, uint16_t context,
                   void *value, size_t max_len)
 {
-    gnrc_netif_t *iface = (gnrc_netif_t*) netif;
-    return gnrc_netapi_get(iface->pid, opt, context, value, max_len);
+    const gnrc_netif_t *netif = container_of(iface, gnrc_netif_t, netif);
+    return gnrc_netapi_get(netif->pid, opt, context, value, max_len);
 }
 
-int netif_set_opt(netif_t *netif, netopt_t opt, uint16_t context,
+int netif_set_opt(netif_t *iface, netopt_t opt, uint16_t context,
                   void *value, size_t value_len)
 {
-    gnrc_netif_t *iface = (gnrc_netif_t*) netif;
-    return gnrc_netapi_set(iface->pid, opt, context, value, value_len);
+    const gnrc_netif_t *netif = container_of(iface, gnrc_netif_t, netif);
+    return gnrc_netapi_set(netif->pid, opt, context, value, value_len);
 }
 
 /** @} */

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -139,7 +139,8 @@ unsigned gnrc_netif_numof(void)
 
 gnrc_netif_t *gnrc_netif_iter(const gnrc_netif_t *prev)
 {
-    return (gnrc_netif_t*) netif_iter((netif_t*) prev);
+    netif_t *result = netif_iter(&prev->netif);
+    return container_of(result, gnrc_netif_t, netif);
 }
 
 gnrc_netif_t *gnrc_netif_get_by_type(netdev_type_t type, uint8_t index)

--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -301,7 +301,7 @@ void gnrc_pktbuf_stats(void)
 #ifdef TEST_SUITES
 bool gnrc_pktbuf_is_empty(void)
 {
-    return (_first_unused == (_unused_t *)gnrc_pktbuf_static_buf) &&
+    return ((uintptr_t)_first_unused == (uintptr_t)gnrc_pktbuf_static_buf) &&
            (_first_unused->size == sizeof(_pktbuf_buf));
 }
 

--- a/sys/net/netif/netif.c
+++ b/sys/net/netif/netif.c
@@ -36,7 +36,7 @@ int netif_register(netif_t *netif)
     return 0;
 }
 
-netif_t *netif_iter(netif_t *last)
+netif_t *netif_iter(const netif_t *last)
 {
     if (last == NULL) {
         return (netif_t *)netif_list.next;

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -1774,7 +1774,7 @@ int _gnrc_netif_send(int argc, char **argv)
     nethdr = (gnrc_netif_hdr_t *)hdr->data;
     nethdr->flags = flags;
     /* and send it */
-    if (gnrc_netif_send((gnrc_netif_t *)iface, pkt) < 1) {
+    if (gnrc_netif_send(container_of(iface, gnrc_netif_t, netif), pkt) < 1) {
         puts("error: unable to send");
         gnrc_pktbuf_release(pkt);
         return 1;

--- a/sys/usb/usbus/dfu/dfu.c
+++ b/sys/usb/usbus/dfu/dfu.c
@@ -116,7 +116,7 @@ void usbus_dfu_init(usbus_t *usbus, usbus_dfu_device_t *handler, unsigned mode)
 
 static void _init(usbus_t *usbus, usbus_handler_t *handler)
 {
-    usbus_dfu_device_t *dfu = (usbus_dfu_device_t*) handler;
+    usbus_dfu_device_t *dfu = container_of(handler, usbus_dfu_device_t, handler_ctrl);
     /* Set up descriptor generators */
     dfu->dfu_descr.next = NULL;
     dfu->dfu_descr.funcs = &_dfu_descriptor;
@@ -257,7 +257,7 @@ static int _control_handler(usbus_t *usbus, usbus_handler_t *handler,
     (void)usbus;
     (void)state;
 
-    usbus_dfu_device_t *dfu = (usbus_dfu_device_t *)handler;
+    usbus_dfu_device_t *dfu = container_of(handler, usbus_dfu_device_t, handler_ctrl);
     DEBUG("DFU: Request: 0x%x\n", setup->request);
 
     /* Process DFU class request */

--- a/tests/pkg_cmsis-nn/Makefile
+++ b/tests/pkg_cmsis-nn/Makefile
@@ -21,3 +21,6 @@ BOARD_WHITELIST := \
   #
 
 include $(RIOTBASE)/Makefile.include
+
+# TODO: Get rid of this flag
+CFLAGS += -Wno-cast-align

--- a/tests/pkg_emlearn/main.c
+++ b/tests/pkg_emlearn/main.c
@@ -18,19 +18,23 @@
  * @}
  */
 
-#include <stdio.h>
 #include <inttypes.h>
+#include <stdalign.h>
+#include <stdio.h>
 
 #include "model.h"
 
-/* the digit array included must be 4-byte aligned */
-__attribute__((__aligned__(4)))
+/* the digit array will be casted to float, so it has to meet that alignment */
+alignas(float)
 #include "blob/digit.h"
 
 int main(void)
 {
+    /* Use intermediate cast to uintptr_t to silence -Wcast-align. Since
+     * we add the alignas() attribute, the alignment is ensured */
+    const float *digit_as_float = (const float *)(uintptr_t)digit;
     printf("Predicted digit: %" PRIi32 "\n",
-           model_predict((const float *)digit, digit_len >> 2));
+           model_predict(digit_as_float, digit_len >> 2));
 
     return 0;
 }

--- a/tests/pkg_utensor/main.cpp
+++ b/tests/pkg_utensor/main.cpp
@@ -18,9 +18,11 @@
  * @}
  */
 
+#include <stdalign.h>
 #include <stdio.h>
 #include <inttypes.h>
 
+alignas(float)
 #include "blob/digit.h"         //contains a sample taken from the MNIST test set
 
 #include "deep_mlp.hpp"         //generated model file
@@ -33,8 +35,12 @@ int main()
     // create the context class, the stage where inferences take place
     Context ctx;
 
+    // because we used alignas(float), we can rest assured that silencing
+    // -Wcast-align with an intermediate cast to uintptr_t is fine
+    float *digit_as_float = (float *)(uintptr_t)digit;
+
     // wrap the input digit in a tensor class
-    auto input_x = new WrappedRamTensor<float>({1, digit_len >> 2}, (float *)digit);
+    auto input_x = new WrappedRamTensor<float>({1, digit_len >> 2}, digit_as_float);
 
     // pass ownership of the tensor to the context
     get_deep_mlp_ctx(ctx, input_x);


### PR DESCRIPTION
### Contribution description

As the title says. This is useful to detect issues when doing things like

```C
uint8_t foo[4];
uint32_t *bar = (uint32_t *)foo;
*bar = 0xacdcacdc;
```

Because in the above example `foo` has an alignment requirement of 1 byte, but `bar` has (on most 32 bit archs) an alignment requirement of 4 bytes. Unaligned writes will (depending on architecture) either result faults, writes to the next aligned address instead (usually rounded always down), or slow performance (and writes no longer being atomically).

### Testing procedure

Green Murdock.

### Issues/PRs references

Depends on:

- [x] https://github.com/RIOT-OS/RIOT/pull/15056
- [x] https://github.com/RIOT-OS/RIOT/pull/15057
- [x] https://github.com/RIOT-OS/RIOT/pull/15059
- [x] https://github.com/RIOT-OS/RIOT/pull/15088
- [x] https://github.com/RIOT-OS/RIOT/pull/15099
- [x] https://github.com/RIOT-OS/RIOT/pull/15100
- [x] https://github.com/RIOT-OS/RIOT/pull/15463
- [x] https://github.com/RIOT-OS/RIOT/pull/15464
- [x] https://github.com/RIOT-OS/RIOT/pull/17149
- [x] https://github.com/RIOT-OS/RIOT/pull/17150
- [x] https://github.com/RIOT-OS/RIOT/pull/17151
- [x] https://github.com/RIOT-OS/RIOT/pull/17153
- [x] https://github.com/RIOT-OS/RIOT/pull/17156
- [x] https://github.com/RIOT-OS/RIOT/pull/17192
- [x] https://github.com/RIOT-OS/RIOT/pull/17194
- [x] https://github.com/RIOT-OS/RIOT/pull/17152
- [x] https://github.com/RIOT-OS/RIOT/pull/17154
- [x] https://github.com/RIOT-OS/RIOT/pull/17155
- [x] https://github.com/RIOT-OS/RIOT/pull/17157
- [x] https://github.com/RIOT-OS/RIOT/pull/17195