### PR TITLE
boards/nucleo-g071rb: add initial support

### DIFF
--- a/boards/nucleo-g071rb/Kconfig
+++ b/boards/nucleo-g071rb/Kconfig
@@ -1,0 +1,30 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-g071rb" if BOARD_NUCLEO_G071RB
+
+config BOARD_NUCLEO_G071RB
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32G071RB
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+    # Clock configuration
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig.g0"
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-g071rb/Makefile
+++ b/boards/nucleo-g071rb/Makefile
@@ -1,0 +1,4 @@
+MODULE = board
+DIRS = $(RIOTBOARD)/common/nucleo
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nucleo-g071rb/Makefile.dep
+++ b/boards/nucleo-g071rb/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-g071rb/Makefile.features
+++ b/boards/nucleo-g071rb/Makefile.features
@@ -1,0 +1,15 @@
+CPU = stm32
+CPU_MODEL = stm32g071rb
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/common/nucleo64/Makefile.features

--- a/boards/nucleo-g071rb/Makefile.include
+++ b/boards/nucleo-g071rb/Makefile.include
@@ -1,0 +1,2 @@
+# load the common Makefile.include for Nucleo boards
+include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-g071rb/doc.txt
+++ b/boards/nucleo-g071rb/doc.txt
@@ -1,0 +1,5 @@
+/**
+@defgroup    boards_nucleo-g071rb STM32 Nucleo-G071RB
+@ingroup     boards_common_nucleo64
+@brief       Support for the STM32 Nucleo-G071RB
+ */

--- a/boards/nucleo-g071rb/include/periph_conf.h
+++ b/boards/nucleo-g071rb/include/periph_conf.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nucleo-g071rb
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the nucleo-g071rb board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+/* Add specific clock configuration (HSE, LSE) for this board here */
+#ifndef CONFIG_BOARD_HAS_LSE
+#define CONFIG_BOARD_HAS_LSE            (1)
+#endif
+
+#include "g0/cfg_clock_default.h"
+#include "cfg_i2c1_pb8_pb9.h"
+#include "cfg_rtt_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM3,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APBENR1_TIM3EN,
+        .bus      = APB1,
+        .irqn     = TIM3_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_tim3
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = USART2,
+        .rcc_mask   = RCC_APBENR1_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 3),
+        .tx_pin     = GPIO_PIN(PORT_A, 2),
+        .rx_af      = GPIO_AF1,
+        .tx_af      = GPIO_AF1,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
+    },
+    {   /* Arduino pinout on D0/D1 */
+        .dev        = USART1,
+        .rcc_mask   = RCC_APBENR2_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_C, 5),
+        .tx_pin     = GPIO_PIN(PORT_C, 4),
+        .rx_af      = GPIO_AF1,
+        .tx_af      = GPIO_AF1,
+        .bus        = APB12,
+        .irqn       = USART1_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_usart2)
+#define UART_1_ISR          (isr_usart1)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name   SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev            = SPI1,
+        .mosi_pin       = GPIO_PIN(PORT_A, 7),  /* Arduino D11 */
+        .miso_pin       = GPIO_PIN(PORT_A, 6),  /* Arduino D12 */
+        .sclk_pin       = GPIO_PIN(PORT_A, 5),  /* Arduino D13 */
+        .cs_pin         = GPIO_UNDEF,
+        .mosi_af        = GPIO_AF0,
+        .miso_af        = GPIO_AF0,
+        .sclk_af        = GPIO_AF0,
+        .cs_af          = GPIO_AF0,
+        .rccmask        = RCC_APBENR2_SPI1EN,
+        .apbbus         = APB12,
+    },
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/stm32/Kconfig
+++ b/cpu/stm32/Kconfig
@@ -292,6 +292,10 @@ config CPU_MODEL_STM32G070RB
     bool
     select CPU_FAM_G0
 
+config CPU_MODEL_STM32G071RB
+    bool
+    select CPU_FAM_G0
+
 # STM32G4
 config CPU_MODEL_STM32G474RE
     bool
