### PR TITLE
boards/nucleo-g431rb: add initial support

### DIFF
--- a/boards/common/nucleo64/include/board.h
+++ b/boards/common/nucleo64/include/board.h
@@ -54,7 +54,8 @@ extern "C" {
  * @{
  */
 #define BTN0_PIN            GPIO_PIN(PORT_C, 13)
-#if defined(CPU_MODEL_STM32L433RC) || defined(CPU_MODEL_STM32G474RE)
+#if defined(CPU_MODEL_STM32L433RC) || defined(CPU_MODEL_STM32G474RE) || \
+    defined(CPU_MODEL_STM32G431RB)
 #define BTN0_MODE           GPIO_IN_PD
 #else
 #define BTN0_MODE           GPIO_IN_PU

--- a/boards/common/nucleo64/include/gpio_params.h
+++ b/boards/common/nucleo64/include/gpio_params.h
@@ -43,7 +43,8 @@ static const  saul_gpio_params_t saul_gpio_params[] =
         .name = "Button(B1 User)",
         .pin  = BTN0_PIN,
         .mode = BTN0_MODE,
-#if !defined(CPU_MODEL_STM32L433RC) && !defined(CPU_MODEL_STM32G474RE)
+#if !defined(CPU_MODEL_STM32L433RC) && !defined(CPU_MODEL_STM32G474RE) && \
+    !defined(CPU_MODEL_STM32G431RB)
         .flags = SAUL_GPIO_INVERTED
 #endif
     },

--- a/boards/common/stm32/include/cfg_timer_tim2.h
+++ b/boards/common/stm32/include/cfg_timer_tim2.h
@@ -37,7 +37,8 @@ static const timer_conf_t timer_config[] = {
 #else
         .max      = 0xffffffff,
 #endif
-#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB)
+#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32WB) || \
+    defined(CPU_FAM_STM32G4)
         .rcc_mask = RCC_APB1ENR1_TIM2EN,
 #else
         .rcc_mask = RCC_APB1ENR_TIM2EN,

--- a/boards/nucleo-g431rb/Kconfig
+++ b/boards/nucleo-g431rb/Kconfig
@@ -1,0 +1,34 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+config BOARD
+    default "nucleo-g431rb" if BOARD_NUCLEO_G431RB
+
+config BOARD_NUCLEO_G431RB
+    bool
+    default y
+    select BOARD_COMMON_NUCLEO64
+    select CPU_MODEL_STM32G431RB
+
+    # Put defined MCU peripherals here (in alphabetical order)
+    select HAS_PERIPH_I2C
+    select HAS_PERIPH_LPUART
+    select HAS_PERIPH_RTC
+    select HAS_PERIPH_RTT
+    select HAS_PERIPH_SPI
+    select HAS_PERIPH_TIMER
+    select HAS_PERIPH_UART
+
+    # Put other features for this board (in alphabetical order)
+    select HAS_RIOTBOOT
+
+    # Clock configuration
+    select BOARD_HAS_HSE
+    select BOARD_HAS_LSE
+
+source "$(RIOTBOARD)/common/stm32/Kconfig.g4"
+source "$(RIOTBOARD)/common/nucleo64/Kconfig"

--- a/boards/nucleo-g431rb/Makefile
+++ b/boards/nucleo-g431rb/Makefile
@@ -1,0 +1,4 @@
+MODULE = board
+DIRS = $(RIOTBOARD)/common/nucleo
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nucleo-g431rb/Makefile.dep
+++ b/boards/nucleo-g431rb/Makefile.dep
@@ -1,0 +1,3 @@
+FEATURES_REQUIRED += periph_lpuart
+
+include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-g431rb/Makefile.features
+++ b/boards/nucleo-g431rb/Makefile.features
@@ -1,0 +1,16 @@
+CPU = stm32
+CPU_MODEL = stm32g431rb
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart periph_lpuart
+
+# Put other features for this board (in alphabetical order)
+FEATURES_PROVIDED += riotboot
+
+# load the common Makefile.features for Nucleo boards
+include $(RIOTBOARD)/common/nucleo64/Makefile.features

--- a/boards/nucleo-g431rb/Makefile.include
+++ b/boards/nucleo-g431rb/Makefile.include
@@ -1,0 +1,2 @@
+# load the common Makefile.include for Nucleo boards
+include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-g431rb/doc.txt
+++ b/boards/nucleo-g431rb/doc.txt
@@ -1,0 +1,26 @@
+/**
+@defgroup    boards_nucleo-g431rb STM32 Nucleo-G431RB
+@ingroup     boards_common_nucleo64
+@brief       Support for the STM32 Nucleo-G431RB
+
+## Flashing the device
+
+The ST Nucleo-G431RB board includes an on-board ST-LINK V3 programmer. The
+easiest way to program the board is to use OpenOCD. Once you have installed
+OpenOCD (look [here](https://github.com/RIOT-OS/RIOT/wiki/OpenOCD) for
+installation instructions), you can flash the board simply by typing
+
+```
+make BOARD=nucleo-g431rb flash
+```
+and debug via GDB by simply typing
+```
+make BOARD=nucleo-g431rb debug
+```
+
+## Supported Toolchains
+
+For using the ST Nucleo-G431RB board we recommend the usage of the
+[GNU Tools for ARM Embedded Processors](https://launchpad.net/gcc-arm-embedded)
+toolchain.
+ */

--- a/boards/nucleo-g431rb/include/periph_conf.h
+++ b/boards/nucleo-g431rb/include/periph_conf.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2020 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nucleo-g431rb
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the nucleo-g431rb board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+/* Add specific clock configuration (HSE, LSE) for this board here */
+#ifndef CONFIG_BOARD_HAS_LSE
+#define CONFIG_BOARD_HAS_LSE            (1)
+#endif
+/* This board provides a 24MHz HSE oscillator */
+#ifndef CONFIG_BOARD_HAS_HSE
+#define CONFIG_BOARD_HAS_HSE            (1)
+#endif
+/* By default, configure a 170MHz SYSCLK with PLL using HSE as input clock */
+#ifndef CONFIG_CLOCK_PLL_M
+#define CONFIG_CLOCK_PLL_M              (6)
+#endif
+
+#include "periph_cpu.h"
+#include "g4/cfg_clock_default.h"
+#include "cfg_i2c1_pb8_pb9.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_tim2.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = LPUART1,
+        .rcc_mask   = RCC_APB1ENR2_LPUART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 3),
+        .tx_pin     = GPIO_PIN(PORT_A, 2),
+        .rx_af      = GPIO_AF12,
+        .tx_af      = GPIO_AF12,
+        .bus        = APB12,
+        .irqn       = LPUART1_IRQn,
+        .type       = STM32_LPUART,
+        .clk_src    = 0, /* Use APB clock */
+    },
+    { /* Connected to Arduino D0/D1 */
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_C, 5),
+        .tx_pin     = GPIO_PIN(PORT_C, 4),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
+    },
+};
+
+#define UART_0_ISR          (isr_lpuart1)
+#define UART_1_ISR          (isr_usart1)
+
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+/**
+ * @name   SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev            = SPI1,
+        .mosi_pin       = GPIO_PIN(PORT_A, 7),  /* Arduino D11 */
+        .miso_pin       = GPIO_PIN(PORT_A, 6),  /* Arduino D12 */
+        .sclk_pin       = GPIO_PIN(PORT_A, 5),  /* Arduino D13 */
+        .cs_pin         = GPIO_UNDEF,
+        .mosi_af        = GPIO_AF5,
+        .miso_af        = GPIO_AF5,
+        .sclk_af        = GPIO_AF5,
+        .cs_af          = GPIO_AF5,
+        .rccmask        = RCC_APB2ENR_SPI1EN,
+        .apbbus         = APB2,
+    },
+};
+
+#define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/stm32/Kconfig
+++ b/cpu/stm32/Kconfig
@@ -297,6 +297,10 @@ config CPU_MODEL_STM32G071RB
     select CPU_FAM_G0
 
 # STM32G4
