### PR TITLE
SUIT: Introduction of a payload storage API for SUIT manifest payloads

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -1049,6 +1049,10 @@ ifneq (,$(filter suit_transport_coap, $(USEMODULE)))
   USEMODULE += nanocoap
 endif
 
+ifneq (,$(filter suit_storage_%, $(USEMODULE)))
+  USEMODULE += suit_storage
+endif
+
 ifneq (,$(filter suit_%,$(USEMODULE)))
   USEMODULE += suit
 endif

--- a/dist/tools/suit/gen_manifest.py
+++ b/dist/tools/suit/gen_manifest.py
@@ -51,28 +51,31 @@ def main(args):
 
     images = []
     for filename_offset in args.slotfiles:
-        split = filename_offset.split(":")
+        comp_name = ["00"]
+        split = filename_offset.split(":", maxsplit=2)
         if len(split) == 1:
             filename, offset = split[0], 0
-        else:
+        elif len(split) == 2:
             filename, offset = split[0], str2int(split[1])
+        else:
+            filename, offset, comp_name = split[0], str2int(split[1]), split[2].split(":")
 
-        images.append((filename, offset))
+        images.append((filename, offset, comp_name))
 
     template["components"] = []
 
     for slot, image in enumerate(images):
-        filename, offset = image
+        filename, offset, comp_name = image
 
         uri = os.path.join(args.urlroot, os.path.basename(filename))
 
         component = {
-            "install-id": ["00"],
+            "install-id": comp_name,
             "vendor-id": uuid_vendor.hex,
             "class-id": uuid_class.hex,
             "file": filename,
             "uri": uri,
-            "bootable": True,
+            "bootable": False,
         }
 
         if offset:

--- a/examples/suit_update/Makefile
+++ b/examples/suit_update/Makefile
@@ -46,7 +46,7 @@ QUIET ?= 1
 #
 
 USEMODULE += nanocoap_sock sock_util
-USEMODULE += suit suit_transport_coap
+USEMODULE += suit suit_transport_coap suit_storage_flashwrite
 
 # Display a progress bar during firmware download
 USEMODULE += progress_bar

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -119,6 +119,7 @@ PSEUDOMODULES += stdio_uart_rx
 PSEUDOMODULES += stm32_eth
 PSEUDOMODULES += stm32_eth_link_up
 PSEUDOMODULES += suit_transport_%
+PSEUDOMODULES += suit_storage_%
 PSEUDOMODULES += wakaama_objects_%
 PSEUDOMODULES += wifi_enterprise
 PSEUDOMODULES += xtimer_on_ztimer

