### PR TITLE
boards/nrf52840dongle: Configure PWM to drive the LEDs

### DIFF
--- a/boards/nrf52840dongle/Kconfig
+++ b/boards/nrf52840dongle/Kconfig
@@ -12,6 +12,7 @@ config BOARD_NRF52840DONGLE
     default y
     select BOARD_COMMON_NRF52
     select CPU_MODEL_NRF52840XXAA
+    select HAS_PERIPH_PWM
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV
     select HAS_RADIO_NRF802154

--- a/boards/nrf52840dongle/Makefile.features
+++ b/boards/nrf52840dongle/Makefile.features
@@ -1,6 +1,7 @@
 CPU_MODEL = nrf52840xxaa
 
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
 

--- a/boards/nrf52840dongle/include/periph_conf.h
+++ b/boards/nrf52840dongle/include/periph_conf.h
@@ -56,6 +56,21 @@ static const uart_conf_t uart_config[] = {
 #define UART_NUMOF          ARRAY_SIZE(uart_config)
 /** @} */
 
+/**
+ * @name   PWM configuration
+ *
+ * For the nRF52840-Dongle board, the PWM0 module is set to drive the LEDs LD1
+ * and the channels LD2 red, green and blue in the four channels of PWM_DEV(0);
+ * other PWM outputs are not configured.
+ *
+ * @{
+ */
+static const pwm_conf_t pwm_config[] = {
+    { NRF_PWM0, { GPIO_PIN(0, 6), GPIO_PIN(0, 8), GPIO_PIN(1, 9), GPIO_PIN(0, 12) } }
+};
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

The nRF52840-Donle board has hardware that lends itself to PWM driving, but did not configure a default PWM setting.

This adds a single PWM peripheral that is configured for the LEDs LD1, LD2#red, LD2#green and LD2#blue.

### Testing procedure

```
$ make BOARD=nrf52840dongle -C tests/periph_pwm all flash term
[...]
> osci
```

and watch the green LED and the roughly-white-appearing RGB LED fade in unison.

The LEDs are driven active-low, which is of no concern to the PWM module but will help understand the values when you test that the documented assignment ("is set to drive the LEDs LD1 and the channels LD2 red, green and blue in the four channels of PWM_DEV(0)") matches:

```
> init 0 0 1000 255
> set 0 0 255 # turn off LD1
> set 0 1 255 # turn off LD2#red, leaving it turquise
> set 0 2 250 # turn off almost all of LD2#green, leaving it blue
> set 0 3 255 # turn off LD2#blue, leaving the faint green from before
```

### Issues/PRs references

This is done a) because it's a peripheral that can reasonably expected to be wired, and b) as a test case for #15106.