### PR TITLE
boards/stm32f0: add Kconfig for clock configuration

### DIFF
--- a/boards/nucleo-f030r8/Kconfig
+++ b/boards/nucleo-f030r8/Kconfig
@@ -21,4 +21,8 @@ config BOARD_NUCLEO_F030R8
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
 
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f031k6/include/periph_conf.h
+++ b/boards/nucleo-f031k6/include/periph_conf.h
@@ -20,14 +20,6 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
-/* Adjust PLL factors:
-  - On nucleo-f031k6, there's no HSE and PREDIV is hard-wired to 2
-  - to reach 48MHz set PLL_MUL to 12 so core clock = (HSI8 / 2) * 12 = 48MHz */
-#define CONFIG_CLOCK_PLL_PREDIV     (2)
-#ifndef CONFIG_CLOCK_PLL_MUL
-#define CONFIG_CLOCK_PLL_MUL        (12)
-#endif
-
 #include "periph_cpu.h"
 #include "f0/cfg_clock_default.h"
 #include "cfg_timer_tim2.h"

--- a/boards/nucleo-f042k6/include/periph_conf.h
+++ b/boards/nucleo-f042k6/include/periph_conf.h
@@ -19,14 +19,6 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
-/* Adjust PLL factors:
-  - On nucleo-f042k6, there's no HSE and PREDIV is hard-wired to 2
-  - to reach 48MHz set PLL_MUL to 12 so core clock = (HSI8 / 2) * 12 = 48MHz */
-#define CONFIG_CLOCK_PLL_PREDIV     (2)
-#ifndef CONFIG_CLOCK_PLL_MUL
-#define CONFIG_CLOCK_PLL_MUL        (12)
-#endif
-
 #include "periph_cpu.h"
 #include "f0/cfg_clock_default.h"
 #include "cfg_timer_tim2.h"

--- a/boards/nucleo-f070rb/Kconfig
+++ b/boards/nucleo-f070rb/Kconfig
@@ -22,4 +22,8 @@ config BOARD_NUCLEO_F070RB
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
 
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f072rb/Kconfig
+++ b/boards/nucleo-f072rb/Kconfig
@@ -23,4 +23,8 @@ config BOARD_NUCLEO_F072RB
     select HAS_PERIPH_UART
     select HAS_PERIPH_SPI
 
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f091rc/Kconfig
+++ b/boards/nucleo-f091rc/Kconfig
@@ -22,4 +22,8 @@ config BOARD_NUCLEO_F091RC
     select HAS_PERIPH_UART
     select HAS_PERIPH_SPI
 
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/stm32f030f4-demo/Kconfig
+++ b/boards/stm32f030f4-demo/Kconfig
@@ -20,3 +20,8 @@ config BOARD_STM32F030F4_DEMO
     select HAS_PERIPH_UART
     select HAS_PERIPH_SPI
     select HAS_PERIPH_RTC