--- a/sys/include/riotboot/flashwrite.h
+++ b/sys/include/riotboot/flashwrite.h
@@ -132,6 +132,14 @@ static inline int riotboot_flashwrite_init(riotboot_flashwrite_t *state,
  */
 int riotboot_flashwrite_putbytes(riotboot_flashwrite_t *state,
                                  const uint8_t *bytes, size_t len, bool more);
+/**
+ * @brief   Force flush the buffer onto the flash
+ *
+ * @param[in,out]   state   ptr to previously used update state
+ *
+ * @returns         0 on success, <0 otherwise
+ */
+int riotboot_flashwrite_flush(riotboot_flashwrite_t *state);
 
 /**
  * @brief   Finish a firmware update (raw version)

--- a/sys/include/riotboot/slot.h
+++ b/sys/include/riotboot/slot.h
@@ -105,6 +105,27 @@ size_t riotboot_slot_offset(unsigned slot);
 void riotboot_slot_dump_addrs(void);
 
 /**
+ * @brief  Get the size of a slot
+ *
+ * @param[in]   slot    slot nr to get the size from
+ *
+ * @returns             The slot size in bytes
+ */
+static inline size_t riotboot_slot_size(unsigned slot)
+{
+    switch(slot) {
+        case 0:
+            return SLOT0_LEN;
+#if NUM_SLOTS==2
+        case 1:
+            return SLOT1_LEN;
+#endif
+        default:
+            return 0;
+    }
+}
+
+/**
  * @brief   Number of configured firmware slots (incl. bootloader slot)
  */
 extern const unsigned riotboot_slot_numof;

--- a/sys/include/suit.h
+++ b/sys/include/suit.h
@@ -36,7 +36,6 @@
 #include "cose/sign.h"
 #include "nanocbor/nanocbor.h"
 #include "uuid.h"
-#include "riotboot/flashwrite.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -205,8 +204,7 @@ typedef struct {
  *
  * Breaks a dependency chain
  */
-typedef struct suit_storage suit_storage_t;
-
+typedef struct suit_storage suit_storage_ref_t;
 
 /**
  * @brief SUIT component struct as decoded from the manifest
@@ -214,7 +212,7 @@ typedef struct suit_storage suit_storage_t;
  * The parameters are references to CBOR-encoded information in the manifest.
  */
 typedef struct {
-    suit_storage_t *storage_backend;            /**< Storage backend used */
+    suit_storage_ref_t *storage_backend;        /**< Storage backend used */
     uint16_t state;                             /**< Component status flags */
     suit_param_ref_t identifier;                /**< Component identifier */
     suit_param_ref_t param_vendor_id;           /**< Vendor ID */
@@ -243,13 +241,11 @@ typedef struct {
     suit_component_t components[CONFIG_SUIT_COMPONENT_MAX];
     unsigned components_len;        /**< Current number of components */
     uint8_t component_current;      /**< Current component index */
-    riotboot_flashwrite_t *writer;  /**< Pointer to the riotboot flash writer */
     /** Manifest validation buffer */
     uint8_t validation_buf[SUIT_COSE_BUF_SIZE];
     char *urlbuf;                   /**< Buffer containing the manifest url */
     size_t urlbuf_len;              /**< Length of the manifest url */
 } suit_manifest_t;
-
 
 /**
  * @brief Component index representing all components
@@ -321,7 +317,7 @@ static inline bool suit_component_check_flag(suit_component_t *component,
  *
  * Each component part is prefixed with @p separator
  *
- * @return          SUIT_OK if succesful
+ * @return          SUIT_OK if successful
  * @return          negative error code on error
  */
 int suit_component_name_to_string(const suit_manifest_t *manifest,
@@ -340,8 +336,8 @@ int suit_component_name_to_string(const suit_manifest_t *manifest,
  * @return              0 on success
  * @return              <0 on error
  */
-int suit_flashwrite_helper(void *arg, size_t offset, uint8_t *buf, size_t len,
-                           int more);
+int suit_storage_helper(void *arg, size_t offset, uint8_t *buf, size_t len,
+                        int more);
 
 #ifdef __cplusplus
 }

--- a/sys/include/suit/handlers.h
+++ b/sys/include/suit/handlers.h
@@ -207,8 +207,8 @@ int suit_handle_manifest_structure_bstr(suit_manifest_t *manifest,
  * @returns             The offset of the nanocbor value inside the manifest
  *                      bytestring
  */
-uint16_t suit_param_ref_to_cbor(suit_manifest_t *manifest,
-                                suit_param_ref_t *ref,
+uint16_t suit_param_ref_to_cbor(const suit_manifest_t *manifest,
+                                const suit_param_ref_t *ref,
                                 nanocbor_value_t *val);
 
 /**
@@ -219,9 +219,9 @@ uint16_t suit_param_ref_to_cbor(suit_manifest_t *manifest,
  * @param   ref         reference to parse
  * @param   val         NanoCBOR value to restore
  */
-void suit_param_cbor_to_ref(suit_manifest_t *manifest,
+void suit_param_cbor_to_ref(const suit_manifest_t *manifest,
                            suit_param_ref_t *ref,
-                           nanocbor_value_t *val);
+                           const nanocbor_value_t *val);
 
 #ifdef __cplusplus
 }

--- a/sys/include/suit/storage.h
+++ b/sys/include/suit/storage.h
@@ -1,0 +1,615 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg
+ *               2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/**
+ * @defgroup    sys_suit_storage SUIT secure firmware OTA upgrade storage
+ *                               infrastructure
+ * @ingroup     sys_suit
+ * @brief       SUIT firmware storage backends
+ *
+ * @{
+ *
+ * @brief       Storage backend functions for SUIT manifests
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * The interface defined here specifies a generic API for SUIT OTA storage
+ * backends.
+ *
+ * The driver allows for creating multiple backends, each possibly servicing
+ * multiple locations. An example of this is a VFS storage backend. This backend
+ * could service multiple file locations on a filesystem.
+ *
+ * A SUIT component ID is formatted as an array of bytestrings. To make it easy
+ * to match and use a string, the location is supplied as string, each component
+ * separated by a separator provided in the driver. If no separator (`\0`) is
+ * set, the components are concatenated without separator. The @ref
+ * suit_storage_driver_t::set_active_location must be called before starting
+ * operations on the backend.
+ *
+ * A write sequence by the caller must start with @ref
+ * suit_storage_driver_t::start. The total length of the image is supplied to
+ * allow the backend to check if the payload fits in the available space.  The
+ * payload data can be supplied piecewise with multiple calls to @ref
+ * suit_storage_driver_t::write. The caller is free to specify the offset, but
+ * the backend may enforce strict monotonicity on the offset and may enforce the
+ * gapless writes. After all bytes are supplied, the @ref
+ * suit_storage_driver_t::finish function must be called to signal the end of
+ * the write stage.
+ *
+ * Only when the @ref suit_storage_driver_t::install is called, the payload must
+ * be marked as valid. The mechanism for this can be backend specific. However
+ * in the case of a firmware image, it must not be bootable before this function
+ * is called. Similarly, a file payload must not be available at its provided
+ * path until after this function is called. The reason behind this is that the
+ * payload often must first be stored on the device before the image_match is
+ * called by the manifest.
+ *
+ * The other option is that the @ref suit_storage_driver_t::erase is called. In
+ * this case the not-yet-installed payload must be erased again as its contents
+ * might not be what is expected by the digest in the manifest. The payload must
+ * then be removed to prevent the possibility of storing malicious code on the
+ * device.
+ *
+ * A form of read access must be implemented to provide a way to read back the
+ * data and check the digest of the payload. @ref suit_storage_driver_t::read
+ * must be implemented, providing piecewise reading of the data. @ref
+ * suit_storage_driver_t::read_ptr is optional to implement, it can provide
+ * direct read access on memory-mapped storage.
+ *
+ * As the storage backend provides a mechanism to store persistent data,
+ * functions are added to set and retrieve the manifest sequence number. While
+ * not strictly required to implement, a firmware without a mechanism to
+ * retrieve and store sequence numbers will always fail to update.
+ *
+ * The @ref suit_storage_driver_t::match_offset function allows the manifest
+ * handler to check the component-offset condition against a storage backend.
+ *
+ * The usual call sequence by a manifest handler is:
+ *
+ * 1.  @ref suit_storage_driver_t::init as on-boot initialization.
+ * 2.  @ref suit_storage_driver_t::get_seq_no to determine if the manifest is
+ *     not replayed.
+ * 3.  @ref suit_storage_driver_t::has_location to determine if the backend
+ *     handles the payload in the manifest.
+ * 4.  @ref suit_storage_driver_t::set_active_location to set the active
+ *     location for the payload.
+ * 5.  @ref suit_storage_driver_t::start to start a payload write sequence.
+ * 6.  At least one @ref suit_storage_driver_t::write calls to write the payload
+ *     data.
+ * 7.  @ref suit_storage_driver_t::finish to mark the end of the payload write.
+ * 8.  @ref suit_storage_driver_t::read or @ref suit_storage_driver_t::read_ptr
+ *     to read back the written payload. This to verify the digest of the
+ *     payload with what is provided in the manifest.
+ * 9.  @ref suit_storage_driver_t::install if the digest matches with what is
+ *     expected and the payload can be installed or marked as valid, or:
+ * 10. @ref suit_storage_driver_t::erase if the digest does not match with what
+ *     is expected and must be erased.
+ * 11. ref suit_storage_driver_t::set_seq_no to update the sequence number
+ *     stored in the backend.
+ *
+ * @warning This API is by design not thread safe
+ */
+
+#ifndef SUIT_STORAGE_H
+#define SUIT_STORAGE_H
+
+#include "suit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Forward declaration for storage struct
+ */
+typedef struct suit_storage suit_storage_t;
+
+/**
+ * @brief SUIT storage backend driver struct
+ */
+typedef struct suit_storage_driver {
+
+    /**
+     * @brief One-time initialization function. Called at boot.
+     *
+     * @param[in]   storage     Storage context
+     */
+    int (*init)(suit_storage_t *storage);
+
+    /**
+     * @brief Start a new payload write sequence
+     *
+     * @param[in]   storage     Storage context
+     * @param[in]   manifest    The suit manifest context
+     * @param[in]   len         Total size of the payload in bytes
+     *
+     * @returns     @ref SUIT_OK on successfully starting the write
+     * @returns     @ref suit_error_t on error
+     */
+    int (*start)(suit_storage_t *storage, const suit_manifest_t *manifest,
+                 size_t len);
+
+    /**
+     * @brief   Write a new chunk of the payload to the storage backend
+     *
+     * @param[in]   storage     Storage context
+     * @param[in]   manifest    The suit manifest context
+     * @param[in]   buf         Buffer to read the payload chunk from
+     * @param[in]   offset      Offset to write at
+     * @param[in]   len         Length of the payload chunk
+     *
+     * @returns     @ref SUIT_OK on successfully writing the chunk
+     * @returns     @ref suit_error_t on error
+     */
+    int (*write)(suit_storage_t *storage, const suit_manifest_t *manifest, const
+                 uint8_t *buf, size_t offset, size_t len);
+
+    /**
+     * @brief Signal that the payload write stage done to the storage backend
+     *
+     * @param[in]   storage     Storage context
+     * @param[in]   manifest    The suit manifest context
+     *
+     * @returns     @ref SUIT_OK on successfully finalizing the write
+     * @returns     @ref suit_error_t on error
+     */
+    int (*finish)(suit_storage_t *storage, const suit_manifest_t *manifest);
+
+    /**
+     * @brief Read a chunk of previously written data back.
+     *
+     * @param[in]   storage     Storage context
+     * @param[out]  buf         Buffer to write the read data in
+     * @param[in]   offset      Offset to read from
+     * @param[in]   len         Number of bytes to read
+     *
+     * @returns     @ref SUIT_OK on successfully reading the chunk
+     * @returns     @ref suit_error_t on error
+     */
+    int (*read)(suit_storage_t *storage, uint8_t *buf, size_t offset,
+                size_t len);
+
+    /**
+     * @brief retrieve a direct read pointer for this storage backend
+     *
+     * @note Optional to implement
+     *
+     * @param[in]   storage     Storage context
+     * @param[out]  buf         Pointer to the location data
+     * @param[out]  len         Full length of the location data
+     *
+     * @returns     @ref SUIT_OK on successfully providing the region
+     * @returns     @ref suit_error_t on error
+     */
+    int (*read_ptr)(suit_storage_t *storage,
+                    const uint8_t **buf, size_t *len);
+
+    /**
+     * @brief Install the payload or mark the payload as valid
+     *
+     * @param[in]   storage     Storage context
+     * @param[in]   manifest    The suit manifest context
+     *
+     * @returns     @ref SUIT_OK on successfully installing the payload
+     * @returns     @ref suit_error_t on error
+     */
+    int (*install)(suit_storage_t *storage, const suit_manifest_t *manifest);
+
+    /**
+     * @brief Erase the previously loaded payload
+     *
+     * @param[in]   storage     Storage context
+     *
+     * @returns     @ref SUIT_OK on successfully erasing the data
+     * @returns     @ref suit_error_t on error
+     */
+    int (*erase)(suit_storage_t *storage);
+
+    /**
+     * @brief Check if this storage backend services a location
+     *
+     * @param[in] storage     Storage context
+     * @param[in] location    Location to check
+     *
+     * @returns             True if this storage driver must be used for the
+     *                      supplied location
+     */
+    bool (*has_location)(const suit_storage_t *storage, const char *location);
+
+    /**
+     * @brief Checks if the supplied offset is true or false for the current
+     *        location
+     *
+     * @note  Optional to implement, should not be implemented if the backend
+     *        doesn't support the image_offset
+     *
+     * @param[in]   storage     Storage context
+     * @param[in]   offset      Offset to check
+     *
+     * @returns     True if the location matches the offset,
+     * @returns     False otherwise
+     */
+    bool (*match_offset)(const suit_storage_t *storage, size_t offset);
+
+    /**
+     * @brief Set the active location of the storage handler
+     *
+     * A storage backend can handle multiple locations, e.g. a VFS backend
+     * targeting multiple files on a filesystem, setting the location selects
+     * the target location for writes or reads.
+     *
+     * @note Must be idempotent
+     *
+     * @param[in]   storage     Storage backend context
+     * @param[in]   location    The location supplied as string with components
+     *                          separated by the
+     *                          @ref suit_storage_driver_t::separator
+     *
+     * @returns     SUIT_OK on success
+     * @returns     SUIT_ERR_STORAGE_UNAVAILABLE if the location is not
+     *                      available.
+     */
+    int (*set_active_location)(suit_storage_t *storage, const char *location);
+
+    /**
+     * @brief Retrieve the sequence number from the storage backend
+     *
+     * @note The sequence number must be global to the storage context, it must
+     *       not depend on the location
+     *
+     * @param[in]   storage     Storage context
+     * @param[out]  seq_no      Retrieved sequence number
+     *
+     * @returns     SUIT_OK on success
+     * @returns     @ref suit_error_t if the sequence number can't be retrieved
+     */
+    int (*get_seq_no)(const suit_storage_t *storage, uint32_t *seq_no);
+
+    /**
+     * @brief Set a new sequence number in the storage backend.
+     *
+     * @param[in]   storage     Storage context
+     * @param[in]   seq_no      Sequence number to store
+     *
+     * @returns     SUIT_OK on success
+     * @returns     @ref suit_error_t if the sequence number can't be stored.
+     */
+    int (*set_seq_no)(suit_storage_t *storage, uint32_t seq_no);
+
+    /**
+     * @brief Component ID separator used by this storage driver.
+     */
+    char separator;
+} suit_storage_driver_t;
+
+/**
+ * @brief Generic storage backend state.
+ */
+struct suit_storage {
+    const suit_storage_driver_t *driver; /**< Storage driver functions */
+};
+
+/**
+ * @brief retrieve a storage backend based on the location ID string
+ *
+ * @param[in]   id  ID string to match
+ *
+ * @returns     The first storage driver that handles this ID
+ * @returns     NULL if none of the storage drivers is able to handle this ID.
+ */
+suit_storage_t *suit_storage_find_by_id(const char *id);
+
+/**
+ * @brief retrieve a storage backend based on the suit component
+ *
+ * @param[in]   manifest    SUIT manifest context
+ * @param[in]   component  Component to find a storage backend for
+ *
+ * @returns     The first storage driver that handles this component
+ * @returns     NULL if none of the storage drivers is able to handle this
+ *              component.
+ */
+suit_storage_t *suit_storage_find_by_component(const suit_manifest_t *manifest,
+                                               const suit_component_t *component);
+
+/**
+ * @brief initialize all storage backends
+ */
+void suit_storage_init_all(void);
+
+/**
+ * @brief Get the highest sequence number among available backends
+ *
+ * @param[out]  seq_no  Retrieved sequence number
+ *
+ * @returns     suit_ok if at least one sequence number is retrieved
+ * @returns     @ref suit_error_t on error
+ */
+int suit_storage_get_highest_seq_no(uint32_t *seq_no);
+
+/**
+ * @brief Set the new sequence number on all available backends
+ *
+ * @param[in]   seq_no  Sequence number to store
+ *
+ * @returns     @ref SUIT_OK on successfully storing the sequence number on at
+ *              least one backend
+ * @returns     @ref suit_error_t on error
+ */
+int suit_storage_set_seq_no_all(uint32_t seq_no);
+
+/**
+ * @name Storage driver helper functions
+ *
+ * For easy access to the @ref suit_storage_driver_t functions.
+ * @{
+ */
+
+/**
+ * @brief get the separator for a storage backend
+ *
+ * @param[in]   storage     Storage context
+ *
+ * @returns     The separator char
+ */
+static inline char suit_storage_get_separator(const suit_storage_t *storage)
+{
+    return storage->driver->separator;
+}
+
+/**
+ * @brief Check if the storage backend implements the @ref
+ * suit_storage_driver_t::read_ptr function
+ *
+ * @param[in]   storage     Storage context
+ *
+ * @returns     True if the function is implemented,
+ * @returns     False otherwise
+ */
+static inline bool suit_storage_has_readptr(const suit_storage_t *storage)
+{
+    return (storage->driver->read_ptr);
+}
+
+/**
+ * @brief Check if the storage backend implements the @ref
+ * suit_storage_driver_t::match_offset function
+ *
+ * @param[in]   storage     Storage context
+ *
+ * @returns     True if the function is implemented,
+ * @returns     False otherwise
+ */
+static inline bool suit_storage_has_offset(const suit_storage_t *storage)
+{
+    return (storage->driver->match_offset);
+}
+
+/**
+ * @brief One-time initialization function. Called at boot.
+ *
+ * @param[in]   storage     Storage context
+ */
+static inline int suit_storage_init(suit_storage_t *storage)
+{
+    return storage->driver->init(storage);
+}
+
+/**
+ * @brief Start a new payload write sequence
+ *
+ * @param[in]   storage     Storage context
+ * @param[in]   manifest    The suit manifest context
+ * @param[in]   len         Total size of the payload in bytes
+ *
+ * @returns     @ref SUIT_OK on successfully starting the write
+ * @returns     @ref suit_error_t on error
+ */
+static inline int suit_storage_start(suit_storage_t *storage,
+                                     const suit_manifest_t *manifest,
+                                     size_t len)
+{
+    return storage->driver->start(storage, manifest, len);
+}
+
+/**
+ * @brief   Write a new chunk of the payload to the storage backend
+ *
+ * @param[in]   storage     Storage context
+ * @param[in]   manifest    The suit manifest context
+ * @param[in]   buf         Buffer to read the payload chunk from
+ * @param[in]   offset      Offset to write at
+ * @param[in]   len         Length of the payload chunk
+ *
+ * @returns     @ref SUIT_OK on successfully writing the chunk
+ * @returns     @ref suit_error_t on error
+ */
+static inline int suit_storage_write(suit_storage_t *storage,
+                                     const suit_manifest_t *manifest,
+                                     const uint8_t *buf, size_t offset,
+                                     size_t len)
+{
+    return storage->driver->write(storage, manifest, buf, offset, len);
+}
+
+/**
+ * @brief Signal that the payload write stage done to the storage backend
+ *
+ * @param[in]   storage     Storage context
+ * @param[in]   manifest    The suit manifest context
+ *
+ * @returns     @ref SUIT_OK on successfully finalizing the write
+ * @returns     @ref suit_error_t on error
+ */
+static inline int suit_storage_finish(suit_storage_t *storage,
+                                      const suit_manifest_t *manifest)
+{
+    return storage->driver->finish(storage, manifest);
+}
+
+/**
+ * @brief Read a chunk of previously written data back.
+ *
+ * @param[in]   storage     Storage context
+ * @param[out]  buf         Buffer to write the read data in
+ * @param[in]   offset      Offset to read from
+ * @param[in]   len         Number of bytes to read
+ *
+ * @returns     @ref SUIT_OK on successfully reading the chunk
+ * @returns     @ref suit_error_t on error
+ */
+static inline int suit_storage_read(suit_storage_t *storage, uint8_t *buf,
+                                    size_t offset, size_t len)
+{
+    return storage->driver->read(storage, buf, offset, len);
+}
+
+/**
+ * @brief retrieve a direct read pointer for this storage backend
+ *
+ * @note Optional to implement
+ *
+ * @param[in]   storage     Storage context
+ * @param[out]  buf         Pointer to the location data
+ * @param[out]  len         Full length of the location data
+ *
+ * @returns     @ref SUIT_OK on successfully providing the region
+ * @returns     @ref suit_error_t on error
+ */
+static inline int suit_storage_read_ptr(suit_storage_t *storage, const uint8_t
+                                        **buf, size_t *len)
+{
+    return storage->driver->read_ptr(storage, buf, len);
+}
+
+/**
+ * @brief Install the payload or mark the payload as valid
+ *
+ * @param[in]   storage     Storage context
+ * @param[in]   manifest    The suit manifest context
+ *
+ * @returns     @ref SUIT_OK on successfully installing the payload
+ * @returns     @ref suit_error_t on error
+ */
+static inline int suit_storage_install(suit_storage_t *storage,
+                                       const suit_manifest_t *manifest)
+{
+    return storage->driver->install(storage, manifest);
+}
+
+/**
+ * @brief Erase the previously loaded payload
+ *
+ * @param[in]   storage     Storage context
+ *
+ * @returns     @ref SUIT_OK on successfully erasing the data
+ * @returns     @ref suit_error_t on error
+ */
+static inline int suit_storage_erase(suit_storage_t *storage)
+{
+    return storage->driver->erase(storage);
+}
+
+/**
+ * @brief Check if this storage backend services a location
+ *
+ * @param[in] storage     Storage context
+ * @param[in] location    Location to check
+ *
+ * @returns             True if this storage driver must be used for the
+ *                      supplied location
+ */
+static inline bool suit_storage_has_location(suit_storage_t *storage,
+                                             const char *location)
+{
+    return storage->driver->has_location(storage, location);
+}
+
+/**
+ * @brief Checks if the supplied offset is true or false for the current
+ *        location
+ *
+ * @note  Optional to implement, should not be implemented if the backend
+ *        doesn't support the image_offset
+ *
+ * @param[in]   storage     Storage context
+ * @param[in]   offset      Offset to check
+ *
+ * @returns     True if the location matches the offset,
+ * @returns     False otherwise
+ */
+static inline int suit_storage_match_offset(const suit_storage_t *storage,
+                                            size_t offset)
+{
+    return storage->driver->match_offset(storage, offset);
+}
+
+/**
+ * @brief Set the active location of the storage handler
+ *
+ * A storage backend can handle multiple locations, e.g. a VFS backend
+ * targeting multiple files on a filesystem, setting the location selects
+ * the target location for writes or reads.
+ *
+ * @note Must be idempotent
+ *
+ * @param[in]   storage     Storage backend context
+ * @param[in]   location    The location supplied as string with components
+ *                          separated by the
+ *                          @ref suit_storage_driver_t::separator
+ *
+ * @returns     SUIT_OK on success
+ * @returns     SUIT_ERR_STORAGE_UNAVAILABLE if the location is not
+ *                      available.
+ */
+static inline int suit_storage_set_active_location(suit_storage_t *storage,
+                                                   const char *location)
+{
+    return storage->driver->set_active_location(storage, location);
+}
+
+/**
+ * @brief Retrieve the sequence number from the storage backend
+ *
+ * @note The sequence number must be global to the storage context, it must
+ *       not depend on the location
+ *
+ * @param[in]   storage     Storage context
+ * @param[out]  seq_no      Retrieved sequence number
+ *
+ * @returns     SUIT_OK on success
+ * @returns     @ref suit_error_t if the sequence number can't be retrieved
+ */
+static inline int suit_storage_get_seq_no(const suit_storage_t *storage,
+                                          uint32_t *seq_no)
+{
+    return storage->driver->get_seq_no(storage, seq_no);
+}
+
+/**
+ * @brief Set a new sequence number in the storage backend.
+ *
+ * @param[in]   storage     Storage context
+ * @param[in]   seq_no      Sequence number to store
+ *
+ * @returns     SUIT_OK on success
+ * @returns     @ref suit_error_t if the sequence number can't be stored.
+ */
+static inline int suit_storage_set_seq_no(suit_storage_t *storage,
+                                          uint32_t seq_no)
+{
+    return storage->driver->set_seq_no(storage, seq_no);
+}
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SUIT_STORAGE_H */
+/** @} */

--- a/sys/include/suit/storage/flashwrite.h
+++ b/sys/include/suit/storage/flashwrite.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg
+ *               2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/**
+ * @defgroup    sys_suit_storage_flashwrite  riotboot flashwrite storage backend
+ * @ingroup     sys_suit_storage
+ * @brief       SUIT riotboot firmware storage backend
+ *
+ * @{
+ *
+ * @brief       riotboot Flashwrite storage backend functions for SUIT manifests
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef SUIT_STORAGE_FLASHWRITE_H
+#define SUIT_STORAGE_FLASHWRITE_H
+
+#include "suit.h"
+#include "riotboot/flashwrite.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief riotboot flashwrite SUIT storage context
+ */
+typedef struct {
+    suit_storage_t storage;       /**< parent struct */
+    riotboot_flashwrite_t writer; /**< Riotboot flashwriter */
+} suit_storage_flashwrite_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SUIT_STORAGE_FLASHWRITE_H */
+/** @} */

--- a/sys/include/suit/storage/ram.h
+++ b/sys/include/suit/storage/ram.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg
+ *               2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/**
+ * @defgroup    sys_suit_storage_ram  ram storage backend
+ * @ingroup     sys_suit_storage
+ * @brief       RAM blob SUIT payload storage backends
+ *
+ * @{
+ *
+ * @brief       RAM-based storage backend for SUIT OTA updates
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * This module implements a RAM-backed storage interface for SUIT. The main
+ * purpose is mock testing the SUIT implementation, however the interface could
+ * also be used for to target backup ram storage by changing @ref
+ * CONFIG_SUIT_STORAGE_RAM_SIZE to store it in backup ram.
+ *
+ * The module uses a .ram.### structure where the number indicates the index of
+ * the memory region being targeted.
+ *
+ * @warning The install function is implemented as a noop. There is no
+ * distinction between valid content and not yet invalidated content.
+ */
+
+#ifndef SUIT_STORAGE_RAM_H
+#define SUIT_STORAGE_RAM_H
+
+#include <stdint.h>
+
+#include "suit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Size of each memory region
+ */
+#ifndef CONFIG_SUIT_STORAGE_RAM_SIZE
+#define CONFIG_SUIT_STORAGE_RAM_SIZE    (64U)
+#endif
+
+/**
+ * @brief Number of allocated regions
+ */
+#ifndef CONFIG_SUIT_STORAGE_RAM_REGIONS
+#define CONFIG_SUIT_STORAGE_RAM_REGIONS (2U)
+#endif
+
+/**
+ * @brief Extra attributes for allocating the RAM struct
+ */
+#ifndef CONFIG_SUIT_STORAGE_RAM_ATTR
+#define CONFIG_SUIT_STORAGE_RAM_ATTR
+#endif
+
+/**
+ * @brief Single in-memory storage region
+ */
+typedef struct {
+    size_t occupied; /**< Region space filled */
+    uint8_t mem[CONFIG_SUIT_STORAGE_RAM_SIZE]; /**< RAM area */
+} suit_storage_ram_region_t;
+
+/**
+ * @brief memory storage state
+ */
+typedef struct CONFIG_SUIT_STORAGE_RAM_ATTR {
+    suit_storage_t storage;       /**< parent struct */
+    /**
+     * @brief ram storage regions
+     */
+    suit_storage_ram_region_t regions[CONFIG_SUIT_STORAGE_RAM_REGIONS];
+    size_t active_region; /**< Active region to write to */
+    uint32_t sequence_no; /**< Ephemeral sequence number */
+} suit_storage_ram_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SUIT_STORAGE_RAM_H */
+/** @} */

--- a/sys/include/suit/transport/mock.h
+++ b/sys/include/suit/transport/mock.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg
+ *               2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+/**
+ * @defgroup    sys_suit_transport_mock SUIT secure firmware OTA mock transport
+ * @ingroup     sys_suit
+ * @brief       SUIT firmware mock transport
+ *
+ * @{
+ *
+ * @brief       Mock transport backend definitions for SUIT manifests
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * The mock transport is a noop transport. Payloads are preloaded in flash and
+ * provided as an array of @ref suit_transport_mock_payload_t to the module.
+ *
+ * Both the array of payloads named `payloads` and the size with name
+ * `num_payloads` must be provided.
+ */
+
+#ifndef SUIT_TRANSPORT_MOCK_H
+#define SUIT_TRANSPORT_MOCK_H
+
+#include "suit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Mock payload.
+ */
+typedef struct {
+    const uint8_t *buf; /**< Ptr to the memory space containing the payload */
+    size_t len;         /**< Length of the payload in bytes */
+} suit_transport_mock_payload_t;
+
+/**
+ * @brief 'fetch' a payload
+ *
+ * The payload fetched from the payloads array is indicated by the @ref
+ * suit_manifest_t::component_current member
+ *
+ * @param[in]   manifest    suit manifest context
+ *
+ * @returns     SUIT_OK if valid
+ * @returns     negative otherwise
+ */
+int suit_transport_mock_fetch(const suit_manifest_t *manifest);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SUIT_TRANSPORT_MOCK_H */
+/** @} */

--- a/sys/riotboot/flashwrite.c
+++ b/sys/riotboot/flashwrite.c
@@ -34,15 +34,10 @@ static inline size_t min(size_t a, size_t b)
     return a <= b ? a : b;
 }
 
-size_t riotboot_flashwrite_slotsize(const riotboot_flashwrite_t *state)
+size_t riotboot_flashwrite_slotsize(
+        const riotboot_flashwrite_t *state)
 {
-    switch (state->target_slot) {
-        case 0: return SLOT0_LEN;
-#if NUM_SLOTS==2
-        case 1: return SLOT1_LEN;
-#endif
-        default: return 0;
-    }
+    return riotboot_slot_size(state->target_slot);
 }
 
 int riotboot_flashwrite_init_raw(riotboot_flashwrite_t *state, int target_slot,

--- a/sys/riotboot/flashwrite.c
+++ b/sys/riotboot/flashwrite.c
@@ -57,6 +57,15 @@ int riotboot_flashwrite_init_raw(riotboot_flashwrite_t *state, int target_slot,
     return 0;
 }
 
+int riotboot_flashwrite_flush(riotboot_flashwrite_t *state)
+{
+    if (flashpage_write_and_verify(state->flashpage, state->flashpage_buf) != FLASHPAGE_OK) {
+        LOG_WARNING(LOG_PREFIX "error writing flashpage %u!\n", state->flashpage);
+        return -1;
+    }
+    return 0;
+}
+
 int riotboot_flashwrite_putbytes(riotboot_flashwrite_t *state,
                                  const uint8_t *bytes, size_t len, bool more)
 {

--- a/sys/suit/Makefile
+++ b/sys/suit/Makefile
@@ -2,4 +2,8 @@ ifneq (,$(filter suit_transport_%,$(USEMODULE)))
   DIRS += transport
 endif
 
+ifneq (,$(filter suit_storage_%,$(USEMODULE)))
+  DIRS += storage
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/suit/handlers.c
+++ b/sys/suit/handlers.c
@@ -37,8 +37,8 @@ static suit_manifest_handler_t _get_handler(int key,
     return map[key];
 }
 
-uint16_t suit_param_ref_to_cbor(suit_manifest_t *manifest,
-                                suit_param_ref_t *ref,
+uint16_t suit_param_ref_to_cbor(const suit_manifest_t *manifest,
+                                const suit_param_ref_t *ref,
                                 nanocbor_value_t *val)
 {
     size_t len = manifest->len - ref->offset;
@@ -47,9 +47,9 @@ uint16_t suit_param_ref_to_cbor(suit_manifest_t *manifest,
     return ref->offset;
 }
 
-void suit_param_cbor_to_ref(suit_manifest_t *manifest,
+void suit_param_cbor_to_ref(const suit_manifest_t *manifest,
                             suit_param_ref_t *ref,
-                            nanocbor_value_t *val)
+                            const nanocbor_value_t *val)
 {
     assert(val->cur >= manifest->buf);
     ref->offset = val->cur - manifest->buf;

--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -26,19 +26,33 @@
 #include <nanocbor/nanocbor.h>
 #include <assert.h>
 
+#include "hashes/sha256.h"
+
 #include "kernel_defines.h"
 #include "suit/conditions.h"
 #include "suit/handlers.h"
 #include "suit/policy.h"
+#include "suit/storage.h"
 #include "suit.h"
-#include "riotboot/hdr.h"
-#include "riotboot/slot.h"
 
 #ifdef MODULE_SUIT_TRANSPORT_COAP
 #include "suit/transport/coap.h"
 #endif
+#include "suit/transport/mock.h"
 
 #include "log.h"
+
+static int _get_component_size(suit_manifest_t *manifest,
+                               suit_component_t *comp,
+                               uint32_t *img_size)
+{
+    nanocbor_value_t param_size;
+    if ((suit_param_ref_to_cbor(manifest, &comp->param_size, &param_size) == 0) ||
+            (nanocbor_get_uint32(&param_size, img_size) < 0)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    return SUIT_OK;
+}
 
 static suit_component_t *_get_component(suit_manifest_t *manifest)
 {
@@ -126,12 +140,16 @@ static int _cond_comp_offset(suit_manifest_t *manifest,
     suit_param_ref_to_cbor(manifest, &comp->param_component_offset,
                            &param_offset);
     nanocbor_get_uint32(&param_offset, &offset);
-    uint32_t other_offset = (uint32_t)riotboot_slot_offset(
-        riotboot_slot_other());
 
-    LOG_INFO("Comparing manifest offset %"PRIx32" with other slot offset %"PRIx32"\n",
-             offset, other_offset);
-    return other_offset == offset ? SUIT_OK : SUIT_ERR_COND;
+    if (!suit_storage_has_offset(comp->storage_backend)) {
+        return SUIT_ERR_COND;
+    }
+
+    LOG_INFO("Comparing manifest offset %"PRIx32" with other slot offset\n",
+             offset);
+
+    return suit_storage_match_offset(comp->storage_backend, offset) ?
+        SUIT_OK : SUIT_ERR_COND;
 }
 
 static int _dtv_set_comp_idx(suit_manifest_t *manifest,
@@ -156,8 +174,21 @@ static int _dtv_set_comp_idx(suit_manifest_t *manifest,
         return SUIT_ERR_INVALID_MANIFEST;
     }
 
+    suit_component_t *component = &manifest->components[new_index];
+    char name[CONFIG_SUIT_COMPONENT_MAX_NAME_LEN];
+
+    suit_storage_t *storage = component->storage_backend;
+    char separator = suit_storage_get_separator(storage);
+
+    /* Done this before in the component stage, shouldn't be different now */
+    suit_component_name_to_string(manifest, component,
+                                  separator, name, sizeof(name));
+
+    suit_storage_set_active_location(storage, name);
+
     /* Update the manifest context */
     manifest->component_current = new_index;
+
     LOG_INFO("Setting component index to %d\n",
               (int)manifest->component_current);
     return 0;
@@ -262,6 +293,25 @@ static int _dtv_set_param(suit_manifest_t *manifest, int key,
     return SUIT_OK;
 }
 
+static int _start_storage(suit_manifest_t *manifest, suit_component_t *comp)
+{
+    uint32_t img_size = 0;
+    char name[CONFIG_SUIT_COMPONENT_MAX_NAME_LEN];
+    char separator = suit_storage_get_separator(comp->storage_backend);
+
+    if (_get_component_size(manifest, comp, &img_size) < 0) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+
+    /* Done this before in the component stage, shouldn't be different now */
+    suit_component_name_to_string(manifest, comp,
+                                  separator, name, sizeof(name));
+
+    suit_storage_set_active_location(comp->storage_backend, name);
+
+    return suit_storage_start(comp->storage_backend, manifest, img_size);
+}
+
 static int _dtv_fetch(suit_manifest_t *manifest, int key,
                       nanocbor_value_t *_it)
 {
@@ -299,8 +349,10 @@ static int _dtv_fetch(suit_manifest_t *manifest, int key,
     LOG_DEBUG("_dtv_fetch() fetching \"%s\" (url_len=%u)\n", manifest->urlbuf,
               (unsigned)url_len);
 
-    int target_slot = riotboot_slot_other();
-    riotboot_flashwrite_init(manifest->writer, target_slot);
+    if (_start_storage(manifest, comp) < 0) {
+        LOG_ERROR("Unable to start storage backend\n");
+        return SUIT_ERR_STORAGE;
+    }
 
     res = -1;
 
@@ -308,7 +360,7 @@ static int _dtv_fetch(suit_manifest_t *manifest, int key,
 #ifdef MODULE_SUIT_TRANSPORT_COAP
     else if (strncmp(manifest->urlbuf, "coap://", 7) == 0) {
         res = suit_coap_get_blockwise_url(manifest->urlbuf, COAP_BLOCKSIZE_64,
-                                          suit_flashwrite_helper,
+                                          suit_storage_helper,
                                           manifest);
     }
 #endif
@@ -355,6 +407,46 @@ static int _get_digest(nanocbor_value_t *bstr, const uint8_t **digest, size_t *d
     return nanocbor_get_bstr(&arr_it, digest, digest_len);
 }
 
+static int _validate_payload(suit_component_t *component, const uint8_t *digest, size_t payload_size)
+{
+    uint8_t payload_digest[SHA256_DIGEST_LENGTH];
+    suit_storage_t *storage = component->storage_backend;
+
+    if (suit_storage_has_readptr(storage)) {
+        /* Direct read possible */
+        const uint8_t *payload = NULL;
+        size_t payload_len = 0;
+
+        suit_storage_read_ptr(storage, &payload, &payload_len);
+        if (payload_size != payload_len) {
+            return SUIT_ERR_STORAGE_EXCEEDED;
+        }
+        sha256(payload, payload_len, payload_digest);
+    }
+    else {
+        /* Piecewise feeding */
+        sha256_context_t ctx;
+        sha256_init(&ctx);
+        size_t pos = 0;
+        while (pos < payload_size) {
+            uint8_t buf[64];
+
+            size_t read_len = (payload_size - pos) > sizeof(buf) ?
+                              sizeof(buf) : payload_size - pos;
+
+            suit_storage_read(storage, buf, pos, read_len);
+            sha256_update(&ctx, buf, read_len);
+
+            pos += read_len;
+        }
+        sha256_final(&ctx, payload_digest);
+    }
+
+    return (memcmp(digest, payload_digest, SHA256_DIGEST_LENGTH) == 0) ?
+        SUIT_OK : SUIT_ERR_DIGEST_MISMATCH;
+}
+
+
 static int _dtv_verify_image_match(suit_manifest_t *manifest, int key,
                                    nanocbor_value_t *_it)
 {
@@ -362,13 +454,10 @@ static int _dtv_verify_image_match(suit_manifest_t *manifest, int key,
     LOG_DEBUG("dtv_image_match\n");
     const uint8_t *digest;
     size_t digest_len;
-    int target_slot = riotboot_slot_other();
     suit_component_t *comp = _get_component(manifest);
 
     uint32_t img_size;
-    nanocbor_value_t param_size;
-    if ((suit_param_ref_to_cbor(manifest, &comp->param_size, &param_size) == 0) ||
-            (nanocbor_get_uint32(&param_size, &img_size) < 0)) {
+    if (_get_component_size(manifest, comp, &img_size) < 0) {
         return SUIT_ERR_INVALID_MANIFEST;
     }
 
@@ -393,21 +482,20 @@ static int _dtv_verify_image_match(suit_manifest_t *manifest, int key,
         return SUIT_ERR_INVALID_MANIFEST;
     }
 
-    res = riotboot_flashwrite_verify_sha256(digest,
-                                            img_size,
-                                            target_slot);
-    if (res != 0) {
-        return SUIT_ERR_COND;
+    /* TODO: replace with generic verification (not only sha256) */
+    LOG_INFO("Starting digest verification against image\n");
+    res = _validate_payload(comp, digest, img_size);
+    if (res == SUIT_OK) {
+        LOG_INFO("Install correct payload\n");
+        suit_storage_install(comp->storage_backend, manifest);
     }
-
-    /**
-     * SUIT transport mock doesn't implement the the 'finish' function. Can be
-     * removed as soon as there is a proper storage abstraction layer for SUIT
-     */
-    if (!IS_ACTIVE(MODULE_SUIT_TRANSPORT_MOCK)) {
-        riotboot_flashwrite_finish(manifest->writer);
+    else {
+        LOG_INFO("Erasing bad payload\n");
+        if (comp->storage_backend->driver->erase) {
+            suit_storage_erase(comp->storage_backend);
+        }
     }
-    return SUIT_OK;
+    return res;
 }
 
 /* begin{code-style-ignore} */

--- a/sys/suit/handlers_command_seq.c
+++ b/sys/suit/handlers_command_seq.c
@@ -47,9 +47,9 @@ static int _get_component_size(suit_manifest_t *manifest,
                                uint32_t *img_size)
 {
     nanocbor_value_t param_size;
-    if ((suit_param_ref_to_cbor(manifest, &comp->param_size, &param_size) == 0) ||
-            (nanocbor_get_uint32(&param_size, img_size) < 0)) {
-        return SUIT_ERR_INVALID_MANIFEST;
+    if ((suit_param_ref_to_cbor(manifest, &comp->param_size, &param_size) == 0)
+            || (nanocbor_get_uint32(&param_size, img_size) < 0)) { return
+        SUIT_ERR_INVALID_MANIFEST;
     }
     return SUIT_OK;
 }
@@ -201,8 +201,7 @@ static int _dtv_run_seq_cond(suit_manifest_t *manifest,
     (void)key;
     LOG_DEBUG("Starting conditional sequence handler\n");
     return suit_handle_manifest_structure_bstr(manifest, it,
-                                               suit_command_sequence_handlers,
-                                               suit_command_sequence_handlers_len);
+            suit_command_sequence_handlers, suit_command_sequence_handlers_len);
 }
 
 static int _dtv_try_each(suit_manifest_t *manifest,
@@ -223,8 +222,8 @@ static int _dtv_try_each(suit_manifest_t *manifest,
         /* `_container` should be CBOR _bstr wrapped according to the spec, but
          * it is not */
         res = suit_handle_manifest_structure_bstr(manifest, &_container,
-                                                  suit_command_sequence_handlers,
-                                                  suit_command_sequence_handlers_len);
+                suit_command_sequence_handlers,
+                suit_command_sequence_handlers_len);
 
         nanocbor_skip(&container);
 
@@ -366,7 +365,7 @@ static int _dtv_fetch(suit_manifest_t *manifest, int key,
 #endif
 #ifdef MODULE_SUIT_TRANSPORT_MOCK
     else if (strncmp(manifest->urlbuf, "test://", 7) == 0) {
-        res = SUIT_OK;
+        res = suit_transport_mock_fetch(manifest);
     }
 #endif
     else {
@@ -379,7 +378,7 @@ static int _dtv_fetch(suit_manifest_t *manifest, int key,
     if (res) {
         suit_component_set_flag(comp, SUIT_COMPONENT_STATE_FETCH_FAILED);
         /* TODO: The leftover data from a failed fetch should be purged. It
-         * could contain potential malicous data from an attacker */
+         * could contain potential malicious data from an attacker */
         LOG_INFO("image download failed with code %i\n", res);
         return res;
     }
@@ -388,7 +387,8 @@ static int _dtv_fetch(suit_manifest_t *manifest, int key,
     return SUIT_OK;
 }
 
-static int _get_digest(nanocbor_value_t *bstr, const uint8_t **digest, size_t *digest_len)
+static int _get_digest(nanocbor_value_t *bstr, const uint8_t **digest, size_t
+                       *digest_len)
 {
     /* Bstr is a byte string with a cbor array containing the type and the
      * digest */
@@ -407,7 +407,8 @@ static int _get_digest(nanocbor_value_t *bstr, const uint8_t **digest, size_t *d
     return nanocbor_get_bstr(&arr_it, digest, digest_len);
 }
 
-static int _validate_payload(suit_component_t *component, const uint8_t *digest, size_t payload_size)
+static int _validate_payload(suit_component_t *component, const uint8_t *digest,
+                             size_t payload_size)
 {
     uint8_t payload_digest[SHA256_DIGEST_LENGTH];
     suit_storage_t *storage = component->storage_backend;
@@ -446,7 +447,6 @@ static int _validate_payload(suit_component_t *component, const uint8_t *digest,
         SUIT_OK : SUIT_ERR_DIGEST_MISMATCH;
 }
 
-
 static int _dtv_verify_image_match(suit_manifest_t *manifest, int key,
                                    nanocbor_value_t *_it)
 {
@@ -463,7 +463,8 @@ static int _dtv_verify_image_match(suit_manifest_t *manifest, int key,
 
     /* Only check the component if it is fetched, but not failed */
     if (!suit_component_check_flag(comp, SUIT_COMPONENT_STATE_FETCHED) ||
-            suit_component_check_flag(comp, SUIT_COMPONENT_STATE_FETCH_FAILED)) {
+            suit_component_check_flag(comp,
+                                      SUIT_COMPONENT_STATE_FETCH_FAILED)) {
         LOG_ERROR("Fetch failed, or nothing fetched, nothing to check: %u\n",
                   comp->state);
         return SUIT_ERR_INVALID_MANIFEST;
@@ -513,4 +514,5 @@ const suit_manifest_handler_t suit_command_sequence_handlers[] = {
 };
 /* end{code-style-ignore} */
 
-const size_t suit_command_sequence_handlers_len = ARRAY_SIZE(suit_command_sequence_handlers);
+const size_t suit_command_sequence_handlers_len =
+        ARRAY_SIZE(suit_command_sequence_handlers);

--- a/sys/suit/storage.c
+++ b/sys/suit/storage.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg
+ *               2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_suit_storage
+ * @{
+ *
+ * @file
+ * @brief       SUIT storage backend helpers
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#include <string.h>
+#include "kernel_defines.h"
+
+#include "suit.h"
+#include "suit/storage.h"
+
+#ifdef MODULE_SUIT_STORAGE_FLASHWRITE
+#include "suit/storage/flashwrite.h"
+extern suit_storage_flashwrite_t suit_storage_flashwrite;
+#endif
+
+#ifdef MODULE_SUIT_STORAGE_RAM
+#include "suit/storage/ram.h"
+extern suit_storage_ram_t suit_storage_ram;
+#endif
+
+static suit_storage_t *reg[] = {
+#ifdef MODULE_SUIT_STORAGE_FLASHWRITE
+    &suit_storage_flashwrite.storage,
+#endif
+#ifdef MODULE_SUIT_STORAGE_RAM
+    &suit_storage_ram.storage,
+#endif
+};
+
+static const size_t reg_size = ARRAY_SIZE(reg);
+
+suit_storage_t *suit_storage_find_by_id(const char *id)
+{
+    for (size_t i = 0; i < reg_size; i++) {
+        if (suit_storage_has_location(reg[i], id)) {
+            return reg[i];
+        }
+    }
+    return NULL;
+}
+
+void suit_storage_init_all(void)
+{
+    for (size_t i = 0; i < reg_size; i++) {
+        suit_storage_init(reg[i]);
+    }
+}
+
+suit_storage_t *suit_storage_find_by_component(const suit_manifest_t *manifest,
+        const suit_component_t *component)
+{
+    for (size_t i = 0; i < reg_size; i++) {
+        char name[CONFIG_SUIT_COMPONENT_MAX_NAME_LEN];
+        if (suit_component_name_to_string(manifest, component,
+                                          reg[i]->driver->separator,
+                                          name, sizeof(name)) == SUIT_OK) {
+
+            if (suit_storage_has_location(reg[i], name)) {
+                return reg[i];
+            }
+        }
+    }
+    return NULL;
+}
+
+int suit_storage_get_highest_seq_no(uint32_t *seq_no)
+{
+    uint32_t max_seq = 0;
+    int res = SUIT_ERR_STORAGE;
+
+    for (size_t i = 0; i < reg_size; i++) {
+        uint32_t seq_no = 0;
+        if (suit_storage_get_seq_no(reg[i], &seq_no) == SUIT_OK) {
+            res = SUIT_OK;
+            if (seq_no > max_seq) {
+                max_seq = seq_no;
+            }
+        }
+    }
+    *seq_no = max_seq;
+    return res;
+}
+
+int suit_storage_set_seq_no_all(uint32_t seq_no)
+{
+    for (size_t i = 0; i < reg_size; i++) {
+        suit_storage_set_seq_no(reg[i], seq_no);
+    }
+    return 0;
+}

--- a/sys/suit/storage/Makefile
+++ b/sys/suit/storage/Makefile
@@ -1,0 +1,5 @@
+MODULE := suit_storage
+SUBMODULES := 1
+BASE_MODULE := suit_storage
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/suit/storage/flashwrite.c
+++ b/sys/suit/storage/flashwrite.c
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg
+ *               2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_suit_storage
+ * @{
+ *
+ * @file
+ * @brief       SUIT flashwrite storage module implementation
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+#include <string.h>
+
+#include "kernel_defines.h"
+#include "log.h"
+
+#include "suit.h"
+#include "suit/storage.h"
+#include "suit/storage/flashwrite.h"
+#include "riotboot/flashwrite.h"
+#include "riotboot/slot.h"
+
+static inline suit_storage_flashwrite_t *_get_fw(suit_storage_t *storage)
+{
+    return container_of(storage, suit_storage_flashwrite_t, storage);
+}
+
+static int _flashwrite_init(suit_storage_t *storage)
+{
+    (void)storage;
+    return 0;
+}
+
+static int _flashwrite_start(suit_storage_t *storage,
+                             const suit_manifest_t *manifest,
+                             size_t len)
+{
+    (void)manifest;
+    (void)len;
+    suit_storage_flashwrite_t *fw = _get_fw(storage);
+    int target_slot = riotboot_slot_other();
+
+    return riotboot_flashwrite_init(&fw->writer, target_slot);
+}
+
+static int _flashwrite_write(suit_storage_t *storage,
+                             const suit_manifest_t *manifest,
+                             const uint8_t *buf, size_t offset, size_t len)
+{
+    (void)manifest;
+    suit_storage_flashwrite_t *fw = _get_fw(storage);
+
+    if (offset == 0) {
+        if (len < RIOTBOOT_FLASHWRITE_SKIPLEN) {
+            LOG_WARNING("_suit_flashwrite(): offset==0, len<4. aborting\n");
+            return -1;
+        }
+        offset = RIOTBOOT_FLASHWRITE_SKIPLEN;
+        buf += RIOTBOOT_FLASHWRITE_SKIPLEN;
+        len -= RIOTBOOT_FLASHWRITE_SKIPLEN;
+    }
+
+    if (offset != fw->writer.offset) {
+        LOG_ERROR("Unexpected offset: %u - expected: %u\n", (unsigned)offset,
+                  (unsigned)fw->writer.offset);
+        return SUIT_ERR_STORAGE;
+    }
+
+    return riotboot_flashwrite_putbytes(&fw->writer, buf, len, 1);
+}
+
+static int _flashwrite_finish(suit_storage_t *storage,
+                              const suit_manifest_t *manifest)
+{
+    (void)manifest;
+    suit_storage_flashwrite_t *fw = _get_fw(storage);
+
+    return riotboot_flashwrite_flush(&fw->writer) <
+           0 ? SUIT_ERR_STORAGE : SUIT_OK;
+}
+
+static int _flashwrite_install(suit_storage_t *storage,
+                               const suit_manifest_t *manifest)
+{
+    (void)manifest;
+    suit_storage_flashwrite_t *fw = _get_fw(storage);
+
+    return riotboot_flashwrite_finish(&fw->writer);
+}
+
+static int _flashwrite_read(suit_storage_t *storage, uint8_t *buf,
+                            size_t offset, size_t len)
+{
+    (void)storage;
+
+    static const char _prefix[] = "RIOT";
+    static const size_t _prefix_len = sizeof(_prefix) - 1;
+    int target_slot = riotboot_slot_other();
+    size_t slot_size = riotboot_slot_size(target_slot);
+
+    /* Insert the "RIOT" magic number */
+    if (offset < (_prefix_len)) {
+        size_t prefix_to_copy = _prefix_len - offset;
+        memcpy(buf, _prefix + offset, prefix_to_copy);
+        len -= prefix_to_copy;
+        offset = _prefix_len;
+        buf += prefix_to_copy;
+
+    }
+    if (offset + len > slot_size) {
+        return -1;
+    }
+
+    uint8_t *slot = (uint8_t *)riotboot_slot_get_hdr(target_slot);
+
+    memcpy(buf, slot + offset, len);
+    return 0;
+}
+
+static bool _flashwrite_has_location(const suit_storage_t *storage,
+                                     const char *location)
+{
+    (void)storage;
+
+    /* Firmware matches at zero length string */
+    return (location[0] == '\0');
+}
+
+static int _flashwrite_set_active_location(suit_storage_t *storage,
+                                           const char *location)
+{
+    (void)storage;
+    (void)location;
+    return 0;
+}
+
+static bool _flashwrite_match_offset(const suit_storage_t *storage,
+                                     size_t offset)
+{
+    (void)storage;
+
+    int target_slot = riotboot_slot_other();
+    uintptr_t slot_start = (intptr_t)riotboot_slot_get_hdr(target_slot);
+
+    return (slot_start == (uintptr_t)offset);
+}
+
+static int _flashwrite_get_seq_no(const suit_storage_t *storage,
+                                  uint32_t *seq_no)
+{
+    (void)storage;
+    uint32_t max_seq_no = 0;
+    bool valid = false;
+
+    for (unsigned i = 0; i < riotboot_slot_numof; i++) {
+        const riotboot_hdr_t *riot_hdr = riotboot_slot_get_hdr(i);
+        if (riotboot_slot_validate(i)) {
+            /* skip slot if metadata broken */
+            continue;
+        }
+        if (!valid || riot_hdr->version > max_seq_no) {
+            max_seq_no = riot_hdr->version;
+            valid = true;
+        }
+    }
+    if (valid) {
+        *seq_no = max_seq_no;
+        return SUIT_OK;
+    }
+
+    return -1;
+}
+
+static int _flashwrite_set_seq_no(suit_storage_t *storage,
+                                  uint32_t seq_no)
+{
+    (void)storage;
+    int target_slot = riotboot_slot_other();
+    const riotboot_hdr_t *hdr = riotboot_slot_get_hdr(target_slot);
+
+    if (hdr->version == seq_no) {
+        return SUIT_OK;
+    }
+
+    return -1;
+}
+
+static const suit_storage_driver_t suit_storage_flashwrite_driver = {
+    .init = _flashwrite_init,
+    .start = _flashwrite_start,
+    .write = _flashwrite_write,
+    .finish = _flashwrite_finish,
+    .read = _flashwrite_read,
+    .install = _flashwrite_install,
+    .has_location = _flashwrite_has_location,
+    .set_active_location = _flashwrite_set_active_location,
+    .match_offset = _flashwrite_match_offset,
+    .get_seq_no = _flashwrite_get_seq_no,
+    .set_seq_no = _flashwrite_set_seq_no,
+    .separator = '\0',
+};
+
+suit_storage_flashwrite_t suit_storage_flashwrite = {
+    .storage = {
+        .driver = &suit_storage_flashwrite_driver,
+    },
+};

--- a/sys/suit/storage/ram.c
+++ b/sys/suit/storage/ram.c
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2020 Koen Zandberg
+ *               2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_suit_storage
+ * @{
+ *
+ * @file
+ * @brief       SUIT ram storage module implementation
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+#include <string.h>
+#include <inttypes.h>
+
+#include "fmt.h"
+#include "kernel_defines.h"
+#include "log.h"
+
+#include "suit.h"
+#include "suit/storage.h"
+#include "suit/storage/ram.h"
+
+static inline suit_storage_ram_t *_get_ram(suit_storage_t *storage)
+{
+    return container_of(storage, suit_storage_ram_t, storage);
+}
+
+static inline const suit_storage_ram_t *_get_ram_const(
+    const suit_storage_t *storage)
+{
+    return container_of(storage, suit_storage_ram_t, storage);
+}
+
+static inline suit_storage_ram_region_t *_get_active_region(
+    suit_storage_ram_t *ram)
+{
+    return &ram->regions[ram->active_region];
+}
+
+static bool _get_region_by_string(const char *location, uint32_t *val)
+{
+    /* Matching on .ram.### */
+    static const char prefix[] = ".ram.";
+    static const size_t prefix_len = sizeof(prefix) - 1;
+
+    /* Check for prefix */
+    if (strncmp(prefix, location, prefix_len) == 0 &&
+        location[prefix_len] != '\n') {
+        /* Advance to the number */
+        location += prefix_len;
+        /* Check if the rest of the string is a number */
+        if (fmt_is_number(location)) {
+            /* grab the number */
+            *val = scn_u32_dec(location, 5);
+            /* Number must be smaller than the number of regions */
+            if (*val < CONFIG_SUIT_STORAGE_RAM_REGIONS) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+static int _ram_init(suit_storage_t *storage)
+{
+
+    suit_storage_ram_t *ram = _get_ram(storage);
+
+    /* Clear the ram regions */
+    memset(ram->regions, 0,
+           sizeof(suit_storage_ram_region_t) * CONFIG_SUIT_STORAGE_RAM_REGIONS);
+    return SUIT_OK;
+}
+
+static int _ram_start(suit_storage_t *storage, const suit_manifest_t *manifest,
+                      size_t len)
+{
+    (void)manifest;
+    suit_storage_ram_t *ram = _get_ram(storage);
+    suit_storage_ram_region_t *region = _get_active_region(ram);
+
+    if (len > CONFIG_SUIT_STORAGE_RAM_SIZE) {
+        return SUIT_ERR_STORAGE_EXCEEDED;
+    }
+
+    region->occupied = 0;
+    return SUIT_OK;
+}
+
+static int _ram_write(suit_storage_t *storage, const suit_manifest_t *manifest,
+                      const uint8_t *buf, size_t offset, size_t len)
+{
+    (void)manifest;
+    suit_storage_ram_t *ram = _get_ram(storage);
+    suit_storage_ram_region_t *region = _get_active_region(ram);
+
+    if (offset + len > CONFIG_SUIT_STORAGE_RAM_SIZE) {
+        return SUIT_ERR_STORAGE_EXCEEDED;
+    }
+
+    memcpy(&region->mem[offset], buf, len);
+    region->occupied += len;
+    return SUIT_OK;
+}
+
+static int _ram_finish(suit_storage_t *storage, const suit_manifest_t *manifest)
+{
+    (void)storage;
+    (void)manifest;
+    return SUIT_OK;
+}
+
+static int _ram_install(suit_storage_t *storage,
+                        const suit_manifest_t *manifest)
+{
+    (void)manifest;
+    (void)storage;
+    return SUIT_OK;
+}
+
+static int _ram_erase(suit_storage_t *storage)
+{
+    suit_storage_ram_t *ram = _get_ram(storage);
+    suit_storage_ram_region_t *region = _get_active_region(ram);
+
+    memset(region->mem, 0, CONFIG_SUIT_STORAGE_RAM_SIZE);
+    return SUIT_OK;
+}
+
+static int _ram_read(suit_storage_t *storage, uint8_t *buf, size_t offset,
+                     size_t len)
+{
+    suit_storage_ram_t *ram = _get_ram(storage);
+    suit_storage_ram_region_t *region = _get_active_region(ram);
+
+    if (offset + len > CONFIG_SUIT_STORAGE_RAM_SIZE) {
+        return SUIT_ERR_STORAGE_EXCEEDED;
+    }
+
+    memcpy(buf, &region->mem[offset], len);
+
+    return SUIT_OK;
+}
+
+static int _ram_read_ptr(suit_storage_t *storage,
+                         const uint8_t **buf, size_t *len)
+{
+    suit_storage_ram_t *ram = _get_ram(storage);
+    suit_storage_ram_region_t *region = _get_active_region(ram);
+
+    *buf = region->mem;
+    *len = region->occupied;
+    return SUIT_OK;
+}
+
+static bool _ram_has_location(const suit_storage_t *storage,
+                              const char *location)
+{
+    (void)storage;
+    uint32_t val;
+
+    return _get_region_by_string(location, &val);
+}
+
+static int _ram_set_active_location(suit_storage_t *storage,
+                                    const char *location)
+{
+    suit_storage_ram_t *ram = _get_ram(storage);
+    uint32_t region = 0;
+
+    if (!_get_region_by_string(location, &region)) {
+        return -1;
+    }
+
+    ram->active_region = region;
+    return SUIT_OK;
+}
+
+static int _ram_get_seq_no(const suit_storage_t *storage, uint32_t *seq_no)
+{
+    const suit_storage_ram_t *ram = _get_ram_const(storage);
+
+    *seq_no = ram->sequence_no;
+    LOG_INFO("Retrieved sequence number: %" PRIu32 "\n", *seq_no);
+    return SUIT_OK;
+}
+
+static int _ram_set_seq_no(suit_storage_t *storage, uint32_t seq_no)
+{
+    suit_storage_ram_t *ram = _get_ram(storage);
+
+    if (ram->sequence_no < seq_no) {
+        LOG_INFO("Stored sequence number: %" PRIu32 "\n", seq_no);
+        ram->sequence_no = seq_no;
+        return SUIT_OK;
+    }
+
+    return SUIT_ERR_SEQUENCE_NUMBER;
+}
+
+static const suit_storage_driver_t suit_storage_ram_driver = {
+    .init = _ram_init,
+    .start = _ram_start,
+    .write = _ram_write,
+    .finish = _ram_finish,
+    .read = _ram_read,
+    .read_ptr = _ram_read_ptr,
+    .install = _ram_install,
+    .erase = _ram_erase,
+    .has_location = _ram_has_location,
+    .set_active_location = _ram_set_active_location,
+    .get_seq_no = _ram_get_seq_no,
+    .set_seq_no = _ram_set_seq_no,
+    .separator = '.',
+};
+
+suit_storage_ram_t suit_storage_ram = {
+    .storage = {
+        .driver = &suit_storage_ram_driver,
+    },
+};

--- a/tests/suit_manifest/Makefile
+++ b/tests/suit_manifest/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-USEMODULE += suit
+USEMODULE += suit suit_storage_ram
+USEMODULE += suit_transport_mock
 USEMODULE += riotboot_hdr
 USEMODULE += embunit
 
@@ -19,7 +20,8 @@ BLOBS += $(MANIFEST_DIR)/manifest2.bin
 BLOBS += $(MANIFEST_DIR)/manifest3.bin
 BLOBS += $(MANIFEST_DIR)/manifest4.bin
 
-USEMODULE += suit_transport_mock
+BLOBS += $(MANIFEST_DIR)/file1.bin
+BLOBS += $(MANIFEST_DIR)/file2.bin
 
 CFLAGS += -DCONFIG_SUIT_COMPONENT_MAX=2
 

--- a/tests/suit_manifest/create_test_data.sh
+++ b/tests/suit_manifest/create_test_data.sh
@@ -39,13 +39,13 @@ gen_manifest "${MANIFEST_DIR}/manifest0.bin" 1 "${MANIFEST_DIR}/file1.bin:$((0x1
 # manifest with invalid seqnr
 sign_manifest "${MANIFEST_DIR}/manifest0.bin" "${MANIFEST_DIR}/manifest1.bin"
 
-(BOARD=invalid gen_manifest "${MANIFEST_DIR}/manifest2.bin".unsigned 2 "${MANIFEST_DIR}/file1.bin:$((0x1000))" "${MANIFEST_DIR}/file2.bin:$((0x2000))")
+(BOARD=invalid gen_manifest "${MANIFEST_DIR}/manifest2.bin".unsigned 2 "${MANIFEST_DIR}/file1.bin:$((0x1000)):ram:0" "${MANIFEST_DIR}/file2.bin:$((0x2000)):ram:0")
 sign_manifest "${MANIFEST_DIR}/manifest2.bin".unsigned "${MANIFEST_DIR}/manifest2.bin"
 
 # valid manifest, valid seqnr, signed
-gen_manifest "${MANIFEST_DIR}/manifest3.bin".unsigned 2 "${MANIFEST_DIR}/file1.bin:$((0x1000))" "${MANIFEST_DIR}/file2.bin:$((0x2000))"
+gen_manifest "${MANIFEST_DIR}/manifest3.bin".unsigned 2 "${MANIFEST_DIR}/file1.bin:0:ram:0"
 sign_manifest "${MANIFEST_DIR}/manifest3.bin".unsigned "${MANIFEST_DIR}/manifest3.bin"
 
 # valid manifest, valid seqnr, signed, 2 components
-gen_manifest "${MANIFEST_DIR}/manifest4.bin".unsigned 2 "${MANIFEST_DIR}/file1.bin" "${MANIFEST_DIR}/file2.bin"
+gen_manifest "${MANIFEST_DIR}/manifest4.bin".unsigned 2 "${MANIFEST_DIR}/file1.bin:0:ram:0" "${MANIFEST_DIR}/file2.bin:0:ram:1"
 sign_manifest "${MANIFEST_DIR}/manifest4.bin".unsigned "${MANIFEST_DIR}/manifest4.bin"

--- a/tests/suit_manifest/include/riotboot/flashwrite.h
+++ b/tests/suit_manifest/include/riotboot/flashwrite.h
@@ -36,6 +36,14 @@ static inline int riotboot_flashwrite_init(riotboot_flashwrite_t *state,
     return 0;
 }
 
+static inline riotboot_flashwrite_verify_sha256(digest,
+                                                img_size,
+                                                target_slot) {
+    (void)digest;
+    (void)img_size;
+    (void)target_slot;
+    return 0;
+}
 #ifdef __cplusplus
 }
 #endif

--- a/tests/suit_manifest/main.c
+++ b/tests/suit_manifest/main.c
@@ -22,6 +22,8 @@
 #include "log.h"
 
 #include "suit.h"
+#include "suit/storage.h"
+#include "suit/transport/mock.h"
 #include "embUnit.h"
 
 #define TEST_MANIFEST_INCLUDE(file) <blob/bin/BOARD_NAME_UNQ/manifests/file>
@@ -34,6 +36,8 @@
 #include TEST_MANIFEST_INCLUDE(manifest3.bin.h)
 #include TEST_MANIFEST_INCLUDE(manifest4.bin.h)
 
+#include TEST_MANIFEST_INCLUDE(file1.bin.h)
+#include TEST_MANIFEST_INCLUDE(file2.bin.h)
 #define SUIT_URL_MAX            128
 
 typedef struct {
@@ -53,17 +57,28 @@ const manifest_blob_t manifest_blobs[] = {
 
 const unsigned manifest_blobs_numof = ARRAY_SIZE(manifest_blobs);
 
+const suit_transport_mock_payload_t payloads[] = {
+    {
+        .buf = file1_bin,
+        .len = sizeof(file1_bin),
+    },
+    {
+        .buf = file2_bin,
+        .len = sizeof(file2_bin),
+    }
+};
+
+const size_t num_payloads = ARRAY_SIZE(payloads);
+
 static int test_suit_manifest(const unsigned char *manifest_bin,
                                 size_t manifest_bin_len)
 {
     char _url[SUIT_URL_MAX];
     suit_manifest_t manifest;
-    riotboot_flashwrite_t writer;
+
 
     memset(&manifest, 0, sizeof(manifest));
-    memset(&writer, 0, sizeof(writer));
 
-    manifest.writer = &writer;
     manifest.urlbuf = _url;
     manifest.urlbuf_len = SUIT_URL_MAX;
 
@@ -79,6 +94,7 @@ static int test_suit_manifest(const unsigned char *manifest_bin,
 
 static void test_suit_manifest_01_manifests(void)
 {
+    suit_storage_set_seq_no_all(1);
     for (unsigned i = 0; i < manifest_blobs_numof; i++) {
         printf("\n--- testing manifest %u\n", i);
         int res = \


### PR DESCRIPTION
### Contribution description

This PR adds an API for generic SUIT payload handling together with two implementations.

The storage driver API allows for creating multiple backends, each possibly servicing
multiple locations. An example of this is a VFS storage backend. This backend
could service multiple file locations on a filesystem.

Two implementations are included in this PR:
 - A RAM based backend. Payloads are stored in a series of ram buffers. Main use of this is testing, but I think it could also be used to store payloads in the backup memory of some microcontrollers.
 - riotboot flashwrite: A backend based on the riotboot flashwrite module. This backend replaces the current direct calls to the riotboot module.

Planned:
 - VFS based: A VFS-based backend to write files on the filesystem via SUIT updates. This could be used to update configuration files via SUIT.
 - MTD: Direct MTD writes can be used for a two-stage update process where the update is first written to an external flash and moved to the internal flash by the bootloader.

### Testing procedure

Both `tests/suit_manifest` and `examples/suit_update` must still behave as usual.
Please also give the API docs in `sys/include/suit/storage.h` a read to check if it is somewhat clear to an uninformed reader.

### Issues/PRs references

A pair of patches riotboot are included, I can split them out if preferred.

Depends on #15092 