### PR TITLE
cpu/stm32l0l1: add MCO configuration and initialization

### DIFF
--- a/cpu/stm32/stmclk/stmclk_l0l1.c
+++ b/cpu/stm32/stmclk/stmclk_l0l1.c
@@ -24,6 +24,7 @@
 #include "cpu.h"
 #include "stmclk.h"
 #include "periph_conf.h"
+#include "periph/gpio.h"
 
 #if defined(CPU_FAM_STM32L1)
 #define REG_CIR     (RCC->CIR)
@@ -118,11 +119,139 @@
 #error "Invalid MSI clock value"
 #endif
 
+/* Configure MCO */
+#ifndef CONFIG_CLOCK_ENABLE_MCO
+#define CONFIG_CLOCK_ENABLE_MCO     0   /* Don't enable MCO by default */
+#endif
+
+/* Configure the MCO clock source: options are PLLCLK (default), HSE, HSI, LSE, LSI, MSI or SYSCLK*/
+#ifndef CONFIG_CLOCK_MCO_USE_PLLCLK
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI) || \
+    IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI) || \
+    IS_ACTIVE(CONFIG_CLOCK_MCO_USE_MSI) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK)
+#define CONFIG_CLOCK_MCO_USE_PLLCLK 0
+#else
+#define CONFIG_CLOCK_MCO_USE_PLLCLK 1   /* Use PLLCLK by default */
+#endif
+#endif /* CONFIG_CLOCK_MCO_USE_PLLCLK */
+
+#ifndef CONFIG_CLOCK_MCO_USE_HSE
+#define CONFIG_CLOCK_MCO_USE_HSE    0
+#endif /* CONFIG_CLOCK_MCO_USE_HSE */
+
+#ifndef CONFIG_CLOCK_MCO_USE_HSI
+#define CONFIG_CLOCK_MCO_USE_HSI    0
+#endif /* CONFIG_CLOCK_MCO_USE_HSI */
+
+#ifndef CONFIG_CLOCK_MCO_USE_LSE
+#define CONFIG_CLOCK_MCO_USE_LSE    0
+#endif /* CONFIG_CLOCK_MCO_USE_LSE */
+
+#ifndef CONFIG_CLOCK_MCO_USE_LSI
+#define CONFIG_CLOCK_MCO_USE_LSI    0
+#endif /* CONFIG_CLOCK_MCO_USE_LSI */
+
+#ifndef CONFIG_CLOCK_MCO_USE_MSI
+#define CONFIG_CLOCK_MCO_USE_MSI    0
+#endif /* CONFIG_CLOCK_MCO_USE_MSI */
+
+#ifndef CONFIG_CLOCK_MCO_USE_SYSCLK
+#define CONFIG_CLOCK_MCO_USE_SYSCLK 0
+#endif /* CONFIG_CLOCK_MCO_USE_SYSCLK */
+
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK) && \
+    (IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_MSI) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK))
+#error "Cannot use PLLCLK as MCO clock source with other clocks"
+#endif
+
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE) && \
+    (IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_MSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK))
+#error "Cannot use HSE as MCO clock source with other clocks"
+#endif
+
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI) && \
+    (IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_MSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK))
+#error "Cannot use HSI as MCO clock source with other clocks"
+#endif
+
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE) && \
+    (IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_MSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK))
+#error "Cannot use LSE as MCO clock source with other clocks"
+#endif
+
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI) && \
+    (IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_MSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK))
+#error "Cannot use LSI as MCO clock source with other clocks"
+#endif
+
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_MSI) && \
+    (IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLL) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK))
+#error "Cannot use MSI as MCO clock source with other clocks"
+#endif
+
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK) && \
+    (IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_MSI) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK))
+#error "Cannot use SYSCLK as MCO clock source with other clocks"
+#endif
+
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK)
+#define CLOCK_MCO_SRC                           (RCC_CFGR_MCOSEL_0)
+#elif IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI)
+#define CLOCK_MCO_SRC                           (RCC_CFGR_MCOSEL_1)
+#elif IS_ACTIVE(CONFIG_CLOCK_MCO_USE_MSI)
+#define CLOCK_MCO_SRC                           (RCC_CFGR_MCOSEL_1 | RCC_CFGR_MCOSEL_0)
+#elif IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE)
+#define CLOCK_MCO_SRC                           (RCC_CFGR_MCOSEL_2)
+#elif IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK)
+#define CLOCK_MCO_SRC                           (RCC_CFGR_MCOSEL_2 | RCC_CFGR_MCOSEL_0)
+#elif IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI)
+#define CLOCK_MCO_SRC                           (RCC_CFGR_MCOSEL_2 | RCC_CFGR_MCOSEL_1)
+#elif IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE)
+#define CLOCK_MCO_SRC                           (RCC_CFGR_MCOSEL_2 | RCC_CFGR_MCOSEL_1 | RCC_CFGR_MCOSEL_0)
+#else
+#error "Invalid MCO clock source selection"
+#endif
+
+/* Configure the MCO prescaler: valid values are 1, 2, 4, 8, 16 */
+#ifndef CONFIG_CLOCK_MCO_PRE
+#define CONFIG_CLOCK_MCO_PRE                    (1)
+#endif
+
+#if CONFIG_CLOCK_MCO_PRE == 1
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_DIV1)
+#elif CONFIG_CLOCK_MCO_PRE == 2
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_DIV2)
+#elif CONFIG_CLOCK_MCO_PRE == 4
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_DIV4)
+#elif CONFIG_CLOCK_MCO_PRE == 8
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_DIV8)
+#elif CONFIG_CLOCK_MCO_PRE == 16
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_DIV16)
+#else
+#error "Invalid MCO prescaler"
+#endif
+
 /* Check whether PLL must be enabled:
   - When PLLCLK is used as SYSCLK
   - When HWRNG feature is used (for the 48MHz clock)
+  - When PLLCLK is used as input for MCO
 */
