### PR TITLE
boards/nucleo: fix xtimer configuration

### DIFF
--- a/boards/common/nucleo/include/board_nucleo.h
+++ b/boards/common/nucleo/include/board_nucleo.h
@@ -32,7 +32,7 @@ extern "C" {
  * @name    Xtimer configuration
  * @{
  */
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0) && \
+#if (defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0)) && \
     !defined(CPU_MODEL_STM32F042K6) && !defined(CPU_MODEL_STM32F031K6)
 #define XTIMER_WIDTH                (16)
 #endif


### PR DESCRIPTION
### Contribution description

`STM32F042K6` and `STM32F031K6` use `TIM2` as there base timer, this is a 32bit timer. The conditional which set `XTIMER_WIDTH` was wrong which led to xtimer being broken, this PR fixes the conditional.

### Testing procedure

`xtimer` tests running of one of the mentioned cpu's now pass:

e.g.

```
BOARD=nucleo-f042k6 make -C tests/xtimer_periodic_wakeup/ flash test
```

```
  26 diff=10
  25 diff=10
  24 diff=10
  23 diff=10
  22 diff=10
  21 diff=10
  20 diff=10
  19 diff=9
  18 diff=9
  17 diff=9
  16 diff=10
  15 diff=9
  14 diff=9
  13 diff=10
  12 diff=9
  11 diff=10
  10 diff=10
   9 diff=9
   8 diff=10
   7 diff=10
   6 diff=10
   5 diff=9
   4 diff=10
   3 diff=2
   2 diff=3
   1 diff=5

Min/max error: 2/29

Test complete.
```

### Issues/PRs references

Fixes error reported in #13204.