### PR TITLE
usbdev_mock: fix possible null pointer dereference

### DIFF
--- a/drivers/usbdev_mock/usbdev_mock.c
+++ b/drivers/usbdev_mock/usbdev_mock.c
@@ -93,8 +93,9 @@ usbdev_ep_t *_new_ep(usbdev_t *dev, usb_ep_type_t type, usb_ep_dir_t dir,
         res->ep.dir = dir;
         res->ep.type = type;
         res->ep.dev = dev;
+        return &res->ep;
     }
-    return &res->ep;
+    return NULL;
 }
 
 int _get(usbdev_t *usbdev, usbopt_t opt,


### PR DESCRIPTION
### Contribution description

There is a potential null pointer dereference in the usbdev mock device driver. As this is only used in test scenarios the abuse potential is nonexistent. 

### Testing procedure

Check the code. The CI should do the rest.

### Issues/PRs references

reported in #15006, thanks @tluio!