### PR TITLE
core/sched_round_robin: Add a simple round robin scheduler to core

### DIFF
--- a/core/include/sched_round_robin.h
+++ b/core/include/sched_round_robin.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 TUBA Freiberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    Sched_RR
+ * @ingroup     sys
+ * @brief       This module module provides round robin scheduling within
+ *              for all runnable threads within each not masked priority.
+ *              Priority 0 is masked by default.
+ *              There is no fainess involved in this scheuler. It schedules,
+ *              when the timer ticks. Keep it as simple as possible.
+ *
+ * @note        start using start_schedule_rr()
+ *
+ * @{
+ *
+ * @file
+ * @brief       Round Robin Scheduler
+ *
+ * @author      Karl Fessel <karl.fessel@ovgu.de>
+ *
+ */
+
+#if !defined(SCHED_RR_TIMER) || defined(DOXYGEN)
+/**
+ * @brief Time between round robin calls in µs
+ *
+ * @details Defaults to 1ms
+ */
+#define SCHED_RR_TIMER 1000
+#endif
+
+#if !defined(SCHED_RR_MASK) || defined(DOXYGEN)
+/**
+ * @brief masks off priorities that should not be scheduled default: 0 is masked
+ */
+#define SCHED_RR_MASK (1 << 0)
+#endif
+
+/**
+ * @brief setup round robin for priority if possible an sensible
+ */
+void sched_round_robin_check_set(uint8_t prio);
+
+/**
+ * @brief remove round robin if active for prio and setup for active priotrity
+ */
+void sched_round_robin_check_remove_set(uint8_t prio);

--- a/core/sched_round_robin.c
+++ b/core/sched_round_robin.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2020 TUBA Freiberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys
+ * @{
+ *
+ * @file
+ * @brief       Round Robin Scheduler implementation
+ *
+ * @author      Karl Fessel <karl.fessel@ovgu.de>
+ *
+ * @}
+ */
+
+#include "thread.h"
+#include "xtimer.h"
+#include "clist.h"
+#include "sched_round_robin.h"
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+static void sched_round_robin_cb(void * d);
+
+static xtimer_t rr_timer = {.callback = sched_round_robin_cb};
+
+static uint8_t current_rr_priority = 0xff;
+
+static void sched_round_robin_cb(void * d)
+{
+    (void)d;
+    /*
+     * reorder current Round Robin priority
+     * (put the current thread at the end of the run queue of its priority)
+     * and setup the schedueler to schedule when returning from the IRQ
+     */
+    if (current_rr_priority != 0xff) {
+        DEBUG_PUTS("Round_Robin_cb");
+        clist_lpoprpush(&sched_runqueues[current_rr_priority]);
+        thread_t * active_thread = thread_get_active();
+        if(active_thread){
+            uint8_t active_priority = active_thread->priority;
+            if(active_priority == current_rr_priority){
+                current_rr_priority = 0xff;
+                thread_yield_higher();
+            } else {
+                current_rr_priority = 0xff;
+                sched_round_robin_check_set(active_priority);
+            }
+        }else{
+           current_rr_priority = 0xff;
+        }
+    }
+}
+
+static inline void sched_round_robin_remove(void)
+{
+    current_rr_priority = 0xff;
+    xtimer_remove(&rr_timer);
+}
+
+static inline void sched_round_robin_set(uint8_t prio)
+{
+    current_rr_priority = prio;
+    xtimer_set(&rr_timer, SCHED_RR_TIMER);
+}
+
+void sched_round_robin_check_set(uint8_t prio)
+{
+    /*return if Round Robin is in use, prio is masked or list lenght is 0 or 1*/
+    if ( current_rr_priority != 0xff ||
+         SCHED_RR_MASK & 1 << prio ||
+         !sched_runqueues[prio].next ||
+         sched_runqueues[prio].next->next ==
+         sched_runqueues[prio].next->next->next) {
+            DEBUG_PUTS("RR_not_set");
+            return;
+    }
+    /*setup timer an Round Robin*/
+    DEBUG_PUTS("RR_set_timer");
+    sched_round_robin_set(prio);
+}
+
+void sched_round_robin_check_remove_set(uint8_t prio)
+{
+    /*may be called when a runqueue is emptied*/
+    if(current_rr_priority == prio){
+        sched_round_robin_remove();
+        thread_t * active_thread = thread_get_active();
+        if(active_thread){
+            uint8_t active_priority = active_thread->priority;
+            sched_round_robin_check_set(active_priority);
+        }
+    }
+}

--- a/examples/thread-duell/Makefile
+++ b/examples/thread-duell/Makefile
@@ -1,0 +1,23 @@
+# name of your application 
+APPLICATION = thread_duell
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+USEMODULE += xtimer
+USEMODULE += sched_round_robin
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# CFLAGS += -DSCHED_RR_TIMER=100000
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/thread-duell/README.md
+++ b/examples/thread-duell/README.md
@@ -1,0 +1,9 @@
+Thread_Duel
+== == == == == ==
+
+this is a thread duel application
+    to show or not to show
+RIOTS multi-threading abilities
+
+it contains:
+* example threads that use the CPU in different patterns

--- a/examples/thread-duell/main.c
+++ b/examples/thread-duell/main.c
@@ -1,0 +1,215 @@
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <thread.h>
+#include <sched.h>
+
+#include <math.h>
+
+#include "xtimer.h"
+
+#define PRINT_STEPS 10
+#define WORK_SCALE  1000
+
+void bad_wait(uint64_t us)
+{
+    /*keep the cpu busy waiting for some time to pass simulate working*/
+    uint64_t until = xtimer_now_usec64() + us;
+
+    while (xtimer_now_usec64() < until) {
+        /*do nothing*/
+    }
+}
+
+void nice_wait(uint64_t us)
+{
+    /*be nice give the core some time to do other things or rest*/
+    xtimer_usleep64(us);
+}
+
+void * thread_nicebreaks(void * d)
+{
+    xtimer_usleep64(200 * 1000);  /*allways be nice at start*/
+#ifdef DEVELHELP
+    const char *name = thread_get_active()->name;
+#else
+    int16_t pid = thread_getpid();
+#endif
+
+    uint32_t w = 0;
+    uint32_t work = *((uint32_t *) d);
+    if (work > 10) {
+        work = 5;
+    }
+    uint32_t rest = (10 - work);
+    uint32_t step = 0;
+
+    /*work some time and rest*/
+    for (;;) {
+        if (w - step >= PRINT_STEPS) {
+            printf(
+#ifdef DEVELHELP
+                "%s: "
+#else
+                "T-Pid %i:"
+#endif
+                "%u, %d\n",
+#ifdef DEVELHELP
+                name,
+#else
+                pid,
+#endif
+                w, work);
+            step = w;
+        }
+        bad_wait(work * WORK_SCALE);
+        w += work;
+        nice_wait(rest * WORK_SCALE);
+    }
+}
+
+
+void * thread_bad(void * d)
+{
+    xtimer_usleep64(200 * 1000);  /*allways be nice at start*/
+#ifdef DEVELHELP
+    const char *name = thread_get_active()->name;
+#else
+    int16_t pid = thread_getpid();
+#endif
+
+    uint32_t w = 0;
+    uint32_t work = *((uint32_t *) d);
+    if (work > 10) {
+        work = 5;
+    }
+    uint32_t rest = (10 - work);
+    uint32_t step = 0;
+
+    /*work some time yield rest blocking*/
+    for (;;) {
+        if (w - step >= PRINT_STEPS) {
+            printf(
+#ifdef DEVELHELP
+                "%s: "
+#else
+                "T-Pid %i:"
+#endif
+                "%u, %d\n",
+#ifdef DEVELHELP
+                name,
+#else
+                pid,
+#endif
+                w, work);
+            step = w;
+        }
+        bad_wait(work * WORK_SCALE);
+        w += work;
+        bad_wait(rest * WORK_SCALE);
+    }
+}
+
+void * thread_restless_yielding(void * d)
+{
+    xtimer_usleep64(200 * 1000);  /*allways be nice at start*/
+#ifdef DEVELHELP
+    const char *name = thread_get_active()->name;
+#else
+    int16_t pid = thread_getpid();
+#endif
+
+    uint32_t w = 0;
+    uint32_t work = *((uint32_t *) d);
+    if (work > 10) {
+        work = 5;
+    }
+    /*uint32_t rest = (10 - work);*/
+    uint32_t step = 0;
+
+    /*work for some time and yield*/
+    for (;;) {
+        if (w - step >= PRINT_STEPS) {
+            printf(
+#ifdef DEVELHELP
+                "%s: "
+#else
+                "T-Pid %i:"
+#endif
+                "%u, %d\n",
+#ifdef DEVELHELP
+                name,
+#else
+                pid,
+#endif
+                w, work);
+            step = w;
+        }
+        bad_wait(work * WORK_SCALE);
+        w += work;
+        thread_yield();
+    }
+}
+
+
+void * thread_restless(void * d)
+{
+    xtimer_usleep64(200 * 1000);  /*allways be nice at start*/
+#ifdef DEVELHELP
+    const char * name = thread_get_active()->name;
+#else
+    int16_t pid = thread_getpid();
+#endif
+
+    uint32_t w = 0;
+    uint32_t work = *((uint32_t *) d);
+    if (work > 10) {
+        work = 5;
+    }
+    /*uint32_t rest = (10 - work);*/
+    uint32_t step = 0;
+
+    /*continue working*/
+    for (;;) {
+        if (w - step >= PRINT_STEPS) {
+            printf(
+#ifdef DEVELHELP
+                "%s: "
+#else
+                "T-Pid %i:"
+#endif
+                "%u, %d\n",
+#ifdef DEVELHELP
+                name,
+#else
+                pid,
+#endif
+                w, work);
+            step = w;
+        }
+        bad_wait(work * WORK_SCALE);
+        w += work;
+    }
+}
+
+int main(void)
+{
+    {
+        static char stack[THREAD_STACKSIZE_DEFAULT];
+        static uint32_t workness = 3;   /* 0-10 workness*/
+        thread_create(stack, sizeof(stack), 7, THREAD_CREATE_STACKTEST,
+                      thread_restless, &workness, "T1");
+    }
+    {
+        static char stack[THREAD_STACKSIZE_DEFAULT];
+        static uint32_t workness = 5;   /* 0-10 workness*/
+        thread_create(stack, sizeof(stack), 7, THREAD_CREATE_STACKTEST,
+                      thread_restless, &workness, "T2");
+    }
+    {
+        static char stack[THREAD_STACKSIZE_DEFAULT];
+        static uint32_t workness = 5;   /* 0-10 workness*/
+        thread_create(stack, sizeof(stack), 7, THREAD_CREATE_STACKTEST,
+                      thread_restless, &workness, "T3");
+    }
+}

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -101,6 +101,7 @@ PSEUDOMODULES += saul_gpio
 PSEUDOMODULES += saul_nrf_temperature
 PSEUDOMODULES += scanf_float
 PSEUDOMODULES += sched_cb
+PSEUDOMODULES += sched_round_robin
 PSEUDOMODULES += semtech_loramac_rx
 PSEUDOMODULES += shell_hooks
 PSEUDOMODULES += slipdev_stdio


### PR DESCRIPTION
includes example
USEMODULE activate round robin for all not masked priorities

inspired by the comments on #14810 i created a core variant of a round robin scheduler 

### Contribution description

This contains a simple round robin for the core scheduler using xtimer to rearrange the run queue.

nothing special is done about fainess to keep this low in memory consumption.

### Testing procedure

compile the example either with or without `USEMODULE += sched_round_robin`

without this module only one of the threads will run.
with this module they run parallel , sharing cpu time.

### Issues/PRs references

similar but non core: #14810
