### PR TITLE
xtimer: introduce xtimer_msleep()

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -147,6 +147,13 @@ void xtimer_init(void);
 static inline void xtimer_sleep(uint32_t seconds);
 
 /**
+ * @brief Pause the execution of a thread for some milliseconds
+ *
+ * @param[in] milliseconds  the amount of milliseconds the thread should sleep
+ */
+static inline void xtimer_msleep(uint32_t milliseconds);
+
+/**
  * @brief Pause the execution of a thread for some microseconds
  *
  * When called from an ISR, this function will spin and thus block the MCU for

--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -172,6 +172,11 @@ static inline void xtimer_spin(xtimer_ticks32_t ticks) {
     _xtimer_spin(ticks.ticks32);
 }
 
+static inline void xtimer_msleep(uint32_t milliseconds)
+{
+    _xtimer_tsleep64(_xtimer_ticks_from_usec64(milliseconds * US_PER_MS));
+}
+
 static inline void xtimer_usleep(uint32_t microseconds)
 {
     _xtimer_tsleep32(_xtimer_ticks_from_usec(microseconds));


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Add a function that sleeps for ms instead of µs.
This will make the conversion to ztimer easier for users as now there is a direct mapping to `ZTIMER_MSEC`.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
