### PR TITLE
mtd: fix return in mtd_erase()

### DIFF
--- a/drivers/mtd/mtd.c
+++ b/drivers/mtd/mtd.c
@@ -183,7 +183,7 @@ int mtd_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t count)
     }
 
     if (mtd->driver->erase) {
-        mtd->driver->erase(mtd, addr, count);
+        return mtd->driver->erase(mtd, addr, count);
     }
 
     uint32_t sector_size = mtd->pages_per_sector * mtd->page_size;


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

If `.erase` is implemented we must return, not execute the fallback code path


### Testing procedure

Run `tests/mtd_flashpage` on stm32.


### Issues/PRs references


fixes #14988
