### PR TITLE
tests/xtimer_{rmutex,mutex}_lock_timeout: Fix compilation

### DIFF
--- a/tests/xtimer_mutex_lock_timeout/main.c
+++ b/tests/xtimer_mutex_lock_timeout/main.c
@@ -25,6 +25,13 @@
 #include "msg.h"
 #include "irq.h"
 
+/* XTIMER_SHIFT can be undefined when using xtimer_on_ztimer on boards
+ * incompatible with xtimers tick conversion, e.g. the waspmote-pro
+ */
+#ifndef XTIMER_SHIFT
+#define XTIMER_SHIFT    (0)
+#endif
+
 /* timeout at one millisecond (1000 us) to make sure it does not spin. */
 #define LONG_MUTEX_TIMEOUT 1000
 

--- a/tests/xtimer_rmutex_lock_timeout/main.c
+++ b/tests/xtimer_rmutex_lock_timeout/main.c
@@ -26,6 +26,13 @@
 #include "msg.h"
 #include "irq.h"
 
+/* XTIMER_SHIFT can be undefined when using xtimer_on_ztimer on boards
+ * incompatible with xtimers tick conversion, e.g. the waspmote-pro
+ */
+#ifndef XTIMER_SHIFT
+#define XTIMER_SHIFT    (0)
+#endif
+
 /* timeout at one millisecond (1000 us) to make sure it does not spin. */
 #define LONG_RMUTEX_TIMEOUT 1000
 


### PR DESCRIPTION
### Contribution description

The two tests reuse the internal `XTIMER_SHIFT` value. However, this value is not provided when `xtimer_on_ztimer` is used. Letting `XTIMER_SHIFT` fall back to zero fixes the issue.

### Testing procedure

```
USEMODULE=xtimer_on_ztimer BOARD=<SOME_BOARD> make -C tests/xtimer_mutex_lock_timeout/
```

will no longer fail to compile.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/14799