### PR TITLE
tests/periph_timer_periodic: Use fmt for in-irq printing

### DIFF
--- a/tests/periph_timer_periodic/Makefile
+++ b/tests/periph_timer_periodic/Makefile
@@ -2,4 +2,6 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_timer_periodic
 
+USEMODULE += fmt
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_timer_periodic/main.c
+++ b/tests/periph_timer_periodic/main.c
@@ -23,6 +23,8 @@
 
 #include "board.h"
 #include "macros/units.h"
+
+#include "fmt.h"
 #include "mutex.h"
 #include "periph/timer.h"
 #include "test_utils/expect.h"
@@ -61,7 +63,9 @@ static void cb(void *arg, int chan)
 {
     unsigned c = count[chan]++;
 
-    printf("[%d] tick\n", chan);
+    print_str("[");
+    print_u32_dec(chan);
+    print_str("] tick\n");
 
     if (c > CYCLES_MAX) {
         timer_stop(TIMER_CYCL);


### PR DESCRIPTION
### Contribution description

This replaces the printf statement in the timer callback with fmt-based
printing and a single puts. This is less heavy on the stack usage than
printf, making this test a bit easier to digest on the smaller
platforms.

Flash size increases by almost 200 bytes on the samr21-xpro with LLVM because of the added fmt module.

### Testing procedure

The printed test output should remain the same.

### Issues/PRs references

reduces the stack size enough to let #14557 pass this test with LLVM on the samr21-xpro :smile: 