### PR TITLE
boards/stm32f1f3: model clock configuration in Kconfig

### DIFF
--- a/boards/common/blxxxpill/Kconfig
+++ b/boards/common/blxxxpill/Kconfig
@@ -17,3 +17,9 @@ config BOARD_COMMON_BLXXXPILL
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
     select HAS_PERIPH_QDEC
+
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/common/iotlab/Kconfig
+++ b/boards/common/iotlab/Kconfig
@@ -17,3 +17,9 @@ config BOARD_COMMON_IOTLAB
 
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
+
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/common/iotlab/Makefile.features
+++ b/boards/common/iotlab/Makefile.features
@@ -11,3 +11,6 @@ FEATURES_PROVIDED += periph_uart
 
 # Put other features for this board (in alphabetical order)
 FEATURES_PROVIDED += riotboot
+
+# iotlab boards provide a custom default Kconfig clock configuration
+KCONFIG_ADD_CONFIG += $(RIOTBOARD)/common/iotlab/clock.config

--- a/boards/common/iotlab/clock.config
+++ b/boards/common/iotlab/clock.config
@@ -1,0 +1,4 @@
+# iotlab based boards provide a 16MHz HSE so they need a predivider of 2
+# to remain with a 72MHz sysclk by default.
+CONFIG_CUSTOM_PLL_PARAMS=y
+CONFIG_CLOCK_PLL_PREDIV=2

--- a/boards/fox/Kconfig
+++ b/boards/fox/Kconfig
@@ -20,3 +20,9 @@ config BOARD_FOX
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/fox/Makefile.features
+++ b/boards/fox/Makefile.features
@@ -8,3 +8,7 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
+
+# fox board provides a custom default Kconfig clock configuration. The same as
+# iotlab boards.
+KCONFIG_ADD_CONFIG += $(RIOTBOARD)/common/iotlab/clock.config

--- a/boards/maple-mini/Kconfig
+++ b/boards/maple-mini/Kconfig
@@ -18,3 +18,5 @@ config BOARD_MAPLE_MINI
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/nucleo-f103rb/Kconfig
+++ b/boards/nucleo-f103rb/Kconfig
@@ -22,4 +22,8 @@ config BOARD_NUCLEO_F103RB
     select HAS_PERIPH_UART
     select HAS_PERIPH_SPI
 
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f302r8/Kconfig
+++ b/boards/nucleo-f302r8/Kconfig
@@ -26,4 +26,8 @@ config BOARD_NUCLEO_F302R8
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f303k8/include/periph_conf.h
+++ b/boards/nucleo-f303k8/include/periph_conf.h
@@ -19,15 +19,6 @@
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
-/* Adjust PLL factors:
-  - On nucleo-f303k8, there's no HSE and PREDIV is hard-wired to 2
-  - to reach the maximum possible system clock (64MHz) set PLL_MUL to 16
-    so system clock = (HSI8 / 2) * 16 = 64MHz */
-#define CONFIG_CLOCK_PLL_PREDIV     (2)
-#ifndef CONFIG_CLOCK_PLL_MUL
-#define CONFIG_CLOCK_PLL_MUL        (16)
-#endif
-
 #include "periph_cpu.h"
 #include "clk_conf.h"
 #include "cfg_timer_tim2.h"

--- a/boards/nucleo-f303re/Kconfig
+++ b/boards/nucleo-f303re/Kconfig
@@ -26,4 +26,8 @@ config BOARD_NUCLEO_F303RE
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f303ze/Kconfig
+++ b/boards/nucleo-f303ze/Kconfig
@@ -25,4 +25,8 @@ config BOARD_NUCLEO_F303ZE
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-f334r8/Kconfig
+++ b/boards/nucleo-f334r8/Kconfig
@@ -26,4 +26,8 @@ config BOARD_NUCLEO_F334R8
     # Put other features for this board (in alphabetical order)
     select HAS_RIOTBOOT
 
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
 source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/olimexino-stm32/Kconfig
