### PR TITLE
ieee802154_hal: add cap for register retention during `off`

### DIFF
--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -110,6 +110,10 @@ typedef enum {
      * It's assumed that @ref IEEE802154_CAP_FRAME_RETRANS is present.
      */
     IEEE802154_CAP_FRAME_RETRANS_INFO,
+    /**
+     * @brief the device retains all register values when off.
+     */
+    IEEE802154_CAP_REG_RETENTION,
 } ieee802154_rf_caps_t;
 
 /**
@@ -484,6 +488,18 @@ struct ieee802154_radio_ops {
      * @pre call to @ref ieee802154_radio_ops::request_on was successful.
      *
      * @post the transceiver state is @ref IEEE802154_TRX_STATE_TRX_OFF
+     * During boot or in case the radio doesn't support @ref
+     * IEEE802154_CAP_REG_RETENTION when @ref off was called, the
+     * Physical Information Base will be undefined. Thus, take into
+     * consideration that the following functions should be called right after
+     * the radio is turned on again:
+     * - @ref set_cca_threshold
+     * - @ref set_cca_mode
+     * - @ref config_phy
+     * - @ref set_csma_params
+     * - @ref set_rx_mode
+     * - @ref set_hw_addr_filter
+     * - @ref set_frame_retrans (if available)
      *
      * @param[in] dev IEEE802.15.4 device descriptor
      *

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -627,9 +627,6 @@ struct ieee802154_radio_ops {
      *
      * @pre the device is on
      *
-     * @note this function pointer can be NULL if the device doesn't support
-     *       hardware address filtering.
-     *
      * @param[in] dev IEEE802.15.4 device descriptor
      * @param[in] short_addr the IEEE802.15.4 short address. If NULL, the short
      *            address is not altered..


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds a radio cap for indicating that the radio can keep the content of all register when off. This is required to indicate the upper layer that in some cases it might be necessary to set the PIB again.

This still leaves room for several use cases:
- Users that don't require register retention (because the CPU hibernates) and simply reboot on wake-up can ignore setting the PIB after `off`.
- Users that require register retention (radio sleeps but CPU is still awake) can set the PIB if the cap is not there.

It also specifies that during boot, the PIB is undefined (so it should be set once `confirm_on` returns 0).

I also piggybacked a misplaced note that was probably a left-over of the cleanup in #14371 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The output of Travis should be enough
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Discussed in #14802 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
