### PR TITLE
boards/stm32l4/wb: add Kconfig for clock configuration

### DIFF
--- a/boards/b-l475e-iot01a/Kconfig
+++ b/boards/b-l475e-iot01a/Kconfig
@@ -25,3 +25,8 @@ config BOARD_B_L475E_IOT01A
 
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
+
+    # Clock configuration
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/nucleo-l412kb/Kconfig
+++ b/boards/nucleo-l412kb/Kconfig
@@ -28,4 +28,7 @@ config BOARD_NUCLEO_L412KB
     # https://github.com/RIOT-OS/RIOT/pull/12144#issuecomment-527090161
     select HAS_RIOTBOOT
 
+    # Clock configuration
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo32/Kconfig"

--- a/boards/nucleo-l432kc/Kconfig
+++ b/boards/nucleo-l432kc/Kconfig
@@ -30,4 +30,7 @@ config BOARD_NUCLEO_L432KC
     # https://github.com/ntfreak/openocd/commit/a4d50544de07f13e3f9644d2b48e41ebdc91a7a3
     select HAS_RIOTBOOT
 
+    # Clock configuration
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo32/Kconfig"

--- a/boards/nucleo-l433rc/Kconfig
+++ b/boards/nucleo-l433rc/Kconfig
@@ -31,4 +31,7 @@ config BOARD_NUCLEO_L433RC
     # https://github.com/ntfreak/openocd/commit/a4d50544de07f13e3f9644d2b48e41ebdc91a7a3
     select HAS_RIOTBOOT
 
+    # Clock configuration
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l452re/Kconfig
+++ b/boards/nucleo-l452re/Kconfig
@@ -26,4 +26,7 @@ config BOARD_NUCLEO_L452RE
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
+    # Clock configuration
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l476rg/Kconfig
+++ b/boards/nucleo-l476rg/Kconfig
@@ -29,4 +29,7 @@ config BOARD_NUCLEO_L476RG
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
+    # Clock configuration
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l496zg/Kconfig
+++ b/boards/nucleo-l496zg/Kconfig
@@ -27,4 +27,7 @@ config BOARD_NUCLEO_L496ZG
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
+    # Clock configuration
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-l4r5zi/Kconfig
+++ b/boards/nucleo-l4r5zi/Kconfig
@@ -26,4 +26,7 @@ config BOARD_NUCLEO_L4R5ZI
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
+    # Clock configuration
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo144/Kconfig"

--- a/boards/nucleo-l4r5zi/include/periph_conf.h
+++ b/boards/nucleo-l4r5zi/include/periph_conf.h
@@ -24,10 +24,6 @@
 #define CONFIG_BOARD_HAS_LSE            1
 #endif
 
-#ifndef CONFIG_CLOCK_PLL_N
-#define CONFIG_CLOCK_PLL_N              (30)
-#endif
-
 #include "periph_cpu.h"
 #include "clk_conf.h"
 #include "cfg_i2c1_pb8_pb9.h"

--- a/boards/nucleo-l552ze-q/include/periph_conf.h
+++ b/boards/nucleo-l552ze-q/include/periph_conf.h
@@ -20,12 +20,6 @@
 #define PERIPH_CONF_H
 
 /* Add specific clock configuration (HSE, LSE) for this board here */
-/* Reach 108MHz by default by setting custom PLL_N factor */
-#ifndef CONFIG_CLOCK_PLL_N
-#define CONFIG_CLOCK_PLL_N              27
-#endif
-
-/* Add specific clock configuration (HSE, LSE) for this board here */
 #ifndef CONFIG_BOARD_HAS_LSE
 #define CONFIG_BOARD_HAS_LSE            1
 #endif

