### PR TITLE
cpu/efm32/periph/timer: fix timer_set_absolute() in 16bit case

### DIFF
--- a/cpu/efm32/periph/timer.c
+++ b/cpu/efm32/periph/timer.c
@@ -128,6 +128,10 @@ static void _timer_init(tim_t dev, unsigned long freq)
         freq_timer / TIMER_Prescaler2Div(init_pre.prescale) / freq) - 1;
 
     TIMER_TopSet(pre, top);
+
+    /* note: when changing this, update timer_set_absolute()'s TopGet,
+     * which assumes either 0xffffffff or 0xffff
+     */
     TIMER_TopSet(tim, _is_wtimer(dev) ? 0xffffffff : 0xffff);
 
     /* enable interrupts for the channels */
@@ -169,9 +173,8 @@ int timer_set_absolute(tim_t dev, int channel, unsigned int value)
             return -1;
         }
 
-        /* this accounts for some timer being 16-bit and others 32-bit */
-        if (value > TIMER_TopGet(tim)) {
-            return -1;
+        if (TIMER_TopGet(tim) == 0xFFFF) {
+            value &= 0xFFFF;
         }
 
         tim->CC[channel].CCV = (uint32_t) value;

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -149,6 +149,9 @@ int timer_set(tim_t dev, int channel, unsigned int timeout);
 /**
  * @brief Set an absolute timeout value for the given channel of the given timer
  *
+ * Timers that are less wide than `unsigned int` accept and truncate overflown
+ * values.
+ *
  * @param[in] dev           the timer device to set
  * @param[in] channel       the channel to set
  * @param[in] value         the absolute compare value when the callback will be


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Previously, the function would return -1 without setting a timer, should the absolute target time exceed the timer width (this could only happen in the 16bit case). This behaves differently than other periph_timers that use a 16bit, which implicitly sets `value & 0xFFFF`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Test e.g., `tests/ztimer_overhead` on an affected board (sltb0001, stk3700, ...).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Fixes #15060.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
