### PR TITLE
ieee802154_hal: add missing const qualifiers

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -232,7 +232,7 @@ static int _set_cca_threshold(ieee802154_dev_t *dev, int8_t threshold)
     return 0;
 }
 
-static int _config_phy(ieee802154_dev_t *dev, ieee802154_phy_conf_t *conf)
+static int _config_phy(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf)
 {
     (void) dev;
     int8_t pow = conf->pow;
@@ -452,7 +452,7 @@ static int _set_rx_mode(ieee802154_dev_t *dev, ieee802154_rx_mode_t mode)
     return 0;
 }
 
-static int _set_csma_params(ieee802154_dev_t *dev, ieee802154_csma_be_t *bd, int8_t retries)
+static int _set_csma_params(ieee802154_dev_t *dev, const ieee802154_csma_be_t *bd, int8_t retries)
 {
     (void) dev;
     if (bd) {

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -620,7 +620,7 @@ struct ieee802154_radio_ops {
      * @return -EINVAL if the configuration is not valid for the device.
      * @return negative errno on error
      */
-    int (*config_phy)(ieee802154_dev_t *dev, ieee802154_phy_conf_t *conf);
+    int (*config_phy)(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf);
 
     /**
      * @brief Set IEEE802.15.4 addresses in hardware address filter
@@ -679,7 +679,7 @@ struct ieee802154_radio_ops {
      * @return -EINVAL if the settings are not supported.
      * @return negative errno on error
      */
-    int (*set_csma_params)(ieee802154_dev_t *dev, ieee802154_csma_be_t *bd,
+    int (*set_csma_params)(ieee802154_dev_t *dev, const ieee802154_csma_be_t *bd,
                            int8_t retries);
 
     /**
@@ -802,7 +802,7 @@ static inline int ieee802154_radio_set_cca_mode(ieee802154_dev_t *dev,
  * @return result of @ref ieee802154_radio_ops::config_phy
  */
 static inline int ieee802154_radio_config_phy(ieee802154_dev_t *dev,
-                                              ieee802154_phy_conf_t *conf)
+                                              const ieee802154_phy_conf_t *conf)
 {
     return dev->driver->config_phy(dev, conf);
 }
@@ -876,7 +876,7 @@ static inline int ieee802154_radio_set_frame_retrans(ieee802154_dev_t *dev,
  * @return result of @ref ieee802154_radio_ops::set_csma_params
  */
 static inline int ieee802154_radio_set_csma_params(ieee802154_dev_t *dev,
-                                                   ieee802154_csma_be_t *bd,
+                                                   const ieee802154_csma_be_t *bd,
                                                    int8_t retries)
 {
     return dev->driver->set_csma_params(dev, bd, retries);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
I forgot to add `const` qualifiers to the `config_phy` and `set_csma_params` functions. This PR adds them and adapts the `cc2538_rf`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`make -C tests/ieee802154_hal` with CC2538 (e.g remote-revb) should compile.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#14950 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
