### PR TITLE
tests/pkg_utensor: increase stacksize with LLVM build on ARM

### DIFF
--- a/tests/pkg_utensor/Makefile
+++ b/tests/pkg_utensor/Makefile
@@ -10,3 +10,11 @@ USEMODULE += models
 EXTERNAL_MODULE_DIRS += $(CURDIR)/models
 
 include $(RIOTBASE)/Makefile.include
+
+# The application requires a little more stacksize on ARM when building with
+# LLVM
+ifneq (,$(filter arch_arm,$(FEATURES_USED)))
+  ifeq (llvm,$(TOOLCHAIN))
+    CFLAGS += -DTHREAD_STACKSIZE_MAIN=2048
+  endif
+endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes #15065 by simply increasing the main stacksize when build with LLVM on ARM.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build `tests/pkg_utensor` with llvm on nrf52840dk (on iotlab) and get a successful test :

<details><summary>BUILD_IN_DOCKER=1 TOOLCHAIN=llvm make BOARD=nrf52840dk -C tests/pkg_utensor/ clean flash test IOTLAB_NODE=auto-ssh</summary>

```
$ BUILD_IN_DOCKER=1 TOOLCHAIN=llvm make BOARD=nrf52840dk -C tests/pkg_utensor/ flash test IOTLAB_NODE=auto-ssh
make: Entering directory '/work/riot/RIOT/tests/pkg_utensor'
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nrf52840dk' -e 'TOOLCHAIN=llvm'  -w '/data/riotbuild/riotbase/tests/pkg_utensor/' 'riot/riotbuild:latest' make 'BOARD=nrf52840dk' 'EXTERNAL_MODULE_DIRS=/data/riotbuild/riotbase/tests/pkg_utensor/models'   
Building application "tests_pkg_utensor" for "nrf52840dk" with MCU "nrf52".

"make" -C /data/riotbuild/riotbase/pkg/utensor
"make" -C /data/riotbuild/riotbase/build/pkg/utensor/src/uTensor/core -f /data/riotbuild/riotbase/pkg/utensor/Makefile.utensor
"make" -C /data/riotbuild/riotbase/build/pkg/utensor/src/uTensor/util -f /data/riotbuild/riotbase/pkg/utensor/Makefile.utensor.util
"make" -C /data/riotbuild/riotbase/build/pkg/utensor/src/uTensor/ops -f /data/riotbuild/riotbase/pkg/utensor/Makefile.utensor.ops
"make" -C /data/riotbuild/riotbase/boards/nrf52840dk
"make" -C /data/riotbuild/riotbase/boards/common/nrf52xxxdk
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/nrf52
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/nrf52/periph
"make" -C /data/riotbuild/riotbase/cpu/nrf52/vectors
"make" -C /data/riotbuild/riotbase/cpu/nrf5x_common
"make" -C /data/riotbuild/riotbase/cpu/nrf5x_common/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/tests/pkg_utensor/models
   text    data     bss     dec     hex filename
 185392       0    2944  188336   2dfb0 /data/riotbuild/riotbase/tests/pkg_utensor/bin/nrf52840dk/tests_pkg_utensor.elf
iotlab-node --jmespath='keys(@)[0]' --format='int'  --list saclay,nrf52840dk,1 --flash /work/riot/RIOT/tests/pkg_utensor/bin/nrf52840dk/tests_pkg_utensor.bin | grep 0
0
r
ssh -t abadie@saclay.iot-lab.info 'socat - tcp:nrf52840dk-1.saclay.iot-lab.info:20000' 
Help: Press s to start test, r to print it is ready
READY
s
START
main(): This is RIOT! (Version: 2020.10-devel-1531-gf69d6d)
Simple MNIST end-to-end uTensor cli example (device)

Predicted label: 7
make: Leaving directory '/work/riot/RIOT/tests/pkg_utensor'
```

</details>

- Build `tests/pkg_utensor` with llvm on samr21-xpro and get a successful test :

<details><summary>BUILD_IN_DOCKER=1 TOOLCHAIN=llvm make BOARD=samr21-xpro -C tests/pkg_utensor/ clean flash test </summary>

```
$ BUILD_IN_DOCKER=1 TOOLCHAIN=llvm make BOARD=samr21-xpro -C tests/pkg_utensor/ flash test
make: Entering directory '/work/riot/RIOT/tests/pkg_utensor'
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=samr21-xpro' -e 'TOOLCHAIN=llvm'  -w '/data/riotbuild/riotbase/tests/pkg_utensor/' 'riot/riotbuild:latest' make 'BOARD=samr21-xpro' 'EXTERNAL_MODULE_DIRS=/data/riotbuild/riotbase/tests/pkg_utensor/models'   
Building application "tests_pkg_utensor" for "samr21-xpro" with MCU "samd21".

"make" -C /data/riotbuild/riotbase/pkg/utensor
"make" -C /data/riotbuild/riotbase/build/pkg/utensor/src/uTensor/core -f /data/riotbuild/riotbase/pkg/utensor/Makefile.utensor
"make" -C /data/riotbuild/riotbase/build/pkg/utensor/src/uTensor/util -f /data/riotbuild/riotbase/pkg/utensor/Makefile.utensor.util
"make" -C /data/riotbuild/riotbase/build/pkg/utensor/src/uTensor/ops -f /data/riotbuild/riotbase/pkg/utensor/Makefile.utensor.ops
"make" -C /data/riotbuild/riotbase/boards/samr21-xpro
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/samd21
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/sam0_common
"make" -C /data/riotbuild/riotbase/cpu/sam0_common/periph
"make" -C /data/riotbuild/riotbase/cpu/samd21/periph
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/tests/pkg_utensor/models
   text    data     bss     dec     hex filename
 194716       0    2908  197624   303f8 /data/riotbuild/riotbase/tests/pkg_utensor/bin/samr21-xpro/tests_pkg_utensor.elf
[INFO] edbg binary not found - building it from source now
CC= CFLAGS= make -C /work/riot/RIOT/dist/tools/edbg
[INFO] updating edbg /work/riot/RIOT/dist/tools/edbg/bin/.pkg-state.git-downloaded
echo 99d15460fcff723f73b16c29c8ca14bff4b33b20 > /work/riot/RIOT/dist/tools/edbg/bin/.pkg-state.git-downloaded
[INFO] patch edbg
[INFO] edbg binary successfully built!
/work/riot/RIOT/dist/tools/edbg/edbg  --target samr21 --verbose --file /work/riot/RIOT/tests/pkg_utensor/bin/samr21-xpro/tests_pkg_utensor.bin --verify || /work/riot/RIOT/dist/tools/edbg/edbg  --target samr21 --verbose --file /work/riot/RIOT/tests/pkg_utensor/bin/samr21-xpro/tests_pkg_utensor.bin --verify --program
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009840 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Verification...
at address 0x4 expected 0x01, read 0x1d
Error: verification failed
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800009840 01.1A.00FB (S)
Clock frequency: 16.0 MHz
Target: SAM R21G18 (Rev C)
Programming................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................. done.
Verification................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................. done.
r
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2020.10-devel-1531-gf69d6d)
Simple MNIST end-to-end uTensor cli example (device)

Predicted label: 7

make: Leaving directory '/work/riot/RIOT/tests/pkg_utensor'
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #15065 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