-#if IS_ACTIVE(CONFIG_USE_CLOCK_PLL) || IS_USED(MODULE_PERIPH_HWRNG)
+#if IS_ACTIVE(CONFIG_USE_CLOCK_PLL) || IS_USED(MODULE_PERIPH_HWRNG) || \
+    (IS_ACTIVE(CONFIG_CLOCK_ENABLE_MCO) && IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK))
 #define CLOCK_ENABLE_PLL            1
 #else
 #define CLOCK_ENABLE_PLL            0
@@ -132,9 +261,11 @@
   - When HSE is used as SYSCLK
   - When PLL is used as SYSCLK and the board provides HSE (since HSE will be
     used as PLL input clock)
+  - When HSE is used as input for MCO
 */
 #if IS_ACTIVE(CONFIG_USE_CLOCK_HSE) || \
-    (IS_ACTIVE(CONFIG_BOARD_HAS_HSE) && IS_ACTIVE(CONFIG_USE_CLOCK_PLL))
+    (IS_ACTIVE(CONFIG_BOARD_HAS_HSE) && IS_ACTIVE(CONFIG_USE_CLOCK_PLL)) || \
+    (IS_ACTIVE(CONFIG_CLOCK_ENABLE_MCO) && IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE))
 #define CLOCK_ENABLE_HSE            1
 #else
 #define CLOCK_ENABLE_HSE            0
@@ -144,9 +275,11 @@
   - When HSI is used as SYSCLK
   - When PLL is used as SYSCLK and the board doesn't provide HSE (since HSI will be
     used as PLL input clock)
+  - When HSI is used as input for MCO
 */
 #if IS_ACTIVE(CONFIG_USE_CLOCK_HSI) || \