+config CPU_MODEL_STM32G431RB
+    bool
+    select CPU_FAM_G4
+
 config CPU_MODEL_STM32G474RE
     bool
     select CPU_FAM_G4
@@ -535,6 +539,7 @@ config CPU_MODEL
     default "stm32g071rb" if CPU_MODEL_STM32G071RB
 
     # STM32G4
+    default "stm32g431rb" if CPU_MODEL_STM32G431RB
     default "stm32g474re" if CPU_MODEL_STM32G474RE
 
     # STM32L0

--- a/cpu/stm32/stm32_mem_lengths.mk
+++ b/cpu/stm32/stm32_mem_lengths.mk
@@ -187,7 +187,9 @@ else ifeq ($(STM32_TYPE), G)
     endif
   endif
   ifeq ($(STM32_FAMILY), 4)
-    ifeq ($(STM32_MODEL), 474)
+    ifeq ($(STM32_MODEL), 431)
+      RAM_LEN = 32K
+    else ifeq ($(STM32_MODEL), 474)
       RAM_LEN = 96K
       CCMRAM_LEN = 32K
     endif

--- a/examples/javascript/Makefile.ci
+++ b/examples/javascript/Makefile.ci
@@ -32,6 +32,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f410rb \
     nucleo-g070rb \
     nucleo-g071rb \
