### PR TITLE
net/eui64: add eui64_to_eui48()

### DIFF
--- a/sys/include/net/eui48.h
+++ b/sys/include/net/eui48.h
@@ -37,6 +37,49 @@ typedef struct {
 } eui48_t;
 
 /**
+ * @name EUI-48 bit flags contained in the first octet
+ *
+ * @see IEEE 802-2001 section 9.2
+ * @{
+ */
+
+/**
+ * @brief Locally administered address.
+ */
+#define EUI48_LOCAL_FLAG    0x02
+
+/**
+ * @brief Group type address.
+ */
+#define EUI48_GROUP_FLAG    0x01
+/** @} */
+
+/**
+ * @brief Set the locally administrated bit in the EUI-48 address.
+ *
+ * @see IEEE 802-2001 section 9.2
+ *
+ * @param   addr    ethernet address
+ */
+static inline void eui48_set_local(eui48_t *addr)
+{
+    addr->uint8[0] |= EUI48_LOCAL_FLAG;
+}
+
+/**
+ * @brief Clear the group address bit to signal the address as individual
+ * address
+ *
+ * @see IEEE 802-2001 section 9.2
+ *
+ * @param   addr    ethernet address
+ */
+static inline void eui48_clear_group(eui48_t *addr)
+{
+    addr->uint8[0] &= ~EUI48_GROUP_FLAG;
+}
+
+/**
  * @brief   Generates an EUI-64 from a 48-bit device address
  *
  * @see     [RFC 2464, section 4](https://tools.ietf.org/html/rfc2464#section-4)
@@ -55,24 +98,6 @@ static inline void eui48_to_eui64(eui64_t *eui64, const eui48_t *addr)
     eui64->uint8[6] = addr->uint8[4];
     eui64->uint8[7] = addr->uint8[5];
 }
-
-/**
- * @name EUI-48 bit flags contained in the first octet
- *
- * @see IEEE 802-2001 section 9.2
- * @{
- */
-
-/**
- * @brief Locally administered address.
- */
-#define EUI48_LOCAL_FLAG  0x02
-
-/**
- * @brief Group type address.
- */
-#define EUI48_GROUP_FLAG        0x01
-/** @} */
 
 /**
  * @brief   Generates an IPv6 interface identifier from a 48-bit device address
@@ -105,32 +130,6 @@ static inline void eui48_from_ipv6_iid(eui48_t *addr, const eui64_t *iid)
     addr->uint8[4] = iid->uint8[6];
     addr->uint8[5] = iid->uint8[7];
 }
-
-/**
- * @brief Set the locally administrated bit in the EUI-48 address.
- *
- * @see IEEE 802-2001 section 9.2
- *
- * @param   addr    ethernet address
- */
-static inline void eui48_set_local(eui48_t *addr)
-{
-    addr->uint8[0] |= EUI48_LOCAL_FLAG;
-}
-
-/**
- * @brief Clear the group address bit to signal the address as individual
- * address
- *
- * @see IEEE 802-2001 section 9.2
- *
- * @param   addr    ethernet address
- */
-static inline void eui48_clear_group(eui48_t *addr)
-{
-    addr->uint8[0] &= ~EUI48_GROUP_FLAG;
-}
-
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/eui48.h
+++ b/sys/include/net/eui48.h
@@ -100,6 +100,31 @@ static inline void eui48_to_eui64(eui64_t *eui64, const eui48_t *addr)
 }
 
 /**
+ * @brief   Generates an EUI-48 from a 64-bit device address
+ *
+ * @warning The resulting EUI-48 is not guaranteed to be unique
+ *          and, hence, marked as only locally unique.
+ *
+ * @param[out] eui48    the resulting EUI-48.
+ * @param[in]  addr     a 64-bit device address
+ */
+static inline void eui64_to_eui48(eui48_t *eui48, const eui64_t *addr)
+{
+    /* Preserve vendor id */
+    eui48->uint8[0] = addr->uint8[0];
+    eui48->uint8[1] = addr->uint8[1];
+    eui48->uint8[2] = addr->uint8[2];
+
+    /* Use most volatile bits */
+    eui48->uint8[3] = addr->uint8[5];
+    eui48->uint8[4] = addr->uint8[6];
+    eui48->uint8[5] = addr->uint8[7];
+
+    /* EUI is only locally unique */
+    eui48_set_local(eui48);
+}
+
+/**
  * @brief   Generates an IPv6 interface identifier from a 48-bit device address
  *
  * @note    The IPv6 IID is derived from the EUI-64 by flipping the U/L bit.


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Provide helper function to mangle a EUI-64 into an EUI-48. (Like `eui48_to_eui64()`)
This can be useful to get predictable, locally unique addreses.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/15083#issuecomment-698744777