-    (!IS_ACTIVE(CONFIG_BOARD_HAS_HSE) && IS_ACTIVE(CONFIG_USE_CLOCK_PLL))
+    (!IS_ACTIVE(CONFIG_BOARD_HAS_HSE) && IS_ACTIVE(CONFIG_USE_CLOCK_PLL)) || \
+    (IS_ACTIVE(CONFIG_CLOCK_ENABLE_MCO) && IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI))
 #define CLOCK_ENABLE_HSI            1
 #else
 #define CLOCK_ENABLE_HSI            0
@@ -154,11 +287,31 @@
 
 /* Check whether MSI must be enabled:
   - When MSI is used as SYSCLK
+  - When MSI is used as input for MCO
 */
-#if IS_ACTIVE(CONFIG_USE_CLOCK_MSI)
+#if IS_ACTIVE(CONFIG_USE_CLOCK_MSI) || \
+    (IS_ACTIVE(CONFIG_CLOCK_ENABLE_MCO) && IS_ACTIVE(CONFIG_CLOCK_MCO_USE_MSI))
 #define CLOCK_ENABLE_MSI            1
 #else
 #define CLOCK_ENABLE_MSI            0
+#endif
+
+/* Check whether LSE must be enabled:
+  - When LSE is used as input for MCO
+*/
+#if (IS_ACTIVE(CONFIG_CLOCK_ENABLE_MCO) && IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE))
+#define CLOCK_ENABLE_LSE            1
+#else
+#define CLOCK_ENABLE_LSE            0
+#endif
+
+/* Check whether LSI must be enabled:
+  - When LSI is used as input for MCO
+*/
+#if (IS_ACTIVE(CONFIG_CLOCK_ENABLE_MCO) && IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI))
+#define CLOCK_ENABLE_LSI            1
+#else
+#define CLOCK_ENABLE_LSI            0
 #endif
 
 /**
@@ -252,6 +405,38 @@ void stmclk_init_sysclk(void)
     if (!IS_ACTIVE(CLOCK_ENABLE_HSI)) {
         /* Disable HSI only if not needed */
         stmclk_disable_hsi();
+    }
+
+    /* Enable the LSE if used for MCO
+     * If available on the board, LSE might also be initialized for RTT/RTC
+     * peripherals. For the monent, this initialization is done in the
+     * corresponding peripheral drivers. */
+    if (IS_ACTIVE(CLOCK_ENABLE_LSE)) {
+        stmclk_dbp_unlock();
+        RCC->CSR |= RCC_CSR_LSEON;
+        while (!(RCC->CSR & RCC_CSR_LSERDY)) {}
+        stmclk_dbp_lock();
+    }
+
+    /* Enable the LSI if used for MCO
+     * If no LSE is available on the board, LSI might also be initialized for
+     * RTT/RTC peripherals. For the monent, this initialization is done in the
+     * corresponding peripheral drivers. */
+    if (IS_ACTIVE(CLOCK_ENABLE_LSI)) {
+        RCC->CSR |= RCC_CSR_LSION;
+        while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
+    }
+
+    /* Configure MCO */
+    if (IS_ACTIVE(CONFIG_CLOCK_ENABLE_MCO)) {
+        /* As stated in the manual, it is highly recommend to change the MCO
+           prescaler before enabling the MCO */
+        RCC->CFGR |= CLOCK_MCO_PRE;
+        RCC->CFGR |= CLOCK_MCO_SRC;
+
+        /* Configure MCO pin (PA8/AF0) */
+        gpio_init(GPIO_PIN(PORT_A, 8), GPIO_OUT);
+        gpio_init_af(GPIO_PIN(PORT_A, 8), GPIO_AF0);
     }
 
     irq_restore(is);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR extends the STM32L0/L1 clock config/initialization with MCO (microcontroller clock output). This feature allows to output one clock source between LSE, LSI, HSE, HSI, MSI, PLLCLK or SYSCLK to a GPIO pin (PA8 with AF0).

This PR makes all possible clock sources usable and also allows to configure the MCO prescaler (among 1, 2, 4, 8, 16, the defaut is 1).

Using one of the MCO clock source will automatically enable the corresponding underlying clock. So for example, it's possible to use HSI as system clock while using the PLLCLK as input clock for MCO.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

