### PR TITLE
sys/architecture: New module to access architecture internals in platform-independent way

### DIFF
--- a/cpu/arm7_common/include/architecture_arch.h
+++ b/cpu/arm7_common/include/architecture_arch.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_arm7_common
+ * @{
+ *
+ * @file
+ * @brief       Architecture details
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ */
+
+#ifndef ARCHITECTURE_ARCH_H
+#define ARCHITECTURE_ARCH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Doc is provided centrally in architecture.h, hide this from Doxygen */
+#ifndef DOXYGEN
+#define ARCHITECTURE_WORD_BITS      (32U)
+#endif /* DOXYGEN */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* ARCHITECTURE_ARCH_H */

--- a/cpu/atmega_common/include/architecture_arch.h
+++ b/cpu/atmega_common/include/architecture_arch.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_atmega_common
+ * @{
+ *
+ * @file
+ * @brief       Architecture details
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ */
+
+#ifndef ARCHITECTURE_ARCH_H
+#define ARCHITECTURE_ARCH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Doc is provided centrally in platform.h, hide this from Doxygen */
+#ifndef DOXYGEN
+#define ARCHITECTURE_WORD_BITS      (8U)
+#endif /* DOXYGEN */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* ARCHITECTURE_ARCH_H */

--- a/cpu/cortexm_common/include/architecture_arch.h
+++ b/cpu/cortexm_common/include/architecture_arch.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_cortexm_common
+ * @{
+ *
+ * @file
+ * @brief       Architecture details
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ */
+
+#ifndef ARCHITECTURE_ARCH_H
+#define ARCHITECTURE_ARCH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Doc is provided centrally in architecture.h, hide this from Doxygen */
+#ifndef DOXYGEN
+#define ARCHITECTURE_WORD_BITS      (32U)
+#endif /* DOXYGEN */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* ARCHITECTURE_ARCH_H */

--- a/cpu/esp_common/include/architecture_arch.h
+++ b/cpu/esp_common/include/architecture_arch.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_esp_common
+ * @{
+ *
+ * @file
+ * @brief       Architecture details
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ */
+
+#ifndef ARCHITECTURE_ARCH_H
+#define ARCHITECTURE_ARCH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Doc is provided centrally in architecture.h, hide this from Doxygen */
+#ifndef DOXYGEN
+#define ARCHITECTURE_WORD_BITS      (32U)
+#endif /* DOXYGEN */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* ARCHITECTURE_ARCH_H */

--- a/cpu/fe310/include/architecture_arch.h
+++ b/cpu/fe310/include/architecture_arch.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_fe310
+ * @{
+ *
+ * @file
+ * @brief       Architecture details
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ */
+
+#ifndef ARCHITECTURE_ARCH_H
+#define ARCHITECTURE_ARCH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Doc is provided centrally in architecture.h, hide this from Doxygen */
+#ifndef DOXYGEN
+#define ARCHITECTURE_WORD_BITS      (32U)
+#endif /* DOXYGEN */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* ARCHITECTURE_ARCH_H */

--- a/cpu/mips32r2_common/include/architecture_arch.h
+++ b/cpu/mips32r2_common/include/architecture_arch.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_mips32r2_common
+ * @{
+ *
+ * @file
+ * @brief       Architecture details
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ */
+
+#ifndef ARCHITECTURE_ARCH_H
+#define ARCHITECTURE_ARCH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Doc is provided centrally in architecture.h, hide this from Doxygen */
+#ifndef DOXYGEN
+#define ARCHITECTURE_WORD_BITS      (32U)
+#endif /* DOXYGEN */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* ARCHITECTURE_ARCH_H */

--- a/cpu/msp430_common/include/architecture_arch.h
+++ b/cpu/msp430_common/include/architecture_arch.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_msp430_common
+ * @{
+ *
+ * @file
+ * @brief       Architecture details
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ */
+
+#ifndef ARCHITECTURE_ARCH_H
+#define ARCHITECTURE_ARCH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Doc is provided centrally in architecture.h, hide this from Doxygen */
+#ifndef DOXYGEN
+#define ARCHITECTURE_WORD_BITS      (16U)
+#endif /* DOXYGEN */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* ARCHITECTURE_ARCH_H */

--- a/cpu/native/include/architecture_arch.h
+++ b/cpu/native/include/architecture_arch.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_native
+ * @{
+ *
+ * @file
+ * @brief       Architecture details
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ */
+
+#ifndef ARCHITECTURE_ARCH_H
+#define ARCHITECTURE_ARCH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Doc is provided centrally in architecture.h, hide this from Doxygen */
+#ifndef DOXYGEN
+#define ARCHITECTURE_WORD_BITS      (32U)
+#endif /* DOXYGEN */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* ARCHITECTURE_ARCH_H */

--- a/sys/include/architecture.h
+++ b/sys/include/architecture.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    sys_architecture    Platform-independent access to architecture
+ *                                  details
+ * @ingroup     sys
+ *
+ * This module provides architecture-independent access to architecture details.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Platform-independent access to architecture details
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef ARCHITECTURE_H
+#define ARCHITECTURE_H
+
+#include <stdint.h>
+
+#include "architecture_arch.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Provide doxygen doc centrally, instead of in every architecture_arch.h */
+#ifdef DOXYGEN
+/**
+ * @brief   Size of a word in bits
+ *
+ * @details Depending on architecture, this can have a value of 8, 16, or 32
+ */
+#define ARCHITECTURE_WORD_BITS      <NUM>
+/**
+ * @brief   Size of a word in bytes
+ *
+ * @details Depending on architecture, this can have a value or 1, 2, or 4.
+ */
+#define ARCHITECTURE_WORD_BYTES     <NUM>
+/**
+ * @brief   Word sized unsigned integer
+ *
+ * @details Synonym to `uint8_t`, `uint16_t` or `uint32_t` depending on
+ *          architecture
+ */
+typedef uint<num>_t uword_t;
+/**
+ * @brief   Word sized signed integer
+ *
+ * @details Synonym to `int8_t`, `int16_t` or `int32_t` depending on
+ *          architecture
+ */
+typedef int<num>_t  sword_t;
+#elif (ARCHITECTURE_WORD_BITS == 8)
+#define ARCHITECTURE_WORD_BYTES     (1U)
+typedef uint8_t     uword_t;
+typedef int8_t      sword_t;
+#elif (ARCHITECTURE_WORD_BITS == 16)
+#define ARCHITECTURE_WORD_BYTES     (2U)
+typedef uint16_t    uword_t;
+typedef int16_t     sword_t;
+#elif (ARCHITECTURE_WORD_BITS == 32)
+#define ARCHITECTURE_WORD_BYTES     (4U)
+typedef uint32_t    uword_t;
+typedef int32_t     sword_t;
+#else
+#error  "Unsupported word size (check ARCHITECTURE_WORD_BITS in architecture_arch.h)"
+#endif
+
+/**
+ * @brief   Type qualifier to use to align data on word boundaries
+ *
+ * Use like this:
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.c}
+ * char WORD_ALIGNED thread_stack[THREAD_STACKSIZE_DEFAULT];
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
+#define WORD_ALIGNED __attribute__((aligned(ARCHITECTURE_WORD_BYTES)))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARCHITECTURE_H */
+/** @} */

--- a/tests/sys_architecture/Makefile
+++ b/tests/sys_architecture/Makefile
@@ -1,0 +1,16 @@
+BOARD ?= samr21-xpro
+include ../Makefile.tests_common
+
+include $(RIOTBASE)/Makefile.include
+
+ifneq (,$(filter arch_32bit,$(FEATURES_USED)))
+  CFLAGS += -DCORRECT_WORD_BITS=32
+endif
+
+ifneq (,$(filter arch_16bit,$(FEATURES_USED)))
+  CFLAGS += -DCORRECT_WORD_BITS=16
+endif
+
+ifneq (,$(filter arch_8bit,$(FEATURES_USED)))
+  CFLAGS += -DCORRECT_WORD_BITS=8
+endif

--- a/tests/sys_architecture/main.c
+++ b/tests/sys_architecture/main.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for sys/architecture
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "assert.h"
+#include "architecture.h"
+
+/* On all but 8bit architectures, at least one of the following should be
+ * misaligned */
+static char unaligned_a[1];
+static char unaligned_b[1];
+
+/* If WORD_ALIGNED is not working correctly, at least one of the following
+ * should be misaligned (except for 8bit architectures, on which alignment
+ * doesn't matter). */
+static char WORD_ALIGNED aligned_a[1];
+static char WORD_ALIGNED aligned_b[1];
+
+static inline unsigned get_misalignemnt(const char *ptr)
+{
+    /* word size is always a power of two, so we can speed up the modulo */
+    return (uintptr_t)ptr & (ARCHITECTURE_WORD_BYTES - 1);
+}
+
+int main(void)
+{
+    /* Most can be evaluated at compile time, so we just do this :-)
+     * Using multiple static asserts in a single function doesn't play nicely
+     * with the non-C11 fallback implementation of static_assert, so we just
+     * use a single use statement.
+     */
+    static_assert(
+        (ARCHITECTURE_WORD_BITS == CORRECT_WORD_BITS) &&
+        (ARCHITECTURE_WORD_BYTES == CORRECT_WORD_BITS / 8) &&
+        (sizeof(uword_t) == ARCHITECTURE_WORD_BYTES) &&
+        (sizeof(sword_t) == ARCHITECTURE_WORD_BYTES),
+        "word size details are incorrect"
+    );
+
+    printf("One word is %u bits or %u bytes in size\n",
+           ARCHITECTURE_WORD_BITS, ARCHITECTURE_WORD_BYTES);
+
+    int failed = 0;
+
+    if (ARCHITECTURE_WORD_BYTES == 1) {
+        puts("Skipping test for WORD_ALIGNED; every alignment is fine on 8bit "
+             "architectures.");
+    }
+    else {
+        printf("%s", "Verifying test works: ");
+        if (get_misalignemnt(unaligned_a) || get_misalignemnt(unaligned_b)) {
+            puts("OK");
+        }
+        else {
+            puts("FAILED");
+            failed = 1;
+        }
+
+        printf("%s", "Verifying WORD_ALIGNED works: ");
+        if (get_misalignemnt(aligned_a) || get_misalignemnt(aligned_b)) {
+            puts("FAILED");
+            failed = 1;
+        }
+        else {
+            puts("OK");
+        }
+    }
+
+    if (failed) {
+        puts("TEST FAILED");
+    }
+    else {
+        puts("TEST SUCCEEDED");
+    }
+
+    return 0;
+}

--- a/tests/sys_architecture/tests/01-run.py
+++ b/tests/sys_architecture/tests/01-run.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+#  Copyright (C) 2020 Otto-von-Guericke-Universität Magdeburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+# @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    # Try to wait for the shell
+    child.expect_exact("TEST SUCCEEDED")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

- Provide `uword_t` as word-sized unsigned integer
    - `sword_t` is same but signed
- Provide `PLATFORM_WORD_BITS` and `PLATFORM_WORD_BYTES` to access word size (measured in bits and bytes, respectively)
- Provide `WORD_ALIGNED` qualifier, e.g. to align thread stacks on word boundary

### Testing procedure

Tested application in `tests/sys_platform` should compile (most tests are `static_asssert()`) and succeed on every platform.

### Issues/PRs references

None