@@ -528,6 +532,7 @@ config CPU_MODEL
 
     # STM32G0
     default "stm32g070rb" if CPU_MODEL_STM32G070RB
+    default "stm32g071rb" if CPU_MODEL_STM32G071RB
 
     # STM32G4
     default "stm32g474re" if CPU_MODEL_STM32G474RE

--- a/examples/javascript/Makefile.ci
+++ b/examples/javascript/Makefile.ci
@@ -31,6 +31,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f334r8 \
     nucleo-f410rb \
     nucleo-g070rb \
+    nucleo-g071rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -47,6 +47,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f334r8 \
     nucleo-f410rb \
     nucleo-g070rb \
+    nucleo-g071rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/examples/lua_basic/Makefile.ci
+++ b/examples/lua_basic/Makefile.ci
@@ -24,6 +24,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f334r8 \
     nucleo-f410rb \
     nucleo-g070rb \
+    nucleo-g071rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l412kb \

--- a/examples/micropython/Makefile.ci
+++ b/examples/micropython/Makefile.ci
@@ -14,6 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-g070rb \
+    nucleo-g071rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
     opencm904 \

--- a/examples/suit_update/Makefile.ci
+++ b/examples/suit_update/Makefile.ci
@@ -16,6 +16,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f303k8 \
     nucleo-f334r8 \
     nucleo-g070rb \
+    nucleo-g071rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/tests/pkg_utensor/Makefile.ci
+++ b/tests/pkg_utensor/Makefile.ci
@@ -23,6 +23,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f334r8 \
     nucleo-f410rb \
     nucleo-g070rb \
+    nucleo-g071rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l412kb \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -58,6 +58,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f334r8 \
     nucleo-f410rb \
     nucleo-g070rb \
+    nucleo-g071rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for the nucleo-g071rb. This board is almost the same as the nucleo-g07rb but the CPU provides LPTIM1 (and LPTIM2) so the rtt peripheral is adapted to work on this CPU. 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `BUILD_IN_DOCKER=1 ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . nucleo-g071rb --jobs=8 --with-test-only`

<details><summary>Results</summary>

```
Failures during compilation:
- [tests/suit_manifest](tests/suit_manifest/compilation.failed)

Failures during test:
- [tests/driver_at86rf2xx_aes](tests/driver_at86rf2xx_aes/test.failed)
- [tests/driver_grove_ledbar](tests/driver_grove_ledbar/test.failed)
- [tests/driver_my9221](tests/driver_my9221/test.failed)
- [tests/emcute](tests/emcute/test.failed)
- [tests/gnrc_dhcpv6_client](tests/gnrc_dhcpv6_client/test.failed)
- [tests/gnrc_dhcpv6_client_6lbr](tests/gnrc_dhcpv6_client_6lbr/test.failed)
- [tests/gnrc_ipv6_ext](tests/gnrc_ipv6_ext/test.failed)
- [tests/gnrc_ipv6_ext_frag](tests/gnrc_ipv6_ext_frag/test.failed)
- [tests/gnrc_ipv6_ext_opt](tests/gnrc_ipv6_ext_opt/test.failed)
- [tests/gnrc_ipv6_nib_dns](tests/gnrc_ipv6_nib_dns/test.failed)
- [tests/gnrc_rpl_srh](tests/gnrc_rpl_srh/test.failed)
- [tests/gnrc_sock_dns](tests/gnrc_sock_dns/test.failed)
- [tests/gnrc_tcp](tests/gnrc_tcp/test.failed)
- [tests/periph_timer_short_relative_set](tests/periph_timer_short_relative_set/test.failed)
- [tests/pkg_libfixmath_unittests](tests/pkg_libfixmath_unittests/test.failed)
- [tests/pkg_semtech-loramac](tests/pkg_semtech-loramac/test.failed)
- [tests/pkg_tensorflow-lite](tests/pkg_tensorflow-lite/test.failed)
```

=> no big surprise here

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
