### PR TITLE
drivers/enc28j60: register with netdev

### DIFF
--- a/drivers/enc28j60/Makefile.dep
+++ b/drivers/enc28j60/Makefile.dep
@@ -1,6 +1,7 @@
 FEATURES_REQUIRED += periph_gpio
 FEATURES_REQUIRED += periph_gpio_irq
 FEATURES_REQUIRED += periph_spi
+
+USEMODULE += eui_provider
 USEMODULE += netdev_eth
 USEMODULE += xtimer
-USEMODULE += luid

--- a/drivers/include/enc28j60.h
+++ b/drivers/include/enc28j60.h
@@ -57,8 +57,10 @@ typedef struct {
  *
  * @param[in] dev           device descriptor
  * @param[in] params        peripheral configuration to use
+ * @param[in]   index       Index of @p params in a global parameter struct array.
+ *                          If initialized manually, pass a unique identifier instead.
  */
-void enc28j60_setup(enc28j60_t *dev, const enc28j60_params_t *params);
+void enc28j60_setup(enc28j60_t *dev, const enc28j60_params_t *params, uint8_t index);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -282,6 +282,7 @@ typedef enum {
     NETDEV_AT86RF2XX,
     NETDEV_CC2538,
     NETDEV_DOSE,
+    NETDEV_ENC28J60,
     NETDEV_MRF24J40,
     NETDEV_NRF802154,
     /* add more if needed */

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -218,7 +218,7 @@ void lwip_bootstrap(void)
     }
 #elif defined(MODULE_ENC28J60)
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
-        enc28j60_setup(&enc28j60_devs[i], &enc28j60_params[i]);
+        enc28j60_setup(&enc28j60_devs[i], &enc28j60_params[i], i);
         if (_netif_add(&netif[0], &enc28j60_devs[i], lwip_netdev_init,
                        tcpip_input) == NULL) {
             DEBUG("Could not add enc28j60 device\n");

--- a/sys/net/gnrc/netif/init_devs/auto_init_enc28j60.c
+++ b/sys/net/gnrc/netif/init_devs/auto_init_enc28j60.c
@@ -60,7 +60,7 @@ void auto_init_enc28j60(void)
         LOG_DEBUG("[auto_init_netif] initializing enc28j60 #%u\n", i);
 
         /* setup netdev device */
-        enc28j60_setup(&dev[i], &enc28j60_params[i]);
+        enc28j60_setup(&dev[i], &enc28j60_params[i], i);
         gnrc_netif_ethernet_create(&_netif[i], stack[i], ENC28J60_MAC_STACKSIZE,
                                    ENC28J60_MAC_PRIO, "enc28j60",
                                    (netdev_t *)&dev[i]);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Register `enc28j60` so we can use `eui_provider` to assign the module a MAC address. 


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14634#issuecomment-698357424
