### PR TITLE
boards/stm32f0: fix missing CLOCK_APB2 define

### DIFF
--- a/boards/common/stm32/include/f0/cfg_clock_default.h
+++ b/boards/common/stm32/include/f0/cfg_clock_default.h
@@ -129,6 +129,10 @@ extern "C" {
 #define CONFIG_CLOCK_APB1_DIV           (1)
 #endif
 #define CLOCK_APB1                      (CLOCK_AHB / CONFIG_CLOCK_APB1_DIV)   /* max: 48MHz */
+/* APB2 and APB1 are the same bus but configuration registers still follows the
+ * split between APB1 and APB2. Since it's the same bus, APB2 clock is equal to APB1 clock.
+ */
+#define CLOCK_APB2                      (CLOCK_APB1)
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR re-adds the CLOCK_APB2 define that was removed in #14921. Even if there's only one APB clock domain on F0, the registers are still split between APB1 and APB2. The value of CLOCK_APB2 is equal to CLOCK_APB1.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Fixes `tests/xtimer_ushort` test application on nucleo-f091rc that is failing on master (as reported in https://github.com/RIOT-OS/RIOT/pull/14923#issuecomment-700658707).

<details><summary>this PR</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=nucleo-f091rc -C tests/xtimer_usleep clean flash test --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-f091rc'  -w '/data/riotbuild/riotbase/tests/xtimer_usleep/' 'riot/riotbuild:latest' make 'BOARD=nucleo-f091rc'    
Building application "tests_xtimer_usleep" for "nucleo-f091rc" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/nucleo-f091rc
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  11164	    132	   2420	  13716	   3594	/data/riotbuild/riotbase/tests/xtimer_usleep/bin/nucleo-f091rc/tests_xtimer_usleep.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/xtimer_usleep/bin/nucleo-f091rc/tests_xtimer_usleep.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-09-29-10:54)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 1000 kHz
Info : STLINK V2J23M9 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.265135
Info : stm32f0x.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for stm32f0x.cpu on 0
Info : Listening on port 37705 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f0x.cpu       hla_target little stm32f0x.cpu       reset

Info : Unable to match requested speed 1000 kHz, using 950 kHz
Info : Unable to match requested speed 1000 kHz, using 950 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0xc1000000 pc: 0x0800075c msp: 0x20000200
Info : device id = 0x10006442
Info : flash size = 256kbytes
auto erase enabled
wrote 12288 bytes from file /work/riot/RIOT/tests/xtimer_usleep/bin/nucleo-f091rc/tests_xtimer_usleep.elf in 0.564122s (21.272 KiB/s)

verified 11296 bytes in 0.184005s (59.951 KiB/s)

Info : Unable to match requested speed 1000 kHz, using 950 kHz
Info : Unable to match requested speed 1000 kHz, using 950 kHz
shutdown command invoked
Done flashing
r
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2020.10-devel-1609-ga7bb4-pr/boards/stm32f0_apb2_clock_fix)
Running test 5 times with 7 distinct sleep times
Slept for 10025 us (expected: 10000 us) Offset: 25 us
Slept for 50026 us (expected: 50000 us) Offset: 26 us
Slept for 10259 us (expected: 10234 us) Offset: 25 us
Slept for 56805 us (expected: 56780 us) Offset: 25 us
Slept for 12147 us (expected: 12122 us) Offset: 25 us
Slept for 98790 us (expected: 98765 us) Offset: 25 us
Slept for 75025 us (expected: 75000 us) Offset: 25 us
Slept for 10025 us (expected: 10000 us) Offset: 25 us
Slept for 50026 us (expected: 50000 us) Offset: 26 us
Slept for 10259 us (expected: 10234 us) Offset: 25 us
Slept for 56805 us (expected: 56780 us) Offset: 25 us
Slept for 12147 us (expected: 12122 us) Offset: 25 us
Slept for 98790 us (expected: 98765 us) Offset: 25 us
Slept for 75025 us (expected: 75000 us) Offset: 25 us
Slept for 10025 us (expected: 10000 us) Offset: 25 us
Slept for 50026 us (expected: 50000 us) Offset: 26 us
Slept for 10259 us (expected: 10234 us) Offset: 25 us
Slept for 56805 us (expected: 56780 us) Offset: 25 us
Slept for 12147 us (expected: 12122 us) Offset: 25 us
Slept for 98790 us (expected: 98765 us) Offset: 25 us
Slept for 75025 us (expected: 75000 us) Offset: 25 us
Slept for 10025 us (expected: 10000 us) Offset: 25 us
Slept for 50026 us (expected: 50000 us) Offset: 26 us
Slept for 10259 us (expected: 10234 us) Offset: 25 us
Slept for 56805 us (expected: 56780 us) Offset: 25 us
Slept for 12147 us (expected: 12122 us) Offset: 25 us
Slept for 98790 us (expected: 98765 us) Offset: 25 us
Slept for 75025 us (expected: 75000 us) Offset: 25 us
Slept for 10025 us (expected: 10000 us) Offset: 25 us
Slept for 50026 us (expected: 50000 us) Offset: 26 us
Slept for 10259 us (expected: 10234 us) Offset: 25 us
Slept for 56805 us (expected: 56780 us) Offset: 25 us
Slept for 12147 us (expected: 12122 us) Offset: 25 us
Slept for 98790 us (expected: 98765 us) Offset: 25 us
Slept for 75025 us (expected: 75000 us) Offset: 25 us
Test ran for 1734932 us

