### PR TITLE
 sys/result_output: Initial result output abstraction

### DIFF
--- a/sys/Makefile
+++ b/sys/Makefile
@@ -164,6 +164,9 @@ endif
 ifneq (,$(filter test_utils_interactive_sync,$(USEMODULE)))
   DIRS += test_utils/interactive_sync
 endif
+ifneq (,$(filter test_utils_result_output,$(USEMODULE)))
+  DIRS += test_utils/result_output
+endif
 ifneq (,$(filter udp,$(USEMODULE)))
   DIRS += net/transport_layer/udp
 endif

--- a/sys/include/test_utils/result_output.h
+++ b/sys/include/test_utils/result_output.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2020 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    test_utils_result_output Test result output
+ * @ingroup     sys
+ * @brief       Utility function for abstraction of test result output format
+ *
+ * @{
+ * @file
+ * @brief       Provides abstraction and convention for output of test results.
+ *
+ * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
+ */
+
+#ifndef TEST_UTILS_RESULT_OUTPUT_H
+#define TEST_UTILS_RESULT_OUTPUT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Outputs integer data.
+ *
+ * The exact output depends on the parser but it will contain formatted
+ * integer data.
+ *
+ * @param[in] turo  parsing instance
+ * @param[in] data  integer data to output
+ */
+void turo_data_int(int turo, int32_t data);
+
+/**
+ * @brief   Outputs boolean data.
+ *
+ * The exact output depends on the parser but it will contain formatted
+ * boolean data.
+ *
+ * @param[in] turo  parsing instance
+ * @param[in] data  boolean data to output
+ */
+void turo_data_bool(int turo, bool data);
+
+/**
+ * @brief   Outputs string data.
+ *
+ * The exact output depends on the parser but it will contain formatted
+ * string data.
+ *
+ * @param[in] turo  parsing instance
+ * @param[in] data  string data to output
+ */
+void turo_data_string(int turo, char* data);
+
+/**
+ * @brief   Outputs a uint8_t array data.
+ *
+ * The exact output depends on the parser but it will contain formatted
+ * size of uint8_t data elements.
+ *
+ * @param[in] turo      parsing instance
+ * @param[in] data      buffer of data to output
+ * @param[in] size_t    amount of elements to output
+ */
+void turo_data_u8_array(int turo, uint8_t* data, size_t size);
+
+/**
+ * @brief   Outputs an int32_t array data.
+ *
+ * The exact output depends on the parser but it will contain formatted
+ * size of int32_t data elements.
+ *
+ * @param[in] turo      parsing instance
+ * @param[in] data      buffer of data to output
+ * @param[in] size_t    amount of elements to output
+ */
+void turo_data_i32_array(int turo, int32_t* data, size_t size);
+
+/**
+ * @brief   Outputs a dict with string data.
+ *
+ * The exact output depends on the parser but it will contain a formatted
+ * dict with a string value.
+ *
+ * @param[in] turo      parsing instance
+ * @param[in] key       dictionary key
+ * @param[in] value     string value of the dictionary
+ */
+void turo_data_string_dict(int turo, char* key, char* value);
+
+/**
+ * @brief   Outputs a dict with integer data.
+ *
+ * The exact output depends on the parser but it will contain a formatted
+ * dict with an integer value.
+ *
+ * @param[in] turo      parsing instance
+ * @param[in] key       dictionary key
+ * @param[in] value     integer value of the dictionary
+ */
+void turo_data_int_dict(int turo, char* key, int32_t value);
+
+/**
+ * @brief   Outputs a successful result.
+ *
+ * The exact output depends on the parser but it will contain a formatted
+ * success result.
+ *
+ * @param[in] turo      parsing instance
+ */
+void turo_result_success(int turo);
+
+/**
+ * @brief   Outputs a failure result.
+ *
+ * The exact output depends on the parser but it will contain a formatted
+ * failure result.
+ *
+ * @param[in] turo      parsing instance
+ */
+void turo_result_error(int turo);
+
+/**
+ * @brief   Outputs a failure result and error code.
+ *
+ * The exact output depends on the parser but it will contain a formatted
+ * error code and result.
+ *
+ * @param[in] turo      parsing instance
+ * @param[in] error     error code to output
+ */
+void turo_result_error_with_code(int turo, int error);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* TEST_UTILS_RESULT_OUTPUT_H */
+/** @} */

--- a/sys/test_utils/Makefile.dep
+++ b/sys/test_utils/Makefile.dep
@@ -1,3 +1,6 @@
 ifneq (,$(filter test_utils_interactive_sync,$(USEMODULE)))
   USEMODULE += stdin
 endif
+ifneq (,$(filter test_utils_result_output,$(USEMODULE)))
+  USEMODULE += fmt
+endif

--- a/sys/test_utils/result_output/Makefile
+++ b/sys/test_utils/result_output/Makefile
@@ -1,0 +1,3 @@
+MODULE = test_utils_result_output
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/test_utils/result_output/result_output.c
+++ b/sys/test_utils/result_output/result_output.c
@@ -25,98 +25,100 @@
 
 #include "test_utils/result_output.h"
 
+#define _DATA_STR   "metrics"
+
 void turo_data_int(int turo, int32_t data)
 {
     (void)turo;
-    print_str("{\"data\": ");
+    print_str("{ \""_DATA_STR"\": ");
     print_s32_dec(data);
-    print_str("}\n");
+    print_str(" }\n");
 }
 
 void turo_data_bool(int turo, bool data)
 {
     (void)turo;
-    print_str("{\"data\": ");
+    print_str("{ \""_DATA_STR"\": ");
     if (data) {
-        print_str("True }\n");
+        print_str("True  }\n");
     }
     else {
-        print_str("False }\n");
+        print_str("False  }\n");
     }
 }
 
 void turo_data_string(int turo, char* data)
 {
     (void)turo;
-    print_str("{\"data\": \"");
+    print_str("{ \""_DATA_STR"\": \"");
     print_str(data);
-    print_str("\"}\n");
+    print_str("\" }\n");
 }
 
 void turo_data_u8_array(int turo, uint8_t* data, size_t size)
 {
     (void)turo;
     assert(size > 0);
-    print_str("{\"data\": [");
+    print_str("{ \"data\": [ ");
     for (size_t i = 0; i < size; i++) {
         print_s32_dec((int32_t)data[i]);
         if (i < size - 1) {
-            print_str(",");
+            print_str(", ");
         }
     }
-    print_str("]}\n");
+    print_str(" ] }\n");
 }
 
 void turo_data_i32_array(int turo, int32_t* data, size_t size)
 {
     (void)turo;
     assert(size > 0);
-    print_str("{\"data\": [");
+    print_str("{ \""_DATA_STR"\": [ ");
     for (size_t i = 0; i < size; i++) {
         print_s32_dec(data[i]);
         if (i < size - 1) {
-            print_str(",");
+            print_str(", ");
         }
     }
-    print_str("]}\n");
+    print_str(" ] }\n");
 }
 
 void turo_data_string_dict(int turo, char* key, char* value)
 {
     (void)turo;
-    print_str("{\"data\": {\"");
+    print_str("{ \""_DATA_STR"\": { \"");
     print_str(key);
-    print_str("\":\"");
+    print_str("\": \"");
     print_str(value);
-    print_str("\"}}\n");
+    print_str("\" } }\n");
 }
 
 void turo_data_int_dict(int turo, char* key, int32_t value)
 {
     (void)turo;
-    print_str("{\"data\": {\"");
+    print_str("{ \""_DATA_STR"\": { \"");
     print_str(key);
-    print_str("\":");
+    print_str("\": ");
     print_s32_dec(value);
-    print_str("}}\n");
+    print_str(" } }\n");
 }
 
 void turo_result_success(int turo)
 {
     (void)turo;
-    print_str("{\"result\": \"Success\"}\n");
+    print_str("{ \"result\": \"Success\" }\n");
 }
 
 void turo_result_error(int turo)
 {
     (void)turo;
-    print_str("{\"result\": \"Error\"}\n");
+    print_str("{ \"result\": \"Error\" }\n");
 }
 
 void turo_result_error_with_code(int turo, int error)
 {
-    print_str("{\"error_code\": ");
+    print_str("{ \"error_code\": ");
     print_s32_dec((int32_t)error);
-    print_str("}\n");
+    print_str(" }\n");
     turo_result_error(turo);
 }

--- a/sys/test_utils/result_output/result_output.c
+++ b/sys/test_utils/result_output/result_output.c
@@ -28,96 +28,95 @@
 void turo_data_int(int turo, int32_t data)
 {
     (void)turo;
-    print_str("data: ");
+    print_str("{\"data\": ");
     print_s32_dec(data);
-    print_str("\n");
+    print_str("}\n");
 }
 
 void turo_data_bool(int turo, bool data)
 {
     (void)turo;
-    print_str("data: ");
+    print_str("{\"data\": ");
     if (data) {
-        print_str("True\n");
+        print_str("True }\n");
     }
     else {
-        print_str("False\n");
+        print_str("False }\n");
     }
 }
 
 void turo_data_string(int turo, char* data)
 {
     (void)turo;
-    print_str("data: ");
+    print_str("{\"data\": \"");
     print_str(data);
-    print_str("\n");
+    print_str("\"}\n");
 }
 
 void turo_data_u8_array(int turo, uint8_t* data, size_t size)
 {
     (void)turo;
     assert(size > 0);
-    print_str("data: [");
+    print_str("{\"data\": [");
     for (size_t i = 0; i < size; i++) {
-        print_byte_hex(data[i]);
+        print_s32_dec((int32_t)data[i]);
         if (i < size - 1) {
             print_str(",");
         }
     }
-    print_str("]\n");
+    print_str("]}\n");
 }
 
 void turo_data_i32_array(int turo, int32_t* data, size_t size)
 {
     (void)turo;
     assert(size > 0);
-    print_str("data: [");
+    print_str("{\"data\": [");
     for (size_t i = 0; i < size; i++) {
         print_s32_dec(data[i]);
         if (i < size - 1) {
             print_str(",");
         }
     }
-    print_str("]\n");
+    print_str("]}\n");
 }
 
 void turo_data_string_dict(int turo, char* key, char* value)
 {
     (void)turo;
-    print_str("data: {\"");
+    print_str("{\"data\": {\"");
     print_str(key);
     print_str("\":\"");
     print_str(value);
-    print_str("\"}\n");
+    print_str("\"}}\n");
 }
 
 void turo_data_int_dict(int turo, char* key, int32_t value)
 {
     (void)turo;
-    print_str("data: {\"");
+    print_str("{\"data\": {\"");
     print_str(key);
     print_str("\":");
     print_s32_dec(value);
-    print_str("}\n");
+    print_str("}}\n");
 }
 
 void turo_result_success(int turo)
 {
     (void)turo;
-    print_str("result: Success\n");
+    print_str("{\"result\": \"Success\"}\n");
 }
 
 void turo_result_error(int turo)
 {
     (void)turo;
-    print_str("result: Error\n");
+    print_str("{\"result\": \"Error\"}\n");
 }
 
 void turo_result_error_with_code(int turo, int error)
 {
-    (void)turo;
-    print_str("error_code: ");
+    print_str("{\"error_code\": ");
     print_s32_dec((int32_t)error);
-    print_str("\n");
-    print_str("result: Error\n");
+    print_str("}\n");
+    turo_result_error(turo);
 }

--- a/sys/test_utils/result_output/result_output.c
+++ b/sys/test_utils/result_output/result_output.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2020 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys
+ * @{
+ *
+ * @file
+ * @brief       Result output implementation
+ *
+ *
+ * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "assert.h"
+#include "fmt.h"
+
+#include "test_utils/result_output.h"
+
+void turo_data_int(int turo, int32_t data)
+{
+    (void)turo;
+    print_str("data: ");
+    print_s32_dec(data);
+    print_str("\n");
+}
+
+void turo_data_bool(int turo, bool data)
+{
+    (void)turo;
+    print_str("data: ");
+    if (data) {
+        print_str("True\n");
+    }
+    else {
+        print_str("False\n");
+    }
+}
+
+void turo_data_string(int turo, char* data)
+{
+    (void)turo;
+    print_str("data: ");
+    print_str(data);
+    print_str("\n");
+}
+
+void turo_data_u8_array(int turo, uint8_t* data, size_t size)
+{
+    (void)turo;
+    assert(size > 0);
+    print_str("data: [");
+    for (size_t i = 0; i < size; i++) {
+        print_byte_hex(data[i]);
+        if (i < size - 1) {
+            print_str(",");
+        }
+    }
+    print_str("]\n");
+}
+
+void turo_data_i32_array(int turo, int32_t* data, size_t size)
+{
+    (void)turo;
+    assert(size > 0);
+    print_str("data: [");
+    for (size_t i = 0; i < size; i++) {
+        print_s32_dec(data[i]);
+        if (i < size - 1) {
+            print_str(",");
+        }
+    }
+    print_str("]\n");
+}
+
+void turo_data_string_dict(int turo, char* key, char* value)
+{
+    (void)turo;
+    print_str("data: {\"");
+    print_str(key);
+    print_str("\":\"");
+    print_str(value);
+    print_str("\"}\n");
+}
+
+void turo_data_int_dict(int turo, char* key, int32_t value)
+{
+    (void)turo;
+    print_str("data: {\"");
+    print_str(key);
+    print_str("\":");
+    print_s32_dec(value);
+    print_str("}\n");
+}
+
+void turo_result_success(int turo)
+{
+    (void)turo;
+    print_str("result: Success\n");
+}
+
+void turo_result_error(int turo)
+{
+    (void)turo;
+    print_str("result: Error\n");
+}
+
+void turo_result_error_with_code(int turo, int error)
+{
+    (void)turo;
+    print_str("error_code: ");
+    print_s32_dec((int32_t)error);
+    print_str("\n");
+    print_str("result: Error\n");
+}

--- a/sys/test_utils/result_output/result_output.c
+++ b/sys/test_utils/result_output/result_output.c
@@ -25,7 +25,7 @@
 
 #include "test_utils/result_output.h"
 
-#define _DATA_STR   "metrics"
+#define _DATA_STR   "data"
 
 void turo_data_int(int turo, int32_t data)
 {

--- a/tests/bench_msg_pingpong/Makefile
+++ b/tests/bench_msg_pingpong/Makefile
@@ -1,5 +1,6 @@
 include ../Makefile.tests_common
 
 USEMODULE += xtimer
+USEMODULE += test_utils_result_output
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/bench_msg_pingpong/main.c
+++ b/tests/bench_msg_pingpong/main.c
@@ -24,6 +24,7 @@
 
 #include "msg.h"
 #include "xtimer.h"
+#include "test_utils/result_output.h"
 
 #ifndef TEST_DURATION
 #define TEST_DURATION       (1000000U)
@@ -53,8 +54,6 @@ static void *_second_thread(void *arg)
 
 int main(void)
 {
-    printf("main starting\n");
-
     kernel_pid_t other = thread_create(_stack,
                                        sizeof(_stack),
                                        (THREAD_PRIORITY_MAIN - 1),
@@ -76,12 +75,12 @@ int main(void)
         n++;
     }
 
-    printf("{ \"result\" : %"PRIu32, n);
+    turo_data_int_dict(0, "n", n);
 #ifdef CLOCK_CORECLOCK
-    printf(", \"ticks\" : %"PRIu32,
-           (uint32_t)((TEST_DURATION/US_PER_MS) * (CLOCK_CORECLOCK/KHZ(1)))/n);
+    turo_data_int_dict(0, "ticks", (uint32_t)((TEST_DURATION/US_PER_MS) *
+                                     (CLOCK_CORECLOCK/KHZ(1)))/n);
 #endif
-    puts(" }");
+    turo_result_success(0);
 
     return 0;
 }

--- a/tests/bench_msg_pingpong/tests/01-run.py
+++ b/tests/bench_msg_pingpong/tests/01-run.py
@@ -12,7 +12,7 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect(r"{ \"result\" : \d+(, \"ticks\" : \d+)? }")
+    child.expect(r"{ \"result\" : \"Success\" }")
 
 
 if __name__ == "__main__":

--- a/tests/bench_msg_pingpong/tests/01-run.py
+++ b/tests/bench_msg_pingpong/tests/01-run.py
@@ -12,7 +12,7 @@ from testrunner import run
 
 
 def testfunc(child):
-    child.expect(r"{ \"result\" : \"Success\" }")
+    child.expect(r"{ \"result\": \"Success\" }")
 
 
 if __name__ == "__main__":

--- a/tests/periph_cpuid/Makefile
+++ b/tests/periph_cpuid/Makefile
@@ -2,4 +2,6 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_cpuid
 
+USEMODULE += test_utils_result_output
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_cpuid/main.c
+++ b/tests/periph_cpuid/main.c
@@ -21,9 +21,11 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 #include "cpu_conf.h"
 #include "periph/cpuid.h"
+#include "test_utils/result_output.h"
 
 int main(void)
 {
@@ -38,11 +40,8 @@ int main(void)
     cpuid_get(id);
 
     /* print the CPUID */
-    printf("CPUID:");
-    for (unsigned int i = 0; i < CPUID_LEN; i++) {
-        printf(" 0x%02x", id[i]);
-    }
-    printf("\n");
+    turo_data_u8_array(0, id, CPUID_LEN);
+    turo_result_success(0);
 
     return 0;
 }

--- a/tests/periph_cpuid/tests/01-run.py
+++ b/tests/periph_cpuid/tests/01-run.py
@@ -15,8 +15,9 @@ def testfunc(child):
     child.expect_exact('This test is reading out the CPUID of the platforms CPU')
     child.expect(r'CPUID_LEN: (\d+)\r\n')
     cpuid_len = int(child.match.group(1))
-    child.expect(r'CPUID:( 0x[0-9a-fA-F]{2})+\s*\r\n')
-    assert child.match.group(0).count(' 0x') == cpuid_len
+    child.expect(r'{ \"data\": \[( \d*,)* \d* \] }')
+    assert child.match.group(0).count(',') == cpuid_len - 1
+    child.expect(r'{ \"result\": \"Success\" }')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description

This provides an abstraction and implementation of simple data print and result functions to be used to standardize RIOT test firmware.

### Testing procedure

run `make flash term -C tests/periph_cpuid` and check the output.

### Issues/PRs references

Fixes #15037
