### PR TITLE
drivers/periph: Remove TIMER from device_enums.h

### DIFF
--- a/boards/ek-lm4f120xl/include/periph_conf.h
+++ b/boards/ek-lm4f120xl/include/periph_conf.h
@@ -40,35 +40,32 @@ extern "C" {
 /** @} */
 
 /**
- * @name Timer configuration
+ * @name    Timer configuration
  * @{
  */
-#define TIMER_NUMOF         (2U)
-#define TIMER_0_EN          1
-#define TIMER_1_EN          1
-#define TIMER_IRQ_PRIO      1
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = WTIMER0_BASE,
+        .max      = 0xffffffff,
+        .irqn     = Timer0A_IRQn,
+        .sysctl   = SYSCTL_PERIPH_WTIMER0,
+        .intbase  = INT_WTIMER0A,
+        .channels = 1
+    },
+    {
+        .dev      = WTIMER1_BASE,
+        .max      = 0xffffffff,
+        .irqn     = Timer1A_IRQn,
+        .sysctl   = SYSCTL_PERIPH_WTIMER1,
+        .intbase  = INT_WTIMER1A,
+        .channels = 1
+    },
+};
 
-/* Timer 0 configuration
- *
- * WTIMER0 is a 32/64bits timer.
- * We use timer_a as TIMER_0
- */
-#define TIMER_0_CHANNELS    1
-#define TIMER_0_MAX_VALUE   (0xffffffff)
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+
 #define TIMER_0_ISR         isr_wtimer0a
-#define TIMER_0_IRQ_CHAN    Timer0A_IRQn
-
-/* Timer 1 configuration
- *
- * WTIMER1 is a 32/64bits timer.
- * We use timer_a as TIMER_1
- */
-
-#define TIMER_1_CHANNELS    1
-#define TIMER_1_MAX_VALUE   (0xffffffff)
 #define TIMER_1_ISR         isr_wtimer1a
-#define TIMER_1_IRQ_CHAN    Timer1A_IRQn
-/** @} */
 
 /**
  * @name UART configuration

--- a/boards/mbed_lpc1768/include/periph_conf.h
+++ b/boards/mbed_lpc1768/include/periph_conf.h
@@ -31,7 +31,6 @@ extern "C" {
  * @{
  */
 #define TIMER_NUMOF         (1U)
-#define TIMER_0_EN          1
 #define TIMER_IRQ_PRIO      1
 
 /* Timer 0 configuration */

--- a/boards/seeeduino_arch-pro/include/periph_conf.h
+++ b/boards/seeeduino_arch-pro/include/periph_conf.h
@@ -32,7 +32,6 @@ extern "C" {
  * @{
  */
 #define TIMER_NUMOF         (1U)
-#define TIMER_0_EN          1
 #define TIMER_IRQ_PRIO      1
 
 /* Timer 0 configuration */

--- a/cpu/ezr32wg/periph/timer.c
+++ b/cpu/ezr32wg/periph/timer.c
@@ -135,4 +135,4 @@ void TIMER_0_ISR(void)
     }
     cortexm_isr_end();
 }
-#endif /* TIMER_0_EN */
+#endif /* TIMER_0_ISR */

--- a/cpu/lm4f120/include/periph_cpu.h
+++ b/cpu/lm4f120/include/periph_cpu.h
@@ -21,7 +21,6 @@
 #ifndef PERIPH_CPU_H
 #define PERIPH_CPU_H
 
-
 #include "cpu.h"
 
 #ifdef __cplusplus
