### PR TITLE
sys/{x,z}timer: assert() successful initialization of periph_timer

### DIFF
--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -31,6 +31,7 @@
 #include "periph_conf.h"
 #endif
 
+#include "assert.h"
 #include "xtimer.h"
 #include "irq.h"
 
@@ -65,7 +66,9 @@ void xtimer_init(void)
 {
 #ifndef MODULE_XTIMER_ON_ZTIMER
     /* initialize low-level timer */
-    timer_init(XTIMER_DEV, XTIMER_HZ, _periph_timer_callback, NULL);
+    int ret = timer_init(XTIMER_DEV, XTIMER_HZ, _periph_timer_callback, NULL);
+    (void)ret;
+    assert(ret == 0);
 #endif
 
     /* register initial overflow tick */

--- a/sys/ztimer/periph_timer.c
+++ b/sys/ztimer/periph_timer.c
@@ -20,6 +20,7 @@
  * @}
  */
 
+#include "assert.h"
 #include "irq.h"
 #include "ztimer/periph_timer.h"
 
@@ -79,6 +80,8 @@ void ztimer_periph_timer_init(ztimer_periph_timer_t *clock, tim_t dev,
     clock->dev = dev;
     clock->super.ops = &_ztimer_periph_timer_ops;
     clock->super.max_value = max_val;
-    timer_init(dev, freq, _ztimer_periph_timer_callback, clock);
+    int ret = timer_init(dev, freq, _ztimer_periph_timer_callback, clock);
+    (void)ret;
+    assert(ret == 0);
     ztimer_init_extend(&clock->super);
 }


### PR DESCRIPTION
### Contribution description

As the title says.

### Testing procedure

1. With assertions enabled, an application using `xtimer` (`ztimer`) should still start
2. With assertions enabled and an invalid clock config, an assertion should trigger for an application using `xtimer` (`ztimer`)

### Issues/PRs references

None