### PR TITLE
[WIP] RFC5444/MANET transport layer

### DIFF
--- a/sys/include/net/rfc5444.h
+++ b/sys/include/net/rfc5444.h
@@ -11,8 +11,8 @@
  * @ingroup     net
  * @brief       Provides types and helper functions related to the Generalized
  *              Mobile Ad Hoc Network (MANET) Packet/Message Format (RFC 5444).
+ * @see [RFC 5444](https://tools.ietf.org/html/rfc5444)
  *
- * @see [RFC 5444](https://tools.ietf.org/html/rfc5444).
  * @{
  *
  * @file

--- a/sys/include/net/rfc5444.h
+++ b/sys/include/net/rfc5444.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_rfc5444 RFC 5444
+ * @ingroup     net
+ * @brief       Provides types and helper functions related to the Generalized
+ *              Mobile Ad Hoc Network (MANET) Packet/Message Format (RFC 5444).
+ *
+ * @see [RFC 5444](https://tools.ietf.org/html/rfc5444).
+ * @{
+ *
+ * @file
+ * @brief   RFC 5444 include gathering header.
+ *
+ * @author  Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+#ifndef NET_RFC5444_H
+#define NET_RFC5444_H
+
+#include "net/rfc5444/addr.h"
+#include "net/rfc5444/hdr.h"
+#include "net/rfc5444/msg.h"
+#include "net/rfc5444/tlv.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   RFC 5444 packet format version
+ *
+ * @see [RFC 5444, Section 5.1]
+ *      (https://tools.ietf.org/html/rfc5444#section-5.1)
+ */
+#define RFC5444_VERSION (0U)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_RFC5444_H */
+/** @} */

--- a/sys/include/net/rfc5444.h
+++ b/sys/include/net/rfc5444.h
@@ -40,6 +40,20 @@ extern "C" {
  */
 #define RFC5444_VERSION (0U)
 
+/**
+ * @brief   Verify if the packet header is a valid header.
+ *
+ * @param[in]   hdr Pointer to packet header.
+ *
+ * @return true if it is valid.
+ * @return false otherwise.
+ */
+static inline bool rfc5444_pkt_hdr_is(const rfc5444_pkt_hdr_t *hdr)
+{
+    return rfc5444_pkt_hdr_version(hdr) == RFC5444_VERSION;
+}
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/rfc5444/addr.h
+++ b/sys/include/net/rfc5444/addr.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_rfc5444
+ * @ingroup     net
+ * @brief       Address block structures for RFC 5444.
+ * @see         <a href="https://tools.ietf.org/html/rfc5444">
+ *                  RFC 5444 - Generalized Mobile Ad Hoc Network (MANET) Packet/Message Format
+ *              </a>
+ * @{
+ *
+ * @file
+ * @brief       Address block structures definitions for RFC 5444.
+ *
+ * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef NET_RFC5444_ADDR_H
+#define NET_RFC5444_ADDR_H
+
+#include <stdint.h>
+
+#include "bitarithm.h"
+#include "byteorder.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Message flags
+ * @{
+ */
+#define RFC5444_ADDR_FLAG_HAS_HEAD           (BIT7)
+#define RFC5444_ADDR_FLAG_HAS_FULL_TAIL      (BIT6)
+#define RFC5444_ADDR_FLAG_HAS_ZERO_TAIL      (BIT5)
+#define RFC5444_ADDR_FLAG_HAS_SINGLE_PRE_LEN (BIT4)
+#define RFC5444_ADDR_FLAG_HAS_MULTI_PRE_LEN  (BIT3)
+/** @} */
+
+/**
+ * @brief   Address block
+ *
+ * @see [RFC 5444, Section 5.3]
+ *      (https://tools.ietf.org/html/rfc5444#section-5.3)
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t num_addr;   /**< Number of addresses represented by this address
+                             block */
+    uint8_t addr_flags; /**< Address block flags */
+} rfc5444_addr_block_t;
+
+/**
+ * @brief   An RFC 5444 address.
+ *
+ * Addresses can be either IPv4 or IPv6 addresses, this container can
+ * hold both type of addresses and the type is identified by the
+ * rfc5444_addr_t::len field.
+ *
+ * @note The RFC 5444 standard doesn't specify which types of addresses are
+ * allowed, but it's assumed that they're IPv4 and IPv6 so any other address
+ * length is invalid.
+ */
+typedef struct {
+    uint8_t len;                    /**< Address length in bytes */
+    union {
+        uint8_t u8[16];             /**< Divided by 16 8-bit words. */
+        network_uint16_t u16[8];    /**< Divided by 8 16-bit words. */
+        network_uint32_t u32[4];    /**< Divided by 4 32-bit words. */
+        network_uint64_t u64[2];    /**< Divided by 2 64-bit words. */
+    };
+} rfc5444_addr_t;
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /**< NET_RFC5444_ADDR_H */
+/** @} */

--- a/sys/include/net/rfc5444/addr.h
+++ b/sys/include/net/rfc5444/addr.h
@@ -7,16 +7,18 @@
  */
 
 /**
+ * @defgroup    net_rfc5444_addr RFC 5444 address blocks
  * @ingroup     net_rfc5444
- * @ingroup     net
- * @brief       Address block structures for RFC 5444.
- * @see         <a href="https://tools.ietf.org/html/rfc5444">
- *                  RFC 5444 - Generalized Mobile Ad Hoc Network (MANET) Packet/Message Format
- *              </a>
+ * @brief       RFC 54444 address block structures.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc5444#section-5.3">
+ *          RFC 5444, Section 5.3
+ *      </a>
+ *
  * @{
  *
  * @file
- * @brief       Address block structures definitions for RFC 5444.
+ * @brief       Definitions for RFC 5444 address block structures
  *
  * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
  */

--- a/sys/include/net/rfc5444/hdr.h
+++ b/sys/include/net/rfc5444/hdr.h
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_rfc5444 RFC 5444
+ * @ingroup     net
+ * @brief
+ * @see         <a href="https://tools.ietf.org/html/rfc5444">
+ *                  RFC 5444 - Generalized Mobile Ad Hoc Network (MANET) Packet/Message Format
+ *              </a>
+ * @{
+ *
+ * @file
+ * @brief
+ *
+ * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+#ifndef NET_RFC5444_HDR_H
+#define NET_RFC5444_HDR_H
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "byteorder.h"
+#include "bitarithm.h"
+
+#include "net/rfc5444/tlv.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Packet header flags
+ * @{
+ */
+#define RFC5444_PKT_HDR_FLAG_HAS_SEQ_NUM (BIT3) /**< Has seq num? */
+#define RFC5444_PKT_HDR_FLAG_HAS_TLV     (BIT2) /**< Has TLV block? */
+/** @} */
+
+/**
+ * @brief   Packet header
+ *
+ * @see [RFC 5444, Section 5.1]
+ *      (https://tools.ietf.org/html/rfc5444#section-5.1)
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t version_and_flags;     /**< Packet version and flags */
+} rfc5444_pkt_hdr_t;
+
+/**
+ * @brief   Packet header version
+ *
+ * @pre @p hdr != NULL
+ *
+ * @param[in]   hdr Pointer to packet header.
+ *
+ * @return uint8_t Version, it MUST be 0 as specified by the standard.
+ */
+static inline uint8_t rfc5444_pkt_hdr_version(const rfc5444_pkt_hdr_t *hdr)
+{
+    return (hdr->version_and_flags & 0xF0) >> 4;
+}
+
+/**
+ * @brief   Packet header flags.
+ *
+ * @pre @p hdr != NULL
+ *
+ * @param[in]   hdr Pointer to packet header.
+ *
+ * @return uint8_t Flags.
+ */
+static inline uint8_t rfc5444_pkt_hdr_flags(const rfc5444_pkt_hdr_t *hdr)
+{
+    return hdr->version_and_flags & 0x0F;
+}
+
+/**
+ * @brief   Packet header sequence number.
+ *
+ * @pre @p hdr != NULL
+ *
+ * @param[in]   hdr Pointer to packet header.
+ *
+ * @return Sequence number or -1 if the packet doesn't provide a sequence
+ *         number.
+ */
+static inline int rfc5444_pkt_hdr_seq_num(const rfc5444_pkt_hdr_t *hdr)
+{
+    if (rfc5444_pkt_hdr_flags(hdr) & RFC5444_PKT_HDR_FLAG_HAS_SEQ_NUM) {
+        /* Read BE uint16_t at <pkt-seq-num>? location */
+        const uint8_t *ptr = ((const uint8_t *)hdr) + sizeof(rfc5444_pkt_hdr_t);
+        return (int)byteorder_bebuftohs(ptr);
+    }
+
+    return -1;
+}
+
+/**
+ * @brief   Packet header TLV block.
+ *
+ * @pre @p != NULL
+ *
+ * @param[in]   hdr Pointer to packet header.
+ *
+ * @return Pointer to TLV block on success.
+ * @return NULL if the packet doesnt't provide a TLV block.
+ * @return NULL if @p hdr is NULL.
+ */
+static inline rfc5444_tlv_block_t *rfc5444_pkt_hdr_tlv_block(
+    rfc5444_pkt_hdr_t *hdr)
+{
+    if (hdr == NULL) {
+        return NULL;
+    }
+
+    const uint8_t flags = rfc5444_pkt_hdr_flags(hdr);
+
+    if (flags & RFC5444_PKT_HDR_FLAG_HAS_TLV) {
+        const size_t seqnum_size =
+            (flags & RFC5444_PKT_HDR_FLAG_HAS_SEQ_NUM) ? sizeof(uint16_t) : 0;
+
+        uint8_t *ptr =
+            (((uint8_t *)hdr) + sizeof(rfc5444_pkt_hdr_t) + seqnum_size);
+        return (rfc5444_tlv_block_t *)ptr;
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief   Total length of the packet header
+ *
+ * @pre @p hdr = NULL
+ *
+ * @param[in]   hdr  Pointer to the packet header.
+ * @param[in]   size Size in bytes of the entire packet.
+ *
+ * @return The size of the packet header in bytes including the seqnum and TLV
+ *         block if any, on success.
+ * @return -EINVAL on invalid packet size.
+ * @return -EINVAL if @p hdr is NULL.
+ */
+static inline int rfc5444_pkt_hdr_sizeof(rfc5444_pkt_hdr_t *hdr, int size)
+{
+    if (hdr == NULL) {
+        return -EINVAL;
+    }
+
+    const uint8_t flags = rfc5444_pkt_hdr_flags(hdr);
+    int count = sizeof(rfc5444_pkt_hdr_t);
+
+    /* verify that the packet does have space for the packet header version
+     * and flags */
+    if (size <= count) {
+        return -EINVAL;
+    }
+
+    /* calculate the space of the sequence number if any */
+    if (flags & RFC5444_PKT_HDR_FLAG_HAS_SEQ_NUM) {
+        count += sizeof(uint16_t);
+        /* verify that the packet does have space for the sequence number */
+        if (size <= count) {
+            return -EINVAL;
+        }
+    }
+
+    /* calculate the space of the TLV block if any */
+    if (flags & RFC5444_PKT_HDR_FLAG_HAS_TLV) {
+        /* verify that the packet does have space at least for the TLV block
+         * length */
+        count += sizeof(rfc5444_tlv_block_t);
+        if (size <= count) {
+            return -EINVAL;
+        }
+
+        uint8_t *ptr = (((uint8_t *)hdr) + count);
+
+        count += (int)byteorder_ntohs(((rfc5444_tlv_block_t *)ptr)->length);
+
+        /* verify that the packet does have space at least for the entire TLV
+         * block */
+        if (size <= count) {
+            return -EINVAL;
+        }
+    }
+
+    return count;
+}
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* NET_RFC5444_HDR_H */
+/** @} */

--- a/sys/include/net/rfc5444/hdr.h
+++ b/sys/include/net/rfc5444/hdr.h
@@ -7,16 +7,14 @@
  */
 
 /**
- * @defgroup    net_rfc5444 RFC 5444
- * @ingroup     net
- * @brief
- * @see         <a href="https://tools.ietf.org/html/rfc5444">
- *                  RFC 5444 - Generalized Mobile Ad Hoc Network (MANET) Packet/Message Format
- *              </a>
+ * @defgroup    net_rfc5444_hdr RFC 5444 packet header
+ * @ingroup     net_rfc5444
+ * @brief       RFC 5444 packet header structures and definitions.
+ *
  * @{
  *
  * @file
- * @brief
+ * @brief       RFC 5444 packet header structures.
  *
  * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
  */
@@ -40,8 +38,8 @@ extern "C" {
  * @name Packet header flags
  * @{
  */
-#define RFC5444_PKT_HDR_FLAG_HAS_SEQ_NUM (BIT3) /**< Has seq num? */
-#define RFC5444_PKT_HDR_FLAG_HAS_TLV     (BIT2) /**< Has TLV block? */
+#define RFC5444_PKT_HDR_FLAG_HAS_SEQ_NUM (BIT3) /**< Has a sequence number? */
+#define RFC5444_PKT_HDR_FLAG_HAS_TLV     (BIT2) /**< Has a TLV block? */
 /** @} */
 
 /**

--- a/sys/include/net/rfc5444/msg.h
+++ b/sys/include/net/rfc5444/msg.h
@@ -7,16 +7,18 @@
  */
 
 /**
+ * @defgroup    net_rfc5444_msg RFC 5444 messages
  * @ingroup     net_rfc5444
- * @ingroup     net
- * @brief       Message structures for RFC 5444.
- * @see         <a href="https://tools.ietf.org/html/rfc5444">
- *                  RFC 5444 - Generalized Mobile Ad Hoc Network (MANET) Packet/Message Format
- *              </a>
+ *
+ * @brief       RFC 5444 message structures and definitions.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc5444#section-5.2">
+ *          RFC 5444, Section 5.2
+ *      </a>
  * @{
  *
  * @file
- * @brief       Message structures definitions for RFC 5444.
+ * @brief       RFC 5444 message structures and definitions.
  *
  * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
  */
@@ -40,7 +42,7 @@ extern "C" {
 #define RFC5444_MSG_FLAG_HAS_ORIG      (BIT7)   /**< Has originator address? */
 #define RFC5444_MSG_FLAG_HAS_HOP_LIMIT (BIT6)   /**< Has hop limit? */
 #define RFC5444_MSG_FLAG_HAS_HOP_COUNT (BIT5)   /**< Has hop count? */
-#define RFC5444_MSG_FLAG_SEQ_NUM       (BIT4)   /**< Has sequence number? */
+#define RFC5444_MSG_FLAG_HAS_SEQ_NUM   (BIT4)   /**< Has sequence number? */
 /** @} */
 
 #define RFC5444_MSG_ADDR_LEN_M         (0x0F)   /**< Address length mask */
@@ -59,15 +61,156 @@ typedef struct __attribute__((packed)) {
 } rfc5444_msg_hdr_t;
 
 /**
- * @brief   Get message address length
+ * @brief   Get message address length.
+ *
+ * The maximum address length is 16-bytes.
+ *
+ * @pre @p hdr != NULL
  *
  * @param[in]   hdr Pointer to message header.
  *
- * @return Address length.
+ * @return Address length, in bytes.
+ * @return -1 if hdr is NULL.
  */
-static inline uint8_t rfc5444_msg_hdr_addr_length(rfc5444_msg_hdr_t *hdr)
+static inline int rfc5444_msg_hdr_addr_len(const rfc5444_msg_hdr_t *hdr)
 {
+    if (hdr == NULL) {
+        return -1;
+    }
+
     return (hdr->flags_and_addr_length & RFC5444_MSG_ADDR_LEN_M);
+}
+
+/**
+ * @brief   Get the originator address of a message.
+ *
+ * @pre @p hdr != NULL
+ *
+ * @param[in]   hdr Pointer to message header.
+ *
+ * @return Pointer to originator address, with a size of
+ *         @ref rfc5444_msg_hdr_addr_len.
+ * @return NULL if the message doesn't have an originator address.
+ */
+static inline uint8_t *rfc5444_msg_hdr_orig_addr(rfc5444_msg_hdr_t *hdr)
+{
+    if ((hdr == NULL) ||
+        !(hdr->flags_and_addr_length & RFC5444_MSG_FLAG_HAS_ORIG)) {
+        return NULL;
+    }
+
+    /* <orig-addr> */
+    return (uint8_t *)((uintptr_t)hdr + sizeof(rfc5444_msg_hdr_t));
+}
+
+/**
+ * @brief   Get the hop limit of a message.
+ *
+ * @pre @p hdr != NULL
+ *
+ * @param[in]   hdr Pointer to message header.
+ *
+ * @return Hop limit, positive integer <= UINT8_MAX.
+ * @return -1 if the message doesn't contain a hop limit.
+ */
+static inline int rfc5444_msg_hdr_hop_limit(const rfc5444_msg_hdr_t *hdr)
+{
+    size_t pos;
+    if ((hdr == NULL) ||
+        !(hdr->flags_and_addr_length & RFC5444_MSG_FLAG_HAS_HOP_LIMIT)) {
+        return -1;
+    }
+
+    /* <msg-type><msg-flags><msg-addr-length><msg-size><msg-orig-addr>? */
+    bool has_orig = hdr->flags_and_addr_length & RFC5444_MSG_FLAG_HAS_ORIG;
+    pos = sizeof(rfc5444_msg_hdr_t)
+        + (has_orig ? (size_t)rfc5444_msg_hdr_addr_len(hdr) : 0);
+
+    return *(uint8_t *)((uintptr_t)hdr + pos);
+}
+
+/**
+ * @brief   Get the hop count of a message.
+ *
+ * @pre @p hdr != NULL
+ *
+ * @param[in]   hdr Pointer to message header.
+ *
+ * @return Hop count, positive integer <= UINT8_MAX.
+ * @return -1 if the message doesn't contain a hop limit.
+ */
+static inline int rfc5444_msg_hdr_hop_count(const rfc5444_msg_hdr_t *hdr)
+{
+    size_t pos;
+    if ((hdr == NULL) ||
+        !(hdr->flags_and_addr_length & RFC5444_MSG_FLAG_HAS_HOP_COUNT)) {
+        return -1;
+    }
+
+    /* <msg-type><msg-flags><msg-addr-length><msg-size><msg-orig-addr>?
+     * <msg-hop-limit> */
+    bool has_orig = hdr->flags_and_addr_length & RFC5444_MSG_FLAG_HAS_ORIG;
+    bool has_hoplimit = hdr->flags_and_addr_length & RFC5444_MSG_FLAG_HAS_HOP_LIMIT;
+    pos = sizeof(rfc5444_msg_hdr_t)
+        + (has_orig ? (size_t)rfc5444_msg_hdr_addr_len(hdr) : 0)
+        + (has_hoplimit ? sizeof(uint8_t) : 0);
+
+    /* <msg-hop-count> */
+    return *(uint8_t *)((uintptr_t)hdr + pos);
+}
+
+/**
+ * @brief   Get the sequence number of a message.
+ *
+ * @pre @p hdr != NULL
+ *
+ * @param[in]   hdr Pointer to message header.
+ *
+ * @return Sequence number, positive integer <= UINT16_MAX.
+ * @return -1 if the message doesn't contain a sequence number.
+ */
+static inline int rfc5444_msg_hdr_seq_num(const rfc5444_msg_hdr_t *hdr)
+{
+    size_t pos;
+    if ((hdr == NULL) ||
+        !(hdr->flags_and_addr_length & RFC5444_MSG_FLAG_HAS_SEQ_NUM)) {
+        return -1;
+    }
+
+    /* <msg-type><msg-flags><msg-addr-length><msg-size><msg-orig-addr>?
+     * <msg-hop-limit><msg-hop-count> */
+    bool has_orig = hdr->flags_and_addr_length & RFC5444_MSG_FLAG_HAS_ORIG;
+    bool has_hoplimit = hdr->flags_and_addr_length & RFC5444_MSG_FLAG_HAS_HOP_LIMIT;
+    bool has_hopcount = hdr->flags_and_addr_length & RFC5444_MSG_FLAG_HAS_HOP_COUNT;
+    pos = sizeof(rfc5444_msg_hdr_t)
+        + (has_orig ? (size_t)rfc5444_msg_hdr_addr_len(hdr) : 0)
+        + (has_hoplimit ? sizeof(uint8_t) : 0)
+        + (has_hopcount ? sizeof(uint8_t) : 0);
+
+    /* <msg-seq-num> */
+    return byteorder_bebuftohs((uint8_t *)((uintptr_t)hdr + pos));
+}
+/**
+ * @brief   Total length of the message header in bytes.
+ *
+ * @pre @p hdr != NULL
+ *
+ * @param[in]   hdr Pointer to message header.
+ *
+ * @return Length of the header, in bytes.
+ */
+static inline int rfc5444_msg_hdr_sizeof(const rfc5444_msg_hdr_t *hdr)
+{
+    bool has_orig = hdr->flags_and_addr_length & RFC5444_MSG_FLAG_HAS_ORIG;
+    bool has_hoplimit = hdr->flags_and_addr_length & RFC5444_MSG_FLAG_HAS_HOP_LIMIT;
+    bool has_hopcount = hdr->flags_and_addr_length & RFC5444_MSG_FLAG_HAS_HOP_COUNT;
+    bool has_seqnum = hdr->flags_and_addr_length & RFC5444_MSG_FLAG_HAS_SEQ_NUM;
+
+    return sizeof(rfc5444_msg_hdr_t)
+         + (has_orig ? (size_t)rfc5444_msg_hdr_addr_len(hdr) : 0)
+         + (has_hoplimit ? sizeof(uint8_t) : 0)
+         + (has_hopcount ? sizeof(uint8_t) : 0)
+         + (has_seqnum ? sizeof(uint16_t): 0);
 }
 
 /**
@@ -82,6 +225,17 @@ typedef struct {
 
 /**
  * @brief   Initialize message iterator.
+ *
+ * The @p len parameter should be calculated before calling the function,
+ * it should be something along the lines of:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.c}
+ * int packet_len = recv(...);
+ * int len = packet_len - rfc5444_pkt_hdr_sizeof(hdr);
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * The @p ptr parameter is a pointer to the start of the messages,
+ * just after the packet header.
  *
  * @param[in]   iter The iterator to initialize.
  * @param[in]   ptr  The pointer to the start of the first message,
@@ -111,17 +265,17 @@ static inline rfc5444_msg_hdr_t *rfc5444_msg_iter_next(rfc5444_msg_iter_t *iter)
 {
     /* verify if we have something to iterate */
     if ((iter == NULL) ||
-        (iter->len <= iter->pos) ||
+        (iter->pos >= iter->len) ||
         ((iter->len - iter->pos) <= sizeof(rfc5444_msg_hdr_t))) {
         return NULL;
     }
 
     rfc5444_msg_hdr_t *current = (rfc5444_msg_hdr_t *)(iter->ptr + iter->pos);
-    iter->pos += (size_t)byteorder_ntohs(current->size);
-    /* verify that the buffer contains the said length by the message */
-    if (iter->pos >= iter->len) {
+    size_t msg_len = byteorder_ntohs(current->size);
+    if ((iter->pos - iter->len) < msg_len) {
         return NULL;
     }
+    iter->pos += msg_len;
 
     return current;
 }

--- a/sys/include/net/rfc5444/msg.h
+++ b/sys/include/net/rfc5444/msg.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_rfc5444
+ * @ingroup     net
+ * @brief       Message structures for RFC 5444.
+ * @see         <a href="https://tools.ietf.org/html/rfc5444">
+ *                  RFC 5444 - Generalized Mobile Ad Hoc Network (MANET) Packet/Message Format
+ *              </a>
+ * @{
+ *
+ * @file
+ * @brief       Message structures definitions for RFC 5444.
+ *
+ * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef NET_RFC5444_MSG_H
+#define NET_RFC5444_MSG_H
+
+#include <stdint.h>
+
+#include "bitarithm.h"
+#include "byteorder.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Message flags
+ * @{
+ */
+#define RFC5444_MSG_FLAG_HAS_ORIG      (BIT7)   /**< Has originator address? */
+#define RFC5444_MSG_FLAG_HAS_HOP_LIMIT (BIT6)   /**< Has hop limit? */
+#define RFC5444_MSG_FLAG_HAS_HOP_COUNT (BIT5)   /**< Has hop count? */
+#define RFC5444_MSG_FLAG_SEQ_NUM       (BIT4)   /**< Has sequence number? */
+/** @} */
+
+#define RFC5444_MSG_ADDR_LEN_M         (0x0F)   /**< Address length mask */
+
+/**
+ * @brief   Message header
+ *
+ * @see [RFC 5444, Section 5.2]
+ *      (https://tools.ietf.org/html/rfc5444#section-5.2)
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t type;                   /**< Message type */
+    uint8_t flags_and_addr_length;  /**< Flags and address length fields */
+    network_uint16_t size;          /**< Total size of the message including
+                                         this header, in bytes */
+} rfc5444_msg_hdr_t;
+
+/**
+ * @brief   Get message address length
+ *
+ * @param[in]   hdr Pointer to message header.
+ *
+ * @return Address length.
+ */
+static inline uint8_t rfc5444_msg_hdr_addr_length(rfc5444_msg_hdr_t *hdr)
+{
+    return (hdr->flags_and_addr_length & RFC5444_MSG_ADDR_LEN_M);
+}
+
+/**
+ * @brief   Iterator over the messages
+ */
+typedef struct {
+    uint8_t *ptr;                   /**< Pointer to the start of the first
+                                         message in the packet */
+    size_t len;                     /**< Length of the messages, in bytes */
+    size_t pos;                     /**< Iterator position, in bytes */
+} rfc5444_msg_iter_t;
+
+/**
+ * @brief   Initialize message iterator.
+ *
+ * @param[in]   iter The iterator to initialize.
+ * @param[in]   ptr  The pointer to the start of the first message,
+ *                   it MUST be a contiguous block of messages.
+ * @param[in]   len  The length of the message block, this determines
+ *                   the parsing behaviour, as this determines when it's
+ *                   finished.
+ */
+static inline void rfc5444_msg_iter_init(rfc5444_msg_iter_t *iter, void *ptr,
+                                         size_t len)
+{
+    iter->ptr = ptr;
+    iter->len = len;
+    iter->pos = 0;
+}
+
+/**
+ * @brief   Get next element of the message iterator.
+ *
+ * @param[in]   iter The message iterator.
+ *
+ * @return NULL on invalid message length
+ * @return NULL on finished parsing
+ * @return Pointer to next message header on success
+ */
+static inline rfc5444_msg_hdr_t *rfc5444_msg_iter_next(rfc5444_msg_iter_t *iter)
+{
+    /* verify if we have something to iterate */
+    if ((iter == NULL) ||
+        (iter->len <= iter->pos) ||
+        ((iter->len - iter->pos) <= sizeof(rfc5444_msg_hdr_t))) {
+        return NULL;
+    }
+
+    rfc5444_msg_hdr_t *current = (rfc5444_msg_hdr_t *)(iter->ptr + iter->pos);
+    iter->pos += (size_t)byteorder_ntohs(current->size);
+    /* verify that the buffer contains the said length by the message */
+    if (iter->pos >= iter->len) {
+        return NULL;
+    }
+
+    return current;
+}
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /**< NET_RFC5444_MSG_H */
+/** @} */

--- a/sys/include/net/rfc5444/tlv.h
+++ b/sys/include/net/rfc5444/tlv.h
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_rfc5444
+ * @ingroup     net
+ *
+ * @{
+ *
+ * @file
+ * @brief       RFC 5444 type-length value representation and helper
+ *              functions.
+ *
+ * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+#ifndef NET_RFC5444_TLV_H
+#define NET_RFC5444_TLV_H
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "bitarithm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name TLV flags
+ * @{
+ */
+#define RFC5444_TLV_FLAG_HAS_TYPE_EXT       (BIT7)  /**< Has type extension? */
+#define RFC5444_TLV_FLAG_HAS_SINGLE_INDEX   (BIT6)  /**< Has single index? */
+#define RFC5444_TLV_FLAG_HAS_MULTI_INDEX    (BIT5)  /**< Has multiple index? */
+#define RFC5444_TLV_FLAG_HAS_VALUE          (BIT4)  /**< Has value? */
+#define RFC5444_TLV_FLAG_HAS_EXT_LEN        (BIT3)  /**< Has extended length? */
+#define RFC5444_TLV_FLAG_IS_MULTIVALUE      (BIT2)  /**< Is multivalue? */
+/** @} */
+
+/**
+ * @brief   Type-Length-Value (TLV) Block.
+ *
+ * @see [RFC 5444, Section 5.4]
+ *      (https://tools.ietf.org/html/rfc5444#section-5.4)
+ */
+typedef struct __attribute__((packed)) {
+    network_uint16_t length;     /**< TLVs length in octets following this field */
+} rfc5444_tlv_block_t;
+
+/**
+ * @brief   Type-Length-Value (TLV).
+ *
+ * @see [RFC 5444, Section 5.4.1]
+ *      (https://tools.ietf.org/html/rfc5444#section-5.4.1)
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t type;   /**< Type of this TLV */
+    uint8_t flags;  /**< TLV flags */
+} rfc5444_tlv_t;
+
+/**
+ * @brief   Length of the TLV block
+ */
+static inline size_t rfc5444_tlv_block_len(const rfc5444_tlv_block_t *block)
+{
+    return (size_t)byteorder_ntohs(block->length);
+}
+
+/**
+ * @brief   Total length of the TLV block
+ *
+ * @pre @p block != NULL
+ *
+ * @param[in]   block Pointer to TLV block.
+ *
+ * @return The size of the TLV block in bytes.
+ */
+static inline size_t rfc5444_tlv_block_sizeof(const rfc5444_tlv_block_t *block)
+{
+    return sizeof(rfc5444_tlv_block_t) + (size_t)byteorder_ntohs(block->length);
+}
+
+/**
+ * @brief   Get the type extension of this TLV, if any.
+ *
+ * @pre @p tlv != NULL
+ *
+ * @param[in]   tlv Pointer to a TLV.
+ *
+ * @return Type extension, on success.
+ * @return -1 if this TLV doesn't have a type extension.
+ */
+static inline int rfc5444_tlv_type_ext(const rfc5444_tlv_t *tlv)
+{
+    if ((tlv == NULL) ||
+        !(tlv & RFC5444_TLV_FLAG_HAS_TYPE_EXT)) {
+        return -1;
+    }
+
+    /* <type-ext> */
+    return *(uint8_t *)((uintptr_t)(tlv) + sizeof(rfc5444_tlv_t));
+}
+
+static inline int rfc5444_tlv_index_start(const rfc5444_tlv_t *tlv)
+{
+    size_t pos;
+    if ((tlv == NULL) ||
+        !((tlv->flags & RFC5444_TLV_FLAG_HAS_SINGLE_INDEX) ||
+          (tlv->flags & RFC5444_TLV_FLAG_HAS_MULTI_INDEX))) {
+        return -1;
+    }
+
+    /* <type>, <flags> */
+    pos = sizeof(rfc5444_tlv_t);
+    /* <type-ext> */
+    if (tlv->flags & RFC5444_TLV_FLAG_HAS_TYPE_EXT) {
+        pos += sizeof(uint8_t);
+    }
+
+    return *(uint8_t *)((uintptr_t)(tlv) + pos);
+}
+
+static inline int rfc5444_tlv_index_stop(const rfc5444_tlv_t *tlv)
+{
+    size_t pos;
+    if ((tlv == NULL) ||
+        !(tlv->flags & RFC5444_TLV_FLAG_HAS_MULTI_INDEX)) {
+        return -1;
+    }
+
+    /* <type>, <flags>, <type-ext>, <index-start> */
+    pos = sizeof(rfc5444_tlv_t);
+        + (tlv->flags & RFC5444_TLV_FLAG_HAS_TYPE_EXT) ? sizeof(uint8_t) : 0
+        + sizeof(uint8_t);
+
+    /* <index-stop> */
+    return *(uint8_t)((uintptr_t)(tlv) + pos);
+}
+
+static inline int rfc5444_tlv_len(const rfc5444_tlv_t *tlv)
+{
+    size_t pos;
+    if ((tlv == NULL) ||
+        !(tlv->flags & RFC5444_TLV_FLAG_HAS_VALUE)) {
+        return -1;
+    }
+
+    /* <type><flags><type-ext> */
+    pos = sizeof(rfc5444_tlv_t);
+        + (tlv->flags & RFC5444_TLV_FLAG_HAS_TYPE_EXT) ? sizeof(uint8_t) : 0;
+
+    /* guard against invalid combination of thassingleindex and
+     * thasmultiindex, according to the truth table on the spec. both flags
+     * aren't allowed at the same time. You can't have a cake and eat it
+     * too, pick one :-) */
+    if ((tlv->flags & RFC5444_TLV_FLAG_HAS_SINGLE_INDEX) &&
+        (tlv->flags & RFC5444_TLV_FLAG_HAS_MULTI_INDEX)) {
+        return -1;
+    }
+
+    /* <index-start>> */
+    if (tlv->flags & RFC5444_TLV_FLAG_HAS_SINGLE_INDEX) {
+        pos += sizeof(uint8_t);
+    }
+    /* <index-start><index-stop> */
+    else if (tlv->flags & RFC5444_TLV_FLAG_HAS_MULTI_INDEX) {
+        pos += sizeof(uint8_t) * 2;
+    }
+
+    int len;
+    /* <length> 16-bits */
+    if (tlv->flags & RFC5444_TLV_FLAG_HAS_EXT_LEN) {
+        len = byteorder_bebuftohs((uint8_t *)((uintptr_t)(tlv) + pos));
+    }
+    /* <length> 8-bits */
+    else {
+        len = *(uint8_t *)((uintptr_t)(tlv) + pos);
+    }
+
+    return len;
+}
+
+static inline int rfc5444_tlv_value(const rfc5444_tlv_t *tlv)
+{
+    return -1;
+}
+
+static inline int rfc5444_tlv_full_type(const rfc5444_tlv_t *tlv)
+{
+    int type_ext;
+    if ((type_ext = rfc5444_tlv_type_ext(tlv)) < 0) {
+        return -1;
+    }
+
+    return (256 * (int)tlv->type) + type_ext;
+}
+
+static inline int rfc5444_tlv_sizeof(const rfc5444_tlv_t *tlv)
+{
+    return -1;
+}
+
+/**
+ * @brief   Iterator over a TLV block.
+ */
+typedef struct {
+    uintptr_t ptr;                  /**< Pointer to the start of the first
+                                         message in the packet */
+    size_t len;                     /**< Length of the messages, in bytes */
+    size_t pos;                     /**< Iterator position, in bytes */
+} rfc5444_tlv_iter_t;
+
+/**
+ * @brief   Initialize TLV iterator.
+ *
+ * @note Caller of the function MUST be sure that at least
+ *       `sizeof(rfc5444_tlv_block_t) + rfc5444_tlv_block_t::length` is
+ *       available from the start of @p block.
+ *
+ * @param[in]   iter    The iterator to initialize.
+ * @param[in]   block   The pointer the TLV block, it MUST contain a contiguous
+ *                      block of TLVs.
+ */
+static inline void rfc5444_tlv_iter_init(rfc5444_tlv_iter_t *iter, rfc5444_tlv_block_t *block)
+{
+    iter->ptr = (uintptr_t)block + sizeof(rfc5444_tlv_block_t);
+    iter->len = ;
+    iter->pos = 0;
+}
+
+/**
+ * @brief   Get the next element of the TLV iterator.
+ *
+ * @param[in]   iter The message iterator.
+ *
+ * @reutrn NULL on invalid TLV length.
+ * @return NULL on finished parsing.
+ * @return Pointer to next TLV on success.
+ */
+static inline void rfc5444_tlv_t *rfc5444_tlv_iter_next(rfc5444_tlv_iter_t *iter)
+{
+    /* verify if we have something to iterate */
+    if ((iter != NULL) ||
+        (iter->pos >= iter->len) ||
+        ((iter->len - iter->pos) <= sizeof(rfc5444_tlv_t))) {
+        return NULL;
+    }
+
+    rfc5444_tlv_t *current = (rfc5444_tlv_t *)(iter->ptr + iter->pos);
+    iter->pos += (size_t)byteorder_ntohs(current->size);
+    /* verify that the buffer contains the said length by the TLV */
+    if (iter->pos >= iter->len) {
+        return NULL;
+    }
+
+    return current;
+}
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* NET_RFC5444_TLV_H */
+/** @} */

--- a/sys/include/net/rfc5444/tlv.h
+++ b/sys/include/net/rfc5444/tlv.h
@@ -7,8 +7,14 @@
  */
 
 /**
+ * @defgroup    net_rfc5444_tlv RFC 5444 TLVs
  * @ingroup     net_rfc5444
- * @ingroup     net
+ * @brief       RFC 5444 type-length value representation and helper
+ *              functions.
+ *
+ * @see <a href="https://tools.ietf.org/html/rfc5444#section-5.4">
+ *          RFC 5444, Section 5.4
+ *      </a>
  *
  * @{
  *
@@ -108,6 +114,17 @@ static inline int rfc5444_tlv_type_ext(const rfc5444_tlv_t *tlv)
     return *(uint8_t *)((uintptr_t)(tlv) + sizeof(rfc5444_tlv_t));
 }
 
+/**
+ * @brief   Get the index-start value of this TLV, if any.
+ *
+ * @pre @p tlv != NULL
+ *
+ * @param[in]   tlv Pointer to a TLV.
+ *
+ * @return index-start value.
+ * @return -1 if @p tlv is NULL.
+ * @return -1 if index-start is not provided.
+ */
 static inline int rfc5444_tlv_index_start(const rfc5444_tlv_t *tlv)
 {
     size_t pos;
@@ -359,7 +376,7 @@ static inline void rfc5444_tlv_iter_init(rfc5444_tlv_iter_t *iter, rfc5444_tlv_b
  *
  * @param[in]   iter The message iterator.
  *
- * @reutrn NULL on invalid TLV length.
+ * @return NULL on invalid TLV length.
  * @return NULL on finished parsing.
  * @return Pointer to next TLV on success.
  */

--- a/tests/unittests/tests-rfc5444/Makefile
+++ b/tests/unittests/tests-rfc5444/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-rfc5444/tests-rfc5444.c
+++ b/tests/unittests/tests-rfc5444/tests-rfc5444.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ */
+
+#include "embUnit.h"
+#include "byteorder.h"
+
+#include "net/rfc5444.h"
+
+#define SEQ_NUM     (2048U) /**< Sequence number for testing */
+#define TLV_TYPE    (1U)    /**< TLV type */
+#define TLV_LEN     (1U)    /**< TLV length */
+#define TLV_VALUE   (0xCA)  /**< 1-byte TLV value */
+
+static void test_pkt_hdr_version__RFC5444_VERSION(void)
+{
+    const rfc5444_pkt_hdr_t hdr = {
+        .version_and_flags = RFC5444_VERSION << 4,
+    };
+
+    TEST_ASSERT_EQUAL_INT(RFC5444_VERSION, rfc5444_pkt_hdr_version(&hdr));
+}
+
+static void test_pkt_hdr_flags__all(void)
+{
+    const rfc5444_pkt_hdr_t hdr = {
+        .version_and_flags = (RFC5444_VERSION << 4)
+                           | RFC5444_PKT_HDR_FLAG_HAS_SEQ_NUM
+                           | RFC5444_PKT_HDR_FLAG_HAS_TLV,
+    };
+
+    const uint8_t flags = rfc5444_pkt_hdr_flags(&hdr);
+
+    TEST_ASSERT_EQUAL_INT(RFC5444_PKT_HDR_FLAG_HAS_SEQ_NUM,
+                          flags & RFC5444_PKT_HDR_FLAG_HAS_SEQ_NUM);
+    TEST_ASSERT_EQUAL_INT(RFC5444_PKT_HDR_FLAG_HAS_TLV,
+                          flags & RFC5444_PKT_HDR_FLAG_HAS_TLV);
+}
+
+static void test_pkt_hdr_extra__no_seq_num_no_tlv_block(void)
+{
+    rfc5444_pkt_hdr_t hdr = {
+        .version_and_flags = RFC5444_VERSION << 4,
+    };
+
+    /* doesn't provide a seqnum so it's 0 */
+    TEST_ASSERT_EQUAL_INT(-1, rfc5444_pkt_hdr_seq_num(&hdr));
+    TEST_ASSERT_NULL(rfc5444_pkt_hdr_tlv_block(&hdr));
+}
+
+static void test_pkt_hdr_extra__seq_num(void)
+{
+    uint8_t pkt[3];
+    const rfc5444_pkt_hdr_t *hdr = (rfc5444_pkt_hdr_t *)pkt;
+
+    pkt[0] = (RFC5444_VERSION << 4)
+           | RFC5444_PKT_HDR_FLAG_HAS_SEQ_NUM;
+
+    byteorder_htobebufs(&pkt[1], SEQ_NUM);
+    TEST_ASSERT_EQUAL_INT(SEQ_NUM, rfc5444_pkt_hdr_seq_num(hdr));
+}
+
+static void test_pkt_hdr_extra__tlv_block(void)
+{
+    rfc5444_tlv_block_t *tlv_block;
+    rfc5444_tlv_iter_t iter;
+    rfc5444_tlv_t *tlv;
+    uint8_t pkt[] = {
+        (RFC5444_VERSION << 4) | RFC5444_PKT_HDR_FLAG_HAS_TLV,
+        /* length of TLV block */
+        0,
+        4,
+        /* TLV */
+        TLV_TYPE,
+        0,
+        TLV_LEN,
+        TLV_VALUE,
+    };
+    const rfc5444_pkt_hdr_t *hdr = (rfc5444_pkt_hdr_t *)pkt;
+
+    tlv_block = rfc5444_pkt_hdr_tlv_block(hdr);
+    TEST_ASSERT_NOT_NULL(tlv_block);
+    TEST_ASSERT_EQUAL_INT(4, rfc5444_tlv_block_sizeof(tlv_block));
+
+    rfc5444_tlv_iter_init(&iter, tlv_block);
+    tlv = rfc5444_tlv_iter_next(&next);
+    TEST_ASSERT_NOT_NULL(tlv);
+
+    TEST_ASSERT_EQUAL_INT(TLV_TYPE, tlv->type);
+    TEST_ASSERT_EQUAL_INT(TLV_LEN, rfc5444_tlv_len(tlv));
+    TEST_ASSERT_EQUAL_INT(TLV_VALUE, *rfc5444_tlv_value(tlv));
+}
+
+static void test_pkt_hdr_extra__seq_num_tlv_block(void)
+{
+}
+
+
+Test *tests_rfc5444_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_pkt_hdr_version__RFC5444_VERSION),
+        new_TestFixture(test_pkt_hdr_flags__all),
+        new_TestFixture(test_pkt_hdr_extra__no_seq_num_no_tlv_block),
+        new_TestFixture(test_pkt_hdr_extra__seq_num),
+        new_TestFixture(test_pkt_hdr_extra__tlv_block),
+        new_TestFixture(test_pkt_hdr_extra__seq_num_tlv_block),
+    };
+
+    EMB_UNIT_TESTCALLER(rfc5444_tests, NULL, NULL, fixtures);
+
+    return (Test *)&rfc5444_tests;
+}
+
+void tests_rfc5444(void)
+{
+    TESTS_RUN(tests_rfc5444_tests());
+}
+
+/** @} */

--- a/tests/unittests/tests-rfc5444/tests-rfc5444.h
+++ b/tests/unittests/tests-rfc5444/tests-rfc5444.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the ``rfc5444`` headers
+ *
+ * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+#ifndef TESTS_RFC5444_H
+#define TESTS_RFC5444_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The entry point of this test suite.
+ */
+void tests_rfc5444(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_RFC5444_H */


### PR DESCRIPTION
### Contribution description

This implements a new transport-layer module for MANET networks using RFC 54444 packets.

*Be warned most of the code could be wrong, this is still on an experimentation phase and most of the code is subject to change. Any recommendation or improvement is well received*.

**Why don't use OONF?**

OONF is a quite complete library to work with RFC 5444, however, it's quite heavy for micro controllers, uses too much memory which is quite scarce these days and is not actively developed. Making it work with RIOT before was difficult, even running tests on CI for example.

**Does it require explicitly GNRC?**

I had a conversation with myself a lot whether to use the `sock_ip`/`sock_udp` modules to make it more portable, e.g.: without requiring a dependency on GNRC, lwIP or anything, as long as sock has an implementation on whatever system it is ported to, however I had a few questions:

- Sock IP/Sock UDP could be used at the same time? RFC 5444 can receive IP datagrams directly by using the `PROTNUM_MANET` next header or UDP datagrams on it's port, it doesn't _explicitly_ require to listen using both methods, however listening for IP and UDP at the same time can be achieved easily with `gnrc_netreg`, with `sock` I'm still unsure about this.
- Packet handling, using `gnrc_pktbuf` makes it easy to handle packets and generally fits well the structure of RFC 5444 messages.
- Along with the last point, `gnrc_netreg` makes the demultiplexing of RFC 5444 messages easier, threads can just register interest for specific messages and `gnrc_manet` will dispatch them using `gnrc_netreg`.

**And for what?**

My interest personally on RFC 5444 mainly is for implementing AODVv2 on the near future completely using RIOT modules, without depending too much on external code. AODVv2 is still a draft, probably it's standardization is not going to happen soon mainly due to lacking implementations to identify edge cases, errors, to test it's performance.

Previous attempts were made (#1767) to implement it, based on that code I did some experiments by updating the code to the new RIOT APIs, etc, and the principal pain point was OONF where in some cases it would eat all the heap space :smile: .

I know that introducing this code into RIOT introduces a maintenance backlog in some cases, for CI, testing, et all and that probably most people wouldn't use it as routing protocols like RPL are more suited for IoT applications, are easier to work with and significantly more stable for what the future holds. Use cases would be devices that are carried anywhere, autonomous devices that are changing their topology at any time,  VoIP applications maybe? However RPL should still work fine for most these cases if I'm not mistaken.

### Testing procedure

Compilation test:

```
make -C tests/gnrc_manet
```

Small to-do list on testing:

- [ ] Unit tests for packet, message and TLV parsing.
- [ ] Integration test, on packet reception, and message sending.
- [ ] Example protocol (maybe NHDP as it's small enough) test.
- [ ] Compatibility test to verify interop with other libraries, only OONF as far I know.
- [ ] Fuzzing as a good thing to have, to catch any unwanted crash, error, or vulnerability.

### Issues/PRs references
