### PR TITLE
cc2538_rf: register with netdev

### DIFF
--- a/boards/cc2538dk/include/board.h
+++ b/boards/cc2538dk/include/board.h
@@ -20,6 +20,7 @@
 
 #include "cpu.h"
 #include "periph/gpio.h"
+#include "cc2538_eui_primary.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/boards/common/remote/include/board_common.h
+++ b/boards/common/remote/include/board_common.h
@@ -26,6 +26,7 @@
 #include "cpu.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
+#include "cc2538_eui_primary.h"
 
 #ifdef __cplusplus
  extern "C" {

--- a/boards/omote/include/board.h
+++ b/boards/omote/include/board.h
@@ -20,6 +20,7 @@
 #include "cpu.h"
 #include "periph/gpio.h"
 #include "periph/spi.h"
+#include "cc2538_eui_primary.h"
 
 #ifdef __cplusplus
  extern "C" {

--- a/boards/openmote-b/include/board.h
+++ b/boards/openmote-b/include/board.h
@@ -23,6 +23,7 @@
 
 #include "cpu.h"
 #include "periph/gpio.h"
+#include "cc2538_eui_primary.h"
 
 #ifdef __cplusplus
  extern "C" {

--- a/boards/openmote-cc2538/include/board.h
+++ b/boards/openmote-cc2538/include/board.h
@@ -21,6 +21,7 @@
 
 #include "cpu.h"
 #include "periph/gpio.h"
+#include "cc2538_eui_primary.h"
 
 #ifdef __cplusplus
  extern "C" {

--- a/cpu/cc2538/include/cc2538_eui_primary.h
+++ b/cpu/cc2538/include/cc2538_eui_primary.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_cc2538
+ * @{
+ *
+ * @file
+ * @brief           CC2538 EUI-64 provider
+ *
+ * @author          Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef CC2538_EUI_PRIMARY_H
+#define CC2538_EUI_PRIMARY_H
+
+#include "net/eui64.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CC2538_EUI64_LOCATION_PRI   (0x00280028) /**< Primary EUI-64 address location */
+#define CC2538_EUI64_LOCATION_SEC   (0x0027FFCC) /**< Secondary EUI-64 address location */
+
+/**
+ * @brief   Get the primary (burned-in) EUI-64 of the device
+ *
+ * @param arg       unused
+ * @param[out] addr The EUI-64
+ *
+ * @return  0
+ */
+static inline int cc2538_get_eui64_primary(const void *arg, eui64_t *addr)
+{
+    (void) arg;
+
+    /*
+     * The primary EUI-64 seems to be written to memory in a non-sequential
+     * byte order, with both 4-byte halves of the address flipped.
+     */
+    addr->uint8[7] = ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[4];
+    addr->uint8[6] = ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[5];
+    addr->uint8[5] = ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[6];
+    addr->uint8[4] = ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[7];
+    addr->uint8[3] = ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[0];
+    addr->uint8[2] = ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[1];
+    addr->uint8[1] = ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[2];
+    addr->uint8[0] = ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[3];
+
+    return 0;
+}
+
+/**
+ * @name    CC2538 comes with an EUI-64
+ * @{
+ */
+#ifndef CC2538_EUI64_CUSTOM
+#define EUI64_PROVIDER_FUNC   cc2538_get_eui64_primary
+#define EUI64_PROVIDER_TYPE   NETDEV_CC2538
+#define EUI64_PROVIDER_INDEX  0
+#endif  /* !CC2538_EUI64_CUSTOM */
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* CC2538_EUI_PRIMARY_H */
+/** @} */

--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -220,7 +220,7 @@ typedef struct {
  * @brief   IRQ handler for RF events
  *
  */
-void _irq_handler(void);
+void cc2538_irq_handler(void);
 
 /**
  * @brief   Trigger a clear channel assessment

--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -38,9 +38,6 @@ extern "C" {
 
 #define CC2538_RF_MAX_DATA_LEN (CC2538_RF_FIFO_SIZE - CC2538_PACKET_LENGTH_SIZE)
 
-#define CC2538_EUI64_LOCATION_PRI   (0x00280028) /**< Primary EUI-64 address location */
-#define CC2538_EUI64_LOCATION_SEC   (0x0027FFCC) /**< Secondary EUI-64 address location */
-
 /* TODO: Move these to sys/include/net/ieee802154.h somehow */
 /* IEEE 802.15.4 defined constants (2.4 GHz logical channels) */
 #define IEEE802154_MIN_FREQ         (2405) /**< Min. frequency (2405 MHz) */
@@ -246,13 +243,6 @@ void cc2538_get_addr_long(uint8_t *addr);
  * @param[out] addr The currently set (2-byte) short address
  */
 void cc2538_get_addr_short(uint8_t *addr);
-
-/**
- * @brief   Get the primary (burned-in) EUI-64 of the device
- *
- * @return  The primary EUI-64 of the device
- */
-uint64_t cc2538_get_eui64_primary(void);
 
 /**
  * @brief   Get the configured channel number of the device

--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -236,16 +236,16 @@ bool cc2538_channel_clear(void);
 /**
  * @brief   Get the configured long address of the device
  *
- * @return  The currently set (8-byte) long address
+ * @param[out] addr The currently set (8-byte) long address
  */
-uint64_t cc2538_get_addr_long(void);
+void cc2538_get_addr_long(uint8_t *addr);
 
 /**
  * @brief   Get the configured short address of the device
  *
- * @return  The currently set (2-byte) short address
+ * @param[out] addr The currently set (2-byte) short address
  */
-uint16_t cc2538_get_addr_short(void);
+void cc2538_get_addr_short(uint8_t *addr);
 
 /**
  * @brief   Get the primary (burned-in) EUI-64 of the device
@@ -321,14 +321,14 @@ void cc2538_setup(cc2538_rf_t *dev);
  *
  * @param[in] addr          (2-byte) short address to set
  */
-void cc2538_set_addr_short(uint16_t addr);
+void cc2538_set_addr_short(const uint8_t *addr);
 
 /**
  * @brief   Set the long address of the device
  *
  * @param[in] addr          (8-byte) short address to set
  */
-void cc2538_set_addr_long(uint64_t addr);
+void cc2538_set_addr_long(const uint8_t *addr);
 
 /**
  * @brief   Set the channel number of the device

--- a/cpu/cc2538/radio/cc2538_rf.c
+++ b/cpu/cc2538/radio/cc2538_rf.c
@@ -198,9 +198,16 @@ void cc2538_setup(cc2538_rf_t *dev)
     netdev->driver = &cc2538_rf_driver;
 
     cc2538_init();
+
+    netdev_register(netdev, NETDEV_CC2538, 0);
+
     cc2538_set_tx_power(CC2538_RF_POWER_DEFAULT);
     cc2538_set_chan(CC2538_RF_CHANNEL_DEFAULT);
-    cc2538_set_addr_long(cc2538_get_eui64_primary());
+
+    /* assign default addresses */
+    netdev_ieee802154_setup(&dev->netdev);
+    cc2538_set_addr_long(dev->netdev.long_addr);
+    cc2538_set_addr_short(dev->netdev.short_addr);
 
     cc2538_on();
 }

--- a/cpu/cc2538/radio/cc2538_rf_getset.c
+++ b/cpu/cc2538/radio/cc2538_rf_getset.c
@@ -85,30 +85,6 @@ unsigned int cc2538_get_chan(void)
     return IEEE802154_FREQ2CHAN(CC2538_MIN_FREQ + RFCORE_XREG_FREQCTRL);
 }
 
-uint64_t cc2538_get_eui64_primary(void)
-{
-    /*
-     * The primary EUI-64 seems to be written to memory in a non-sequential
-     * byte order, with both 4-byte halves of the address flipped.
-     */
-    uint64_t eui64 = ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[4];
-    eui64 <<= 8;
-    eui64 |= ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[5];
-    eui64 <<= 8;
-    eui64 |= ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[6];
-    eui64 <<= 8;
-    eui64 |= ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[7];
-    eui64 <<= 8;
-    eui64 |= ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[0];
-    eui64 <<= 8;
-    eui64 |= ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[1];
-    eui64 <<= 8;
-    eui64 |= ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[2];
-    eui64 <<= 8;
-    eui64 |= ((uint8_t*)CC2538_EUI64_LOCATION_PRI)[3];
-    return eui64;
-}
-
 bool cc2538_get_monitor(void)
 {
     return NOT(RFCORE->XREG_FRMFILT0bits.FRAME_FILTER_EN);

--- a/cpu/cc2538/radio/cc2538_rf_getset.c
+++ b/cpu/cc2538/radio/cc2538_rf_getset.c
@@ -62,29 +62,22 @@ static const uint8_t power_lut[NUM_POWER_LEVELS] = {
     255, /**<   7 dBm */
 };
 
-uint64_t cc2538_get_addr_long(void)
+void cc2538_get_addr_long(uint8_t *addr)
 {
-    uint64_t addr = RFCORE_FFSM_EXT_ADDR0;
-    addr <<= 8;
-    addr |= RFCORE_FFSM_EXT_ADDR1;
-    addr <<= 8;
-    addr |= RFCORE_FFSM_EXT_ADDR2;
-    addr <<= 8;
-    addr |= RFCORE_FFSM_EXT_ADDR3;
-    addr <<= 8;
-    addr |= RFCORE_FFSM_EXT_ADDR4;
-    addr <<= 8;
-    addr |= RFCORE_FFSM_EXT_ADDR5;
-    addr <<= 8;
-    addr |= RFCORE_FFSM_EXT_ADDR6;
-    addr <<= 8;
-    addr |= RFCORE_FFSM_EXT_ADDR7;
-    return addr;
+    addr[7] = RFCORE_FFSM_EXT_ADDR0;
+    addr[6] = RFCORE_FFSM_EXT_ADDR1;
+    addr[5] = RFCORE_FFSM_EXT_ADDR2;
+    addr[4] = RFCORE_FFSM_EXT_ADDR3;
+    addr[3] = RFCORE_FFSM_EXT_ADDR4;
+    addr[2] = RFCORE_FFSM_EXT_ADDR5;
+    addr[1] = RFCORE_FFSM_EXT_ADDR6;
+    addr[0] = RFCORE_FFSM_EXT_ADDR7;
 }
 
-uint16_t cc2538_get_addr_short(void)
+void cc2538_get_addr_short(uint8_t *addr)
 {
-    return (RFCORE_FFSM_SHORT_ADDR0 << 8) | RFCORE_FFSM_SHORT_ADDR1;
+    addr[1] = RFCORE_FFSM_SHORT_ADDR0;
+    addr[0] = RFCORE_FFSM_SHORT_ADDR1;
 }
 
 unsigned int cc2538_get_chan(void)
@@ -147,22 +140,22 @@ int cc2538_get_tx_power(void)
     return OUTPUT_POWER_MIN + best_index;
 }
 
-void cc2538_set_addr_long(uint64_t addr)
+void cc2538_set_addr_long(const uint8_t *addr)
 {
-    RFCORE_FFSM_EXT_ADDR0 = addr >> (7 * 8);
-    RFCORE_FFSM_EXT_ADDR1 = addr >> (6 * 8);
-    RFCORE_FFSM_EXT_ADDR2 = addr >> (5 * 8);
-    RFCORE_FFSM_EXT_ADDR3 = addr >> (4 * 8);
-    RFCORE_FFSM_EXT_ADDR4 = addr >> (3 * 8);
-    RFCORE_FFSM_EXT_ADDR5 = addr >> (2 * 8);
-    RFCORE_FFSM_EXT_ADDR6 = addr >> (1 * 8);
-    RFCORE_FFSM_EXT_ADDR7 = addr >> (0 * 8);
+    RFCORE_FFSM_EXT_ADDR0 = addr[7];
+    RFCORE_FFSM_EXT_ADDR1 = addr[6];
+    RFCORE_FFSM_EXT_ADDR2 = addr[5];
+    RFCORE_FFSM_EXT_ADDR3 = addr[4];
+    RFCORE_FFSM_EXT_ADDR4 = addr[3];
+    RFCORE_FFSM_EXT_ADDR5 = addr[2];
+    RFCORE_FFSM_EXT_ADDR6 = addr[1];
+    RFCORE_FFSM_EXT_ADDR7 = addr[0];
 }
 
-void cc2538_set_addr_short(uint16_t addr)
+void cc2538_set_addr_short(const uint8_t *addr)
 {
-    RFCORE_FFSM_SHORT_ADDR1 = addr;
-    RFCORE_FFSM_SHORT_ADDR0 = addr >> 8;
+    RFCORE_FFSM_SHORT_ADDR0 = addr[1];
+    RFCORE_FFSM_SHORT_ADDR1 = addr[0];
 }
 
 void cc2538_set_chan(unsigned int chan)

--- a/cpu/cc2538/radio/cc2538_rf_internal.c
+++ b/cpu/cc2538/radio/cc2538_rf_internal.c
@@ -64,7 +64,7 @@ void isr_rfcoreerr(void)
 
 void isr_rfcorerxtx(void)
 {
-   _irq_handler();
+   cc2538_irq_handler();
 
     cortexm_isr_end();
 }

--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -56,7 +56,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
                 return -EOVERFLOW;
             }
             else {
-                *(uint16_t*)value = cc2538_get_addr_short();
+                cc2538_get_addr_short(value);
             }
             return sizeof(uint16_t);
 
@@ -65,7 +65,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
                 return -EOVERFLOW;
             }
             else {
-                *(uint64_t*)value = cc2538_get_addr_long();
+                cc2538_get_addr_long(value);
             }
             return sizeof(uint64_t);
 
@@ -164,7 +164,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t value_
                 res = -EOVERFLOW;
             }
             else {
-                cc2538_set_addr_short(*((const uint16_t*)value));
+                cc2538_set_addr_short(value);
                 res = sizeof(uint16_t);
             }
             break;
@@ -174,7 +174,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t value_
                 res = -EOVERFLOW;
             }
             else {
-                cc2538_set_addr_long(*((const uint64_t*)value));
+                cc2538_set_addr_long(value);
                 res = sizeof(uint64_t);
             }
             break;
