### PR TITLE
pkt/nimble/netif: fix deadlock on connection loss

### DIFF
--- a/pkg/nimble/netif/include/nimble_netif_conn.h
+++ b/pkg/nimble/netif/include/nimble_netif_conn.h
@@ -216,6 +216,18 @@ static inline int nimble_netif_conn_connected(const uint8_t *addr)
     return (nimble_netif_conn_get_by_addr(addr) != NIMBLE_NETIF_CONN_INVALID);
 }
 
+/**
+ * @brief   Test if the given connection is (still) open
+ *
+ * @param[in] conn          Connection to test
+ *
+ * @return  != 0 if true
+ * @return  0 if false
+ */
+static inline int nimble_netif_conn_is_open(const nimble_netif_conn_t *conn)
+{
+    return (conn->coc != NULL);
+}
 
 /**
  * @brief   Convenience function to check if any context is currently in the


### PR DESCRIPTION
### Contribution description
On long-term measurements using nodes with `nimble_netif` and multiple BLE connections in parallel, I observed in rare cases that a node's `nimble_netif` thread got stuck, making that node practically deaf as no more (IP) packets could be send by that node. 

This was caused by a deadlock in the `nimble_netif` implementation, that is triggered when the following situation happens:
1. the `nimble_netif` thread is blocked because of a previous packet still in transfer: `_send_pkt()` waiting for the `FLAG_TX_UNSTALLED` flag)
2. the BLE connection responsible for issuing the `BLE_L2CAP_EVENT_COC_TX_UNSTALLED` event is disconnected

In that case, the `nimble_netif` thread will stay in state `bl allfl`, waiting for the `UNSTALLED` event indefinitely.

This PR fixes this by setting an additional thread flag (`FLAG_TX_NOTCONN`) in case a BLE connection is terminated. Now if a thread is blocked while sending, and the corresponding BLE connecting is terminated in the mean time, the send process is aborted and the `nimble_netif` thread returns to active duty.

### Testing procedure
I was not able to produce a reliable test case on my desk, but I can confirm that I do not observe this deadlock anymore in any of my 1h-12h, 15 node experiments anymore.

For testing I'd say a quick verification of existing IP-over-BLE apps (e.g. `gnrc_networking` @ `nrf52dk`) still works as expected should do?!

### Issues/PRs references
none