### PR TITLE
boards/stm32f3: fix clock configuration for HSI

### DIFF
--- a/boards/common/stm32/include/f1f3/cfg_clock_default.h
+++ b/boards/common/stm32/include/f1f3/cfg_clock_default.h
@@ -36,14 +36,20 @@ extern "C" {
  * @name    Clock settings
  * @{
  */
-/* give the target core clock (HCLK) frequency [in Hz],
- * maximum: 72MHz */
-#define CLOCK_CORECLOCK     MHZ(72)
 /* 0: no external high speed crystal available
  * else: actual crystal frequency [in Hz] */
 #ifndef CLOCK_HSE
 #define CLOCK_HSE           MHZ(8)
 #endif
+
+/* give the target core clock (HCLK) frequency [in Hz],
+ * maximum: 72MHz when input clock is HSE, 64MHz when input clock is HSI */
+#if CLOCK_HSE
+#define CLOCK_CORECLOCK     MHZ(72)
+#else
+#define CLOCK_CORECLOCK     MHZ(64)
+#endif
+
 /* 0: no external low speed crystal available,
  * 1: external crystal available (always 32.768kHz) */
 #ifndef CLOCK_LSE


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes #14958 by simply setting CLOCK_CORECLOCK to 64MHz when HSE is not used. This is a temporary fix until #14923 is merged and which contains a complete refactoring of the clock configuration.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- `examples/hello-world` on nucleo-f303k8 and nucleo-f303re should work. It's broken on master as reported in #14958.

I applied this patch to check the clocks:

```diff
diff --git a/examples/hello-world/main.c b/examples/hello-world/main.c
index f51bf8c0a0..7a1910279c 100644
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -20,6 +20,9 @@
  */
 
 #include <stdio.h>
+#include <inttypes.h>
+
+#include "board.h"
 
 int main(void)
 {
@@ -28,5 +31,15 @@ int main(void)
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);
 
+    printf("Clock coreclock: %" PRIu32 "\n", (uint32_t)CLOCK_CORECLOCK);
+    printf("AHB clock: %" PRIu32 "\n", (uint32_t)CLOCK_AHB);
+    printf("APB1 clock: %" PRIu32 "\n", (uint32_t)CLOCK_APB1);
+#ifdef CLOCK_APB2
+    printf("APB2 clock: %" PRIu32 "\n", (uint32_t)CLOCK_APB2);
+#endif
+#ifdef CLOCK_PLLQ
+    printf("PLLQ clock: %" PRIu32 "\n", (uint32_t)CLOCK_PLLQ);
+#endif
+
     return 0;
 }
```

<details><summary>nucleo-f303re</summary>

```
BUILD_IN_DOCKER=1 make BOARD=nucleo-f303re -C examples/hello-world flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-f303re'  -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make 'BOARD=nucleo-f303re'    
Building application "hello-world" for "nucleo-f303re" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/nucleo-f303re
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/bootloader
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   9052	    112	   2324	  11488	   2ce0	/data/riotbuild/riotbase/examples/hello-world/bin/nucleo-f303re/hello-world.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/examples/hello-world/bin/nucleo-f303re/hello-world.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01383-gd46f28c2e-dirty (2020-08-20-10:53)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 1000 kHz
Info : STLINK V2J25M14 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.252984
Info : stm32f3x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32f3x.cpu on 0
Info : Listening on port 42313 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f3x.cpu       hla_target little stm32f3x.cpu       reset

Info : Unable to match requested speed 1000 kHz, using 950 kHz
Info : Unable to match requested speed 1000 kHz, using 950 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08000580 msp: 0x20000200
Info : device id = 0x10036446
Info : flash size = 512kbytes
auto erase enabled
wrote 10240 bytes from file /work/riot/RIOT/examples/hello-world/bin/nucleo-f303re/hello-world.elf in 0.614696s (16.268 KiB/s)

verified 9164 bytes in 0.229962s (38.916 KiB/s)

Info : Unable to match requested speed 1000 kHz, using 950 kHz
Info : Unable to match requested speed 1000 kHz, using 950 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-09-07 09:32:47,354 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2020-09-07 09:32:48,809 # main(): This is RIOT! (Version: 2020.10-devel-1259-g1c95f-pr/boards/stm32f3_clock_hsi)
2020-09-07 09:32:48,814 # Hello World!
2020-09-07 09:32:48,815 # You are running RIOT on a(n) nucleo-f303re board.
2020-09-07 09:32:48,820 # This board features a(n) stm32 MCU.
2020-09-07 09:32:48,821 # Clock coreclock: 72000000
2020-09-07 09:32:48,826 # AHB clock: 72000000
2020-09-07 09:32:48,827 # APB1 clock: 36000000
2020-09-07 09:32:48,832 # APB2 clock: 72000000
2020-09-07 09:32:49,887 # Exiting Pyterm
```

</details>

<details><summary>nucleo-f303k8</summary>

```
BUILD_IN_DOCKER=1 make BOARD=nucleo-f303k8 -C examples/hello-world flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-f303k8'  -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make 'BOARD=nucleo-f303k8'    
Building application "hello-world" for "nucleo-f303k8" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/nucleo-f303k8
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/bootloader
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8856	    112	   2312	  11280	   2c10	/data/riotbuild/riotbase/examples/hello-world/bin/nucleo-f303k8/hello-world.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/examples/hello-world/bin/nucleo-f303k8/hello-world.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01383-gd46f28c2e-dirty (2020-08-20-10:53)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 1000 kHz
Info : STLINK V2J25M14 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.282213
Info : stm32f3x.cpu: hardware has 6 breakpoints, 4 watchpoints
Info : starting gdb server for stm32f3x.cpu on 0
Info : Listening on port 46347 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f3x.cpu       hla_target little stm32f3x.cpu       reset

Info : Unable to match requested speed 1000 kHz, using 950 kHz
Info : Unable to match requested speed 1000 kHz, using 950 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x08000528 msp: 0x20000200
Info : device id = 0x10016438
Info : flash size = 64kbytes
auto erase enabled
wrote 10240 bytes from file /work/riot/RIOT/examples/hello-world/bin/nucleo-f303k8/hello-world.elf in 0.611637s (16.350 KiB/s)

verified 8968 bytes in 0.227764s (38.451 KiB/s)

Info : Unable to match requested speed 1000 kHz, using 950 kHz
Info : Unable to match requested speed 1000 kHz, using 950 kHz
shutdown command invoked
Done flashing
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"  
Twisted not available, please install it if you want to use pyterm's JSON capabilities
2020-09-07 09:33:39,327 # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2020-09-07 09:33:41,294 # main(): This is RIOT! (Version: 2020.10-devel-1259-g1c95f-pr/boards/stm32f3_clock_hsi)
2020-09-07 09:33:41,299 # Hello World!
2020-09-07 09:33:41,301 # You are running RIOT on a(n) nucleo-f303k8 board.
2020-09-07 09:33:41,305 # This board features a(n) stm32 MCU.
2020-09-07 09:33:41,307 # Clock coreclock: 64000000
2020-09-07 09:33:41,308 # AHB clock: 64000000
2020-09-07 09:33:41,311 # APB1 clock: 32000000
2020-09-07 09:33:41,317 # APB2 clock: 64000000
2020-09-07 09:33:42,623 # Exiting Pyterm
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #14958 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
