### PR TITLE
gnrc_ipv6_nib: only multicast probe UNREACHABLE neighbor if 6LR

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.h
@@ -34,7 +34,6 @@
 extern "C" {
 #endif
 
-#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN) || defined(DOXYGEN)
 /**
  * @brief   Additional (local) status to ARO status values for tentative
  *          addresses
@@ -57,6 +56,7 @@ extern "C" {
  */
 #define _ADDR_REG_STATUS_UNAVAIL        (255)
 
+#if IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LN) || defined(DOXYGEN)
 /**
  * @brief   Resolves address statically from destination address using reverse
  *          translation of the IID

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -233,7 +233,19 @@ void _handle_snd_ns(_nib_onl_entry_t *nbr)
             }
             /* intentionally falls through */
         case GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNREACHABLE:
-            _probe_nbr(nbr, false);
+            if (!IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LR) ||
+                /* if neighbor is a 6LoWPAN node (i.e. address registartion
+                 * state is non-garbage-collectible), only probe if it is a
+                 * router (where the solicited-nodes multicast address MUST
+                 * be set; only MAY otherwise).
+                 * See:
+                 * - https://tools.ietf.org/html/rfc6775#section-5.2
+                 * - https://tools.ietf.org/html/rfc6775#section-6.5.5
+                 */
+                (_get_ar_state(nbr) == GNRC_IPV6_NIB_NC_INFO_AR_STATE_GC) ||
+                (nbr->info & GNRC_IPV6_NIB_NC_INFO_IS_ROUTER)) {
+                _probe_nbr(nbr, false);
+            }
             break;
         default:
             break;


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This is a companion to https://github.com/RIOT-OS/RIOT/pull/15077. It stops routers from sending out multicast probes for unreachable non-routing 6LNs

Non-routing 6LNs do not have to join the solicited nodes address, so probing for a neighbor using that address may be in vain and only spamming the LLN with unnecessary messages. RFC 6775 basically assumes this in section 5.2:

> There is no need to join the solicited-node multicast address, since _nobody_ multicasts NSs in this type of network.

6LRs however MUST join that address as routers [MAY use multicast NS to resolve their addresses](https://tools.ietf.org/html/rfc6775#section-6.5.5), so it is fine to still probe for them:

> Routers MAY also use multicast NSs as in [RFC4861] to resolve each others link-layer addresses.  Thus, routers MAY multicast NSs for other routers, for example, as a result of receiving some routing protocol update.  Routers MUST respond to multicast NSs.  This implies that routers MUST join the solicited-node multicast addresses as specified in [RFC4861].

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Use the testing procedures from https://github.com/RIOT-OS/RIOT/pull/15077. No multicast NS should be seen if you sniff the loopback interface (use Wireshark display filter `icmpv6.type == 135 && ipv6.dst < ff02::2:0:0 && ipv6.dst >= ff02::1:ff00:0` to confirm). When the sleepy node application is compiled with `gnrc_ipv6_router_default` instead of `gnrc_ipv6_default`, multicast NS should be sent out again.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
See https://github.com/RIOT-OS/RIOT/pull/15077#issuecomment-698265391
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
