### PR TITLE
net/emcute: fix buffer overflow in _willupd_msg()

### DIFF
--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -483,11 +483,10 @@ int emcute_willupd_msg(const void *data, size_t len)
     mutex_lock(&txlock);
 
     size_t pos = set_len(tbuf, (len + 1));
-    len += (pos + 1);
     tbuf[pos++] = WILLMSGUPD;
     memcpy(&tbuf[pos], data, len);
 
-    return syncsend(WILLMSGRESP, len, true);
+    return syncsend(WILLMSGRESP, (pos + len), true);
 }
 
 void emcute_run(uint16_t port, const char *id)


### PR DESCRIPTION
### Contribution description
fixes #15028

The `len` variable was indeed broken, or at least the call to `memcpy` included a buffer overflow. Should be fixed now.

### Testing procedure
- run a RIOT (e.g. `native`) node with the `examples/emcute_mqttsn` example
- run MQTT-SN gateway -> simply run `make mosquitto_rsmb` from the example application
- make sure you are using global addresses -> mosquitto_rsmb does not support link local ones...

- connect the RIOT node to tlhe gateway specifying a last will message
- update the last will message using the `will` shell command

All this should run without errors :-)

### Issues/PRs references
fixes #15028