### PR TITLE
ztimer: fix ztimer_spin() time_left == duration case

### DIFF
--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -456,7 +456,7 @@ void ztimer_sleep(ztimer_clock_t *clock, uint32_t duration);
  */
 static inline void ztimer_spin(ztimer_clock_t *clock, uint32_t duration) {
     uint32_t end = ztimer_now(clock) + duration;
-    while ((end - ztimer_now(clock)) < duration) {}
+    while ((end - ztimer_now(clock)) <= duration) {}
 }
 
 /**

--- a/sys/include/ztimer.h
+++ b/sys/include/ztimer.h
@@ -456,6 +456,9 @@ void ztimer_sleep(ztimer_clock_t *clock, uint32_t duration);
  */
 static inline void ztimer_spin(ztimer_clock_t *clock, uint32_t duration) {
     uint32_t end = ztimer_now(clock) + duration;
+
+    /* Rely on integer overflow. `end - now` will be smaller than `duration`,
+     * counting down, until it underflows to UINT32_MAX. Loop ends then. */
     while ((end - ztimer_now(clock)) <= duration) {}
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Previously, the spinning loop would not spin at all if entered with "remaining time == duration", which happens if the clock is slow or the system fast.
This PR fixes the faulty comparison.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
