### PR TITLE
SUIT: fail fetch if the image size doesn't match expected

### DIFF
--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -375,6 +375,7 @@ static int _dtv_verify_image_match(suit_manifest_t *manifest, int key,
     if (res != 0) {
         return SUIT_ERR_COND;
     }
+    riotboot_flashwrite_finish(manifest->writer);
     return SUIT_OK;
 }
 

--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -375,7 +375,14 @@ static int _dtv_verify_image_match(suit_manifest_t *manifest, int key,
     if (res != 0) {
         return SUIT_ERR_COND;
     }
-    riotboot_flashwrite_finish(manifest->writer);
+
+    /**
+     * SUIT transport mock doesn't implement the the 'finish' function. Can be
+     * removed as soon as there is a proper storage abstraction layer for SUIT
+     */
+    if (!IS_ACTIVE(MODULE_SUIT_TRANSPORT_MOCK)) {
+        riotboot_flashwrite_finish(manifest->writer);
+    }
     return SUIT_OK;
 }
 

--- a/sys/suit/transport/coap.c
+++ b/sys/suit/transport/coap.c
@@ -348,8 +348,8 @@ static void _suit_handle_url(const char *url)
     if (size >= 0) {
         LOG_INFO("suit_coap: got manifest with size %u\n", (unsigned)size);
 
-        riotboot_flashwrite_t writer;
 #ifdef MODULE_SUIT
+        riotboot_flashwrite_t writer;
         suit_manifest_t manifest;
         memset(&manifest, 0, sizeof(manifest));
 
@@ -376,9 +376,6 @@ static void _suit_handle_url(const char *url)
 
 #endif
         if (res == 0) {
-            LOG_INFO("suit_coap: finalizing image flash\n");
-            riotboot_flashwrite_finish(&writer);
-
             const riotboot_hdr_t *hdr = riotboot_slot_get_hdr(
                 riotboot_slot_other());
             riotboot_hdr_print(hdr);


### PR DESCRIPTION
### Contribution description

This adds a few more checks to the fetch code to ensure that the fetched binary matched the size given in the manifest.

### Testing procedure

Verify the workflow with `examples/suit_update`

### Issues/PRs references

None