### PR TITLE
net/lora : Expose configurations to Kconfig

### DIFF
--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -176,7 +176,7 @@ void sx127x_init_radio_settings(sx127x_t *dev)
     sx127x_set_spreading_factor(dev, CONFIG_LORA_SF_DEFAULT);
     sx127x_set_coding_rate(dev, CONFIG_LORA_CR_DEFAULT);
     sx127x_set_crc(dev, LORA_PAYLOAD_CRC_ON_DEFAULT);
-    sx127x_set_freq_hop(dev, LORA_FREQUENCY_HOPPING_DEFAULT);
+    sx127x_set_freq_hop(dev, IS_ACTIVE(CONFIG_LORA_FREQUENCY_HOPPING_DEFAULT) ? true : false);
     sx127x_set_hop_period(dev, LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT);
     sx127x_set_fixed_header_len_mode(dev, LORA_FIXED_HEADER_LEN_MODE_DEFAULT);
     sx127x_set_iq_invert(dev, IS_ACTIVE(CONFIG_LORA_IQ_INVERTED_DEFAULT) ? true : false);
@@ -293,7 +293,7 @@ static int _init_gpios(sx127x_t *dev)
     }
     else {
         /* if frequency hopping is enabled, DIO2 pin must be defined */
-        assert(LORA_FREQUENCY_HOPPING_DEFAULT == false);
+        assert(!IS_ACTIVE(CONFIG_LORA_FREQUENCY_HOPPING_DEFAULT));
     }
 
     /* check if DIO3 pin is defined */

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -177,7 +177,7 @@ void sx127x_init_radio_settings(sx127x_t *dev)
     sx127x_set_coding_rate(dev, CONFIG_LORA_CR_DEFAULT);
     sx127x_set_crc(dev, LORA_PAYLOAD_CRC_ON_DEFAULT);
     sx127x_set_freq_hop(dev, IS_ACTIVE(CONFIG_LORA_FREQUENCY_HOPPING_DEFAULT) ? true : false);
-    sx127x_set_hop_period(dev, LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT);
+    sx127x_set_hop_period(dev, CONFIG_LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT);
     sx127x_set_fixed_header_len_mode(dev, LORA_FIXED_HEADER_LEN_MODE_DEFAULT);
     sx127x_set_iq_invert(dev, IS_ACTIVE(CONFIG_LORA_IQ_INVERTED_DEFAULT) ? true : false);
     sx127x_set_payload_length(dev, LORA_PAYLOAD_LENGTH_DEFAULT);

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -27,6 +27,7 @@
 #include "timex.h"
 #include "ztimer.h"
 #include "thread.h"
+#include "kernel_defines.h"
 
 #include "periph/gpio.h"
 #include "periph/spi.h"
@@ -178,7 +179,7 @@ void sx127x_init_radio_settings(sx127x_t *dev)
     sx127x_set_freq_hop(dev, LORA_FREQUENCY_HOPPING_DEFAULT);
     sx127x_set_hop_period(dev, LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT);
     sx127x_set_fixed_header_len_mode(dev, LORA_FIXED_HEADER_LEN_MODE_DEFAULT);
-    sx127x_set_iq_invert(dev, LORA_IQ_INVERTED_DEFAULT);
+    sx127x_set_iq_invert(dev, IS_ACTIVE(CONFIG_LORA_IQ_INVERTED_DEFAULT) ? true : false);
     sx127x_set_payload_length(dev, LORA_PAYLOAD_LENGTH_DEFAULT);
     sx127x_set_preamble_length(dev, CONFIG_LORA_PREAMBLE_LENGTH_DEFAULT);
     sx127x_set_symbol_timeout(dev, CONFIG_LORA_SYMBOL_TIMEOUT_DEFAULT);

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -180,7 +180,7 @@ void sx127x_init_radio_settings(sx127x_t *dev)
     sx127x_set_fixed_header_len_mode(dev, LORA_FIXED_HEADER_LEN_MODE_DEFAULT);
     sx127x_set_iq_invert(dev, LORA_IQ_INVERTED_DEFAULT);
     sx127x_set_payload_length(dev, LORA_PAYLOAD_LENGTH_DEFAULT);
-    sx127x_set_preamble_length(dev, LORA_PREAMBLE_LENGTH_DEFAULT);
+    sx127x_set_preamble_length(dev, CONFIG_LORA_PREAMBLE_LENGTH_DEFAULT);
     sx127x_set_symbol_timeout(dev, LORA_SYMBOL_TIMEOUT_DEFAULT);
     sx127x_set_rx_single(dev, SX127X_RX_SINGLE);
     sx127x_set_tx_timeout(dev, SX127X_TX_TIMEOUT_DEFAULT);

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -178,7 +178,8 @@ void sx127x_init_radio_settings(sx127x_t *dev)
     sx127x_set_crc(dev, LORA_PAYLOAD_CRC_ON_DEFAULT);
     sx127x_set_freq_hop(dev, IS_ACTIVE(CONFIG_LORA_FREQUENCY_HOPPING_DEFAULT) ? true : false);
     sx127x_set_hop_period(dev, CONFIG_LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT);
