### PR TITLE
sys/evtimer: copy warning from xtimer

### DIFF
--- a/sys/include/evtimer.h
+++ b/sys/include/evtimer.h
@@ -78,6 +78,10 @@ typedef struct {
 /**
  * @brief   Initializes an event timer
  *
+ * @warning BEWARE! Callbacks from evtimer_init() are being executed
+ * in interrupt context.
+ * DON'T USE THIS FUNCTION unless you know *exactly* what that means.
+ *
  * @param[in] evtimer   An event timer
  * @param[in] handler   An event handler function
  */


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Callbacks from evtimer are still executed in interrupt context.
While xtimer warns about this, evtimer leaves the user unsuspecting.

Copy the warning from xtimer to keep users vigilant.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
