### PR TITLE
pkg/openthread: migrate to event loop

### DIFF
--- a/pkg/openthread/Makefile.dep
+++ b/pkg/openthread/Makefile.dep
@@ -3,4 +3,5 @@ USEMODULE += openthread_contrib
 USEMODULE += openthread_contrib_netdev
 USEMODULE += l2util
 USEMODULE += xtimer
+USEMODULE += event
 FEATURES_REQUIRED += cpp

--- a/pkg/openthread/contrib/platform_alarm.c
+++ b/pkg/openthread/contrib/platform_alarm.c
@@ -28,8 +28,25 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static xtimer_t ot_timer;
-static msg_t ot_alarm_msg;
+static void _ev_timer_handler(event_t *event)
+{
+    (void) event;
+    otPlatAlarmMilliFired(openthread_get_instance());
+}
+
+static event_t ev_timer = {
+    .handler = _ev_timer_handler
+};
+
+void _timeout_cb(void *arg)
+{
+    (void) arg;
+    event_post(openthread_get_evq(), &ev_timer);
+}
+
+static xtimer_t ot_timer = {
+    .callback = _timeout_cb,
+};
 
 /**
  * Set the alarm to fire at @p aDt milliseconds after @p aT0.
@@ -44,14 +61,13 @@ void otPlatAlarmMilliStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)
     (void)aT0;
 
     DEBUG("openthread: otPlatAlarmStartAt: aT0: %" PRIu32 ", aDT: %" PRIu32 "\n", aT0, aDt);
-    ot_alarm_msg.type = OPENTHREAD_XTIMER_MSG_TYPE_EVENT;
 
     if (aDt == 0) {
-        msg_send(&ot_alarm_msg, thread_getpid());
+        event_post(openthread_get_evq(), &ev_timer);
     }
     else {
         int dt = aDt * US_PER_MS;
-        xtimer_set_msg(&ot_timer, dt, &ot_alarm_msg, thread_getpid());
+        xtimer_set(&ot_timer, dt);
     }
 }
 

--- a/pkg/openthread/contrib/platform_functions_wrapper.c
+++ b/pkg/openthread/contrib/platform_functions_wrapper.c
@@ -77,25 +77,36 @@ const ot_command_t otCommands[] =
     { "thread", &ot_thread },
 };
 
-uint8_t ot_exec_command(otInstance *ot_instance, const char* command, void *arg, void* answer) {
+void _exec_cmd(event_t *event) {
+    ot_job_t *job = (ot_job_t*) event;
+
     uint8_t res = 0xFF;
     /* Check running thread */