--- a/boards/p-l496g-cell02/Kconfig
+++ b/boards/p-l496g-cell02/Kconfig
@@ -21,3 +21,8 @@ config BOARD_P_L496G_CELL02
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    # Clock configuration
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/p-nucleo-wb55/Kconfig
+++ b/boards/p-nucleo-wb55/Kconfig
@@ -25,3 +25,9 @@ config BOARD_P_NUCLEO_WB55
     # Put other features for this board (in alphabetical order)
     select HAS_ARDUINO
     select HAS_RIOTBOOT
+
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/stm32l476g-disco/Kconfig
+++ b/boards/stm32l476g-disco/Kconfig
@@ -21,3 +21,8 @@ config BOARD_STM32L476G_DISCO
 
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
+
+    # Clock configuration
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/cpu/stm32/include/clk/l4l5wb/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/l4l5wb/cfg_clock_default.h
@@ -145,6 +145,8 @@ extern "C" {
     defined(CPU_LINE_STM32L4S5xx) || defined(CPU_LINE_STM32L4S7xx) || \
     defined(CPU_LINE_STM32L4S9xx)
 #define CONFIG_CLOCK_PLL_N              (30)
+#elif defined(CPU_FAM_STM32L5)
+#define CONFIG_CLOCK_PLL_N              (27)
 #else
 #define CONFIG_CLOCK_PLL_N              (20)
 #endif

--- a/cpu/stm32/include/clk/l4l5wb/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/l4l5wb/cfg_clock_default.h
@@ -139,7 +139,15 @@ extern "C" {
       (IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_HSE) && (CLOCK_HSE == MHZ(16)))
 #define CONFIG_CLOCK_PLL_N              (32)
 #else
+#if defined(CPU_LINE_STM32L4A6xx) || defined(CPU_LINE_STM32L4P5xx) || \
+    defined(CPU_LINE_STM32L4Q5xx) || defined(CPU_LINE_STM32L4R5xx) || \
+    defined(CPU_LINE_STM32L4R7xx) || defined(CPU_LINE_STM32L4R9xx) || \
+    defined(CPU_LINE_STM32L4S5xx) || defined(CPU_LINE_STM32L4S7xx) || \
+    defined(CPU_LINE_STM32L4S9xx)
+#define CONFIG_CLOCK_PLL_N              (30)
+#else
 #define CONFIG_CLOCK_PLL_N              (20)
+#endif
 #endif
 #endif
 #ifndef CONFIG_CLOCK_PLL_Q

--- a/cpu/stm32/include/clk/l4l5wb/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/l4l5wb/cfg_clock_default.h
@@ -104,7 +104,8 @@ extern "C" {
 #endif
 #endif /* CONFIG_CLOCK_PLL_SRC_MSI */
 #ifndef CONFIG_CLOCK_PLL_SRC_HSE
-#if IS_ACTIVE(CONFIG_BOARD_HAS_HSE)
+#if IS_ACTIVE(CONFIG_BOARD_HAS_HSE) && \
+    !IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_HSI) && !IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_MSI)
 #define CONFIG_CLOCK_PLL_SRC_HSE        1
 #else
 #define CONFIG_CLOCK_PLL_SRC_HSE        0
@@ -126,13 +127,20 @@ extern "C" {
 #elif IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_HSE) && (CLOCK_HSE == MHZ(8))
 #define CONFIG_CLOCK_PLL_M              (1)     /* HSE at 8MHz */
 #elif IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_HSE) && (CLOCK_HSE == MHZ(32))
-#define CONFIG_CLOCK_PLL_M              (5)     /* HSE at 32MHz */
+#define CONFIG_CLOCK_PLL_M              (4)     /* HSE at 32MHz */
 #else
 #define CONFIG_CLOCK_PLL_M              (2)     /* HSI at 16MHz */
 #endif
 #endif
 #ifndef CONFIG_CLOCK_PLL_N
+#if IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_HSE) && (CLOCK_HSE == MHZ(32))
+#define CONFIG_CLOCK_PLL_N              (16)
+#elif IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_HSI) || \
+      (IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_HSE) && (CLOCK_HSE == MHZ(16)))
+#define CONFIG_CLOCK_PLL_N              (32)
+#else
 #define CONFIG_CLOCK_PLL_N              (20)
