### PR TITLE
tests/periph_timer_{periodic, short_relative_set}: Drop include of `xtimer.h`

### DIFF
--- a/tests/periph_timer_periodic/main.c
+++ b/tests/periph_timer_periodic/main.c
@@ -22,11 +22,20 @@
 #include <stdint.h>
 
 #include "board.h"
-#include "test_utils/expect.h"
-
+#include "macros/units.h"
 #include "mutex.h"
 #include "periph/timer.h"
-#include "xtimer.h"
+#include "test_utils/expect.h"
+
+/* recreate logic to obtain valid XTIMER_DEV used in xtimer.h, but don't include
+ * xtimer.h, as this leads to issues on some boards when the xtimer module is
+ * not used */
+#ifndef XTIMER_DEV
+#define XTIMER_DEV  TIMER_DEV(0)
+#endif
+#ifndef XTIMER_HZ
+#define XTIMER_HZ   MHZ(1)
+#endif
 
 /* We use the timer used for xtimer with the frequency used by xtimer here
  * to make sure we have a known valid timer configuration.

--- a/tests/periph_timer_short_relative_set/main.c
+++ b/tests/periph_timer_short_relative_set/main.c
@@ -23,20 +23,35 @@
 #include <stdlib.h>
 
 #include "board.h"
+#include "macros/units.h"
 #include "thread.h"
 #include "thread_flags.h"
 
 #include "periph/timer.h"
 
-#ifndef TEST_TIMER_DEV
-# include "xtimer.h"
-# define TEST_TIMER_DEV      XTIMER_DEV
-# define TEST_TIMER_FREQ     XTIMER_HZ
-# define TEST_TIMER_WIDTH    XTIMER_WIDTH
-#else
-# ifndef TEST_TIMER_FREQ
-#  define TEST_TIMER_FREQ     (1000000LU)
+/* recreate logic to obtain valid XTIMER_DEV used in xtimer.h, but don't include
+ * xtimer.h, as this leads to issues on some boards when the xtimer module is
+ * not used */
+#ifndef XTIMER_DEV
+# define XTIMER_DEV         TIMER_DEV(0)
+#endif
+#ifndef XTIMER_HZ
+# define XTIMER_HZ          MHZ(1)
+#endif
+#ifndef XTIMER_WIDTH
+# if(TIMER_0_MAX_VALUE) == 0xfffffful
+#  define XTIMER_WIDTH      (24)
+# elif (TIMER_0_MAX_VALUE) == 0xffff
+#  define XTIMER_WIDTH      (16)
+# else
+#  define XTIMER_WIDTH      (32)
 # endif
+#endif /* !defined(XTIMER_WIDTH) */
+
+#ifndef TEST_TIMER_FREQ
+# define TEST_TIMER_DEV     XTIMER_DEV
+# define TEST_TIMER_FREQ    XTIMER_HZ
+# define TEST_TIMER_WIDTH   XTIMER_WIDTH
 #endif
 
 #ifndef TEST_MAX_DIFF


### PR DESCRIPTION
### Contribution description

These tests don't use the `xtimer` module, but still include `xtimer.h`. This leads to compilation errors in https://github.com/RIOT-OS/RIOT/pull/14799. This drops the `#include` of `xtimer.h` and replicates the fall-back logic in `xtimer.h` needed for compilation.

This is certainly not the best and final solution. IMO, it would be nice to add a function to `periph_timer` that allows iterating over supported frequencies. But let's get this in as intermediate solution until such a feature is added.

### Testing procedure

Generated binaries should not change.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/14799