### PR TITLE
Makefile.include: intial features check before dependency resolution

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -379,6 +379,9 @@ ifeq (1,$(TEST_KCONFIG))
   KCONFIG_MODULES := $(call lowercase,$(patsubst CONFIG_MODULE_%,%,$(filter CONFIG_MODULE_%,$(.VARIABLES))))
   USEMODULE := $(KCONFIG_MODULES)
 else
+  # check if required features are provided and update $(FEATURES_USED)
+  include $(RIOTMAKE)/features_check.inc.mk
+
   # handle removal of default modules
   USEMODULE += $(filter-out $(DISABLE_MODULE), $(DEFAULT_MODULE))
 


### PR DESCRIPTION
### Contribution description

In #13349 the initial inclusion of features was inadvertently removed, it was kept in `info-boards-supported` but removed in `Makefile.include`. This PR re-introduces it. 

### Testing procedure

Found in #15011, with this PR you can check against `FEATURES_USED`:

Rebase on #15011 and apply this patch:

```diff
diff --git a/cpu/arm7_common/Makefile.dep b/cpu/arm7_common/Makefile.dep
index 004481beba..fabfff3190 100644
 # include common periph code
 USEMODULE += cortexm_common_periph
 
-ifneq (,$(filter picolibc,$(FEATURES_OPTIONAL) $(FEATURES_REQUIRED)))
+ifneq (,$(filter picolibc,$(FEATURES_USED)))
   # Use Picolibc when explicitly selected
   USEMODULE += picolibc
 else
diff --git a/cpu/fe310/Makefile.dep b/cpu/fe310/Makefile.dep
index 196cb33cca..99efb3df64 100644
--- a/cpu/fe310/Makefile.dep
+++ b/cpu/fe310/Makefile.dep
@@ -1,4 +1,4 @@
-ifneq (,$(filter picolibc,$(FEATURES_OPTIONAL) $(FEATURES_REQUIRED)))
+ifneq (,$(filter picolibc,$(FEATURES_USED)))
   USEMODULE += picolibc
 else
   USEMODULE += newlib_nano
```

```
BOARD=samr21-xpro FEATURES_OPTIONAL=picolibc make -C examples/gnrc_networking info-modules | grep picolibc
picolibc
picolibc_syscalls_default
```

For good measure `./dist/tools/buildsystem_sanity_check/save_all_dependencies_resolution_variables.sh` could be run, but IMO
the fix is necessary and obvious.

### Issues/PRs references

Introduced in #13349
Found in #15011
