### PR TITLE
cpu/stm32gx: add MCO configuration and initialization

### DIFF
--- a/cpu/stm32/stmclk/stmclk_gx.c
+++ b/cpu/stm32/stmclk/stmclk_gx.c
@@ -20,6 +20,7 @@
 #include "cpu.h"
 #include "stmclk.h"
 #include "periph_conf.h"
+#include "periph/gpio.h"
 
 #if defined(CPU_FAM_STM32G0)
 #define PLL_M_MIN                   (1)
@@ -131,10 +132,149 @@
 #endif
 #endif /* CPU_FAM_STM32G4 */
 
+/* Configure MCO */
+#ifndef CONFIG_CLOCK_ENABLE_MCO
+#define CONFIG_CLOCK_ENABLE_MCO     0   /* Don't enable MCO by default */
+#endif
+
+/* Configure the MCO clock source: options are PLLCLK (default), HSE, HSI, LSE, LSI or SYSCLK*/
+#ifndef CONFIG_CLOCK_MCO_USE_PLLCLK
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI) || \
+    IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI) || \
+    IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK)
+#define CONFIG_CLOCK_MCO_USE_PLLCLK 0
+#else
+#define CONFIG_CLOCK_MCO_USE_PLLCLK 1   /* Use PLLCLK by default */
+#endif
+#endif /* CONFIG_CLOCK_MCO_USE_PLLCLK */
+
+#ifndef CONFIG_CLOCK_MCO_USE_HSE
+#define CONFIG_CLOCK_MCO_USE_HSE    0
+#endif /* CONFIG_CLOCK_MCO_USE_HSE */
+
+#ifndef CONFIG_CLOCK_MCO_USE_HSI
+#define CONFIG_CLOCK_MCO_USE_HSI    0
+#endif /* CONFIG_CLOCK_MCO_USE_HSI */
+
+#ifndef CONFIG_CLOCK_MCO_USE_LSE
+#define CONFIG_CLOCK_MCO_USE_LSE    0
+#endif /* CONFIG_CLOCK_MCO_USE_LSE */
+
+#ifndef CONFIG_CLOCK_MCO_USE_LSI
+#define CONFIG_CLOCK_MCO_USE_LSI    0
+#endif /* CONFIG_CLOCK_MCO_USE_LSI */
+
+#ifndef CONFIG_CLOCK_MCO_USE_SYSCLK
+#define CONFIG_CLOCK_MCO_USE_SYSCLK 0
+#endif /* CONFIG_CLOCK_MCO_USE_SYSCLK */
+
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK) && \
+    (IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK))
+#error "Cannot use PLLCLK as MCO clock source with other clocks"
+#endif
+
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE) && \
+    (IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK))
+#error "Cannot use HSE as MCO clock source with other clocks"
+#endif
+
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI) && \
+    (IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK))
+#error "Cannot use HSI as MCO clock source with other clocks"
+#endif
+
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE) && \
+    (IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK))
+#error "Cannot use LSE as MCO clock source with other clocks"
+#endif
+
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI) && \
+    (IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK))
+#error "Cannot use LSI as MCO clock source with other clocks"
+#endif
+
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK) && \
+    (IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE) || IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI) || \
+     IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK))
+#error "Cannot use SYSCLK as MCO clock source with other clocks"
+#endif
+
+#if IS_ACTIVE(CONFIG_CLOCK_MCO_USE_SYSCLK)
+#define CLOCK_MCO_SRC                           (RCC_CFGR_MCOSEL_0)
+#elif IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI)
+#define CLOCK_MCO_SRC                           (RCC_CFGR_MCOSEL_1 | RCC_CFGR_MCOSEL_0)
+#elif IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE)
+#define CLOCK_MCO_SRC                           (RCC_CFGR_MCOSEL_2)
+#elif IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK)
+#define CLOCK_MCO_SRC                           (RCC_CFGR_MCOSEL_2 | RCC_CFGR_MCOSEL_0)
+#elif IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI)
+#define CLOCK_MCO_SRC                           (RCC_CFGR_MCOSEL_2 | RCC_CFGR_MCOSEL_1)
+#elif IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE)
+#define CLOCK_MCO_SRC                           (RCC_CFGR_MCOSEL_2 | RCC_CFGR_MCOSEL_1 | RCC_CFGR_MCOSEL_0)
+#else
+#error "Invalid MCO clock source selection"
+#endif
+
+/* Configure the MCO prescaler: valid values are 1, 2, 4, 8, 16 on G4
+   and 1, 2, 4, 8, 16, 32, 64, 128 on G0 */
+#ifndef CONFIG_CLOCK_MCO_PRE
+#define CONFIG_CLOCK_MCO_PRE                    (1)
+#endif
+
+/* Define MCO prescalers for G0 for compatibility with G4 */
+#if defined(CPU_FAM_STM32G0)
+#if CONFIG_CLOCK_MCO_PRE == 1
+#define CLOCK_MCO_PRE                           (0)
+#elif CONFIG_CLOCK_MCO_PRE == 2
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_0)
+#elif CONFIG_CLOCK_MCO_PRE == 4
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_1)
+#elif CONFIG_CLOCK_MCO_PRE == 8
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_1 | RCC_CFGR_MCOPRE_0)
+#elif CONFIG_CLOCK_MCO_PRE == 16
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_2)
+#elif CONFIG_CLOCK_MCO_PRE == 32
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_2 | RCC_CFGR_MCOPRE_0)
+#elif CONFIG_CLOCK_MCO_PRE == 64
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_2 | RCC_CFGR_MCOPRE_1)
+#elif CONFIG_CLOCK_MCO_PRE == 128
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_2 | RCC_CFGR_MCOPRE_1 | RCC_CFGR_MCOPRE_0)
+#else
+#error "Invalid MCO prescaler"
+#endif
+#else /* CPU_FAM_STM32G4 */
+#if CONFIG_CLOCK_MCO_PRE == 1
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_DIV1)
+#elif CONFIG_CLOCK_MCO_PRE == 2
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_DIV2)
+#elif CONFIG_CLOCK_MCO_PRE == 4
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_DIV4)
+#elif CONFIG_CLOCK_MCO_PRE == 8
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_DIV8)
+#elif CONFIG_CLOCK_MCO_PRE == 16
+#define CLOCK_MCO_PRE                           (RCC_CFGR_MCOPRE_DIV16)
+#else
+#error "Invalid MCO prescaler"
+#endif
+#endif
+
 /* Check whether PLL must be enabled:
   - When PLLCLK is used as SYSCLK
+  - When PLLCLK is used as MCO clock source
 */
