### PR TITLE
cpu/native: pull xtimer when RTC is used

### DIFF
--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -16,7 +16,8 @@ endif
 ifeq (,$(filter stdio_%,$(USEMODULE)))
   USEMODULE += stdio_native
 endif
-ifeq (,$(filter periph_rtc,$(USEMODULE)))
+
+ifneq (,$(filter periph_rtc,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 


### PR DESCRIPTION
### Contribution description
#14766 implemented `rtc_set_alarm` using xtimer, but the module is pulled when RTC is _not_ used. This fixes it.

### Testing procedure
`tests/periph_rtc` should still work. The list of modules in `hello-world` for example should not show ` xtimer` anymore.

### Issues/PRs references
#14766