### PR TITLE
pkg/uwb_core: initial support

### DIFF
--- a/boards/dwm1001/include/board.h
+++ b/boards/dwm1001/include/board.h
@@ -77,9 +77,9 @@ extern "C" {
  * @name    DW1000 UWB transceiver
  * @{
  */
-#define DW1000_PARAM_SPI_DEV        SPI_DEV(1)
-#define DW1000_PARAM_CS_PIN         GPIO_DEV(0, 17)
-#define DW1000_PARAM_INT_PIN        GPIO_DEV(0, 19)
+#define DW1000_PARAM_SPI            SPI_DEV(1)
+#define DW1000_PARAM_CS_PIN         GPIO_PIN(0, 17)
+#define DW1000_PARAM_INT_PIN        GPIO_PIN(0, 19)
 /** @} */
 
 #ifdef __cplusplus

--- a/examples/twr_aloha/Makefile
+++ b/examples/twr_aloha/Makefile
@@ -1,0 +1,57 @@
+APPLICATION = twr-aloha
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= dwm1001
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# Include uwb-core, uwb-dw1000
+USEPKG += uwb-core
+USEPKG += uwb-dw1000
+
+# Include all ranging algorithms
+USEMODULE += uwb-core_twr_ss
+USEMODULE += uwb-core_twr_ss_ack
+USEMODULE += uwb-core_twr_ss_ext
+USEMODULE += uwb-core_twr_ds
+USEMODULE += uwb-core_twr_ds_ext
+
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+# Set the device role: 0x0 for tag, 0x4 for an anchor
+DW1000_ROLE ?= 0x00
+CFLAGS += -DDW1000_ROLE_DEFAULT=$(DW1000_ROLE)
+
+# All uwb-core applications need to enable `-fms-extensions`
+CFLAGS += -fms-extensions
+ifneq (,$(filter llvm,$(TOOLCHAIN)))
+  CFLAGS += -Wno-microsoft-anon-tag
+endif
+
+# Enable verbose mode to get all logs
+CFLAGS += -DMYNEWT_VAL_RNG_VERBOSE=2
+# Enable RX diagnostics
+CFLAGS += -DDW1000_RX_DIAGNOSTIC=1
+
+# Fix the TWR algorithm:
+# - UWB_DATA_CODE_SS_TWR
+# - UWB_DATA_CODE_SS_TWR_EXT
+# - UWB_DATA_CODE_SS_TWR_ACK
+# - UWB_DATA_CODE_DS_TWR
+# - UWB_DATA_CODE_DS_TWR_EXT
+UWB_TWR_ALGORITHM_ONLY_ONE ?= UWB_DATA_CODE_SS_TWR
+# Uncomment to fix the TWR algoritm
+# CFLAGS += -DUWB_TWR_ALGORITHM_ONLY_ONE=$(UWB_TWR_ALGORITHM_ONLY_ONE)
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/twr_aloha/Makefile.ci
+++ b/examples/twr_aloha/Makefile.ci
@@ -1,0 +1,12 @@
+BOARD_INSUFFICIENT_MEMORY := \
+    i-nucleo-lrwan1 \
+    nucleo-f031k6 \
+    nucleo-f042k6 \
+    nucleo-l011k4 \
+    nucleo-l031k6 \
+    nucleo-l053r8 \
+    stk3200 \
+    stm32f030f4-demo \
+    stm32f0discovery \
+    stm32l0538-disco \
+    #

--- a/examples/twr_aloha/README.md
+++ b/examples/twr_aloha/README.md
@@ -1,0 +1,68 @@
+## Decawave TWR_ALOHA Example
+
+This example allows testing different two-way ranging algorithms between
+two boards supporting a dw1000 device. This makes use of the uwb-core
+pkg. This example is based on the twr-aloha example in
+[uwb-apps](https://github.com/Decawave/uwb-apps/tree/master/apps/twr_aloha).
+
+### Setup
+
+1. Flash one node as the tag (Default configuration)
+
+    $ make -C examples/twr_aloha/ flash term
+
+2. Flash the second node as an anchor
+
+    $ DW1000_ROLE=0x4 make -C examples/twr_aloha/ flash term
+
+3. On the tag node begin ranging, you will see ranging estimations where
+the "raz" field is "range" in meters.
+
+```
+ main(): This is RIOT! (Version: 2020.10-devel-1384-g5b7ad-wip/uwb-dw1000)
+ pkg uwb-dw1000 + uwb-core test application
+ {"utime": 49412,"exec": "/home/francisco/workspace/RIOT/examples/twr_aloha/control.c"}
+ {"device_id"="deca0130","panid="DECA","addr"="1303","part_id"="cad11303","lot_id"="402c188"}
+ {"utime": 49412,"msg": "frame_duration = 201 usec"}
+ {"utime": 49412,"msg": "SHR_duration = 139 usec"}
+ {"utime": 49412,"msg": "holdoff = 821 usec"}
+ Node role: TAG
+ {"utime": 120995,"c": 274,"uid": 4867,"ouid": 4660,"raz": [0.766359],"los": [1.000000]}
+> range start
+ range start
+ Start ranging
+ {"utime": 5214098,"c": 274,"uid": 4867,"ouid": 4660,"raz": [0.778875],"los": [1.000000]}
+ {"utime": 5232368,"c": 274,"uid": 4867,"ouid": 4660,"raz": [0.777146],"los": [1.000000]}
+ {"utime": 5250631,"c": 274,"uid": 4867,"ouid": 4660,"raz": [0.796009],"los": [1.000000]}
+ {"utime": 5268894,"c": 274,"uid": 4867,"ouid": 4660,"raz": [0.756952],"los": [1.000000]}
+ {"utime": 5287157,"c": 274,"uid": 4867,"ouid": 4660,"raz": [0.787994],"los": [1.000000]}
+```
+
+4. Trying different ranging algorithms
+
+The algorithm used for ranging is selected by modifying the `mode` variable
+in the uwb_ev_cb function in main.c. If multiple modes are enabled it will switch among them.
+
+To use only one algorithm, compile as follows:
+
+    $ UWB_TWR_ALGORITHM_ONLY_ONE=UWB_DATA_CODE_SS_TWR make -C examples/twr_aloha/ flash term
+
+The different algorithm options are:
+
+- UWB_DATA_CODE_SS_TWR
+- UWB_DATA_CODE_SS_TWR_EXT
+- UWB_DATA_CODE_SS_TWR_ACK
+- UWB_DATA_CODE_DS_TWR
+- UWB_DATA_CODE_DS_TWR_EXT
+
+### Notes
+
+The application example fixes the `short_address` of the anchor to
+`ANCHOR_ADDRESS`, by default `0x1234`. All tags will send ranging requests
+to that address.
+
+This value can be overridden with a `CFLAG += -DANCHOR_ADDRESS=$(VALUE)`.
+
+Ranging request are sent every 40ms, this value can also be overridden
+by changing the default value of `RANGE_REQUEST_T_US`, e.g:
+`CFLAG += -DRANGE_REQUEST_T_US=10000` to set it at 10ms.

--- a/examples/twr_aloha/control.c
+++ b/examples/twr_aloha/control.c
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ *
+ * @}
+ */
+
+#include <assert.h>
+#include <math.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "uwb/uwb.h"
+#include "uwb_rng/uwb_rng.h"
+#include "dpl/dpl.h"
+#include "control.h"
+
+#include "shell_commands.h"
+#include "shell.h"
+#include "xtimer.h"
+
+static struct dpl_callout _rng_req_callout;
+static uint8_t _ranging_enabled_flag;
+static struct dpl_event _slot_event;
+
+/* forward declaration */
+static void _slot_complete_cb(struct dpl_event *ev);
+static bool _complete_cb(struct uwb_dev *inst, struct uwb_mac_interface *cbs);
+static bool _rx_timeout_cb(struct uwb_dev *inst, struct uwb_mac_interface *cbs);
+
+static int _range_cli_cmd(int argc, char **argv)
+{
+    (void)argc;
+
+    if (!strcmp(argv[1], "start")) {
+        printf("Start ranging\n");
+        dpl_callout_reset(&_rng_req_callout, RANGE_REQUEST_T_US);
+        _ranging_enabled_flag = 1;
+    }
+    else if (!strcmp(argv[1], "stop")) {
+        printf("Stop ranging\n");
+        dpl_callout_stop(&_rng_req_callout);
+        _ranging_enabled_flag = 0;
+    }
+    else {
+        puts("Usage:");
+        puts("\trange start: to start ranging");
+        puts("\trange stop:  to stop  ranging");
+    }
+
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "range", "Control command", _range_cli_cmd },
+    { NULL, NULL, NULL }
+};
+
+/* Structure of extension callbacks common for mac layer */
+static struct uwb_mac_interface _uwb_mac_cbs = (struct uwb_mac_interface){
+    .id = UWBEXT_APP0,
+    .complete_cb = _complete_cb,
+    .rx_timeout_cb = _rx_timeout_cb,
+};
+
+/**
+ * @brief Range request complete callback.
+ *
+ * This callback is part of the  struct uwb_mac_interface extension
+ * interface and invoked of the completion of a range request in the
+ * context of this example. The struct uwb_mac_interface is in the
+ * interrupt context and is used to schedule events an event queue.
+ *
+ * Processing should be kept to a minimum given the interrupt context.
+ * All algorithms activities should be deferred to a thread on an event
+ * queue. The callback should return true if and only if it can determine
+ * if it is the sole recipient of this event.
+ *
+ * @note The MAC extension interface is a linked-list of callbacks,
+ * subsequentcallbacks on the list will be not be called if the callback
+ * returns true.
+ *
+ * @param[in] inst  Pointer to struct uwb_dev.
+ * @param[in] cbs   Pointer to struct uwb_mac_interface.
+ * *
+ * @return true if valid recipient for the event, false otherwise
+ */
+static bool _complete_cb(struct uwb_dev *inst, struct uwb_mac_interface *cbs)
+{
+    (void)cbs;
+
+    if (inst->fctrl != FCNTL_IEEE_RANGE_16 &&
+        inst->fctrl != (FCNTL_IEEE_RANGE_16 | UWB_FCTRL_ACK_REQUESTED)) {
+        return false;
+    }
+    /* on completion of a range request setup an event to keep listening,
+       if is anchor */
+    dpl_eventq_put(dpl_eventq_dflt_get(), &_slot_event);
+    return true;
+}
+
+/**
+ * @brief API for receive timeout callback.
+ *
+ * @param[in] inst  Pointer to struct uwb_dev.
+ * @param[in] cbs   Pointer to struct uwb_mac_interface.
+ *
+ * @return true on success
+ */
+static bool _rx_timeout_cb(struct uwb_dev *inst, struct uwb_mac_interface *cbs)
+{
+    struct uwb_rng_instance *rng = (struct uwb_rng_instance *)cbs->inst_ptr;
+
+    if (inst->role & UWB_ROLE_ANCHOR) {
+        /* Restart receiver */
+        uwb_phy_forcetrxoff(inst);
+        uwb_rng_listen(rng, 0xfffff, UWB_NONBLOCKING);
+    }
+    return true;
+}
+
+/**
+ * @brief In the example this function represents the event context
+ * processing of the received range request which has been offloaded from
+ * ISR context to an event queue.
+ */
+static void _slot_complete_cb(struct dpl_event *ev)
+{
+    assert(ev != NULL);
+
+    struct uwb_rng_instance *rng = (struct uwb_rng_instance *)
+        dpl_event_get_arg(ev);
+    struct uwb_dev *inst = rng->dev_inst;
+
+    if (inst->role & UWB_ROLE_ANCHOR) {
+        uwb_rng_listen(rng, 0xfffff, UWB_NONBLOCKING);
+    }
+}
+
+/**
+ * @brief An event callback to send range request every RANGE_REQUEST_T_US.
+ * On every request it will switch the used ranging algorithm.
+ */
+static void uwb_ev_cb(struct dpl_event *ev)
+{
+    struct uwb_rng_instance *rng = (struct uwb_rng_instance *)ev->arg;
+    struct uwb_dev *inst = rng->dev_inst;
+
+    if (inst->role & UWB_ROLE_ANCHOR) {
+        if (dpl_sem_get_count(&rng->sem) == 1) {
+            uwb_rng_listen(rng, 0xfffff, UWB_NONBLOCKING);
+        }
+    }
+    else {
+        int mode_v[8] = { 0 }, mode_i = 0, mode = -1;
+        static int last_used_mode = 0;
+        if (IS_USED(MODULE_UWB_CORE_TWR_SS)) {
+            mode_v[mode_i++] = UWB_DATA_CODE_SS_TWR;
+        }
+        if (IS_USED(MODULE_UWB_CORE_TWR_SS_ACK)) {
+            mode_v[mode_i++] = UWB_DATA_CODE_SS_TWR_ACK;
+        }
+        if (IS_USED(MODULE_UWB_CORE_TWR_SS_EXT)) {
+            mode_v[mode_i++] = UWB_DATA_CODE_SS_TWR_EXT;
+        }
+        if (IS_USED(MODULE_UWB_CORE_TWR_DS)) {
+            mode_v[mode_i++] = UWB_DATA_CODE_DS_TWR;
+        }
+        if (IS_USED(MODULE_UWB_CORE_TWR_DS_EXT)) {
+            mode_v[mode_i++] = UWB_DATA_CODE_DS_TWR_EXT;
+        }
+        if (++last_used_mode >= mode_i) {
+            last_used_mode = 0;
+        }
+        mode = mode_v[last_used_mode];
+#ifdef UWB_TWR_ALGORITHM_ONLY_ONE
+        mode = UWB_TWR_ALGORITHM_ONLY_ONE;
+#endif
+        if (mode > 0) {
+            uwb_rng_request(rng, ANCHOR_ADDRESS, mode);
+        }
+    }
+
+    /* reset the callback if ranging is enabled */
+    if (_ranging_enabled_flag) {
+        dpl_callout_reset(&_rng_req_callout, RANGE_REQUEST_T_US);
+    }
+}
+
+void init_ranging(void)
+{
+    struct uwb_dev *udev = uwb_dev_idx_lookup(0);
+    struct uwb_rng_instance *rng =
+        (struct uwb_rng_instance *)uwb_mac_find_cb_inst_ptr(udev, UWBEXT_RNG);
+
+    assert(rng);
+
+    /* set up local mac callbacks */
+    _uwb_mac_cbs.inst_ptr = rng;
+    uwb_mac_append_interface(udev, &_uwb_mac_cbs);
+
+    uint32_t utime = xtimer_now_usec();
+
+    printf("{\"utime\": %" PRIu32 ",\"exec\": \"%s\"}\n", utime, __FILE__);
+    printf("{\"device_id\"=\"%" PRIx32 "\"", udev->device_id);
+    printf(",\"panid=\"%X\"", udev->pan_id);
+    printf(",\"addr\"=\"%X\"", udev->uid);
+    printf(",\"part_id\"=\"%" PRIx32 "\"",
+              (uint32_t)(udev->euid & 0xffffffff));
+    printf(",\"lot_id\"=\"%" PRIx32 "\"}\n", (uint32_t)(udev->euid >> 32));
+    printf("{\"utime\": %"PRIu32",\"msg\": \"frame_duration = %d usec\"}\n",
+              utime, uwb_phy_frame_duration(udev, sizeof(twr_frame_final_t)));
+    printf("{\"utime\": %"PRIu32",\"msg\": \"SHR_duration = %d usec\"}\n",
+              utime, uwb_phy_SHR_duration(udev));
+    printf("{\"utime\": %"PRIu32",\"msg\": \"holdoff = %d usec\"}\n", utime,
+              (uint16_t)ceilf(uwb_dwt_usecs_to_usecs(rng->config.
+                                                     tx_holdoff_delay)));
+
+    if (IS_USED(MODULE_UWB_CORE_TWR_SS_ACK)) {
+        uwb_set_autoack(udev, true);
+        uwb_set_autoack_delay(udev, 12);
+    }
+
+    dpl_callout_init(&_rng_req_callout, dpl_eventq_dflt_get(),
+                     uwb_ev_cb, rng);
+    dpl_callout_reset(&_rng_req_callout, RANGE_REQUEST_T_US);
+    dpl_event_init(&_slot_event, _slot_complete_cb, rng);
+
+    /* Apply config */
+    uwb_mac_config(udev, NULL);
+    uwb_txrf_config(udev, &udev->config.txrf);
+
+    if ((udev->role & UWB_ROLE_ANCHOR)) {
+        printf("Node role: ANCHOR \n");
+        udev->my_short_address = ANCHOR_ADDRESS;
+        uwb_set_uid(udev, udev->my_short_address);
+        /* anchor starts listening by default */
+        _ranging_enabled_flag = 1;
+    }
+    else {
+        _ranging_enabled_flag = 0;
+        printf("Node role: TAG \n");
+    }
+
+    /* define buffer to be used by the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+}

--- a/examples/twr_aloha/control.h
+++ b/examples/twr_aloha/control.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ *
+ * @}
+ */
+
+
+#ifndef CONTROL_H
+#define CONTROL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "timex.h"
+
+/**
+ * @brief Anchor address
+ */
+#ifndef ANCHOR_ADDRESS
+#define ANCHOR_ADDRESS      0x1234
+#endif
+
+/**
+ * @brief Range request period
+ */
+#ifndef RANGE_REQUEST_T_US
+#define RANGE_REQUEST_T_US      (40 * US_PER_MS)
+#endif
+
+/**
+ * @brief Starts ranging
+ */
+void init_ranging(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CONTROL_H */

--- a/examples/twr_aloha/main.c
+++ b/examples/twr_aloha/main.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Two way ranging example
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "control.h"
+
+int main(void)
+{
+    puts("pkg uwb-dw1000 + uwb-core test application");
+    /* this should start ranging... */
+    init_ranging();
+    return 1;
+}

--- a/pkg/uwb-core/Makefile
+++ b/pkg/uwb-core/Makefile
@@ -1,0 +1,53 @@
+PKG_NAME=uwb-core
+PKG_URL=https://github.com/Decawave/uwb-core
+PKG_VERSION=8ffba63755a932a89d841872ce5bdf35b9c78777
+PKG_LICENSE=Apache-2.0
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+CFLAGS += -Wno-implicit-int
+CFLAGS += -Wno-int-conversion
+CFLAGS += -Wno-strict-prototypes
+CFLAGS += -Wno-maybe-uninitialized
+CFLAGS += -Wno-missing-braces
+CFLAGS += -Wno-missing-declarations
+CFLAGS += -Wno-missing-field-initializers
+CFLAGS += -Wno-old-style-definition
+CFLAGS += -Wno-return-type
+CFLAGS += -Wno-sign-compare
+CFLAGS += -Wno-unused-but-set-variable
+CFLAGS += -Wno-unused-parameter
+CFLAGS += -Wno-unused-variable
+CFLAGS += -fms-extensions
+
+ifneq (,$(filter llvm,$(TOOLCHAIN)))
+  CFLAGS += -Wno-microsoft-anon-tag
+endif
+
+IGNORE_MODULES := uwb-core_dpl \
+                  uwb-core_config \
+                  uwb-core_contrib \
+                  #
+
+UWB_CORE_MODULES := $(filter-out $(IGNORE_MODULES),$(filter uwb-core%,$(USEMODULE)))
+
+UWB_CORE_PATH_dsp        = lib/dsp/src
+UWB_CORE_PATH_uwb_json   = lib/json/src
+UWB_CORE_PATH_uwbcfg     = sys/uwbcfg/src/
+UWB_CORE_PATH_rng        = lib/uwb_rng/src
+UWB_CORE_PATH_rng_math   = lib/rng_math/src
+UWB_CORE_PATH_twr_ss     = lib/twr_ss/src
+UWB_CORE_PATH_twr_ss_ack = lib/twr_ss_ack/src
+UWB_CORE_PATH_twr_ss_ext = lib/twr_ss_ext/src
+UWB_CORE_PATH_twr_ds     = lib/twr_ds/src
+UWB_CORE_PATH_twr_ds_ext = lib/twr_ds_ext/src
+
+all: $(UWB_CORE_MODULES)
+	"$(MAKE)" -C $(PKG_SOURCE_DIR)/hw/drivers/uwb/src -f $(RIOTBASE)/Makefile.base MODULE=$(PKG_NAME)
+
+uwb-core_config:
+	"$(MAKE)" -C $(PKG_SOURCE_DIR)/porting/dpl/riot/src -f $(RIOTBASE)/Makefile.base MODULE=$@
+
+uwb-core_uwbcfg: uwb-core_config
+uwb-core_%:
+	"$(MAKE)" -C $(PKG_SOURCE_DIR)/$(UWB_CORE_PATH_$*) -f $(RIOTBASE)/Makefile.base MODULE=$@

--- a/pkg/uwb-core/Makefile.dep
+++ b/pkg/uwb-core/Makefile.dep
@@ -1,0 +1,36 @@
+USEMODULE += uwb-core_dpl
+USEMODULE += uwb-core_contrib
+
+DEFAULT_MODULE += auto_init_uwb-core
+
+USEMODULE += sema
+USEMODULE += event_callback
+USEMODULE += xtimer
+USEMODULE += fmt
+
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_spi
+
+ifneq (,$(filter uwb-core_twr_%,$(USEMODULE)))
+  USEMODULE += uwb-core_rng
+endif
+
+ifneq (,$(filter uwb-core_rng,$(USEMODULE)))
+  USEMODULE += uwb-core_rng_math
+  USEMODULE += uwb-core_dsp
+  USEMODULE += uwb-core_uwb_json
+endif
+
+ifneq (,$(filter uwb-core_uwbcfg,$(USEMODULE)))
+  USEMODULE += uwb-core_config
+endif
+
+# Some stdlib functions used by the pkg are not in avr-gcc
+FEATURES_BLACKLIST += arch_avr8
+# uwb-core has specific compilation sources when compiling kernel
+# libraries these introduce additional compilation issues that have not
+# been addressed in this port
+FEATURES_BLACKLIST += arch_native
+
+# LLVM ARM shows issues with missing definitions for stdatomic
+TOOLCHAINS_BLACKLIST += llvm

--- a/pkg/uwb-core/Makefile.include
+++ b/pkg/uwb-core/Makefile.include
@@ -1,0 +1,22 @@
+INCLUDES += -I$(PKGDIRBASE)/uwb-core/hw/drivers/uwb/include/ \
+            -I$(PKGDIRBASE)/uwb-core/lib/euclid/include \
+            -I$(PKGDIRBASE)/uwb-core/lib/dsp/include \
+            -I$(PKGDIRBASE)/uwb-core/lib/json/include \
+            -I$(PKGDIRBASE)/uwb-core/lib/rng_math/include \
+            -I$(PKGDIRBASE)/uwb-core/lib/twr_ss/include \
+            -I$(PKGDIRBASE)/uwb-core/lib/twr_ss_ext/include \
+            -I$(PKGDIRBASE)/uwb-core/lib/twr_ss_ack/include \
+            -I$(PKGDIRBASE)/uwb-core/lib/twr_ds/include \
+            -I$(PKGDIRBASE)/uwb-core/lib/twr_ds_ext/include \
+            -I$(PKGDIRBASE)/uwb-core/lib/uwb_rng/include \
+            -I$(PKGDIRBASE)/uwb-core/porting/dpl/riot/include/ \
+            -I$(PKGDIRBASE)/uwb-core/sys/uwbcfg/include \
+            -I$(RIOTPKG)/uwb-core/include \
+            #
+
+DIRS += $(RIOTPKG)/uwb-core/dpl \
+        $(RIOTPKG)/uwb-core/contrib \
+        #
+
+# A cflag to indicate in pkg code that we are building for RIOT
+CFLAGS += -DRIOT

--- a/pkg/uwb-core/contrib/Makefile
+++ b/pkg/uwb-core/contrib/Makefile
@@ -1,0 +1,9 @@
+MODULE = uwb-core_contrib
+
+SRC = uwb_core.c
+
+ifneq (,$(filter auto_init_uwb-core,$(USEMODULE)))
+  SRC += uwb_core_init.c
+endif
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/uwb-core/contrib/uwb_core.c
+++ b/pkg/uwb-core/contrib/uwb_core.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core bootstrapping  functions
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#include <stdatomic.h>
+
+#include "thread.h"
+#include "event.h"
+#include "event/callback.h"
+#include "uwb_core.h"
+
+#ifndef UWB_CORE_STACKSIZE
+#define UWB_CORE_STACKSIZE  (THREAD_STACKSIZE_LARGE)
+#endif
+#ifndef UWB_CORE_PRIO
+#define UWB_CORE_PRIO       (THREAD_PRIORITY_MAIN - 5)
+#endif
+
+static char _stack_uwb_core[UWB_CORE_STACKSIZE];
+
+static event_queue_t _queue;
+
+atomic_uint dpl_in_critical = 0;
+
+static void *_uwb_core_thread(void *arg)
+{
+    (void)arg;
+    event_queue_init(&_queue);
+    event_loop(&_queue);
+    /* never reached */
+    return NULL;
+}
+
+event_queue_t *uwb_core_get_eventq(void)
+{
+    return &_queue;
+}
+
+void uwb_core_riot_init(void)
+{
+    thread_create(_stack_uwb_core, sizeof(_stack_uwb_core),
+                  UWB_CORE_PRIO,
+                  THREAD_CREATE_STACKTEST,
+                  _uwb_core_thread, NULL,
+                  "uwb_core");
+}

--- a/pkg/uwb-core/contrib/uwb_core_init.c
+++ b/pkg/uwb-core/contrib/uwb_core_init.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core bootstrapping  core
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#include "thread.h"
+
+#include "dpl/dpl.h"
+#include "uwb_core.h"
+
+#include "uwb_dw1000.h"
+#include "uwb_dw1000_params.h"
+
+#include "twr_ss/twr_ss.h"
+#include "twr_ss_ext/twr_ss_ext.h"
+#include "twr_ss_ack/twr_ss_ack.h"
+#include "twr_ds/twr_ds.h"
+#include "twr_ds_ext/twr_ds_ext.h"
+
+static dw1000_dev_instance_t dev;
+static uint8_t _dw1000_rx_buffer[MYNEWT_VAL(UWB_RX_BUFFER_SIZE)];
+static uint8_t _dw1000_tx_buffer[MYNEWT_VAL(DW1000_HAL_SPI_BUFFER_SIZE)];
+
+void uwb_core_init(void)
+{
+    /* this will start the thread handling the event queue for uwb-core */
+    uwb_core_riot_init();
+    /* inits the dw1000 devices linked list */
+    uwb_dw1000_init();
+    /* set preallocated buffers to avoid malloc/calloc */
+    uwb_dw1000_set_buffs(&dev, _dw1000_tx_buffer, _dw1000_rx_buffer);
+    /* setup dw1000 device */
+    uwb_dw1000_setup(&dev, (void *) &dw1000_params[0]);
+    /* this will start a thread handling dw1000 device*/
+    uwb_dw1000_config_and_start(&dev);
+
+    /* init uwb pkg's */
+    if (IS_USED(MODULE_UWB_CORE_RNG)) {
+        extern void uwb_rng_pkg_init(void);
+        uwb_rng_pkg_init();
+    }
+
+    /* uwb configuration module */
+    if (IS_USED(MODULE_UWB_CORE_UWBCFG)) {
+        extern int uwbcfg_pkg_init(void);
+        uwbcfg_pkg_init();
+    }
+
+    /* ranging algorithms */
+    if (IS_USED(MODULE_UWB_CORE_RNG)) {
+        twr_ss_pkg_init();
+    }
+    if (IS_USED(MODULE_UWB_CORE_RNG)) {
+        twr_ss_ack_pkg_init();
+    }
+    if (IS_USED(MODULE_UWB_CORE_RNG)) {
+        twr_ss_ext_pkg_init();
+    }
+    if (IS_USED(MODULE_UWB_CORE_RNG)) {
+        twr_ds_pkg_init();
+    }
+    if (IS_USED(MODULE_UWB_CORE_RNG)) {
+        twr_ds_ext_pkg_init();
+    }
+}

--- a/pkg/uwb-core/doc.txt
+++ b/pkg/uwb-core/doc.txt
@@ -1,0 +1,121 @@
+/**
+ * @defgroup pkg_uwb_core Device driver model for the Decawave Impulse Radio-Ultra Wideband (IR-UWB) transceiver(s)
+ * @ingroup  pkg
+ * @brief    Hardware and architecture agnostic platform for IoT
+ *           Location Based Services (LBS)
+ * @see      https://github.com/Decawave/uwb-core
+ */
+
+# Decawave uwb-core RIOT Port
+
+The distribution https://github.com/decawave/uwb-core contains the
+device driver model for the Decawave Impulse Radio-Ultra Wideband
+(IR-UWB) transceiver(s). The driver includes hardware abstraction
+layers (HAL), media access control (MAC) layer, Ranging Services (RNG).
+The uwb-core driver and RIOT combine to create a hardware and
+architecture agnostic platform for IoT Location Based Services (LBS).
+
+## Abstraction details
+
+uwb-core is meant as a hardware and architecture agnostic library. It
+was developed with MyNewt as its default OS, but its abstractions are
+well defined which makes it easy to use with another OS.
+
+A porting layer DPL (Decawave Porting Layer) has been implemented that
+wraps around OS functionalities and modules: mutex, semaphores, threads,
+etc.. In most cases the mapping is direct although some specific
+functionalities might not be supported.
+
+Since the library was used on top of mynewt most configuration values
+are prefixed with `MYNEWT_VAL_%`, all configurations can be found under
+`pkg/uwb-core/include/syscfg`.
+
+In MyNewt there is always a default event thread, since we don't have
+this in RIOT when using this pkg an event thread is started which will
+run as this default event thread.
+
+To work this library needs to be built on top of an UWB device
+implementing the `uwb` api (see [uwb](https://github.com/Decawave/uwb-core/tree/master/hw/drivers/uwb).
+This port uses [uwb-dw1000](https://github.com/Decawave/uwb-dw1000) as
+device driver for dw1000 modules.
+
+The library can be used by directly including the different module headers.
+
+## Current support
+
+uwb-core comes with many utility libraries, only ranging related libraries
+are described here. For more info refer to [uwb-core](https://github.com/Decawave/uwb-core).
+
+- uwb-core_uwb: The uwb-core driver implements the MAC layers and
+  exports a MAC extension interface for additional services.
+  In the case of this port the api implementation is provided mainly by
+  the uwb-dw1000 pkg.
+
+- uwb-core_rng: ranging base class, provides the api to perform ranging.
+  It can use any of the twr_% ranging algorithms mentioned below,
+  for details on each algorithm refer to the pertinent literature.
+
+- uwb-core_twr_ss: single side two way ranging
+
+- uwb-core_twr_ss_ack: : single side two way ranging using hardware
+  generated ACK as the response.
+
+- uwb-core_twr_ss_ext: single side two way ranging with extended frames.
+
+- uwb-core_twr_ds: double side two-way ranging
+
+- uwb-core_twr_ds_ext: double side wo way ranging with extended frames.
+
+## Usage example
+
+The most simple examples would be a tdoa blinking tag, here the device
+is considered awake.
+
+```c
+    // IEEE 802.15.4e standard blink
+    ieee_blink_frame_t tdoa_blink_frame = {
+        .fctrl = 0xC5,  /* frame type (0xC5 for a blink) using 64-bit addressing */
+        .seq_num = 0,   /* sequence number, incremented for each new frame. */
+        .long_address = 0,  /* device ID */
+    };
+    // Set device address
+    tdoa_blink_frame.long_address = udev->my_long_address;
+    // Write tx data and start transmission
+    uwb_write_tx(udev, tdoa_blink_frame.array, 0, sizeof(ieee_blink_frame_t));
+    uwb_start_tx(udev);
+    // Increase sequence number
+    tdoa_blink_frame.seq_num++;
+```
+
+The following can be wrapped into a timer callback to setup a blinking tag.
+
+For more examples check the [uwb-apps](https://github.com/Decawave/uwb-apps)
+repository as well as [examples/twr_aloha](https://github.com/RIOT-OS/RIOT/tree/master/examples/twr-aloha)
+
+## Watchout!
+
+uwb-core uses anonymous structures, therefore any application using this
+pkg must also set at application level:
+
+  CFLAGS += -fms-extensions
+
+If building with llvm then also `CFLAGS += -Wno-microsoft-anon-tag` must
+be added, although it is currently blacklisted because of missing stdatomic
+definitions.
+
+## Todos
+
+The uwb-core pkg comes with a wide range of feature that are currently
+untested and not supported in this port, these will be incrementally
+included:
+
+- [ ] `uwb_cpp`: Clock Calibration Packet (CCP) Service
+- [ ] `tdma`: uwb-core offers TDMA support
+- [ ] `uwb_wcs`: Wireless Clock Synchronization (WCS) Service
+- [ ] `rtdoa`: Reverse Time Difference of Arrival profiles
+- [ ] `cir`: Circular impulse response
+- [ ] `nrng`: N-ranges support
+- [ ] other modules in `lib`
+
+uwb-core uses dynamic allocation for some of its internal modules. It
+would be nice to make this optional when possible.

--- a/pkg/uwb-core/dpl/Makefile
+++ b/pkg/uwb-core/dpl/Makefile
@@ -1,0 +1,3 @@
+MODULE = uwb-core_dpl
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/uwb-core/dpl/dpl_callout.c
+++ b/pkg/uwb-core/dpl/dpl_callout.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core DPL (Decawave Porting Layer) callout
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#include <assert.h>
+
+#include "xtimer.h"
+#include "dpl/dpl_callout.h"
+
+static void _dpl_callout_timer_cb(void* arg)
+{
+    struct dpl_callout *c = (struct dpl_callout *) arg;
+    assert(c);
+
+    /* post the event if there is a queue, otherwise call the callback
+       here */
+    if (c->c_q) {
+        dpl_eventq_put(c->c_q, &c->c_e);
+    } else {
+        c->c_e.e.callback(&c->c_e);
+    }
+}
+
+void dpl_callout_init(struct dpl_callout *c, struct dpl_eventq *q,
+                      dpl_event_fn *e_cb, void *e_arg)
+{
+    dpl_event_init(&c->c_e, e_cb, e_arg);
+    c->c_q = q;
+    c->timer.callback = _dpl_callout_timer_cb;
+    c->timer.arg = (void*) c;
+}
+
+dpl_error_t dpl_callout_reset(struct dpl_callout *c, dpl_time_t ticks)
+{
+    xtimer_ticks32_t val = {.ticks32 = ticks};
+    xtimer_set(&(c->timer), xtimer_usec_from_ticks(val));
+    return DPL_OK;
+}
+
+void dpl_callout_stop(struct dpl_callout *c)
+{
+    xtimer_remove(&(c->timer));
+}

--- a/pkg/uwb-core/dpl/dpl_mutex.c
+++ b/pkg/uwb-core/dpl/dpl_mutex.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       Decawave Porting Layer mutex RIOT wrapper
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#include "mutex.h"
+#include "dpl/dpl_mutex.h"
+
+dpl_error_t dpl_mutex_init(struct dpl_mutex *mu)
+{
+    if (!mu) {
+        return DPL_INVALID_PARAM;
+    }
+    mutex_init(&mu->mutex);
+    return DPL_OK;
+}
+
+dpl_error_t dpl_mutex_release(struct dpl_mutex *mu)
+{
+    if (!mu) {
+        return DPL_INVALID_PARAM;
+    }
+
+    mutex_unlock(&mu->mutex);
+    return DPL_OK;
+}
+
+dpl_error_t dpl_mutex_pend(struct dpl_mutex *mu, uint32_t timeout)
+{
+    int rc = DPL_OK;
+
+    if (!mu) {
+        return DPL_INVALID_PARAM;
+    }
+
+    if (!timeout) {
+        rc = mutex_trylock(&mu->mutex);
+    }
+    else {
+        /* TODO: no timeout equivalent */
+        mutex_lock(&mu->mutex);
+    }
+    return rc;
+}

--- a/pkg/uwb-core/dpl/dpl_sem.c
+++ b/pkg/uwb-core/dpl/dpl_sem.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       Decawave Porting Layer semaphore RIOT wrapper
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "irq.h"
+#include "dpl/dpl_sem.h"
+
+dpl_error_t dpl_sem_init(struct dpl_sem *sem, uint16_t tokens)
+{
+    if (!sem) {
+        return DPL_INVALID_PARAM;
+    }
+
+    sema_create(&sem->sema, tokens);
+    return DPL_OK;
+}
+
+dpl_error_t dpl_sem_release(struct dpl_sem *sem)
+{
+    int ret;
+
+    if (!sem) {
+        return DPL_INVALID_PARAM;
+    }
+
+    ret = sema_post(&sem->sema);
+
+    return (ret) ? DPL_ERROR : DPL_OK;
+}
+
+uint16_t dpl_sem_get_count(struct dpl_sem *sem)
+{
+    unsigned state = irq_disable();
+    unsigned int value = sem->sema.value;
+    irq_restore(state);
+    return value;
+}
+
+dpl_error_t dpl_sem_pend(struct dpl_sem *sem, dpl_time_t timeout)
+{
+    int ret = sema_wait_timed(&sem->sema, timeout);
+    return (ret) ? DPL_ERROR : DPL_OK;
+}

--- a/pkg/uwb-core/dpl/dpl_task.c
+++ b/pkg/uwb-core/dpl/dpl_task.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       Decawave Porting Layer tasks RIOT wrapper
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#include "dpl/dpl_error.h"
+#include "dpl/dpl_tasks.h"
+#include "thread.h"
+
+#ifndef LOG_LEVEL
+#define LOG_LEVEL   LOG_INFO
+#endif
+#include "log.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int dpl_task_init(struct dpl_task *t, const char *name, dpl_task_func_t func,
+                  void *arg, uint8_t prio, dpl_time_t sanity_itvl,
+                  dpl_stack_t *stack_bottom, uint16_t stack_size)
+{
+    (void) sanity_itvl;
+
+    LOG_INFO("dpl: starting thread %s\n", name);
+
+    kernel_pid_t pid = thread_create(stack_bottom, (int) stack_size,
+                                     prio, THREAD_CREATE_STACKTEST,
+                                     func, arg, name);
+
+    t->pid = pid;
+
+    return (pid) ? DPL_ERROR : DPL_OK;;
+}
+
+int dpl_task_remove(struct dpl_task *t)
+{
+    thread_zombify();
+    return thread_kill_zombie(t->pid);
+}
+
+uint8_t dpl_task_count(void)
+{
+    return sched_num_threads;
+}
+
+void dpl_task_yield(void)
+{
+    thread_yield();
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/pkg/uwb-core/include/dpl/dpl.h
+++ b/pkg/uwb-core/include/dpl/dpl.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       Abstraction layer for RIOT adaption
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef DPL_DPL_H
+#define DPL_DPL_H
+
+#include "syscfg/syscfg.h"
+#include "dpl/dpl_types.h"
+#include "dpl/dpl_error.h"
+#include "dpl/dpl_eventq.h"
+#include "dpl/dpl_callout.h"
+#include "dpl/dpl_cputime.h"
+#include "dpl/dpl_mutex.h"
+#include "dpl/dpl_os.h"
+#include "dpl/dpl_sem.h"
+#include "dpl/dpl_tasks.h"
+#include "dpl/dpl_time.h"
+#include "kernel_defines.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#endif /* DPL_DPL_H */

--- a/pkg/uwb-core/include/dpl/dpl_callout.h
+++ b/pkg/uwb-core/include/dpl/dpl_callout.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core DPL (Decawave Porting Layer) callout abstraction
+ *
+ * Callout sets a timer that on expiration will post an event to an
+ * event queue. This mimics the same as MyNewt callout api.
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef DPL_DPL_CALLOUT_H
+#define DPL_DPL_CALLOUT_H
+
+#include "xtimer.h"
+
+#include "dpl/dpl_types.h"
+#include "dpl/dpl_eventq.h"
+#include "dpl/dpl_error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   callout structure
+ */
+struct dpl_callout {
+    xtimer_t timer;         /**< timer */
+    struct dpl_event c_e;   /**< callout event */
+    struct dpl_eventq *c_q; /**< callout event queue */
+};
+
+/**
+ * @brief   Initialize a callout.
+ *
+ * Callouts are used to schedule events in the future onto an event
+ * queue. Callout timers are scheduled using the dpl_callout_reset()
+ * function.  When the timer expires, an event is posted to the event
+ * queue specified in dpl_callout_init(). The event argument given here
+ * is posted in the ev_arg field of that event.
+ *
+ * @param[out]  c       callout to initialize
+ * @param[in]   q       event queue to queue event in
+ * @param[in]   e_cb    callback function
+ * @param[in]   e_arg   callback function argument
+ */
+void dpl_callout_init(struct dpl_callout *c, struct dpl_eventq *q,
+                      dpl_event_fn *e_cb, void *e_arg);
+
+/**
+ * @brief   Reset the callout to fire off in 'ticks' ticks.
+ *
+ * @param[in]   c       callout to reset
+ * @param[in]   ticks   number of ticks to wait before posting an event
+ *
+ * @return 0 on success, non-zero on failure
+ */
+dpl_error_t dpl_callout_reset(struct dpl_callout *c, dpl_time_t ticks);
+
+/**
+ * @brief   Stops the callout from firing.
+ *
+ * @param[in]   c   the callout to stop
+ */
+void dpl_callout_stop(struct dpl_callout *c);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DPL_DPL_CALLOUT_H */

--- a/pkg/uwb-core/include/dpl/dpl_cputime.h
+++ b/pkg/uwb-core/include/dpl/dpl_cputime.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core DPL (Decawave Porting Layer) cputime abstraction
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef DPL_DPL_CPUTIME_H
+#define DPL_DPL_CPUTIME_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+#include "xtimer.h"
+#include "hal/hal_timer.h"
+
+/**
+ * Returns the low 32 bits of cputime.
+ *
+ * @return uint32_t The lower 32 bits of cputime
+ */
+static inline uint32_t dpl_cputime_get32(void)
+{
+    return xtimer_now().ticks32;
+}
+
+/**
+ * Converts the given number of microseconds into cputime ticks.
+ *
+ * @param usecs The number of microseconds to convert to ticks
+ *
+ * @return uint32_t The number of ticks corresponding to 'usecs'
+ */
+static inline uint32_t dpl_cputime_usecs_to_ticks(uint32_t usecs)
+{
+    return xtimer_ticks_from_usec(usecs).ticks32;
+}
+
+/**
+ * Convert the given number of ticks into microseconds.
+ *
+ * @param ticks The number of ticks to convert to microseconds.
+ *
+ * @return uint32_t The number of microseconds corresponding to 'ticks'
+ */
+static inline uint32_t dpl_cputime_ticks_to_usecs(uint32_t ticks)
+{
+    xtimer_ticks32_t val = {.ticks32 = ticks};
+    return xtimer_usec_from_ticks(val);
+}
+
+/**
+ * Wait until the number of ticks has elapsed. This is a blocking delay.
+ *
+ * @param ticks The number of ticks to wait.
+ */
+static inline void dpl_cputime_delay_ticks(uint32_t ticks)
+{
+    xtimer_ticks32_t val = {.ticks32 = ticks};
+    xtimer_tsleep32((xtimer_ticks32_t) val);
+}
+
+/**
+ * Wait until 'usecs' microseconds has elapsed. This is a blocking delay.
+ *
+ * @param usecs The number of usecs to wait.
+ */
+static inline void dpl_cputime_delay_usecs(uint32_t usecs)
+{
+    xtimer_usleep(usecs);
+}
+
+/**
+ * Initialize a CPU timer, using the given HAL timer.
+ *
+ * @param timer The timer to initialize. Cannot be NULL.
+ * @param fp    The timer callback function. Cannot be NULL.
+ * @param arg   Pointer to data object to pass to timer.
+ */
+static inline void dpl_cputime_timer_init(struct hal_timer *timer, hal_timer_cb fp,
+        void *arg)
+{
+    timer->timer.callback = fp;
+    timer->timer.arg = arg;
+}
+
+/**
+ * Start a cputimer that will expire at 'cputime'. If cputime has already
+ * passed, the timer callback will still be called (at interrupt context).
+ *
+ * NOTE: This must be called when the timer is stopped.
+ *
+ * @param timer     Pointer to timer to start. Cannot be NULL.
+ * @param cputime   The cputime at which the timer should expire.
+ *
+ * @return int 0 on success; EINVAL if timer already started or timer struct
+ *         invalid
+ *
+ */
+static inline int dpl_cputime_timer_start(struct hal_timer *timer, uint32_t cputime)
+{
+    xtimer_set(&timer->timer, xtimer_now_usec() + cputime);
+    return 0;
+}
+
+/**
+ * Sets a cpu timer that will expire 'usecs' microseconds from the current
+ * cputime.
+ *
+ * NOTE: This must be called when the timer is stopped.
+ *
+ * @param timer Pointer to timer. Cannot be NULL.
+ * @param usecs The number of usecs from now at which the timer will expire.
+ *
+ * @return int 0 on success; EINVAL if timer already started or timer struct
+ *         invalid
+ */
+static inline int dpl_cputime_timer_relative(struct hal_timer *timer, uint32_t usecs)
+{
+    uint32_t now = xtimer_now_usec();
+    if (now > usecs) {
+        xtimer_set(&timer->timer, now);
+    } else {
+        xtimer_set(&timer->timer, 0);
+    }
+    return 0;
+}
+
+/**
+ *  @brief   Stops a cputimer from running.
+ *
+ * The timer is removed from the timer queue and interrupts are disabled
+ * if no timers are left on the queue. Can be called even if timer is
+ * not running.
+ *
+ * @param timer Pointer to cputimer to stop. Cannot be NULL.
+ */
+static inline void dpl_cputime_timer_stop(struct hal_timer *timer)
+{
+    xtimer_remove(&timer->timer);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DPL_DPL_CPUTIME_H */

--- a/pkg/uwb-core/include/dpl/dpl_error.h
+++ b/pkg/uwb-core/include/dpl/dpl_error.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core DPL (Decawave Porting Layer) error types
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef DPL_DPL_ERROR_H
+#define DPL_DPL_ERROR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief DPL error types
+ */
+enum dpl_error {
+    DPL_OK = 0,
+    DPL_ENOMEM = 1,
+    DPL_EINVAL = 2,
+    DPL_INVALID_PARAM = 3,
+    DPL_MEM_NOT_ALIGNED = 4,
+    DPL_BAD_MUTEX = 5,
+    DPL_TIMEOUT = 6,
+    DPL_ERR_IN_ISR = 7,
+    DPL_ERR_PRIV = 8,
+    DPL_OS_NOT_STARTED = 9,
+    DPL_ENOENT = 10,
+    DPL_EBUSY = 11,
+    DPL_ERROR = 12,
+};
+
+/**
+ * @brief   dep error type
+ */
+typedef enum dpl_error dpl_error_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DPL_DPL_ERROR_H */

--- a/pkg/uwb-core/include/dpl/dpl_eventq.h
+++ b/pkg/uwb-core/include/dpl/dpl_eventq.h
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core DPL (Decawave Porting Layer) event queue wrappers
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef DPL_DPL_EVENTQ_H
+#define DPL_DPL_EVENTQ_H
+
+#include <dpl/dpl_types.h>
+
+#include "uwb_core.h"
+#include "event/callback.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief dpl event wrapper
+ */
+struct dpl_event
+{
+    event_callback_t e; /**< the event callback */
+    void *arg;          /**< the event argument */
+};
+
+/**
+ * @brief dpl event queue wrapper
+ */
+struct dpl_eventq
+{
+    event_queue_t q;    /**< the event queue */
+};
+
+/**
+ * @brief dpl event callback function
+ */
+typedef void dpl_event_fn(struct dpl_event *ev);
+
+/**
+ * @brief   Init a event
+ *
+ * @param[in]   ev      pointer to event to set
+ * @param[in]   fn      event callback function
+ * @param[in]   arg     event argument
+ */
+static inline void dpl_event_init(struct dpl_event *ev, dpl_event_fn * fn,
+                                 void *arg)
+{
+    /*
+     * Need to clear list_node manually since init function below does not do
+     * this.
+     */
+    ev->e.super.list_node.next = NULL;
+    event_callback_init(&ev->e, (void(*)(void *))fn, ev);
+    ev->arg = arg;
+}
+
+/**
+ * @brief   Check if event is in queue
+ *
+ * @param[in]   ev      event to check
+ *
+ * @return  true if event is queues, false otherwise
+ */
+static inline bool dpl_event_is_queued(struct dpl_event *ev)
+{
+    return (ev->e.super.list_node.next != NULL);
+}
+
+/**
+ * @brief   Runs an event
+ *
+ * @param[in]   ev      event to run
+ */
+static inline void *dpl_event_get_arg(struct dpl_event *ev)
+{
+    return ev->arg;
+}
+
+/**
+ * @brief   Set the vent arg
+ *
+ * @param[in]   ev      event
+ * @param[in]   arg     arg to set event
+ */
+static inline void dpl_event_set_arg(struct dpl_event *ev, void *arg)
+{
+    ev->arg = arg;
+}
+
+/**
+ * @brief   Runs an event
+ *
+ * @param[in]   ev      event to run
+ */
+static inline void dpl_event_run(struct dpl_event *ev)
+{
+    ev->e.super.handler(&ev->e.super);
+}
+
+/**
+ * @brief   Initialize the event queue
+ *
+ * @param[in]   evq     The event queue to initialize
+ */
+static inline void dpl_eventq_init(struct dpl_eventq *evq)
+{
+    event_queue_init_detached(&evq->q);
+}
+
+/**
+ * @brief   Check whether the event queue is initialized.
+ *
+ * @param[in]   evq     the event queue to check
+ */
+static inline int dpl_eventq_inited(struct dpl_eventq *evq)
+{
+    return evq->q.waiter != NULL;
+}
+
+/**
+ * @brief   Deinitialize an event queue
+ *
+ * @note    Not supported in RIOT
+ *
+ * @param[in]   evq     the event queue to deinit
+ */
+static inline void dpl_eventq_deinit(struct dpl_eventq *evq)
+{
+    (void) evq;
+    /* Can't deinit an eventq in RIOT */
+}
+
+/**
+ * @brief   Get next event from event queue, blocking.
+ *
+ * @param[in]   evq     the event queue to pull an event from
+ *
+ * @return  the event from the queue
+ */
+static inline struct dpl_event * dpl_eventq_get(struct dpl_eventq *evq)
+{
+    if (evq->q.waiter == NULL) {
+        event_queue_claim(&evq->q);
+    }
+
+    return (struct dpl_event *) event_wait(&evq->q);
+}
+
+/**
+ * @brief   Get next event from event queue, non-blocking
+ *
+ * @return  event from the queue, or NULL if none available.
+ */
+static inline struct dpl_event * dpl_eventq_get_no_wait(struct dpl_eventq *evq)
+{
+    if (evq->q.waiter == NULL) {
+        event_queue_claim(&evq->q);
+    }
+
+    return (struct dpl_event *) event_get(&evq->q);
+}
+
+/**
+ * @brief   Put an event on the event queue.
+ *
+ * @param[in]   evq     event queue
+ * @param[in]   ev      event to put in queue
+ */
+static inline void dpl_eventq_put(struct dpl_eventq *evq, struct dpl_event *ev)
+{
+    event_post(&evq->q, &ev->e.super);
+}
+
+/**
+ * @brief   Remove an event from the queue.
+ *
+ * @param[in]   evq     event queue to remove the event from
+ * @param[in]   ev      event to remove from the queue
+ */
+static inline void dpl_eventq_remove(struct dpl_eventq *evq, struct dpl_event *ev)
+{
+    event_cancel(&evq->q, &ev->e.super);
+}
+
+/**
+ * @brief   Gets and runs an event from the queue callback.
+ *
+ * @param[in]   evq     The event queue to pull the item off.
+ */
+static inline void dpl_eventq_run(struct dpl_eventq *evq)
+{
+    struct dpl_event *ev = dpl_eventq_get(evq);
+    dpl_event_run(ev);
+}
+
+/**
+ * @brief   Check if queue is empty
+ *
+ * @param[in]   evq     the event queue to check
+ *
+ * @return      true    if empty, false otherwise
+ */
+static inline bool dpl_eventq_is_empty(struct dpl_eventq *evq)
+{
+    return clist_count(&(evq->q.event_list)) == 0;
+}
+
+/**
+ * @brief   Retrieves the default event queue.
+ *
+ * As there is no default event queue in RIOT, uwb-core will start and
+ * handle a default event queue.
+ *
+ * @return  the default event queue.
+ */
+static inline struct dpl_eventq * dpl_eventq_dflt_get(void)
+{
+    return (struct dpl_eventq*) uwb_core_get_eventq();
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DPL_DPL_EVENTQ_H */

--- a/pkg/uwb-core/include/dpl/dpl_mutex.h
+++ b/pkg/uwb-core/include/dpl/dpl_mutex.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core DPL (Decawave Porting Layer) mutex wrappers
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef DPL_DPL_MUTEX_H
+#define DPL_DPL_MUTEX_H
+
+#include "dpl_types.h"
+#include "dpl_error.h"
+
+#include "mutex.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief dpl mutex wrapper
+ */
+struct dpl_mutex {
+    mutex_t mutex;  /**< the mutex */
+};
+
+/**
+ * @brief Initializes a mutex object.
+ *
+ * @param[out]  mu  pre-allocated mutex structure, must not be NULL.
+ */
+dpl_error_t dpl_mutex_init(struct dpl_mutex *mu);
+
+/**
+ * @brief Pend (wait) for a mutex.
+ *
+ * @param[in]   mu      Pointer to mutex.
+ * @param[in]   timeout Timeout, in os ticks.
+ *                A timeout of 0 means do not wait if not available.
+ *                A timeout of OS_TIMEOUT_NEVER means wait forever.
+ *
+ * @return dpl_error_t
+ *      DPL_INVALID_PARM    mutex passed in was NULL
+ *      DPL_OK              no error
+ */
+dpl_error_t dpl_mutex_pend(struct dpl_mutex *mu, dpl_time_t timeout);
+
+/**
+ *
+ * @brief Release a mutex.
+ *
+ * @return dpl_error_t
+ *      DPL_INVALID_PARM    mutex was NULL
+ *      DPL_OK              no error
+ */
+dpl_error_t dpl_mutex_release(struct dpl_mutex *mu);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DPL_DPL_MUTEX_H */

--- a/pkg/uwb-core/include/dpl/dpl_os.h
+++ b/pkg/uwb-core/include/dpl/dpl_os.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core DPL (Decawave Porting Layer) error types
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef DPL_DPL_OS_H
+#define DPL_DPL_OS_H
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdatomic.h>
+
+#include "irq.h"
+#include "dpl/dpl_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Entering and exiting critical section defines
+ * @{
+ */
+#define DPL_ENTER_CRITICAL(_sr) (_sr = dpl_hw_enter_critical())
+#define DPL_EXIT_CRITICAL(_sr) (dpl_hw_exit_critical(_sr))
+#define DPL_ASSERT_CRITICAL() assert(dpl_hw_is_in_critical())
+/** @} */
+
+/**
+ * @brief   variable to check if ISR are disabled
+ */
+extern atomic_uint dpl_in_critical;
+
+/**
+ * @brief   CPU status register
+ */
+typedef uint32_t dpl_sr_t;
+
+/**
+ * @brief   Disable ISRs
+ *
+ * @return  current isr context
+ */
+static inline uint32_t dpl_hw_enter_critical(void)
+{
+    uint32_t ctx = irq_disable();
+    unsigned int count = atomic_load(&dpl_in_critical);
+    atomic_store(&dpl_in_critical, count + 1);
+    return ctx;
+}
+
+/**
+ * @brief   Restores ISR context
+ *
+ * @param[in]   ctx      ISR context to restore.
+ */
+static inline void dpl_hw_exit_critical(uint32_t ctx)
+{
+    unsigned int count = atomic_load(&dpl_in_critical);
+    atomic_store(&dpl_in_critical, count - 1);
+    irq_restore((unsigned)ctx);
+}
+
+/**
+ * @brief Check if is in critical section
+ *
+ * @return true, if in critical section, false otherwise
+ */
+static inline bool dpl_hw_is_in_critical(void)
+{
+    /*
+     * XXX Currently RIOT does not support an API for finding out if interrupts
+     *     are currently disabled, hence in a critical section in this context.
+     *     So for now, we use this global variable to keep this state for us.
+     */
+    return (atomic_load(&dpl_in_critical) > 0);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DPL_DPL_OS_H */

--- a/pkg/uwb-core/include/dpl/dpl_sem.h
+++ b/pkg/uwb-core/include/dpl/dpl_sem.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core DPL (Decawave Porting Layer) semapahore wrappers
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef DPL_DPL_SEM_H
+#define DPL_DPL_SEM_H
+
+#include <stdint.h>
+
+#include "dpl_types.h"
+#include "dpl_error.h"
+
+#include "sema.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief dpl semaphore wrapper
+ */
+struct dpl_sem {
+    sema_t sema;    /**< the semaphore */
+};
+
+/**
+ * @brief Initialize a semaphore
+ *
+ * @param[in]   sem     pointer to semaphore
+ * @param[in]   tokens  # of tokens the semaphore should contain initially.
+ *
+ * @return dpl_error_t
+ *      DPL_INVALID_PARM     Semaphore passed in was NULL.
+ *      DPL_OK               no error.
+ */
+dpl_error_t dpl_sem_init(struct dpl_sem *sem, uint16_t tokens);
+
+/**
+ * @brief Pend (wait) for a semaphore.
+ *
+ * @param[in]   sem     pointer to semaphore.
+ * @param[in]   timeout timeout, in os ticks.
+ *                A timeout of 0 means do not wait if not available.
+ *                A timeout of DPL_TIMEOUT_NEVER means wait forever.
+ *
+ *
+ * @return dpl_error_t
+ *      DPL_INVALID_PARM     semaphore passed in was NULL.
+ *      DPL_TIMEOUT          semaphore was owned by another task and timeout=0
+ *      DPL_OK               no error
+ */
+dpl_error_t dpl_sem_pend(struct dpl_sem *sem, dpl_time_t timeout);
+
+/**
+ * @brief Release a semaphore.
+ *
+ * @param[in]   sem     pointer to the semaphore to be released
+ *
+ * @return dpl_error_t
+ *      DPL_INVALID_PARM    semaphore passed in was NULL.
+ *      DPL_OK              no error
+ */
+dpl_error_t dpl_sem_release(struct dpl_sem *sem);
+
+/**
+ * @brief Get current semaphore's count
+ */
+uint16_t dpl_sem_get_count(struct dpl_sem *sem);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DPL_DPL_SEM_H */

--- a/pkg/uwb-core/include/dpl/dpl_tasks.h
+++ b/pkg/uwb-core/include/dpl/dpl_tasks.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core DPL (Decawave Porting Layer) thread/task wrappers
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef DPL_DPL_TASKS_H
+#define DPL_DPL_TASKS_H
+
+#include "dpl_types.h"
+
+#include "kernel_types.h"
+#include "thread.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief dpl task wrapper
+ */
+struct dpl_task {
+    kernel_pid_t pid;   /**< the process id */
+};
+
+/**
+ * @brief dpl task function
+ */
+typedef thread_task_func_t dpl_task_func_t;
+
+/**
+ * @brief Initialize a task.
+ *
+ * This function initializes the task structure pointed to by t,
+ * clearing and setting it's stack pointer, provides sane defaults
+ * and sets the task as ready to run, and inserts it into the operating
+ * system scheduler.
+ *
+ * @param[in]   t               the task to initialize
+ * @param[in]   name            task name
+ * @param[in]   func            task function to call
+ * @param[in]   arg             argument to pass in task init function
+ * @param[in]   prio            task priority
+ * @param[in]   sanity_itvl     UNUSED
+ * @param[in]   stack_bottom    pointer to bottom of the stack
+ * @param[in]   stack_size      task stack size
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+int dpl_task_init(struct dpl_task *t, const char *name, dpl_task_func_t func,
+                  void *arg, uint8_t prio, dpl_time_t sanity_itvl,
+                  dpl_stack_t *stack_bottom, uint16_t stack_size);
+
+/**
+ * @brief removes specified task
+ *
+ * NOTE: This interface is currently experimental and not ready for common use
+ */
+int dpl_task_remove(struct dpl_task *t);
+
+/**
+ * @brief Return the number of tasks initialized.
+ *
+ * @return number of tasks initialized
+ */
+uint8_t dpl_task_count(void);
+
+/**
+ * @brief   Lets current thread yield.
+ */
+void dpl_task_yield(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DPL_DPL_TASKS_H */

--- a/pkg/uwb-core/include/dpl/dpl_time.h
+++ b/pkg/uwb-core/include/dpl/dpl_time.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core DPL (Decawave Porting Layer) time abstraction
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef DPL_DPL_TIME_H
+#define DPL_DPL_TIME_H
+
+#include "xtimer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief DPL ticks per seconds
+ */
+#define DPL_TICKS_PER_SEC (XTIMER_HZ)
+
+/**
+ * @brief Returns the low 32 bits of cputime.
+ *
+ * @return uint32_t The lower 32 bits of cputime
+ */
+static inline dpl_time_t dpl_time_get(void)
+{
+    return xtimer_now().ticks32;
+}
+
+/**
+ * @brief Converts the given number of milliseconds into cputime ticks.
+ *
+ * @param[in]   ms          The number of milliseconds to convert to ticks
+ * @param[out]  out_ticks   The number of ticks corresponding to 'ms'
+ *
+ * @return dpl_error_t  DPL_OK - no error
+ */
+static inline dpl_error_t dpl_time_ms_to_ticks(uint32_t ms, dpl_time_t *out_ticks)
+{
+    *out_ticks = xtimer_ticks_from_usec(ms * US_PER_MS).ticks32;
+    return DPL_OK;
+}
+
+/**
+ * @brief Convert the given number of ticks into milliseconds.
+ *
+ * @param[in]   ticks   The number of ticks to convert to milliseconds.
+ * @param[out]  out_ms  The converted milliseconds from 'ticks'
+ *
+ * @return dpl_error_t  DPL_OK - no error
+ */
+static inline dpl_error_t  dpl_time_ticks_to_ms(dpl_time_t ticks, uint32_t *out_ms)
+{
+    xtimer_ticks32_t val = {.ticks32 = ticks};
+    *out_ms = xtimer_usec_from_ticks(val) * US_PER_MS;
+    return DPL_OK;
+}
+
+/**
+ * @brief   Converts the given number of milliseconds into cputime ticks.
+ *
+ * @param[in]   ms  The number of milliseconds to convert to ticks
+ *
+ * @return  uint32_t    The number of ticks corresponding to 'ms'
+ */
+static inline dpl_time_t dpl_time_ms_to_ticks32(uint32_t ms)
+{
+    return xtimer_ticks_from_usec(ms * US_PER_MS).ticks32;
+}
+
+/**
+ * @brief   Convert the given number of ticks into milliseconds.
+ *
+ * @param[in]   ticks   The number of ticks to convert to milliseconds.
+ *
+ * @return  uint32_t    The number of milliseconds corresponding to 'ticks'
+ */
+static inline dpl_time_t dpl_time_ticks_to_ms32(dpl_time_t ticks)
+{
+    xtimer_ticks32_t val = {.ticks32 = ticks};
+    return xtimer_usec_from_ticks(val) * US_PER_MS;
+}
+
+/**
+ * @brief   Wait until the number of ticks has elapsed, BLOICKING.
+ *
+ * @param[in]   ticks   The number of ticks to wait.
+ */
+static inline void dpl_time_delay(dpl_time_t ticks)
+{
+    xtimer_ticks32_t val = {.ticks32 = ticks};
+    xtimer_tsleep32((xtimer_ticks32_t) val);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DPL_DPL_TIME_H */

--- a/pkg/uwb-core/include/dpl/dpl_types.h
+++ b/pkg/uwb-core/include/dpl/dpl_types.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core DPL (Decawave Porting Layer) types
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef DPL_DPL_TYPES_H
+#define DPL_DPL_TYPES_H
+
+#include <stdint.h>
+#include <math.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    PI approximated value macro definition
+ */
+#ifndef M_PI
+#define M_PI 3.1415926535
+#endif
+
+/**
+ * @name    Macro to wait forever on events and mutexes
+ * @{
+ */
+#define DPL_TIMEOUT_NEVER   (UINT32_MAX)
+#define DPL_WAIT_FOREVER    (DPL_TIMEOUT_NEVER)
+/** @} */
+
+/**
+ * @name    Decawave porting layer (DPL) stack alignment requirement
+ * @{
+ */
+#define DPL_STACK_ALIGNMENT (4)
+/** @} */
+
+/**
+ * @brief dpl time type
+ */
+typedef uint32_t dpl_time_t;
+
+/**
+ * @brief dpl stack buffer type
+ */
+typedef char dpl_stack_t;
+
+/**
+ * @brief dpl float 32 type
+ */
+typedef float dpl_float32_t;
+/**
+ * @brief dpl float 64 type
+ */
+typedef double dpl_float64_t;
+
+/**
+ * @name    Decawave porting layer (DPL) float type macros
+ * @{
+ */
+#define DPL_FLOAT32_INIT(__X) ((float)__X)
+#define DPL_FLOAT64_INIT(__X) ((double)__X)
+#define DPL_FLOAT64TO32(__X) (float)(__X)
+#define DPL_FLOAT32_I32_TO_F32(__X) (float)(__X)
+#define DPL_FLOAT64_I32_TO_F64(__X) ((double)(__X))
+#define DPL_FLOAT64_I64_TO_F64(__X) ((double)(__X))
+#define DPL_FLOAT64_U64_TO_F64(__X) ((double)(__X))
+#define DPL_FLOAT64_F64_TO_U64(__X) ((uint64_t)(__X))
+#define DPL_FLOAT32_INT(__X) ((int32_t)__X)
+#define DPL_FLOAT64_INT(__X) ((int64_t)__X)
+#define DPL_FLOAT64_FROM_F32(__X) (double)(__X)
+#define DPL_FLOAT32_FROM_F64(__X) (float)(__X)
+#define DPL_FLOAT32_CEIL(__X) (ceilf(__X))
+#define DPL_FLOAT64_CEIL(__X) (ceil(__X))
+#define DPL_FLOAT32_FABS(__X) fabsf(__X)
+#define DPL_FLOAT32_FMOD(__X, __Y) fmodf(__X, __Y)
+#define DPL_FLOAT64_FMOD(__X, __Y) fmod(__X, __Y)
+#define DPL_FLOAT32_NAN() nanf("")
+#define DPL_FLOAT64_NAN() nan("")
+#define DPL_FLOAT32_ISNAN(__X) isnan(__X)
+#define DPL_FLOAT64_ISNAN(__X) DPL_FLOAT32_ISNAN(__X)
+#define DPL_FLOAT32_LOG10(__X) (log10f(__X))
+#define DPL_FLOAT64_LOG10(__X) (log10(__X))
+#define DPL_FLOAT64_ASIN(__X) asin(__X)
+#define DPL_FLOAT64_ATAN(__X) atan(__X)
+#define DPL_FLOAT32_SUB(__X, __Y) ((__X)-(__Y))
+#define DPL_FLOAT64_SUB(__X, __Y) ((__X)-(__Y))
+#define DPL_FLOAT32_ADD(__X, __Y) ((__X)+(__Y))
+#define DPL_FLOAT64_ADD(__X, __Y) ((__X)+(__Y))
+#define DPL_FLOAT32_MUL(__X, __Y) ((__X)*(__Y))
+#define DPL_FLOAT64_MUL(__X, __Y) ((__X)*(__Y))
+#define DPL_FLOAT32_DIV(__X, __Y) ((__X)/(__Y))
+#define DPL_FLOAT64_DIV(__X, __Y) ((__X)/(__Y))
+#define DPL_FLOAT32_PRINTF_PRIM "%s%d.%03d"
+#define DPL_FLOAT32_PRINTF_VALS(__X) (__X)<0?"-":"", (int)(fabsf(__X)), (int)(fabsf((__X)-(int)(__X))*1000)
+#define DPL_FLOAT64_PRINTF_PRIM "%s%d.%06d"
+#define DPL_FLOAT64_PRINTF_VALS(__X) (__X)<0?"-":"", (int)(fabs(__X)), (int)(fabs((__X)-(int)(__X))*1000000)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DPL_DPL_TYPES_H */

--- a/pkg/uwb-core/include/log/dpl_log.h
+++ b/pkg/uwb-core/include/log/dpl_log.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       System logging header for uwb-core
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef LOG_DPL_LOG_H
+#define LOG_DPL_LOG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "log.h"
+
+/**
+ * @name Logging convenience defines wrappers
+ * @{
+ */
+#define LOG_WARN(...)       LOG(LOG_WARNING, __VA_ARGS__)
+#define LOG_CRITICAL(...)   LOG(LOG_ERROR, __VA_ARGS__)
+#define log_register(__X, __Y, __Z, __A, __B) {}
+/** @} */
+
+/**
+ * @brief Empty log structure
+ */
+struct log {
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LOG_DPL_LOG_H */

--- a/pkg/uwb-core/include/mcu/mcu.h
+++ b/pkg/uwb-core/include/mcu/mcu.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       Abstraction layer for RIOT adaption
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef MCU_MCU_H
+#define MCU_MCU_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* empty header */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MCU_MCU_H */

--- a/pkg/uwb-core/include/os/os.h
+++ b/pkg/uwb-core/include/os/os.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       Abstraction layer for RIOT adaption
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+#ifndef OS_OS_H
+#define OS_OS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OS_OS_H */

--- a/pkg/uwb-core/include/os/os_dev.h
+++ b/pkg/uwb-core/include/os/os_dev.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       Abstraction layer for RIOT adaption
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+#ifndef OS_OS_DEV_H
+#define OS_OS_DEV_H
+
+#include "dpl/dpl.h"
+#include "dpl/queue.h"
+
+#include "net/ieee802154.h"
+#include "net/netdev.h"
+#include "net/netdev/ieee802154.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Device structure.
+ */
+struct os_dev {
+    netdev_ieee802154_t netdev;        /**< Netdev parent struct */
+};
+
+/**
+ * @brief   Unused define, void cast
+ */
+#define OS_DEV_SETHANDLERS(__dev, __open, __close)          \
+    (void) __dev;                \
+    (void) __open;                \
+    (void) __close;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* OS_OS_DEV_H */

--- a/pkg/uwb-core/include/stats/stats.h
+++ b/pkg/uwb-core/include/stats/stats.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       Abstraction layer for RIOT adaption
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef STATS_STATS_H
+#define STATS_STATS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* empty header */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STATS_STATS_H */

--- a/pkg/uwb-core/include/syscfg/syscfg.h
+++ b/pkg/uwb-core/include/syscfg/syscfg.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core system configurations
+  *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef SYSCFG_SYSCFG_H
+#define SYSCFG_SYSCFG_H
+
+#include "kernel_defines.h"
+
+/**
+ * @name    MyNewt header inclusion macro definitions
+ * @{
+ *
+ * This macro exists to ensure code includes this header when needed.  If code
+ * checks the existence of a setting directly via ifdef without including this
+ * header, the setting macro will silently evaluate to 0.  In contrast, an
+ * attempt to use these macros without including this header will result in a
+ * compiler error.
+ */
+#define MYNEWT_VAL(_name)                       MYNEWT_VAL_ ## _name
+#define MYNEWT_VAL_CHOICE(_name, _val)          MYNEWT_VAL_ ## _name ## __ ## _val
+/** @} */
+
+
+/*** @decawave-uwb-core/hw/drivers/uwb */
+#include "syscfg_uwb.h"
+
+/*** @decawave-uwb-core/lib/twr_ds */
+#include "syscfg_twr_ds.h"
+
+/*** @decawave-uwb-core/lib/twr_ds_ext */
+#include "syscfg_twr_ds_ext.h"
+
+/*** @decawave-uwb-core/lib/twr_ss */
+#include "syscfg_twr_ss.h"
+
+/*** @decawave-uwb-core/lib/twr_ss_ack */
+#include "syscfg_twr_ss_ack.h"
+
+/*** @decawave-uwb-core/lib/twr_ss_ext */
+#include "syscfg_twr_ss_ext.h"
+
+/*** @decawave-uwb-core/lib/uwb_rng */
+#include "syscfg_uwb_rng.h"
+
+/*** @decawave-uwb-core/sys/uwbcfg */
+#include "syscfg_uwbcfg.h"
+
+/*** @decawave-uwb-dw1000/hw/drivers/uwb/uwb_dw1000 */
+#include "syscfg_uwb_dw1000.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSCFG_SYSCFG_H */

--- a/pkg/uwb-core/include/syscfg/syscfg_twr_ds.h
+++ b/pkg/uwb-core/include/syscfg/syscfg_twr_ds.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-dw100 double side two-way ranging module configurations
+ *              taken from decawave-uwb-core/lib/twr_ds/syscfg.yml
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef SYSCFG_SYSCFG_TWR_DS_H
+#define SYSCFG_SYSCFG_TWR_DS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Enable toplevel ranging services
+ */
+#ifndef MYNEWT_VAL_TWR_DS_ENABLED
+#define MYNEWT_VAL_TWR_DS_ENABLED (IS_ACTIVE(MODULE_UWB_CORE_TWR_DS))
+#endif
+
+/**
+ * @brief TOA timeout delay for DS TWR (usec)
+ */
+#ifndef MYNEWT_VAL_TWR_DS_RX_TIMEOUT
+#define MYNEWT_VAL_TWR_DS_RX_TIMEOUT (((uint16_t)0x30))
+#endif
+
+/**
+ * @brief tx holdoff delay for DS TWR (usec)
+ */
+#ifndef MYNEWT_VAL_TWR_DS_TX_HOLDOFF
+#define MYNEWT_VAL_TWR_DS_TX_HOLDOFF (((uint32_t)0x0300))
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSCFG_SYSCFG_TWR_DS_H */

--- a/pkg/uwb-core/include/syscfg/syscfg_twr_ds_ext.h
+++ b/pkg/uwb-core/include/syscfg/syscfg_twr_ds_ext.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core double side extended two-way ranging module configurations
+ *              taken from decawave-uwb-core/lib/twr_ds_ext/syscfg.yml
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef SYSCFG_SYSCFG_TWR_DS_EXT_H
+#define SYSCFG_SYSCFG_TWR_DS_EXT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Enable double sided extended two way ranging
+ */
+#ifndef MYNEWT_VAL_TWR_DS_EXT_ENABLED
+#define MYNEWT_VAL_TWR_DS_EXT_ENABLED IS_ACTIVE(MODULE_UWB_CORE_TWR_DS_EXT)
+#endif
+
+/**
+ * @brief Enable double sided extended two way ranging
+ */
+#ifndef MYNEWT_VAL_TWR_DS_EXT_RX_TIMEOUT
+#define MYNEWT_VAL_TWR_DS_EXT_RX_TIMEOUT (((uint16_t)0x40))
+#endif
+
+/**
+ * @brief tx holdoff delay for DS TWR extended frame (usec)
+ */
+#ifndef MYNEWT_VAL_TWR_DS_EXT_TX_HOLDOFF
+#define MYNEWT_VAL_TWR_DS_EXT_TX_HOLDOFF (((uint32_t)0x0400))
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSCFG_SYSCFG_TWR_DS_EXT_H */

--- a/pkg/uwb-core/include/syscfg/syscfg_twr_ss.h
+++ b/pkg/uwb-core/include/syscfg/syscfg_twr_ss.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core single-sided two-way ranging module configurations
+ *              taken from decawave-uwb-core/lib/twr_ss/syscfg.yml
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef SYSCFG_SYSCFG_TWR_SS_H
+#define SYSCFG_SYSCFG_TWR_SS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Enable ranging services
+ */
+#ifndef MYNEWT_VAL_TWR_SS_ENABLED
+#define MYNEWT_VAL_TWR_SS_ENABLED (IS_ACTIVE(MODULE_UWB_CORE_TWR_SS))
+#endif
+
+/**
+ * @brief TOA timeout delay for SS TWR (usec)
+ */
+#ifndef MYNEWT_VAL_TWR_SS_RX_TIMEOUT
+#define MYNEWT_VAL_TWR_SS_RX_TIMEOUT (((uint16_t)0x30))
+#endif
+
+/**
+ * @brief tx holdoff delay for SS TWR (usec)
+ */
+#ifndef MYNEWT_VAL_TWR_SS_TX_HOLDOFF
+#define MYNEWT_VAL_TWR_SS_TX_HOLDOFF (((uint32_t)0x0300))
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSCFG_SYSCFG_TWR_SS_H */

--- a/pkg/uwb-core/include/syscfg/syscfg_twr_ss_ack.h
+++ b/pkg/uwb-core/include/syscfg/syscfg_twr_ss_ack.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       Single sided ranging using a hw generated ack module configurations
+ *              taken from decawave-uwb-core/lib/twr_ss_ack/syscfg.yml
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef SYSCFG_SYSCFG_TWR_SS_ACK_H
+#define SYSCFG_SYSCFG_TWR_SS_ACK_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Enable toplevel ranging services
+ */
+#ifndef MYNEWT_VAL_TWR_SS_ACK_ENABLED
+#define MYNEWT_VAL_TWR_SS_ACK_ENABLED (IS_ACTIVE(MODULE_UWB_CORE_TWR_SS_ACK))
+#endif
+
+/**
+ * @brief tx holdoff delay used to know how long to wait for SS TWR ACK message (usec)
+ */
+#ifndef MYNEWT_VAL_TWR_SS_ACK_RX_TIMEOUT
+#define MYNEWT_VAL_TWR_SS_ACK_RX_TIMEOUT (((uint16_t)0x100))
+#endif
+
+/**
+ * @brief TOA timeout delay for SS TWR (usec)
+ */
+#ifndef MYNEWT_VAL_TWR_SS_ACK_TX_HOLDOFF
+#define MYNEWT_VAL_TWR_SS_ACK_TX_HOLDOFF (((uint32_t)0x800))
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSCFG_SYSCFG_TWR_SS_ACK_H */

--- a/pkg/uwb-core/include/syscfg/syscfg_twr_ss_ext.h
+++ b/pkg/uwb-core/include/syscfg/syscfg_twr_ss_ext.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core single-sided two-way ranging module configurations
+ *              taken from decawave-uwb-core/lib/twr_ss_ext/syscfg.yml
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef SYSCFG_SYSCFG_TWR_SS_EXT_H
+#define SYSCFG_SYSCFG_TWR_SS_EXT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Enable Single Sided extended ranging services
+ */
+#ifndef MYNEWT_VAL_TWR_SS_EXT_ENABLED
+#define MYNEWT_VAL_TWR_SS_EXT_ENABLED (IS_ACTIVE(MODULE_UWB_CORE_TWR_SS_EXT))
+#endif
+
+/**
+ * @brief TOA timeout delay for SS EXT TWR (usec)
+ */
+#ifndef MYNEWT_VAL_TWR_SS_EXT_RX_TIMEOUT
+#define MYNEWT_VAL_TWR_SS_EXT_RX_TIMEOUT (((uint16_t)0x40))
+#endif
+
+/**
+ * @brief tx holdoff delay for SS EXT TWR (usec)
+ */
+#ifndef MYNEWT_VAL_TWR_SS_EXT_TX_HOLDOFF
+#define MYNEWT_VAL_TWR_SS_EXT_TX_HOLDOFF (((uint32_t)0x0400))
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSCFG_SYSCFG_TWR_SS_EXT_H */

--- a/pkg/uwb-core/include/syscfg/syscfg_uwb.h
+++ b/pkg/uwb-core/include/syscfg/syscfg_uwb.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core uwb module configurations
+ *              taken from decawave-uwb-core/hw/drivers/uwb/syscfg.yml
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef SYSCFG_SYSCFG_UWB_H
+#define SYSCFG_SYSCFG_UWB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Interrupt task priority for instance 0
+ */
+#ifndef MYNEWT_VAL_UWB_DEV_TASK_PRIO
+#define MYNEWT_VAL_UWB_DEV_TASK_PRIO    (THREAD_PRIORITY_MAIN - 5)
+#endif
+
+/**
+ * @brief Size of interrupt task stack
+ */
+#ifndef MYNEWT_VAL_UWB_DEV_TASK_STACK_SZ
+#define MYNEWT_VAL_UWB_DEV_TASK_STACK_SZ (1024)
+#endif
+
+/**
+ * @brief Size of the rx buffer in the uwb_dev
+ */
+#ifndef MYNEWT_VAL_UWB_RX_BUFFER_SIZE
+#define MYNEWT_VAL_UWB_RX_BUFFER_SIZE (1024)
+#endif
+
+/**
+ * @brief Enable init messages showing each package has been initialised
+ */
+#ifndef MYNEWT_VAL_UWB_PKG_INIT_LOG
+#define MYNEWT_VAL_UWB_PKG_INIT_LOG (1)
+#endif
+
+/**
+ * @brief Maximum size of rxdiag structure
+ */
+#ifndef MYNEWT_VAL_UWB_DEV_RXDIAG_MAXLEN
+#define MYNEWT_VAL_UWB_DEV_RXDIAG_MAXLEN (20)
+#endif
+
+/**
+ * @brief UWB_0 Device Enable. BSP uses this to enable the specific uwb device
+ *
+ * @note in uwb-core you need to tell exactly how many uwb-device there
+ *       are, ideally thus would be done different
+ */
+#ifndef MYNEWT_VAL_UWB_DEVICE_0
+#define MYNEWT_VAL_UWB_DEVICE_0 (1)
+#endif
+
+/**
+ * @brief Max number of UWB_DEVICES allowed in system
+ *
+ * @note uwb-core uses arrays to keep track of devices, currently se use
+ *       linked list, this is temporary...
+ */
+#ifndef MYNEWT_VAL_UWB_DEVICE_MAX
+#define MYNEWT_VAL_UWB_DEVICE_MAX (3)
+#endif
+
+/**
+ * @brief If ipatov and sts timestamps differ by more than this value
+ *       they are considered invalid
+ */
+#ifndef MYNEWT_VAL_UWB_STS_TS_MATCH_THRESHOLD
+#define MYNEWT_VAL_UWB_STS_TS_MATCH_THRESHOLD (30)
+#endif
+
+/**
+ * @brief Default Anchor X Coordinate
+ */
+#ifndef MYNEWT_VAL_LOCAL_COORDINATE_X
+#define MYNEWT_VAL_LOCAL_COORDINATE_X (((float)0.0f))
+#endif
+
+/**
+ * @brief Default Anchor Y Coordinate
+ */
+#ifndef MYNEWT_VAL_LOCAL_COORDINATE_Y
+#define MYNEWT_VAL_LOCAL_COORDINATE_Y (((float)0.0f))
+#endif
+
+/**
+ * @brief Default Anchor Z Coordinate
+ */
+#ifndef MYNEWT_VAL_LOCAL_COORDINATE_Z
+#define MYNEWT_VAL_LOCAL_COORDINATE_Z (((float)0.0f))
+#endif
+
+/**
+ * @brief Range Measurement Variance
+ */
+#ifndef MYNEWT_VAL_RANGE_VARIANCE
+#define MYNEWT_VAL_RANGE_VARIANCE (((float)5.4444e-04))
+#endif
+
+/**
+ * @brief Azimuth Measurement Variance
+ */
+#ifndef MYNEWT_VAL_AZIMUTH_VARIANCE
+#define MYNEWT_VAL_AZIMUTH_VARIANCE (((float)2.91e-2))
+#endif
+
+/**
+ * @brief OS Latency Guardband (usec)
+ */
+#ifndef MYNEWT_VAL_OS_LATENCY
+#define MYNEWT_VAL_OS_LATENCY (((uint32_t)800))
+#endif
+
+/**
+ * @brief Default Pan ID
+ */
+#ifndef MYNEWT_VAL_PANID
+#define MYNEWT_VAL_PANID (((const uint16_t)0xdeca))
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSCFG_SYSCFG_UWB_H */

--- a/pkg/uwb-core/include/syscfg/syscfg_uwb_rng.h
+++ b/pkg/uwb-core/include/syscfg/syscfg_uwb_rng.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core uwb_rng module configurations
+ *              taken from decawave-uwb-core/lib/uwb_rng/syscfg.yml
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef SYSCFG_SYSCFG_UWB_RNG_H
+#define SYSCFG_SYSCFG_UWB_RNG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief uwb-core uwb_rng module is enabled
+ */
+#ifndef MYNEWT_VAL_UWB_RNG_ENABLED
+#define MYNEWT_VAL_UWB_RNG_ENABLED ((IS_ACTIVE(MODULE_UWB_CORE_RNG)))
+#endif
+
+/**
+ * @brief TOA timeout delay for TWR (usec)
+ */
+#ifndef MYNEWT_VAL_RNG_RX_TIMEOUT
+#define MYNEWT_VAL_RNG_RX_TIMEOUT (((uint16_t)0x20))
+#endif
+
+/**
+ * @brief worstcase tx holdoff delay for all TWR modes (usec)
+ */
+#ifndef MYNEWT_VAL_RNG_TX_HOLDOFF
+#define MYNEWT_VAL_RNG_TX_HOLDOFF (((uint32_t)0x0320))
+#endif
+
+/**
+ * @brief Show debug output from postprocess
+ */
+#ifndef MYNEWT_VAL_RNG_VERBOSE
+#define MYNEWT_VAL_RNG_VERBOSE (0)
+#endif
+
+/**
+ * @brief JSON buffer size
+ */
+#ifndef MYNEWT_VAL_UWB_RNG_JSON_BUFSIZE
+#define MYNEWT_VAL_UWB_RNG_JSON_BUFSIZE (256)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSCFG_SYSCFG_UWB_RNG_H */

--- a/pkg/uwb-core/include/syscfg/syscfg_uwbcfg.h
+++ b/pkg/uwb-core/include/syscfg/syscfg_uwbcfg.h
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-core uwbcfg module configurations
+ *              taken from decawave-uwb-core/sys/uwbcfg/syscfg.yml
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef SYSCFG_SYSCFG_UWBCFG_H
+#define SYSCFG_SYSCFG_UWBCFG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Enable uwbcfg module
+ */
+#ifndef MYNEWT_VAL_UWBCFG_ENABLED
+#define MYNEWT_VAL_UWBCFG_ENABLED (IS_ACTIVE(MODULE_UWB_CORE_UWBCFG))
+#endif
+
+/**
+ * @brief   Apply configuration on uwbcfg module setup
+ */
+#ifndef MYNEWT_VAL_UWBCFG_APPLY_AT_INIT
+#define MYNEWT_VAL_UWBCFG_APPLY_AT_INIT (1)
+#endif
+
+/**
+ * @brief   Default channel
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_CH
+#define MYNEWT_VAL_UWBCFG_DEF_CH ("5")
+#endif
+
+/**
+ * @brief   Default UWB PRF (MHz)
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_PRF
+#define MYNEWT_VAL_UWBCFG_DEF_PRF ("64")
+#endif
+
+/**
+ * @brief   Default UWB Datarate (110k, 850k, 6m8)
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_DATARATE
+#define MYNEWT_VAL_UWBCFG_DEF_DATARATE ("6m8")
+#endif
+
+/**
+ * @brief   Default UWB PAC Length (8, 16, 32, 64)
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_PACLEN
+#define MYNEWT_VAL_UWBCFG_DEF_PACLEN ("8")
+#endif
+
+/**
+ * @brief   Default UWB External clock delay
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_EXT_CLKDLY
+#define MYNEWT_VAL_UWBCFG_DEF_EXT_CLKDLY ("0")
+#endif
+
+/**
+ * @brief   Default MAC FrameFilter (0x0000 = no filter)
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_FRAME_FILTER
+#define MYNEWT_VAL_UWBCFG_DEF_FRAME_FILTER ("0x0000")
+#endif
+
+/**
+ * @brief   Default UWB Role
+ *
+ *  - Tag          "0x00"
+ *  - Node         "0x01"
+ *  - Pan master   "0x02"
+ *  - Anchor       "0x04"
+ *  - Panmaster    "0x07"
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_ROLE
+#define MYNEWT_VAL_UWBCFG_DEF_ROLE ("0x0")
+#endif
+
+/**
+ * @brief Default UWB RX Antenna delay
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_RX_ANTDLY
+#define MYNEWT_VAL_UWBCFG_DEF_RX_ANTDLY ("0x4050")
+#endif
+
+/**
+ * @brief Default UWB RX Antenna separation distance in m
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_RX_ANTSEP
+#define MYNEWT_VAL_UWBCFG_DEF_RX_ANTSEP ("0.0205")
+#endif
+
+/**
+ * @brief UWBCFG_DEF_RX_DIAG_EN
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_RX_DIAG_EN
+#define MYNEWT_VAL_UWBCFG_DEF_RX_DIAG_EN ("0x1")
+#endif
+
+/**
+ * @brief Default UWB PDOA Mode (0, 1, 2, 3)
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_RX_PDOA_MODE
+#define MYNEWT_VAL_UWBCFG_DEF_RX_PDOA_MODE ("0")
+#endif
+
+/**
+ * @brief Default UWB PHR Mode (s, e)
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_RX_PHR_MODE
+#define MYNEWT_VAL_UWBCFG_DEF_RX_PHR_MODE ("e")
+#endif
+
+/**
+ * @brief Default UWB PHR Rate (0 = std, 1 = data)
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_RX_PHR_RATE
+#define MYNEWT_VAL_UWBCFG_DEF_RX_PHR_RATE ("0")
+#endif
+
+/**
+ * @brief Default UWB RX Preamble Code Index
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_RX_PREAM_CIDX
+#define MYNEWT_VAL_UWBCFG_DEF_RX_PREAM_CIDX ("9")
+#endif
+
+/**
+ * @brief Default UWB SFD Timeout (-1=auto, timeout in symbols)
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_RX_SFD_TO
+#define MYNEWT_VAL_UWBCFG_DEF_RX_SFD_TO ("-1")
+#endif
+
+/**
+ * @brief Default UWB SFD Type (0, 1)
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_RX_SFD_TYPE
+#define MYNEWT_VAL_UWBCFG_DEF_RX_SFD_TYPE ("1")
+#endif
+
+/**
+ * @brief Default UWB Sts Length (32-2040 in steps of 8)
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_RX_STS_LEN
+#define MYNEWT_VAL_UWBCFG_DEF_RX_STS_LEN ("64")
+#endif
+
+/**
+ * @brief Default UWB Sts Mode (0, 1, 2, sdc, 4z)
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_RX_STS_MODE
+#define MYNEWT_VAL_UWBCFG_DEF_RX_STS_MODE ("0")
+#endif
+
+/**
+ * @brief Default UWB Coarse TX Power (0,3,6,..,18)
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_TXRF_POWER_COARSE
+#define MYNEWT_VAL_UWBCFG_DEF_TXRF_POWER_COARSE ("15")
+#endif
+
+/**
+ * @brief Default UWB FINE TX Power (0,1,2,..,31)
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_TXRF_POWER_FINE
+#define MYNEWT_VAL_UWBCFG_DEF_TXRF_POWER_FINE ("22")
+#endif
+
+/**
+ * @brief Default UWB FINE TX Power (0,1,2,..,31)
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_TXRF_VCM_LO
+#define MYNEWT_VAL_UWBCFG_DEF_TXRF_VCM_LO ("15")
+#endif
+
+/**
+ * @brief Default UWB TX Antenna delay
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_TX_ANTDLY
+#define MYNEWT_VAL_UWBCFG_DEF_TX_ANTDLY ("0x4050")
+#endif
+
+/**
+ * @brief Default UWB RX Antenna separation distance in m
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_TX_PREAM_CIDX
+#define MYNEWT_VAL_UWBCFG_DEF_TX_PREAM_CIDX ("9")
+#endif
+
+/**
+ * @brief Default UWB Preamble Length
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_TX_PREAM_LEN
+#define MYNEWT_VAL_UWBCFG_DEF_TX_PREAM_LEN ("128")
+#endif
+
+/**
+ * @brief Default XTAL Trim value (0xff = no trim, or use OTP value)
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_XTAL_TRIM
+#define MYNEWT_VAL_UWBCFG_DEF_XTAL_TRIM ("0xff")
+#endif
+
+/**
+ * @brief   Offset relative leading edge to start extracting CIR from
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_CIR_OFFSET
+#define MYNEWT_VAL_UWBCFG_DEF_CIR_OFFSET ("0")
+#endif
+
+/**
+ * @brief   Number of bins to extract from CIR
+ */
+#ifndef MYNEWT_VAL_UWBCFG_DEF_CIR_SIZE
+#define MYNEWT_VAL_UWBCFG_DEF_CIR_SIZE ("0")
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSCFG_SYSCFG_UWBCFG_H */

--- a/pkg/uwb-core/include/sysinit/sysinit.h
+++ b/pkg/uwb-core/include/sysinit/sysinit.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       sysinit abstraction layer for RIOT adaption
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef SYSINIT_SYSINIT_H
+#define SYSINIT_SYSINIT_H
+
+#include "assert.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief DPL assert macro
+ */
+#define SYSINIT_PANIC_ASSERT(rc)        assert(rc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSINIT_SYSINIT_H */

--- a/pkg/uwb-core/include/uwb_core.h
+++ b/pkg/uwb-core/include/uwb_core.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ *
+ * @{
+ *
+ * @file
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ */
+
+#ifndef UWB_CORE_H
+#define UWB_CORE_H
+
+#include <stdint.h>
+#include "event.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Priority used for
+ */
+#ifndef UWB_CORE__PRIO
+#define UWB_CORE__PRIO            (THREAD_PRIORITY_MAIN - 2)
+#endif
+
+/**
+ * @brief   Stacksize used for
+ */
+#ifndef UWB_CORE__STACKSIZE
+#define UWB_CORE__STACKSIZE       (THREAD_STACKSIZE_DEFAULT)
+#endif
+
+/**
+ * @brief   Setup and run uwb-core thread
+ */
+void uwb_core_riot_init(void);
+
+/**
+ * @brief   Retrieves the default event queue.
+ *
+ * As there is no default event queue in RIOT, uwb-core will start and
+ * handle a default event queue.
+ *
+ * @return  the default event queue.
+ */
+event_queue_t *uwb_core_get_eventq(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UWB_CORE_H */
+/** @} */

--- a/pkg/uwb-core/patches/0001-uwb-uwb.c-use-RIOT-specific-uwb_dev_idx_lookup.patch
+++ b/pkg/uwb-core/patches/0001-uwb-uwb.c-use-RIOT-specific-uwb_dev_idx_lookup.patch
@@ -1,0 +1,33 @@
+From 0a9b2ebbe97dbe10a7bc9afdf3914b099c0264da Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Fri, 14 Aug 2020 14:14:23 +0200
+Subject: [PATCH 1/7] uwb/uwb.c: use RIOT specific uwb_dev_idx_lookup()
+
+---
+ hw/drivers/uwb/src/uwb.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/hw/drivers/uwb/src/uwb.c b/hw/drivers/uwb/src/uwb.c
+index 70c1b71..69e6714 100644
+--- a/hw/drivers/uwb/src/uwb.c
++++ b/hw/drivers/uwb/src/uwb.c
+@@ -31,6 +31,8 @@
+ #else
+ #include <stdlib.h>
+ #endif
++
++#if !defined(RIOT)
+ struct uwb_dev*
+ uwb_dev_idx_lookup(int idx)
+ {
+@@ -48,6 +50,7 @@ uwb_dev_idx_lookup(int idx)
+     return (struct uwb_dev*)odev;
+ }
+ EXPORT_SYMBOL(uwb_dev_idx_lookup);
++#endif
+ 
+ /**
+  * API to register extension  callbacks for different services.
+-- 
+2.28.0
+

--- a/pkg/uwb-core/patches/0002-lib-twr_-enable-stats-optionally.patch
+++ b/pkg/uwb-core/patches/0002-lib-twr_-enable-stats-optionally.patch
@@ -1,0 +1,758 @@
+From cac1c7aeb1db0732519fa6ae27f3f34234c83615 Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Fri, 14 Aug 2020 14:22:29 +0200
+Subject: [PATCH 2/7] lib/twr_*: enable stats optionally
+
+---
+ lib/twr_ds/src/twr_ds.c                   | 41 +++++++++++++----------
+ lib/twr_ds/syscfg.yml                     |  3 ++
+ lib/twr_ds_ext/src/twr_ds_ext.c           | 17 +++++++---
+ lib/twr_ds_ext/syscfg.yml                 |  3 ++
+ lib/twr_ds_ext_nrng/src/twr_ds_ext_nrng.c | 16 ++++++---
+ lib/twr_ds_ext_nrng/syscfg.yml            |  3 ++
+ lib/twr_ds_nrng/src/twr_ds_nrng.c         | 16 ++++++---
+ lib/twr_ds_nrng/syscfg.yml                |  3 ++
+ lib/twr_ss/src/twr_ss.c                   |  6 ++++
+ lib/twr_ss/syscfg.yml                     |  3 ++
+ lib/twr_ss_ack/src/twr_ss_ack.c           |  8 +++--
+ lib/twr_ss_ack/syscfg.yml                 |  3 ++
+ lib/twr_ss_ext/src/twr_ss_ext.c           | 15 ++++++---
+ lib/twr_ss_ext/syscfg.yml                 |  3 ++
+ lib/twr_ss_ext_nrng/src/twr_ss_ext_nrng.c |  9 ++++-
+ lib/twr_ss_ext_nrng/syscfg.yml            |  3 ++
+ lib/twr_ss_nrng/src/twr_ss_nrng.c         | 39 ++++++++++++++++++---
+ lib/twr_ss_nrng/syscfg.yml                |  3 ++
+ 18 files changed, 151 insertions(+), 43 deletions(-)
+
+diff --git a/lib/twr_ds/src/twr_ds.c b/lib/twr_ds/src/twr_ds.c
+index c73c412..cb5de6a 100644
+--- a/lib/twr_ds/src/twr_ds.c
++++ b/lib/twr_ds/src/twr_ds.c
+@@ -51,6 +51,23 @@
+ #endif
+ #endif
+ 
++#if MYNEWT_VAL(TWR_DS_STATS)
++STATS_SECT_START(twr_ds_stat_section)
++    STATS_SECT_ENTRY(complete)
++    STATS_SECT_ENTRY(start_tx_error)
++STATS_SECT_END
++
++STATS_NAME_START(twr_ds_stat_section)
++    STATS_NAME(twr_ds_stat_section, complete)
++    STATS_NAME(twr_ds_stat_section, start_tx_error)
++STATS_NAME_END(twr_ds_stat_section)
++
++STATS_SECT_DECL(twr_ds_stat_section) g_twr_ds_stat;
++#define DS_STATS_INC(__X) STATS_INC(g_twr_ds_stat, __X)
++#else
++#define DS_STATS_INC(__X) {}
++#endif
++
+ static bool rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs);
+ 
+ static struct uwb_mac_interface g_cbs[] = {
+@@ -72,18 +89,6 @@ static struct uwb_mac_interface g_cbs[] = {
+ #endif
+ };
+ 
+-STATS_SECT_START(twr_ds_stat_section)
+-    STATS_SECT_ENTRY(complete)
+-    STATS_SECT_ENTRY(start_tx_error)
+-STATS_SECT_END
+-
+-STATS_NAME_START(twr_ds_stat_section)
+-    STATS_NAME(twr_ds_stat_section, complete)
+-    STATS_NAME(twr_ds_stat_section, start_tx_error)
+-STATS_NAME_END(twr_ds_stat_section)
+-
+-STATS_SECT_DECL(twr_ds_stat_section) g_twr_ds_stat;
+-
+ static struct uwb_rng_config g_config = {
+     .tx_holdoff_delay = MYNEWT_VAL(TWR_DS_TX_HOLDOFF),         // Send Time delay in usec.
+     .rx_timeout_delay = MYNEWT_VAL(TWR_DS_RX_TIMEOUT)       // Receive response timeout in usec
+@@ -137,6 +142,7 @@ void twr_ds_pkg_init(void)
+         uwb_rng_append_config(g_cbs[i].inst_ptr, &g_rng_cfgs[i]);
+     }
+ 
++#if MYNEWT_VAL(TWR_DS_STATS)
+     rc = stats_init(
+         STATS_HDR(g_twr_ds_stat),
+         STATS_SIZE_INIT_PARMS(g_twr_ds_stat, STATS_SIZE_32),
+@@ -145,6 +151,7 @@ void twr_ds_pkg_init(void)
+ 
+     rc = stats_register("twr_ds", STATS_HDR(g_twr_ds_stat));
+     assert(rc == 0);
++#endif
+ 
+ }
+ 
+@@ -231,7 +238,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+ 
+                 /* Start tx now, the remaining settings can be done whilst sending anyway */
+                 if (uwb_start_tx(inst).start_tx_error){
+-                    STATS_INC(g_twr_ds_stat, start_tx_error);
++                    DS_STATS_INC(start_tx_error);
+                     dpl_sem_release(&rng->sem);
+                 }
+ 
+@@ -291,7 +298,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+                 uwb_set_rxauto_disable(inst, true);
+ 
+                 if (uwb_start_tx(inst).start_tx_error){
+-                    STATS_INC(g_twr_ds_stat, start_tx_error);
++                    DS_STATS_INC(start_tx_error);
+                     dpl_sem_release(&rng->sem);
+                 }
+                 /* Setup when to listen for response, relative the end of our transmitted frame */
+@@ -337,11 +344,11 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+                 uwb_set_delay_start(inst, txd.response_tx_delay);
+ 
+                 if (uwb_start_tx(inst).start_tx_error) {
+-                    STATS_INC(g_twr_ds_stat, start_tx_error);
++                    DS_STATS_INC(start_tx_error);
+                     dpl_sem_release(&rng->sem);
+                     rng_issue_complete(inst);
+                 } else {
+-                    STATS_INC(g_twr_ds_stat, complete);
++                    DS_STATS_INC(complete);
+                     rng->control.complete_after_tx = 1;
+                 }
+ 
+@@ -352,7 +359,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+                 // This code executes on the device that initialed the original request, and has now receive the final response timestamp.
+                 // This marks the completion of the double-single-two-way request.
+ 
+-                STATS_INC(g_twr_ds_stat, complete);
++                DS_STATS_INC(complete);
+                 dpl_sem_release(&rng->sem);
+                 rng_issue_complete(inst);
+                 break;
+diff --git a/lib/twr_ds/syscfg.yml b/lib/twr_ds/syscfg.yml
+index cb12594..288b8fd 100644
+--- a/lib/twr_ds/syscfg.yml
++++ b/lib/twr_ds/syscfg.yml
+@@ -10,3 +10,6 @@ syscfg.defs:
+       TWR_DS_RX_TIMEOUT:
+         description: 'TOA timeout delay for DS TWR (usec)'
+         value: ((uint16_t)0x30)
++      TWR_DS_STATS:
++        description: 'Enable statistics for the twr_ds module'
++        value: 1
+diff --git a/lib/twr_ds_ext/src/twr_ds_ext.c b/lib/twr_ds_ext/src/twr_ds_ext.c
+index 95f38fe..07cc28c 100644
+--- a/lib/twr_ds_ext/src/twr_ds_ext.c
++++ b/lib/twr_ds_ext/src/twr_ds_ext.c
+@@ -67,6 +67,7 @@ static struct uwb_mac_interface g_cbs[] = {
+ #endif
+ };
+ 
++#if MYNEWT_VAL(TWR_DS_EXT_STATS)
+ STATS_SECT_START(twr_ds_ext_stat_section)
+     STATS_SECT_ENTRY(complete)
+     STATS_SECT_ENTRY(tx_error)
+@@ -78,6 +79,10 @@ STATS_NAME_START(twr_ds_ext_stat_section)
+ STATS_NAME_END(twr_ds_ext_stat_section)
+ 
+ static STATS_SECT_DECL(twr_ds_ext_stat_section) g_twr_ds_ext_stat;
++#define DS_STATS_INC(__X) STATS_INC(g_twr_ds_ext_stat, __X)
++#else
++#define DS_STATS_INC(__X) {}
++#endif
+ 
+ static struct uwb_rng_config g_config = {
+     .tx_holdoff_delay = MYNEWT_VAL(TWR_DS_EXT_TX_HOLDOFF),         // Send Time delay in usec.
+@@ -132,6 +137,7 @@ void twr_ds_ext_pkg_init(void)
+         uwb_rng_append_config(g_cbs[i].inst_ptr, &g_rng_cfgs[i]);
+     }
+ 
++#if MYNEWT_VAL(TWR_DS_EXT_STATS)
+     rc = stats_init(
+         STATS_HDR(g_twr_ds_ext_stat),
+         STATS_SIZE_INIT_PARMS(g_twr_ds_ext_stat, STATS_SIZE_32),
+@@ -140,6 +146,7 @@ void twr_ds_ext_pkg_init(void)
+ 
+     rc = stats_register("twr_ds_ext", STATS_HDR(g_twr_ds_ext_stat));
+     assert(rc == 0);
++#endif
+ }
+ 
+ 
+@@ -224,7 +231,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+                 uwb_set_rxauto_disable(inst, true);
+ 
+                 if (uwb_start_tx(inst).start_tx_error){
+-                    STATS_INC(g_twr_ds_ext_stat, tx_error);
++                    DS_STATS_INC(tx_error);
+                     dpl_sem_release(&rng->sem);
+                 }
+ 
+@@ -293,7 +300,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+                 uwb_set_rxauto_disable(inst, true);
+ 
+                 if (uwb_start_tx(inst).start_tx_error){
+-                    STATS_INC(g_twr_ds_ext_stat, tx_error);
++                    DS_STATS_INC(tx_error);
+                     dpl_sem_release(&rng->sem);
+                 }
+                 /* Setup when to listen for response, relative the end of our transmitted frame */
+@@ -348,11 +355,11 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+                 uwb_rng_clear_twr_data(&frame->remote);
+ 
+                 if (uwb_start_tx(inst).start_tx_error) {
+-                    STATS_INC(g_twr_ds_ext_stat, tx_error);
++                    DS_STATS_INC(tx_error);
+                     dpl_sem_release(&rng->sem);
+                     rng_issue_complete(inst);
+                 }else{
+-                    STATS_INC(g_twr_ds_ext_stat, complete);
++                    DS_STATS_INC(complete);
+                     rng->control.complete_after_tx = 1;
+                 }
+                 break;
+@@ -362,7 +369,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+                 // This code executes on the device that initialed the original request, and has now receive the final response timestamp.
+                 // This marks the completion of the double-single-two-way request.
+ 
+-                STATS_INC(g_twr_ds_ext_stat, complete);
++                DS_STATS_INC(complete);
+                 dpl_sem_release(&rng->sem);
+                 rng_issue_complete(inst);
+                 break;
+diff --git a/lib/twr_ds_ext/syscfg.yml b/lib/twr_ds_ext/syscfg.yml
+index 199a671..fe80282 100644
+--- a/lib/twr_ds_ext/syscfg.yml
++++ b/lib/twr_ds_ext/syscfg.yml
+@@ -10,3 +10,6 @@ syscfg.defs:
+       TWR_DS_EXT_RX_TIMEOUT:
+         description: 'TOA timeout delay for DS TWR extended frame (usec)'
+         value: ((uint16_t)0x40)
++      TWR_DS_EXT_STATS:
++        description: 'Enable statistics for the twr_ds_ext module'
++        value: 1
+diff --git a/lib/twr_ds_ext_nrng/src/twr_ds_ext_nrng.c b/lib/twr_ds_ext_nrng/src/twr_ds_ext_nrng.c
+index b2a821e..2b15ae1 100644
+--- a/lib/twr_ds_ext_nrng/src/twr_ds_ext_nrng.c
++++ b/lib/twr_ds_ext_nrng/src/twr_ds_ext_nrng.c
+@@ -65,6 +65,7 @@ static struct uwb_mac_interface g_cbs = {
+             .final_cb = tx_final_cb,
+ };
+ 
++#if MYNEWT_VAL(TWR_DS_EXT_NRNG_STATS)
+ STATS_SECT_START(twr_ds_ext_nrng_stat_section)
+     STATS_SECT_ENTRY(complete)
+     STATS_SECT_ENTRY(rx_error)
+@@ -78,6 +79,11 @@ STATS_NAME_START(twr_ds_ext_nrng_stat_section)
+ STATS_NAME_END(twr_ds_ext_nrng_stat_section)
+ 
+ static STATS_SECT_DECL(twr_ds_ext_nrng_stat_section) g_stat;
++#define DS_STATS_INC(__X) STATS_INC(g_stat, __X)
++#else
++#define DS_STATS_INC(__X) {}
++#endif
++
+ 
+ static struct uwb_rng_config g_config = {
+     .tx_holdoff_delay = MYNEWT_VAL(TWR_DS_EXT_NRNG_TX_HOLDOFF),         // Send Time delay in usec.
+@@ -96,6 +102,7 @@ void twr_ds_ext_nrng_pkg_init(void){
+     printf("{\"utime\": %lu,\"msg\": \"twr_ds_ext_nrng_pkg_init\"}\n",os_cputime_ticks_to_usecs(os_cputime_get32()));
+     uwb_mac_append_interface(hal_dw1000_inst(0), &g_cbs);
+ 
++#if MYNEWT_VAL(TWR_DS_EXT_NRNG_STATS)
+     int rc = stats_init(
+     STATS_HDR(g_stat),
+     STATS_SIZE_INIT_PARMS(g_stat, STATS_SIZE_32),
+@@ -104,6 +111,7 @@ void twr_ds_ext_nrng_pkg_init(void){
+ 
+     rc = stats_register("twr_ds_ext_nrng", STATS_HDR(g_stat));
+     assert(rc == 0);
++#endif
+ }
+ 
+ 
+@@ -145,7 +153,7 @@ rx_timeout_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs){
+     if(inst->fctrl != FCNTL_IEEE_N_RANGES_16){
+         return false;
+     }
+-    STATS_INC(g_stat, rx_timeout);
++    DS_STATS_INC(rx_timeout);
+     assert(inst->nrng);
+     switch(inst->nrng->code){
+         case UWB_DATA_CODE_DS_TWR_NRNG_EXT ... UWB_DATA_CODE_DS_TWR_NRNG_EXT_FINAL:
+@@ -191,7 +199,7 @@ rx_error_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs){
+     if(inst->fctrl != FCNTL_IEEE_N_RANGES_16){
+         return false;
+     }
+-    STATS_INC(g_stat, rx_error);
++    DS_STATS_INC(rx_error);
+     assert(inst->nrng);
+     struct nrng_instance * nrng = inst->nrng;
+     os_error_t err = os_sem_release(&nrng->sem);
+@@ -371,7 +379,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+                     if (cbs!=NULL && cbs->start_tx_error_cb)
+                         cbs->start_tx_error_cb(inst, cbs);
+                 }else{
+-                    STATS_INC(g_stat, complete);
++                    DS_STATS_INC(complete);
+                     os_sem_release(&nrng->sem);
+                     struct uwb_mac_interface * cbs = NULL;
+                     if(!(SLIST_EMPTY(&inst->interface_cbs))){
+@@ -416,7 +424,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+                 if(idx == nnodes -1){
+                     os_sem_release(&nrng->sem);
+                     nrng->resp_count = 0;
+-                    STATS_INC(g_stat, complete);
++                    DS_STATS_INC(complete);
+                     struct uwb_mac_interface * cbs = NULL;
+                     if(!(SLIST_EMPTY(&inst->interface_cbs))){
+                         SLIST_FOREACH(cbs, &inst->interface_cbs, next){
+diff --git a/lib/twr_ds_ext_nrng/syscfg.yml b/lib/twr_ds_ext_nrng/syscfg.yml
+index 5fd3404..92a952b 100644
+--- a/lib/twr_ds_ext_nrng/syscfg.yml
++++ b/lib/twr_ds_ext_nrng/syscfg.yml
+@@ -12,3 +12,6 @@ syscfg.defs:
+         value: ((uint16_t)0x10)
+       TWR_DS_EXT_NRNG_TX_GUARD_DELAY:
+         value: ((uint16_t)0x150)
++      TWR_DS_EXT_NRNG_STATS:
++        description: 'Enable statistics for the twr_ds_ext_nrng module'
++        value: 1
+diff --git a/lib/twr_ds_nrng/src/twr_ds_nrng.c b/lib/twr_ds_nrng/src/twr_ds_nrng.c
+index b32b2f8..3aea94a 100644
+--- a/lib/twr_ds_nrng/src/twr_ds_nrng.c
++++ b/lib/twr_ds_nrng/src/twr_ds_nrng.c
+@@ -61,6 +61,7 @@ static struct uwb_mac_interface g_cbs = {
+             .rx_error_cb = rx_error_cb,
+ };
+ 
++#if MYNEWT_VAL(TWR_DS_NRNG_STATS)
+ STATS_SECT_START(twr_ds_nrng_stat_section)
+     STATS_SECT_ENTRY(complete)
+     STATS_SECT_ENTRY(rx_timeout)
+@@ -74,6 +75,10 @@ STATS_NAME_START(twr_ds_nrng_stat_section)
+ STATS_NAME_END(twr_ds_nrng_stat_section)
+ 
+ static STATS_SECT_DECL(twr_ds_nrng_stat_section) g_stat;
++#define DS_STATS_INC(__X) STATS_INC(g_stat, __X)
++#else
++#define DS_STATS_INC(__X) {}
++#endif
+ 
+ static struct uwb_rng_config g_config = {
+     .tx_holdoff_delay = MYNEWT_VAL(TWR_DS_NRNG_TX_HOLDOFF),         // Send Time delay in usec.
+@@ -101,6 +106,7 @@ void twr_ds_nrng_pkg_init(void){
+     uwb_mac_append_interface(uwb_dev_idx_lookup(0), &g_cbs);
+     nrng_append_config(nrng, &g_rng_cfgs);
+ 
++#if MYNEWT_VAL(TWR_DS_NRNG_STATS)
+     int rc = stats_init(
+     STATS_HDR(g_stat),
+     STATS_SIZE_INIT_PARMS(g_stat, STATS_SIZE_32),
+@@ -109,7 +115,7 @@ void twr_ds_nrng_pkg_init(void){
+ 
+     rc = stats_register("twr_ds_nrng", STATS_HDR(g_stat));
+     assert(rc == 0);
+-
++#endif
+ }
+ 
+ 
+@@ -139,7 +145,7 @@ rx_timeout_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs){
+     if(inst->fctrl != FCNTL_IEEE_N_RANGES_16){
+         return false;
+     }
+-    STATS_INC(g_stat, rx_timeout);
++    DS_STATS_INC(rx_timeout);
+     switch(inst->nrng->code){
+         case UWB_DATA_CODE_DS_TWR_NRNG ... UWB_DATA_CODE_DS_TWR_NRNG_FINAL:
+         {
+@@ -183,7 +189,7 @@ rx_error_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs){
+     if(inst->fctrl != FCNTL_IEEE_N_RANGES_16){
+         return false;
+     }
+-    STATS_INC(g_stat, rx_error);
++    DS_STATS_INC(rx_error);
+     assert(inst->nrng);
+     struct nrng_instance * nrng = inst->nrng;
+     if(os_sem_get_count(&nrng->sem) == 0){
+@@ -381,7 +387,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+                     if (cbs!=NULL && cbs->start_tx_error_cb)
+                         cbs->start_tx_error_cb(inst, cbs);
+                 }else{
+-                    STATS_INC(g_stat, complete);
++                    DS_STATS_INC(complete);
+                     os_sem_release(&nrng->sem);
+                     struct uwb_mac_interface * cbs = NULL;
+                     if(!(SLIST_EMPTY(&inst->interface_cbs))){
+@@ -430,7 +436,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+                 frame->transmission_timestamp = dw1000_read_txtime_lo(inst);
+                 if(idx == nnodes -1)
+                 {
+-                    STATS_INC(g_stat, complete);
++                    DS_STATS_INC(complete);
+                     os_sem_release(&nrng->sem);
+                     struct uwb_mac_interface * cbs = NULL;
+                     if(!(SLIST_EMPTY(&inst->interface_cbs))){
+diff --git a/lib/twr_ds_nrng/syscfg.yml b/lib/twr_ds_nrng/syscfg.yml
+index 804234a..28777c1 100644
+--- a/lib/twr_ds_nrng/syscfg.yml
++++ b/lib/twr_ds_nrng/syscfg.yml
+@@ -12,3 +12,6 @@ syscfg.defs:
+         value: ((uint16_t)0x10)
+       TWR_DS_NRNG_TX_GUARD_DELAY:
+         value: ((uint16_t)0x100)
++      TWR_DS_NRNG_STATS:
++        description: 'Enable statistics for the twr_ds_nrng module'
++        value: 1
+diff --git a/lib/twr_ss/src/twr_ss.c b/lib/twr_ss/src/twr_ss.c
+index 84c5084..7394ef4 100644
+--- a/lib/twr_ss/src/twr_ss.c
++++ b/lib/twr_ss/src/twr_ss.c
+@@ -76,6 +76,7 @@ static struct uwb_mac_interface g_cbs[] = {
+ #endif
+ };
+ 
++#if MYNEWT_VAL(TWR_SS_STATS)
+ STATS_SECT_START(twr_ss_stat_section)
+     STATS_SECT_ENTRY(complete)
+     STATS_SECT_ENTRY(tx_error)
+@@ -88,6 +89,9 @@ STATS_NAME_END(twr_ss_stat_section)
+ 
+ STATS_SECT_DECL(twr_ss_stat_section) g_twr_ss_stat;
+ #define SS_STATS_INC(__X) STATS_INC(g_twr_ss_stat, __X)
++#else
++#define SS_STATS_INC(__X) {}
++#endif
+ 
+ static struct uwb_rng_config g_config = {
+     .tx_holdoff_delay = MYNEWT_VAL(TWR_SS_TX_HOLDOFF),         // Send Time delay in usec.
+@@ -143,6 +147,7 @@ twr_ss_pkg_init(void)
+         uwb_rng_append_config(g_cbs[i].inst_ptr, &g_rng_cfgs[i]);
+     }
+ 
++#if MYNEWT_VAL(TWR_SS_STATS)
+     rc = stats_init(
+         STATS_HDR(g_twr_ss_stat),
+         STATS_SIZE_INIT_PARMS(g_twr_ss_stat, STATS_SIZE_32),
+@@ -151,6 +156,7 @@ twr_ss_pkg_init(void)
+ 
+     rc |= stats_register("twr_ss", STATS_HDR(g_twr_ss_stat));
+     assert(rc == 0);
++#endif
+ }
+ 
+ /**
+diff --git a/lib/twr_ss/syscfg.yml b/lib/twr_ss/syscfg.yml
+index e2ab7a5..05dc497 100644
+--- a/lib/twr_ss/syscfg.yml
++++ b/lib/twr_ss/syscfg.yml
+@@ -10,3 +10,6 @@ syscfg.defs:
+       TWR_SS_RX_TIMEOUT:
+         description: 'TOA timeout delay for SS TWR (usec)'
+         value: ((uint16_t)0x30)
++      TWR_SS_STATS:
++        description: 'Enable statistics for the twr_ss module'
++        value: 1
+diff --git a/lib/twr_ss_ack/src/twr_ss_ack.c b/lib/twr_ss_ack/src/twr_ss_ack.c
+index f0e0884..a64ce37 100644
+--- a/lib/twr_ss_ack/src/twr_ss_ack.c
++++ b/lib/twr_ss_ack/src/twr_ss_ack.c
+@@ -78,7 +78,7 @@ static struct uwb_mac_interface g_cbs[] = {
+ #endif
+ };
+ 
+-
++#if MYNEWT_VAL(TWR_SS_ACK_STATS)
+ STATS_SECT_START(twr_ss_ack_stat_section)
+     STATS_SECT_ENTRY(complete)
+     STATS_SECT_ENTRY(tx_error)
+@@ -97,7 +97,9 @@ STATS_NAME_END(twr_ss_ack_stat_section)
+ 
+ STATS_SECT_DECL(twr_ss_ack_stat_section) g_twr_ss_ack_stat;
+ #define SS_STATS_INC(__X) STATS_INC(g_twr_ss_ack_stat, __X)
+-
++#else
++#define SS_STATS_INC(__X) {}
++#endif
+ 
+ static struct uwb_rng_config g_config = {
+     .tx_holdoff_delay = MYNEWT_VAL(TWR_SS_ACK_TX_HOLDOFF),       // Send Time delay in usec.
+@@ -154,6 +156,7 @@ twr_ss_ack_pkg_init(void)
+         uwb_rng_append_config(g_cbs[i].inst_ptr, &g_rng_cfgs[i]);
+     }
+ 
++#if MYNEWT_VAL(TWR_SS_ACK_STATS)
+     rc = stats_init(
+         STATS_HDR(g_twr_ss_ack_stat),
+         STATS_SIZE_INIT_PARMS(g_twr_ss_ack_stat, STATS_SIZE_32),
+@@ -162,6 +165,7 @@ twr_ss_ack_pkg_init(void)
+ 
+     rc |= stats_register("twr_ss_ack", STATS_HDR(g_twr_ss_ack_stat));
+     assert(rc == 0);
++#endif
+ }
+ 
+ /**
+diff --git a/lib/twr_ss_ack/syscfg.yml b/lib/twr_ss_ack/syscfg.yml
+index 4a27a9c..52177a2 100644
+--- a/lib/twr_ss_ack/syscfg.yml
++++ b/lib/twr_ss_ack/syscfg.yml
+@@ -10,3 +10,6 @@ syscfg.defs:
+       TWR_SS_ACK_RX_TIMEOUT:
+         description: 'TOA timeout delay for SS TWR (usec)'
+         value: ((uint16_t)0x100)
++      TWR_SS_ACK_STATS:
++        description: 'Enable statistics for the twr_ss_ack module'
++        value: 1
+diff --git a/lib/twr_ss_ext/src/twr_ss_ext.c b/lib/twr_ss_ext/src/twr_ss_ext.c
+index 6e55a13..2ea3384 100644
+--- a/lib/twr_ss_ext/src/twr_ss_ext.c
++++ b/lib/twr_ss_ext/src/twr_ss_ext.c
+@@ -74,6 +74,7 @@ static struct uwb_mac_interface g_cbs[] = {
+ #endif
+ };
+ 
++#if MYNEWT_VAL(TWR_SS_EXT_STATS)
+ STATS_SECT_START(twr_ss_ext_stat_section)
+     STATS_SECT_ENTRY(complete)
+     STATS_SECT_ENTRY(tx_error)
+@@ -85,6 +86,10 @@ STATS_NAME_START(twr_ss_ext_stat_section)
+ STATS_NAME_END(twr_ss_ext_stat_section)
+ 
+ static STATS_SECT_DECL(twr_ss_ext_stat_section) g_twr_ss_ext_stat;
++#define SS_STATS_INC(__X) STATS_INC(g_twr_ss_ext_stat __X)
++#else
++#define SS_STATS_INC(__X) {}
++#endif
+ 
+ static struct uwb_rng_config g_config = {
+     .tx_holdoff_delay = MYNEWT_VAL(TWR_SS_EXT_TX_HOLDOFF),         // Send Time delay in usec.
+@@ -140,12 +145,14 @@ twr_ss_ext_pkg_init(void)
+         uwb_rng_append_config(g_cbs[i].inst_ptr, &g_rng_cfgs[i]);
+     }
+ 
++#if MYNEWT_VAL(TWR_SS_EXT_STATS)
+     rc = stats_init(
+         STATS_HDR(g_twr_ss_ext_stat),
+         STATS_SIZE_INIT_PARMS(g_twr_ss_ext_stat, STATS_SIZE_32),
+         STATS_NAME_INIT_PARMS(twr_ss_ext_stat_section));
+     rc |= stats_register("twr_ss_ext", STATS_HDR(g_twr_ss_ext_stat));
+     assert(rc == 0);
++#endif
+ }
+ 
+ /**
+@@ -241,7 +248,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+                 uwb_set_delay_start(inst, txd.response_tx_delay);
+ 
+                 if (uwb_start_tx(inst).start_tx_error){
+-                    STATS_INC(g_twr_ss_ext_stat, tx_error);
++                    SS_STATS_INC(tx_error);
+                     dpl_sem_release(&rng->sem);
+                 }
+                 /* Setup when to listen for response, relative the end of our transmitted frame */
+@@ -284,12 +291,12 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+                 uwb_set_delay_start(inst, txd.response_tx_delay);
+ 
+                 if (uwb_start_tx(inst).start_tx_error){
+-                    STATS_INC(g_twr_ss_ext_stat, tx_error);
++                    SS_STATS_INC(tx_error);
+                     dpl_sem_release(&rng->sem);
+                     rng_issue_complete(inst);
+                 }
+                 else{
+-                    STATS_INC(g_twr_ss_ext_stat, complete);
++                    SS_STATS_INC(complete);
+                     rng->control.complete_after_tx = 1;
+                 }
+                 break;
+@@ -301,7 +308,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+                 if (inst->frame_len != sizeof(twr_frame_final_t))
+                    break;
+ 
+-                STATS_INC(g_twr_ss_ext_stat, complete);
++                SS_STATS_INC(complete);
+                 dpl_sem_release(&rng->sem);
+                 rng_issue_complete(inst);
+                 break;
+diff --git a/lib/twr_ss_ext/syscfg.yml b/lib/twr_ss_ext/syscfg.yml
+index fcca45a..a71963f 100644
+--- a/lib/twr_ss_ext/syscfg.yml
++++ b/lib/twr_ss_ext/syscfg.yml
+@@ -10,3 +10,6 @@ syscfg.defs:
+       TWR_SS_EXT_RX_TIMEOUT:
+         description: 'TOA timeout delay for SS EXT TWR (usec)'
+         value: ((uint16_t)0x40)
++      TWR_SS_EXT_STATS:
++        description: 'Enable statistics for the twr_ss_ext module'
++        value: 1
+diff --git a/lib/twr_ss_ext_nrng/src/twr_ss_ext_nrng.c b/lib/twr_ss_ext_nrng/src/twr_ss_ext_nrng.c
+index 3808785..759f928 100644
+--- a/lib/twr_ss_ext_nrng/src/twr_ss_ext_nrng.c
++++ b/lib/twr_ss_ext_nrng/src/twr_ss_ext_nrng.c
+@@ -67,6 +67,7 @@ static struct uwb_mac_interface g_cbs = {
+             .final_cb = tx_final_cb,
+ };
+ 
++#if MYNEWT_VAL(TWR_SS_EXT_NRNG_STATS)
+ STATS_SECT_START(twr_ss_ext_nrng_stat_section)
+     STATS_SECT_ENTRY(complete)
+     STATS_SECT_ENTRY(rx_error)
+@@ -80,6 +81,10 @@ STATS_NAME_START(twr_ss_ext_nrng_stat_section)
+ STATS_NAME_END(twr_ss_ext_nrng_stat_section)
+ 
+ static STATS_SECT_DECL(twr_ss_ext_nrng_stat_section) g_stat;
++#define SS_STATS_INC(__X) STATS_INC(g_stat, __X)
++#else
++#define SS_STATS_INC(__X) {}
++#endif
+ 
+ static struct uwb_rng_config g_config = {
+     .tx_holdoff_delay = MYNEWT_VAL(TWR_SS_EXT_NRNG_TX_HOLDOFF),         // Send Time delay in usec.
+@@ -107,12 +112,14 @@ void twr_ss_ext_nrng_pkg_init(void)
+     uwb_mac_append_interface(uwb_dev_idx_lookup(0), &g_cbs);
+     nrng_append_config(nrng, &g_rng_cfgs);
+ 
++#if MYNEWT_VAL(TWR_SS_EXT_NRNG_STATS)
+     int rc = stats_init(
+     STATS_HDR(g_stat),
+     STATS_SIZE_INIT_PARMS(g_stat, STATS_SIZE_32),
+     STATS_NAME_INIT_PARMS(twr_ss_ext_nrng_stat_section));
+     rc |= stats_register("ss_ext_nrng", STATS_HDR(g_stat));
+     assert(rc == 0);
++#endif
+ }
+ 
+ /**
+@@ -144,7 +151,7 @@ rx_error_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs){
+     }
+     struct uwb_rng_instance * rng = inst->rng;
+     if(os_sem_get_count(&rng->sem) == 0){
+-        STATS_INC(g_stat, rx_error);
++        SS_STATS_INC(rx_error);
+         os_error_t err = os_sem_release(&rng->sem);
+         assert(err == OS_OK);
+         return true;
+diff --git a/lib/twr_ss_ext_nrng/syscfg.yml b/lib/twr_ss_ext_nrng/syscfg.yml
+index 997def3..ff8c789 100644
+--- a/lib/twr_ss_ext_nrng/syscfg.yml
++++ b/lib/twr_ss_ext_nrng/syscfg.yml
+@@ -12,6 +12,9 @@ syscfg.defs:
+         value: ((uint16_t)0x10)
+       TWR_SS_EXT_NRNG_TX_GUARD_DELAY:
+         value: ((uint32_t)0x90)
++      TWR_SS_EXT_NRNG_STATS:
++        description: 'Enable statistics for the twr_ss_ext_nrng module'
++        value: 1
+       CELL_ENABLED:
+         description: 'Cell network model on slot decoding'
+         value: 0
+diff --git a/lib/twr_ss_nrng/src/twr_ss_nrng.c b/lib/twr_ss_nrng/src/twr_ss_nrng.c
+index b6550f6..f5a60fc 100644
+--- a/lib/twr_ss_nrng/src/twr_ss_nrng.c
++++ b/lib/twr_ss_nrng/src/twr_ss_nrng.c
+@@ -52,6 +52,24 @@
+ #define DIAGMSG(s,u)
+ #endif
+ 
++#if MYNEWT_VAL(TWR_SS_NRNG_STATS)
++STATS_SECT_START(twr_ss_nrng_stat_section)
++    STATS_SECT_ENTRY(complete)
++    STATS_SECT_ENTRY(start_tx_error)
++STATS_SECT_END
++
++STATS_NAME_START(twr_ss_nrng_stat_section)
++    STATS_NAME(twr_ss_nrng_stat_section, complete)
++    STATS_NAME(twr_ss_nrng_stat_section, start_tx_error)
++STATS_NAME_END(twr_ss_nrng_stat_section)
++
++STATS_SECT_DECL(twr_ss_nrng_stat_section) g_twr_ss_nrng_stat;
++#define SS_STATS_INC(__X) STATS_INC(g_twr_ss_nrng_stat, __X)
++#else
++#define SS_STATS_INC(__X) {}
++#endif
++
++
+ static bool rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs);
+ static bool rx_timeout_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs);
+ static bool rx_error_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs);
+@@ -93,6 +111,17 @@ void twr_ss_nrng_pkg_init(void)
+     g_cbs.inst_ptr = nrng;
+     uwb_mac_append_interface(udev, &g_cbs);
+     nrng_append_config(nrng, &g_rng_cfgs);
++
++#if MYNEWT_VAL(TWR_SS_NRNG_STATS)
++    int rc = stats_init(
++    STATS_HDR(g_twr_ss_nrng_stat),
++    STATS_SIZE_INIT_PARMS(g_twr_ss_nrng_stat, STATS_SIZE_32),
++    STATS_NAME_INIT_PARMS(twr_ss_nrng_stat_section));
++    assert(rc == 0);
++
++    rc = stats_register("twr_ss_nrng", STATS_HDR(g_twr_ss_nrng_stat));
++    assert(rc == 0);
++#endif
+ }
+ 
+ 
+@@ -126,7 +155,7 @@ rx_error_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+         return false;
+ 
+     if(dpl_sem_get_count(&nrng->sem) == 0){
+-        NRNG_STATS_INC(rx_error);
++        SS_STATS_INC(rx_error);
+         dpl_error_t err = dpl_sem_release(&nrng->sem);
+         assert(err == DPL_OK);
+         return true;
+@@ -150,7 +179,7 @@ rx_timeout_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+         return false;
+ 
+     if(dpl_sem_get_count(&nrng->sem) == 0){
+-        NRNG_STATS_INC(rx_timeout);
++        SS_STATS_INC(rx_timeout);
+         // In the case of a NRNG timeout is used to mark the end of the request
+         // and is used to call the completion callback
+         if(!(SLIST_EMPTY(&inst->interface_cbs))){
+@@ -179,7 +208,7 @@ reset_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+     if(dpl_sem_get_count(&nrng->sem) == 0){
+         dpl_error_t err = dpl_sem_release(&nrng->sem);
+         assert(err == DPL_OK);
+-        NRNG_STATS_INC(reset);
++        SS_STATS_INC(reset);
+         return true;
+     }
+     else
+@@ -203,7 +232,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+ 
+     if(dpl_sem_get_count(&nrng->sem) == 1){
+         // unsolicited inbound
+-        NRNG_STATS_INC(rx_unsolicited);
++        SS_STATS_INC(rx_unsolicited);
+         return false;
+     }
+ 
+@@ -213,7 +242,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+     if (_frame->dst_address != inst->my_short_address && _frame->dst_address != UWB_BROADCAST_ADDRESS)
+         return true;
+ 
+-    NRNG_STATS_INC(rx_complete);
++    SS_STATS_INC(rx_complete);
+ 
+     switch(_frame->code){
+         case UWB_DATA_CODE_SS_TWR_NRNG:
+diff --git a/lib/twr_ss_nrng/syscfg.yml b/lib/twr_ss_nrng/syscfg.yml
+index 7ef5969..a296efd 100644
+--- a/lib/twr_ss_nrng/syscfg.yml
++++ b/lib/twr_ss_nrng/syscfg.yml
+@@ -12,6 +12,9 @@ syscfg.defs:
+         value: ((uint16_t)0x10)
+       TWR_SS_NRNG_TX_GUARD_DELAY:
+         value: ((uint32_t)0x120)
++      TWR_SS_NRNG_STATS:
++        description: 'Enable statistics for the twr_ss_nrng module'
++        value: 1
+       CELL_ENABLED:
+         description: 'Cell network model on slot decoding'
+         value: 1
+-- 
+2.28.0
+

--- a/pkg/uwb-core/patches/0003-lib-tofdb-use-DPL_ENOENT-instead-of-OS_ENOENT.patch
+++ b/pkg/uwb-core/patches/0003-lib-tofdb-use-DPL_ENOENT-instead-of-OS_ENOENT.patch
@@ -1,0 +1,25 @@
+From 478d952b17c33ed5644172c9b4aebf4cdf7bec62 Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Fri, 14 Aug 2020 15:04:20 +0200
+Subject: [PATCH 3/7] lib/tofdb/: use DPL_ENOENT instead of OS_ENOENT
+
+---
+ lib/tofdb/src/tofdb.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/tofdb/src/tofdb.c b/lib/tofdb/src/tofdb.c
+index e6c8015..7d75942 100644
+--- a/lib/tofdb/src/tofdb.c
++++ b/lib/tofdb/src/tofdb.c
+@@ -28,7 +28,7 @@ int tofdb_get_tof(uint16_t addr, uint32_t *tof)
+             goto ret;
+         }
+     }
+-    return OS_ENOENT;
++    return DPL_ENOENT;
+ ret:
+     return OS_OK;
+ }
+-- 
+2.28.0
+

--- a/pkg/uwb-core/patches/0004-sys-uwbcfg-use-DPL_ENOENT-instead-of-OS_ENOENT.patch
+++ b/pkg/uwb-core/patches/0004-sys-uwbcfg-use-DPL_ENOENT-instead-of-OS_ENOENT.patch
@@ -1,0 +1,25 @@
+From 2304bef6c63b15411fae3050554edc0538ae93d9 Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Fri, 14 Aug 2020 15:08:22 +0200
+Subject: [PATCH 4/7] sys/uwbcfg: use DPL_ENOENT instead of OS_ENOENT
+
+---
+ sys/uwbcfg/src/uwbcfg.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sys/uwbcfg/src/uwbcfg.c b/sys/uwbcfg/src/uwbcfg.c
+index 595c19b..4c4678e 100644
+--- a/sys/uwbcfg/src/uwbcfg.c
++++ b/sys/uwbcfg/src/uwbcfg.c
+@@ -149,7 +149,7 @@ uwbcfg_set(int argc, char **argv, char *val)
+                 return CONF_VALUE_SET(val, CONF_STRING, g_uwb_config[i]);
+         }
+     }
+-    return OS_ENOENT;
++    return DPL_ENOENT;
+ }
+ 
+ char*
+-- 
+2.28.0
+

--- a/pkg/uwb-core/patches/0005-treewide-use-dpl_log.h-instaed-of-log.h-to-avoid-con.patch
+++ b/pkg/uwb-core/patches/0005-treewide-use-dpl_log.h-instaed-of-log.h-to-avoid-con.patch
@@ -1,0 +1,78 @@
+From 86db74c73938d86a3bcf581af2174991cef632fe Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Fri, 14 Aug 2020 15:11:06 +0200
+Subject: [PATCH 5/7] treewide: use dpl_log.h instaed of log.h to avoid
+ conflict
+
+---
+ lib/panmaster/src/panmaster.c | 10 +++++-----
+ sys/uwbcfg/src/uwbcfg.c       |  2 +-
+ sys/uwbcfg/src/uwbcfg_priv.h  | 10 +++++-----
+ 3 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/lib/panmaster/src/panmaster.c b/lib/panmaster/src/panmaster.c
+index a1234b6..f2d9fef 100644
+--- a/lib/panmaster/src/panmaster.c
++++ b/lib/panmaster/src/panmaster.c
+@@ -2,7 +2,7 @@
+ #include <dpl/dpl.h>
+ #include <syscfg/syscfg.h>
+ #include <sysinit/sysinit.h>
+-#include <log/log.h>
++#include <log/dpl_log.h>
+ #include <config/config.h>
+ 
+ #include "panmaster/panmaster.h"
+@@ -23,10 +23,10 @@ static uint16_t pan_id = 0x0000;
+ static volatile int nodes_loaded = 0;
+ 
+ #define LOG_MODULE_PAN_MASTER (91)
+-#define PM_INFO(...)     LOG_INFO(&_log, LOG_MODULE_PAN_MASTER, __VA_ARGS__)
+-#define PM_DEBUG(...)    LOG_DEBUG(&_log, LOG_MODULE_PAN_MASTER, __VA_ARGS__)
+-#define PM_WARN(...)     LOG_WARN(&_log, LOG_MODULE_PAN_MASTER, __VA_ARGS__)
+-#define PM_ERR(...)      LOG_ERROR(&_log, LOG_MODULE_PAN_MASTER, __VA_ARGS__)
++#define PM_INFO(...)     LOG_INFO(__VA_ARGS__)
++#define PM_DEBUG(...)    LOG_DEBUG(__VA_ARGS__)
++#define PM_WARN(...)     LOG_WARN(__VA_ARGS__)
++#define PM_ERR(...)      LOG_ERROR(__VA_ARGS__)
+ static struct log _log;
+ 
+ /*
+diff --git a/sys/uwbcfg/src/uwbcfg.c b/sys/uwbcfg/src/uwbcfg.c
+index 4c4678e..c7c97ea 100644
+--- a/sys/uwbcfg/src/uwbcfg.c
++++ b/sys/uwbcfg/src/uwbcfg.c
+@@ -21,7 +21,7 @@
+ #include <stdio.h>
+ 
+ #include <dpl/dpl.h>
+-#include <log/log.h>
++#include <log/dpl_log.h>
+ #include <syscfg/syscfg.h>
+ #include <sysinit/sysinit.h>
+ #include <config/config.h>
+diff --git a/sys/uwbcfg/src/uwbcfg_priv.h b/sys/uwbcfg/src/uwbcfg_priv.h
+index 8f7f05b..4158b34 100644
+--- a/sys/uwbcfg/src/uwbcfg_priv.h
++++ b/sys/uwbcfg/src/uwbcfg_priv.h
+@@ -20,12 +20,12 @@
+ #ifndef __UWBCFG_PRIV_H_
+ #define __UWBCFG_PRIV_H_
+ 
+-#include <log/log.h>
++#include <log/dpl_log.h>
+ #define LOG_MODULE_UWBCFG (92)
+-#define UC_INFO(...)     LOG_INFO(&_uwbcfg_log, LOG_MODULE_UWBCFG, __VA_ARGS__)
+-#define UC_DEBUG(...)    LOG_DEBUG(&_uwbcfg_log, LOG_MODULE_UWBCFG, __VA_ARGS__)
+-#define UC_WARN(...)     LOG_WARN(&_uwbcfg_log, LOG_MODULE_UWBCFG, __VA_ARGS__)
+-#define UC_ERR(...)      LOG_ERROR(&_uwbcfg_log, LOG_MODULE_UWBCFG, __VA_ARGS__)
++#define UC_INFO(...)     LOG_INFO(__VA_ARGS__)
++#define UC_DEBUG(...)    LOG_DEBUG(__VA_ARGS__)
++#define UC_WARN(...)     LOG_WARN(__VA_ARGS__)
++#define UC_ERR(...)      LOG_ERROR(__VA_ARGS__)
+ 
+ enum {
+     CFGSTR_CH=0,
+-- 
+2.28.0
+

--- a/pkg/uwb-core/patches/0006-lib-json-src-use-fmt-to-avoid-newlib-issue.patch
+++ b/pkg/uwb-core/patches/0006-lib-json-src-use-fmt-to-avoid-newlib-issue.patch
@@ -1,0 +1,41 @@
+From b7dd28c1fa7610baa00950e8798392102dfd69f9 Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Thu, 17 Sep 2020 17:00:09 +0200
+Subject: [PATCH 6/7] lib/json/src: use fmt to avoid newlib issue
+
+---
+ lib/json/src/json_encode.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/lib/json/src/json_encode.c b/lib/json/src/json_encode.c
+index 4de928e..377fd18 100644
+--- a/lib/json/src/json_encode.c
++++ b/lib/json/src/json_encode.c
+@@ -21,6 +21,8 @@
+ #include <string.h>
+ #include <inttypes.h>
+ 
++#include "fmt.h"
++
+ #ifdef __KERNEL__
+ #include <linux/kernel.h>
+ #else
+@@ -70,13 +72,11 @@ json_encode_value(struct json_encoder *encoder, struct json_value *jv)
+             encoder->je_write(encoder->je_arg, encoder->je_encode_buf, len);
+             break;
+         case JSON_VALUE_TYPE_UINT64:
+-            len = sprintf(encoder->je_encode_buf, "%" PRIu64,
+-                    jv->jv_val.u);
++            len = fmt_u64_dec(encoder->je_encode_buf, jv->jv_val.u);
+             encoder->je_write(encoder->je_arg, encoder->je_encode_buf, len);
+             break;
+         case JSON_VALUE_TYPE_INT64:
+-            len = sprintf(encoder->je_encode_buf, "%" PRIi64,
+-                    jv->jv_val.u);
++            len = fmt_s64_dec(encoder->je_encode_buf, jv->jv_val.u);
+             encoder->je_write(encoder->je_arg, encoder->je_encode_buf, len);
+             break;
+         case JSON_VALUE_TYPE_FLOAT64:
+-- 
+2.28.0
+

--- a/pkg/uwb-core/patches/0007-lib-uwb_rng-always-set-rssi-to-vrssi-0.patch
+++ b/pkg/uwb-core/patches/0007-lib-uwb_rng-always-set-rssi-to-vrssi-0.patch
@@ -1,0 +1,34 @@
+From f51123d3cfcd811090367a65d5bf029897aceb98 Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Mon, 21 Sep 2020 13:42:56 +0200
+Subject: [PATCH 7/7] lib/uwb_rng: always set rssi to vrssi[0]
+
+---
+ lib/uwb_rng/src/uwb_rng.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/lib/uwb_rng/src/uwb_rng.c b/lib/uwb_rng/src/uwb_rng.c
+index ccc91c5..3218f61 100644
+--- a/lib/uwb_rng/src/uwb_rng.c
++++ b/lib/uwb_rng/src/uwb_rng.c
+@@ -981,12 +981,17 @@ complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
+     frame->local.rssi = uwb_calc_rssi(inst, inst->rxdiag);
+     frame->local.fppl = uwb_calc_fppl(inst, inst->rxdiag);
+ 
++
+     if (inst->capabilities.sts) {
+         frame->local.flags.has_sts = inst->config.rx.stsMode != DWT_STS_MODE_OFF;
+         frame->local.flags.has_valid_sts = !(inst->status.sts_ts_error || inst->status.sts_pream_error);
+         frame->local.vrssi[0] = frame->local.rssi;
+         frame->local.vrssi[1] = uwb_calc_seq_rssi(inst, inst->rxdiag, UWB_RXDIAG_STS);
+         frame->local.vrssi[2] = uwb_calc_seq_rssi(inst, inst->rxdiag, UWB_RXDIAG_STS2);
++    } else {
++        frame->local.vrssi[0] = frame->local.rssi;
++        frame->local.vrssi[1] = DPL_FLOAT32_NAN();
++        frame->local.vrssi[2] = DPL_FLOAT32_NAN();
+     }
+ 
+     /* Postprocess in thread context */
+-- 
+2.28.0
+

--- a/pkg/uwb-core/patches/0008-porting-dpl-add-riot-files.patch
+++ b/pkg/uwb-core/patches/0008-porting-dpl-add-riot-files.patch
@@ -1,0 +1,1012 @@
+From 5662eb0df6c47d0e391de43887c7433912863514 Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Tue, 3 Nov 2020 14:12:01 +0100
+Subject: [PATCH 8/8] porting/dpl: add riot files
+
+---
+ porting/dpl/riot/include/config/config.h | 369 ++++++++++++++++
+ porting/dpl/riot/include/dpl/queue.h     | 525 +++++++++++++++++++++++
+ porting/dpl/riot/src/config.c            |  83 ++++
+ 3 files changed, 977 insertions(+)
+ create mode 100644 porting/dpl/riot/include/config/config.h
+ create mode 100644 porting/dpl/riot/include/dpl/queue.h
+ create mode 100644 porting/dpl/riot/src/config.c
+
+diff --git a/porting/dpl/riot/include/config/config.h b/porting/dpl/riot/include/config/config.h
+new file mode 100644
+index 0000000..4dc4b69
+--- /dev/null
++++ b/porting/dpl/riot/include/config/config.h
+@@ -0,0 +1,369 @@
++/*
++ * Licensed to the Apache Software Foundation (ASF) under one
++ * or more contributor license agreements.  See the NOTICE file
++ * distributed with this work for additional information
++ * regarding copyright ownership.  The ASF licenses this file
++ * to you under the Apache License, Version 2.0 (the
++ * "License"); you may not use this file except in compliance
++ * with the License.  You may obtain a copy of the License at
++ *
++ *  http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing,
++ * software distributed under the License is distributed on an
++ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
++ * KIND, either express or implied.  See the License for the
++ * specific language governing permissions and limitations
++ * under the License.
++ */
++#ifndef __SYS_CONFIG_H_
++#define __SYS_CONFIG_H_
++
++/**
++ * @addtogroup SysConfig Configuration of Apache Mynewt System
++ * @{
++ */
++
++#include <errno.h>
++#include <dpl/queue.h>
++#include <stdio.h>
++#include <stdint.h>
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++/** @cond INTERNAL_HIDDEN */
++
++#define CONF_MAX_DIR_DEPTH	8	/* max depth of config tree */
++#define CONF_MAX_NAME_LEN	(8 * CONF_MAX_DIR_DEPTH)
++#define CONF_MAX_VAL_LEN	256
++#define CONF_NAME_SEPARATOR	"/"
++
++#define CONF_NMGR_OP		0
++
++/** @endcond */
++
++/**
++ * Type of configuration value.
++ */
++typedef enum conf_type {
++    CONF_NONE = 0,
++    CONF_DIR,
++    /** 8-bit signed integer */
++    CONF_INT8,
++    /** 16-bit signed integer */
++    CONF_INT16,
++    /** 32-bit signed integer */
++    CONF_INT32,
++    /** 64-bit signed integer */
++    CONF_INT64,
++    /** String */
++    CONF_STRING,
++    /** Bytes */
++    CONF_BYTES,
++    /** Floating point */
++    CONF_FLOAT,
++    /** Double precision */
++    CONF_DOUBLE,
++    /** Boolean */
++    CONF_BOOL,
++} __attribute__((__packed__)) conf_type_t;
++
++/**
++ * Parameter to commit handler describing where data is going to.
++ */
++enum conf_export_tgt {
++    /** Value is to be persisted */
++    CONF_EXPORT_PERSIST,
++    /** Value is to be display */
++    CONF_EXPORT_SHOW
++};
++
++typedef enum conf_export_tgt conf_export_tgt_t;
++
++/**
++ * Handler for getting configuration items, this handler is called
++ * per-configuration section.  Configuration sections are delimited
++ * by '/', for example:
++ *
++ *  - section/name/value
++ *
++ * Would be passed as:
++ *
++ *  - argc = 3
++ *  - argv[0] = section
++ *  - argv[1] = name
++ *  - argv[2] = value
++ *
++ * The handler returns the value into val, null terminated, up to
++ * val_len_max.
++ *
++ * @param argc          The number of sections in the configuration variable
++ * @param argv          The array of configuration sections
++ * @param val           A pointer to the buffer to return the configuration
++ *                      value into.
++ * @param val_len_max   The maximum length of the val buffer to copy into.
++ *
++ * @return A pointer to val or NULL if error.
++ */
++typedef char *(*conf_get_handler_t)(int argc, char **argv, char *val, int val_len_max);
++
++/**
++ * Set the configuration variable pointed to by argc and argv.  See
++ * description of ch_get_handler_t for format of these variables.  This sets the
++ * configuration variable to the shadow value, but does not apply the configuration
++ * change.  In order to apply the change, call the ch_commit() handler.
++ *
++ * @param argc   The number of sections in the configuration variable.
++ * @param argv   The array of configuration sections
++ * @param val    The value to configure that variable to
++ *
++ * @return 0 on success, non-zero error code on failure.
++ */
++typedef int (*conf_set_handler_t)(int argc, char **argv, char *val);
++
++/**
++ * Commit shadow configuration state to the active configuration.
++ *
++ * @return 0 on success, non-zero error code on failure.
++ */
++typedef int (*conf_commit_handler_t)(void);
++
++/**
++ * Called per-configuration variable being exported.
++ *
++ * @param name The name of the variable to export
++ * @param val  The value of the variable to export
++ */
++typedef void (*conf_export_func_t)(char *name, char *val);
++
++/**
++ * Export all of the configuration variables, calling the export_func
++ * per variable being exported.
++ *
++ * @param export_func  The export function to call.
++ * @param tgt          The target of the export, either for persistence or display.
++ *
++ * @return 0 on success, non-zero error code on failure.
++ */
++typedef int (*conf_export_handler_t)(conf_export_func_t export_func,
++        conf_export_tgt_t tgt);
++
++/**
++ * Configuration handler, used to register a config item/subtree.
++ */
++struct conf_handler {
++    SLIST_ENTRY(conf_handler) ch_list;
++    /**
++     * The name of the conifguration item/subtree
++     */
++    char *ch_name;
++    /** Get configuration value */
++    conf_get_handler_t ch_get;
++    /** Set configuration value */
++    conf_set_handler_t ch_set;
++    /** Commit configuration value */
++    conf_commit_handler_t ch_commit;
++    /** Export configuration value */
++    conf_export_handler_t ch_export;
++};
++
++void conf_init(void);
++void conf_store_init(void);
++
++/**
++ * Register a handler for configurations items.
++ *
++ * @param cf Structure containing registration info.
++ *
++ * @return 0 on success, non-zero on failure.
++ */
++//int conf_register(struct conf_handler *cf);
++#define conf_register(__A) printf("%s:%d not implemented", __func__, __LINE__)
++
++/**
++ * Load configuration from registered persistence sources. Handlers for
++ * configuration subtrees registered earlier will be called for encountered
++ * values.
++ *
++ * @return 0 on success, non-zero on failure.
++ */
++int conf_load(void);
++
++/**
++ * Load configuration from a specific registered persistence source.
++ * Handlers will be called for configuration subtree for
++ * encountered values.
++ *
++ * @param name of the configuration subtree.
++ * @return 0 on success, non-zero on failure.
++ */
++int conf_load_one(char *name);
++
++/**
++ * @brief Loads the configuration if it hasn't been loaded since reboot.
++ *
++ * @return 0 on success, non-zero on failure.
++ */
++int conf_ensure_loaded(void);
++
++/**
++ * Config setting comes as a result of conf_load().
++ *
++ * @return 1 if yes, 0 if not.
++ */
++int conf_set_from_storage(void);
++
++/**
++ * Save currently running configuration. All configuration which is different
++ * from currently persisted values will be saved.
++ *
++ * @return 0 on success, non-zero on failure.
++ */
++int conf_save(void);
++
++/**
++ * Save currently running configuration for configuration subtree.
++ *
++ * @param name Name of the configuration subtree.
++ *
++ * @return 0 on success, non-zero on failure.
++ */
++int conf_save_tree(char *name);
++
++/**
++ * Write a single configuration value to persisted storage (if it has
++ * changed value).
++ *
++ * @param name Name/key of the configuration item.
++ * @param var Value of the configuration item.
++ *
++ * @return 0 on success, non-zero on failure.
++ */
++int conf_save_one(const char *name, char *var);
++
++/**
++ * Set configuration item identified by @p name to be value @p val_str.
++ * This finds the configuration handler for this subtree and calls it's
++ * set handler.
++ *
++ * @param name Name/key of the configuration item.
++ * @param val_str Value of the configuration item.
++ *
++ * @return 0 on success, non-zero on failure.
++ */
++int conf_set_value(char *name, char *val_str);
++
++/**
++ * Get value of configuration item identified by @p name.
++ * This calls the configuration handler ch_get for the subtree.
++ *
++ * Configuration handler can copy the string to @p buf, the maximum
++ * number of bytes it will copy is limited by @p buf_len.
++ *
++ * Return value will be pointer to beginning of the value. Note that
++ * this might, or might not be the same as buf.
++ *
++ * @param name Name/key of the configuration item.
++ * @param val_str Value of the configuration item.
++ *
++ * @return pointer to value on success, NULL on failure.
++ */
++char *conf_get_value(char *name, char *buf, int buf_len);
++
++/**
++ * Get stored value of configuration item identified by @p name.
++ * This traverses the configuration area(s), and copies the value
++ * of the latest value.
++ *
++ * Value is copied to @p buf, the maximum number of bytes it will copy is
++ * limited by @p buf_len.
++ *
++ * @param name Name/key of the configuration item.
++ * @param val_str Value of the configuration item.
++ *
++ * @return 0 on success, non-zero on failure.
++ */
++int conf_get_stored_value(char *name, char *buf, int buf_len);
++
++/**
++ * Call commit for all configuration handler. This should apply all
++ * configuration which has been set, but not applied yet.
++ *
++ * @param name Name of the configuration subtree, or NULL to commit everything.
++ *
++ * @return 0 on success, non-zero on failure.
++ */
++int conf_commit(char *name);
++
++/**
++ * Convenience routine for converting value passed as a string to native
++ * data type.
++ *
++ * @param val_str Value of the configuration item as string.
++ * @param type Type of the value to convert to.
++ * @param vp Pointer to variable to fill with the decoded value.
++ * @param vp Size of that variable.
++ *
++ * @return 0 on success, non-zero on failure.
++ */
++int conf_value_from_str(char *val_str, enum conf_type type, void *vp,
++                        int maxlen);
++
++/**
++ * Convenience routine for converting byte array passed as a base64
++ * encoded string.
++ *
++ * @param val_str Value of the configuration item as string.
++ * @param vp Pointer to variable to fill with the decoded value.
++ * @param len Size of that variable. On return the number of bytes in the array.
++ *
++ * @return 0 on success, non-zero on failure.
++ */
++int conf_bytes_from_str(char *val_str, void *vp, int *len);
++
++/**
++ * Convenience routine for converting native data type to a string.
++ *
++ * @param type Type of the value to convert from.
++ * @param vp Pointer to variable to convert.
++ * @param buf Buffer where string value will be stored.
++ * @param buf_len Size of the buffer.
++ *
++ * @return 0 on success, non-zero on failure.
++ */
++char *conf_str_from_value(enum conf_type type, void *vp, char *buf,
++  int buf_len);
++
++/** Return the length of a configuration string from buffer length. */
++#define CONF_STR_FROM_BYTES_LEN(len) (((len) * 4 / 3) + 4)
++
++/**
++ * Convenience routine for converting byte array into a base64
++ * encoded string.
++ *
++ * @param vp Pointer to variable to convert.
++ * @param vp_len Number of bytes to convert.
++ * @param buf Buffer where string value will be stored.
++ * @param buf_len Size of the buffer.
++ *
++ * @return 0 on success, non-zero on failure.
++ */
++char *conf_str_from_bytes(void *vp, int vp_len, char *buf, int buf_len);
++
++/**
++ * Convert a string into a value of type
++ */
++#define CONF_VALUE_SET(str, type, val)                                  \
++    conf_value_from_str((str), (type), &(val), sizeof(val))
++
++#ifdef __cplusplus
++}
++#endif
++
++/**
++ * @} SysConfig
++ */
++
++#endif /* __SYS_CONFIG_H_ */
+diff --git a/porting/dpl/riot/include/dpl/queue.h b/porting/dpl/riot/include/dpl/queue.h
+new file mode 100644
+index 0000000..4e74970
+--- /dev/null
++++ b/porting/dpl/riot/include/dpl/queue.h
+@@ -0,0 +1,525 @@
++/*
++ * Copyright (c) 1991, 1993
++ *    The Regents of the University of California.  All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ * 1. Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ * 2. Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in the
++ *    documentation and/or other materials provided with the distribution.
++ * 4. Neither the name of the University nor the names of its contributors
++ *    may be used to endorse or promote products derived from this software
++ *    without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
++ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
++ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
++ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
++ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
++ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
++ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ *
++ *    @(#)queue.h    8.5 (Berkeley) 8/20/94
++ * $FreeBSD: src/sys/sys/queue.h,v 1.32.2.7 2002/04/17 14:21:02 des Exp $
++ */
++
++#ifndef DPL_QUEUE_H
++#define DPL_QUEUE_H
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++/*
++ * This file defines five types of data structures: singly-linked lists,
++ * singly-linked tail queues, lists, tail queues, and circular queues.
++ *
++ * A singly-linked list is headed by a single forward pointer. The elements
++ * are singly linked for minimum space and pointer manipulation overhead at
++ * the expense of O(n) removal for arbitrary elements. New elements can be
++ * added to the list after an existing element or at the head of the list.
++ * Elements being removed from the head of the list should use the explicit
++ * macro for this purpose for optimum efficiency. A singly-linked list may
++ * only be traversed in the forward direction.  Singly-linked lists are ideal
++ * for applications with large datasets and few or no removals or for
++ * implementing a LIFO queue.
++ *
++ * A singly-linked tail queue is headed by a pair of pointers, one to the
++ * head of the list and the other to the tail of the list. The elements are
++ * singly linked for minimum space and pointer manipulation overhead at the
++ * expense of O(n) removal for arbitrary elements. New elements can be added
++ * to the list after an existing element, at the head of the list, or at the
++ * end of the list. Elements being removed from the head of the tail queue
++ * should use the explicit macro for this purpose for optimum efficiency.
++ * A singly-linked tail queue may only be traversed in the forward direction.
++ * Singly-linked tail queues are ideal for applications with large datasets
++ * and few or no removals or for implementing a FIFO queue.
++ *
++ * A list is headed by a single forward pointer (or an array of forward
++ * pointers for a hash table header). The elements are doubly linked
++ * so that an arbitrary element can be removed without a need to
++ * traverse the list. New elements can be added to the list before
++ * or after an existing element or at the head of the list. A list
++ * may only be traversed in the forward direction.
++ *
++ * A tail queue is headed by a pair of pointers, one to the head of the
++ * list and the other to the tail of the list. The elements are doubly
++ * linked so that an arbitrary element can be removed without a need to
++ * traverse the list. New elements can be added to the list before or
++ * after an existing element, at the head of the list, or at the end of
++ * the list. A tail queue may be traversed in either direction.
++ *
++ * A circle queue is headed by a pair of pointers, one to the head of the
++ * list and the other to the tail of the list. The elements are doubly
++ * linked so that an arbitrary element can be removed without a need to
++ * traverse the list. New elements can be added to the list before or after
++ * an existing element, at the head of the list, or at the end of the list.
++ * A circle queue may be traversed in either direction, but has a more
++ * complex end of list detection.
++ *
++ * For details on the use of these macros, see the queue(3) manual page.
++ *
++ *
++ *                      SLIST   LIST    STAILQ  TAILQ   CIRCLEQ
++ * _HEAD                +       +       +       +       +
++ * _HEAD_INITIALIZER    +       +       +       +       +
++ * _ENTRY               +       +       +       +       +
++ * _INIT                +       +       +       +       +
++ * _EMPTY               +       +       +       +       +
++ * _FIRST               +       +       +       +       +
++ * _NEXT                +       +       +       +       +
++ * _PREV                -       -       -       +       +
++ * _LAST                -       -       +       +       +
++ * _FOREACH             +       +       +       +       +
++ * _FOREACH_REVERSE     -       -       -       +       +
++ * _INSERT_HEAD         +       +       +       +       +
++ * _INSERT_BEFORE       -       +       -       +       +
++ * _INSERT_AFTER        +       +       +       +       +
++ * _INSERT_TAIL         -       -       +       +       +
++ * _REMOVE_HEAD         +       -       +       -       -
++ * _REMOVE              +       +       +       +       +
++ *
++ */
++
++/*
++ * Singly-linked List declarations.
++ */
++#define    SLIST_HEAD(name, type)                          \
++struct name {                                           \
++    struct type *slh_first;    /* first element */         \
++}
++
++#define    SLIST_HEAD_INITIALIZER(head)                    \
++    { NULL }
++
++#define    SLIST_ENTRY(type)                               \
++struct {                                                \
++    struct type *sle_next;  /* next element */          \
++}
++
++/*
++ * Singly-linked List functions.
++ */
++#define SLIST_EMPTY(head)   ((head)->slh_first == NULL)
++
++#define SLIST_FIRST(head)   ((head)->slh_first)
++
++#define SLIST_FOREACH(var, head, field)                 \
++    for ((var) = SLIST_FIRST((head));                   \
++        (var);                                          \
++        (var) = SLIST_NEXT((var), field))
++
++#define SLIST_INIT(head) do {                           \
++        SLIST_FIRST((head)) = NULL;                     \
++} while (0)
++
++#define SLIST_INSERT_AFTER(slistelm, elm, field) do {           \
++    SLIST_NEXT((elm), field) = SLIST_NEXT((slistelm), field);   \
++    SLIST_NEXT((slistelm), field) = (elm);                      \
++} while (0)
++
++#define SLIST_INSERT_HEAD(head, elm, field) do {            \
++    SLIST_NEXT((elm), field) = SLIST_FIRST((head));         \
++    SLIST_FIRST((head)) = (elm);                            \
++} while (0)
++
++#define SLIST_NEXT(elm, field)    ((elm)->field.sle_next)
++
++#define SLIST_REMOVE(head, elm, type, field) do {           \
++    if (SLIST_FIRST((head)) == (elm)) {                     \
++        SLIST_REMOVE_HEAD((head), field);                   \
++    }                                                       \
++    else {                                                  \
++        struct type *curelm = SLIST_FIRST((head));          \
++        while (SLIST_NEXT(curelm, field) != (elm))          \
++            curelm = SLIST_NEXT(curelm, field);             \
++        SLIST_NEXT(curelm, field) =                         \
++            SLIST_NEXT(SLIST_NEXT(curelm, field), field);   \
++    }                                                       \
++} while (0)
++
++#define SLIST_REMOVE_HEAD(head, field) do {                         \
++    SLIST_FIRST((head)) = SLIST_NEXT(SLIST_FIRST((head)), field);   \
++} while (0)
++
++/*
++ * Singly-linked Tail queue declarations.
++ */
++#define    STAILQ_HEAD(name, type)                        \
++struct name {                                \
++    struct type *stqh_first;/* first element */            \
++    struct type **stqh_last;/* addr of last next element */        \
++}
++
++#define    STAILQ_HEAD_INITIALIZER(head)                    \
++    { NULL, &(head).stqh_first }
++
++#define    STAILQ_ENTRY(type)                        \
++struct {                                \
++    struct type *stqe_next;    /* next element */            \
++}
++
++/*
++ * Singly-linked Tail queue functions.
++ */
++#define    STAILQ_EMPTY(head)    ((head)->stqh_first == NULL)
++
++#define    STAILQ_FIRST(head)    ((head)->stqh_first)
++
++#define    STAILQ_FOREACH(var, head, field)                \
++    for((var) = STAILQ_FIRST((head));                \
++       (var);                            \
++       (var) = STAILQ_NEXT((var), field))
++
++#define    STAILQ_INIT(head) do {                        \
++    STAILQ_FIRST((head)) = NULL;                    \
++    (head)->stqh_last = &STAILQ_FIRST((head));            \
++} while (0)
++
++#define    STAILQ_INSERT_AFTER(head, tqelm, elm, field) do {        \
++    if ((STAILQ_NEXT((elm), field) = STAILQ_NEXT((tqelm), field)) == NULL)\
++        (head)->stqh_last = &STAILQ_NEXT((elm), field);        \
++    STAILQ_NEXT((tqelm), field) = (elm);                \
++} while (0)
++
++#define    STAILQ_INSERT_HEAD(head, elm, field) do {            \
++    if ((STAILQ_NEXT((elm), field) = STAILQ_FIRST((head))) == NULL)    \
++        (head)->stqh_last = &STAILQ_NEXT((elm), field);        \
++    STAILQ_FIRST((head)) = (elm);                    \
++} while (0)
++
++#define    STAILQ_INSERT_TAIL(head, elm, field) do {            \
++    STAILQ_NEXT((elm), field) = NULL;                \
++    *(head)->stqh_last = (elm);                    \
++    (head)->stqh_last = &STAILQ_NEXT((elm), field);            \
++} while (0)
++
++#define    STAILQ_LAST(head, type, field)                    \
++    (STAILQ_EMPTY(head) ?                        \
++        NULL :                            \
++            ((struct type *)                    \
++        ((char *)((head)->stqh_last) - offsetof(struct type, field))))
++
++#define    STAILQ_NEXT(elm, field)    ((elm)->field.stqe_next)
++
++#define    STAILQ_REMOVE(head, elm, type, field) do {            \
++    if (STAILQ_FIRST((head)) == (elm)) {                \
++        STAILQ_REMOVE_HEAD(head, field);            \
++    }                                \
++    else {                                \
++        struct type *curelm = STAILQ_FIRST((head));        \
++        while (STAILQ_NEXT(curelm, field) != (elm))        \
++            curelm = STAILQ_NEXT(curelm, field);        \
++        if ((STAILQ_NEXT(curelm, field) =            \
++             STAILQ_NEXT(STAILQ_NEXT(curelm, field), field)) == NULL)\
++            (head)->stqh_last = &STAILQ_NEXT((curelm), field);\
++    }                                \
++} while (0)
++
++#define    STAILQ_REMOVE_HEAD(head, field) do {                \
++    if ((STAILQ_FIRST((head)) =                    \
++         STAILQ_NEXT(STAILQ_FIRST((head)), field)) == NULL)        \
++        (head)->stqh_last = &STAILQ_FIRST((head));        \
++} while (0)
++
++#define    STAILQ_REMOVE_HEAD_UNTIL(head, elm, field) do {            \
++    if ((STAILQ_FIRST((head)) = STAILQ_NEXT((elm), field)) == NULL)    \
++        (head)->stqh_last = &STAILQ_FIRST((head));        \
++} while (0)
++
++#define STAILQ_REMOVE_AFTER(head, elm, field) do {            \
++    if ((STAILQ_NEXT(elm, field) =                    \
++         STAILQ_NEXT(STAILQ_NEXT(elm, field), field)) == NULL)    \
++        (head)->stqh_last = &STAILQ_NEXT((elm), field);        \
++} while (0)
++
++
++#ifndef __KERNEL__
++/*
++ * List declarations.
++ */
++#define    LIST_HEAD(name, type)                        \
++struct name {                                \
++    struct type *lh_first;    /* first element */            \
++}
++
++#define    LIST_HEAD_INITIALIZER(head)                    \
++    { NULL }
++
++#define    LIST_ENTRY(type)                        \
++struct {                                \
++    struct type *le_next;    /* next element */            \
++    struct type **le_prev;    /* address of previous next element */    \
++}
++
++/*
++ * List functions.
++ */
++
++#define    LIST_EMPTY(head)    ((head)->lh_first == NULL)
++
++#define    LIST_FIRST(head)    ((head)->lh_first)
++
++#define    LIST_FOREACH(var, head, field)                    \
++    for ((var) = LIST_FIRST((head));                \
++        (var);                            \
++        (var) = LIST_NEXT((var), field))
++
++#define    LIST_INIT(head) do {                        \
++    LIST_FIRST((head)) = NULL;                    \
++} while (0)
++
++#define    LIST_INSERT_AFTER(listelm, elm, field) do {            \
++    if ((LIST_NEXT((elm), field) = LIST_NEXT((listelm), field)) != NULL)\
++        LIST_NEXT((listelm), field)->field.le_prev =        \
++            &LIST_NEXT((elm), field);                \
++    LIST_NEXT((listelm), field) = (elm);                \
++    (elm)->field.le_prev = &LIST_NEXT((listelm), field);        \
++} while (0)
++
++#define    LIST_INSERT_BEFORE(listelm, elm, field) do {            \
++    (elm)->field.le_prev = (listelm)->field.le_prev;        \
++    LIST_NEXT((elm), field) = (listelm);                \
++    *(listelm)->field.le_prev = (elm);                \
++    (listelm)->field.le_prev = &LIST_NEXT((elm), field);        \
++} while (0)
++
++#define    LIST_INSERT_HEAD(head, elm, field) do {                \
++    if ((LIST_NEXT((elm), field) = LIST_FIRST((head))) != NULL)    \
++        LIST_FIRST((head))->field.le_prev = &LIST_NEXT((elm), field);\
++    LIST_FIRST((head)) = (elm);                    \
++    (elm)->field.le_prev = &LIST_FIRST((head));            \
++} while (0)
++
++#define    LIST_NEXT(elm, field)    ((elm)->field.le_next)
++
++#define    LIST_REMOVE(elm, field) do {                    \
++    if (LIST_NEXT((elm), field) != NULL)                \
++        LIST_NEXT((elm), field)->field.le_prev =         \
++            (elm)->field.le_prev;                \
++    *(elm)->field.le_prev = LIST_NEXT((elm), field);        \
++} while (0)
++#endif
++
++/*
++ * Tail queue declarations.
++ */
++#define    TAILQ_HEAD(name, type)                        \
++struct name {                                \
++    struct type *tqh_first;    /* first element */            \
++    struct type **tqh_last;    /* addr of last next element */        \
++}
++
++#define    TAILQ_HEAD_INITIALIZER(head)                    \
++    { NULL, &(head).tqh_first }
++
++#define    TAILQ_ENTRY(type)                        \
++struct {                                \
++    struct type *tqe_next;    /* next element */            \
++    struct type **tqe_prev;    /* address of previous next element */    \
++}
++
++/*
++ * Tail queue functions.
++ */
++#define    TAILQ_EMPTY(head)    ((head)->tqh_first == NULL)
++
++#define    TAILQ_FIRST(head)    ((head)->tqh_first)
++
++#define    TAILQ_FOREACH(var, head, field)                    \
++    for ((var) = TAILQ_FIRST((head));                \
++        (var);                            \
++        (var) = TAILQ_NEXT((var), field))
++
++#define    TAILQ_FOREACH_REVERSE(var, head, headname, field)        \
++    for ((var) = TAILQ_LAST((head), headname);            \
++        (var);                            \
++        (var) = TAILQ_PREV((var), headname, field))
++
++#define    TAILQ_INIT(head) do {                        \
++    TAILQ_FIRST((head)) = NULL;                    \
++    (head)->tqh_last = &TAILQ_FIRST((head));            \
++} while (0)
++
++#define    TAILQ_INSERT_AFTER(head, listelm, elm, field) do {        \
++    if ((TAILQ_NEXT((elm), field) = TAILQ_NEXT((listelm), field)) != NULL)\
++        TAILQ_NEXT((elm), field)->field.tqe_prev =         \
++            &TAILQ_NEXT((elm), field);                \
++    else                                \
++        (head)->tqh_last = &TAILQ_NEXT((elm), field);        \
++    TAILQ_NEXT((listelm), field) = (elm);                \
++    (elm)->field.tqe_prev = &TAILQ_NEXT((listelm), field);        \
++} while (0)
++
++#define    TAILQ_INSERT_BEFORE(listelm, elm, field) do {            \
++    (elm)->field.tqe_prev = (listelm)->field.tqe_prev;        \
++    TAILQ_NEXT((elm), field) = (listelm);                \
++    *(listelm)->field.tqe_prev = (elm);                \
++    (listelm)->field.tqe_prev = &TAILQ_NEXT((elm), field);        \
++} while (0)
++
++#define    TAILQ_INSERT_HEAD(head, elm, field) do {            \
++    if ((TAILQ_NEXT((elm), field) = TAILQ_FIRST((head))) != NULL)    \
++        TAILQ_FIRST((head))->field.tqe_prev =            \
++            &TAILQ_NEXT((elm), field);                \
++    else                                \
++        (head)->tqh_last = &TAILQ_NEXT((elm), field);        \
++    TAILQ_FIRST((head)) = (elm);                    \
++    (elm)->field.tqe_prev = &TAILQ_FIRST((head));            \
++} while (0)
++
++#define    TAILQ_INSERT_TAIL(head, elm, field) do {            \
++    TAILQ_NEXT((elm), field) = NULL;                \
++    (elm)->field.tqe_prev = (head)->tqh_last;            \
++    *(head)->tqh_last = (elm);                    \
++    (head)->tqh_last = &TAILQ_NEXT((elm), field);            \
++} while (0)
++
++#define    TAILQ_LAST(head, headname)                    \
++    (*(((struct headname *)((head)->tqh_last))->tqh_last))
++
++#define    TAILQ_NEXT(elm, field) ((elm)->field.tqe_next)
++
++#define    TAILQ_PREV(elm, headname, field)                \
++    (*(((struct headname *)((elm)->field.tqe_prev))->tqh_last))
++
++#define    TAILQ_REMOVE(head, elm, field) do {                \
++    if ((TAILQ_NEXT((elm), field)) != NULL)                \
++        TAILQ_NEXT((elm), field)->field.tqe_prev =         \
++            (elm)->field.tqe_prev;                \
++    else                                \
++        (head)->tqh_last = (elm)->field.tqe_prev;        \
++    *(elm)->field.tqe_prev = TAILQ_NEXT((elm), field);        \
++} while (0)
++
++/*
++ * Circular queue declarations.
++ */
++#define    CIRCLEQ_HEAD(name, type)                    \
++struct name {                                \
++    struct type *cqh_first;        /* first element */        \
++    struct type *cqh_last;        /* last element */        \
++}
++
++#define    CIRCLEQ_HEAD_INITIALIZER(head)                    \
++    { (void *)&(head), (void *)&(head) }
++
++#define    CIRCLEQ_ENTRY(type)                        \
++struct {                                \
++    struct type *cqe_next;        /* next element */        \
++    struct type *cqe_prev;        /* previous element */        \
++}
++
++/*
++ * Circular queue functions.
++ */
++#define    CIRCLEQ_EMPTY(head)    ((head)->cqh_first == (void *)(head))
++
++#define    CIRCLEQ_FIRST(head)    ((head)->cqh_first)
++
++#define    CIRCLEQ_FOREACH(var, head, field)                \
++    for ((var) = CIRCLEQ_FIRST((head));                \
++        (var) != (void *)(head) || ((var) = NULL);            \
++        (var) = CIRCLEQ_NEXT((var), field))
++
++#define    CIRCLEQ_FOREACH_REVERSE(var, head, field)            \
++    for ((var) = CIRCLEQ_LAST((head));                \
++        (var) != (void *)(head) || ((var) = NULL);            \
++        (var) = CIRCLEQ_PREV((var), field))
++
++#define    CIRCLEQ_INIT(head) do {                        \
++    CIRCLEQ_FIRST((head)) = (void *)(head);                \
++    CIRCLEQ_LAST((head)) = (void *)(head);                \
++} while (0)
++
++#define    CIRCLEQ_INSERT_AFTER(head, listelm, elm, field) do {        \
++    CIRCLEQ_NEXT((elm), field) = CIRCLEQ_NEXT((listelm), field);    \
++    CIRCLEQ_PREV((elm), field) = (listelm);                \
++    if (CIRCLEQ_NEXT((listelm), field) == (void *)(head))        \
++        CIRCLEQ_LAST((head)) = (elm);                \
++    else                                \
++        CIRCLEQ_PREV(CIRCLEQ_NEXT((listelm), field), field) = (elm);\
++    CIRCLEQ_NEXT((listelm), field) = (elm);                \
++} while (0)
++
++#define    CIRCLEQ_INSERT_BEFORE(head, listelm, elm, field) do {        \
++    CIRCLEQ_NEXT((elm), field) = (listelm);                \
++    CIRCLEQ_PREV((elm), field) = CIRCLEQ_PREV((listelm), field);    \
++    if (CIRCLEQ_PREV((listelm), field) == (void *)(head))        \
++        CIRCLEQ_FIRST((head)) = (elm);                \
++    else                                \
++        CIRCLEQ_NEXT(CIRCLEQ_PREV((listelm), field), field) = (elm);\
++    CIRCLEQ_PREV((listelm), field) = (elm);                \
++} while (0)
++
++#define    CIRCLEQ_INSERT_HEAD(head, elm, field) do {            \
++    CIRCLEQ_NEXT((elm), field) = CIRCLEQ_FIRST((head));        \
++    CIRCLEQ_PREV((elm), field) = (void *)(head);            \
++    if (CIRCLEQ_LAST((head)) == (void *)(head))            \
++        CIRCLEQ_LAST((head)) = (elm);                \
++    else                                \
++        CIRCLEQ_PREV(CIRCLEQ_FIRST((head)), field) = (elm);    \
++    CIRCLEQ_FIRST((head)) = (elm);                    \
++} while (0)
++
++#define    CIRCLEQ_INSERT_TAIL(head, elm, field) do {            \
++    CIRCLEQ_NEXT((elm), field) = (void *)(head);            \
++    CIRCLEQ_PREV((elm), field) = CIRCLEQ_LAST((head));        \
++    if (CIRCLEQ_FIRST((head)) == (void *)(head))            \
++        CIRCLEQ_FIRST((head)) = (elm);                \
++    else                                \
++        CIRCLEQ_NEXT(CIRCLEQ_LAST((head)), field) = (elm);    \
++    CIRCLEQ_LAST((head)) = (elm);                    \
++} while (0)
++
++#define    CIRCLEQ_LAST(head)    ((head)->cqh_last)
++
++#define    CIRCLEQ_NEXT(elm,field)    ((elm)->field.cqe_next)
++
++#define    CIRCLEQ_PREV(elm,field)    ((elm)->field.cqe_prev)
++
++#define    CIRCLEQ_REMOVE(head, elm, field) do {                \
++    if (CIRCLEQ_NEXT((elm), field) == (void *)(head))        \
++        CIRCLEQ_LAST((head)) = CIRCLEQ_PREV((elm), field);    \
++    else                                \
++        CIRCLEQ_PREV(CIRCLEQ_NEXT((elm), field), field) =    \
++            CIRCLEQ_PREV((elm), field);                \
++    if (CIRCLEQ_PREV((elm), field) == (void *)(head))        \
++        CIRCLEQ_FIRST((head)) = CIRCLEQ_NEXT((elm), field);    \
++    else                                \
++        CIRCLEQ_NEXT(CIRCLEQ_PREV((elm), field), field) =    \
++            CIRCLEQ_NEXT((elm), field);                \
++} while (0)
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /* DPL_QUEUE_H */
+diff --git a/porting/dpl/riot/src/config.c b/porting/dpl/riot/src/config.c
+new file mode 100644
+index 0000000..9e4bde1
+--- /dev/null
++++ b/porting/dpl/riot/src/config.c
+@@ -0,0 +1,83 @@
++/*
++ * Licensed to the Apache Software Foundation (ASF) under one
++ * or more contributor license agreements.  See the NOTICE file
++ * distributed with this work for additional information
++ * regarding copyright ownership.  The ASF licenses this file
++ * to you under the Apache License, Version 2.0 (the
++ * "License"); you may not use this file except in compliance
++ * with the License.  You may obtain a copy of the License at
++ *
++ *  http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing,
++ * software distributed under the License is distributed on an
++ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
++ * KIND, either express or implied.  See the License for the
++ * specific language governing permissions and limitations
++ * under the License.
++ */
++
++#include "config/config.h"
++#include <stdio.h>
++#include <stdbool.h>
++#include <stdlib.h>
++#include <string.h>
++
++int conf_value_from_str(char *val_str, enum conf_type type, void *vp, int maxlen)
++{
++    int32_t val;
++    int64_t val64;
++    char *eptr;
++
++    if (!val_str) {
++        goto err;
++    }
++    switch (type) {
++    case CONF_INT8:
++    case CONF_INT16:
++    case CONF_INT32:
++    case CONF_BOOL:
++        val = strtol(val_str, &eptr, 0);
++        if (*eptr != '\0') {
++            goto err;
++        }
++        if (type == CONF_BOOL) {
++            if (val < 0 || val > 1) {
++                goto err;
++            }
++            *(bool *)vp = val;
++        } else if (type == CONF_INT8) {
++            if (val < INT8_MIN || val > UINT8_MAX) {
++                goto err;
++            }
++            *(int8_t *)vp = val;
++        } else if (type == CONF_INT16) {
++            if (val < INT16_MIN || val > UINT16_MAX) {
++                goto err;
++            }
++            *(int16_t *)vp = val;
++        } else if (type == CONF_INT32) {
++            *(int32_t *)vp = val;
++        }
++        break;
++    case CONF_INT64:
++        val64 = strtoll(val_str, &eptr, 0);
++        if (*eptr != '\0') {
++            goto err;
++        }
++        *(int64_t *)vp = val64;
++        break;
++    case CONF_STRING:
++        val = strlen(val_str);
++        if (val + 1 > maxlen) {
++            goto err;
++        }
++        strcpy(vp, val_str);
++        break;
++    default:
++        goto err;
++    }
++    return 0;
++err:
++    return EINVAL;
++}
+-- 
+2.28.0
+

--- a/pkg/uwb-dw1000/Makefile
+++ b/pkg/uwb-dw1000/Makefile
@@ -1,0 +1,26 @@
+PKG_NAME=uwb-dw1000
+PKG_URL=https://github.com/Decawave/uwb-dw1000/
+PKG_VERSION=6eaa85e6d429450d19a6ddeb2de05303016c0dd2
+PKG_LICENSE=Apache-2.0
+
+include $(RIOTBASE)/pkg/pkg.mk
+
+CFLAGS += -Wno-address-of-packed-member
+CFLAGS += -Wno-enum-conversion
+CFLAGS += -Wno-maybe-uninitialized
+CFLAGS += -Wno-missing-braces
+CFLAGS += -Wno-missing-declarations
+CFLAGS += -Wno-sign-compare
+CFLAGS += -Wno-return-type
+CFLAGS += -Wno-unused-but-set-variable
+CFLAGS += -Wno-unused-function
+CFLAGS += -Wno-unused-parameter
+CFLAGS += -Wno-unused-variable
+CFLAGS += -fms-extensions
+
+ifneq (,$(filter llvm,$(TOOLCHAIN)))
+  CFLAGS += -Wno-microsoft-anon-tag
+endif
+
+all:
+	"$(MAKE)" -C $(PKG_SOURCE_DIR)/hw/drivers/uwb/uwb_dw1000/src -f $(RIOTPKG)/uwb-dw1000/uwb-dw1000.mk MODULE=uwb-dw1000

--- a/pkg/uwb-dw1000/Makefile.dep
+++ b/pkg/uwb-dw1000/Makefile.dep
@@ -1,0 +1,13 @@
+USEMODULE += uwb-dw1000_hal
+DEFAULT_MODULE += auto_init_uwb-dw1000
+
+USEMODULE += xtimer
+
+FEATURES_REQUIRED += periph_gpio_irq
+FEATURES_REQUIRED += periph_spi
+
+# Some of the pkg operation would overflow on 16bit
+FEATURES_REQUIRED += arch_32bit
+
+# LLVM ARM shows issues with missing definitions for stdatomic
+TOOLCHAINS_BLACKLIST += llvm

--- a/pkg/uwb-dw1000/Makefile.include
+++ b/pkg/uwb-dw1000/Makefile.include
@@ -1,0 +1,5 @@
+INCLUDES += -I$(PKGDIRBASE)/uwb-dw1000/hw/drivers/uwb/uwb_dw1000/include \
+            -I$(RIOTPKG)/uwb-dw1000/include \
+            #
+
+DIRS += $(RIOTPKG)/uwb-dw1000/hal

--- a/pkg/uwb-dw1000/doc.txt
+++ b/pkg/uwb-dw1000/doc.txt
@@ -1,0 +1,41 @@
+/**
+ * @defgroup pkg_uwb_dw1000 Driver implementation for the uwb-core driver for Decawave DW1000 transceiver
+ * @ingroup  pkg
+ * @brief    uwb-core driver for Decawave DW1000 transceiver
+ * @see      https://github.com/Decawave/uwb-dw1000
+ */
+
+# Decawave uwb-dw1000 RIOT Port
+
+The distribution https://github.com/decawave/uwb-core contains the
+device driver implementation for the Decawave Impulse Radio-Ultra
+Wideband (IR-UWB) transceiver(s). The driver includes hardware abstraction
+layers (HAL), media access control (MAC) layer, Ranging Services (RNG).
+
+## Abstraction details
+
+uwb-dw1000 is meant as a hardware and architecture agnostic driver. It
+was developed with MyNewt as its default OS, but its abstractions are
+well defined which makes it easy to use with another OS.
+
+A porting layer DPL (Decawave Porting Layer) has been implemented that
+wraps around OS functionalities and modules: mutex, semaphores, threads,
+etc.. In most cases the mapping is direct although some specific
+functionalities might not be supported. This layer is found in the uwb-core
+pkg.
+
+A hardware abstraction layer is defined under `hal` which wraps around
+modules such as: periph_gpio, periph_spi, etc.
+
+Since the library was used on top of mynewt most configuration values
+are prefixed with `MYNEWT_VAL_%`, all configurations can be found under
+`pkg/uwb-dw1000/include/syscfg`.
+
+## Todos
+
+The uwb-dw1000 can be used to provide a netdev driver for the dw1000
+module.
+
+uwb-dw1000 repository uses fixed length arrays to keep track of the
+devices that are present. This port uses linked list but some of the
+upstream code is not compatible with this.

--- a/pkg/uwb-dw1000/hal/Makefile
+++ b/pkg/uwb-dw1000/hal/Makefile
@@ -1,0 +1,3 @@
+MODULE = uwb-dw1000_hal
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/uwb-dw1000/hal/uwb_dw1000.c
+++ b/pkg/uwb-dw1000/hal/uwb_dw1000.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_dw1000
+ * @{
+ *
+ * @file
+ * @brief       Glue code for running uwb-core for RIOT
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#include "dpl/dpl.h"
+#include "dw1000/dw1000_phy.h"
+#include "dw1000/dw1000_hal.h"
+#include "uwb_dw1000.h"
+#include "uwb_dw1000_config.h"
+
+#include "uwb/uwb.h"
+#include "uwb/uwb_mac.h"
+
+#include "utlist.h"
+#include "thread.h"
+
+#ifndef LOG_LEVEL
+#define LOG_LEVEL   LOG_NONE
+#endif
+#include "log.h"
+
+
+#ifndef DW1000_THREAD_PRIORITY
+#define DW1000_THREAD_PRIORITY  MYNEWT_VAL_UWB_DEV_TASK_PRIO
+#endif
+
+/* Link list head */
+static struct _dw1000_dev_instance_t * dw1000_instance_head;
+
+/* Default instance configuration */
+static const dw1000_dev_instance_t dw1000_instance_config_default = {
+    .uwb_dev = {
+        .idx = 0,
+        .role = DW1000_ROLE_DEFAULT,
+        .task_prio = DW1000_THREAD_PRIORITY,
+        .status = {0},
+        .rx_ant_separation = DW1000_RX_ANTSEP_DEFAULT,
+        .attrib = {
+            .nsfd = DW1000_NSFD_DEFAULT,
+            .nsync = DW1000_NSYNC_DEFAULT,
+            .nphr = DW1000_NPHR_DEFAULT ,
+        },
+        .config = {
+            .channel = DW1000_CHANNEL_DEFAULT,
+            .prf = DW1000_PRF_DEFAULT,
+            .dataRate = DW1000_DATARATE_DEFAULT,
+            .rx = {
+                .pacLength = DW1000_PACLEN_DEFAULT,
+                .preambleCodeIndex = DW1000_RX_PREAM_CIDX_DEFAULT,
+                .sfdType = DW1000_RX_SFD_TYPE_DEFAULT,
+                .phrMode = DW1000_RX_PHR_MODE_DEFAULT,
+                .sfdTimeout = DW1000_RX_SFD_TO_DEFAULT,
+                .timeToRxStable = DW1000_RX_STABLE_TIME_US ,
+                .frameFilter = DW1000_FRAME_FILTER_DEFAULT,
+                .xtalTrim = DW1000_XTAL_TRIM_DEFAULT,
+            },
+            .tx ={
+                .preambleCodeIndex = DW1000_TX_PREAM_CIDX_DEAULT,
+                .preambleLength = DW1000_TX_PREAM_LEN_DEFAULT,
+            },
+            .txrf={
+                .PGdly = DW1000_CHANNEL_DEFAULT,
+                .BOOSTNORM = dw1000_power_value(DW1000_txrf_config_9db, 2.5),
+                .BOOSTP500 = dw1000_power_value(DW1000_txrf_config_9db, 2.5),
+                .BOOSTP250 = dw1000_power_value(DW1000_txrf_config_9db, 2.5),
+                .BOOSTP125 = dw1000_power_value(DW1000_txrf_config_9db, 2.5)
+            },
+            .trxoff_enable = DW1000_TRXOFF_ENABLE,
+            .rxdiag_enable = DW1000_RX_DIAGNOSTIC,
+            .dblbuffon_enabled = DW1000_DOUBLE_BUFFER_ENABLE,
+            .LDE_enable = DW1000_LDE_ENABLE,
+            .LDO_enable = DW1000_LDO_ENABLE,
+            .sleep_enable =  DW1000_SLEEP_ENABLE,
+            .wakeup_rx_enable = DW1000_WAKEUP_RX_ENABLE,
+            .rxauto_enable = DW1000_RX_AUTO_ENABLE,
+            .cir_enable = 0,             /**< Default behavior for CIR interface */
+            .cir_pdoa_slave = 0,         /**< First instance should not act as pdoa slave */
+            .blocking_spi_transfers = 1, /**< Nonblocking spi transfers are not supported */
+        },
+    }
+};
+
+void _uwb_dw1000_set_idx(dw1000_dev_instance_t* dev)
+{
+    int count = 0;
+    dw1000_dev_instance_t *elt = NULL;
+    LL_COUNT(dw1000_instance_head, elt, count);
+    dev->uwb_dev.idx = count++;
+    /* prepend to list */
+    LL_PREPEND(dw1000_instance_head, dev);
+}
+
+void uwb_dw1000_setup(dw1000_dev_instance_t* dev, dw1000_params_t* params)
+{
+    /* set semaphore */
+    dpl_sem_init(params->spi_sem, 0x1);
+    /* set default uwb config */
+    memcpy(dev, &dw1000_instance_config_default,
+           sizeof(dw1000_dev_instance_t));
+    /* set uwb_dev idx */
+    _uwb_dw1000_set_idx(dev);
+    /* this will set the configuration and init uwb_dev which ATM only
+       allocates an RX and TX buffer if none is yet available */
+    dw1000_dev_init((struct os_dev *) dev, (void *) params);
+}
+
+void uwb_dw1000_config_and_start(dw1000_dev_instance_t* dev)
+{
+    dw1000_dev_config(dev);
+}
+
+void uwb_dw1000_set_buffs(dw1000_dev_instance_t* dev, uint8_t* tx_buf,
+                          uint8_t* rx_buf)
+{
+    dev->uwb_dev.rxbuf = rx_buf;
+    dev->uwb_dev.txbuf = tx_buf;
+}
+
+void uwb_dw1000_init(void)
+{
+    dw1000_instance_head = NULL;
+}
+
+struct uwb_dev* uwb_dev_idx_lookup(int idx)
+{
+    dw1000_dev_instance_t *current = dw1000_instance_head;
+
+    while (current) {
+        if (current->uwb_dev.idx == idx) {
+            LOG_DEBUG("uwb_dev: found dev of idx %d\n", idx);
+            break;
+        }
+        current = current->next;
+    }
+
+    return (struct uwb_dev*) &current->uwb_dev;
+}
+
+/**
+ * API to choose DW1000 instances based on parameters.
+ *
+ * @param idx  Indicates number of instances for the chosen bsp.
+ * @return dw1000_dev_instance_t
+ */
+
+struct _dw1000_dev_instance_t * hal_dw1000_inst(uint8_t idx)
+{
+    dw1000_dev_instance_t *current = dw1000_instance_head;
+
+    for (uint8_t i = 0; i < idx; i++) {
+        current = current->next;
+    }
+
+    return current;
+}

--- a/pkg/uwb-dw1000/hal/uwb_dw1000_spi.c
+++ b/pkg/uwb-dw1000/hal/uwb_dw1000_spi.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_dw1000
+ * @{
+ *
+ * @file
+ * @brief       SPI abstraction layer implementation
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#include "hal/hal_spi.h"
+#include "periph/spi.h"
+
+static uint32_t spi_clk[SPI_NUMOF] = { SPI_CLK_1MHZ };
+static uint32_t spi_mode[SPI_NUMOF] = { SPI_MODE_0 };
+
+int hal_spi_set_txrx_cb(int spi_num, hal_spi_txrx_cb txrx_cb, void *arg)
+{
+    (void) txrx_cb;
+    (void) spi_num;
+    (void) arg;
+    return 0;
+}
+
+int hal_spi_init(int spi_num, void *cfg, uint8_t spi_type)
+{
+    (void) cfg;
+    (void) spi_type;
+    spi_init(spi_num);
+    return 0;
+}
+
+int hal_spi_config(int spi_num, struct hal_spi_settings *settings)
+{
+    spi_clk[spi_num] = settings->baudrate;
+    spi_mode[spi_num] = settings->data_mode;
+    return 0;
+}
+
+int hal_spi_enable(int spi_num)
+{
+    (void) spi_num;
+    return 0;
+}
+
+int hal_spi_disable(int spi_num)
+{
+    (void) spi_num;
+    return 0;
+}
+
+int hal_spi_txrx(int spi_num, void *txbuf, void *rxbuf, int cnt)
+{
+    spi_acquire(spi_num,
+                SPI_CS_UNDEF,
+                spi_mode[spi_num],
+                spi_clk[spi_num]);
+
+    spi_transfer_bytes(spi_num,
+                       SPI_CS_UNDEF,
+                       false,
+                       txbuf,
+                       rxbuf,
+                       cnt);
+
+    spi_release(spi_num);
+    return 0;
+}
+
+int hal_spi_txrx_noblock(int spi_num, void *txbuf, void *rxbuf, int cnt)
+{
+    (void) spi_num;
+    (void) txbuf;
+    (void) rxbuf;
+    (void) cnt;
+    return 0;
+}
+
+int hal_spi_deinit(int spi_num)
+{
+    (void) spi_num;
+    return 0;
+}

--- a/pkg/uwb-dw1000/include/hal/hal_gpio.h
+++ b/pkg/uwb-dw1000/include/hal/hal_gpio.h
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_dw1000
+ * @{
+ *
+ * @file
+ * @brief       GPIO abstraction layer RIOT adaption
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef HAL_HAL_GPIO_H
+#define HAL_HAL_GPIO_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Map hal_gpio_pull_t enum types to gpio_mode_t enum types
+ */
+enum {
+    /** Pull-up/down not enabled */
+    HAL_GPIO_PULL_NONE = GPIO_IN,
+    /** Pull-up enabled */
+    HAL_GPIO_PULL_UP = GPIO_IN_PU,
+    /** Pull-down enabled */
+    HAL_GPIO_PULL_DOWN = GPIO_IN_PD
+};
+/**
+ * @brief hal_gpio_pull type
+ */
+typedef gpio_mode_t hal_gpio_pull_t;
+
+/**
+ * @brief Map hal_gpio_irq_trig_t enum types to gpio_flank_t enum types
+ */
+enum {
+#ifdef GPIO_NONE
+    HAL_GPIO_TRIG_NONE = GPIO_NONE,
+#endif
+    /** IRQ occurs on rising edge */
+    HAL_GPIO_TRIG_RISING = GPIO_RISING,
+    /** IRQ occurs on falling edge */
+    HAL_GPIO_TRIG_FALLING = GPIO_FALLING,
+    /** IRQ occurs on either edge */
+    HAL_GPIO_TRIG_BOTH = GPIO_BOTH,
+    /** IRQ occurs when line is low */
+#ifdef GPIO_LOW
+    HAL_GPIO_TRIG_LOW = GPIO_LOW,
+#endif
+    /** IRQ occurs when line is high */
+#ifdef GPIO_HIGH
+    HAL_GPIO_TRIG_HIGH = GPIO_HIGH
+#endif
+};
+/**
+ * @brief hal_gpio_irq_trig type
+ */
+typedef gpio_flank_t hal_gpio_irq_trig_t;
+
+/**
+ * @brief Function proto for GPIO irq handler functions
+ */
+typedef gpio_cb_t hal_gpio_irq_handler_t;
+
+/**
+ * Initializes the specified pin as an input
+ *
+ * @param pin   Pin number to set as input
+ * @param pull  pull type
+ *
+ * @return int  0: no error; -1 otherwise.
+ */
+static inline int hal_gpio_init_in(gpio_t pin, hal_gpio_pull_t pull)
+{
+    return gpio_init(pin, pull);
+}
+
+/**
+ * Initialize the specified pin as an output, setting the pin to the specified
+ * value.
+ *
+ * @param pin Pin number to set as output
+ * @param val Value to set pin
+ *
+ * @return int  0: no error; -1 otherwise.
+ */
+static inline int hal_gpio_init_out(gpio_t pin, int val)
+{
+    int res = gpio_init(pin, GPIO_OUT);
+    gpio_write(pin, val);
+    return res;
+}
+
+/**
+ * Write a value (either high or low) to the specified pin.
+ *
+ * @param pin Pin to set
+ * @param val Value to set pin (0:low 1:high)
+ */
+static inline void hal_gpio_write(gpio_t pin, int val)
+{
+    gpio_write(pin, val);
+}
+
+/**
+ * Reads the specified pin.
+ *
+ * @param pin Pin number to read
+ *
+ * @return int 0: low, 1: high
+ */
+static inline int hal_gpio_read(gpio_t pin)
+{
+    return gpio_read(pin);
+}
+
+/**
+ * Toggles the specified pin
+ *
+ * @param pin Pin number to toggle
+ *
+ * @return current gpio state int 0: low, 1: high
+ */
+static inline int hal_gpio_toggle(gpio_t pin)
+{
+    gpio_toggle(pin);
+    return gpio_read(pin);
+}
+
+/**
+ * Initialize a given pin to trigger a GPIO IRQ callback.
+ *
+ * @param pin     The pin to trigger GPIO interrupt on
+ * @param handler The handler function to call
+ * @param arg     The argument to provide to the IRQ handler
+ * @param trig    The trigger mode (e.g. rising, falling)
+ * @param pull    The mode of the pin (e.g. pullup, pulldown)
+ *
+ * @return 0 on success, non-zero error code on failure.
+ */
+static inline int hal_gpio_irq_init(gpio_t pin,
+                                    hal_gpio_irq_handler_t handler,
+                                    void *arg,
+                                    hal_gpio_irq_trig_t trig,
+                                    hal_gpio_pull_t pull)
+{
+    return gpio_init_int(pin, pull, trig, handler, arg);
+}
+
+/**
+ * Release a pin from being configured to trigger IRQ on state change.
+ *
+ * @param pin The pin to release
+ */
+static inline void hal_gpio_irq_release(gpio_t pin)
+{
+    /* can't release the interrupt so ar least disable it */
+    gpio_irq_disable(pin);
+}
+
+/**
+ * Enable IRQs on the passed pin
+ *
+ * @param pin The pin to enable IRQs on
+ */
+static inline void hal_gpio_irq_enable(gpio_t pin)
+{
+    gpio_irq_enable(pin);
+}
+
+/**
+ * Disable IRQs on the passed pin
+ *
+ * @param pin The pin to disable IRQs on
+ */
+static inline void hal_gpio_irq_disable(gpio_t pin)
+{
+    gpio_irq_disable(pin);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_HAL_GPIO_H */

--- a/pkg/uwb-dw1000/include/hal/hal_spi.h
+++ b/pkg/uwb-dw1000/include/hal/hal_spi.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_dw1000
+ * @{
+ *
+ * @file
+ * @brief       SPI abstraction layer RIOT adaption
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef HAL_HAL_SPI_H
+#define HAL_HAL_SPI_H
+
+#include "periph/spi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** SPI mode 0 */
+#define HAL_SPI_MODE0               (SPI_MODE_0)
+/** SPI mode 1 */
+#define HAL_SPI_MODE1               (SPI_MODE_1)
+/** SPI mode 2 */
+#define HAL_SPI_MODE2               (SPI_MODE_2)
+/** SPI mode 3 */
+#define HAL_SPI_MODE3               (SPI_MODE_3)
+
+/**
+ * @brief Prototype for tx/rx callback
+ */
+typedef void (*hal_spi_txrx_cb)(void *arg, int len);
+
+/**
+ * @brief since one spi device can control multiple devices, some configuration
+ * can be changed on the fly from the hal
+ */
+struct hal_spi_settings {
+    /** Data mode of SPI driver, defined by HAL_SPI_MODEn */
+    spi_mode_t         data_mode;
+    /** Baudrate in kHz */
+    spi_clk_t          baudrate;
+};
+
+/**
+ * @brief Configure the spi. Must be called after the spi is initialized (after
+ * hal_spi_init is called) and when the spi is disabled (user must call
+ * hal_spi_disable if the spi has been enabled through hal_spi_enable prior
+ * to calling this function). Can also be used to reconfigure an initialized
+ * SPI (assuming it is disabled as described previously).
+ *
+ * @param spi_num The number of the SPI to configure.
+ * @param psettings The settings to configure this SPI with
+ *
+ * @return int 0 on success, non-zero error code on failure.
+ */
+int hal_spi_config(int spi_num, struct hal_spi_settings *psettings);
+
+/**
+ * @brief Sets the txrx callback (executed at interrupt context) when the
+ * buffer is transferred by the master or the slave using the non-blocking API.
+ * Cannot be called when the spi is enabled. This callback will also be called
+ * when chip select is de-asserted on the slave.
+ *
+ * NOTE: This callback is only used for the non-blocking interface and must
+ * be called prior to using the non-blocking API.
+ *
+ * @param spi_num   SPI interface on which to set callback
+ * @param txrx_cb   Callback function
+ * @param arg       Argument to be passed to callback function
+ *
+ * @return int 0 on success, non-zero error code on failure.
+ */
+int hal_spi_set_txrx_cb(int spi_num, hal_spi_txrx_cb txrx_cb, void *arg);
+
+/**
+ * @brief Enables the SPI. This does not start a transmit or receive operation;
+ * it is used for power mgmt. Cannot be called when a SPI transfer is in
+ * progress.
+ *
+ * @param spi_num
+ *
+ * @return int 0 on success, non-zero error code on failure.
+ */
+int hal_spi_enable(int spi_num);
+
+/**
+ * @brief Disables the SPI. Used for power mgmt. It will halt any current SPI transfers
+ * in progress.
+ *
+ * @param spi_num
+ *
+ * @return int 0 on success, non-zero error code on failure.
+ */
+int hal_spi_disable(int spi_num);
+
+/**
+ * @brief Blocking interface to send a buffer and store the received values from the
+ * slave. The transmit and receive buffers are either arrays of 8-bit (uint8_t)
+ * values or 16-bit values depending on whether the spi is configured for 8 bit
+ * data or more than 8 bits per value. The 'cnt' parameter is the number of
+ * 8-bit or 16-bit values. Thus, if 'cnt' is 10, txbuf/rxbuf would point to an
+ * array of size 10 (in bytes) if the SPI is using 8-bit data; otherwise
+ * txbuf/rxbuf would point to an array of size 20 bytes (ten, uint16_t values).
+ *
+ * NOTE: these buffers are in the native endian-ness of the platform.
+ *
+ *     MASTER: master sends all the values in the buffer and stores the
+ *             stores the values in the receive buffer if rxbuf is not NULL.
+ *             The txbuf parameter cannot be NULL.
+ *     SLAVE: cannot be called for a slave; returns -1
+ *
+ * @param spi_num   SPI interface to use
+ * @param txbuf     Pointer to buffer where values to transmit are stored.
+ * @param rxbuf     Pointer to buffer to store values received from peer.
+ * @param cnt       Number of 8-bit or 16-bit values to be transferred.
+ *
+ * @return int 0 on success, non-zero error code on failure.
+ */
+int hal_spi_txrx(int spi_num, void *txbuf, void *rxbuf, int cnt);
+
+/**
+ * @brief Non-blocking interface to send a buffer and store received values. Can be
+ * used for both master and slave SPI types. The user must configure the
+ * callback (using hal_spi_set_txrx_cb); the txrx callback is executed at
+ * interrupt context when the buffer is sent.
+ *
+ * The transmit and receive buffers are either arrays of 8-bit (uint8_t)
+ * values or 16-bit values depending on whether the spi is configured for 8 bit
+ * data or more than 8 bits per value. The 'cnt' parameter is the number of
+ * 8-bit or 16-bit values. Thus, if 'cnt' is 10, txbuf/rxbuf would point to an
+ * array of size 10 (in bytes) if the SPI is using 8-bit data; otherwise
+ * txbuf/rxbuf would point to an array of size 20 bytes (ten, uint16_t values).
+ *
+ * NOTE: these buffers are in the native endian-ness of the platform.
+ *
+ *     MASTER: master sends all the values in the buffer and stores the
+ *             stores the values in the receive buffer if rxbuf is not NULL.
+ *             The txbuf parameter cannot be NULL
+ *     SLAVE: Slave "preloads" the data to be sent to the master (values
+ *            stored in txbuf) and places received data from master in rxbuf
+ *            (if not NULL). The txrx callback occurs when len values are
+ *            transferred or master de-asserts chip select. If txbuf is NULL,
+ *            the slave transfers its default byte. Both rxbuf and txbuf cannot
+ *            be NULL.
+ *
+ * @param spi_num   SPI interface to use
+ * @param txbuf     Pointer to buffer where values to transmit are stored.
+ * @param rxbuf     Pointer to buffer to store values received from peer.
+ * @param cnt       Number of 8-bit or 16-bit values to be transferred.
+ *
+ * @return int 0 on success, non-zero error code on failure.
+ */
+int hal_spi_txrx_noblock(int spi_num, void *txbuf, void *rxbuf, int cnt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_HAL_SPI_H */

--- a/pkg/uwb-dw1000/include/hal/hal_timer.h
+++ b/pkg/uwb-dw1000/include/hal/hal_timer.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_dw1000
+ * @{
+ *
+ * @file
+ * @brief       Timer abstraction layer RIOT adaption
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef HAL_HAL_TIMER_H
+#define HAL_HAL_TIMER_H
+
+#include "xtimer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   HAL timer callback
+ */
+typedef xtimer_callback_t hal_timer_cb;
+
+/**
+ * @brief   The HAL timer structure.
+ */
+struct hal_timer {
+    xtimer_t timer;     /**< the timer */
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HAL_HAL_TIMER_H */

--- a/pkg/uwb-dw1000/include/syscfg_uwb_dw1000.h
+++ b/pkg/uwb-dw1000/include/syscfg_uwb_dw1000.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-dw1000 module configurations
+ *              taken from decawave-uwb-dw1000/hw/drivers/uwb/uwb_dw1000
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef SYSCFG_UWB_DW1000_H
+#define SYSCFG_UWB_DW1000_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Used to check that the UWB_DEV has been setup correctly
+ *        at compile time.
+ * @note  (UWB_DEV_RXDIAG_MAXLEN > 19)
+ */
+#ifndef MYNEWT_VAL_UWB_DW1000_API_CHECKS
+#define MYNEWT_VAL_UWB_DW1000_API_CHECKS (1)
+#endif
+
+/**
+ * @brief Size of spi read/write buffer, sets the
+ *        maximum allowed nonblocking read operation
+ */
+#ifndef MYNEWT_VAL_DW1000_HAL_SPI_BUFFER_SIZE
+#define MYNEWT_VAL_DW1000_HAL_SPI_BUFFER_SIZE (256)
+#endif
+
+/**
+ * @brief The maximum number of bytes in a single transfer that the
+ *        SPI hardware supports.
+ *
+ * @note RIOT spi implementation will take care of splitting if this max
+ *       value is exceeded. If asynchronous (non-blocking) spi is ever
+ *       added to RIOT this value will need to be adapted to the platform
+ *       specific value.
+ */
+#ifndef MYNEWT_VAL_DW1000_HAL_SPI_MAX_CNT
+#define MYNEWT_VAL_DW1000_HAL_SPI_MAX_CNT (1024)
+#endif
+
+/**
+ * @brief Max size spi read in bytes that is always done with blocking io.
+ *        Reads longer than this value will be done with non-blocking io.
+ * @note  Ignore in RIOT since non-blocking SPI is not yet enabled
+ */
+#ifndef MYNEWT_VAL_DW1000_DEVICE_SPI_RD_MAX_NOBLOCK
+#define MYNEWT_VAL_DW1000_DEVICE_SPI_RD_MAX_NOBLOCK (9)
+#endif
+
+/**
+ * @brief Enable range bias correction polynomial
+ */
+#ifndef MYNEWT_VAL_DW1000_BIAS_CORRECTION_ENABLED
+#define MYNEWT_VAL_DW1000_BIAS_CORRECTION_ENABLED (0)
+#endif
+
+/**
+ * @brief Tx Power dBm
+ */
+#ifndef MYNEWT_VAL_DW1000_DEVICE_TX_PWR
+#define MYNEWT_VAL_DW1000_DEVICE_TX_PWR (((float)-14.3f))
+#endif
+
+/**
+ * @brief Antenna Gain dB
+ */
+#ifndef MYNEWT_VAL_DW1000_DEVICE_ANT_GAIN
+#define MYNEWT_VAL_DW1000_DEVICE_ANT_GAIN (((float)1.0f))
+#endif
+
+/**
+ * @brief Enable showing rx and tx activity on leds
+ */
+#ifndef MYNEWT_VAL_DW1000_RXTX_LEDS
+#define MYNEWT_VAL_DW1000_RXTX_LEDS (1)
+#endif
+
+/**
+ * @brief Enable showing rx and tx activity on gpios
+ */
+#ifndef MYNEWT_VAL_DW1000_RXTX_GPIO
+#define MYNEWT_VAL_DW1000_RXTX_GPIO (0)
+#endif
+
+/**
+ * @brief Toggle LED_1 for every range packet received
+ */
+#ifndef MYNEWT_VAL_DW1000_RNG_INDICATE_LED
+#define MYNEWT_VAL_DW1000_RNG_INDICATE_LED (0)
+#endif
+
+/**
+ * @brief Expose event counter cli api
+ */
+#ifndef MYNEWT_VAL_DW1000_CLI_EVENT_COUNTERS
+#define MYNEWT_VAL_DW1000_CLI_EVENT_COUNTERS (0)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSCFG_UWB_DW1000_H */

--- a/pkg/uwb-dw1000/include/uwb_dw1000.h
+++ b/pkg/uwb-dw1000/include/uwb_dw1000.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_dw1000
+ *
+ * @{
+ *
+ * @file
+ * @brief       Abstraction layer for RIOT adaption
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+#ifndef UWB_DW1000_H
+#define UWB_DW1000_H
+
+#include <stdint.h>
+
+#include "dw1000/dw1000_dev.h"
+#include "dw1000/dw1000_hal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Device initialization parameters
+ */
+typedef struct dw1000_dev_cfg dw1000_params_t;
+
+/**
+ * @brief   Device descriptor for the driver
+ */
+typedef struct {
+    dw1000_dev_instance_t dev;         /**< dwDevice parent struct */
+} uwb_dw1000_t;
+
+/**
+ * @brief   Sets device linked list to 0, not really needed...
+ */
+void uwb_dw1000_init(void);
+
+/**
+ * @brief   Sets the tx and rx buffer for the uwb_dev in the dw1000 instance
+ *
+ * @note If this is not set before uwb_dw1000_setup() is called then
+ *       the buffers will be dynamically allocated.
+ *
+ * @param[in]   dev     dw1000 device instance pointer
+ * @param[in]   tx_buf  transmit buffer
+ * @param[in]   rx_buf  receive buffer
+ */
+void uwb_dw1000_set_buffs(dw1000_dev_instance_t* dev, uint8_t* tx_buf,
+                          uint8_t* rx_buf);
+
+/**
+ * @brief   Setup a dw1000 device
+ *
+ * This will setup the dw1000 dev instance and the uwb_dev instance within.
+ *
+ * @param[out]  dev     dw1000 device descriptor
+ * @param[in]   params  receive buffer
+ */
+void uwb_dw1000_setup(dw1000_dev_instance_t* dev, dw1000_params_t* params);
+
+/**
+ * @brief   Configure and start the dw1000
+ *
+ * This will wakeup and setup the dw1000 device, configure the mac and
+ * phy. Setting up the mac will also call dw1000_tasks_init() that will
+ * handle the device interrupts.
+ *
+ * @param[out]  dev     dw1000 device descriptor
+ */
+void uwb_dw1000_config_and_start(dw1000_dev_instance_t* dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UWB_DW1000_H */

--- a/pkg/uwb-dw1000/include/uwb_dw1000_config.h
+++ b/pkg/uwb-dw1000/include/uwb_dw1000_config.h
@@ -1,0 +1,263 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_core
+ * @{
+ *
+ * @file
+ * @brief       uwb-dw1000 radio configurations
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ * @}
+ */
+
+#ifndef UWB_DW1000_CONFIG_H
+#define UWB_DW1000_CONFIG_H
+
+#include "dw1000/dw1000_regs.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Default UWB Role
+ *
+ *  - Tag          "0x00"
+ *  - Node         "0x01"
+ *  - Pan master   "0x02"
+ *  - Anchor       "0x04"
+ *  - Panmaster    "0x07"
+ */
+#ifndef DW1000_ROLE_DEFAULT
+#define DW1000_ROLE_DEFAULT         0x0
+#endif
+
+/**
+ * @brief   Default Number of symbols in start of frame delimiter
+ */
+#ifndef DW1000_NSFD_DEFAULT
+#define DW1000_NSFD_DEFAULT         8
+#endif
+
+/**
+ * @brief   Default Number of symbols in preamble sequence
+ */
+#ifndef DW1000_NSYNC_DEFAULT
+#define DW1000_NSYNC_DEFAULT         128
+#endif
+
+/**
+ * @brief   Default Number of symbols in phy header
+ */
+#ifndef DW1000_NPHR_DEFAULT
+#define DW1000_NPHR_DEFAULT         21
+#endif
+
+
+/**
+ * @brief   Default channel
+ */
+#ifndef DW1000_CHANNEL_DEFAULT
+#define DW1000_CHANNEL_DEFAULT      5
+#if DW1000_CHANNEL_DEFAULT > 7 || DW1000_CHANNEL_DEFAULT < 1
+#error "DW1000_CHANNEL_DEFAULT must be 1..7"
+#endif
+#endif
+
+/**
+ * @brief   Default Pulse generator delay
+ */
+#ifndef DW1000_TX_PGDELAY_DEFAULT
+#if DW1000_CHANNEL_DEFAULT == 1
+#define DW1000_TX_PGDELAY_DEFAULT   TC_PGDELAY_CH1
+#elif DW1000_CHANNEL_DEFAULT == 2
+#define DW1000_TX_PGDELAY_DEFAULT   TC_PGDELAY_CH2
+#elif DW1000_CHANNEL_DEFAULT == 3
+#define DW1000_TX_PGDELAY_DEFAULT   TC_PGDELAY_CH3
+#elif DW1000_CHANNEL_DEFAULT == 4
+#define DW1000_TX_PGDELAY_DEFAULT   TC_PGDELAY_CH4
+#elif DW1000_CHANNEL_DEFAULT == 5
+#define DW1000_TX_PGDELAY_DEFAULT   TC_PGDELAY_CH5
+#elif DW1000_CHANNEL_DEFAULT == 6
+#define DW1000_TX_PGDELAY_DEFAULT   TC_PGDELAY_CH7
+#elif DW1000_CHANNEL_DEFAULT == 7
+#define DW1000_TX_PGDELAY_DEFAULT   TC_PGDELAY_CH7
+#endif
+#endif
+
+/**
+ * @brief   Default UWB Pulse Repetition Frequency (MHz)
+ *
+ * - DWT_PRF_16M
+ * - DWT_PRF_64M
+ */
+#ifndef DW1000_PRF_DEFAULT
+#define DW1000_PRF_DEFAULT          DWT_PRF_64M
+#endif
+
+/**
+ * @brief   Default UWB Datarate (110k, 850k, 6m8)
+ *
+ * - DWT_BR_110K
+ * - DWT_BR_850K
+ * - DWT_BR_6M8
+ */
+#ifndef DW1000_DATARATE_DEFAULT
+#define DW1000_DATARATE_DEFAULT     DWT_BR_6M8
+#endif
+
+/**
+ * @brief   Default UWB Acquisition Chunk Size (Relates to RX preamble length)
+ *
+ * - 8
+ * - 16
+ * - 32
+ * - 64
+ */
+#ifndef DW1000_PACLEN_DEFAULT
+#define DW1000_PACLEN_DEFAULT       DWT_PAC8
+#endif
+
+/**
+ * @brief Default UWB RX Preamble Code Index
+ */
+#ifndef DW1000_RX_PREAM_CIDX_DEFAULT
+#define DW1000_RX_PREAM_CIDX_DEFAULT    9
+#endif
+
+/**
+ * @brief Default UWB SFD Type
+ *
+ * - true: use non standard SFD for better performance
+ * - false: use standard SFD
+ */
+#ifndef DW1000_RX_SFD_TYPE_DEFAULT
+#define DW1000_RX_SFD_TYPE_DEFAULT  true
+#endif
+
+/**
+ * @brief Default UWB SFD Timeout (-1=auto, timeout in symbols)
+ *
+ */
+#ifndef DW1000_RX_SFD_TO_DEFAULT
+#define DW1000_RX_SFD_TO_DEFAULT   (128 + 1 + 8 - 8) /* (preamble length + 1 + SFD length - PAC size) */
+#endif
+
+/**
+ * @brief Default UWB PHR Mode
+ *
+ * - 0x0 - standard DWT_PHRMODE_STD
+ * - 0x3 - extended frames DWT_PHRMODE_EXT
+ */
+#ifndef DW1000_RX_PHR_MODE_DEFAULT
+#define DW1000_RX_PHR_MODE_DEFAULT      DWT_PHRMODE_EXT
+#endif
+
+/**
+ * @brief Enable RX Frame Quality diagnositics (rssi, fppl, etc.)
+ */
+#ifndef DW1000_RX_DIAGNOSTIC
+#define DW1000_RX_DIAGNOSTIC    0
+#endif
+
+
+/**
+ * @brief Default UWB RX Antenna separation distance in m
+ */
+#ifndef DW1000_TX_PREAM_CIDX_DEAULT
+#define DW1000_TX_PREAM_CIDX_DEAULT     9
+#endif
+
+/**
+ * @brief Default UWB Preamble Length
+ *
+ * - DWT_PLEN_4096 : Standard preamble length 4096 symbols
+ * - DWT_PLEN_2048 : Non-standard preamble length 2048 symbols
+ * - DWT_PLEN_1536 : Non-standard preamble length 1536 symbols
+ * - DWT_PLEN_1024 : Standard preamble length 1024 symbols
+ * - DWT_PLEN_512  : Non-standard preamble length 512 symbols
+ * - DWT_PLEN_256  : Non-standard preamble length 256 symbols
+ * - DWT_PLEN_128  : Non-standard preamble length 128 symbols
+ * - DWT_PLEN_64   : Standard preamble length 64 symbols
+ * - DWT_PLEN_32   : When setting length 32 symbols this is 0x0,  which is programmed to byte 2 of the TX_FCTRL register
+ * - DWT_PLEN_72   : Non-standard length 72
+ */
+#ifndef DW1000_TX_PREAM_LEN_DEFAULT
+#define DW1000_TX_PREAM_LEN_DEFAULT     DWT_PLEN_128
+#endif
+
+/**
+ * @brief Default UWB RX Antenna separation distance in m
+ */
+#ifndef DW1000_RX_ANTSEP_DEFAULT
+#define DW1000_RX_ANTSEP_DEFAULT       0.0205
+#endif
+
+/**
+ * @brief   Default MAC FrameFilter (0x0000 = no filter)
+ */
+#ifndef DW1000_FRAME_FILTER_DEFAULT
+#define DW1000_FRAME_FILTER_DEFAULT     0x0000
+#endif
+
+/**
+ * @brief   Default MAC FrameFilter Crystal Trim value, 0xff == not set
+ */
+#ifndef DW1000_XTAL_TRIM_DEFAULT
+#define DW1000_XTAL_TRIM_DEFAULT        0x10
+#endif
+
+/**
+ * @brief    Time until the Receiver is stable, (in us)
+ */
+#ifndef DW1000_RX_STABLE_TIME_US
+#define DW1000_RX_STABLE_TIME_US        6
+#endif
+
+/**
+ * @brief Enables forced TRXOFF in start_tx and start_tx interface
+ */
+#define DW1000_TRXOFF_ENABLE            1
+
+/**
+ * @brief Enables double buffer
+ */
+#define DW1000_DOUBLE_BUFFER_ENABLE    false
+
+/**
+ * @brief Load LDE microcode on wake up
+ */
+#define DW1000_LDE_ENABLE   true
+
+/**
+ * @brief Load the LDO tune value on wake up
+ */
+#define DW1000_LDO_ENABLE   false
+
+/**
+ * @brief Enable sleep
+ */
+#define DW1000_SLEEP_ENABLE     true
+
+/**
+ * @brief Wakeup to Rx state
+ */
+#define DW1000_WAKEUP_RX_ENABLE true
+
+/**
+ * @brief On error re-enable
+ */
+#define DW1000_RX_AUTO_ENABLE    true
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UWB_DW1000_CONFIG_H */

--- a/pkg/uwb-dw1000/include/uwb_dw1000_params.h
+++ b/pkg/uwb-dw1000/include/uwb_dw1000_params.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_uwb_dw1000
+ *
+ * @{
+ * @file
+ * @brief       Default configuration
+ *
+ * @author      Francisco Molina <francois-xavier.molina@inria.fr>
+ */
+
+#ifndef UWB_DW1000_PARAMS_H
+#define UWB_DW1000_PARAMS_H
+
+#include "board.h"
+#include "uwb_dw1000.h"
+#include "dpl/dpl_sem.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters
+ * @{
+ */
+#ifndef DW1000_SPI_SEM
+static struct dpl_sem sem_spi;
+#define DW1000_SPI_SEM              &sem_spi
+#endif
+#ifndef DW1000_PARAM_SPI
+#define DW1000_PARAM_SPI            (SPI_DEV(1))
+#endif
+#ifndef DW1000_PARAM_SPI_CLK_LOW
+#define DW1000_PARAM_SPI_CLK_LOW    (SPI_CLK_1MHZ)
+#endif
+#ifndef DW1000_PARAM_SPI_CLK_HIGH
+#define DW1000_PARAM_SPI_CLK_HIGH   (SPI_CLK_10MHZ)
+#endif
+#ifndef DW1000_SPI_MODE
+#define DW1000_SPI_MODE             (SPI_MODE_0)
+#endif
+#ifndef DW1000_PARAM_CS_PIN
+#define DW1000_PARAM_CS_PIN         (GPIO_PIN(0, 17))
+#endif
+#ifndef DW1000_PARAM_IRQ_PIN
+#define DW1000_PARAM_IRQ_PIN        (GPIO_PIN(0, 19))
+#endif
+#ifndef DW1000_PARAM_RESET_PIN
+#define DW1000_PARAM_RESET_PIN      (GPIO_PIN(0, 24))
+#endif
+#ifndef DW1000_RX_ANTENNA_DELAY
+#define DW1000_RX_ANTENNA_DELAY     (0x4042)
+#endif
+#ifndef DW1000_TX_ANTENNA_DELAY
+#define DW1000_TX_ANTENNA_DELAY     (0x4042)
+#endif
+#ifndef DW1000_EXT_CLOCK_DELAY
+#define DW1000_EXT_CLOCK_DELAY      (0)
+#endif
+
+#ifndef DW1000_PARAMS
+#define DW1000_PARAMS           { .spi_sem = DW1000_SPI_SEM, \
+                                  .spi_baudrate = DW1000_PARAM_SPI_CLK_HIGH, \
+                                  .spi_baudrate_low = DW1000_PARAM_SPI_CLK_LOW, \
+                                  .spi_num = DW1000_PARAM_SPI, \
+                                  .rst_pin = DW1000_PARAM_RESET_PIN, \
+                                  .irq_pin = DW1000_PARAM_IRQ_PIN, \
+                                  .ss_pin = DW1000_PARAM_CS_PIN, \
+                                  .rx_antenna_delay = DW1000_RX_ANTENNA_DELAY, \
+                                  .tx_antenna_delay = DW1000_TX_ANTENNA_DELAY, \
+                                  .ext_clock_delay = DW1000_EXT_CLOCK_DELAY }
+#endif
+/**@}*/
+
+/**
+ * @brief   Configuration struct
+ */
+static const dw1000_params_t dw1000_params[] =
+{
+    DW1000_PARAMS
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UWB_DW1000_PARAMS_H */
+/** @} */

--- a/pkg/uwb-dw1000/patches/0001-uwb_dw1000-include-dw1000-dw1000_dev-add-linked-list.patch
+++ b/pkg/uwb-dw1000/patches/0001-uwb_dw1000-include-dw1000-dw1000_dev-add-linked-list.patch
@@ -1,0 +1,25 @@
+From 068dbad87ebebc9cf5d91bb9397dbd148420769e Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Fri, 14 Aug 2020 13:38:05 +0200
+Subject: [PATCH 1/5] uwb_dw1000/include/dw1000/dw1000_dev: add linked list
+ next ptr
+
+---
+ hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h b/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h
+index aec0bec..2dcd7f8 100644
+--- a/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h
++++ b/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h
+@@ -204,6 +204,7 @@ typedef struct _dw1000_dev_instance_t{
+     /* To allow translation from ticks to usecs in gdb during backtrace*/
+     uint32_t bt_ticks2usec;
+ #endif
++    struct _dw1000_dev_instance_t* next;
+ } dw1000_dev_instance_t;
+ 
+ //! SPI and other init parameters
+-- 
+2.28.0
+

--- a/pkg/uwb-dw1000/patches/0002-uwb_dw1000-dw1000_hal-send-spi-cmd-and-data-separetl.patch
+++ b/pkg/uwb-dw1000/patches/0002-uwb_dw1000-dw1000_hal-send-spi-cmd-and-data-separetl.patch
@@ -1,0 +1,57 @@
+From 8fc632df3880e9bc53766b8e2559c6e71c4d3c28 Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Fri, 14 Aug 2020 13:55:11 +0200
+Subject: [PATCH 2/5] uwb_dw1000/dw1000_hal: send spi cmd and data separetly
+ for RIOT
+
+---
+ hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c b/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
+index c9107fa..b85e32a 100644
+--- a/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
++++ b/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
+@@ -310,7 +310,7 @@ hal_dw1000_read(struct _dw1000_dev_instance_t * inst,
+ 
+     hal_gpio_write(inst->ss_pin, 0);
+ 
+-#if !defined(MYNEWT)
++#if !defined(MYNEWT) && !defined(RIOT)
+     /* Linux mode really, for when we can't split the command and data */
+     assert(cmd_size + length < inst->uwb_dev.txbuf_size);
+     assert(cmd_size + length < MYNEWT_VAL(DW1000_HAL_SPI_MAX_CNT));
+@@ -322,7 +322,7 @@ hal_dw1000_read(struct _dw1000_dev_instance_t * inst,
+                       inst->uwb_dev.txbuf, cmd_size+length);
+     memcpy(buffer, inst->uwb_dev.txbuf + cmd_size, length);
+ #else
+-    rc = hal_spi_txrx(inst->spi_num, (void*)cmd, 0, cmd_size);
++    rc = hal_spi_txrx(inst->spi_num, (void*)cmd, NULL, cmd_size);
+     assert(rc == DPL_OK);
+     int step = (inst->uwb_dev.txbuf_size > MYNEWT_VAL(DW1000_HAL_SPI_MAX_CNT)) ?
+         MYNEWT_VAL(DW1000_HAL_SPI_MAX_CNT) : inst->uwb_dev.txbuf_size;
+@@ -537,7 +537,7 @@ hal_dw1000_write(struct _dw1000_dev_instance_t * inst, const uint8_t * cmd, uint
+ 
+     hal_gpio_write(inst->ss_pin, 0);
+ 
+-#if !defined(MYNEWT)
++#if !defined(MYNEWT) && !defined(RIOT)
+     /* Linux mode really, for when we can't split the command and data */
+     assert(cmd_size + length < inst->uwb_dev.txbuf_size);
+     assert(cmd_size + length < MYNEWT_VAL(DW1000_HAL_SPI_MAX_CNT));
+@@ -549,10 +549,10 @@ hal_dw1000_write(struct _dw1000_dev_instance_t * inst, const uint8_t * cmd, uint
+                       0, cmd_size+length);
+     assert(rc == DPL_OK);
+ #else
+-    rc = hal_spi_txrx(inst->spi_num, (void*)cmd, 0, cmd_size);
++    rc = hal_spi_txrx(inst->spi_num, (void*)cmd, NULL, cmd_size);
+     assert(rc == DPL_OK);
+     if (length) {
+-        hal_spi_txrx(inst->spi_num, (void*)buffer, 0, length);
++        hal_spi_txrx(inst->spi_num, (void*)buffer, NULL, length);
+     }
+ #endif
+ 
+-- 
+2.28.0
+

--- a/pkg/uwb-dw1000/patches/0003-uwb_dw1000-dw1000_hal-define-even-if-DW1000_DEVICE_0.patch
+++ b/pkg/uwb-dw1000/patches/0003-uwb_dw1000-dw1000_hal-define-even-if-DW1000_DEVICE_0.patch
@@ -1,0 +1,36 @@
+From ed15486f7890a3ffb0426c153cefb951d822e93e Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Fri, 14 Aug 2020 13:56:25 +0200
+Subject: [PATCH 3/5] uwb_dw1000/dw1000_hal: define even if DW1000_DEVICE_0 is
+ unset
+
+In RIOT multiple DW1000 devices will be speficied thorugh a link
+list so `hal_dw1000_inst` must be customly defined.
+
+The rest of the api should still be defined
+---
+ hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c b/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
+index b85e32a..90ccd6c 100644
+--- a/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
++++ b/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
+@@ -262,6 +262,8 @@ hal_dw1000_inst(uint8_t idx)
+     return 0;
+ }
+ 
++#endif
++
+ /**
+  * API to reset all the gpio pins.
+  *
+@@ -756,5 +758,3 @@ hal_dw1000_get_rst(struct _dw1000_dev_instance_t * inst)
+ {
+     return hal_gpio_read(inst->rst_pin);
+ }
+-
+-#endif
+-- 
+2.28.0
+

--- a/pkg/uwb-dw1000/patches/0004-uwb_dw1000-dw1000_hal-replace-OS_-_CRTICAL-with-DPL_.patch
+++ b/pkg/uwb-dw1000/patches/0004-uwb_dw1000-dw1000_hal-replace-OS_-_CRTICAL-with-DPL_.patch
@@ -1,0 +1,35 @@
+From 445e0e92d874d9af5b4e679328e07ec32e79b07a Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Fri, 14 Aug 2020 15:19:26 +0200
+Subject: [PATCH 4/5] uwb_dw1000/dw1000_hal: replace OS_%_CRTICAL with
+ DPL_%_CRITICAL
+
+---
+ hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c b/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
+index 90ccd6c..30539a5 100644
+--- a/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
++++ b/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
+@@ -723,7 +723,7 @@ hal_dw1000_wakeup(struct _dw1000_dev_instance_t * inst)
+         goto early_exit;
+     }
+ 
+-    OS_ENTER_CRITICAL(sr);
++    DPL_ENTER_CRITICAL(sr);
+ 
+     hal_spi_disable(inst->spi_num);
+     hal_gpio_write(inst->ss_pin, 0);
+@@ -738,7 +738,7 @@ hal_dw1000_wakeup(struct _dw1000_dev_instance_t * inst)
+     // (check PLL bit in IRQ?)
+     dpl_cputime_delay_usecs(5000);
+ 
+-    OS_EXIT_CRITICAL(sr);
++    DPL_EXIT_CRITICAL(sr);
+ 
+     rc = dpl_sem_release(inst->spi_sem);
+     assert(rc == DPL_OK);
+-- 
+2.28.0
+

--- a/pkg/uwb-dw1000/patches/0005-uwb_dw1000-dw1000_hal-os_sr_t-by-dpl_sr_t.patch
+++ b/pkg/uwb-dw1000/patches/0005-uwb_dw1000-dw1000_hal-os_sr_t-by-dpl_sr_t.patch
@@ -1,0 +1,25 @@
+From 715f6687e3b2b77f63303e3c231fbeb2c8588e97 Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Thu, 17 Sep 2020 12:26:44 +0200
+Subject: [PATCH 5/5] uwb_dw1000/dw1000_hal: os_sr_t by dpl_sr_t
+
+---
+ hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c b/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
+index 30539a5..4cff459 100644
+--- a/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
++++ b/hw/drivers/uwb/uwb_dw1000/src/dw1000_hal.c
+@@ -715,7 +715,7 @@ int
+ hal_dw1000_wakeup(struct _dw1000_dev_instance_t * inst)
+ {
+     int rc = DPL_OK;
+-    os_sr_t sr;
++    dpl_sr_t sr;
+     assert(inst->spi_sem);
+     rc = dpl_sem_pend(inst->spi_sem, DPL_TIMEOUT_NEVER);
+     if (rc != DPL_OK) {
+-- 
+2.28.0
+

--- a/pkg/uwb-dw1000/patches/0006-dw1000-dw1000_dev-use-gpio_t-types-for-dev_cfg.patch
+++ b/pkg/uwb-dw1000/patches/0006-dw1000-dw1000_dev-use-gpio_t-types-for-dev_cfg.patch
@@ -1,0 +1,29 @@
+From e8207fa0b9ececc5e1d5e3c4fe1bc491b4d74884 Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Wed, 7 Oct 2020 14:11:43 +0200
+Subject: [PATCH 6/6] dw1000/dw1000_dev: use gpio_t types for dev_cfg
+
+---
+ hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h b/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h
+index 2dcd7f8..e149054 100644
+--- a/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h
++++ b/hw/drivers/uwb/uwb_dw1000/include/dw1000/dw1000_dev.h
+@@ -214,9 +214,9 @@ struct dw1000_dev_cfg {
+     int spi_baudrate;             //!< SPI Baudrate (<20MHz)
+     int spi_baudrate_low;         //!< Low SPI Baudrate (<2MHz)
+     uint8_t spi_num;              //!< SPI number
+-    uint8_t rst_pin;              //!< Reset pin
+-    uint8_t irq_pin;              //!< Interrupt request pin
+-    uint8_t ss_pin;               //!< Slave select pin
++    gpio_t rst_pin;               //!< Reset pin
++    gpio_t irq_pin;               //!< Interrupt request pin
++    gpio_t ss_pin;                //!< Slave select pin
+ 
+     uint16_t rx_antenna_delay;    //!< Receive antenna delay
+     uint16_t tx_antenna_delay;    //!< Transmit antenna delay
+-- 
+2.28.0
+

--- a/pkg/uwb-dw1000/patches/0007-uwb_dw1000-dw1000_mac-avoid-conflict-with-msp430-N.patch
+++ b/pkg/uwb-dw1000/patches/0007-uwb_dw1000-dw1000_mac-avoid-conflict-with-msp430-N.patch
@@ -1,0 +1,47 @@
+From cea55ec226b13c3c57c492af76d08573e834f164 Mon Sep 17 00:00:00 2001
+From: Francisco Molina <femolina@uc.cl>
+Date: Wed, 7 Oct 2020 16:14:22 +0200
+Subject: [PATCH 7/7] uwb_dw1000/dw1000_mac: avoid conflict with msp430 #N
+
+---
+ hw/drivers/uwb/uwb_dw1000/src/dw1000_mac.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/hw/drivers/uwb/uwb_dw1000/src/dw1000_mac.c b/hw/drivers/uwb/uwb_dw1000/src/dw1000_mac.c
+index c4e5a3e..0d520b9 100644
+--- a/hw/drivers/uwb/uwb_dw1000/src/dw1000_mac.c
++++ b/hw/drivers/uwb/uwb_dw1000/src/dw1000_mac.c
+@@ -1841,25 +1841,25 @@ dpl_float32_t
+ dw1000_calc_fppl(struct _dw1000_dev_instance_t * inst,
+                  struct _dw1000_dev_rxdiag_t * diag)
+ {
+-    dpl_float32_t A, N, v, fppl;
++    dpl_float32_t A, n, v, fppl;
+     if (diag->pacc_cnt == 0 ||
+         (!diag->fp_amp && !diag->fp_amp2 && !diag->fp_amp3)) {
+         return DPL_FLOAT32_NAN();
+     }
+     A = (inst->uwb_dev.config.prf == DWT_PRF_16M) ? DPL_FLOAT32_INIT(113.77f) : DPL_FLOAT32_INIT(121.74f);
+ #ifdef __KERNEL__
+-    N = ui32_to_f32(diag->pacc_cnt);
++    n = ui32_to_f32(diag->pacc_cnt);
+     v = f32_add(f32_add(ui32_to_f32(diag->fp_amp*diag->fp_amp),
+                         ui32_to_f32(diag->fp_amp2*diag->fp_amp2)),
+                 ui32_to_f32(diag->fp_amp3*diag->fp_amp3));
+-    v = f32_div(v, f32_mul(N, N));
++    v = f32_div(v, f32_mul(n, n));
+     fppl = f32_sub(f32_mul(DPL_FLOAT32_INIT(10.0), f64_to_f32(log10_soft(f32_to_f64(v)))), A);
+ #else
+-    N = (float)(diag->pacc_cnt);
++    n = (float)(diag->pacc_cnt);
+     v = (float)(diag->fp_amp*diag->fp_amp) +
+         (float)(diag->fp_amp2*diag->fp_amp2) +
+         (float)(diag->fp_amp3*diag->fp_amp3);
+-    v /= N * N;
++    v /= n * n;
+     fppl = 10.0f * log10f(v) - A;
+ #endif
+     return fppl;
+-- 
+2.28.0
+

--- a/pkg/uwb-dw1000/uwb-dw1000.mk
+++ b/pkg/uwb-dw1000/uwb-dw1000.mk
@@ -1,0 +1,13 @@
+# exclude submodule sources from *.c wildcard source selection
+
+IGNORE_SRC = \
+    dw1000_pkg.c \
+    dw1000_cli.c \
+    dw1000_cli_priv.c \
+    dw1000_sysfs.c \
+    dw1000_debugfs.c \
+    #
+
+SRC := $(filter-out $(IGNORE_SRC),$(wildcard *.c))
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -113,6 +113,11 @@ void auto_init(void)
         extern void openwsn_bootstrap(void);
         openwsn_bootstrap();
     }
+    if (IS_USED(MODULE_AUTO_INIT_UWB_CORE)) {
+        LOG_DEBUG("Bootstrapping uwb core.\n");
+        extern void uwb_core_init(void);
+        uwb_core_init();
+    }
     if (IS_USED(MODULE_GCOAP) &&
         !IS_ACTIVE(CONFIG_GCOAP_NO_AUTO_INIT)) {
         LOG_DEBUG("Auto init gcoap.\n");


### PR DESCRIPTION
### Contribution description

This PR adds support for Decawave [uwb-core](https://github.com/Decawave/uwb-core), this provide a series of libraries to perform ranging between UWB devices.

The library contains multiple modules and in this initial PR not all are supported, please check the pkg documentation for details. So far TWR is supported, the other modules will be added in subsequent PR's.

For details on the pkg please refer to the pkg documentation.

This PR also includes the `uwb-dw1000`, in the future this could be used to provide a netdev interface for the dw1000 driver.

~~NOTE: 150a798 needs to be fixed, I don't understand the issue yet.~~

### Testing procedure

There is an examples under `examples/twr_aloha`, checking that the example works.
