### PR TITLE
drivers/at86rf215: implement Reduced Power Consumption

### DIFF
--- a/drivers/at86rf215/Kconfig
+++ b/drivers/at86rf215/Kconfig
@@ -27,6 +27,11 @@ config AT86RF215_TRIM_VAL_EN
     help
         Enable crystal oscillator trimming.
 
+config AT86RF215_RPC_EN
+    bool "Enable Reduced Power Consumption"
+    help
+        Reduce Power Consumption in RX IDLE by duty-cycling the RF circuitry.
+
 config AT86RF215_TRIM_VAL
     int "Trim value for the crystal oscillator"
     range 0 15

--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -81,7 +81,11 @@ void at86rf215_reset_and_cfg(at86rf215_t *dev)
     dev->csma_minbe       = AT86RF215_CSMA_MIN_BE_DEFAULT;
 
     dev->flags |= AT86RF215_OPT_AUTOACK
-               |  AT86RF215_OPT_CSMA;
+               |  AT86RF215_OPT_CSMA
+#if CONFIG_AT86RF215_RPC
+               |  AT86RF215_OPT_RPC
+#endif
+               ;
 
     /* apply the configuration */
     at86rf215_reset(dev);
@@ -337,6 +341,8 @@ bool at86rf215_cca(at86rf215_t *dev)
     at86rf215_reg_and(dev, dev->RF->RG_IRQM, ~(RF_IRQ_EDC | RF_IRQ_TRXRDY));
     at86rf215_reg_and(dev, dev->BBC->RG_PC, ~PC_BBEN_MASK);
 
+    at86rf215_disable_rpc(dev);
+
     /* start energy detect */
     at86rf215_reg_write(dev, dev->RF->RG_EDC, RF_EDSINGLE);
     while (!(at86rf215_reg_read(dev, dev->RF->RG_IRQS) & RF_IRQ_EDC)) {}
@@ -347,6 +353,7 @@ bool at86rf215_cca(at86rf215_t *dev)
     at86rf215_reg_or(dev, dev->RF->RG_IRQM, RF_IRQ_EDC | RF_IRQ_TRXRDY);
     at86rf215_reg_or(dev, dev->BBC->RG_PC, PC_BBEN_MASK);
 
+    at86rf215_enable_rpc(dev);
     at86rf215_set_idle_from_rx(dev, old_state);
 
     return clear;

--- a/drivers/at86rf215/at86rf215_getset.c
+++ b/drivers/at86rf215/at86rf215_getset.c
@@ -204,6 +204,38 @@ int8_t at86rf215_get_ed_level(at86rf215_t *dev)
     return at86rf215_reg_read(dev, dev->RF->RG_EDV);
 }
 
+void at86rf215_enable_rpc(at86rf215_t *dev)
+{
+    if (!(dev->flags & AT86RF215_OPT_RPC) || !CONFIG_AT86RF215_RPC_EN) {
+        return;
+    }
+
+    /* no Reduced Power mode available for OFDM */
+
+#ifdef MODULE_NETDEV_IEEE802154_MR_OQPSK
+    {
+        /* MR-O-QPSK */
+        at86rf215_reg_or(dev, dev->BBC->RG_OQPSKC2, OQPSKC2_RPC_MASK);
+    }
+#endif
+}
+
+void at86rf215_disable_rpc(at86rf215_t *dev)
+{
+    if (!(dev->flags & AT86RF215_OPT_RPC) || !CONFIG_AT86RF215_RPC_EN) {
+        return;
+    }
+
+    /* no Reduced Power mode available for OFDM */
+
+#ifdef MODULE_NETDEV_IEEE802154_MR_OQPSK
+    {
+        /* MR-O-QPSK */
+        at86rf215_reg_and(dev, dev->BBC->RG_OQPSKC2, ~OQPSKC2_RPC_MASK);
+    }
+#endif
+}
+
 void at86rf215_set_option(at86rf215_t *dev, uint16_t option, bool state)
 {
     /* set option field */
@@ -243,7 +275,14 @@ void at86rf215_set_option(at86rf215_t *dev, uint16_t option, bool state)
             }
 
             break;
+        case AT86RF215_OPT_RPC:
+            if (state) {
+                at86rf215_enable_rpc(dev);
+            } else {
+                at86rf215_disable_rpc(dev);
+            }
 
+            break;
         default:
             /* do nothing */
             break;

--- a/drivers/at86rf215/at86rf215_netdev.c
+++ b/drivers/at86rf215/at86rf215_netdev.c
@@ -863,6 +863,7 @@ static void _handle_edc(at86rf215_t *dev)
         dev->state = AT86RF215_STATE_IDLE;
 
         at86rf215_enable_baseband(dev);
+        at86rf215_enable_rpc(dev);
         at86rf215_tx_done(dev);
 
         netdev->event_callback(netdev, NETDEV_EVENT_TX_MEDIUM_BUSY);
@@ -944,6 +945,7 @@ static void _isr(netdev_t *netdev)
         } else if (rf_irq_mask & RF_IRQ_TRXRDY) {
             /* disable baseband for energy detection */
             at86rf215_disable_baseband(dev);
+            at86rf215_disable_rpc(dev);
             /* switch to state RX for energy detection */
             at86rf215_rf_cmd(dev, CMD_RF_RX);
             /* start energy measurement */

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -115,6 +115,15 @@ enum {
 /** @} */
 
 /**
+ * @name    Enable Reduced Power Consumption
+ * @{
+ */
+#ifndef CONFIG_AT86RF215_RPC_EN
+#define CONFIG_AT86RF215_RPC_EN                 (0)
+#endif
+/** @} */
+
+/**
  * @name    Default PHY Mode
  * @{
  */


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Reduced Power Consumption is available for MR-O-QPSK and MR-FSK.
In this mode the receiver will be turned off periodically, defaulting to a 50% duty cycle.

This reduces power consumption when in IDLE RX by almost 50% and is therefore enabled by default.

Reduced Power Consumption needs to be disabled during CCA.

### Testing procedure

Receiving frames with MR-O-QPSK (and MR-FSK) should work as reliable as before.
MR-OFDM and legacy O-QPSK should not be affected.


### Issues/PRs references

split off #12128