### PR TITLE
sys/net: remove unused routing directory

### DIFF
--- a/sys/net/routing/Makefile
+++ b/sys/net/routing/Makefile
@@ -1,1 +1,0 @@
-include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description
When NHDP was removed in #13396 the `routing` directory was emptied, and is no longer needed. This removes it.

### Testing procedure
Green CI.

### Issues/PRs references
Pointed out by @akshaim in https://github.com/RIOT-OS/RIOT/pull/15007#discussion_r494405879
#13396
