### PR TITLE
suit: Introduce per-component flags

### DIFF
--- a/sys/include/suit.h
+++ b/sys/include/suit.h
@@ -71,6 +71,11 @@ extern "C" {
  * @{
  */
 /**
+ * @brief Bit flags used to determine if SUIT manifest contains components
+ */
+#define SUIT_STATE_HAVE_COMPONENTS          (1 << 0)
+
+/**
  * @brief COSE signature OK
  */
 #define SUIT_STATE_COSE_AUTHENTICATED       (1 << 1)
@@ -178,10 +183,10 @@ typedef struct {
  * These state flags apply to individual components inside a manifest.
  * @{
  */
-#define SUIT_COMPONENT_STATE_FETCHED       0x01 /**< Component is fetched */
-#define SUIT_COMPONENT_STATE_FETCH_FAILED  0x02 /**< Component fetched but failed */
-#define SUIT_COMPONENT_STATE_VERIFIED      0x04 /**< Component is verified */
-#define SUIT_COMPONENT_STATE_FINALIZED     0x08 /**< Component successfully installed */
+#define SUIT_COMPONENT_STATE_FETCHED       (1 << 0) /**< Component is fetched */
+#define SUIT_COMPONENT_STATE_FETCH_FAILED  (1 << 1) /**< Component fetched but failed */
+#define SUIT_COMPONENT_STATE_VERIFIED      (1 << 2) /**< Component is verified */
+#define SUIT_COMPONENT_STATE_FINALIZED     (1 << 3) /**< Component successfully installed */
 /** @} */
 
 /**
@@ -225,10 +230,6 @@ typedef struct {
     size_t urlbuf_len;              /**< Length of the manifest url */
 } suit_manifest_t;
 
-/**
- * @brief Bit flags used to determine if SUIT manifest contains components
- */
-#define SUIT_MANIFEST_HAVE_COMPONENTS   (0x1)
 
 /**
  * @brief Component index representing all components

--- a/sys/include/suit.h
+++ b/sys/include/suit.h
@@ -65,6 +65,12 @@ extern "C" {
 #define SUIT_VERSION                        (1)
 
 /**
+ * @name SUIT manifest status flags
+ *
+ * These flags apply to the full manifest.
+ * @{
+ */
+/**
  * @brief COSE signature OK
  */
 #define SUIT_STATE_COSE_AUTHENTICATED       (1 << 1)
@@ -73,6 +79,7 @@ extern "C" {
  * @brief COSE payload matches SUIT manifest digest
  */
 #define SUIT_STATE_FULLY_AUTHENTICATED      (1 << 2)
+/** @} */
 
 /**
  * @brief SUIT error codes
@@ -166,11 +173,24 @@ typedef struct {
 } suit_param_ref_t;
 
 /**
+ * @name SUIT component flags.
+ *
+ * These state flags apply to individual components inside a manifest.
+ * @{
+ */
+#define SUIT_COMPONENT_STATE_FETCHED       0x01 /**< Component is fetched */
+#define SUIT_COMPONENT_STATE_FETCH_FAILED  0x02 /**< Component fetched but failed */
+#define SUIT_COMPONENT_STATE_VERIFIED      0x04 /**< Component is verified */
+#define SUIT_COMPONENT_STATE_FINALIZED     0x08 /**< Component successfully installed */
+/** @} */
+
+/**
  * @brief SUIT component struct as decoded from the manifest
  *
  * The parameters are references to CBOR-encoded information in the manifest.
  */
 typedef struct {
+    uint16_t state;                             /**< Component status flags */
     suit_param_ref_t identifier;                /**< Component identifier */
     suit_param_ref_t param_vendor_id;           /**< Vendor ID */
     suit_param_ref_t param_class_id;            /**< Class ID */
@@ -209,10 +229,6 @@ typedef struct {
  * @brief Bit flags used to determine if SUIT manifest contains components
  */
 #define SUIT_MANIFEST_HAVE_COMPONENTS   (0x1)
-/**
- * @brief Bit flags used to determine if SUIT manifest contains an image
- */
-#define SUIT_MANIFEST_HAVE_IMAGE        (0x2)
 
 /**
  * @brief Component index representing all components
@@ -252,6 +268,32 @@ int suit_parse(suit_manifest_t *manifest, const uint8_t *buf, size_t len);
  * @return                  -1 on invalid manifest policy
  */
 int suit_policy_check(suit_manifest_t *manifest);
+
+/**
+ * @brief Set a component flag
+ *
+ * @param   component   Component to set flag for
+ * @param   flag        Flag to set
+ */
+static inline void suit_component_set_flag(suit_component_t *component,
+                                           uint16_t flag)
+{
+    component->state |= flag;
+}
+
+/**
+ * @brief Check a component flag
+ *
+ * @param   component   Component to check a flag for
+ * @param   flag        Flag to check
+ *
+ * @returns             True if the flag is set
+ */
+static inline bool suit_component_check_flag(suit_component_t *component,
+                                             uint16_t flag)
+{
+    return (component->state & flag);
+}
 
 /**
  * @brief Helper function for writing bytes on flash a specified offset

--- a/sys/suit/handlers_common.c
+++ b/sys/suit/handlers_common.c
@@ -76,7 +76,7 @@ static int _component_handler(suit_manifest_t *manifest, int key,
     }
     manifest->components_len = n;
     if (n) {
-        manifest->state |= SUIT_MANIFEST_HAVE_COMPONENTS;
+        manifest->state |= SUIT_STATE_HAVE_COMPONENTS;
     }
     return 0;
 }

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -374,11 +374,6 @@ static void _suit_handle_url(const char *url)
             return;
         }
 
-        LOG_INFO("suit_parse() success\n");
-        if (!(manifest.state & SUIT_MANIFEST_HAVE_IMAGE)) {
-            LOG_INFO("manifest parsed, but no image fetched\n");
-            return;
-        }
 #endif
         if (res == 0) {
             LOG_INFO("suit_coap: finalizing image flash\n");


### PR DESCRIPTION
### Contribution description

Now that the SUIT module in RIOT starts to gain support for multiple components, a single `HAVE_IMAGE` flag no longer cuts it. This PR introduces a set of flags per component and adds manifest sanity checks to different directives.

### Testing procedure

Test the SUIT update example workflow.

### Issues/PRs references

None