### PR TITLE
boards/samr21-xpro: fix reading EUI-64 from EDBG on cold boot 

### DIFF
--- a/boards/samr21-xpro/include/board.h
+++ b/boards/samr21-xpro/include/board.h
@@ -65,7 +65,11 @@ extern "C" {
 static inline int _edbg_get_eui64(const void *arg, eui64_t *addr)
 {
     (void) arg;
-    return edbg_get_eui64(addr);
+
+    /* EDBG can take a while to respond on cold boot */
+    unsigned tries = 10000;
+    while (--tries && edbg_get_eui64(addr)) {}
+    return tries ? 0 : -1;
 }
 
 /**

--- a/drivers/include/edbg_eui.h
+++ b/drivers/include/edbg_eui.h
@@ -30,6 +30,9 @@ extern "C" {
 /**
  * @brief   Get the unique EUI64 address from a Atmel EDBG debugger
  *
+ * @note    The EDBG firmware may take a while to start up, so on cold
+ *          boot this function can return error when called to soon.
+ *
  * @param[out] addr     memory location to copy the address into.
  *
  * @return              0 on success, error otherwise.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The samr21 starts up faster than EDBG, so on cold boot reading the ID will fail.

Fix this by re-trying to get the EUI-64 from EUI.
On warm boot / reset this works on the first try, but on cold boot it can spin a couple thousand times.

### Testing procedure

Flash `examples/gnrc_networking` on the `samr21-xpro`.
When you unplug the board and plug it in again, the MAC address should now stay the same.


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/15079#issuecomment-699945825