-    sx127x_set_fixed_header_len_mode(dev, LORA_FIXED_HEADER_LEN_MODE_DEFAULT);
+    sx127x_set_fixed_header_len_mode(dev, IS_ACTIVE(CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT) ?
+                                                    true : false);
     sx127x_set_iq_invert(dev, IS_ACTIVE(CONFIG_LORA_IQ_INVERTED_DEFAULT) ? true : false);
     sx127x_set_payload_length(dev, LORA_PAYLOAD_LENGTH_DEFAULT);
     sx127x_set_preamble_length(dev, CONFIG_LORA_PREAMBLE_LENGTH_DEFAULT);

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -181,7 +181,7 @@ void sx127x_init_radio_settings(sx127x_t *dev)
     sx127x_set_iq_invert(dev, LORA_IQ_INVERTED_DEFAULT);
     sx127x_set_payload_length(dev, LORA_PAYLOAD_LENGTH_DEFAULT);
     sx127x_set_preamble_length(dev, CONFIG_LORA_PREAMBLE_LENGTH_DEFAULT);
-    sx127x_set_symbol_timeout(dev, LORA_SYMBOL_TIMEOUT_DEFAULT);
+    sx127x_set_symbol_timeout(dev, CONFIG_LORA_SYMBOL_TIMEOUT_DEFAULT);
     sx127x_set_rx_single(dev, SX127X_RX_SINGLE);
     sx127x_set_tx_timeout(dev, SX127X_TX_TIMEOUT_DEFAULT);
 }

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -173,7 +173,7 @@ void sx127x_init_radio_settings(sx127x_t *dev)
     sx127x_set_tx_power(dev, SX127X_RADIO_TX_POWER);
     sx127x_set_bandwidth(dev, CONFIG_LORA_BW_DEFAULT);
     sx127x_set_spreading_factor(dev, CONFIG_LORA_SF_DEFAULT);
-    sx127x_set_coding_rate(dev, LORA_CR_DEFAULT);
+    sx127x_set_coding_rate(dev, CONFIG_LORA_CR_DEFAULT);
     sx127x_set_crc(dev, LORA_PAYLOAD_CRC_ON_DEFAULT);
     sx127x_set_freq_hop(dev, LORA_FREQUENCY_HOPPING_DEFAULT);
     sx127x_set_hop_period(dev, LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT);

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -181,7 +181,7 @@ void sx127x_init_radio_settings(sx127x_t *dev)
     sx127x_set_fixed_header_len_mode(dev, IS_ACTIVE(CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT) ?
                                                     true : false);
     sx127x_set_iq_invert(dev, IS_ACTIVE(CONFIG_LORA_IQ_INVERTED_DEFAULT) ? true : false);
-    sx127x_set_payload_length(dev, LORA_PAYLOAD_LENGTH_DEFAULT);
+    sx127x_set_payload_length(dev, CONFIG_LORA_PAYLOAD_LENGTH_DEFAULT);
     sx127x_set_preamble_length(dev, CONFIG_LORA_PREAMBLE_LENGTH_DEFAULT);
     sx127x_set_symbol_timeout(dev, CONFIG_LORA_SYMBOL_TIMEOUT_DEFAULT);
     sx127x_set_rx_single(dev, SX127X_RX_SINGLE);

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -171,7 +171,7 @@ void sx127x_init_radio_settings(sx127x_t *dev)
     sx127x_set_channel(dev, SX127X_CHANNEL_DEFAULT);
     sx127x_set_modem(dev, SX127X_MODEM_DEFAULT);
     sx127x_set_tx_power(dev, SX127X_RADIO_TX_POWER);
-    sx127x_set_bandwidth(dev, LORA_BW_DEFAULT);
+    sx127x_set_bandwidth(dev, CONFIG_LORA_BW_DEFAULT);
     sx127x_set_spreading_factor(dev, LORA_SF_DEFAULT);
     sx127x_set_coding_rate(dev, LORA_CR_DEFAULT);
     sx127x_set_crc(dev, LORA_PAYLOAD_CRC_ON_DEFAULT);

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -172,7 +172,7 @@ void sx127x_init_radio_settings(sx127x_t *dev)
     sx127x_set_modem(dev, SX127X_MODEM_DEFAULT);
     sx127x_set_tx_power(dev, SX127X_RADIO_TX_POWER);
     sx127x_set_bandwidth(dev, CONFIG_LORA_BW_DEFAULT);
