### PR TITLE
nrf802154: register with netdev

### DIFF
--- a/cpu/nrf52/radio/nrf802154/nrf802154.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154.c
@@ -25,7 +25,6 @@
 #include <errno.h>
 
 #include "cpu.h"
-#include "luid.h"
 #include "mutex.h"
 
 #include "net/ieee802154.h"
@@ -253,6 +252,8 @@ static int _init(netdev_t *dev)
 {
     (void)dev;
 
+    netdev_register(&nrf802154_dev.netdev, NETDEV_NRF802154, 0);
+
     int result = timer_init(NRF802154_TIMER, TIMER_FREQ, _timer_cb, NULL);
     assert(result >= 0);
     (void)result;
@@ -294,9 +295,7 @@ static int _init(netdev_t *dev)
     NRF_RADIO->MODECNF0 |= RADIO_MODECNF0_RU_Msk;
 
     /* assign default addresses */
-    luid_get(nrf802154_dev.long_addr, IEEE802154_LONG_ADDRESS_LEN);
-    memcpy(nrf802154_dev.short_addr, &nrf802154_dev.long_addr[6],
-           IEEE802154_SHORT_ADDRESS_LEN);
+    netdev_ieee802154_setup(&nrf802154_dev);
 
     /* set default channel */
     _set_chan(nrf802154_dev.chan);

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -281,6 +281,7 @@ typedef enum {
     NETDEV_AT86RF215,
     NETDEV_AT86RF2XX,
     NETDEV_DOSE,
+    NETDEV_NRF802154,
     /* add more if needed */
 } netdev_type_t;
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Register `nrf802154` with netdev so we don't have to generate a EUI inside the driver but can make use of an EUI provider if available.


### Testing procedure

```
2020-09-10 00:04:16,833 # Iface  6  HWaddr: 70:0E  Channel: 26  NID: 0x23 
2020-09-10 00:04:16,838 #           Long HWaddr: 2E:24:F6:CA:24:EA:70:0E 
2020-09-10 00:04:16,843 #            TX-Power: 0dBm L2-PDU:102  MTU:1280  HL:64  RTR  
2020-09-10 00:04:16,845 #           6LO  IPHC  
2020-09-10 00:04:16,849 #           Source address length: 8
2020-09-10 00:04:16,851 #           Link type: wireless
2020-09-10 00:04:16,857 #           inet6 addr: fe80::2c24:f6ca:24ea:700e  scope: link  VAL
2020-09-10 00:04:16,860 #           inet6 group: ff02::2
2020-09-10 00:04:16,862 #           inet6 group: ff02::1
2020-09-10 00:04:16,866 #           inet6 group: ff02::1:ffea:700e
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
