### PR TITLE
README: Add more badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 [![Nightly CI status master][master-ci-badge]][master-ci-link]
+[![GitHub release][release-badge]][release-link]
+[![License][license-badge]][license-link]
+[![API docs][api-badge]][api-link]
+[![Wiki][wiki-badge]][wiki-link]
+[![Stack Overflow questions][stackoverflow-badge]][stackoverflow-link]
+[![Twitter][twitter-badge]][twitter-link]
 [![IRC][irc-badge]][irc-link]
 [![Matrix][matrix-badge]][matrix-link]
 
@@ -124,9 +130,21 @@ For more information, see the RIOT website:
 https://www.riot-os.org
 
 
+[api-badge]: https://img.shields.io/badge/docs-API-informational.svg
+[api-link]: https://riot-os.org/api/
+[irc-badge]: https://img.shields.io/badge/chat-IRC-brightgreen.svg
+[irc-link]: https://webchat.freenode.net?channels=%23riot-os
+[license-badge]: https://img.shields.io/github/license/RIOT-OS/RIOT
+[license-link]: https://github.com/RIOT-OS/RIOT/blob/master/LICENSE
 [master-ci-badge]: https://ci.riot-os.org/RIOT-OS/RIOT/master/latest/badge.svg
 [master-ci-link]: https://ci.riot-os.org/nightlies.html#master
-[irc-badge]: https://img.shields.io/badge/IRC-join%20chat%20%E2%86%92-blue.svg
-[irc-link]: https://webchat.freenode.net?channels=%23riot-os
-[matrix-badge]: https://img.shields.io/badge/Matrix-join%20chat%20%E2%86%92-blue.svg
+[matrix-badge]: https://img.shields.io/badge/chat-Matrix-brightgreen.svg
 [matrix-link]: https://matrix.to/#/#riot-os:matrix.org
+[release-badge]: https://img.shields.io/github/release/RIOT-OS/RIOT.svg
+[release-link]: https://github.com/RIOT-OS/RIOT/releases/latest
+[stackoverflow-badge]: https://img.shields.io/stackexchange/stackoverflow.com/t/%5Briot-os%5D?label=stackoverflow%20questions
+[stackoverflow-link]:  https://stackoverflow.com/questions/tagged/riot-os
+[twitter-badge]: https://img.shields.io/badge/social-Twitter-informational.svg
+[twitter-link]: https://twitter.com/RIOT_OS
+[wiki-badge]: https://img.shields.io/badge/docs-Wiki-informational.svg
+[wiki-link]: https://github.com/RIOT-OS/RIOT/wiki


### PR DESCRIPTION
The README document was missing several relevant badges/links:

- Latest release
- License info
- API docs
- Wiki
- StackOverflow
- Twitter

The addition of these links will, hopefully, help people
quickly navigate the broader ecosystem.

Additionally, all badges (except for the CI badge) now
conform to roughly the same style.