### PR TITLE
ztimer: use uint32_t in ztimer_periodic_wakeup

### DIFF
--- a/sys/ztimer/util.c
+++ b/sys/ztimer/util.c
@@ -55,14 +55,13 @@ void ztimer_sleep(ztimer_clock_t *clock, uint32_t duration)
     mutex_lock(&mutex);
 }
 
-void ztimer_periodic_wakeup(ztimer_clock_t *clock, ztimer_now_t *last_wakeup,
+void ztimer_periodic_wakeup(ztimer_clock_t *clock, uint32_t *last_wakeup,
                             uint32_t period)
 {
     unsigned state = irq_disable();
-    ztimer_now_t now = ztimer_now(clock);
-    ztimer_now_t target = *last_wakeup + period;
-    ztimer_now_t offset = target - now;
-
+    uint32_t now = ztimer_now(clock);
+    uint32_t target = *last_wakeup + period;
+    uint32_t offset = target - now;
     irq_restore(state);
 
     if (offset <= period) {


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Previously, ztimer_periodic_wakeup() would use "ztimer_now_t" as type for the "last wakeup time", which is typedef'ed to either uint32_t or uint64_t, depending on whether ztimer_now64 is used.
This provided some protection against overflows (period since last wakeup longer than 2**32), in case the optional "ztimer_now64" module was used.

Unfortunately that breaks the simple mapping of xtimer_periodic_wakeup() of ztimer_xtimer_compat, causing compilation errors because of the type mismatch, as xtimer_periodic_wakeup expects a pointer to an uint32_t.

This PR makes ztimer_periodic_wakeup only use the 32bit part of ztimer_now().

The added side effect is that ztimer_periodic_wakeup() now behaves (or fails) the same independent of ztimer_now64 being active.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- compile e.g., tests/xtimer_periodic_wakeup with ```USEMODULE+=ztimer_xtimer_compat ztimer_now64```

This should fail on master, succeed with this PR.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
