### PR TITLE
drivers/at86rf215: implement battery monitor, add power bus

### DIFF
--- a/drivers/at86rf215/Kconfig
+++ b/drivers/at86rf215/Kconfig
@@ -12,6 +12,24 @@ menuconfig KCONFIG_USEMODULE_AT86RF215
 
 if KCONFIG_USEMODULE_AT86RF215
 
+menuconfig KCONFIG_USEMODULE_AT86RF215_BATMON
+    bool "AT86RF215 Battery Monitor"
+    depends on USEMODULE_AT86RF215
+    help
+        Configure the AT86RF215 battery monitor using Kconfig.
+
+config AT86RF215_BATMON_THRESHOLD
+    int "Treshold voltage (in mV) of the battery monitor"
+    range 1700 3675
+    default 1800
+    depends on KCONFIG_USEMODULE_AT86RF215_BATMON
+    help
+        If the supply voltage falls below the configured threshold
+        a SYS_BUS_POWER_EVENT_LOW_VOLTAGE event is generated on the
+        SYS_BUS_POWER bus.
+
+        Battery Monitoring is disabled when the device is in Deep Sleep.
+
 config AT86RF215_USE_CLOCK_OUTPUT
     bool "Enable clock output"
     help

--- a/drivers/at86rf215/Makefile.dep
+++ b/drivers/at86rf215/Makefile.dep
@@ -9,6 +9,10 @@ ifeq (,$(filter at86rf215_subghz at86rf215_24ghz,$(USEMODULE)))
   DEFAULT_MODULE += at86rf215_24ghz
 endif
 
+ifneq (,$(filter at86rf215_batmon,$(USEMODULE)))
+  USEMODULE += sys_bus_power
+endif
+
 DEFAULT_MODULE += netdev_ieee802154_multimode
 
 DEFAULT_MODULE += netdev_ieee802154_oqpsk

--- a/drivers/at86rf215/at86rf215_internal.c
+++ b/drivers/at86rf215/at86rf215_internal.c
@@ -69,6 +69,11 @@ int at86rf215_hardware_reset(at86rf215_t *dev)
         return -ENODEV;
     }
 
+    /* enable battery monitor */
+    if (IS_ACTIVE(MODULE_AT86RF215_BATMON)) {
+        at86rf215_enable_batmon(dev, CONFIG_AT86RF215_BATMON_THRESHOLD);
+    }
+
     /* clear interrupts */
     at86rf215_reg_read(dev, RG_RF09_IRQS);
     at86rf215_reg_read(dev, RG_RF24_IRQS);

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -124,6 +124,16 @@ enum {
 /** @} */
 
 /**
+ * @name    Default Battery Monitor trigger threshold (in mV)
+ *          if battery monitoring is enabled
+ * @{
+ */
+#ifndef CONFIG_AT86RF215_BATMON_THRESHOLD
+#define CONFIG_AT86RF215_BATMON_THRESHOLD       (1800)
+#endif
+/** @} */
+
+/**
  * @name    Default PHY Mode
  * @{
  */
@@ -590,6 +600,24 @@ void at86rf215_tx_done(at86rf215_t *dev);
  * @return                  false if channel is determined busy
  */
 bool at86rf215_cca(at86rf215_t *dev);
+
+/**
+ * @brief   Generate an interrupt if supply voltage drops below the configured
+ *          threshold.
+ *
+ * @param[in] dev           device to configure
+ * @param[in] voltage       Threshold voltage in mV
+ *
+ * @return                  0 on success, error otherwise
+ */
+int at86rf215_enable_batmon(at86rf215_t *dev, unsigned voltage);
+
+/**
+ * @brief   Disable the Battery Monitor interrupt.
+ *
+ * @param[in] dev           device to configure
+ */
+void at86rf215_disable_batmon(at86rf215_t *dev);
 
 #ifdef __cplusplus
 }

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -127,6 +127,7 @@ PSEUDOMODULES += stm32_eth_auto
 PSEUDOMODULES += stm32_eth_link_up
 PSEUDOMODULES += suit_transport_%
 PSEUDOMODULES += suit_storage_%
+PSEUDOMODULES += sys_bus_%
 PSEUDOMODULES += wakaama_objects_%
 PSEUDOMODULES += wifi_enterprise
 PSEUDOMODULES += xtimer_on_ztimer

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -158,6 +158,9 @@ endif
 ifneq (,$(filter suit%,$(USEMODULE)))
   DIRS += suit
 endif
