### PR TITLE
cpu/lpc1768: Fix uart initialization

### DIFF
--- a/boards/mbed_lpc1768/include/periph_conf.h
+++ b/boards/mbed_lpc1768/include/periph_conf.h
@@ -53,6 +53,7 @@ static const uart_conf_t uart_config[] = {
     {
         .dev = (LPC_UART_TypeDef*)LPC_UART0,
         .irq_rx = UART0_IRQn,
+        .clk_offset = 3,
         .pinsel = 0,
         .pinsel_shift = 2,
         .pinsel_af = 1,
@@ -60,8 +61,9 @@ static const uart_conf_t uart_config[] = {
     {
         .dev = (LPC_UART_TypeDef*)LPC_UART2,
         .irq_rx = UART2_IRQn,
+        .clk_offset = 24,
         .pinsel = 0,
-        .pinsel_shift = 20,
+        .pinsel_shift = 10,
         .pinsel_af = 1,
     }
 };

--- a/boards/seeeduino_arch-pro/include/periph_conf.h
+++ b/boards/seeeduino_arch-pro/include/periph_conf.h
@@ -54,6 +54,7 @@ static const uart_conf_t uart_config[] = {
     {
         .dev = (LPC_UART_TypeDef*)LPC_UART0,
         .irq_rx = UART0_IRQn,
+        .clk_offset = 3,
         .pinsel = 0,
         .pinsel_shift = 2,
         .pinsel_af = 1,
@@ -61,6 +62,7 @@ static const uart_conf_t uart_config[] = {
     {
         .dev = (LPC_UART_TypeDef*)LPC_UART3,
         .irq_rx = UART3_IRQn,
+        .clk_offset = 25,
         .pinsel = 0,
         .pinsel_shift = 0,
         .pinsel_af = 2

--- a/cpu/lpc1768/include/periph_cpu.h
+++ b/cpu/lpc1768/include/periph_cpu.h
@@ -81,6 +81,7 @@ typedef enum {
 typedef struct {
     LPC_UART_TypeDef *dev;  /**< pointer to the UART device */
     uint8_t irq_rx;         /**< RX IRQ number */
+    uint8_t clk_offset;     /**< The offset of the periph in the clk sel */
     uint8_t pinsel;         /**< PINSEL# of the RX and TX pin */
     uint8_t pinsel_shift;   /**< TX/RX bitshift of the PINSEL# register */
     uint8_t pinsel_af;      /**< Alternate function of the PINSEL# register */


### PR DESCRIPTION
### Contribution description

It turns out the during the small fixes in #14916 a bug was introduced.
The `pinsel_shift` should be multiplied by 2 as each bitfield is 2 bits.
This corrects the problem and shows testing should be done before merging and not only once the pr is opened.

### Testing procedure

Run any shell based test and type help.

### Issues/PRs references