@@ -34,7 +33,7 @@ extern "C" {
  */
 #define HAVE_GPIO_T
 typedef uint32_t gpio_t;
-#define GPIO_PIN(x,y) ((gpio_t)((x<<4) | y))
+#define GPIO_PIN(x, y) ((gpio_t)((x<<4) | y))
 /** @} */
 
 #ifndef DOXYGEN
@@ -105,6 +104,18 @@ typedef enum {
     ADC_RES_16BIT = 0xd00,            /**< not supported by hardware */
 } adc_res_t;
 #endif /* ndef DOXYGEN */
+
+/**
+ * @brief   Define timer configuration values
+ */
+typedef struct {
+    uint32_t dev;       /**< Address of timer base */
+    uint32_t max;       /**< Max tick value of timer */
+    int irqn;           /**< Number of the higher timer IRQ channel */
+    uint32_t sysctl;    /**< Address of timer system control */
+    uint32_t intbase;   /**< Interrupt base of timer */
+    int channels;       /**< Number of channels for the timer */
+} timer_conf_t;
 
 /**
  * @brief   Override SPI hardware chip select macro

--- a/cpu/lpc1768/periph/timer.c
+++ b/cpu/lpc1768/periph/timer.c
@@ -41,10 +41,10 @@ static timer_isr_ctx_t config[TIMER_NUMOF];
 
 int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 {
-    if (dev == TIMER_0) {
+    if (dev == 0) {
         /* save callback */
-        config[TIMER_0].cb = cb;
-        config[TIMER_0].arg = arg;
+        config[dev].cb = cb;
+        config[dev].arg = arg;
         /* enable power for timer */
         TIMER_0_CLKEN();
         /* let timer run with full frequency */
@@ -65,7 +65,7 @@ int timer_init(tim_t dev, unsigned long freq, timer_cb_t cb, void *arg)
 
 int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 {
-    if (dev == TIMER_0) {
+    if (dev == 0) {
         switch (channel) {
             case 0:
                 TIMER_0_DEV->MR0 = value;
@@ -90,7 +90,7 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
 
 int timer_clear(tim_t dev, int channel)
 {
-    if (dev == TIMER_0 && channel >= 0 && channel < TIMER_0_CHANNELS) {
+    if (dev == 0 && channel >= 0 && channel < TIMER_0_CHANNELS) {
         TIMER_0_DEV->MCR &= ~(1 << (channel * 3));
         return 0;
     }
@@ -99,7 +99,7 @@ int timer_clear(tim_t dev, int channel)
 
 unsigned int timer_read(tim_t dev)
 {
-    if (dev == TIMER_0) {
+    if (dev == 0) {
         return (unsigned int)TIMER_0_DEV->TC;
     }
     return 0;
@@ -107,40 +107,41 @@ unsigned int timer_read(tim_t dev)
 
 void timer_start(tim_t dev)
 {
-    if (dev == TIMER_0) {
+    if (dev == 0) {
         TIMER_0_DEV->TCR |= 1;
     }
 }
 
 void timer_stop(tim_t dev)
 {
-    if (dev == TIMER_0) {
+    if (dev == 0) {
         TIMER_0_DEV->TCR &= ~(1);
     }
 }
 
-#if TIMER_0_EN
+#ifdef TIMER_0_ISR
 void TIMER_0_ISR(void)
 {
+    uint32_t timer = 0;
     if (TIMER_0_DEV->IR & MR0_FLAG) {
         TIMER_0_DEV->IR |= (MR0_FLAG);
         TIMER_0_DEV->MCR &= ~(1 << 0);
-        config[TIMER_0].cb(config[TIMER_0].arg, 0);
+        config[timer].cb(config[timer].arg, 0);
     }
     if (TIMER_0_DEV->IR & MR1_FLAG) {
         TIMER_0_DEV->IR |= (MR1_FLAG);
         TIMER_0_DEV->MCR &= ~(1 << 3);
-        config[TIMER_0].cb(config[TIMER_0].arg, 1);
+        config[timer].cb(config[timer].arg, 1);
     }
     if (TIMER_0_DEV->IR & MR2_FLAG) {
         TIMER_0_DEV->IR |= (MR2_FLAG);
         TIMER_0_DEV->MCR &= ~(1 << 6);
-        config[TIMER_0].cb(config[TIMER_0].arg, 2);
+        config[timer].cb(config[timer].arg, 2);
     }
     if (TIMER_0_DEV->IR & MR3_FLAG) {
         TIMER_0_DEV->IR |= (MR3_FLAG);
         TIMER_0_DEV->MCR &= ~(1 << 9);
-        config[TIMER_0].cb(config[TIMER_0].arg, 3);
+        config[timer].cb(config[timer].arg, 3);
     }
     cortexm_isr_end();
 }

--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -39,7 +39,6 @@ extern "C" {
  * @{
  */
 #define TIMER_NUMOF        (1U)
-#define TIMER_0_EN         1
 
 /**
  * @brief xtimer configuration

--- a/drivers/include/periph/dev_enums.h
+++ b/drivers/include/periph/dev_enums.h
@@ -30,25 +30,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Legacy definition of timers
- */
-enum {
-#if TIMER_0_EN
-    TIMER_0,                /**< 1st timer */
-#endif
-#if TIMER_1_EN
-    TIMER_1,                /**< 2nd timer */
-#endif
-#if TIMER_2_EN
-    TIMER_2,                /**< 3rd timer */
-#endif
-#if TIMER_3_EN
-    TIMER_3,                /**< 4th timer */
-#endif
-    TIMER_UNDEFINED         /**< deprecated legacy undefined values */
-};
-
-/**
  * @brief   Legacy definitions of I2C devices
  */
 enum {


### PR DESCRIPTION
### Contribution description

In order to remove the need for the legacy device_enums and clean things up, all boards using `TIMER` definitions from device_enums have been updated.

This includes:
ek-lm4f120xl - Updated to support `timer_config`.
mbed_lpc1768 - Since only timer0 is used, defines have been updated to use that, `timer_config` is not used
seeeduino_arch-pro - Updated to support `timer_config`
native - Implementation does not require device_enums.h

### Testing procedure
Use tests/periph_timer on each of the boards

### Issues/PRs references
Step forward with #7941
