### PR TITLE
openthread: add support for radios compatible with SubMAC

### DIFF
--- a/examples/openthread/Makefile
+++ b/examples/openthread/Makefile
@@ -19,6 +19,9 @@ BOARD_WHITELIST := \
                     remote-revb \
                     omote \
                     openmote-cc2538 \
+                    nrf52840dk \
+                    nrf52840-mdk \
+                    reel \
                     #
 
 # This has to be the absolute path to the RIOT base directory:

--- a/examples/openthread/Makefile
+++ b/examples/openthread/Makefile
@@ -28,6 +28,8 @@ USEMODULE += openthread-$(OPENTHREAD_TYPE)
 # Comment the following line in order to disable the OpenThread CLI
 USEMODULE += openthread-cli
 
+USEMODULE += netdev_default
+
 #Define PANID, CHANNEL and UART_BAUDRATE used by default
 OPENTHREAD_PANID ?= 0xbeef
 OPENTHREAD_CHANNEL ?= 26

--- a/examples/openthread/Makefile
+++ b/examples/openthread/Makefile
@@ -4,7 +4,22 @@ APPLICATION = openthread
 BOARD ?= samr21-xpro
 
 # These are the boards that OpenThread stack has been tested on
-BOARD_WHITELIST := samr21-xpro iotlab-m3 fox iotlab-a8-m3 frdm-kw41z openlabs-kw41z-mini-256kib openlabs-kw41z-mini phynode-kw41z usb-kw41z
+BOARD_WHITELIST := \
+                    samr21-xpro \
+                    iotlab-m3 \
+                    fox \
+                    iotlab-a8-m3 \
+                    frdm-kw41z \
+                    openlabs-kw41z-mini-256kib \
+                    openlabs-kw41z-mini \
+                    phynode-kw41z \
+                    usb-kw41z \
+                    cc2538dk \
+                    remote-reva \
+                    remote-revb \
+                    omote \
+                    openmote-cc2538 \
+                    #
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..

--- a/pkg/openthread/Makefile.dep
+++ b/pkg/openthread/Makefile.dep
@@ -4,4 +4,9 @@ USEMODULE += openthread_contrib_netdev
 USEMODULE += l2util
 USEMODULE += xtimer
 USEMODULE += event
+
+ifneq (,$(filter cc2538_rf,$(USEMODULE)))
+  USEMODULE += netdev_ieee802154_submac
+endif
+
 FEATURES_REQUIRED += cpp

--- a/pkg/openthread/Makefile.dep
+++ b/pkg/openthread/Makefile.dep
@@ -5,7 +5,7 @@ USEMODULE += l2util
 USEMODULE += xtimer
 USEMODULE += event
 
-ifneq (,$(filter cc2538_rf,$(USEMODULE)))
+ifneq (,$(filter cc2538_rf nrf802154,$(USEMODULE)))
   USEMODULE += netdev_ieee802154_submac
 endif
 

--- a/pkg/openthread/contrib/openthread.c
+++ b/pkg/openthread/contrib/openthread.c
@@ -34,6 +34,10 @@
 #include "kw41zrf.h"
 #endif
 
+#ifdef MODULE_CC2538_RF
+#include "cc2538_rf.h"
+#endif
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -43,6 +47,10 @@
 
 #ifdef MODULE_KW41ZRF
 #define OPENTHREAD_NETIF_NUMOF        (1U)
+#endif
+
+#ifdef MODULE_CC2538_RF
+static cc2538_rf_t cc2538_rf_dev;
 #endif
 
 #ifdef MODULE_AT86RF2XX
@@ -70,6 +78,10 @@ void openthread_bootstrap(void)
 #ifdef MODULE_KW41ZRF
     kw41zrf_setup(&kw41z_dev);
     netdev_t *netdev = (netdev_t *) &kw41z_dev;
+#endif
+#ifdef MODULE_CC2538_RF
+    cc2538_setup(&cc2538_rf_dev);
+    netdev_t *netdev = (netdev_t*) &cc2538_rf_dev;
 #endif
 
     openthread_radio_init(netdev, tx_buf, rx_buf);

--- a/pkg/openthread/contrib/openthread.c
+++ b/pkg/openthread/contrib/openthread.c
@@ -38,6 +38,10 @@
 #include "cc2538_rf.h"
 #endif
 
+#ifdef MODULE_NRF802154
+#include "nrf802154.h"
+#endif
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -61,6 +65,10 @@ static at86rf2xx_t at86rf2xx_dev;
 static kw41zrf_t kw41z_dev;
 #endif
 
+#ifdef MODULE_NRF802154
+static nrf802154_t nrf802154_dev;
+#endif
+
 static uint8_t rx_buf[OPENTHREAD_NETDEV_BUFLEN];
 static uint8_t tx_buf[OPENTHREAD_NETDEV_BUFLEN];
 static char ot_thread_stack[2 * THREAD_STACKSIZE_MAIN];
@@ -82,6 +90,10 @@ void openthread_bootstrap(void)
 #ifdef MODULE_CC2538_RF
     cc2538_setup(&cc2538_rf_dev);
     netdev_t *netdev = (netdev_t*) &cc2538_rf_dev;
+#endif
+#ifdef MODULE_NRF802154
+    nrf802154_setup(&nrf802154_dev);
+    netdev_t *netdev = (netdev_t*) &nrf802154_dev;
 #endif
 
     openthread_radio_init(netdev, tx_buf, rx_buf);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds OpenThread support for the radios compatible with the SubMAC
This work requires the `netdev_ieee802154_submac_t` interface of IEEE 802.15.4 SubMAC (#14950 ) to work.

This acts as a showcase for the IEEE 802.15.4 Radio HAL and SubMAC, since all APIs are hardware independent now. Thus, it's possible to transparently integrate OpenThread with any radio that implements the IEEE 802.15.4 Radio HAL.

In the future, we could drop the `netdev_ieee802154_submac_t` interface and implement the platform abstraction directly on top of the Radio HAL or SubMAC.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run `make -C examples/openthread` with any CC2538 based board (e.g remote-revb).

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Now this depends on #15237 
#10045 
#13376 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