-#if IS_ACTIVE(CONFIG_USE_CLOCK_PLL)
+#if IS_ACTIVE(CONFIG_USE_CLOCK_PLL) || \
+    (IS_ACTIVE(CONFIG_CLOCK_ENABLE_MCO) && IS_ACTIVE(CONFIG_CLOCK_MCO_USE_PLLCLK))
 #define CLOCK_ENABLE_PLL            1
 #else
 #define CLOCK_ENABLE_PLL            0
@@ -144,9 +284,11 @@
   - When HSE is used as SYSCLK
   - When PLL is used as SYSCLK and the board provides HSE (since HSE will be
     used as PLL input clock)
+  - When HSE is used as MCO clock source
 */
 #if IS_ACTIVE(CONFIG_USE_CLOCK_HSE) || \
-    (IS_ACTIVE(CONFIG_BOARD_HAS_HSE) && IS_ACTIVE(CONFIG_USE_CLOCK_PLL))
+    (IS_ACTIVE(CONFIG_BOARD_HAS_HSE) && IS_ACTIVE(CONFIG_USE_CLOCK_PLL)) || \
+    (IS_ACTIVE(CONFIG_CLOCK_ENABLE_MCO) && IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSE))
 #define CLOCK_ENABLE_HSE            1
 #else
 #define CLOCK_ENABLE_HSE            0
@@ -156,14 +298,29 @@
   - When HSI is used as SYSCLK
   - When PLL is used as SYSCLK and the board doesn't provide HSE (since HSI will be
     used as PLL input clock)
+  - When HSI is used as MCO clock source
 */
 #if IS_ACTIVE(CONFIG_USE_CLOCK_HSI) || \
-    (!IS_ACTIVE(CONFIG_BOARD_HAS_HSE) && IS_ACTIVE(CONFIG_USE_CLOCK_PLL))
+    (!IS_ACTIVE(CONFIG_BOARD_HAS_HSE) && IS_ACTIVE(CONFIG_USE_CLOCK_PLL)) || \
+    (IS_ACTIVE(CONFIG_CLOCK_ENABLE_MCO) && IS_ACTIVE(CONFIG_CLOCK_MCO_USE_HSI))
 #define CLOCK_ENABLE_HSI            1
 #else
 #define CLOCK_ENABLE_HSI            0
 #endif
 