@@ -394,18 +394,12 @@ static int _init(netdev_t *netdev)
     _dev = netdev;
 
     uint16_t chan = cc2538_get_chan();
-    uint16_t addr_short = cc2538_get_addr_short();
-    uint64_t addr_long = cc2538_get_addr_long();
 
     netdev_ieee802154_reset(&dev->netdev);
 
     /* Initialise netdev_ieee802154_t struct */
     netdev_ieee802154_set(&dev->netdev, NETOPT_CHANNEL,
                           &chan, sizeof(chan));
-    netdev_ieee802154_set(&dev->netdev, NETOPT_ADDRESS,
-                          &addr_short, sizeof(addr_short));
-    netdev_ieee802154_set(&dev->netdev, NETOPT_ADDRESS_LONG,
-                          &addr_long, sizeof(addr_long));
 
     cc2538_set_state(dev, NETOPT_STATE_IDLE);
 

--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -34,7 +34,7 @@
 /* Reference pointer for the IRQ handler */
 static netdev_t *_dev;
 
-void _irq_handler(void)
+void cc2538_irq_handler(void)
 {
     RFCORE_SFR_RFIRQF0 = 0;
     RFCORE_SFR_RFIRQF1 = 0;

--- a/cpu/cc2538/radio/cc2538_rf_radio_ops.c
+++ b/cpu/cc2538/radio/cc2538_rf_radio_ops.c
@@ -307,7 +307,7 @@ static int _request_set_trx_state(ieee802154_dev_t *dev, ieee802154_trx_state_t 
     return 0;
 }
 
-void _irq_handler(void)
+void cc2538_irq_handler(void)
 {
     uint_fast8_t flags_f0 = RFCORE_SFR_RFIRQF0;
     uint_fast8_t flags_f1 = RFCORE_SFR_RFIRQF1;

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -280,6 +280,7 @@ typedef enum {
     NETDEV_ANY = 0,         /**< Will match any device type */
     NETDEV_AT86RF215,
     NETDEV_AT86RF2XX,
+    NETDEV_CC2538,
     NETDEV_DOSE,
     /* add more if needed */
 } netdev_type_t;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

In moving towards registering all 802.15.4 radios with netdev for a common init path, also convert `cc2538_rf`.
All CC2538 chips already come with an EUI-64 that was used by the driver before, so convert it to a EUI provider so that the generic code path can make use of it now.

### Testing procedure

The MAC address should stay the same as on `master`

```
2020-09-10 13:19:52,130 # Iface  6  HWaddr: 00:12  Channel: 26  Page: 0  NID: 0x23 
2020-09-10 13:19:52,134 #           Long HWaddr: 00:12:4B:00:18:F1:D6:5E 
2020-09-10 13:19:52,141 #            TX-Power: 0dBm  State: IDLE 
2020-09-10 13:19:52,144 #           AUTOACK  L2-PDU:102  MTU:1280  HL:64  RTR  
2020-09-10 13:19:52,145 #           6LO  IPHC  
2020-09-10 13:19:52,147 #           Source address length: 8
2020-09-10 13:19:52,148 #           Link type: wireless
2020-09-10 13:19:52,157 #           inet6 addr: fe80::212:4b00:18f1:d65e  scope: link  VAL
2020-09-10 13:19:52,158 #           inet6 group: ff02::2
2020-09-10 13:19:52,159 #           inet6 group: ff02::1
2020-09-10 13:19:52,160 #           inet6 group: ff02::1:fff1:d65e
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