-    sx127x_set_spreading_factor(dev, LORA_SF_DEFAULT);
+    sx127x_set_spreading_factor(dev, CONFIG_LORA_SF_DEFAULT);
     sx127x_set_coding_rate(dev, LORA_CR_DEFAULT);
     sx127x_set_crc(dev, LORA_PAYLOAD_CRC_ON_DEFAULT);
     sx127x_set_freq_hop(dev, LORA_FREQUENCY_HOPPING_DEFAULT);

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -44,8 +44,8 @@ extern "C" {
 #endif
 
 /** @brief Symbols timeout (s) */
-#ifndef LORA_SYMBOL_TIMEOUT_DEFAULT
-#define LORA_SYMBOL_TIMEOUT_DEFAULT            (10U)
+#ifndef CONFIG_LORA_SYMBOL_TIMEOUT_DEFAULT
+#define CONFIG_LORA_SYMBOL_TIMEOUT_DEFAULT          (10U)
 #endif
 
 /** @brief Set default bandwidth to 125kHz */

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -99,11 +99,6 @@ extern "C" {
 #define CONFIG_LORA_CR_DEFAULT                      (LORA_CR_4_8)
 #endif
 
-/** @brief Set fixed payload length on */
-#ifndef LORA_FIX_LENGTH_PAYLOAD_ON_DEFAULT
-#define LORA_FIX_LENGTH_PAYLOAD_ON_DEFAULT     (false)
-#endif
-
 /** @brief Set this to true to enable inverted IQ mode */
 #ifdef DOXYGEN
 #define CONFIG_LORA_IQ_INVERTED_DEFAULT

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -124,9 +124,17 @@ extern "C" {
 #define CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT
 #endif
 
-/** @brief Enable payload CRC, optional */
+/** @brief Enable/disable payload CRC, optional
+ *
+ * @deprecated Use inverse @ref CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT instead.
+ * Will be removed after 2021.04 release
+*/
 #ifndef LORA_PAYLOAD_CRC_ON_DEFAULT
-#define LORA_PAYLOAD_CRC_ON_DEFAULT            (true)
+#if IS_ACTIVE(CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT)
+#define LORA_PAYLOAD_CRC_ON_DEFAULT                 (false)
+#else
+#define LORA_PAYLOAD_CRC_ON_DEFAULT                 (true)
+#endif
 #endif
 
 /** @brief Set payload length, unused with implicit header */

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -40,16 +40,35 @@ extern "C" {
 #define LORA_FREQUENCY_RESOLUTION_DEFAULT      (61.03515625)
 #endif
 
-/** @brief Preamble length, same for Tx and Rx */
+/** @brief Preamble length, same for Tx and Rx
+ *
+ * Configure preamble used in LoRa frame. Each LoRa frame begins with a
+ * preamble. It starts with a series of upchirps to cover the whole frequency
+ * band of the particular channel assigned. The last two upchirps encode the
+ * sync word. Sync word is used to differentiate between LoRa transmissions that
+ * use the same frequency bands. The sync word is followed by two and a quarter
+ * downchirps, for a duration of 2.25 symbols. The total duration of this
+ * preamble can be configured between 10.25 and 65,539.25 symbol hence the value
+ * can range from 8 to 65537.
+*/
 #ifndef CONFIG_LORA_PREAMBLE_LENGTH_DEFAULT
 #define CONFIG_LORA_PREAMBLE_LENGTH_DEFAULT         (8U)
 #endif
 
-/** @brief Symbols timeout (s) */
+/** @brief Symbol timeout period in symbols
+ *
+ * Configure symbol time out in terms of number of symbols. One symbol has a
+ * length in time of (2^SF)/BW seconds.
+*/
 #ifndef CONFIG_LORA_SYMBOL_TIMEOUT_DEFAULT
 #define CONFIG_LORA_SYMBOL_TIMEOUT_DEFAULT          (10U)
 #endif
 
+/** @brief Set channel bandwidth
+ *
+ * Configure the channel bandwidth. Refer to country specific regulation on
+ * channel usage to identify the correct bandwidth.
+*/
 #if IS_ACTIVE(CONFIG_LORA_BW_DEFAULT_125)
 #define CONFIG_LORA_BW_DEFAULT                      (LORA_BW_125_KHZ)
 #elif IS_ACTIVE(CONFIG_LORA_BW_DEFAULT_250)
@@ -58,11 +77,20 @@ extern "C" {
 #define CONFIG_LORA_BW_DEFAULT                      (LORA_BW_500_KHZ)
 #endif
 
-/** @brief Set default bandwidth to 125kHz */
 #ifndef CONFIG_LORA_BW_DEFAULT
 #define CONFIG_LORA_BW_DEFAULT                      (LORA_BW_125_KHZ)
 #endif
 
+/** @brief Set Spreading Factor (SF)
+ *
+ * Configure Spreading Factor (SF). SF denotes the amount of spreading code
+ * applied to the original data signal. A larger SF increases the time on air,
+ * which increases energy consumption, reduces the data rate, and improves
+ * communication range. Each step up in spreading factor effectively doubles the
+ * time on air to transmit the same amount of data. Refer to country specific
+ * air time usage regulations before varying the SF. To calculate air time refer
+ * https://www.loratools.nl/#/airtime .
+*/
 #if IS_ACTIVE(CONFIG_LORA_SF_DEFAULT_SF6)
 #define CONFIG_LORA_SF_DEFAULT                      (LORA_SF6)
 #elif IS_ACTIVE(CONFIG_LORA_SF_DEFAULT_SF7)
@@ -79,11 +107,22 @@ extern "C" {
 #define CONFIG_LORA_SF_DEFAULT                      (LORA_SF12)
 #endif
 
-/** @brief Set default spreading factor to 12 */
 #ifndef CONFIG_LORA_SF_DEFAULT
 #define CONFIG_LORA_SF_DEFAULT                      (LORA_SF12)
 #endif
 
+/** @brief Set Coding Rate (CR)
+ *
+ * Configure Coding Rate (CR). CR denotes the implementation of forward error
+ * correction (FEC). This may be done by encoding 4-bit data with redundancies
+ * into 5-bit, 6-bit, 7-bit, or 8-bit. Coding Rate (CR) value need to be
+ * adjusted according to conditions of the channel used for data transmission.
+ * If there are too many interferences in the channel, then it’s recommended to
+ * increase the value of CR. However, the rise in CR value will also increase
+ * the duration for the transmission. Refer to country specific air time usage
+ * regulations before varying the CR. To calculate air time refer
+ * https://www.loratools.nl/#/airtime .
+*/
 #if IS_ACTIVE(CONFIG_LORA_CR_DEFAULT_CR_4_5)
 #define CONFIG_LORA_CR_DEFAULT                      (LORA_CR_4_5)
 #elif IS_ACTIVE(CONFIG_LORA_CR_DEFAULT_CR_4_6)
@@ -94,35 +133,54 @@ extern "C" {
 #define CONFIG_LORA_CR_DEFAULT                      (LORA_CR_4_8)
 #endif
 
-/** @brief Set default coding rate to 8 */
 #ifndef CONFIG_LORA_CR_DEFAULT
 #define CONFIG_LORA_CR_DEFAULT                      (LORA_CR_4_8)
 #endif
 
-/** @brief Set this to true to enable inverted IQ mode */
+/** @brief Set this to 1 to enable inverted I/Q mode
+ *
+ * Enable this to invert the IQ signals used in RF modulation circuit. For more
+ * information on I/Q modulation technique visit http://www.ni.com/tutorial/4805/en/
+*/
 #ifdef DOXYGEN
 #define CONFIG_LORA_IQ_INVERTED_DEFAULT
 #endif
 
-/** @brief Set this to true to enable frequency hopping */
+/** @brief Set this to 1 to enable frequency hopping
+ *
+ * If Frequency hopping spread spectrum (FHSS) is enabled a portion of each LoRa
+ * packet is transmitted on each hopping channel from a look up table of
+ * frequencies managed by the host microcontroller.
+*/
 #ifdef DOXYGEN
 #define CONFIG_LORA_FREQUENCY_HOPPING_DEFAULT
 #endif
 
-/** @brief Frequency hopping period */
+/** @brief Frequency hopping period in symbols
+ *
+ * Configure the hopping period, in symbols, time which each transmission will
+ * dwell in any given channel. One symbol has a length in time of (2^SF)/BW
+ * seconds.
+*/
 #ifndef CONFIG_LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT
 #define CONFIG_LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT (0U)
 #endif
 
-/** @brief Set this to true to enable fixed header length mode (implicit header) */
+/** @brief Set this to 1 to enable fixed header length mode (implicit header)
+ *
+ * If fixed header length mode ( implicit header mode) is enabled, PHY header
+ * (`PHDR`) in LoRa frame is discarded. For more information, refer to the
+ * section "LoRa frame structure" in this
+ * <a href="https://link.springer.com/article/10.1186/s13638-019-1542-x">publication</a>
+*/
 #ifdef DOXYGEN
 #define CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT
 #endif
 
 /** @brief Enable/disable payload CRC, optional
  *
- * @deprecated Use inverse @ref CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT instead.
- * Will be removed after 2021.04 release
+ * @deprecated Use inverse `CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT` instead.
+ * Will be removed after 2021.04 release.
 */
 #ifndef LORA_PAYLOAD_CRC_ON_DEFAULT
 #if IS_ACTIVE(CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT)
@@ -132,7 +190,12 @@ extern "C" {
 #endif
 #endif
 
-/** @brief Set payload length, unused with implicit header */
+/** @brief Configure payload length
+ *
+ * Configure the length of payload. The configuration is unused when using
+ * explicit header mode ( @ref CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT ) as
+ * `PHDR` carries the length information.
+*/
 #ifndef CONFIG_LORA_PAYLOAD_LENGTH_DEFAULT
 #define CONFIG_LORA_PAYLOAD_LENGTH_DEFAULT          (0U)
 #endif

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -63,9 +63,25 @@ extern "C" {
 #define CONFIG_LORA_BW_DEFAULT                      (LORA_BW_125_KHZ)
 #endif
 
+#if IS_ACTIVE(CONFIG_LORA_SF_DEFAULT_SF6)
+#define CONFIG_LORA_SF_DEFAULT                      (LORA_SF6)
+#elif IS_ACTIVE(CONFIG_LORA_SF_DEFAULT_SF7)
+#define CONFIG_LORA_SF_DEFAULT                      (LORA_SF7)
+#elif IS_ACTIVE(CONFIG_LORA_SF_DEFAULT_SF8)
+#define CONFIG_LORA_SF_DEFAULT                      (LORA_SF8)
+#elif IS_ACTIVE(CONFIG_LORA_SF_DEFAULT_SF9)
+#define CONFIG_LORA_SF_DEFAULT                      (LORA_SF9)
+#elif IS_ACTIVE(CONFIG_LORA_SF_DEFAULT_SF10)
+#define CONFIG_LORA_SF_DEFAULT                      (LORA_SF10)
+#elif IS_ACTIVE(CONFIG_LORA_SF_DEFAULT_SF11)
+#define CONFIG_LORA_SF_DEFAULT                      (LORA_SF11)
+#elif IS_ACTIVE(CONFIG_LORA_SF_DEFAULT_SF12)
+#define CONFIG_LORA_SF_DEFAULT                      (LORA_SF12)
+#endif
+
 /** @brief Set default spreading factor to 12 */
-#ifndef LORA_SF_DEFAULT
-#define LORA_SF_DEFAULT                        (LORA_SF12)
+#ifndef CONFIG_LORA_SF_DEFAULT
+#define CONFIG_LORA_SF_DEFAULT                      (LORA_SF12)
 #endif
 
 /** @brief Set default coding rate to 8 */

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -24,6 +24,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "kernel_defines.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -48,9 +50,17 @@ extern "C" {
 #define CONFIG_LORA_SYMBOL_TIMEOUT_DEFAULT          (10U)
 #endif
 
+#if IS_ACTIVE(CONFIG_LORA_BW_DEFAULT_125)
+#define CONFIG_LORA_BW_DEFAULT                      (LORA_BW_125_KHZ)
+#elif IS_ACTIVE(CONFIG_LORA_BW_DEFAULT_250)
+#define CONFIG_LORA_BW_DEFAULT                      (LORA_BW_250_KHZ)
+#elif IS_ACTIVE(CONFIG_LORA_BW_DEFAULT_500)
+#define CONFIG_LORA_BW_DEFAULT                      (LORA_BW_500_KHZ)
+#endif
+
 /** @brief Set default bandwidth to 125kHz */
-#ifndef LORA_BW_DEFAULT
-#define LORA_BW_DEFAULT                        (LORA_BW_125_KHZ)
+#ifndef CONFIG_LORA_BW_DEFAULT
+#define CONFIG_LORA_BW_DEFAULT                      (LORA_BW_125_KHZ)
 #endif
 
 /** @brief Set default spreading factor to 12 */

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -84,9 +84,19 @@ extern "C" {
 #define CONFIG_LORA_SF_DEFAULT                      (LORA_SF12)
 #endif
 
+#if IS_ACTIVE(CONFIG_LORA_CR_DEFAULT_CR_4_5)
+#define CONFIG_LORA_CR_DEFAULT                      (LORA_CR_4_5)
+#elif IS_ACTIVE(CONFIG_LORA_CR_DEFAULT_CR_4_6)
+#define CONFIG_LORA_CR_DEFAULT                      (LORA_CR_4_6)
+#elif IS_ACTIVE(CONFIG_LORA_CR_DEFAULT_CR_4_7)
+#define CONFIG_LORA_CR_DEFAULT                      (LORA_CR_4_7)
+#elif IS_ACTIVE(CONFIG_LORA_CR_DEFAULT_CR_4_8)
+#define CONFIG_LORA_CR_DEFAULT                      (LORA_CR_4_8)
+#endif
+
 /** @brief Set default coding rate to 8 */
-#ifndef LORA_CR_DEFAULT
-#define LORA_CR_DEFAULT                        (LORA_CR_4_8)
+#ifndef CONFIG_LORA_CR_DEFAULT
+#define CONFIG_LORA_CR_DEFAULT                      (LORA_CR_4_8)
 #endif
 
 /** @brief Set fixed payload length on */

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -108,7 +108,7 @@ extern "C" {
 #endif
 
 #ifndef CONFIG_LORA_SF_DEFAULT
-#define CONFIG_LORA_SF_DEFAULT                      (LORA_SF12)
+#define CONFIG_LORA_SF_DEFAULT                      (LORA_SF7)
 #endif
 
 /** @brief Set Coding Rate (CR)
@@ -134,7 +134,7 @@ extern "C" {
 #endif
 
 #ifndef CONFIG_LORA_CR_DEFAULT
-#define CONFIG_LORA_CR_DEFAULT                      (LORA_CR_4_8)
+#define CONFIG_LORA_CR_DEFAULT                      (LORA_CR_4_5)
 #endif
 
 /** @brief Set this to 1 to enable inverted I/Q mode

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -109,9 +109,9 @@ extern "C" {
 #define CONFIG_LORA_IQ_INVERTED_DEFAULT
 #endif
 
-/** @brief Frequency hopping on */
-#ifndef LORA_FREQUENCY_HOPPING_DEFAULT
-#define LORA_FREQUENCY_HOPPING_DEFAULT         (false)
+/** @brief Set this to true to enable frequency hopping */
+#ifdef DOXYGEN
+#define CONFIG_LORA_FREQUENCY_HOPPING_DEFAULT
 #endif
 
 /** @brief Frequency hopping period */

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -104,9 +104,9 @@ extern "C" {
 #define LORA_FIX_LENGTH_PAYLOAD_ON_DEFAULT     (false)
 #endif
 
-/** @brief Set inverted IQ on */
-#ifndef LORA_IQ_INVERTED_DEFAULT
-#define LORA_IQ_INVERTED_DEFAULT               (false)
+/** @brief Set this to true to enable inverted IQ mode */
+#ifdef DOXYGEN
+#define CONFIG_LORA_IQ_INVERTED_DEFAULT
 #endif
 
 /** @brief Frequency hopping on */

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -115,8 +115,8 @@ extern "C" {
 #endif
 
 /** @brief Frequency hopping period */
-#ifndef LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT
-#define LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT  (0U)
+#ifndef CONFIG_LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT
+#define CONFIG_LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT (0U)
 #endif
 
 /** @brief Set fixed header length mode (implicit header) */

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -39,8 +39,8 @@ extern "C" {
 #endif
 
 /** @brief Preamble length, same for Tx and Rx */
-#ifndef LORA_PREAMBLE_LENGTH_DEFAULT
-#define LORA_PREAMBLE_LENGTH_DEFAULT           (8U)
+#ifndef CONFIG_LORA_PREAMBLE_LENGTH_DEFAULT
+#define CONFIG_LORA_PREAMBLE_LENGTH_DEFAULT         (8U)
 #endif
 
 /** @brief Symbols timeout (s) */

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -138,10 +138,9 @@ extern "C" {
 #endif
 
 /** @brief Set payload length, unused with implicit header */
-#ifndef LORA_PAYLOAD_LENGTH_DEFAULT
-#define LORA_PAYLOAD_LENGTH_DEFAULT            (0U)
+#ifndef CONFIG_LORA_PAYLOAD_LENGTH_DEFAULT
+#define CONFIG_LORA_PAYLOAD_LENGTH_DEFAULT          (0U)
 #endif
-
 /** @} */
 
 /**

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -119,9 +119,9 @@ extern "C" {
 #define CONFIG_LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT (0U)
 #endif
 
-/** @brief Set fixed header length mode (implicit header) */
-#ifndef LORA_FIXED_HEADER_LEN_MODE_DEFAULT
-#define LORA_FIXED_HEADER_LEN_MODE_DEFAULT     (false)
+/** @brief Set this to true to enable fixed header length mode (implicit header) */
+#ifdef DOXYGEN
+#define CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT
 #endif
 
 /** @brief Enable payload CRC, optional */

--- a/sys/net/Kconfig
+++ b/sys/net/Kconfig
@@ -12,6 +12,7 @@ rsource "credman/Kconfig"
 rsource "gnrc/Kconfig"
 rsource "sock/Kconfig"
 rsource "link_layer/Kconfig"
+rsource "lora/Kconfig"
 rsource "netif/Kconfig"
 
 endmenu # Networking

--- a/sys/net/lora/Kconfig
+++ b/sys/net/lora/Kconfig
@@ -1,0 +1,155 @@
+# Copyright (c) 2020 Freie Universitaet Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+menuconfig KCONFIG_USEMODULE_LORA
+    bool "Configure LoRa PHY"
+    depends on USEMODULE_LORA
+    help
+        Configure LoRa PHY using Kconfig.
+
+if KCONFIG_USEMODULE_LORA
+
+config LORA_PREAMBLE_LENGTH_DEFAULT
+    int "Preamble length"
+    range 8 65537
+    default 8
+    help
+        Configure preamble used in LoRa frame. Each LoRa frame begins with a
+        preamble. It starts with a series of upchirps to cover the whole
+        frequency band of the particular channel assigned. The last two upchirps
+        encode the sync word. Sync word is used to differntiate between LoRa
+        transmissions that use the same frequency bands. The sync word is
+        followed by two and a quarter downchirps, for a duration of 2.25
+        symbols. The total duration of this preamble can be configured between
+        10.25 and 65,539.25 symbol hence the range 8 to 65537.
+
+config LORA_SYMBOL_TIMEOUT_DEFAULT
+    int "Symbol timeout period in symbols"
+    default 10
+    help
+        Configure symbol time out in terms of number of symbols. One symbol has
+        a length in time of (2^SF)/BW seconds.
+
+choice
+    bool "Channel bandwidth"
+    default LORA_BW_DEFAULT_125
+    help
+        Configure the channel bandwidth. Refer to country specific regulations
+        on channel usage to identify the correct bandwidth.
+
+config LORA_BW_DEFAULT_125
+    bool "125kHz"
+
+config LORA_BW_DEFAULT_250
+    bool "250kHz"
+
+config LORA_BW_DEFAULT_500
+    bool "500kHz"
+
+endchoice
+
+choice
+    bool "Spreading factor"
+    default LORA_SF_DEFAULT_SF12
+    help
+        Configure Spreading Factor (SF). SF denotes the amount of spreading code
+        applied to the original data signal. A larger SF increases the time on
+        air, which increases energy consumption, reduces the data rate, and
+        improves communication range. Each step up in spreading factor
+        effectively doubles the time on air to transmit the same amount of data.
+        Refer to country specific air time usage regulations before varying the
+        SF. To calculate air time refer https://www.loratools.nl/#/airtime .
+
+config LORA_SF_DEFAULT_SF6
+    bool "SF6"
+
+config LORA_SF_DEFAULT_SF7
+    bool "SF7"
+
+config LORA_SF_DEFAULT_SF8
+    bool "SF8"
+
+config LORA_SF_DEFAULT_SF9
+    bool "SF9"
+
+config LORA_SF_DEFAULT_SF10
+    bool "SF10"
+
+config LORA_SF_DEFAULT_SF11
+    bool "SF11"
+
+config LORA_SF_DEFAULT_SF12
+    bool "SF12"
+
+endchoice
+
+choice
+    bool "Coding rate"
+    default LORA_CR_DEFAULT_CR_4_8
+    help
+        Configure Coding rate (CR). CR denotes the implementation of forward
+        error correction (FEC). This may be done by encoding 4-bit data with
+        redundancies into 5-bit, 6-bit, 7-bit, or 8-bit. Coding Rate (CR) value
+        need to be adjusted according to conditions of the channel used for data
+        transmission. If there are too many interferences in the channel, then
+        it’s recommended to increase the value of CR. However, the rise in CR
+        value will also increase the duration for the transmission. Refer to
+        country specific air time usage regulations before varying the CR. To
+        calculate air time refer https://www.loratools.nl/#/airtime .
+
+config LORA_CR_DEFAULT_CR_4_5
+    bool "CR 4/5"
+
+config LORA_CR_DEFAULT_CR_4_6
+    bool "CR 4/6"
+
+config LORA_CR_DEFAULT_CR_4_7
+    bool "CR 4/7"
+
+config LORA_CR_DEFAULT_CR_4_8
+    bool "CR 4/8"
+
+endchoice
+
+config LORA_IQ_INVERTED_DEFAULT
+    bool "Enable inverted I/Q mode"
+    help
+        Enable this to invert the IQ signals used in RF modulation circuit. For
+        more information on I/Q modulation technique visit
+        http://www.ni.com/tutorial/4805/en/
+
+config LORA_FREQUENCY_HOPPING_DEFAULT
+    bool "Enable Frequency hopping spread spectrum (FHSS)"
+    help
+        Enabling Frequency hopping spread spectrum (FHSS) would imply that a
+        portion of each LoRa packet is transmitted on each hopping channel from
+        a look up table of frequencies managed by the host microcontroller.
+
+config LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT
+    int "Frequency hopping period in symbols"
+    default 0
+    help
+        Configure the hopping period, in symbols, time which each transmission
+        will dwell in any given channel. One symbol has a length in time of
+        (2^SF)/BW seconds.
+
+config LORA_FIXED_HEADER_LEN_MODE_DEFAULT
+    bool "Enable fixed header length mode (implicit header)"
+    help
+        Enable fixed header length mode ( implicit header) to discard PHY header
+        (PHDR).
+
+config LORA_PAYLOAD_CRC_OFF_DEFAULT
+    bool "Disable payload CRC"
+
+config LORA_PAYLOAD_LENGTH_DEFAULT
+    int "Payload Length"
+    default 0
+    help
+        Configure the length of payload. The option is unused while using
+        explicit header mode as PHDR carries the length information.
+
+endif # KCONFIG_USEMODULE_LORA

--- a/sys/net/lora/Kconfig
+++ b/sys/net/lora/Kconfig
@@ -53,7 +53,7 @@ endchoice
 
 choice
     bool "Spreading factor"
-    default LORA_SF_DEFAULT_SF12
+    default LORA_SF_DEFAULT_SF7
     help
         Configure Spreading Factor (SF). SF denotes the amount of spreading code
         applied to the original data signal. A larger SF increases the time on
@@ -88,7 +88,7 @@ endchoice
 
 choice
     bool "Coding rate"
-    default LORA_CR_DEFAULT_CR_4_8
+    default LORA_CR_DEFAULT_CR_4_5
     help
         Configure Coding rate (CR). CR denotes the implementation of forward
         error correction (FEC). This may be done by encoding 4-bit data with


### PR DESCRIPTION
### Contribution description - 

This PR exposes compile configurations in **net/lora** to Kconfig.

Skipped `LORA_FREQUENCY_RESOLUTION_DEFAULT` since it was planned to be removed. #13318

### Testing procedure

1. New documentation was built using Doxygen 

   The build works fine.

  2. Test files were added to tests/net_lora

      The test file can be found [here](https://github.com/akshaim/RIOT/commit/2336b333eb3d676e8a659c7927b16f3e3f980501)

      Compiled binaries for b-l072z-lrwan1 and tested on the evaluation board. 

3. Tested gnrc_lorawan example in `examples 
`
#### Default State:

##### Firmware Output
```
main(): This is RIOT! (Version: 2020.10-devel-1308-gae087-Kconfig_lora_tests)
CONFIG_LORA_PREAMBLE_LENGTH_DEFAULT=(8U)
CONFIG_LORA_SYMBOL_TIMEOUT_DEFAULT=(10U)
CONFIG_LORA_BW_DEFAULT=(LORA_BW_125_KHZ)
CONFIG_LORA_SF_DEFAULT=(LORA_SF7)
CONFIG_LORA_CR_DEFAULT=(LORA_CR_4_5)
CONFIG_LORA_IQ_INVERTED_DEFAULT=CONFIG_LORA_IQ_INVERTED_DEFAULT
CONFIG_LORA_FREQUENCY_HOPPING_DEFAULT=CONFIG_LORA_FREQUENCY_HOPPING_DEFAULT
CONFIG_LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT=(0U)
CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT=CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT
CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT=CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT
LORA_PAYLOAD_CRC_ON_DEFAULT=(true)
CONFIG_LORA_PAYLOAD_LENGTH_DEFAULT=(0U)

```
#### Usage with CFLAGS :
```
CFLAGS += -DCONFIG_LORA_PREAMBLE_LENGTH_DEFAULT=10
CFLAGS += -DCONFIG_LORA_SYMBOL_TIMEOUT_DEFAULT=20
CFLAGS += -DCONFIG_LORA_BW_DEFAULT=LORA_BW_250_KHZ
CFLAGS += -DCONFIG_LORA_SF_DEFAULT=LORA_SF8
CFLAGS += -DCONFIG_LORA_CR_DEFAULT=LORA_CR_4_6
CFLAGS += -DCONFIG_LORA_IQ_INVERTED_DEFAULT=1
CFLAGS += -DCONFIG_LORA_FREQUENCY_HOPPING_DEFAULT=1
CFLAGS += -DCONFIG_LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT=10
# CFLAGS += -DCONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT=1
CFLAGS += -DLORA_PAYLOAD_CRC_ON_DEFAULT=1
CFLAGS += -DCONFIG_LORA_PAYLOAD_LENGTH_DEFAULT=10
```

##### Firmware Output

```
main(): This is RIOT! (Version: 2020.10-devel-1308-gae087-Kconfig_lora_tests)
CONFIG_LORA_PREAMBLE_LENGTH_DEFAULT=10
CONFIG_LORA_SYMBOL_TIMEOUT_DEFAULT=20
CONFIG_LORA_BW_DEFAULT=LORA_BW_250_KHZ
CONFIG_LORA_SF_DEFAULT=LORA_SF8
DCONFIG_LORA_CR_DEFAULT=LORA_CR_4_6
DCONFIG_LORA_IQ_INVERTED_DEFAULT=1
DCONFIG_LORA_FREQUENCY_HOPPING_DEFAULT=1
CONFIG_LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT=10
CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT=CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT
CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT=CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT
CFLAGS += -DLORA_PAYLOAD_CRC_ON_DEFAULT=1
CFLAGS += -DCONFIG_LORA_PAYLOAD_LENGTH_DEFAULT=10
```

#### Usage with menuconfig :

`make menuconfig`

##### Default Firmware Output

```
main(): This is RIOT! (Version: 2020.10-devel-1308-gae087-Kconfig_lora_tests)
CONFIG_LORA_PREAMBLE_LENGTH_DEFAULT=8
CONFIG_LORA_SYMBOL_TIMEOUT_DEFAULT=10
CONFIG_LORA_BW_DEFAULT=(LORA_BW_125_KHZ)
CONFIG_LORA_SF_DEFAULT=(LORA_SF7)
CONFIG_LORA_CR_DEFAULT=(LORA_CR_4_5)
CONFIG_LORA_IQ_INVERTED_DEFAULT=CONFIG_LORA_IQ_INVERTED_DEFAULT
CONFIG_LORA_FREQUENCY_HOPPING_DEFAULT=CONFIG_LORA_FREQUENCY_HOPPING_DEFAULT
CONFIG_LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT=(0U)
CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT=CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT
CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT=CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT
LORA_PAYLOAD_CRC_ON_DEFAULT=(true)
CONFIG_LORA_PAYLOAD_LENGTH_DEFAULT=10
```

##### Configured Firmware Output

```
main(): This is RIOT! (Version: 2020.10-devel-1308-gae087-Kconfig_lora_tests)
CONFIG_LORA_PREAMBLE_LENGTH_DEFAULT=10
CONFIG_LORA_SYMBOL_TIMEOUT_DEFAULT=15
CONFIG_LORA_BW_DEFAULT=(LORA_BW_250_KHZ)
CONFIG_LORA_SF_DEFAULT=(LORA_SF9)
CONFIG_LORA_CR_DEFAULT=(LORA_CR_4_6)
CONFIG_LORA_IQ_INVERTED_DEFAULT=1
CONFIG_LORA_FREQUENCY_HOPPING_DEFAULT=1
CONFIG_LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT=100
CONFIG_LORA_FIXED_HEADER_LEN_MODE_DEFAULT=1
CONFIG_LORA_PAYLOAD_CRC_OFF_DEFAULT=1
LORA_PAYLOAD_CRC_ON_DEFAULT=(false)
CONFIG_LORA_PAYLOAD_LENGTH_DEFAULT=0
```

**MACROS were successfully configured.**

### Issues/PRs references

#12888 