To test this PR, one needs a logic analyzer or a scope to verify the clock output on PA8 when MCO is enabled. I'm using a chinese saelae logic analyzer with PulseView on Ubuntu. In this setup, I cannot have a clean measure for clock frequency > 24MHz because my logic analyzer has a maximum sample rate of 48MHz.

Here I provide the output of MCO measured with a nucleo-l073rz, PA8 is available on D7. Any application can be used, so here I'm testing with `examples/hello-world`.

<details><summary>MCO: LSE => expected frequency is 32768kHz</summary>

![image](https://user-images.githubusercontent.com/1375137/94114559-cbe36800-fe48-11ea-9aaf-df5f8534149f.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_PLL=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_LSE=1 -DCONFIG_CLOCK_MCO_PRE=1" BUILD_IN_DOCKER=1  make BOARD=nucleo-l073rz -C examples/hello-world flash term --no-print-directory
```
</details>

<details><summary>MCO: LSI => expected frequency is 37kHz (but the actual value is very inaccurate)</summary>

![image](https://user-images.githubusercontent.com/1375137/94114649-eae1fa00-fe48-11ea-87d6-3d5dfb77ce0c.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_PLL=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_LSI=1 -DCONFIG_CLOCK_MCO_PRE=1" BUILD_IN_DOCKER=1  make BOARD=nucleo-l073rz -C examples/hello-world flash term --no-print-directory
```
</details>

<details><summary>MCO: HSI => expected frequency is 16MHz</summary>

![image](https://user-images.githubusercontent.com/1375137/94114753-11079a00-fe49-11ea-97e0-ebd6ea6c6ad5.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_PLL=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_HSI=1 -DCONFIG_CLOCK_MCO_PRE=1" BUILD_IN_DOCKER=1  make BOARD=nucleo-l073rz -C examples/hello-world flash term --no-print-directory
```
</details>

<details><summary>MCO: HSI (16MHz) + prescaler 16 => expected frequency is 1MHz</summary>

![image](https://user-images.githubusercontent.com/1375137/94114850-2ed4ff00-fe49-11ea-810d-03fea0f9fd76.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_PLL=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_HSI=1 -DCONFIG_CLOCK_MCO_PRE=16" BUILD_IN_DOCKER=1  make BOARD=nucleo-l073rz -C examples/hello-world flash term --no-print-directory
```
</details>

<details><summary>MCO: MSI (4194kHz) + no prescaler</summary>

![image](https://user-images.githubusercontent.com/1375137/94114989-63e15180-fe49-11ea-8880-2a9e89180fb0.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_PLL=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_MSI=1 -DCONFIG_CLOCK_MCO_PRE=1" BUILD_IN_DOCKER=1  make BOARD=nucleo-l073rz -C examples/hello-world flash term --no-print-directory
```
</details>

<details><summary>MCO: PLLCLK + HSI used as SYSCLK (16MHz) + prescaler 8 => expected frequency is 4MHz (because PLLCLK is 32MHz by default)</summary>

![image](https://user-images.githubusercontent.com/1375137/94115250-bcb0ea00-fe49-11ea-8274-13b1b29c43db.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_HSI=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_PLLCLK=1 -DCONFIG_CLOCK_MCO_PRE=8" BUILD_IN_DOCKER=1  make BOARD=nucleo-l073rz -C examples/hello-world flash term --no-print-directory
```
</details>

<details><summary>MCO: SYSCLK + HSI used as SYSCLK + prescaler 8 => expected frequency is 2MHz</summary>

![image](https://user-images.githubusercontent.com/1375137/94115402-f3870000-fe49-11ea-8d52-cf76a00033e3.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_HSI=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_SYSCLK=1 -DCONFIG_CLOCK_MCO_PRE=8" BUILD_IN_DOCKER=1  make BOARD=nucleo-l073rz -C examples/hello-world flash term --no-print-directory
```
</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick one item in #14975 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