+    nucleo-g431rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/examples/lua_REPL/Makefile.ci
+++ b/examples/lua_REPL/Makefile.ci
@@ -48,6 +48,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f410rb \
     nucleo-g070rb \
     nucleo-g071rb \
+    nucleo-g431rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/examples/lua_basic/Makefile.ci
+++ b/examples/lua_basic/Makefile.ci
@@ -25,6 +25,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f410rb \
     nucleo-g070rb \
     nucleo-g071rb \
+    nucleo-g431rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l412kb \

--- a/examples/suit_update/Makefile.ci
+++ b/examples/suit_update/Makefile.ci
@@ -17,6 +17,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f334r8 \
     nucleo-g070rb \
     nucleo-g071rb \
+    nucleo-g431rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \

--- a/tests/pkg_utensor/Makefile.ci
+++ b/tests/pkg_utensor/Makefile.ci
@@ -24,6 +24,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f410rb \
     nucleo-g070rb \
     nucleo-g071rb \
+    nucleo-g431rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l412kb \

--- a/tests/unittests/Makefile.ci
+++ b/tests/unittests/Makefile.ci
@@ -59,6 +59,7 @@ BOARD_INSUFFICIENT_MEMORY := \
     nucleo-f410rb \
     nucleo-g070rb \
     nucleo-g071rb \
+    nucleo-g431rb \
     nucleo-l031k6 \
     nucleo-l053r8 \
     nucleo-l073rz \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for the [Nucleo-g431rb board](https://www.st.com/en/evaluation-tools/nucleo-g431rb.html). The board is very similar to g474re.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure


Run `BUILD_IN_DOCKER=1 ./dist/tools/compile_and_test_for_board/compile_and_test_for_board.py . nucleo-g431rb --jobs=8 --with-test-only`

<details><summary>Results</summary>

```
Failures during compilation:
- [examples/suit_update](examples/suit_update/compilation.failed)

Failures during test:
- [examples/lorawan](examples/lorawan/test.failed)
- [tests/driver_at86rf2xx_aes](tests/driver_at86rf2xx_aes/test.failed)
- [tests/driver_grove_ledbar](tests/driver_grove_ledbar/test.failed)
- [tests/driver_my9221](tests/driver_my9221/test.failed)
- [tests/emcute](tests/emcute/test.failed)
- [tests/gnrc_dhcpv6_client](tests/gnrc_dhcpv6_client/test.failed)
- [tests/gnrc_dhcpv6_client_6lbr](tests/gnrc_dhcpv6_client_6lbr/test.failed)
- [tests/gnrc_ipv6_ext](tests/gnrc_ipv6_ext/test.failed)
- [tests/gnrc_ipv6_ext_frag](tests/gnrc_ipv6_ext_frag/test.failed)
- [tests/gnrc_ipv6_ext_opt](tests/gnrc_ipv6_ext_opt/test.failed)
- [tests/gnrc_ipv6_nib_dns](tests/gnrc_ipv6_nib_dns/test.failed)
- [tests/gnrc_rpl_srh](tests/gnrc_rpl_srh/test.failed)
- [tests/gnrc_sock_dns](tests/gnrc_sock_dns/test.failed)
- [tests/gnrc_tcp](tests/gnrc_tcp/test.failed)
- [tests/periph_timer_short_relative_set](tests/periph_timer_short_relative_set/test.failed)
- [tests/pkg_libfixmath_unittests](tests/pkg_libfixmath_unittests/test.failed)
- [tests/pkg_semtech-loramac](tests/pkg_semtech-loramac/test.failed)
```

=> No surprise

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
