### PR TITLE
boards/nucleo-l452re: add i2c config

### DIFF
--- a/boards/nucleo-l452re/Kconfig
+++ b/boards/nucleo-l452re/Kconfig
@@ -15,6 +15,7 @@ config BOARD_NUCLEO_L452RE
     select CPU_MODEL_STM32L452RE
 
     # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
     select HAS_PERIPH_PWM
     select HAS_PERIPH_RTC
     select HAS_PERIPH_RTT

--- a/boards/nucleo-l452re/Makefile.features
+++ b/boards/nucleo-l452re/Makefile.features
@@ -2,6 +2,7 @@ CPU = stm32
 CPU_MODEL = stm32l452re
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/nucleo-l452re/include/periph_conf.h
+++ b/boards/nucleo-l452re/include/periph_conf.h
@@ -27,6 +27,7 @@
 
 #include "periph_cpu.h"
 #include "l4/cfg_clock_80_1.h"
+#include "cfg_i2c1_pb8_pb9.h"
 #include "cfg_rtt_default.h"
 #include "cfg_timer_tim2.h"
 


### PR DESCRIPTION

### Contribution description

This Pr adds the i2c config.

### Testing procedure

Connect an i2c driver and test, I ran with `tests/bmx280`

```
2020-09-08 13:28:18,444 # TTemperature [°C]: 25.11
2020-09-08 13:28:18,446 #    Pressure [Pa]: 100976
2020-09-08 13:28:18,448 #   Humidity [%rH]: 49.00
2020-09-08 13:28:18,448 # 
2020-09-08 13:28:18,452 # +-------------------------------------+
2020-09-08 13:28:18,452 # 
2020-09-08 13:28:18,688 # main(): This is RIOT! (Version: 2020.10-devel-1273-ge5ad7-pr-14866)
2020-09-08 13:28:18,690 # BMX280 test application
2020-09-08 13:28:18,690 # 
2020-09-08 13:28:18,693 # +------------Initializing------------+
2020-09-08 13:28:18,725 # Initialization successful
2020-09-08 13:28:18,725 # 
2020-09-08 13:28:18,728 # +------------Calibration Data------------+
2020-09-08 13:28:18,730 # dig_T1: 28837
2020-09-08 13:28:18,731 # dig_T2: 26401
2020-09-08 13:28:18,732 # dig_T3: 50
2020-09-08 13:28:18,733 # dig_P1: 36102
2020-09-08 13:28:18,734 # dig_P2: -10634
2020-09-08 13:28:18,735 # dig_P3: 3024
2020-09-08 13:28:18,737 # dig_P4: 5967
2020-09-08 13:28:18,738 # dig_P5: 42
2020-09-08 13:28:18,739 # dig_P6: -7
2020-09-08 13:28:18,740 # dig_P7: 12300
2020-09-08 13:28:18,741 # dig_P8: -12000
2020-09-08 13:28:18,742 # dig_P9: 5000
2020-09-08 13:28:18,743 # dig_H1: 75
2020-09-08 13:28:18,744 # dig_H2: 340
2020-09-08 13:28:18,745 # dig_H3: 0
2020-09-08 13:28:18,746 # dig_H4: 373
2020-09-08 13:28:18,747 # dig_H5: 50
2020-09-08 13:28:18,748 # dig_H6: 30
2020-09-08 13:28:18,748 # 
2020-09-08 13:28:18,752 # +--------Starting Measurements--------+
2020-09-08 13:28:18,800 # Temperature [°C]: 25.12
2020-09-08 13:28:18,802 #    Pressure [Pa]: 100976
2020-09-08 13:28:18,805 #   Humidity [%rH]: 49.17
2020-09-08 13:28:18,805 # 
2020-09-08 13:28:18,808 # +-------------------------------------+
2020-09-08 13:28:18,808 # 
```

