### PR TITLE
boards/stm32l0l1: model clock configuration in kconfig

### DIFF
--- a/boards/b-l072z-lrwan1/Kconfig
+++ b/boards/b-l072z-lrwan1/Kconfig
@@ -28,3 +28,8 @@ config BOARD_B_L072Z_LRWAN1
     # The 0.10.0 openocd version in Ubuntu Bionic doesn't work. The change was
     # introduced after Jun 8, 2017 - v0.10.0-1-20170607-2132-dev.
     select HAS_RIOTBOOT
+
+    # Clock configuration
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/i-nucleo-lrwan1/Kconfig
+++ b/boards/i-nucleo-lrwan1/Kconfig
@@ -22,3 +22,8 @@ config BOARD_I_NUCLEO_LRWAN1
     select HAS_PERIPH_SPI_GPIO_MODE
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    # Clock configuration
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/im880b/Kconfig
+++ b/boards/im880b/Kconfig
@@ -20,3 +20,8 @@ config BOARD_IM880B
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    # Clock configuration
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/limifrog-v1/Kconfig
+++ b/boards/limifrog-v1/Kconfig
@@ -18,3 +18,5 @@ config BOARD_LIMIFROG_V1
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/lobaro-lorabox/Kconfig
+++ b/boards/lobaro-lorabox/Kconfig
@@ -20,3 +20,8 @@ config BOARD_LOBARO_LORABOX
     select HAS_PERIPH_SPI_GPIO_MODE
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    # Clock configuration
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/lsn50/Kconfig
+++ b/boards/lsn50/Kconfig
@@ -28,3 +28,8 @@ config BOARD_LSN50
     # The 0.10.0 openocd version in Ubuntu Bionic doesn't work. The change was
     # introduced after Jun 8, 2017 - v0.10.0-1-20170607-2132-dev.
     select HAS_RIOTBOOT
+
+    # Clock configuration
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/nucleo-l031k6/Kconfig
+++ b/boards/nucleo-l031k6/Kconfig
@@ -24,4 +24,7 @@ config BOARD_NUCLEO_L031K6
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
 
+    # Clock configuration
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo32/Kconfig"

--- a/boards/nucleo-l053r8/Kconfig
+++ b/boards/nucleo-l053r8/Kconfig
@@ -22,4 +22,7 @@ config BOARD_NUCLEO_L053R8
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
 
+    # Clock configuration
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-l073rz/Kconfig
+++ b/boards/nucleo-l073rz/Kconfig
@@ -32,4 +32,7 @@ config BOARD_NUCLEO_L073RZ
     # introduced after Jun 8, 2017 - v0.10.0-1-20170607-2132-dev.
     select HAS_RIOTBOOT
 
+    # Clock configuration
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nz32-sc151/Kconfig
+++ b/boards/nz32-sc151/Kconfig
@@ -23,3 +23,5 @@ config BOARD_NZ32_SC151
     select HAS_PERIPH_SPI_GPIO_MODE
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/stm32l0538-disco/Kconfig
+++ b/boards/stm32l0538-disco/Kconfig
@@ -18,3 +18,5 @@ config BOARD_STM32L0538_DISCO
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/cpu/stm32/kconfigs/Kconfig.clk
+++ b/cpu/stm32/kconfigs/Kconfig.clk
@@ -6,7 +6,7 @@
 #
 
 menu "STM32 clock configuration"
-    depends on CPU_FAM_G0 || CPU_FAM_G4
+    depends on CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1
 
 choice
 bool "Clock source selection"
@@ -14,6 +14,10 @@ default USE_CLOCK_PLL
 
 config USE_CLOCK_PLL
     bool "PLL"
+
+config USE_CLOCK_MSI
+    bool "Use direct multi-speed frequency internal oscillator (MSI)"
+    depends on CPU_FAM_L0 || CPU_FAM_L1
 
 config USE_CLOCK_HSE
     bool "Direct High frequency external oscillator (HSE)"
@@ -24,6 +28,7 @@ config USE_CLOCK_HSI
 
 endchoice
 
+if CPU_FAM_G0 || CPU_FAM_G4
 config CLOCK_PLL_M
     int "M: PLLIN division factor" if USE_CLOCK_PLL
     default 1 if CPU_FAM_G0
@@ -45,7 +50,7 @@ config CLOCK_PLL_R
     default 6 if BOARD_HAS_HSE
     default 5
     range 2 8