+#endif
 #endif
 #ifndef CONFIG_CLOCK_PLL_Q
 #define CONFIG_CLOCK_PLL_Q              (2)

--- a/cpu/stm32/kconfigs/Kconfig.clk
+++ b/cpu/stm32/kconfigs/Kconfig.clk
@@ -6,7 +6,7 @@
 #
 
 menu "STM32 clock configuration"
-    depends on CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1
+    depends on CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 
 choice
 bool "Clock source selection"
@@ -17,7 +17,7 @@ config USE_CLOCK_PLL
 
 config USE_CLOCK_MSI
     bool "Use direct multi-speed frequency internal oscillator (MSI)"
-    depends on CPU_FAM_L0 || CPU_FAM_L1
+    depends on CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 
 config USE_CLOCK_HSE
     bool "Direct High frequency external oscillator (HSE)"
@@ -28,33 +28,64 @@ config USE_CLOCK_HSI
 
 endchoice
 
-if CPU_FAM_G0 || CPU_FAM_G4
+if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+choice
+bool "Source clock for PLL" if USE_CLOCK_PLL
+default CLOCK_PLL_SRC_HSE if BOARD_HAS_HSE
+default CLOCK_PLL_SRC_MSI
+
+config CLOCK_PLL_SRC_MSI
+    bool "Use MSI source clock"
+
+config CLOCK_PLL_SRC_HSE
+    bool "Use HSE source clock"
+    depends on BOARD_HAS_HSE
+
+config CLOCK_PLL_SRC_HSI
+    bool "Use HSI16 source clock"
+endchoice
+
+endif  # CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+
+if CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+config CUSTOM_PLL_PARAMS
+    bool "Configure PLL parameters"
+    depends on USE_CLOCK_PLL
+
 config CLOCK_PLL_M
-    int "M: PLLIN division factor" if USE_CLOCK_PLL
+    int "M: PLLIN division factor" if CUSTOM_PLL_PARAMS
     default 1 if CPU_FAM_G0
-    default 4 if CPU_FAM_G4
     default 6 if CPU_FAM_G4 && BOARD_HAS_HSE
-    range 1 8 if CPU_FAM_G0
+    default 4 if CPU_FAM_G4
+    default 6 if (CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB) && CLOCK_PLL_SRC_MSI
+    default 4 if CPU_FAM_WB && CLOCK_PLL_SRC_HSE
+    default 2 if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+    range 1 8 if CPU_FAM_G0 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
     range 1 16 if CPU_FAM_G4
 
 config CLOCK_PLL_N
-    int "N: PLLIN multiply factor" if USE_CLOCK_PLL
-    default 20 if CPU_FAM_G0
-    default 40 if CPU_FAM_G4
-    range 8 86 if CPU_FAM_G0
+    int "N: PLLIN multiply factor" if CUSTOM_PLL_PARAMS
+    default 16 if CPU_FAM_WB
+    default 30 if CPU_LINE_STM32L4A6XX || CPU_LINE_STM32L4P5XX || CPU_LINE_STM32L4Q5XX || CPU_LINE_STM32L4R5XX || CPU_LINE_STM32L4R7XX || CPU_LINE_STM32L4R9XX || CPU_LINE_STM32L4S5XX || CPU_LINE_STM32L4S7XX || CPU_LINE_STM32L4S9XX
+    default 27 if CPU_FAM_L5
+    default 20 if CPU_FAM_G0 || CPU_FAM_L4
+    default 85 if CPU_FAM_G4
+    range 8 86 if CPU_FAM_G0 || CPU_FAM_L4 || CPU_FAM_L5
     range 8 127 if CPU_FAM_G4