```

</details>

<details><summary>master</summary>

```
$ BUILD_IN_DOCKER=1 make BOARD=nucleo-f091rc -C tests/xtimer_usleep clean flash test --no-print-directory 
Launching build container using image "riot/riotbuild:latest".
docker run --rm --tty --user $(id -u) -v '/usr/share/zoneinfo/Europe/Paris:/etc/localtime:ro' -v '/work/riot/RIOT:/data/riotbuild/riotbase:delegated' -e 'RIOTBASE=/data/riotbuild/riotbase' -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' -e 'BUILD_DIR=/data/riotbuild/riotbase/build' -e 'RIOTPROJECT=/data/riotbuild/riotbase' -e 'RIOTCPU=/data/riotbuild/riotbase/cpu' -e 'RIOTBOARD=/data/riotbuild/riotbase/boards' -e 'RIOTMAKE=/data/riotbuild/riotbase/makefiles'      -e 'BOARD=nucleo-f091rc'  -w '/data/riotbuild/riotbase/tests/xtimer_usleep/' 'riot/riotbuild:latest' make 'BOARD=nucleo-f091rc'    
Building application "tests_xtimer_usleep" for "nucleo-f091rc" with MCU "stm32".

"make" -C /data/riotbuild/riotbase/boards/nucleo-f091rc
"make" -C /data/riotbuild/riotbase/boards/common/nucleo
"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/cpu/stm32
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common
"make" -C /data/riotbuild/riotbase/cpu/cortexm_common/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/periph
"make" -C /data/riotbuild/riotbase/cpu/stm32/stmclk
"make" -C /data/riotbuild/riotbase/cpu/stm32/vectors
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotbase/sys/div
"make" -C /data/riotbuild/riotbase/sys/isrpipe
"make" -C /data/riotbuild/riotbase/sys/newlib_syscalls_default
"make" -C /data/riotbuild/riotbase/sys/pm_layered
"make" -C /data/riotbuild/riotbase/sys/stdio_uart
"make" -C /data/riotbuild/riotbase/sys/test_utils/interactive_sync
"make" -C /data/riotbuild/riotbase/sys/tsrb
"make" -C /data/riotbuild/riotbase/sys/xtimer
   text	   data	    bss	    dec	    hex	filename
  11132	    132	   2420	  13684	   3574	/data/riotbuild/riotbase/tests/xtimer_usleep/bin/nucleo-f091rc/tests_xtimer_usleep.elf
/work/riot/RIOT/dist/tools/openocd/openocd.sh flash /work/riot/RIOT/tests/xtimer_usleep/bin/nucleo-f091rc/tests_xtimer_usleep.elf
### Flashing Target ###
Open On-Chip Debugger 0.10.0+dev-01406-gca211373d-dirty (2020-09-29-10:54)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
hla_swd
Info : The selected transport took over low-level target control. The results might differ compared to plain JTAG/SWD
srst_only separate srst_nogate srst_open_drain connect_assert_srst