-    if (openthread_get_pid() == thread_getpid()) {
-        for (uint8_t i = 0; i < ARRAY_SIZE(otCommands); i++) {
-            if (strcmp(command, otCommands[i].name) == 0) {
-                res = (*otCommands[i].function)(ot_instance, arg, answer);
-                break;
-            }
+    for (uint8_t i = 0; i < ARRAY_SIZE(otCommands); i++) {
+        if (strcmp(job->command, otCommands[i].name) == 0) {
+            res = (*otCommands[i].function)(openthread_get_instance(), job->arg, job->answer);
+            break;
         }
-        if (res == 0xFF) {
-            DEBUG("Wrong ot_COMMAND name\n");
-            res = 1;
-        }
-    } else {
-        DEBUG("ERROR: ot_exec_job needs to run in OpenThread thread\n");
     }
-    return res;
+    if (res == 0xFF) {
+        DEBUG("Wrong ot_COMMAND name\n");
+        res = 1;
+    }
+    job->status = res;
 }
+
+uint8_t ot_call_command(char* command, void *arg, void* answer)
+{
+    ot_job_t job = {.ev.handler = _exec_cmd};
+
+    job.command = command;
+    job.arg = arg;
+    job.answer = answer;
+
+    event_post(openthread_get_evq(), &job.ev);
+    return job.status;
+}
+
 
 void output_bytes(const char* name, const uint8_t *aBytes, uint8_t aLength)
 {

--- a/pkg/openthread/contrib/platform_misc.c
+++ b/pkg/openthread/contrib/platform_misc.c
@@ -19,9 +19,30 @@
 
 #include "openthread/platform/misc.h"
 #include "periph/pm.h"
+#include "ot.h"
+#include "openthread/tasklet.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
+
+static void _ev_tasklets_handler(event_t *event)
+{
+    (void) event;
+    otInstance *instance = openthread_get_instance();
+    while (otTaskletsArePending(instance)) {
+        otTaskletsProcess(instance);
+    }
+}
+
+static event_t ev_tasklet = {
+    .handler = _ev_tasklets_handler
+};
+
+/* OpenThread will call this when switching state from empty tasklet to non-empty tasklet. */
+void otTaskletsSignalPending(otInstance *aInstance) {
+    (void) aInstance;
+    event_post(openthread_get_evq(), &ev_tasklet);
+}
 
 void otPlatReset(otInstance *aInstance)
 {

--- a/pkg/openthread/contrib/platform_uart.c
+++ b/pkg/openthread/contrib/platform_uart.c
@@ -25,6 +25,7 @@
 #include "periph/uart.h"
 #include "openthread/platform/uart.h"
 #include "ot.h"
+#include "event.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -33,6 +34,18 @@
 
 static serial_msg_t gSerialMessage[OPENTHREAD_NUMBER_OF_SERIAL_BUFFER];
 static uint16_t frameLength = 0;
+
+static void _ev_serial_handler(event_t *event)
+{
+    (void) event;
+    /* Tell OpenThread about the reception of a CLI command */
+    otPlatUartReceived((uint8_t*)gSerialMessage[0].buf, gSerialMessage[0].length);
+    gSerialMessage[0].serial_buffer_status = OPENTHREAD_SERIAL_BUFFER_STATUS_FREE;
+}
+
+static event_t ev_serial = {
+    .handler = _ev_serial_handler
+};
 
 static void uart_handler(void* arg, char c) {
     (void)arg;
@@ -47,10 +60,7 @@ static void uart_handler(void* arg, char c) {
                 gSerialMessage[0].buf[frameLength] = c;
                 frameLength++;
                 gSerialMessage[0].length = frameLength;
-                msg_t msg;
-                msg.type = OPENTHREAD_SERIAL_MSG_TYPE_EVENT;
-                msg.content.ptr = &gSerialMessage[0];
-                msg_send_int(&msg, openthread_get_pid());
+                event_post(openthread_get_evq(), &ev_serial);
                 frameLength = 0;
             }
             break;

--- a/pkg/openthread/include/ot.h
+++ b/pkg/openthread/include/ot.h
@@ -34,22 +34,7 @@ extern "C" {
 #include "net/netdev.h"
 #include "thread.h"
 #include "openthread/instance.h"
-
-/**
- * @name    Openthread message types
- * @{
- */
-/** @brief   xtimer message receiver event */
-#define OPENTHREAD_XTIMER_MSG_TYPE_EVENT                    (0x2235)
-/** @brief   message received from driver */
-#define OPENTHREAD_NETDEV_MSG_TYPE_EVENT                    (0x2236)
-/** @brief   event indicating a serial (UART) message was sent to OpenThread */
-#define OPENTHREAD_SERIAL_MSG_TYPE_EVENT                    (0x2237)
-/** @brief   event for frame reception */
-#define OPENTHREAD_MSG_TYPE_RECV                            (0x2238)
-/** @brief   event indicating an OT_JOB message */
-#define OPENTHREAD_JOB_MSG_TYPE_EVENT                       (0x2240)
-/** @} */
+#include "event.h"
 
 /**
  * @name    Openthread constants
@@ -90,6 +75,8 @@ typedef struct {
  * @brief   Struct containing an OpenThread job
  */
 typedef struct {
+    event_t ev;                             /**< Event associated to the OpenThread job */
+    int status;                             /**< Status of the job */
     const char *command;                    /**< A pointer to the job name string. */
     void *arg;                              /**< arg for the job **/
     void *answer;                           /**< answer from the job **/
@@ -111,6 +98,20 @@ void recv_pkt(otInstance *aInstance, netdev_t *dev);
  * @param[in]  event              just occurred netdev event
  */
 void send_pkt(otInstance *aInstance, netdev_t *dev, netdev_event_t event);
+
+/**
+ * @brief Get OpenThread event queue
+ *
+ * @return pointer to the event queue
+ */
+event_queue_t *openthread_get_evq(void);
+
+/**
+ * @brief Get pointer to the OpenThread instance
+ *
+ * @return pointer to the OpenThread instance
+ */
+otInstance* openthread_get_instance(void);
 
 /**
  * @brief   Bootstrap OpenThread


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR migrates OpenThread the OpenThread implementation from message queues to event threads. 
Besides saving ROM and RAM, this:
a) Opens the door for using an external event queue e.g when using GNRC on top of OpenThread (TBD :)
b) Makes OpenThread more responsive: it seems the message queue was getting full from time to time. Now everything seems to run smoothly.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
This one is easier to test with IoT-LAB. Book a list of nodes (I'm booking the full row of nodes in Grenoble). Use `examples/openthread`:
a) Check that after some seconds there's only one leader. All the others should be either router or child. Use the `state` command.
<details><summary> Output </summary>

```state
1600340780.719295;m3-302;> state
1600340780.720192;m3-354;> state
1600340780.720756;m3-354;child
1600340780.721226;m3-354;Done
1600340780.721968;m3-358;> state
1600340780.722468;m3-358;leader
1600340780.722754;m3-358;Done
1600340780.723118;m3-316;> state
1600340780.723384;m3-316;router
1600340780.723643;m3-316;Done
1600340780.723936;m3-302;router
1600340780.724196;m3-302;Done
1600340780.724485;m3-312;> state
1600340780.724745;m3-312;router
1600340780.725003;m3-312;Done
1600340780.725292;m3-336;> state
1600340780.725552;m3-336;router
1600340780.725836;m3-336;Done
1600340780.726122;m3-340;> state
1600340780.726421;m3-340;router
1600340780.726693;m3-340;Done
1600340780.726981;m3-327;> state
1600340780.727239;m3-327;router
1600340780.727495;m3-327;Done
1600340780.727780;m3-319;> state
1600340780.728037;m3-319;router
1600340780.728295;m3-319;Done
1600340780.728580;m3-332;> state
1600340780.728837;m3-332;router
1600340780.729092;m3-332;Done
1600340780.729375;m3-308;> state
1600340780.729651;m3-308;router
1600340780.729910;m3-308;Done
1600340780.730196;m3-299;> state
1600340780.730482;m3-299;router
1600340780.730739;m3-299;Done
1600340780.731025;m3-305;> state
1600340780.731282;m3-305;router
1600340780.731537;m3-305;Done
1600340780.731823;m3-344;> state
1600340780.732079;m3-344;router
1600340780.732334;m3-344;Done
1600340780.732605;m3-350;> state
1600340780.732713;m3-350;router
1600340780.732821;m3-350;Done
1600340780.732941;m3-323;> state
1600340780.733049;m3-323;router
1600340780.733157;m3-323;Done
```

</details>

b) Try pinging between nodes. Here's a multihop example:
```
1600340542.747002;m3-302;> ipaddr
1600340542.748039;m3-302;fdde:ad00:beef:0:0:ff:fe00:8c00
1600340542.748873;m3-302;fdde:ad00:beef:0:5b8b:1df0:2de1:7b3a
1600340542.749094;m3-302;fe80:0:0:0:a0b4:1e9d:852f:3e3b
1600340542.750302;m3-302;Done
m3-350; ping fdde:ad00:beef:0:5b8b:1df0:2de1:7b3a
1600341093.283009;m3-350; ping fdde:ad00:beef:0:5b8b:1df0:2de1:7b3a
1600341093.313566;m3-350;> 16 bytes from fdde:ad00:beef:0:5b8b:1df0:2de1:7b3a: icmp_seq=26 hlim=64 time=30ms
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
