### PR TITLE
ipv6: Declare unsigned long long literal

### DIFF
--- a/sys/include/net/ipv6/addr.h
+++ b/sys/include/net/ipv6/addr.h
@@ -687,7 +687,7 @@ static inline void ipv6_addr_set_all_routers_multicast(ipv6_addr_t *addr, unsign
  */
 static inline void ipv6_addr_set_solicited_nodes(ipv6_addr_t *out, const ipv6_addr_t *in)
 {
-    out->u64[0] = byteorder_htonll(0xff02000000000000);
+    out->u64[0] = byteorder_htonll(0xff02000000000000ull);
     out->u32[2] = byteorder_htonl(1);
     out->u8[12] = 0xff;
     out->u8[13] = in->u8[13];


### PR DESCRIPTION
### Contribution description

The literal number 0xff02000000000000 used in the IPv6 headers gets declared as a long long integer.

My impression is that large literals should always be annotated with their type, this is common practice in other places in the code. I can't say for sure that it's violating the C standard (that's a complex beast), and neither GCC nor clang complain about the literal when used in a position where a unsigned long long is expected, but my gut feeling is that somewhere there's probably a rule that literals are promoted up to some type (C2Rust seems to think it's unsigned long), and larger literals are technically overflowing somewhere (even though things keep working as the overflow is optimized out again).

### Testing procedure

For applications that use the ipv6_addr_set_solicited_nodes function (eg. examples/coap), this does not change the binaries. (There's always the changes from branch names; what I checked was whether there was any change around occurrences of the constant in objdump, which there were not).

### Issues/PRs references

This helps #9799 because the C2Rust transpiler is a bit stricter than most compilers when it comes to literals.