### PR TITLE
makefiles: Pass explicit float mode to clang

### DIFF
--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -61,18 +61,13 @@ endif # BUILD_IN_DOCKER
 CFLAGS += -DCPU_MODEL_$(call uppercase_and_underscore,$(CPU_MODEL))
 CFLAGS += -DCPU_CORE_$(call uppercase_and_underscore,$(CPU_CORE))
 
-# Add corresponding FPU CFLAGS
-# clang assumes there is an FPU, no CFLAGS necessary
-ifneq (llvm, $(TOOLCHAIN))
-  ifeq ($(CPU_CORE),cortex-m7)
-    _CORTEX_HW_FPU_CFLAGS = -mfloat-abi=hard -mfpu=fpv5-sp-d16
-  else
-    _CORTEX_HW_FPU_CFLAGS = -mfloat-abi=hard -mfpu=fpv4-sp-d16
-  endif
-endif
 # Add soft or hard FPU CFLAGS depending on the module
 ifneq (,$(filter cortexm_fpu,$(USEMODULE)))
-  CFLAGS_FPU ?= $(_CORTEX_HW_FPU_CFLAGS)
+  ifeq ($(CPU_CORE),cortex-m7)
+    CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv5-sp-d16
+  else
+    CFLAGS_FPU ?= -mfloat-abi=hard -mfpu=fpv4-sp-d16
+  endif
 else
   CFLAGS_FPU ?= -mfloat-abi=soft
 endif


### PR DESCRIPTION
### Contribution description (~= commit message)

The assumption that clang defaults to hard-float on ARM architectures
does not hold on Debian systems where [set-correct-float-abi].
As setting the flags that are implied on most systems does no harm, the
flags for the selected hard- or soft float behavior are now set
independently of the toolchain.

[set-correct-float-abi]: https://salsa.debian.org/pkg-llvm-team/llvm-toolchain/-/blob/10/debian/patches/26-set-correct-float-abi.diff

### Testing procedure

Build any example with `TOOLCHAIN=llvm BOARD=nrf52840`.

No binary should change as a result of it (ie. any build should still pass), but in addition, it should also pass with Debian's clang.

### Issues/PRs references

Closes: https://github.com/RIOT-OS/RIOT/issues/15026