### PR TITLE
cpu/stm32: cleanup bootloader_stm32 build system management

### DIFF
--- a/cpu/stm32/Makefile
+++ b/cpu/stm32/Makefile
@@ -1,5 +1,9 @@
 MODULE = cpu
 
-DIRS = $(RIOTCPU)/cortexm_common periph stmclk vectors bootloader
+DIRS = $(RIOTCPU)/cortexm_common periph stmclk vectors
+
+ifneq (,$(filter bootloader_stm32,$(USEMODULE)))
+  DIRS += bootloader
+endif
 
 include $(RIOTBASE)/Makefile.base

--- a/cpu/stm32/Makefile.dep
+++ b/cpu/stm32/Makefile.dep
@@ -8,10 +8,6 @@ ifneq (,$(filter periph_usbdev,$(FEATURES_USED)))
   USEMODULE += xtimer
 endif
 
-ifneq (,$(filter bootloader_stm32,$(FEATURES_USED)))
-  USEMODULE += bootloader_stm32
-endif
-
 ifneq (,$(filter periph_uart_nonblocking,$(USEMODULE)))
   USEMODULE += tsrb
 endif

--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -21,6 +21,9 @@ endif
 # select cpu_check_address pseudomodule if the corresponding feature is used
 USEMODULE += $(filter cpu_check_address, $(FEATURES_USED))
 
+# select bootloader_stm32 module if the feature is used
+USEMODULE += $(filter bootloader_stm32, $(FEATURES_USED))
+
 # include puf_sram if used
 USEMODULE += $(filter puf_sram, $(FEATURES_USED))
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

In current master, the stm32 bootloader module is always built, although it should only be built when the corresponding feature is used.
This PR improves the current situation by:
- move the logic that adds `bootloader_stm32` to USEMODULE if the feature is used from `cpu/stm32/Makefile.dep` to `makefiles/features_modules.inc.mk`
- only build stm32/bootloader when the module is pulled-in

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock
- Verify that the stm32 bootloader module is not built when it's not required:

<details><summary>this PR</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=nucleo-l073rz -C examples/hello-world --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-l073rz'  -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make 'BOARD=nucleo-l073rz'    
Building application "hello-world" for "nucleo-l073rz" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/nucleo-l073rz
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8640	    112	   2312	  11064	   2b38	/data/riotbuild/riotbase/examples/hello-world/bin/nucleo-l073rz/hello-world.elf
```

The bootloader is correctly built with `tests/stm32_bootloader`:

```
$ BUILD_IN_DOCKER=1 make BOARD=nucleo-l073rz -C tests/stm32_bootloader --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-l073rz'  -w '/data/riotbuild/riotbase/tests/stm32_bootloader/' 'riot/riotbuild:latest' make 'BOARD=nucleo-l073rz'    
Building application "tests_stm32_bootloader" for "nucleo-l073rz" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/nucleo-l073rz
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/bootloader           <==== the bootloader is built only when required
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/shell
"make" -C /data/riotbuild/riotbase/sys/shell/commands
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/usb_board_reset
   text	   data	    bss	    dec	    hex	filename
  12824	    132	   2376	  15332	   3be4	/data/riotbuild/riotbase/tests/stm32_bootloader/bin/nucleo-l073rz/tests_stm32_bootloader.elf
```

</details>

<details><summary>master</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=nucleo-l073rz -C examples/hello-world --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-l073rz'  -w '/data/riotbuild/riotbase/examples/hello-world/' 'riot/riotbuild:latest' make 'BOARD=nucleo-l073rz'    
Building application "hello-world" for "nucleo-l073rz" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/nucleo-l073rz
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/bootloader           <==== the bootloader is built, but is not required
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
   text	   data	    bss	    dec	    hex	filename
   8596	    112	   2312	  11020	   2b0c	/data/riotbuild/riotbase/examples/hello-world/bin/nucleo-l073rz/hello-world.elf
```

</details>

Another possibility to check this PR is to apply the following patch and verify that a build that doesn't require the bootloader feature is successful with this PR but will fail in master:

```diff
diff --git a/cpu/stm32/bootloader/reset.c b/cpu/stm32/bootloader/reset.c
index 0a8e10c58f..d732a85ced 100644
--- a/cpu/stm32/bootloader/reset.c
+++ b/cpu/stm32/bootloader/reset.c
@@ -33,6 +33,8 @@
 #define MAGIC               sched_context_switch_request
 #define BOOTLOADER_MAGIC    0xB007AFFE
 
+#error
+
 /* called by reset_handler_default() before memory is initialized */
 void pre_startup(void)
 {
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
