### PR TITLE
boards/hifive1[b]: always set Kconfig values for clock configuration

### DIFF
--- a/boards/hifive1/Kconfig
+++ b/boards/hifive1/Kconfig
@@ -38,32 +38,28 @@ config USE_CLOCK_HFROSC
     bool "Direct High frequency internal oscillator (HFROSC)"
 endchoice
 
-if USE_CLOCK_HFXOSC_PLL
+# the configuration macros must always be defined for clock.c to compile
 config CLOCK_PLL_F
-    int "F: REFR multiply factor"
+    int "F: REFR multiply factor" if USE_CLOCK_HFXOSC_PLL
     default 39
 
 config CLOCK_PLL_Q
-    int "Q: VCO divide factor"
+    int "Q: VCO divide factor" if USE_CLOCK_HFXOSC_PLL
     default 1
-endif
 
 config CLOCK_DESIRED_FREQUENCY
-    int "Desired clock frequency"
+    int "Desired clock frequency" if USE_CLOCK_HFROSC_PLL
     default 320000000
     range 1000000 320000000
-    depends on USE_CLOCK_HFROSC_PLL
 
-if USE_CLOCK_HFROSC
 config CLOCK_HFROSC_TRIM
-    int "TRIM: input frequency multiplier"
+    int "TRIM: input frequency multiplier" if USE_CLOCK_HFROSC
     default 6
     range 0 31
 
 config CLOCK_HFROSC_DIV
-    int "DIV: output frequency divider"
+    int "DIV: output frequency divider" if USE_CLOCK_HFROSC
     default 1
     range 0 63
-endif
 
 endmenu

--- a/boards/hifive1b/Kconfig
+++ b/boards/hifive1b/Kconfig
@@ -40,32 +40,29 @@ config USE_CLOCK_HFROSC
     bool "Direct High frequency internal oscillator (HFROSC)"
 endchoice
 
-if USE_CLOCK_HFXOSC_PLL
+# the configuration macros must always be defined for clock.c to compile
 config CLOCK_PLL_F
-    int "F: REFR multiply factor"
+    int "F: REFR multiply factor" if USE_CLOCK_HFXOSC_PLL
     default 39
 
 config CLOCK_PLL_Q
-    int "Q: VCO divide factor"
+    int "Q: VCO divide factor" if USE_CLOCK_HFXOSC_PLL
     default 1
-endif
 
 config CLOCK_DESIRED_FREQUENCY
-    int "Desired clock frequency"
+    int
+    prompt "Desired clock frequency" if USE_CLOCK_HFROSC_PLL
     default 320000000
     range 1000000 320000000
-    depends on USE_CLOCK_HFROSC_PLL
 
-if USE_CLOCK_HFROSC
 config CLOCK_HFROSC_TRIM
-    int "TRIM: input frequency multiplier"
+    int "TRIM: input frequency multiplier" if USE_CLOCK_HFROSC
     default 6
     range 0 31
 
 config CLOCK_HFROSC_DIV
-    int "DIV: output frequency divider"
+    int "DIV: output frequency divider" if USE_CLOCK_HFROSC
     default 1
     range 0 63
-endif
 
 endmenu


### PR DESCRIPTION
### Contribution description
As `clock.c` for the fe310 now uses C conditionals instead of `#ifdef` the configuration macros should always be defined. This PR moves the dependencies of these symbols to the condition to show up the prompt. For the users nothing changes: they are not able to configure these parameters when the correspondent clock source is not selected. But Kconfig will generate the macro assigning to it the default value that applies.

### Testing procedure
- Configuration of clocks should still be possible via Kconfig
- Check that now (compared to master) macros like `CLOCK_PLL_Q` will always be defined even when other clock source is selected in `autoconf.h`.

### Issues/PRs references
Related to #14896
