### PR TITLE
cpu/sam0_common: implement pm_off()

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -454,6 +454,11 @@ typedef struct {
 void gpio_init_mux(gpio_t pin, gpio_mux_t mux);
 
 /**
+ * @brief   CPU provides own pm_off() function
+ */
+#define PROVIDES_PM_LAYERED_OFF
+
+/**
  * @brief   Called before the power management enters a power mode
  *
  * @param[in] deep

--- a/cpu/sam0_common/periph/pm.c
+++ b/cpu/sam0_common/periph/pm.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_sam0_common
+ * @ingroup     drivers_periph_pm
+ * @{
+ *
+ * @file
+ * @brief       Implementation of pm_off()
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ *
+ * @}
+ */
+
+#include "periph/pm.h"
+
+void pm_off(void)
+{
+    irq_disable();
+
+#ifdef PM_SLEEPCFG_SLEEPMODE_OFF
+    PM->SLEEPCFG.bit.SLEEPMODE = PM_SLEEPCFG_SLEEPMODE_OFF;
+    while (PM->SLEEPCFG.bit.SLEEPMODE != PM_SLEEPCFG_SLEEPMODE_OFF) {}
+
+    cortexm_sleep(1);
+#else
+    pm_set(0);
+#endif
+}


### PR DESCRIPTION
### Contribution description

Use the OFF mode instead of whatever lowest standby / hibernate mode was provided my `pm_set()`


### Testing procedure

`pm off` should turn off the CPU.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
