### PR TITLE
sys/ztimer: fix auto_init doc

### DIFF
--- a/sys/ztimer/auto_init.c
+++ b/sys/ztimer/auto_init.c
@@ -20,16 +20,16 @@
  *
  * Anyhow, this configures ztimer as follows:
  *
- * 1. if ztimer_msec in USEMODULE:
- * 1.1. assume ztimer_msec uses periph_timer
+ * 1. if ztimer_usec in USEMODULE:
+ * 1.1. assume ztimer_usec uses periph_timer
  * 1.2a. if no config given
  * 1.2a.1a. use xtimer config if available
  * 1.2a.1b. default to TIMER_DEV(0), 32bit
  * 1.2b. else, use config
  *
- * 2. if ztimer_usec in USEMODULE:
+ * 2. if ztimer_msec in USEMODULE:
  * 2.1a. if periph_rtt in USEMODULE: use that
- * 2.1b: else: convert from ZTIMER_MSEC
+ * 2.1b: else: convert from ZTIMER_USEC
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  *


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

usec <-> msec are confused in ztimer's auto_init doxygen.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
