### PR TITLE
drivers/lsm303dlhc: slightly enhance the initialization code

### DIFF
--- a/drivers/lsm303dlhc/lsm303dlhc.c
+++ b/drivers/lsm303dlhc/lsm303dlhc.c
@@ -42,15 +42,15 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, const lsm303dlhc_params_t *params)
     int res;
     uint8_t tmp;
 
+    DEBUG("lsm303dlhc init...");
     /* Acquire exclusive access to the bus. */
     i2c_acquire(DEV_I2C);
 
-    DEBUG("lsm303dlhc reboot...");
+    /* reboot sensor */
     res = i2c_write_reg(DEV_I2C, DEV_ACC_ADDR,
                         LSM303DLHC_REG_CTRL5_A, LSM303DLHC_REG_CTRL5_A_BOOT, 0);
     /* Release the bus for other threads. */
     i2c_release(DEV_I2C);
-    DEBUG("[OK]\n");
 
     /* configure accelerometer */
     /* enable all three axis and set sample rate */
@@ -85,6 +85,12 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, const lsm303dlhc_params_t *params)
     i2c_release(DEV_I2C);
     /* configure mag data ready pin */
     gpio_init(DEV_MAG_PIN, GPIO_IN);
+    if (ENABLE_DEBUG && res == 0) {
+        DEBUG("[OK]\n");
+    }
+    else {
+        DEBUG("[Failed]\n");
+    }
 
     return (res < 0) ? -1 : 0;
 }

--- a/drivers/lsm303dlhc/lsm303dlhc.c
+++ b/drivers/lsm303dlhc/lsm303dlhc.c
@@ -49,8 +49,6 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, const lsm303dlhc_params_t *params)
     /* reboot sensor */
     res = i2c_write_reg(DEV_I2C, DEV_ACC_ADDR,
                         LSM303DLHC_REG_CTRL5_A, LSM303DLHC_REG_CTRL5_A_BOOT, 0);
-    /* Release the bus for other threads. */
-    i2c_release(DEV_I2C);
 
     /* configure accelerometer */
     /* enable all three axis and set sample rate */
@@ -58,7 +56,6 @@ int lsm303dlhc_init(lsm303dlhc_t *dev, const lsm303dlhc_params_t *params)
           | LSM303DLHC_CTRL1_A_YEN
           | LSM303DLHC_CTRL1_A_ZEN
           | DEV_ACC_RATE);
-    i2c_acquire(DEV_I2C);
     res += i2c_write_reg(DEV_I2C, DEV_ACC_ADDR,
                          LSM303DLHC_REG_CTRL1_A, tmp, 0);
     /* update on read, MSB @ low address, scale and high-resolution */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a minor cleanup (although more could be done) of the lsm303dlhc:
- it removes a useless release/acquire sequence in the init phase
- it improves the debugging messages

I applied this change because of #15045: while trying the understand the problems with iotlab-m3, I noticed that enabling the I2C peripheral (in acquire) and disabling it (in release) was putting the peripheral in an unstable state (I still need to figure out why).
Without this PR, the lsm303dlhc would always fail to initialize on iotlab-m3 but with this PR, the driver initialization is successful and some sensor data can be read.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build and flash `tests/driver_lsm303dlhc` on an `iotlab-m3` board. On master, the application fails to initialize, with this PR it succeeds and some data can be read (but there are some failures):

<details><summary>this PR:</summary>

```
$ IOTLAB_NODE=auto-ssh BUILD_IN_DOCKER=1 make BOARD=iotlab-m3 -C tests/driver_lsm303dlhc flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=iotlab-m3'  -w '/data/riotbuild/riotbase/tests/driver_lsm303dlhc/' 'riot/riotbuild:latest' make 'BOARD=iotlab-m3'    
Building application "tests_driver_lsm303dlhc" for "iotlab-m3" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/iotlab-m3
"make" -C /data/riotbuild/riotbase/boards/common/iotlab
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/bootloader
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/lsm303dlhc
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  12392	    112	   2356	  14860	   3a0c	/data/riotbuild/riotbase/tests/driver_lsm303dlhc/bin/iotlab-m3/tests_driver_lsm303dlhc.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,m3,1 --flash /work/riot/RIOT/tests/driver_lsm303dlhc/bin/iotlab-m3/tests_driver_lsm303dlhc.bin | grep 0
0
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:m3-1.saclay.iot-lab.info:20000' 
[ ... skip messages before reset ... ]
main(): This is RIOT! (Version: 2020.10-devel-1458-g9db6b0-pr/drivers/lsm303dlhc_enh_init)
LSM303DLHC temperature test application

Initializing LSM303DLHC sensor
[OK]

Accelerometer x: 660 y: 168 z: -200

Failed reading value


Failed reading magnetometer values

Accelerometer x: 652 y: 172 z: -204

Failed reading value

```

</details>

<details><summary>master:</summary>

```
$ IOTLAB_NODE=auto-ssh BUILD_IN_DOCKER=1 make BOARD=iotlab-m3 -C tests/driver_lsm303dlhc flash term --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=iotlab-m3'  -w '/data/riotbuild/riotbase/tests/driver_lsm303dlhc/' 'riot/riotbuild:latest' make 'BOARD=iotlab-m3'    
Building application "tests_driver_lsm303dlhc" for "iotlab-m3" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/iotlab-m3
"make" -C /data/riotbuild/riotbase/boards/common/iotlab
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/bootloader
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/lsm303dlhc
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  12376	    112	   2356	  14844	   39fc	/data/riotbuild/riotbase/tests/driver_lsm303dlhc/bin/iotlab-m3/tests_driver_lsm303dlhc.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,m3,1 --flash /work/riot/RIOT/tests/driver_lsm303dlhc/bin/iotlab-m3/tests_driver_lsm303dlhc.bin | grep 0
0
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:m3-1.saclay.iot-lab.info:20000' 
main(): This is RIOT! (Version: 2020.10-devel-1460-g64f6b)
LSM303DLHC temperature test application

Initializing LSM303DLHC sensor
[Failed]

```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

related to #15045

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