-endif
+endif  # CPU_FAM_G0
 
 if CPU_FAM_G4
 choice
@@ -72,7 +77,7 @@ config CLOCK_PLL_R
     default 4 if PLL_R_DIV_4
     default 6 if PLL_R_DIV_6
     default 8 if PLL_R_DIV_8
-endif
+endif  # CPU_FAM_G4
 
 if CPU_FAM_G0
 choice
@@ -115,7 +120,99 @@ config CLOCK_HSISYS_DIV
     default 32 if CLOCK_HSISYS_DIV_32
     default 64 if CLOCK_HSISYS_DIV_64
     default 128 if CLOCK_HSISYS_DIV_128
-endif
+endif  # CPU_FAM_G0
+
+endif  # CPU_FAM_G0 || CPU_FAM_G4
+
+if CPU_FAM_L0 || CPU_FAM_L1
+config CLOCK_PLL_DIV
+    int "Main PLL division factor" if USE_CLOCK_PLL
+    default 2
+    range 2 4
+
+choice
+bool "Main PLL multiply factor" if USE_CLOCK_PLL
+default PLL_MUL_4
+
+config PLL_MUL_3
+    bool "Multiply by 3"
+
+config PLL_MUL_4
+    bool "Multiply by 4"
+
+config PLL_MUL_6
+    bool "Multiply by 6"
+
+config PLL_MUL_8
+    bool "Multiply by 8"
+
+config PLL_MUL_12
+    bool "Multiply by 12"
+
+config PLL_MUL_16
+    bool "Multiply by 16"
+
+config PLL_MUL_24
+    bool "Multiply by 24"
+
+config PLL_MUL_32
+    bool "Multiply by 32"
+
+config PLL_MUL_48
+    bool "Multiply by 48"
+
+endchoice
+
+config CLOCK_PLL_MUL
+    int
+    default 3 if PLL_MUL_3
+    default 4 if PLL_MUL_4
+    default 6 if PLL_MUL_6
+    default 8 if PLL_MUL_8
+    default 12 if PLL_MUL_12
+    default 16 if PLL_MUL_16
+    default 24 if PLL_MUL_24
+    default 32 if PLL_MUL_32
+    default 48 if PLL_MUL_48
+
+choice
+bool "Desired MSI clock frequency" if USE_CLOCK_MSI
+default CLOCK_MSI_4MHZ
+
+config CLOCK_MSI_65KHZ
+    bool "65.536kHz"
+
+config CLOCK_MSI_130KHZ
+    bool "131.072kHz"
+
+config CLOCK_MSI_260KHZ
+    bool "262.144kHz"
+
+config CLOCK_MSI_520KHZ
+    bool "524.288kHz"
+
+config CLOCK_MSI_1MHZ
+    bool "1.048MHz"
+
+config CLOCK_MSI_2MHZ
+    bool "2.097MHz"
+
+config CLOCK_MSI_4MHZ
+    bool "4.194MHz"
+
+endchoice
+
+config CLOCK_MSI
+    int
+    default 65536 if CLOCK_MSI_65KHZ
+    default 131072 if CLOCK_MSI_130KHZ
+    default 262144 if CLOCK_MSI_260KHZ
+    default 524288 if CLOCK_MSI_520KHZ
+    default 1048000 if CLOCK_MSI_1MHZ
+    default 2097000 if CLOCK_MSI_2MHZ
+    default 4194000 if CLOCK_MSI_4MHZ
+
+endif  # CPU_FAM_L0 || CPU_FAM_L1
 
 choice
 bool "APB1 prescaler (division factor of HCLK to produce PCLK1)"
@@ -147,7 +244,8 @@ config CLOCK_APB1_DIV
     default 16 if CLOCK_APB1_DIV_16
 
 choice
-bool "APB2 prescaler (division factor of HCLK to produce PCLK2)"  if CPU_FAM_G4
+bool "APB2 prescaler (division factor of HCLK to produce PCLK2)"
+depends on CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1
 default CLOCK_APB2_DIV_1
 
 config CLOCK_APB2_DIV_1


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR models the clock configuration of STM32 L0 and L1 in Kconfig.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Change the clock configuration using make menuconfig: verify the parameter are correctly displayed, ranges are correct (follow the datasheet)
- Verify that affected boards are still functional

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Based on #14945 
Tick an item in #14975 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
