### PR TITLE
ztimer/core: ensure half-period tick when ztimer_now64 is used

### DIFF
--- a/sys/ztimer/core.c
+++ b/sys/ztimer/core.c
@@ -296,7 +296,13 @@ static void _ztimer_update(ztimer_clock_t *clock)
             clock->ops->set(clock, clock->list.next->offset);
         }
         else {
-            clock->ops->cancel(clock);
+            if (IS_USED(MODULE_ZTIMER_NOW64)) {
+                /* ensure there's at least one ISR per half period */
+                clock->ops->set(clock, clock->max_value >> 1);
+            }
+            else {
+                clock->ops->cancel(clock);
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

ztimer has an (so far undocumented and unused) option to keep every clock's current time in 64bit.
The overflows are handled by the regular checkpointing of ztimer_now().

For 32bit clocks (clocks that are not extended), if nothing calls ztimer_now() within a period, that overflow is lost.

This PR adds a periodig half-period tick to those timers, ensuring no overflow is lost.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Tough (time consuming).

- use an empty application (where nothing calls ztimer_now()
- compile with USEMODULE+=ztimer_now64
- posssbly print the time once
- wait 2**32 us (or whatever the timebase is)
- use other means to trigger printing the current time (as 64bit value)

Without this PR, the second print should have lost the 32bit overflow.
With this PR, the time should be correctly larger than 2**32.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
