### PR TITLE
{drivers/apds99xx, sys/net/gnrc/netreg}: Drop xtimer includes

### DIFF
--- a/drivers/apds99xx/apds99xx.c
+++ b/drivers/apds99xx/apds99xx.c
@@ -23,7 +23,6 @@
 
 #include "irq.h"
 #include "log.h"
-#include "xtimer.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -34,7 +34,9 @@
 #include "fmt.h"
 #include "log.h"
 #include "sched.h"
+#if (CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US > 0U)
 #include "xtimer.h"
+#endif
 
 #include "net/gnrc/netif.h"
 #include "net/gnrc/netif/internal.h"

--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -24,7 +24,9 @@
 #include "net/gnrc/icmpv6.h"
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/udp.h"
+#ifdef MODULE_GNRC_TCP
 #include "net/gnrc/tcp.h"
+#endif
 
 #define _INVALID_TYPE(type) (((type) < GNRC_NETTYPE_UNDEF) || ((type) >= GNRC_NETTYPE_NUMOF))
 

--- a/tests/driver_apds99xx_full/main.c
+++ b/tests/driver_apds99xx_full/main.c
@@ -35,9 +35,9 @@
 
 #include <stdio.h>
 
+#include "mutex.h"
 #include "thread.h"
 #include "thread_flags.h"
-#include "xtimer.h"
 
 #include "apds99xx.h"
 #include "apds99xx_params.h"


### PR DESCRIPTION
### Contribution description

tl;dr: I get compilation issues with `xtimer.h` is included, but `USEMODULE += xtimer` is missing when the clock config of the `wasmote-pro` is fixed. See https://github.com/RIOT-OS/RIOT/pull/14799 for details on why this is so.

This PR drops includes to `xtimer.h` where the module is not actually used.

- drivers/apds99xx is not using xtimer, but including `xtimer.h`. This resulted in compilation issues on the `waspmote-pro`
    - `xtimer.h` pulled in `mutex.h` indirectly. I had to explicitly included it now to fix compilation issues
- sys/net/gnrc/netreg is including `xtimer.h` indirectly through `net/gnrc/tcp.h`, even when `gnrc_tcp` is not used
    - Stop including `net/gnrc/tcp.h` unless module `gnrc_tcp` is used
- sys/net/gnrc/netif/gnrc_netif.c includes `xtimer.h`, but only needs xtimer when `CONFIG_GNRC_NETIF_MIN_WAIT_AFTER_SEND_US` is set to a positive number (default is zero)
    - Btw: Is `xtimer` pulled in as dependency by the build system, if it is non-zero. (But out of scope of this PR.)

### Testing procedure

This should change no binaries.

### Issues/PRs references

Spun out of https://github.com/RIOT-OS/RIOT/pull/14799