+/* Check whether LSE must be enabled */
+#if IS_ACTIVE(CONFIG_CLOCK_ENABLE_MCO) && IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSE)
+#define CLOCK_ENABLE_LSE            1
+#else
+#define CLOCK_ENABLE_LSE            0
+#endif
+
+/* Check whether LSI must be enabled */
+#if IS_ACTIVE(CONFIG_CLOCK_ENABLE_MCO) && IS_ACTIVE(CONFIG_CLOCK_MCO_USE_LSI)
+#define CLOCK_ENABLE_LSI            1
+#else
+#define CLOCK_ENABLE_LSI            0
+#endif
 
 /** Determine the required flash wait states from the core clock frequency */
 #if defined(CPU_FAM_STM32G0)
@@ -277,6 +434,38 @@ void stmclk_init_sysclk(void)
     if (!IS_ACTIVE(CLOCK_ENABLE_HSI)) {
         /* Disable HSI only if not used */
         stmclk_disable_hsi();
+    }
+
+    /* Enable the LSE if required for MCO
+     * If available on the board, LSE might also be initialized for RTT/RTC
+     * peripherals. For the monent, this initialization is done in the
+     * corresponding peripheral drivers. */
+    if (IS_ACTIVE(CLOCK_ENABLE_LSE)) {
+        stmclk_dbp_unlock();
+        RCC->BDCR |= RCC_BDCR_LSEON;
+        while (!(RCC->BDCR & RCC_BDCR_LSERDY)) {}
+        stmclk_dbp_lock();
+    }
+
+    /* Enable the LSI if required for MCO
+     * If no LSE is available on the board, LSI might also be initialized for
+     * RTT/RTC peripherals. For the monent, this initialization is done in the
+     * corresponding peripheral drivers. */
+    if (IS_ACTIVE(CLOCK_ENABLE_LSI)) {
+        RCC->CSR |= RCC_CSR_LSION;
+        while (!(RCC->CSR & RCC_CSR_LSIRDY)) {}
+    }
+
+    /* Configure MCO */
+    if (IS_ACTIVE(CONFIG_CLOCK_ENABLE_MCO)) {
+        /* As stated in the manual, it is highly recommended to change the MCO
+           prescaler before enabling the MCO */
+        RCC->CFGR |= CLOCK_MCO_PRE;
+        RCC->CFGR |= CLOCK_MCO_SRC;
+
+        /* Configure MCO pin (PA8 with AF0) */
+        gpio_init(GPIO_PIN(PORT_A, 8), GPIO_OUT);
+        gpio_init_af(GPIO_PIN(PORT_A, 8), GPIO_AF0);
     }
 
 #if IS_USED(MODULE_PERIPH_HWRNG)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR extends the STM32G0/G4 clock config/initialization with support for MCO (microcontroller clock output). This feature allows to output one clock source among LSE,LSI, HSE, HSI, PLLCLK or SYSCLK to a GPIO pin (PA8 with AF0).

The MCO prescaler can also be configured (from 1 to 128 on G0 and 1 to 16 on G4).

Using one of the MCO clock source will automatically enable the corresponding underlying clock (LSE, LSI, HSE, HSI or PLL). So for example, it's possible to use HSI as system clock while using the PLLCLK as input clock for MCO.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

To test this PR, one needs a logic analyzer or a scope to verify the clock output on PA8 when MCO is enabled. I'm using a chinese saelae logic analyzer with PulseView on Ubuntu. In this setup, I cannot have a clean measure for clock frequency > 24MHz because my logic analyzer has a maximum sample rate of 48MHz.

Here I provide the output of MCO measured with a nucleo-g070rb and nucleo-g474re. PA8 is available on D7. Any application can be used, so here I'm testing with examples/hello-world.

- **nucleo-g070rb**:

<details><summary>MCO: LSE => expected frequency is 32.768kHz</summary>

