### PR TITLE
drivers/at86rf2xx: fix at86rf2xx_set_rxsensitivity

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -51,20 +51,6 @@ static const uint8_t dbm_to_tx_pow_915[] = { 0x1d, 0x1c, 0x1b, 0x1a, 0x19, 0x17,
                                              0x04, 0x03, 0x02, 0x01, 0x00, 0x86,
                                              0x40, 0x84, 0x83, 0x82, 0x80, 0xc1,
                                              0xc0 };
-static const int16_t rx_sens_to_dbm[] = { -110, -98, -94, -91, -88, -85, -82,
-                                          -79, -76, -73, -70, -67, -63, -60, -57,
-                                          -54 };
-static const uint8_t dbm_to_rx_sens[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                          0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                          0x01, 0x01, 0x01, 0x01, 0x02, 0x02,
-                                          0x02, 0x03, 0x03, 0x03, 0x04, 0x04,
-                                          0x04, 0x05, 0x05, 0x05, 0x06, 0x06,
-                                          0x06, 0x07, 0x07, 0x07, 0x08, 0x08,
-                                          0x08, 0x09, 0x09, 0x09, 0x0a, 0x0a,
-                                          0x0a, 0x0b, 0x0b, 0x0b, 0x0b, 0x0c,
-                                          0x0c, 0x0c, 0x0d, 0x0d, 0x0d, 0x0e,
-                                          0x0e, 0x0e, 0x0f };
-
 static int16_t _tx_pow_to_dbm_212b(uint8_t channel, uint8_t page, uint8_t reg)
 {
     if (page == 0 || page == 2) {
@@ -99,18 +85,6 @@ static const uint8_t dbm_to_tx_pow[] = { 0x0f, 0x0f, 0x0f, 0x0e, 0x0e, 0x0e,
                                          0x0e, 0x0d, 0x0d, 0x0d, 0x0c, 0x0c,
                                          0x0b, 0x0b, 0x0a, 0x09, 0x08, 0x07,
                                          0x06, 0x05, 0x03, 0x00 };
-static const int16_t rx_sens_to_dbm[] = { -101, -94, -91, -88, -85, -82, -79,
-                                          -76, -73, -70, -67, -64, -61, -58, -55,
-                                          -52 };
-static const uint8_t dbm_to_rx_sens[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                          0x00, 0x01, 0x01, 0x01, 0x02, 0x02,
-                                          0x02, 0x03, 0x03, 0x03, 0x04, 0x04,
-                                          0x04, 0x05, 0x05, 0x05, 0x06, 0x06,
-                                          0x06, 0x07, 0x07, 0x07, 0x08, 0x08,
-                                          0x08, 0x09, 0x09, 0x09, 0x0a, 0x0a,
-                                          0x0a, 0x0b, 0x0b, 0x0b, 0x0c, 0x0c,
-                                          0x0c, 0x0d, 0x0d, 0x0d, 0x0e, 0x0e,
-                                          0x0e, 0x0f };
 #else
 static const int16_t tx_pow_to_dbm[] = { 3, 3, 2, 2, 1, 1, 0,
                                          -1, -2, -3, -4, -5, -7, -9, -12, -17 };
@@ -118,18 +92,6 @@ static const uint8_t dbm_to_tx_pow[] = { 0x0f, 0x0f, 0x0f, 0x0e, 0x0e, 0x0e,
                                          0x0e, 0x0d, 0x0d, 0x0c, 0x0c, 0x0b,
                                          0x0b, 0x0a, 0x09, 0x08, 0x07, 0x06,
                                          0x05, 0x03, 0x00 };
-static const int16_t rx_sens_to_dbm[] = { -101, -91, -88, -85, -82, -79, -76
-                                          -73, -70, -67, -64, -61, -58, -55, -52,
-                                          -49 };
-static const uint8_t dbm_to_rx_sens[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                                          0x00, 0x00, 0x00, 0x00, 0x01, 0x01,
-                                          0x01, 0x02, 0x02, 0x02, 0x03, 0x03,
-                                          0x03, 0x04, 0x04, 0x04, 0x05, 0x05,
-                                          0x05, 0x06, 0x06, 0x06, 0x07, 0x07,
-                                          0x07, 0x08, 0x08, 0x08, 0x09, 0x09,
-                                          0x09, 0x0a, 0x0a, 0x0a, 0x0b, 0x0b,
-                                          0x0b, 0x0c, 0x0c, 0x0c, 0x0d, 0x0d,
-                                          0x0d, 0x0e, 0x0e, 0x0e, 0x0f };
 #endif
 
 void at86rf2xx_get_addr_short(const at86rf2xx_t *dev, network_uint16_t *addr)
@@ -304,27 +266,34 @@ void at86rf2xx_set_txpower(const at86rf2xx_t *dev, int16_t txpower)
 #endif
 }
 
-int16_t at86rf2xx_get_rxsensitivity(const at86rf2xx_t *dev)
+int8_t at86rf2xx_get_rxsensitivity(const at86rf2xx_t *dev)
 {
     uint8_t rxsens = at86rf2xx_reg_read(dev, AT86RF2XX_REG__RX_SYN)
                      & AT86RF2XX_RX_SYN__RX_PDT_LEVEL;
-    return rx_sens_to_dbm[rxsens];
+    /* From datasheet (see below) */
+    return rxsens > 0 ? RSSI_BASE_VAL + ((rxsens - 1) * 3) : MIN_RX_SENSITIVITY;
 }
 
-void at86rf2xx_set_rxsensitivity(const at86rf2xx_t *dev, int16_t rxsens)
+void at86rf2xx_set_rxsensitivity(const at86rf2xx_t *dev, int8_t rxsens)
 {
-    rxsens += MIN_RX_SENSITIVITY;
-
-    if (rxsens < 0) {
-        rxsens = 0;
+    uint8_t hwval;
+    /* From datasheet, rxsens = @ref RSSI_BASE_VAL + (3 * (RX_PDT_LEVEL-1)).
+     * If rxsens < @ref RSSI_BASE_VAL, the RX sensitivity is equal to @ref
+     * MIN_RX_SENSITIVITY.
+     */
+    if (rxsens < RSSI_BASE_VAL) {
+        hwval = 0;
     }
-    else if (rxsens > MAX_RX_SENSITIVITY) {
-        rxsens = MAX_RX_SENSITIVITY;
+    else if (rxsens > RSSI_BASE_VAL + (3 * (AT86RF2XX_RX_SYN__RX_PDT_LEVEL)) - 1) {
+        hwval = AT86RF2XX_RX_SYN__RX_PDT_LEVEL;
+    }
+    else {
+        hwval = ((rxsens - RSSI_BASE_VAL + 3) / 3);
     }
 
     uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__RX_SYN);
     tmp &= ~(AT86RF2XX_RX_SYN__RX_PDT_LEVEL);
-    tmp |= (dbm_to_rx_sens[rxsens] & AT86RF2XX_RX_SYN__RX_PDT_LEVEL);
+    tmp |= (hwval & AT86RF2XX_RX_SYN__RX_PDT_LEVEL);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__RX_SYN, tmp);
 }
 

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -95,19 +95,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Max Receiver sensitivity value in dBm
- */
-#if MODULE_AT86RF233
-#   define MAX_RX_SENSITIVITY              (-52)
-#elif MODULE_AT86RF212B
-#   define MAX_RX_SENSITIVITY              (-54)
-#elif MODULE_AT86RFA1 || MODULE_AT86RFR2
-#   define MAX_RX_SENSITIVITY              (-48)
-#else
-#   define MAX_RX_SENSITIVITY              (-49)
-#endif
-
-/**
  * @brief   Min Receiver sensitivity value in dBm
  */
 #if MODULE_AT86RF233
@@ -455,7 +442,7 @@ void at86rf2xx_set_txpower(const at86rf2xx_t *dev, int16_t txpower);
  *
  * @return                  configured receiver sensitivity in dBm
  */
-int16_t at86rf2xx_get_rxsensitivity(const at86rf2xx_t *dev);
+int8_t at86rf2xx_get_rxsensitivity(const at86rf2xx_t *dev);
 
 /**
  * @brief   Set the receiver sensitivity of the given device [in dBm]
@@ -468,7 +455,7 @@ int16_t at86rf2xx_get_rxsensitivity(const at86rf2xx_t *dev);
  * @param[in] dev           device to write to
  * @param[in] rxsens        rx sensitivity in dBm
  */
-void at86rf2xx_set_rxsensitivity(const at86rf2xx_t *dev, int16_t rxsens);
+void at86rf2xx_set_rxsensitivity(const at86rf2xx_t *dev, int8_t rxsens);
 
 /**
  * @brief   Get the maximum number of retransmissions


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes the function for setting RX sensitivity. The version in master doesn't set the correct values, as described in #15015 .
I discovered the compiler generates similar code when using precomputed tables or math operations, so I left the operations because I think they are easier to understand.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Use the following patch:
```diff
diff --git a/drivers/at86rf2xx/at86rf2xx.c b/drivers/at86rf2xx/at86rf2xx.c
index a399f060c2..1bcfb0df6b 100644
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -85,10 +85,14 @@ static void at86rf2xx_enable_smart_idle(at86rf2xx_t *dev)
             AT86RF2XX_TRX_RPC_MASK__XAH_TX_RPC_EN |
             AT86RF2XX_TRX_RPC_MASK__IPAN_RPC_EN);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_RPC, tmp);
-    at86rf2xx_set_rxsensitivity(dev, RSSI_BASE_VAL);
 #else
     (void) dev;
 #endif
+    for (int i = -115; i< -40; i++) {
+        printf("rx_sens: %i: hw_val:", i);
+        at86rf2xx_set_rxsensitivity(dev, i);
+        printf(" get: %i\n", at86rf2xx_get_rxsensitivity(dev));
+    }
 }
 
 void at86rf2xx_reset(at86rf2xx_t *dev)
diff --git a/drivers/at86rf2xx/at86rf2xx_getset.c b/drivers/at86rf2xx/at86rf2xx_getset.c
index 543750a395..764ea71b5f 100644
--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -291,6 +291,7 @@ void at86rf2xx_set_rxsensitivity(const at86rf2xx_t *dev, int8_t rxsens)
         hwval = ((rxsens - RSSI_BASE_VAL + 3) / 3);
     }
 
+    printf("%i", hwval);
     uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__RX_SYN);
     tmp &= ~(AT86RF2XX_RX_SYN__RX_PDT_LEVEL);
     tmp |= (hwval & AT86RF2XX_RX_SYN__RX_PDT_LEVEL);

```

Reboot the node and check the RX sensitivity to be set, the internal HW value and the value of the getter:
E.g 
```
020-09-16 14:48:43,662 # rx_sens: -96: hw_val:0 get: -101
2020-09-16 14:48:43,665 # rx_sens: -95: hw_val:0 get: -101
2020-09-16 14:48:43,666 # rx_sens: -94: hw_val:1 get: -94
2020-09-16 14:48:43,668 # rx_sens: -93: hw_val:1 get: -94
2020-09-16 14:48:43,670 # rx_sens: -92: hw_val:1 get: -94
2020-09-16 14:48:43,672 # rx_sens: -91: hw_val:2 get: -91
2020-09-16 14:48:43,673 # rx_sens: -90: hw_val:2 get: -91
2020-09-16 14:48:43,674 # rx_sens: -89: hw_val:2 get: -91
2020-09-16 14:48:43,676 # rx_sens: -88: hw_val:3 get: -88
```

The getter should always return a value less or equal to the set RX sensitivity. The range of the HW value is {0, 15}.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#15015 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
