### PR TITLE
doc/memo: Link to RDMs in development

### DIFF
--- a/doc/memos/README.md
+++ b/doc/memos/README.md
@@ -4,3 +4,10 @@ The index below lists the RDMs that were published so far.
 
 - [RDM0 : RIOT Developer Memo Format, Publishing and Maintenance Process](./rdm0000.md)
 - [RDM1 : RIOT Design Goals](./rdm0001.md)
+
+# RDM development process
+
+New Developer Memos are shaped in pull requests and are merged when accepted.
+
+RDMs currently being prepared are [accessible in the issue
+tracker](https://github.com/RIOT-OS/RIOT/pulls?q=is%3Apr+is%3Aopen+label%3A%22Area%3A+RDM%22+).


### PR DESCRIPTION
### Contribution description

The RDMs page lists the currently released memos, but the ones currently in progress are at least as relevant to casual readers because they are where input is needed. This documents a) that they are agreed on in PRs, and b) where those currently under discussion can be found.