### PR TITLE
build system: use riscv-none-elf as triplet

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -126,6 +126,8 @@ for p in \
          arm-none-eabi \
          avr mips-mti-elf \
          msp430-elf \
+         riscv-none-elf \
+         riscv64-unknown-elf \
          riscv-none-embed \
          xtensa-esp32-elf \
          xtensa-esp8266-elf \
@@ -141,6 +143,8 @@ for p in \
          arm-none-eabi \
          mips-mti-elf \
          msp430-elf \
+         riscv-none-elf \
+         riscv64-unknown-elf \
          riscv-none-embed \
          xtensa-esp32-elf \
          xtensa-esp8266-elf \

--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -1,5 +1,19 @@
 # Target architecture for the build.
-TARGET_ARCH_RISCV ?= riscv-none-embed
+TARGET_ARCH_RISCV ?= riscv-none-elf
+
+# If TARGET_ARCH wasn't set by user, also check if riscv64-unknown-elf
+# or riscv-none-embed is present.
+ifeq (riscv-none-elf,$(TARGET_ARCH_RISCV))
+  ifeq (,$(shell which $(TARGET_ARCH_RISCV)-gcc))
+    ifneq (,$(shell which riscv64-unknown-elf-gcc))
+      TARGET_ARCH_RISCV := riscv64-unknown-elf
+    else ifneq (,$(shell which riscv-none-embed-gcc))
+      $(info Falling back to legacy riscv-none-embed toolchain)
+      TARGET_ARCH_RISCV := riscv-none-embed
+    endif
+  endif
+endif
+
 TARGET_ARCH ?= $(TARGET_ARCH_RISCV)
 
 # define build specific options


### PR DESCRIPTION
### Contribution description

Use `riscv-none-elf` instead of legacy `riscv-none-embed` as target triplet for RISC-V development. However, if `ricsv-none-elf` is not present but `riscv-none-embed` is, fall back to legacy triplet (and print an info message about this behavior).


### Testing procedure

E.g. `make BOARD=hifive1 -C examples/default` and `make BUILD_IN_DOCKER=1 BOARD=hifive1 -C examples/default` should now work both, even if the local toolchain is build from upstream sources (which requires `riscv-none-elf` as triplet).

### Issues/PRs references

None