### PR TITLE
cpu/stm32: fix minor bug in Makefile logic when determining CPU_CORE

### DIFF
--- a/cpu/stm32/stm32_info.mk
+++ b/cpu/stm32/stm32_info.mk
@@ -22,7 +22,7 @@ else ifneq (,$(filter $(CPU_FAM),g4 wb))
   CPU_CORE = cortex-m4
 else ifeq (f7,$(CPU_FAM))
   CPU_CORE = cortex-m7
-else ifneq (,$(CPU_FAM),g0 l0)
+else ifneq (,$(filter $(CPU_FAM),g0 l0))
   CPU_CORE = cortex-m0plus
 else
   $(error Not supported CPU family: 'stm32$(CPU_FAM)')


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a minor bug in the Makefile logic that determines an STM32 CPU core: there's a missing call to `filter`.  It's minor because g0 and l0 families are the last families being checked so other supported families should have already been handled at this point.
But for not supported families, like l5 or h7, make always goes in this branch if the new families handling branches are added after.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

A green Murdock should be enough, the fix is obvious enough that no other checks are required.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Will be required by the coming stm32l5 port.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