![image](https://user-images.githubusercontent.com/1375137/94232205-ca2baa00-ff05-11ea-9624-17a4f1a2313c.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_PLL=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_LSE=1 -DCONFIG_CLOCK_MCO_PRE=1" BUILD_IN_DOCKER=1  make BOARD=nucleo-g070rb -C examples/hello-world flash term --no-print-directory
```

</details>

<details><summary>MCO: LSI => expected frequency is 32kHz</summary>

![image](https://user-images.githubusercontent.com/1375137/94232283-f47d6780-ff05-11ea-99e2-e4120116182c.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_PLL=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_LSI=1 -DCONFIG_CLOCK_MCO_PRE=1" BUILD_IN_DOCKER=1  make BOARD=nucleo-g070rb -C examples/hello-world flash term --no-print-directory
```

</details>

<details><summary>MCO: HSI => expected frequency is 16MHz</summary>

![image](https://user-images.githubusercontent.com/1375137/94232346-137bf980-ff06-11ea-9fb1-88473105f97e.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_PLL=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_HSI=1 -DCONFIG_CLOCK_MCO_PRE=1" BUILD_IN_DOCKER=1  make BOARD=nucleo-g070rb -C examples/hello-world flash term --no-print-directory
```

</details>

<details><summary>MCO: PLLCLK + MCO prescaler 8 + SYSCLK = HSI => expected frequency is 8MHz (PLLCLK is 64MHz)</summary>

![image](https://user-images.githubusercontent.com/1375137/94232401-30b0c800-ff06-11ea-8680-4c9505ef379d.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_HSI=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_PLLCLK=1 -DCONFIG_CLOCK_MCO_PRE=8" BUILD_IN_DOCKER=1  make BOARD=nucleo-g070rb -C examples/hello-world flash term --no-print-directory
```

</details>

<details><summary>MCO: SYSCLK + SYSCLK = HSI => expected frequency is 16MHz</summary>

![image](https://user-images.githubusercontent.com/1375137/94232453-4faf5a00-ff06-11ea-9a04-5fdbd759d5d8.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_HSI=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_SYSCLK=1 -DCONFIG_CLOCK_MCO_PRE=1" BUILD_IN_DOCKER=1  make BOARD=nucleo-g070rb -C examples/hello-world flash term --no-print-directory
```

</details>

- **nucleo-g474re**:

<details><summary>MCO: LSE => expected frequency is 32.768kHz</summary>

![image](https://user-images.githubusercontent.com/1375137/94232557-8d13e780-ff06-11ea-8fe0-bf0815249c8a.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_PLL=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_LSE=1 -DCONFIG_CLOCK_MCO_PRE=1" BUILD_IN_DOCKER=1  make BOARD=nucleo-g474re -C examples/hello-world flash term --no-print-directory
```

</details>

<details><summary>MCO: LSI => expected frequency is 32kHz</summary>

![image](https://user-images.githubusercontent.com/1375137/94232605-aa48b600-ff06-11ea-9fd1-d44a57a60ce9.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_PLL=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_LSI=1 -DCONFIG_CLOCK_MCO_PRE=1" BUILD_IN_DOCKER=1  make BOARD=nucleo-g474re -C examples/hello-world flash term --no-print-directory
```

</details>

<details><summary>MCO: HSE + prescaler 4 => expected frequency is 24MHz / 4 => 6MHz</summary>

![image](https://user-images.githubusercontent.com/1375137/94232649-c6e4ee00-ff06-11ea-8651-828b5bfa2d08.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_PLL=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_HSE=1 -DCONFIG_CLOCK_MCO_PRE=4" BUILD_IN_DOCKER=1  make BOARD=nucleo-g474re -C examples/hello-world flash term --no-print-directory
```

</details>

<details><summary>MCO: HSI => expected frequency is 16MHz</summary>

![image](https://user-images.githubusercontent.com/1375137/94232720-e845da00-ff06-11ea-9795-40d836671018.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_PLL=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_HSI=1" BUILD_IN_DOCKER=1  make BOARD=nucleo-g474re -C examples/hello-world flash term --no-print-directory
```

</details>

<details><summary>MCO: PLLCLK + prescaler 16=> expected frequency is 10.625MHz (PLLCLK is 170MHz)</summary>

![image](https://user-images.githubusercontent.com/1375137/94233373-14158f80-ff08-11ea-8c32-787538101c7f.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_PLL=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_PLLCLK=1 -DCONFIG_CLOCK_MCO_PRE=16" BUILD_IN_DOCKER=1  make BOARD=nucleo-g474re -C examples/hello-world flash term --no-print-directory
```

</details>

<details><summary>MCO: SYSCLK + prescaler 2 + SYSCLK = HSE => expected frequency is 12MHz</summary>

![image](https://user-images.githubusercontent.com/1375137/94238867-3e1f7f80-ff11-11ea-84df-245bbf575032.png)

```
$ CFLAGS="-DCONFIG_USE_CLOCK_HSE=1 -DCONFIG_CLOCK_ENABLE_MCO=1 -DCONFIG_CLOCK_MCO_USE_SYSCLK=1  -DCONFIG_CLOCK_MCO_PRE=2" BUILD_IN_DOCKER=1  make BOARD=nucleo-g474re -C examples/hello-world flash term --no-print-directory
```

</details>


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Tick one item in #14975
Based on #14898 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
