### PR TITLE
drivers/cc2420: register with netdev

### DIFF
--- a/drivers/cc2420/Makefile.dep
+++ b/drivers/cc2420/Makefile.dep
@@ -1,5 +1,4 @@
 USEMODULE += xtimer
-USEMODULE += luid
 USEMODULE += ieee802154
 USEMODULE += netdev_ieee802154
 FEATURES_REQUIRED += periph_gpio

--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -101,11 +101,13 @@ typedef struct {
  *
  * @param[out] dev          device descriptor
  * @param[in]  params       device parameters
+ * @param[in]  index        index of @p params in a global parameter struct array.
+ *                          If initialized manually, pass a unique identifier instead.
  *
  * @return                  0 on success
  * @return                  -1 on error
  */
-void cc2420_setup(cc2420_t *dev, const cc2420_params_t *params);
+void cc2420_setup(cc2420_t *dev, const cc2420_params_t *params, uint8_t index);
 
 /**
  * @brief   Initialize a given CC2420 device

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -319,6 +319,7 @@ typedef enum {
     NETDEV_NRF24L01P_NG,
     NETDEV_SOCKET_ZEP,
     NETDEV_SX126X,
+    NETDEV_CC2420,
     /* add more if needed */
 } netdev_type_t;
 /** @} */

--- a/sys/net/gnrc/netif/init_devs/auto_init_cc2420.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_cc2420.c
@@ -57,7 +57,7 @@ void auto_init_cc2420(void)
     for (unsigned i = 0; i < CC2420_NUMOF; i++) {
         LOG_DEBUG("[auto_init_netif] initializing cc2420 #%u\n", i);
 
-        cc2420_setup(&cc2420_devs[i], &cc2420_params[i]);
+        cc2420_setup(&cc2420_devs[i], &cc2420_params[i], i);
         gnrc_netif_ieee802154_create(&_netif[i], _cc2420_stacks[i], CC2420_MAC_STACKSIZE,
                                      CC2420_MAC_PRIO, "cc2420",
                                      (netdev_t *)&cc2420_devs[i]);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Register `cc2420` with netdev so we don't have to generate a EUI inside the driver but can make use of an EUI provider if available.

### Testing procedure

Run e.g. `examples/gnrc_networking` on `telosb` or `z1`.
### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
