### PR TITLE
cpu/stm32l4: improve clock initialization

### DIFF
--- a/boards/common/stm32/include/l4/cfg_clock_default.h
+++ b/boards/common/stm32/include/l4/cfg_clock_default.h
@@ -107,7 +107,7 @@ extern "C" {
     IS_ACTIVE(CONFIG_BOARD_HAS_HSE)
 #define CONFIG_CLOCK_PLL_SRC_MSI        0
 #else
-#define CONFIG_CLOCK_PLL_SRC_MSI        1       /* Use MSI an input clock by default */
+#define CONFIG_CLOCK_PLL_SRC_MSI        1       /* Use MSI as input clock by default */
 #endif
 #endif /* CONFIG_CLOCK_PLL_SRC_MSI */
 #ifndef CONFIG_CLOCK_PLL_SRC_HSE
@@ -120,11 +120,29 @@ extern "C" {
 #ifndef CONFIG_CLOCK_PLL_SRC_HSI
 #define CONFIG_CLOCK_PLL_SRC_HSI        0
 #endif
+#if IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_MSI)
+#define CLOCK_PLL_SRC                   (CONFIG_CLOCK_MSI)
+#elif IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_HSE)
+#define CLOCK_PLL_SRC                   (CLOCK_HSE)
+#else /* CONFIG_CLOCK_PLL_SRC_ */
+#define CLOCK_PLL_SRC                   (CLOCK_HSI)
+#endif
 #ifndef CONFIG_CLOCK_PLL_M
-#define CONFIG_CLOCK_PLL_M              (6)
+#if IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_MSI)
+#define CONFIG_CLOCK_PLL_M              (6)     /* MSI at 48MHz */
+#elif IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_HSE) && (CLOCK_HSE == MHZ(8))
+#define CONFIG_CLOCK_PLL_M              (1)     /* HSE at 8MHz */
+#elif IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_HSE) && (CLOCK_HSE == MHZ(32))
+#define CONFIG_CLOCK_PLL_M              (5)     /* HSE at 32MHz */
+#else
+#define CONFIG_CLOCK_PLL_M              (2)     /* HSI at 16MHz */
+#endif
 #endif
 #ifndef CONFIG_CLOCK_PLL_N
 #define CONFIG_CLOCK_PLL_N              (20)
+#endif
+#ifndef CONFIG_CLOCK_PLL_Q
+#define CONFIG_CLOCK_PLL_Q              (2)
 #endif
 #ifndef CONFIG_CLOCK_PLL_R
 #define CONFIG_CLOCK_PLL_R              (2)
@@ -143,13 +161,6 @@ extern "C" {
 #define CLOCK_CORECLOCK                 (CONFIG_CLOCK_MSI)
 
 #elif IS_ACTIVE(CONFIG_USE_CLOCK_PLL)
-#if IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_MSI)
-#define CLOCK_PLL_SRC                   (CONFIG_CLOCK_MSI)
-#elif IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_HSE)
-#define CLOCK_PLL_SRC                   (CLOCK_HSE)
-#else /* CONFIG_CLOCK_PLL_SRC_ */
-#define CLOCK_PLL_SRC                   (CLOCK_HSI)
-#endif
 /* PLL configuration: make sure your values are legit!
  *
  * compute by: CORECLOCK = (((PLL_IN / M) * N) / R)

--- a/boards/common/stm32/include/l4/cfg_clock_default.h
+++ b/boards/common/stm32/include/l4/cfg_clock_default.h
@@ -152,9 +152,6 @@ extern "C" {
 #define CLOCK_CORECLOCK                 (CLOCK_HSI)
 
 #elif IS_ACTIVE(CONFIG_USE_CLOCK_HSE)
-#if !IS_ACTIVE(CONFIG_BOARD_HAS_HSE)
-#error "The board doesn't provide an HSE oscillator"
-#endif
 #define CLOCK_CORECLOCK                 (CLOCK_HSE)
 
 #elif IS_ACTIVE(CONFIG_USE_CLOCK_MSI)

--- a/boards/p-nucleo-wb55/include/periph_conf.h
+++ b/boards/p-nucleo-wb55/include/periph_conf.h
@@ -35,10 +35,6 @@
 
 #define CLOCK_HSE                       MHZ(32)
 
-#ifndef CONFIG_CLOCK_PLL_M
-#define CONFIG_CLOCK_PLL_M              (5)
-#endif
-
 /* EXTAHB (HCLK2) max freq 32 Mhz*/
 #define CLOCK_EXTAHB_DIV    RCC_EXTCFGR_C2HPRE_3
 #define CLOCK_EXTAHB        (CLOCK_CORECLOCK / 2)

--- a/cpu/stm32/stmclk/stmclk_l4wb.c
+++ b/cpu/stm32/stmclk/stmclk_l4wb.c
@@ -307,17 +307,6 @@ void stmclk_init_sysclk(void)
         while (!(RCC->CR & RCC_CR_MSIRDY)) {}
     }
 
-    if (IS_ACTIVE(CONFIG_USE_CLOCK_HSE)) {
-        /* Select HSE as system clock and configure the different prescalers */
-        RCC->CFGR &= ~RCC_CFGR_SW;
-        RCC->CFGR |= RCC_CFGR_SW_HSE;
-    }
-    else if (IS_ACTIVE(CONFIG_USE_CLOCK_MSI)) {
-        /* Select MSI as system clock and configure the different prescalers */
-        RCC->CFGR &= ~RCC_CFGR_SW;
-        RCC->CFGR |= RCC_CFGR_SW_MSI;
-    }
-
     if (IS_ACTIVE(CLOCK_ENABLE_PLL)) {
         if (IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_MSI)) {
             if (IS_ACTIVE(CONFIG_BOARD_HAS_LSE)) {
@@ -343,12 +332,24 @@ void stmclk_init_sysclk(void)
 
         RCC->CR |= (RCC_CR_PLLON);
         while (!(RCC->CR & RCC_CR_PLLRDY)) {}
+    }
 
-        if (IS_ACTIVE(CONFIG_USE_CLOCK_PLL)) {
-            /* now that the PLL is running, we use it as system clock if needed */
-            RCC->CFGR |= RCC_CFGR_SW_PLL;
-            while ((RCC->CFGR & RCC_CFGR_SWS) != RCC_CFGR_SWS_PLL) {}
-        }
+    /* Configure the system clock (SYSCLK) */
+    RCC->CFGR &= ~RCC_CFGR_SW;
+    if (IS_ACTIVE(CONFIG_USE_CLOCK_HSE)) {
+        /* Select HSE as system clock */
+        RCC->CFGR |= RCC_CFGR_SW_HSE;
+        while ((RCC->CFGR & RCC_CFGR_SWS) != RCC_CFGR_SWS_HSE) {}
+    }
+    else if (IS_ACTIVE(CONFIG_USE_CLOCK_MSI)) {
+        /* Select MSI as system clock */
+        RCC->CFGR |= RCC_CFGR_SW_MSI;
+        while ((RCC->CFGR & RCC_CFGR_SWS) != RCC_CFGR_SWS_MSI) {}
+    }
+    else if (IS_ACTIVE(CONFIG_USE_CLOCK_PLL)) {
+        /* Select PLL as system clock */
+        RCC->CFGR |= RCC_CFGR_SW_PLL;
+        while ((RCC->CFGR & RCC_CFGR_SWS) != RCC_CFGR_SWS_PLL) {}
     }
 
     if (IS_ACTIVE(CLOCK_ENABLE_48MHZ)) {

--- a/cpu/stm32/stmclk/stmclk_l4wb.c
+++ b/cpu/stm32/stmclk/stmclk_l4wb.c
@@ -84,6 +84,26 @@
 #error "PLL configuration: PLL R value is invalid"
 #endif
 #endif
+
+#if defined(CPU_FAM_STM32WB)
+#if (CONFIG_CLOCK_PLL_Q < 1 || CONFIG_CLOCK_PLL_Q > 8)
+#error "PLL configuration: PLL Q value is invalid"
+#else
+#define PLL_Q                       ((CONFIG_CLOCK_PLL_Q - 1) << RCC_PLLCFGR_PLLQ_Pos)
+#endif
+#else
+#if (CONFIG_CLOCK_PLL_Q == 2)
+#define PLL_Q                       (0)
+#elif (CONFIG_CLOCK_PLL_Q == 4)
+#define PLL_Q                       (RCC_PLLCFGR_PLLQ_0)
+#elif (CONFIG_CLOCK_PLL_Q == 6)
+#define PLL_Q                       (RCC_PLLCFGR_PLLQ_1)
+#elif (CONFIG_CLOCK_PLL_Q == 8)
+#define PLL_Q                       (RCC_PLLCFGR_PLLQ_0 | RCC_PLLCFGR_PLLQ_1)
+#else
+#error "PLL configuration: PLL Q value is invalid"
+#endif
+#endif
 /** @} */
 
 #if CONFIG_CLOCK_MSI == KHZ(100)
@@ -168,6 +188,53 @@
 #endif
 #endif /* CPU_FAM_STM32WB */
 
+/* Configure 48MHz clock source */
+#define CLOCK_PLLQ                  ((CLOCK_PLL_SRC / CONFIG_CLOCK_PLL_M) * CONFIG_CLOCK_PLL_N) / CONFIG_CLOCK_PLL_Q
+
+#if CLOCK_PLLQ == MHZ(48)
+#define CLOCK48MHZ_USE_PLLQ         1
+#elif CONFIG_CLOCK_MSI == MHZ(48)
+#define CLOCK48MHZ_USE_MSI          1
+#else
+#define CLOCK48MHZ_USE_PLLQ         0
+#define CLOCK48MHZ_USE_MSI          0
+#endif
+
+#if IS_ACTIVE(CLOCK48MHZ_USE_PLLQ)
+#define CLOCK48MHZ_SELECT           (RCC_CCIPR_CLK48SEL_1)
+#elif IS_ACTIVE(CLOCK48MHZ_USE_MSI)
+#define CLOCK48MHZ_SELECT           (RCC_CCIPR_CLK48SEL_1 | RCC_CCIPR_CLK48SEL_0)
+#else
+#define CLOCK48MHZ_SELECT           (0)
+#endif
+
+/* Only periph_hwrng requires 48MHz for the moment */
+#if IS_USED(MODULE_PERIPH_HWRNG)
+#if !IS_ACTIVE(CLOCK48MHZ_USE_PLLQ) && !IS_ACTIVE(CLOCK48MHZ_USE_MSI)
+#error "No 48MHz clock source available, HWRNG cannot work"
+#endif
+#define CLOCK_ENABLE_48MHZ          1
+#else
+#define CLOCK_ENABLE_48MHZ          0
+#endif
+
+/* Check if PLL is required */
+#if IS_ACTIVE(CONFIG_USE_CLOCK_PLL) || \
+    (IS_ACTIVE(CLOCK_ENABLE_48MHZ) && IS_ACTIVE(CLOCK48MHZ_USE_PLLQ))
+#define CLOCK_ENABLE_PLL            1
+#else
+#define CLOCK_ENABLE_PLL            0
+#endif
+
+/* Check if MSI is required */
+#if IS_ACTIVE(CONFIG_USE_CLOCK_MSI) || \
+    (IS_ACTIVE(CLOCK_ENABLE_PLL) && IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_MSI)) || \
+    (IS_ACTIVE(CLOCK_ENABLE_48MHZ) && IS_ACTIVE(CLOCK48MHZ_USE_MSI))
+#define CLOCK_ENABLE_MSI            1
+#else
+#define CLOCK_ENABLE_MSI            0
+#endif
+
 /**
  * @name    Deduct the needed flash wait states from the core clock frequency
  * @{
@@ -182,7 +249,6 @@
 #define FLASH_WAITSTATES        ((CLOCK_AHB - 1) / 16000000U)
 #endif
 /** @} */
-
 
 void stmclk_init_sysclk(void)
 {
@@ -232,36 +298,28 @@ void stmclk_init_sysclk(void)
         while (!(RCC->CR & RCC_CR_HSERDY)) {}
     }
 
-    if (IS_ACTIVE(CONFIG_USE_CLOCK_HSE)) {
-        /* Select HSE as system clock and configure the different prescalers */
-        RCC->CFGR &= ~RCC_CFGR_SW;
-        RCC->CFGR |= RCC_CFGR_SW_HSE;
-    }
-    else if (IS_ACTIVE(CONFIG_USE_CLOCK_MSI)) {
+    if (IS_ACTIVE(CLOCK_ENABLE_MSI)) {
 #if defined(CPU_FAM_STM32WB)
         RCC->CR |= (CLOCK_MSIRANGE | RCC_CR_MSION);
 #else
         RCC->CR |= (CLOCK_MSIRANGE | RCC_CR_MSION | RCC_CR_MSIRGSEL);
 #endif
         while (!(RCC->CR & RCC_CR_MSIRDY)) {}
-
-        if (CONFIG_CLOCK_MSI == MHZ(48)) {
-            /* select the MSI clock for the 48MHz clock tree (USB, RNG) */
-            RCC->CCIPR = (RCC_CCIPR_CLK48SEL_0 | RCC_CCIPR_CLK48SEL_1);
-        }
-        /* Select MSI as system clock and configure the different prescalers */
-        RCC->CFGR = (RCC_CFGR_SW_MSI | CLOCK_AHB_DIV | CLOCK_APB1_DIV | CLOCK_APB2_DIV);
     }
-    else if (IS_ACTIVE(CONFIG_USE_CLOCK_PLL)) {
-        if (IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_MSI)) {
-            /* reset clock to MSI with 48MHz, disables all other clocks */
-#if defined(CPU_FAM_STM32WB)
-            RCC->CR |= (CLOCK_MSIRANGE | RCC_CR_MSION);
-#else
-            RCC->CR |= (CLOCK_MSIRANGE | RCC_CR_MSION | RCC_CR_MSIRGSEL);
-#endif
-            while (!(RCC->CR & RCC_CR_MSIRDY)) {}
 
+    if (IS_ACTIVE(CONFIG_USE_CLOCK_HSE)) {
+        /* Select HSE as system clock and configure the different prescalers */
+        RCC->CFGR &= ~RCC_CFGR_SW;
+        RCC->CFGR |= RCC_CFGR_SW_HSE;
+    }
+    else if (IS_ACTIVE(CONFIG_USE_CLOCK_MSI)) {
+        /* Select MSI as system clock and configure the different prescalers */
+        RCC->CFGR &= ~RCC_CFGR_SW;
+        RCC->CFGR |= RCC_CFGR_SW_MSI;
+    }
+
+    if (IS_ACTIVE(CLOCK_ENABLE_PLL)) {
+        if (IS_ACTIVE(CONFIG_CLOCK_PLL_SRC_MSI)) {
             if (IS_ACTIVE(CONFIG_BOARD_HAS_LSE)) {
                 /* configure the low speed clock domain */
                 stmclk_enable_lfclk();
@@ -269,21 +327,33 @@ void stmclk_init_sysclk(void)
                 RCC->CR |= RCC_CR_MSIPLLEN;
                 while (!(RCC->CR & RCC_CR_MSIRDY)) {}
             }
-
-            if (CONFIG_CLOCK_MSI == MHZ(48)) {
-                /* select the MSI clock for the 48MHz clock tree (USB, RNG) */
-                RCC->CCIPR = (RCC_CCIPR_CLK48SEL_0 | RCC_CCIPR_CLK48SEL_1);
-            }
         }
 
         /* now we can safely configure and start the PLL */
-        RCC->PLLCFGR = (PLL_SRC | PLL_M | PLL_N | PLL_R | RCC_PLLCFGR_PLLREN);
+        RCC->PLLCFGR = (PLL_SRC | PLL_M | PLL_N | PLL_R | PLL_Q);
+        if (IS_ACTIVE(CONFIG_USE_CLOCK_PLL)) {
+            /* Enable PLLCLK if PLL is used as system clock */
+            RCC->PLLCFGR |= RCC_PLLCFGR_PLLREN;
+        }
+
+        if (IS_ACTIVE(CLOCK48MHZ_USE_PLLQ)) {
+            /* Enable PLLQ if PLL is used as 48MHz source clock */
+            RCC->PLLCFGR |= RCC_PLLCFGR_PLLQEN;
+        }
+
         RCC->CR |= (RCC_CR_PLLON);
         while (!(RCC->CR & RCC_CR_PLLRDY)) {}
 
-        /* now that the PLL is running, we use it as system clock */
-        RCC->CFGR |= RCC_CFGR_SW_PLL;
-        while ((RCC->CFGR & RCC_CFGR_SWS) != RCC_CFGR_SWS_PLL) {}
+        if (IS_ACTIVE(CONFIG_USE_CLOCK_PLL)) {
+            /* now that the PLL is running, we use it as system clock if needed */
+            RCC->CFGR |= RCC_CFGR_SW_PLL;
+            while ((RCC->CFGR & RCC_CFGR_SWS) != RCC_CFGR_SWS_PLL) {}
+        }
+    }
+
+    if (IS_ACTIVE(CLOCK_ENABLE_48MHZ)) {
+        /* configure the clock used for the 48MHz clock tree (USB, RNG) */
+        RCC->CCIPR = CLOCK48MHZ_SELECT;
     }
 
     if (!IS_ACTIVE(CONFIG_USE_CLOCK_HSI) ||


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR provides again several improvements in the L4/WB clock initialization and configuration:
- It configures and allows to select between available 48MHz clock sources (either PPLQ or MSI48). And ensure a 48MHz clock is available when a feature requires it (only HWRNG for the moment). This particular point fixes an issue in the current master when MSI is not used or doesn't give a 48MHz clock: in this case, HWRNG doesn't work.
- A better distinction is made between a clock source requirement and it's usage. For example, PLL must be enabled in several case: if it's used as system clock or if PLLQ is used as 48MHz clock source. MSI must be enabled if used as system clock, if used as PLL input clock or if it can be used as 48MHz clock source.
- A better distinction is made between a clock source activation and it's selection as system clock source (other families should follow this scheme but I'll address in follow-up PRs or in the already opened PRs).
- It also configures good default values for PLLM in the common `cfg_clock_default.h` header and thus remove the need to define a specific value for `p-nucleo-wb55`

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Verify that hwrng peripheral is working when MSI is not used as system clock or not used as PLL input clock:
  ```
  $ CFLAGS=-DCONFIG_USE_CLOCK_HSI=1 make BOARD=<l4 board> -C tests/periph_hwrng flash test
  ```
  => this is broken on master but is fixed by this PR
- Verify other clock configurations are working:
  Use this patch:

```diff
diff --git a/examples/hello-world/main.c b/examples/hello-world/main.c
index f51bf8c0a0..7a1910279c 100644
--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -20,6 +20,9 @@
  */
 
 #include <stdio.h>
+#include <inttypes.h>
+
+#include "board.h"
 
 int main(void)
 {
@@ -28,5 +31,15 @@ int main(void)
     printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
     printf("This board features a(n) %s MCU.\n", RIOT_MCU);
 
+    printf("Clock coreclock: %" PRIu32 "\n", (uint32_t)CLOCK_CORECLOCK);
+    printf("AHB clock: %" PRIu32 "\n", (uint32_t)CLOCK_AHB);
+    printf("APB1 clock: %" PRIu32 "\n", (uint32_t)CLOCK_APB1);
+#ifdef CLOCK_APB2
+    printf("APB2 clock: %" PRIu32 "\n", (uint32_t)CLOCK_APB2);
+#endif
+#ifdef CLOCK_PLLQ
+    printf("PLLQ clock: %" PRIu32 "\n", (uint32_t)CLOCK_PLLQ);
+#endif
+
     return 0;
 }
  ```

  ```
  $ CFLAGS=-DCONFIG_USE_CLOCK_HSE=1 make BOARD=<l4 board> -C examples/hello-world flash term   => only possible on p-nucleo-wb55
  $ CFLAGS=-DCONFIG_USE_CLOCK_MSI=1 make BOARD=<l4 board> -C examples/hello-world flash term
  $ CFLAGS=-DCONFIG_CLOCK_PLL_SRC_MSI=1 make BOARD=<l4 board> -C examples/hello-world flash term
  $ CFLAGS=-DCONFIG_CLOCK_PLL_SRC_HSI=1 make BOARD=<l4 board> -C examples/hello-world flash term
  $ CFLAGS=-DCONFIG_CLOCK_PLL_SRC_HSE=1 make BOARD=<l4 board> -C examples/hello-world flash term
  ```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick one item in #14975 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