+++ b/boards/olimexino-stm32/Kconfig
@@ -23,3 +23,9 @@ config BOARD_OLIMEXINO_STM32
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/opencm904/Kconfig
+++ b/boards/opencm904/Kconfig
@@ -16,3 +16,8 @@ config BOARD_OPENCM904
     # Put defined MCU peripherals here (in alphabetical order)
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    # Clock configuration
+    select BOARD_HAS_HSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/spark-core/Kconfig
+++ b/boards/spark-core/Kconfig
@@ -17,3 +17,5 @@ config BOARD_SPARK_CORE
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/boards/stm32f3discovery/Kconfig
+++ b/boards/stm32f3discovery/Kconfig
@@ -21,3 +21,8 @@ config BOARD_STM32F3DISCOVERY
     select HAS_PERIPH_SPI
     select HAS_PERIPH_TIMER
     select HAS_PERIPH_UART
+
+    # Clock configuration
+    select BOARD_HAS_HSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig"

--- a/cpu/stm32/include/clk/f1f3/cfg_clock_default.h
+++ b/cpu/stm32/include/clk/f1f3/cfg_clock_default.h
@@ -84,16 +84,28 @@ extern "C" {
 #define CLOCK_HSI                       MHZ(8)
 
 /* The following parameters configure a 72MHz system clock with HSE (8MHz or
-   16MHz) and HSI (8MHz) as input clock */
+   16MHz) and HSI (8MHz) as input clock
+   On stm32f303x6, stm32f303x8, stm32f303xB, stm32f303xC, stm32f328x8 and
+   stm32f358xC lines, PREDIV is hard-wired to 2 (see RM0316 p.126 to p.128).
+   To reach the maximum possible system clock (64MHz) set PLL_PREDIV to 2 and
+   PLL_MUL to 16, so system clock = (HSI8 / 2) * 16 = 64MHz
+*/
 #ifndef CONFIG_CLOCK_PLL_PREDIV
-#if IS_ACTIVE(CONFIG_BOARD_HAS_HSE) && (CLOCK_HSE == MHZ(16))
+#if (IS_ACTIVE(CONFIG_BOARD_HAS_HSE) && (CLOCK_HSE == MHZ(16))) || \
+    defined(CPU_LINE_STM32F303x6) || defined(CPU_LINE_STM32F303x8) || \
+    defined(CPU_LINE_STM32F303xB) || defined(CPU_LINE_STM32F303xC) || \
+    defined(CPU_LINE_STM32F328x8) || defined(CPU_LINE_STM32F358xC)
 #define CONFIG_CLOCK_PLL_PREDIV         (2)
 #else
 #define CONFIG_CLOCK_PLL_PREDIV         (1)
 #endif
 #endif
 #ifndef CONFIG_CLOCK_PLL_MUL
+#if defined(CPU_LINE_STM32F303x8)
+#define CONFIG_CLOCK_PLL_MUL            (16)
+#else
 #define CONFIG_CLOCK_PLL_MUL            (9)
+#endif
 #endif
 
 #if IS_ACTIVE(CONFIG_USE_CLOCK_HSI)

--- a/cpu/stm32/kconfigs/Kconfig.clk
+++ b/cpu/stm32/kconfigs/Kconfig.clk
@@ -6,7 +6,7 @@
 #
 
 menu "STM32 clock configuration"
-    depends on CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_F0 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+    depends on !CPU_FAM_F2 && !CPU_FAM_F4 && !CPU_FAM_F7
 
 choice
 bool "Clock source selection"
@@ -112,19 +112,23 @@ endif  # CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5
 
 endif  # CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 
-if CPU_FAM_F0
+if CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3
 config CLOCK_PLL_PREDIV
