### PR TITLE
ztimer: add ztimer_spin()

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -445,6 +445,19 @@ void ztimer_periodic_wakeup(ztimer_clock_t *clock, uint32_t *last_wakeup,
 void ztimer_sleep(ztimer_clock_t *clock, uint32_t duration);
 
 /**
+ * @brief   Busy-wait specified duration
+ *
+ * @note: This blocks lower priority threads. Use only for *very* short delays.
+ *
+ * @param[in]   clock           ztimer clock to use
+ * @param[in]   duration        duration to spin, in @p clock time units
+ */
+static inline void ztimer_spin(ztimer_clock_t *clock, uint32_t duration) {
+    uint32_t end = ztimer_now(clock) + duration;
+    while ((end - ztimer_now(clock)) < duration) {}
+}
+
+/**
  * @brief Set a timer that wakes up a thread
  *
  * This function sets a timer that will wake up a thread when the timer has


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This adds a simple busy waiting function intended for blocking, but precise short delays.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

It has only two lines, but take a hard look at the logic, analyzing what happens if e.g., the thread gets scheduled away.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
