### PR TITLE
build system: Overwrite TARGET_ARCH per arch

### DIFF
--- a/cpu/arm7_common/Makefile.include
+++ b/cpu/arm7_common/Makefile.include
@@ -1,5 +1,6 @@
 # Target architecture for the build. Use arm-none-eabi if you are unsure.
-TARGET_ARCH ?= arm-none-eabi
+TARGET_ARCH_ARM7 ?= arm-none-eabi
+TARGET_ARCH ?= $(TARGET_ARCH_ARM7)
 
 INCLUDES += -I$(RIOTBASE)/cpu/arm7_common/include/
 

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -18,7 +18,8 @@ include $(RIOTCPU)/esp_common/Makefile.include
 
 # regular Makefile
 
-TARGET_ARCH ?= xtensa-esp32-elf
+TARGET_ARCH_ESP32 ?= xtensa-esp32-elf
+TARGET_ARCH ?= $(TARGET_ARCH_ESP32)
 
 PSEUDOMODULES += esp_eth_hw
 PSEUDOMODULES += esp_gdbstub

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -24,7 +24,8 @@ include $(RIOTCPU)/esp_common/Makefile.include
 
 # regular Makefile
 
-TARGET_ARCH ?= xtensa-esp8266-elf
+TARGET_ARCH_ESP8266 ?= xtensa-esp8266-elf
+TARGET_ARCH ?= $(TARGET_ARCH_ESP8266)
 
 PSEUDOMODULES += esp_sw_timer
 

--- a/makefiles/arch/atmega.inc.mk
+++ b/makefiles/arch/atmega.inc.mk
@@ -1,5 +1,6 @@
 # Target architecture for the build. Use avr if you are unsure.
-TARGET_ARCH ?= avr
+TARGET_ARCH_AVR ?= avr
+TARGET_ARCH ?= $(TARGET_ARCH_AVR)
 
 CFLAGS_CPU   = -mmcu=$(CPU) $(CFLAGS_FPU)
 CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums

--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -3,7 +3,8 @@ ifeq (,$(CPU_MODEL))
 endif
 
 # Target triple for the build. Use arm-none-eabi if you are unsure.
-TARGET_ARCH ?= arm-none-eabi
+TARGET_ARCH_CORTEXM ?= arm-none-eabi
+TARGET_ARCH ?= $(TARGET_ARCH_CORTEXM)
 
 # define build specific options
 CFLAGS_CPU   = -mcpu=$(MCPU) -mlittle-endian -mthumb $(CFLAGS_FPU)

--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -1,5 +1,6 @@
 # Target triple for the build.
-TARGET_ARCH ?= mips-mti-elf
+TARGET_ARCH_MIPS ?= mips-mti-elf
+TARGET_ARCH ?= $(TARGET_ARCH_MIPS)
 
 ABI = 32
 

--- a/makefiles/arch/msp430.inc.mk
+++ b/makefiles/arch/msp430.inc.mk
@@ -1,5 +1,6 @@
 # Target architecture for the build. Use msp430-elf if you are unsure.
-TARGET_ARCH ?= msp430-elf
+TARGET_ARCH_MSP430 ?= msp430-elf
+TARGET_ARCH ?= $(TARGET_ARCH_MSP430)
 
 MSP430_SUPPORT_FILES ?= $(RIOTCPU)/msp430_common/vendor/msp430-gcc-support-files
 

--- a/makefiles/arch/riscv.inc.mk
+++ b/makefiles/arch/riscv.inc.mk
@@ -1,5 +1,6 @@
 # Target architecture for the build.
-TARGET_ARCH ?= riscv-none-embed
+TARGET_ARCH_RISCV ?= riscv-none-embed
+TARGET_ARCH ?= $(TARGET_ARCH_RISCV)
 
 # define build specific options
 CFLAGS_CPU   = -march=rv32imac -mabi=ilp32 -mcmodel=medlow -msmall-data-limit=8


### PR DESCRIPTION
### Contribution description

Add `TARGET_ARCH_<ARCH>` for each architecture (e.g. `TARGET_ARCH_CORTEX` for Cortex M) to allow users to overwrite the target triple for a specific arch from ~/.profile or ~/.bashrc (or the like) without overwriting it for all others as well.


### Testing procedure

Green Murdock

### Issues/PRs references

Can be used to solve the issues addressed by https://github.com/RIOT-OS/RIOT/pull/14972. (But makes sense regardless of what the default target triple of the RISC V toolchain is chosen.)