### PR TITLE
cpu/arm7_common: Fix compilation with -Wcast-align

### DIFF
--- a/cpu/arm7_common/arm_cpu.c
+++ b/cpu/arm7_common/arm_cpu.c
@@ -32,6 +32,10 @@ __attribute__((used, section(".irq_stack"), aligned(4))) uint8_t irq_stack[ISR_S
 __attribute__((used, section(".abt_stack"), aligned(4))) uint8_t abt_stack[ABT_STACKSIZE];
 __attribute__((used, section(".svc_stack"), aligned(4))) uint8_t svc_stack[ISR_STACKSIZE];
 
+#if (ISR_STACKSIZE % 4)
+#error "ISR_STACKSIZE must be a multiple of 4"
+#endif
+
 void thread_yield_higher(void)
 {
     if (irq_is_in()) {
@@ -129,13 +133,14 @@ void *thread_isr_stack_pointer(void)
 /* This function returns the number of bytes used on the ISR stack */
 int thread_isr_stack_usage(void)
 {
-    uint32_t *ptr = (uint32_t*) &irq_stack[0];
+    uint32_t *ptr = (uint32_t *)(uintptr_t)&irq_stack[0];
+    uint32_t *end = (uint32_t *)(uintptr_t)&irq_stack[ISR_STACKSIZE];
 
-    while(((*ptr) == STACK_CANARY_WORD) && (ptr < (uint32_t*) &irq_stack[ISR_STACKSIZE])) {
+    while(((*ptr) == STACK_CANARY_WORD) && (ptr < end)) {
         ++ptr;
     }
 
-    ptrdiff_t num_used_words = (uint32_t*) &irq_stack[ISR_STACKSIZE] - ptr;
+    ptrdiff_t num_used_words = (uintptr_t)end - (uintptr_t)ptr;
 
     return num_used_words;
 }

--- a/cpu/arm7_common/arm_cpu.c
+++ b/cpu/arm7_common/arm_cpu.c
@@ -25,12 +25,12 @@
 #define STACK_MARKER    (0x77777777)
 #define REGISTER_CNT    (12)
 
-__attribute__((used, section(".usr_stack"))) uint8_t usr_stack[USR_STACKSIZE];
-__attribute__((used, section(".und_stack"))) uint8_t und_stack[UND_STACKSIZE];
-__attribute__((used, section(".fiq_stack"))) uint8_t fiq_stack[FIQ_STACKSIZE];
-__attribute__((used, section(".irq_stack"))) uint8_t irq_stack[ISR_STACKSIZE];
-__attribute__((used, section(".abt_stack"))) uint8_t abt_stack[ABT_STACKSIZE];
-__attribute__((used, section(".svc_stack"))) uint8_t svc_stack[ISR_STACKSIZE];
+__attribute__((used, section(".usr_stack"), aligned(4))) uint8_t usr_stack[USR_STACKSIZE];
+__attribute__((used, section(".und_stack"), aligned(4))) uint8_t und_stack[UND_STACKSIZE];
+__attribute__((used, section(".fiq_stack"), aligned(4))) uint8_t fiq_stack[FIQ_STACKSIZE];
+__attribute__((used, section(".irq_stack"), aligned(4))) uint8_t irq_stack[ISR_STACKSIZE];
+__attribute__((used, section(".abt_stack"), aligned(4))) uint8_t abt_stack[ABT_STACKSIZE];
+__attribute__((used, section(".svc_stack"), aligned(4))) uint8_t svc_stack[ISR_STACKSIZE];
 
 void thread_yield_higher(void)
 {


### PR DESCRIPTION
### Contribution description

- Enforced that stacks are aligned to word size in C code
    - Hopefully, this was already the case through the linker script. In this case, the actual alignment just got more explicit and visible in the C code. Otherwise, this fixes a bug
- Enforced that ISR_STACKSIZE is a multiple of 4 (so that the end pointer is also aligned to word size)
- With this, all casts from pointer to `uint32_t` pointers now don't drop alignment requirements
    - Silenced all `-Wcast-align` warnings

### Testing procedure

Hopefully, this doesn't change binaries. But if so, stack usage should still be properly measured.

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/14955