+    range 6 127 if CPU_FAM_WB
 
-if CPU_FAM_G0
+if CPU_FAM_G0 || CPU_FAM_WB
 config CLOCK_PLL_R
-    int "Q: VCO division factor" if USE_CLOCK_PLL
+    int "Q: VCO division factor" if CUSTOM_PLL_PARAMS
+    default 2 if CPU_FAM_WB
     default 6 if BOARD_HAS_HSE
     default 5
     range 2 8
-endif  # CPU_FAM_G0
+endif  # CPU_FAM_G0 || CPU_FAM_WB
 
-if CPU_FAM_G4
+if CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5
 choice
-bool "R: Main PLL division factor for PLL 'R' clock (system clock)" if USE_CLOCK_PLL
+bool "R: Main PLL division factor for PLL 'R' clock (system clock)" if CUSTOM_PLL_PARAMS
 default PLL_R_DIV_2
 
 config PLL_R_DIV_2
@@ -77,52 +108,9 @@ config CLOCK_PLL_R
     default 4 if PLL_R_DIV_4
     default 6 if PLL_R_DIV_6
     default 8 if PLL_R_DIV_8
-endif  # CPU_FAM_G4
+endif  # CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5
 
-if CPU_FAM_G0
-choice
-bool "HSISYS division factor" if USE_CLOCK_HSI
-default CLOCK_HSISYS_DIV_1
-
-config CLOCK_HSISYS_DIV_1
-    bool "Divide HSISYS by 1"
-
-config CLOCK_HSISYS_DIV_2
-    bool "Divide HSISYS by 2"
-
-config CLOCK_HSISYS_DIV_4
-    bool "Divide HSISYS by 4"
-
-config CLOCK_HSISYS_DIV_8
-    bool "Divide HSISYS by 8"
-
-config CLOCK_HSISYS_DIV_16
-    bool "Divide HSISYS by 16"
-
-config CLOCK_HSISYS_DIV_32
-    bool "Divide HSISYS by 32"
-
-config CLOCK_HSISYS_DIV_64
-    bool "Divide HSISYS by 64"
-
-config CLOCK_HSISYS_DIV_128
-    bool "Divide HSISYS by 128"
-
-endchoice
-
-config CLOCK_HSISYS_DIV
-    int
-    default 1 if CLOCK_HSISYS_DIV_1
-    default 2 if CLOCK_HSISYS_DIV_2
-    default 4 if CLOCK_HSISYS_DIV_4
-    default 8 if CLOCK_HSISYS_DIV_8
-    default 16 if CLOCK_HSISYS_DIV_16
-    default 32 if CLOCK_HSISYS_DIV_32
-    default 64 if CLOCK_HSISYS_DIV_64
-    default 128 if CLOCK_HSISYS_DIV_128
-endif  # CPU_FAM_G0
-
-endif  # CPU_FAM_G0 || CPU_FAM_G4
+endif  # CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 
 if CPU_FAM_L0 || CPU_FAM_L1
 config CLOCK_PLL_DIV
@@ -174,31 +162,107 @@ config CLOCK_PLL_MUL
     default 24 if PLL_MUL_24
     default 32 if PLL_MUL_32
     default 48 if PLL_MUL_48
+endif  # CPU_FAM_L0 || CPU_FAM_L1
 
+if CPU_FAM_G0
 choice
