### PR TITLE
cpu/stm32: Fix CPU_HAS_BITBAND

### DIFF
--- a/cpu/stm32/include/cpu_conf.h
+++ b/cpu/stm32/include/cpu_conf.h
@@ -131,7 +131,7 @@ extern "C" {
  * @brief   Bit-Band configuration
  * @{
  */
-#ifdef SRAM_BB_BASE
+#if defined(SRAM_BB_BASE) && !defined(CPU_FAM_STM32F1)
 #define CPU_HAS_BITBAND 1
 #endif
 /** @} */


### PR DESCRIPTION
### Contribution description

On STM32F1 `SRAM_BB_BASE` is defined, but that family does not support bit-banding. The test of bitband support checks for this macro and assumes correct vendor header files, which sadly is not the case for the STM32F1.

This PR works around the bug in vendor header files.

### Testing procedure

E.g. the blue pill should now report no bit-banding support, while it incorrectly reported bit-banding support in `master`.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14516#issuecomment-697321801