### PR TITLE
sys/net/gnrc/netif: Fix compilation on waspmote-pro

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -23,14 +23,14 @@
 #include "net/ethernet.h"
 #include "net/ipv6.h"
 #include "net/gnrc.h"
-#ifdef MODULE_GNRC_IPV6_NIB
+#if IS_USED(MODULE_GNRC_IPV6_NIB)
 #include "net/gnrc/ipv6/nib.h"
 #include "net/gnrc/ipv6.h"
-#endif /* MODULE_GNRC_IPV6_NIB */
+#endif /* IS_USED(MODULE_GNRC_IPV6_NIB) */
 #include "net/gnrc/netif/pktq.h"
-#ifdef MODULE_NETSTATS
+#if IS_USED(MODULE_NETSTATS)
 #include "net/netstats.h"
-#endif
+#endif /* IS_USED(MODULE_NETSTATS) */
 #include "fmt.h"
 #include "log.h"
 #include "sched.h"


### PR DESCRIPTION
### Contribution description

`xtimer.h` must not be included, when the xtimer module is not use. Otherwise compilation on the waspmote-pro with https://github.com/RIOT-OS/RIOT/pull/14799 will not longer work. `gnrc_netif_pktq` includes `xtimer.h` and uses `xtimer`, but `gnrc_netif` includes `gnrc_netif_pktq.h` regardless of whether `gnrc_netif_pktq` is used. This makes sure that `gnrc_netif_pktq.h` is only included when actually used.


### Testing procedure

No changes in generated binaries

### Issues/PRs references

Needed for https://github.com/RIOT-OS/RIOT/pull/14799