### PR TITLE
xtimer: remove _xtimer_set_absolute

### DIFF
--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -78,19 +78,6 @@ static inline uint32_t _xtimer_lltimer_mask(uint32_t val)
 
 uint32_t _xtimer_now(void);
 
-/**
- * @brief Sets the timer to the appropriate timer_list or list_head.
- *
- * @note    The target to set the timer to has to be at least bigger then the
- *          ticks needed to jump into the function and calculate '_xtimer_now()'.
- *          So that 'now' did not pass the target.
- *          This is crucial when using low CPU frequencies and/or when the
- *          '_xtimer_now()' call needs multiple xtimer ticks to evaluate.
- *
- * @param[in] timer   pointer to xtimer_t which is added to the list.
- * @param[in] target  Absolute target value in ticks.
- */
-int _xtimer_set_absolute(xtimer_t *timer, uint32_t target);
 void _xtimer_set64(xtimer_t *timer, uint32_t offset, uint32_t long_offset);
 void _xtimer_periodic_wakeup(uint32_t *last_wakeup, uint32_t period);
 void _xtimer_set_wakeup(xtimer_t *timer, uint32_t offset, kernel_pid_t pid);

--- a/tests/bench_timers/README.md
+++ b/tests/bench_timers/README.md
@@ -79,7 +79,6 @@ a test for xtimer.
 The application will mix calls to the following xtimer functions:
 
  - `_xtimer_set`
- - `_xtimer_set_absolute`
  - `_xtimer_periodic_wakeup`
  - `_xtimer_spin`
 

--- a/tests/bench_timers/main.c
+++ b/tests/bench_timers/main.c
@@ -60,10 +60,9 @@
 enum test_variants {
     TEST_XTIMER_SET             = 0,
     TEST_PARALLEL               = 1,
-    TEST_XTIMER_SET_ABSOLUTE    = 2,
-    TEST_XTIMER_PERIODIC_WAKEUP = 4,
-    TEST_XTIMER_SPIN            = 6,
-    TEST_VARIANT_NUMOF          = 8,
+    TEST_XTIMER_PERIODIC_WAKEUP = 2,
+    TEST_XTIMER_SPIN            = 4,
+    TEST_VARIANT_NUMOF          = 6,
 };
 #else /* TEST_XTIMER */
 /*
@@ -131,8 +130,6 @@ static const result_presentation_t presentation = {
             .sub_labels = (const char *[]){
                 [TEST_XTIMER_SET] = "_xt_set",
                 [TEST_XTIMER_SET | TEST_PARALLEL] = "_xt_set race",
-                [TEST_XTIMER_SET_ABSOLUTE] = "_xt_set_abs",
-                [TEST_XTIMER_SET_ABSOLUTE | TEST_PARALLEL] = "_xt_set_abs race",
                 [TEST_XTIMER_PERIODIC_WAKEUP] = "_xt_periodic",
                 [TEST_XTIMER_PERIODIC_WAKEUP | TEST_PARALLEL] = "_xt_periodic race",
                 [TEST_XTIMER_SPIN] = "_xt_spin",
@@ -147,8 +144,6 @@ static const result_presentation_t presentation = {
     .offsets = (const unsigned[]) {
         [TEST_XTIMER_SET]                               = TEST_MIN_REL,
         [TEST_XTIMER_SET | TEST_PARALLEL]               = TEST_MIN_REL,
-        [TEST_XTIMER_SET_ABSOLUTE]                      = TEST_MIN,
-        [TEST_XTIMER_SET_ABSOLUTE | TEST_PARALLEL]      = TEST_MIN,
         [TEST_XTIMER_PERIODIC_WAKEUP]                   = TEST_MIN_REL,
         [TEST_XTIMER_PERIODIC_WAKEUP | TEST_PARALLEL]   = TEST_MIN_REL,
         [TEST_XTIMER_SPIN]                              = TEST_MIN_REL,
@@ -387,9 +382,6 @@ static void run_test(test_ctx_t *ctx, uint32_t interval, unsigned int variant)
             case TEST_XTIMER_SET:
                 print_str("rel ");
                 break;
-            case TEST_XTIMER_SET_ABSOLUTE:
-                print_str("abs ");
-                break;
             case TEST_XTIMER_PERIODIC_WAKEUP:
                 print_str("per ");
                 break;
@@ -422,10 +414,6 @@ static void run_test(test_ctx_t *ctx, uint32_t interval, unsigned int variant)
         case TEST_XTIMER_SET:
             _xtimer_set(&xt, interval);
             break;
-        case TEST_XTIMER_SET_ABSOLUTE:
-            now = READ_TUT();
-            ctx->target_tut = now + interval;
-            _xtimer_set_absolute(&xt, ctx->target_tut);
             break;
         case TEST_XTIMER_PERIODIC_WAKEUP:
             _xtimer_periodic_wakeup(&now, interval);

--- a/tests/bench_timers/main.c
+++ b/tests/bench_timers/main.c
@@ -403,7 +403,7 @@ static void run_test(test_ctx_t *ctx, uint32_t interval, unsigned int variant)
 
     spin_random_delay();
     if (variant & TEST_PARALLEL) {
-        _xtimer_set(&xt_parallel, interval);
+        _xtimer_set64(&xt_parallel, interval, 0);
         //~ interval += XTIMER_BACKOFF;
         spin_random_delay();
     }
@@ -412,8 +412,7 @@ static void run_test(test_ctx_t *ctx, uint32_t interval, unsigned int variant)
     ctx->target_tut = now + interval;
     switch (variant & ~TEST_PARALLEL) {
         case TEST_XTIMER_SET:
-            _xtimer_set(&xt, interval);
-            break;
+            _xtimer_set64(&xt, interval, 0);
             break;
         case TEST_XTIMER_PERIODIC_WAKEUP:
             _xtimer_periodic_wakeup(&now, interval);


### PR DESCRIPTION
### Contribution description

Currently `_xtimer_set_absolute` is declared but there is no definition for it. This PR removes the function and its usage in `tests/bench_timers`. 

This PR also includes the cleanup to replace usage of `_xtimer_set` with `_xtimer_set64` in https://github.com/RIOT-OS/RIOT/commit/1a96e32db186823258998e52baeada822d07b10c.

### Testing procedure

1. Compile `bench_timers` tests for testing xtimer and flash: 
```
cd tests/bench_timers
BOARD=<board> make test-xtimer
BOARD=<board> make flash term
```

The test should compile and run succesfully.
