### PR TITLE
sys/net/uhcp: use LOG_xxx functions

### DIFF
--- a/dist/tools/uhcpd/Makefile
+++ b/dist/tools/uhcpd/Makefile
@@ -11,7 +11,7 @@ RIOT_INCLUDE=$(RIOTBASE)/sys/include
 SRCS:=$(UHCP_DIR)/uhcp.c uhcpd.c
 HDRS:=$(RIOT_INCLUDE)/net/uhcp.h
 bin/uhcpd: $(SRCS) $(HDRS)
-	$(CC) $(CFLAGS) $(CFLAGS_EXTRA) -I$(RIOT_INCLUDE) $(SRCS) -o $@
+	$(CC) $(CFLAGS) $(CFLAGS_EXTRA) -I$(RIOT_INCLUDE) -I. $(SRCS) -o $@
 
 clean:
 	rm -f bin/uhcpd

--- a/dist/tools/uhcpd/log.h
+++ b/dist/tools/uhcpd/log.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     core_util
+ * @{
+ *
+ * @file
+ * @brief       System logging dummy header
+ *
+ * This header offers a bunch of "LOG_*" functions that just use printf,
+ * without honouring a verbosity level.
+ *
+ * This is a dummy header for the purpose of sharing code that uses the
+ * LOG_xxx() functions between RIOT and host utilities without having to
+ * manually include all dependencies of the 'real' log module.
+ *
+ * @author      Benjamin Valentin <benjamin.valentin@ml-pa.com>
+ */
+
+#ifndef LOG_H
+#define LOG_H
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name Logging convenience defines
+ * @{
+ */
+#define LOG_ERROR(...) printf(__VA_ARGS__)
+#define LOG_WARNING(...) printf(__VA_ARGS__)
+#define LOG_INFO(...) printf(__VA_ARGS__)
+#define LOG_DEBUG(...) printf(__VA_ARGS__)
+/** @} */
+
+#endif /* LOG_H */
+/** @} */

--- a/sys/net/application_layer/uhcp/uhcpc.c
+++ b/sys/net/application_layer/uhcp/uhcpc.c
@@ -7,8 +7,8 @@
  */
 
 #include <arpa/inet.h>
-#include <stdio.h>
 
+#include "log.h"
 #include "net/af.h"
 #include "net/sock/udp.h"
 #include "net/uhcp.h"
@@ -39,14 +39,14 @@ void uhcp_client(uhcp_iface_t iface)
     /* create listening socket */
     int res = sock_udp_create(&sock, &local, NULL, 0);
     if (res < 0) {
-        puts("uhcp_client(): cannot create listening socket");
+        LOG_ERROR("uhcp_client(): cannot create listening socket\n");
         return;
     }
 
     uint8_t buf[sizeof(uhcp_push_t) + 16];
 
     while(1) {
-        puts("uhcp_client(): sending REQ...");
+        LOG_INFO("uhcp_client(): sending REQ...\n");
         sock_udp_send(&sock, &req, sizeof(uhcp_req_t), &req_target);
         res = sock_udp_recv(&sock, buf, sizeof(buf), 10U*US_PER_SEC, &remote);
         if (res > 0) {
@@ -54,7 +54,7 @@ void uhcp_client(uhcp_iface_t iface)
             xtimer_sleep(60);
         }
         else {
-            puts("uhcp_client(): no reply received");
+            LOG_ERROR("uhcp_client(): no reply received\n");
         }
     }
 }

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -146,8 +146,8 @@ void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime,
     if ((_prefix_len == prefix_len) &&
         (ipv6_addr_match_prefix(&_prefix,
                                 (ipv6_addr_t *)prefix) >= prefix_len)) {
-        LOG_WARNING("gnrc_uhcpc: uhcp_handle_prefix(): got same prefix "
-                    "again\n");
+        LOG_INFO("gnrc_uhcpc: uhcp_handle_prefix(): got same prefix "
+                 "again\n");
 #ifdef MODULE_GNRC_SIXLOWPAN_CTX
         if (gnrc_netif_is_6ln(gnrc_netif_get_by_pid(gnrc_wireless_interface))) {
             /* always update 6LoWPAN compression context so it does not time


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Using `gnrc_border_router` with `uhcp` is quite noisy.
uhcpc will regularly refresh the prefix and print a bunch of status messages.

Allow the user to tone it down by setting a higher `LOG_LEVEL`.
For this, convert calls to `printf()` and `puts()` to `LOG_xxx()`.

This requires a dummy header for `uhcpd`.


### Testing procedure

Run `examples/gnrc_border_router ` with `CFLAGS += -DLOG_LEVEL=LOG_WARNING` and enjoy the silence.


### Issues/PRs references

#14893 allows to use the RIOT build system for host utilities as well, so we could do away with dummy headers.