-bool "Desired MSI clock frequency" if USE_CLOCK_MSI
+bool "HSISYS division factor" if USE_CLOCK_HSI
+default CLOCK_HSISYS_DIV_1
+
+config CLOCK_HSISYS_DIV_1
+    bool "Divide HSISYS by 1"
+
+config CLOCK_HSISYS_DIV_2
+    bool "Divide HSISYS by 2"
+
+config CLOCK_HSISYS_DIV_4
+    bool "Divide HSISYS by 4"
+
+config CLOCK_HSISYS_DIV_8
+    bool "Divide HSISYS by 8"
+
+config CLOCK_HSISYS_DIV_16
+    bool "Divide HSISYS by 16"
+
+config CLOCK_HSISYS_DIV_32
+    bool "Divide HSISYS by 32"
+
+config CLOCK_HSISYS_DIV_64
+    bool "Divide HSISYS by 64"
+
+config CLOCK_HSISYS_DIV_128
+    bool "Divide HSISYS by 128"
+
+endchoice
+
+config CLOCK_HSISYS_DIV
+    int
+    default 1 if CLOCK_HSISYS_DIV_1
+    default 2 if CLOCK_HSISYS_DIV_2
+    default 4 if CLOCK_HSISYS_DIV_4
+    default 8 if CLOCK_HSISYS_DIV_8
+    default 16 if CLOCK_HSISYS_DIV_16
+    default 32 if CLOCK_HSISYS_DIV_32
+    default 64 if CLOCK_HSISYS_DIV_64
+    default 128 if CLOCK_HSISYS_DIV_128
+endif  # CPU_FAM_G0
+
+if CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+choice
+bool "Desired MSI clock frequency" if USE_CLOCK_MSI || (USE_CLOCK_PLL && CLOCK_PLL_SRC_MSI)
+default CLOCK_MSI_48MHZ if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 default CLOCK_MSI_4MHZ
 
 config CLOCK_MSI_65KHZ
-    bool "65.536kHz"
+    bool "65.536kHz" if CPU_FAM_L0 || CPU_FAM_L1
+
+config CLOCK_MSI_100KHZ
+    bool "100kHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 
 config CLOCK_MSI_130KHZ
-    bool "131.072kHz"
+    bool "131.072kHz" if CPU_FAM_L0 || CPU_FAM_L1
+
+config CLOCK_MSI_200KHZ
+    bool "200kHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 
 config CLOCK_MSI_260KHZ
-    bool "262.144kHz"
+    bool "262.144kHz" if CPU_FAM_L0 || CPU_FAM_L1
+
+config CLOCK_MSI_400KHZ
+    bool "400kHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 
 config CLOCK_MSI_520KHZ
-    bool "524.288kHz"
+    bool "524.288kHz" if CPU_FAM_L0 || CPU_FAM_L1
+
+config CLOCK_MSI_800KHZ
+    bool "800kHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 
 config CLOCK_MSI_1MHZ
-    bool "1.048MHz"
+    bool
+    prompt "1MHz"
 
 config CLOCK_MSI_2MHZ
-    bool "2.097MHz"
+    bool
+    prompt "2MHz"
 
 config CLOCK_MSI_4MHZ
-    bool "4.194MHz"
+    bool
+    prompt "4MHz"
+
+config CLOCK_MSI_8MHZ
+    bool "8MHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+
+config CLOCK_MSI_16MHZ
+    bool "16MHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+
+config CLOCK_MSI_24MHZ
+    bool "24MHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+
+config CLOCK_MSI_32MHZ
+    bool "32MHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+
+config CLOCK_MSI_48MHZ
+    bool "48MHz" if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 
 endchoice
 
@@ -208,14 +272,27 @@ config CLOCK_MSI
     default 131072 if CLOCK_MSI_130KHZ
     default 262144 if CLOCK_MSI_260KHZ
     default 524288 if CLOCK_MSI_520KHZ
