### PR TITLE
doc/kconfig: add a note about possible CPU intermediate hierarchy level

### DIFF
--- a/doc/doxygen/src/kconfig/kconfig.md
+++ b/doc/doxygen/src/kconfig/kconfig.md
@@ -352,7 +352,9 @@ Features may be provided by any hierarchy symbol. Usually symbols are selected
 from more specific to less specific. This means that a `CPU_MODEL_<model>`
 symbol usually would select the correspondent `CPU_FAM_<family>` symbol,
 which would in turn select the `CPU_CORE_<core>`. This may change in some cases
-where `CPU_COMMON_` symbols are defined to avoid repetition.
+where `CPU_COMMON_` symbols are defined to avoid repetition. For convenience and
+if it makes sense within a CPU vendor family, it's also allowed to use
+intermediate grouping levels, like `CPU_LINE_<xxx>` used for STM32.
 
 In addition to the symbols of the hierarchy described above, a default value
 to the `CPU` symbol should be assigned, which will match the value of the `CPU`


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

As requested in https://github.com/RIOT-OS/RIOT/pull/14998#issuecomment-700617037, this PR slightly extends the Kconfig documentation page with a mention saying it's allowed to add intermediate grouping levels in CPU for convenience if it better reflects the hierarchy used by a given vendor.

Better wording is welcome !

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just read!

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Documentation about this was requested in https://github.com/RIOT-OS/RIOT/pull/14998#issuecomment-700617037
Based on #14998

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
