### PR TITLE
cpu/nrf52: Remove unused static inline USB poweroff

### DIFF
--- a/cpu/nrf52/periph/usbdev.c
+++ b/cpu/nrf52/periph/usbdev.c
@@ -114,11 +114,6 @@ static inline void poweron(nrfusb_t *usbdev)
     usbdev->device->ENABLE = USBD_ENABLE_ENABLE_Msk;
 }
 
-static inline void poweroff(nrfusb_t *usbdev)
-{
-    usbdev->device->ENABLE = 0x00;
-}
-
 static void usb_attach(nrfusb_t *usbdev)
 {
     DEBUG("nrfusb: Enabling pull-up\n");


### PR DESCRIPTION
### Contribution description

The removed function was never in used, and this is breaking builds using LLVM that treats unused static inlines as an error.

### Testing procedure

`make -C examples/hello-world  TOOLCHAIN=llvm BOARD=nrf52840dongle all`

As the function was not used locally, this should not alter any produced binaries, and just remove the build failure on LLVM.