### PR TITLE
makefiles/info-global.inc.mk: add initial default modules inclusion

### DIFF
--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -56,6 +56,10 @@ define board_unsatisfied_features
     BOARDS_FEATURES_MISSING += "$$(BOARD) $$(FEATURES_MISSING)"
     BOARDS_WITH_MISSING_FEATURES += $$(BOARD)
   else
+    # add default modules
+    include $(RIOTMAKE)/defaultmodules.inc.mk
+    USEMODULE += $(filter-out $(DISABLE_MODULE),$(DEFAULT_MODULE))
+
     include $(RIOTMAKE)/dependency_resolution.inc.mk
 
     ifneq (,$$(FEATURES_MISSING))


### PR DESCRIPTION
### Contribution description

In #14132 the cache mechanism was removed, but `default` modules initial inclusion
should still be present to mimic `Makefile.include` unless I'm missing soemthing.

I think none of the initially included `default` modules has an impact on dependencies so `save_all_dependencies` should be the same.

### Testing procedure

`./dist/tools/buildsystem_sanity_
check/save_all_dependencies_resolution_variables.sh`, but if its not the same it would mean that something in `$(RIOTMAKE)/defaultmodules.inc.mk` is triggering some dependency.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