-    int "PLLIN division factor" if CUSTOM_PLL_PARAMS && !CPU_LINE_STM32F031X6 && !CPU_LINE_STM32F042X6
-    default 2 if CPU_LINE_STM32F031X6 || CPU_LINE_STM32F042X6
+    int "PLLIN division factor" if CUSTOM_PLL_PARAMS && !CPU_LINE_STM32F031X6 && !CPU_LINE_STM32F042X6 && !CPU_LINE_STM32F303X8
+    # iotlab based boards provide a 16MHz HSE so they need a predivider of 2
+    # to remain with a 72MHz sysclk by default.
+    default 2 if CPU_LINE_STM32F031X6 || CPU_LINE_STM32F042X6 || CPU_LINE_STM32F303X8 || (CPU_FAM_F1 && (BOARD_IOTLAB_M3 || BOARD_IOTLAB_A8_M3 || BOARD_FOX))
     default 1
     range 1 16
 
 config CLOCK_PLL_MUL
     int "PLLIN multiply factor" if CUSTOM_PLL_PARAMS
+    default 16 if CPU_LINE_STM32F303X8
     default 12 if CPU_LINE_STM32F031X6 || CPU_LINE_STM32F042X6
-    default 6
+    default 9 if CPU_FAM_F1 || CPU_FAM_F3
+    default 6 if CPU_FAM_F0
     range 2 16
-endif
+endif  # CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3
 
 if CPU_FAM_L0 || CPU_FAM_L1
 config CLOCK_PLL_DIV
@@ -307,6 +311,7 @@ endif  # CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 choice
 bool "APB1 prescaler (division factor of HCLK to produce PCLK1)"
 default CLOCK_APB1_DIV_4 if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+default CLOCK_APB1_DIV_2 if CPU_FAM_F1 || CPU_FAM_F3
 default CLOCK_APB1_DIV_1
 
 config CLOCK_APB1_DIV_1
@@ -336,7 +341,7 @@ config CLOCK_APB1_DIV
 
 choice
 bool "APB2 prescaler (division factor of HCLK to produce PCLK2)"
-depends on CPU_FAM_G4 || CPU_FAM_L0 || CPU_FAM_L1 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
+depends on !CPU_FAM_G0 && !CPU_FAM_F0
 default CLOCK_APB2_DIV_2 if CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 default CLOCK_APB2_DIV_1
 

--- a/cpu/stm32/kconfigs/Kconfig.clk
+++ b/cpu/stm32/kconfigs/Kconfig.clk
@@ -115,9 +115,7 @@ endif  # CPU_FAM_G0 || CPU_FAM_G4 || CPU_FAM_L4 || CPU_FAM_L5 || CPU_FAM_WB
 if CPU_FAM_F0 || CPU_FAM_F1 || CPU_FAM_F3
 config CLOCK_PLL_PREDIV
     int "PLLIN division factor" if CUSTOM_PLL_PARAMS && !CPU_LINE_STM32F031X6 && !CPU_LINE_STM32F042X6 && !CPU_LINE_STM32F303X8
-    # iotlab based boards provide a 16MHz HSE so they need a predivider of 2
-    # to remain with a 72MHz sysclk by default.
-    default 2 if CPU_LINE_STM32F031X6 || CPU_LINE_STM32F042X6 || CPU_LINE_STM32F303X8 || (CPU_FAM_F1 && (BOARD_IOTLAB_M3 || BOARD_IOTLAB_A8_M3 || BOARD_FOX))
+    default 2 if CPU_LINE_STM32F031X6 || CPU_LINE_STM32F042X6 || CPU_LINE_STM32F303X8
     default 1
     range 1 16
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR models the clock configuration of STM32 F0, F1 and L3 in Kconfig.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Change the clock configuration using make menuconfig: verify the parameter are correctly displayed, ranges are correct (follow the datasheet)
- Verify that affected boards are still functional

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Based on ~#14923~ #14967
Tick an item in #14975 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