Info : clock speed 1000 kHz
Info : STLINK V2J23M9 (API v2) VID:PID 0483:374B
Info : Target voltage: 3.257255
Info : stm32f0x.cpu: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for stm32f0x.cpu on 0
Info : Listening on port 35979 for gdb connections
    TargetName         Type       Endian TapName            State       
--  ------------------ ---------- ------ ------------------ ------------
 0* stm32f0x.cpu       hla_target little stm32f0x.cpu       reset

Info : Unable to match requested speed 1000 kHz, using 950 kHz
Info : Unable to match requested speed 1000 kHz, using 950 kHz
target halted due to debug-request, current mode: Thread 
xPSR: 0xc1000000 pc: 0x0800075c msp: 0x20000200
Info : device id = 0x10006442
Info : flash size = 256kbytes
auto erase enabled
wrote 12288 bytes from file /work/riot/RIOT/tests/xtimer_usleep/bin/nucleo-f091rc/tests_xtimer_usleep.elf in 0.550538s (21.797 KiB/s)

verified 11264 bytes in 0.170237s (64.616 KiB/s)

Info : Unable to match requested speed 1000 kHz, using 950 kHz
Info : Unable to match requested speed 1000 kHz, using 950 kHz
shutdown command invoked
Done flashing
r
/work/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200" --no-reconnect --noprefix --no-repeat-command-on-empty-line 
Twisted not available, please install it if you want to use pyterm's JSON capabilities
Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
READY
s
START
main(): This is RIOT! (Version: 2020.10-devel-1613-g109012)
Running test 5 times with 7 distinct sleep times
Slept for 10012 us (expected: 10000 us) Offset: 12 us
Slept for 50012 us (expected: 50000 us) Offset: 12 us
Slept for 10246 us (expected: 10234 us) Offset: 12 us
Slept for 56792 us (expected: 56780 us) Offset: 12 us
Slept for 12134 us (expected: 12122 us) Offset: 12 us
Slept for 98777 us (expected: 98765 us) Offset: 12 us
Slept for 75012 us (expected: 75000 us) Offset: 12 us
Slept for 10012 us (expected: 10000 us) Offset: 12 us
Slept for 50012 us (expected: 50000 us) Offset: 12 us
Slept for 10246 us (expected: 10234 us) Offset: 12 us
Slept for 56792 us (expected: 56780 us) Offset: 12 us
Slept for 12134 us (expected: 12122 us) Offset: 12 us
Slept for 98777 us (expected: 98765 us) Offset: 12 us
Slept for 75012 us (expected: 75000 us) Offset: 12 us
Slept for 10012 us (expected: 10000 us) Offset: 12 us
Slept for 50012 us (expected: 50000 us) Offset: 12 us
Slept for 10246 us (expected: 10234 us) Offset: 12 us
Slept for 56792 us (expected: 56780 us) Offset: 12 us
Slept for 12134 us (expected: 12122 us) Offset: 12 us
Slept for 98777 us (expected: 98765 us) Offset: 12 us
Slept for 75012 us (expected: 75000 us) Offset: 12 us
Slept for 10012 us (expected: 10000 us) Offset: 12 us
Slept for 50012 us (expected: 50000 us) Offset: 12 us
Slept for 10246 us (expected: 10234 us) Offset: 12 us
Slept for 56792 us (expected: 56780 us) Offset: 12 us
Slept for 12134 us (expected: 12122 us) Offset: 12 us
Slept for 98777 us (expected: 98765 us) Offset: 12 us
Slept for 75012 us (expected: 75000 us) Offset: 12 us
Slept for 10012 us (expected: 10000 us) Offset: 12 us
Slept for 50012 us (expected: 50000 us) Offset: 12 us
Slept for 10246 us (expected: 10234 us) Offset: 12 us
Slept for 56792 us (expected: 56780 us) Offset: 12 us
Slept for 12134 us (expected: 12122 us) Offset: 12 us
Slept for 98777 us (expected: 98765 us) Offset: 12 us
Slept for 75012 us (expected: 75000 us) Offset: 12 us
Test ran for 1649701 us
Host timer measured 3300178 us (client measured 1649701 us)

make: *** [/work/riot/RIOT/tests/xtimer_usleep/../../Makefile.include:761: test] Error 1
```

</details>


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

bug introduced in #14921

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
