### PR TITLE
pipe_dynamic: Guard against accidental NULL ptr dereference

### DIFF
--- a/sys/pipe/pipe_dynamic.c
+++ b/sys/pipe/pipe_dynamic.c
@@ -39,10 +39,12 @@ struct mallocd_pipe
 pipe_t *pipe_malloc(unsigned size)
 {
     struct mallocd_pipe *m_pipe = malloc(sizeof (*m_pipe) + size);
-    if (m_pipe) {
-        ringbuffer_init(&m_pipe->rb, m_pipe->buffer, size);
-        pipe_init(&m_pipe->pipe, &m_pipe->rb, free);
+    if (!m_pipe) {
+        /* Malloc returned NULL */
+        return NULL;
     }
+    ringbuffer_init(&m_pipe->rb, m_pipe->buffer, size);
+    pipe_init(&m_pipe->pipe, &m_pipe->rb, free);
     return &m_pipe->pipe;
 }
 


### PR DESCRIPTION
### Contribution description

This cleans the code of the pipe_dynamic file to guard against a possible NULL pointer dereference if the order of the `mallocd_pipe` struct is modified. The current code should be safe as the first member of the struct is dereferenced, so a NULL pointer remains a NULL pointer. The modified code compiles to the same binary.

### Testing procedure

I don't think we have a test for this :(

### Issues/PRs references

See #15006