-    default 1048000 if CLOCK_MSI_1MHZ
-    default 2097000 if CLOCK_MSI_2MHZ
-    default 4194000 if CLOCK_MSI_4MHZ
+    default 100000 if CLOCK_MSI_100KHZ
+    default 200000 if CLOCK_MSI_200KHZ
+    default 400000 if CLOCK_MSI_400KHZ
+    default 800000 if CLOCK_MSI_800KHZ
+    default 1000000 if CLOCK_MSI_1MHZ && (CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB)
+    default 1048000 if CLOCK_MSI_1MHZ && (CPU_FAM_L0 || CPU_FAM_L1)
+    default 2000000 if CLOCK_MSI_2MHZ && (CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB)
+    default 2097000 if CLOCK_MSI_2MHZ && (CPU_FAM_L0 || CPU_FAM_L1)
+    default 4000000 if CLOCK_MSI_4MHZ && (CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB)
+    default 4194000 if CLOCK_MSI_4MHZ && (CPU_FAM_L0 || CPU_FAM_L1)
+    default 8000000 if CLOCK_MSI_8MHZ
+    default 16000000 if CLOCK_MSI_16MHZ
+    default 24000000 if CLOCK_MSI_24MHZ
+    default 32000000 if CLOCK_MSI_32MHZ
+    default 48000000 if CLOCK_MSI_48MHZ
 
-endif  # CPU_FAM_L0 || CPU_FAM_L1
+endif  # CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 
 choice
 bool "APB1 prescaler (division factor of HCLK to produce PCLK1)"
+default CLOCK_APB1_DIV_4 if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 default CLOCK_APB1_DIV_1
 
 config CLOCK_APB1_DIV_1
@@ -245,7 +322,8 @@ config CLOCK_APB1_DIV
 
 choice
 bool "APB2 prescaler (division factor of HCLK to produce PCLK2)"
-depends on CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1
+depends on CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+default CLOCK_APB2_DIV_2 if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 default CLOCK_APB2_DIV_1
 
 config CLOCK_APB2_DIV_1

--- a/cpu/stm32/stmclk/stmclk_l4wb.c
+++ b/cpu/stm32/stmclk/stmclk_l4wb.c
@@ -31,6 +31,7 @@
 /* map CMSIS defines not present in stm32wb55xx.h */
 #if defined(CPU_FAM_STM32WB)
 #define RCC_PLLCFGR_PLLSRC_HSE      (RCC_PLLCFGR_PLLSRC_0 | RCC_PLLCFGR_PLLSRC_1)
+#define RCC_PLLCFGR_PLLSRC_HSI      (RCC_PLLCFGR_PLLSRC_1)
 #define RCC_PLLCFGR_PLLSRC_MSI      (RCC_PLLCFGR_PLLSRC_0)
 #define RCC_CFGR_SW_MSI             (0x00000000U)
 #define RCC_CFGR_SW_HSI             (RCC_CFGR_SW_0)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a follow-up of #14866 that adds the possibility to configure stm32l4/wb families CPUs using Kconfig. All affected boards are updated accordingly.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Apply the following patch:

```diff
diff --git a/examples/hello-world/main.c b/examples/hello-world/main.c
index f51bf8c0a0..7a1910279c 100644
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -20,6 +20,9 @@
  */
 
 #include <stdio.h>
+#include <inttypes.h>
+
+#include "board.h"
 
 int main(void)
 {
@@ -28,5 +31,15 @@ int main(void)
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);
 
+    printf("Clock coreclock: %" PRIu32 "\n", (uint32_t)CLOCK_CORECLOCK);
+    printf("AHB clock: %" PRIu32 "\n", (uint32_t)CLOCK_AHB);
+    printf("APB1 clock: %" PRIu32 "\n", (uint32_t)CLOCK_APB1);
+#ifdef CLOCK_APB2
+    printf("APB2 clock: %" PRIu32 "\n", (uint32_t)CLOCK_APB2);
+#endif
+#ifdef CLOCK_PLLQ
+    printf("PLLQ clock: %" PRIu32 "\n", (uint32_t)CLOCK_PLLQ);
+#endif
+
     return 0;
 }
```

- Run `make BOARD=<stm32l4/wb board> -C examples/hello-world clean menuconfig` and configure the clock as you wish

- Build and flash the application. Verify that the clock values are correct

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Depends on ~#14866~ #15000
Related to #14975

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
