### PR TITLE
cpu/fe310: run RTT at 1 Hz if RTC is selected

### DIFF
--- a/cpu/fe310/include/periph_cpu.h
+++ b/cpu/fe310/include/periph_cpu.h
@@ -173,7 +173,11 @@ typedef struct {
 #define RTT_MIN_FREQUENCY   (1U)                    /* in Hz */
 
 #ifndef RTT_FREQUENCY
+#ifdef MODULE_PERIPH_RTC
+#define RTT_FREQUENCY       (RTT_MIN_FREQUENCY)     /* in Hz */
+#else
 #define RTT_FREQUENCY       (RTT_MAX_FREQUENCY)     /* in Hz */
+#endif
 #endif
 
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The RTC on the fe310 is emulated using the RTT.
This only works if the RTT frequency is 1 Hz, so default to that value in case `periph_rtc` is selected.


### Testing procedure

`tests/periph_rtc` should work again.


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/14878#pullrequestreview-496729649
