### PR TITLE
stdio_semihosting: Extend with RISC-V support

### DIFF
--- a/makefiles/stdio.inc.mk
+++ b/makefiles/stdio.inc.mk
@@ -46,7 +46,7 @@ endif
 
 ifneq (,$(filter stdio_semihosting,$(USEMODULE)))
   USEMODULE += xtimer
-  FEATURES_REQUIRED += cpu_core_cortexm
+  FEATURES_REQUIRED_ANY += cpu_core_cortexm|arch_riscv
 endif
 
 # enable stdout buffering for modules that benefit from sending out buffers in larger chunks


### PR DESCRIPTION
### Contribution description

RISC-V support semihosting in very similar way as the cortex-m
microcontrollers. The code calls a breakpoint instruction and the
attached debugger reads/writes registers and memory for stdio.

The RISC-V architecture doesn't support a call number with the EBREAK
instruction, to allow the debugger to detect a semihosting break point,
the EBREAK instruction is wrapped in a SLLI and SRAI instruction. These
use x0 as output register, making them NOP instructions.

One caveat when using this is that the RISC-V core traps the EBREAK
instruction with trap code 3 when no debugger is attached. Restarting
the application with the debugger attached avoids this.

This also piggybacks some enhancements to the fe310 and RISC-V makefiles to fix and expose the CPU_CORE_*, CPU_ARCH_* and CPU_MODEL_* to the compiler.

### Testing procedure

Test with `tests/sys_stdio_semihosting` on a RISC-V based board. The core might hang in trap number 3 (breakpoint) when initially attaching, restarting the core should solve this and it should work fine after this.

### Issues/PRs references

None