### PR TITLE
suit: Move policy check to before fetch

### DIFF
--- a/sys/include/suit.h
+++ b/sys/include/suit.h
@@ -87,6 +87,7 @@ typedef enum {
                                          current sequence number */
     SUIT_ERR_SIGNATURE        = -6, /**< Unable to verify signature */
     SUIT_ERR_DIGEST_MISMATCH  = -7, /**< Digest mismatch with COSE and SUIT */
+    SUIT_ERR_POLICY_FORBIDDEN = -8, /**< Denied because of policy mismatch */
 } suit_error_t;
 
 /**

--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -270,6 +270,13 @@ static int _dtv_fetch(suit_manifest_t *manifest, int key,
 
     const uint8_t *url;
     size_t url_len;
+
+    /* Check the policy before fetching anything */
+    int res = suit_policy_check(manifest);
+    if (res) {
+        return SUIT_ERR_POLICY_FORBIDDEN;
+    }
+
     suit_component_t *comp = _get_component(manifest);
 
     nanocbor_value_t param_uri;
@@ -289,7 +296,7 @@ static int _dtv_fetch(suit_manifest_t *manifest, int key,
     int target_slot = riotboot_slot_other();
     riotboot_flashwrite_init(manifest->writer, target_slot);
 
-    int res = -1;
+    res = -1;
 
     if (0) {}
 #ifdef MODULE_SUIT_TRANSPORT_COAP

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -379,12 +379,6 @@ static void _suit_handle_url(const char *url)
             LOG_INFO("manifest parsed, but no image fetched\n");
             return;
         }
-
-        res = suit_policy_check(&manifest);
-        if (res) {
-            return;
-        }
-
 #endif
         if (res == 0) {
             LOG_INFO("suit_coap: finalizing image flash\n");


### PR DESCRIPTION




### Contribution description

This PR moves the policy check in the SUIT code to before the fetch stage. This prevents the whole payload fetch if the manifest fails the policy check.

### Testing procedure

`tests/suit_manifest` succeeding is enough here.

### Issues/PRs references

None