+
+    # Clock configuration
+    select BOARD_HAS_HSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/stm32f0discovery/Kconfig
+++ b/boards/stm32f0discovery/Kconfig
@@ -19,3 +19,8 @@ config BOARD_STM32F0DISCOVERY
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    # Clock configuration
+    select BOARD_HAS_HSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/cpu/stm32/include/clk/f0/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/f0/cfg_clock_default.h
@@ -78,12 +78,22 @@ extern "C" {
 
 #define CLOCK_HSI                       MHZ(8)
 
-/* The following parameters configure a 48MHz system clock with HSI (or default HSE) as input clock */
+/* The following parameters configure a 48MHz system clock with HSI (or default HSE) as input clock
+On stm32f031x6 and stm32f042x6 lines, there's no HSE and PREDIV is hard-wired to 2,
+so to reach 48MHz set PLL_PREDIV to 2 and PLL_MUL to 12 so core clock = (HSI8 / 2) * 12 = 48MHz */
 #ifndef CONFIG_CLOCK_PLL_PREDIV
+#if defined(CPU_LINE_STM32F031x6) || defined(CPU_LINE_STM32F042x6)
+#define CONFIG_CLOCK_PLL_PREDIV         (2)
+#else
 #define CONFIG_CLOCK_PLL_PREDIV         (1)
 #endif
+#endif
 #ifndef CONFIG_CLOCK_PLL_MUL
+#if defined(CPU_LINE_STM32F031x6) || defined(CPU_LINE_STM32F042x6)
+#define CONFIG_CLOCK_PLL_MUL            (12)
+#else
 #define CONFIG_CLOCK_PLL_MUL            (6)
+#endif
 #endif
 
 #if IS_ACTIVE(CONFIG_USE_CLOCK_HSI)

--- a/cpu/stm32/kconfigs/Kconfig.clk
+++ b/cpu/stm32/kconfigs/Kconfig.clk
@@ -114,13 +114,13 @@ endif  # CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 
 if CPU_FAM_F0
 config CLOCK_PLL_PREDIV
-    int "PLLIN division factor" if USE_CLOCK_PLL && !CPU_LINE_STM32F031X6 && !CPU_LINE_STM32F042X6
+    int "PLLIN division factor" if CUSTOM_PLL_PARAMS && !CPU_LINE_STM32F031X6 && !CPU_LINE_STM32F042X6
     default 2 if CPU_LINE_STM32F031X6 || CPU_LINE_STM32F042X6
     default 1
     range 1 16
 
 config CLOCK_PLL_MUL
-    int "PLLIN multiply factor" if USE_CLOCK_PLL
+    int "PLLIN multiply factor" if CUSTOM_PLL_PARAMS
     default 12 if CPU_LINE_STM32F031X6 || CPU_LINE_STM32F042X6
     default 6
     range 2 16
@@ -128,12 +128,12 @@ endif
 
 if CPU_FAM_L0 || CPU_FAM_L1
 config CLOCK_PLL_DIV
-    int "Main PLL division factor" if USE_CLOCK_PLL
+    int "Main PLL division factor" if CUSTOM_PLL_PARAMS
     default 2
     range 2 4
 
 choice
-bool "Main PLL multiply factor" if USE_CLOCK_PLL
+bool "Main PLL multiply factor" if CUSTOM_PLL_PARAMS
 default PLL_MUL_4
 
 config PLL_MUL_3

--- a/cpu/stm32/kconfigs/Kconfig.clk
+++ b/cpu/stm32/kconfigs/Kconfig.clk
@@ -6,7 +6,7 @@
 #
 
 menu "STM32 clock configuration"
-    depends on CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+    depends on CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_F0 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 
 choice
 bool "Clock source selection"
@@ -47,11 +47,11 @@ endchoice
 
 endif  # CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 
-if CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 config CUSTOM_PLL_PARAMS
     bool "Configure PLL parameters"
     depends on USE_CLOCK_PLL
 
+if CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 config CLOCK_PLL_M
     int "M: PLLIN division factor" if CUSTOM_PLL_PARAMS
     default 1 if CPU_FAM_G0
@@ -111,6 +111,20 @@ config CLOCK_PLL_R
 endif  # CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5
 
 endif  # CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+
+if CPU_FAM_F0
+config CLOCK_PLL_PREDIV
+    int "PLLIN division factor" if USE_CLOCK_PLL && !CPU_LINE_STM32F031X6 && !CPU_LINE_STM32F042X6
+    default 2 if CPU_LINE_STM32F031X6 || CPU_LINE_STM32F042X6
+    default 1
+    range 1 16
+
+config CLOCK_PLL_MUL
+    int "PLLIN multiply factor" if USE_CLOCK_PLL
+    default 12 if CPU_LINE_STM32F031X6 || CPU_LINE_STM32F042X6
+    default 6
+    range 2 16
+endif
 
 if CPU_FAM_L0 || CPU_FAM_L1
 config CLOCK_PLL_DIV


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a follow-up of #14921 that adds the possibility to configure stm32f0 CPUs using Kconfig. All affected boards are updated accordingly.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Apply the following patch:

```diff
diff --git a/examples/hello-world/main.c b/examples/hello-world/main.c
index f51bf8c0a0..7a1910279c 100644
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -20,6 +20,9 @@
  */
 
 #include <stdio.h>
+#include <inttypes.h>
+
+#include "board.h"
 
 int main(void)
 {
@@ -28,5 +31,15 @@ int main(void)
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);
 
+    printf("Clock coreclock: %" PRIu32 "\n", (uint32_t)CLOCK_CORECLOCK);
+    printf("AHB clock: %" PRIu32 "\n", (uint32_t)CLOCK_AHB);
+    printf("APB1 clock: %" PRIu32 "\n", (uint32_t)CLOCK_APB1);
+#ifdef CLOCK_APB2
+    printf("APB2 clock: %" PRIu32 "\n", (uint32_t)CLOCK_APB2);
+#endif
+#ifdef CLOCK_PLLQ
+    printf("PLLQ clock: %" PRIu32 "\n", (uint32_t)CLOCK_PLLQ);
+#endif
+
     return 0;
 }
```

- Run `make BOARD=<stm32f0 board> -C examples/hello-world clean menuconfig` and configure the clock as you wish

- Build and flash the application. Verify that the clock values are correct (only APB1 is available on stm32f0)

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Based on ~~#14921~~ #14968
Related to #14975

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