+ifneq (,$(filter sys_bus,$(USEMODULE)))
+  DIRS += bus
+endif
 ifneq (,$(filter tcp,$(USEMODULE)))
   DIRS += net/transport_layer/tcp
 endif

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -44,6 +44,11 @@ ifneq (,$(filter crypto_%,$(USEMODULE)))
   USEMODULE += crypto
 endif
 
+ifneq (,$(filter sys_bus_%,$(USEMODULE)))
+  USEMODULE += sys_bus
+  USEMODULE += core_msg_bus
+endif
+
 ifneq (,$(filter rtt_cmd,$(USEMODULE)))
   FEATURES_REQUIRED += periph_rtt
 endif

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -58,6 +58,11 @@ void auto_init(void)
         extern void auto_init_event_thread(void);
         auto_init_event_thread();
     }
+    if (IS_USED(MODULE_SYS_BUS)) {
+        LOG_DEBUG("Auto init system buses.\n");
+        extern void auto_init_sys_bus(void);
+        auto_init_sys_bus();
+    }
     if (IS_USED(MODULE_MCI)) {
         LOG_DEBUG("Auto init mci.\n");
         extern void mci_initialize(void);

--- a/sys/bus/Makefile
+++ b/sys/bus/Makefile
@@ -1,0 +1,3 @@
+MODULE = sys_bus
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/bus/sys_bus_init.c
+++ b/sys/bus/sys_bus_init.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_bus
+ * @{
+ *
+ * @file
+ * @brief       System Buses
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include "sys/bus.h"
+
+msg_bus_t _sys_bus[SYS_BUS_NUMOF];
+
+void auto_init_sys_bus(void)
+{
+    for (unsigned i = 0; i < SYS_BUS_NUMOF; ++i) {
+        msg_bus_init(&_sys_bus[i]);
+    }
+}

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -768,6 +768,16 @@ typedef enum {
     NETOPT_RSSI,
 
     /**
+     * @brief (uint16_t) Set the battery monitor voltage (in mV).
+     *
+     * When set, a @ref SYS_BUS_POWER_EVENT_LOW_VOLTAGE event is generated
+     * on the SYS_BUS_POWER bus if the supply voltage falls below the set value.
+     *
+     * Set to 0 to disable battery monitoring.
+     */
+    NETOPT_BATMON,
+
+    /**
      * @brief   (array of byte array) get link layer multicast groups as array
      *          of byte arrays (length of each byte array corresponds to the
      *          length of @ref NETOPT_ADDRESS) or join a link layer multicast

--- a/sys/include/sys/bus.h
+++ b/sys/include/sys/bus.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys
+ * @defgroup    sys_bus System Buses for common events
+ * @{
+ *
+ * @file
+ * @brief       This provides System Buses for common events.
+ *
+ * @warning     Bus Events will be lost if receiver message queue is full.
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef SYS_BUS_H
+#define SYS_BUS_H
+
+#include <assert.h>
+#include "msg_bus.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief System Bus types
+ */
+typedef enum {
+#if MODULE_SYS_BUS_POWER
+    SYS_BUS_POWER,      /**< Events related to system power */
+#endif
+    SYS_BUS_NUMOF       /**< Number of enabled system buses */
+} sys_bus_t;
+
+/**
+ * @brief Power Bus Events
+ */
+typedef enum {
+    /**
+     * @brief Supply voltage fallen below threshold
+     */
+    SYS_BUS_POWER_EVENT_LOW_VOLTAGE,
+
+    /* add more if needed, but not more than 32 */
+} sys_bus_power_event_t;
+
+/**
+ * @brief The System Bus array - do not use directly
+ */
+extern msg_bus_t _sys_bus[SYS_BUS_NUMOF];
+
+/**
+ * @brief Get a System Bus for a category of events.
+ *
+ * @param[in] bus           The event category of the the user
+ *                          is interested in
+ *
+ * @return                  The message bus for those events
+ */
+static inline msg_bus_t *sys_bus_get(sys_bus_t bus)
+{
+    return &_sys_bus[bus];
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYS_BUS_H */
+/** @} */

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -126,6 +126,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_NUM_GATEWAYS]          = "NETOPT_NUM_GATEWAYS",
     [NETOPT_LINK_CHECK]            = "NETOPT_LINK_CHECK",
     [NETOPT_RSSI]                  = "NETOPT_RSSI",
+    [NETOPT_BATMON]                = "NETOPT_BATMON",
     [NETOPT_L2_GROUP]              = "NETOPT_L2_GROUP",
     [NETOPT_L2_GROUP_LEAVE]        = "NETOPT_L2_GROUP_LEAVE",
     [NETOPT_NUMOF]                 = "NETOPT_NUMOF",

--- a/tests/driver_at86rf215/Makefile
+++ b/tests/driver_at86rf215/Makefile
@@ -2,5 +2,6 @@ BOARD ?= openmote-b
 
 # the radio driver to test
 USEMODULE += at86rf215
+USEMODULE += at86rf215_batmon
 
 include ../driver_netdev_common/Makefile.netdev.mk

--- a/tests/driver_at86rf215/main.c
+++ b/tests/driver_at86rf215/main.c
@@ -1,1 +1,98 @@
-../driver_netdev_common/main.c
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for at86rf215 driver
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "at86rf215.h"
+#include "thread.h"
+#include "shell.h"
+#include "shell_commands.h"
+#include "sys/bus.h"
+
+#include "net/gnrc/pktdump.h"
+#include "net/gnrc.h"
+
+static char batmon_stack[THREAD_STACKSIZE_MAIN];
+
+void *batmon_thread(void *arg)
+{
+    (void) arg;
+
+    msg_t msg;
+    msg_bus_entry_t sub;
+    msg_bus_t *bus = sys_bus_get(SYS_BUS_POWER);
+
+    msg_bus_attach(bus, &sub);
+    msg_bus_subscribe(&sub, SYS_BUS_POWER_EVENT_LOW_VOLTAGE);
+
+    while (1) {
+        msg_receive(&msg);
+        puts("NA NA NA NA NA NA NA NA NA NA NA NA NA BATMON");
+    }
+}
+
+static int cmd_enable_batmon(int argc, char **argv)
+{
+    int res;
+    uint16_t voltage;
+    gnrc_netif_t* netif = gnrc_netif_iter(NULL);
+
+    if (argc < 2) {
+        printf("usage: %s <treshold_mV>\n", argv[0]);
+        return -1;
+    }
+
+    if (netif == NULL) {
+        puts("no netif found");
+        return -1;
+    }
+
+    voltage = atoi(argv[1]);
+    res     = gnrc_netapi_set(netif->pid, NETOPT_BATMON, 0,
+                              &voltage, sizeof(voltage));
+
+    if (res != sizeof(voltage)) {
+        puts("value out of range");
+    }
+
+    return res;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "batmon", "Enable the battery monitor", cmd_enable_batmon },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    /* enable pktdump output */
+    gnrc_netreg_entry_t dump = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                          gnrc_pktdump_pid);
+    gnrc_netreg_register(GNRC_NETTYPE_UNDEF, &dump);
+
+    /* create battery monitor thread */
+    thread_create(batmon_stack, sizeof(batmon_stack), THREAD_PRIORITY_MAIN - 1,
+                  THREAD_CREATE_STACKTEST, batmon_thread, NULL, "batmon");
+
+    /* start the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -43,8 +43,10 @@ BOARD_INSUFFICIENT_MEMORY := \
     lsn50 \
     maple-mini \
     mega-xplained \
+    mcb2388 \
     microbit \
     microduino-corerf \
+    msba2 \
     msb-430 \
     msb-430h \
     nrf51dk \


### PR DESCRIPTION
### Contribution description

The at86rf215 can generate an interrupt if the supply voltage falls below a certain level.

Since such an event can have multiple consumers, a new system power bus is introduced.
Threads interested in power events can subscribe to it and will all be notified in case of an event.

New bus types for different event categories can be added in the future.

### Testing procedure

Run `tests/driver_at86rf215` on a board with the radio connected.

You can configure a battery monitor threshold (in mV) with

```
2020-09-08 11:04:59,111 #  batmon 2500
```

If you configure a threshold that is above the supply voltage, a battery monitor event should be triggered immediatly.

```
2020-09-08 11:06:11,733 #  batmon 3500
2020-09-08 11:06:11,737 # NA NA NA NA NA NA NA NA NA NA NA NA NA BATMON
```


### Issues/PRs references

split off #12128
