### PR TITLE
driver/at86rf2xx: fix asserts in _set func

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -498,17 +498,17 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 
     switch (opt) {
         case NETOPT_ADDRESS:
-            assert(len <= sizeof(network_uint16_t));
+            assert(len == sizeof(network_uint16_t));
             at86rf2xx_set_addr_short(dev, val);
             /* don't set res to set netdev_ieee802154_t::short_addr */
             break;
         case NETOPT_ADDRESS_LONG:
-            assert(len <= sizeof(eui64_t));
+            assert(len == sizeof(eui64_t));
             at86rf2xx_set_addr_long(dev, val);
             /* don't set res to set netdev_ieee802154_t::long_addr */
             break;
         case NETOPT_NID:
-            assert(len <= sizeof(uint16_t));
+            assert(len == sizeof(uint16_t));
             at86rf2xx_set_pan(dev, *((const uint16_t *)val));
             /* don't set res to set netdev_ieee802154_t::pan */
             break;


### PR DESCRIPTION
### Contribution description
Just stumbled upon these lines: correct me if I am wrong, but checking for less then in the assert seems to be wrong to me. If the length of the given buffer (`val`) is smaller than the target value, the assert will not complain and we will pass 1 to N bytes of arbitrary memory to the subsequent set functions. That can't be good, right?

Having a `len` larger than the target value will simply lead to 1 to N bytes being ignored, that sounds suboptimal but does not hurt. So shouldn't this be equal (like in the commit below) or larger then?

If I am completely off here feel free to close this PR :-)

### Testing procedure
Run GNRC networking on any board with DEVELHELP enabled. If it does not crash on boot, we die not break anything :-)

### Issues/PRs references
none