### PR TITLE
sys/pipe/pipe_dynamic: fix possible null pointer dereference

### DIFF
--- a/sys/pipe/pipe_dynamic.c
+++ b/sys/pipe/pipe_dynamic.c
@@ -42,8 +42,9 @@ pipe_t *pipe_malloc(unsigned size)
     if (m_pipe) {
         ringbuffer_init(&m_pipe->rb, m_pipe->buffer, size);
         pipe_init(&m_pipe->pipe, &m_pipe->rb, free);
+        return &m_pipe->pipe;
     }
-    return &m_pipe->pipe;
+    return NULL;
 }
 
 void pipe_free(pipe_t *rp)


### PR DESCRIPTION
### Contribution description

There is a potential null pointer dereference in pipe_dynamic code. The code is currently is currently unused in our code base.

### Testing procedure

Check the code. The CI should do the rest.

### Issues/PRs references

reported in #15006, thanks @tluio!