### PR TITLE
nRF52 PWM fixes

### DIFF
--- a/cpu/nrf52/periph/pwm.c
+++ b/cpu/nrf52/periph/pwm.c
@@ -115,7 +115,7 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
 
     /* setup the sequence */
     dev(pwm)->SEQ[0].PTR = (uint32_t)pwm_seq[pwm];
-    dev(pwm)->SEQ[0].CNT = pwm_channels(pwm);
+    dev(pwm)->SEQ[0].CNT = PWM_CHANNELS;
     dev(pwm)->SEQ[0].REFRESH = 0;
     dev(pwm)->SEQ[0].ENDDELAY = 0;
 

--- a/cpu/nrf52/periph/pwm.c
+++ b/cpu/nrf52/periph/pwm.c
@@ -90,9 +90,6 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
 
     /* pin configuration */
     for (unsigned i = 0; i < PWM_CHANNELS; i++) {
-        if (pwm_config[pwm].pin[i] != GPIO_UNDEF) {
-            NRF_P0->PIN_CNF[pwm_config[pwm].pin[i]] = PIN_CNF_SET;
-        }
         /* either left aligned pol or inverted duty cycle */
         pwm_seq[pwm][i] = (POL_MASK & mode) ? POL_MASK : res;
         dev(pwm)->PSEL.OUT[i] = pwm_config[pwm].pin[i];


### PR DESCRIPTION
### Contribution description

These fixes simplify code in the nRF52 driver:

* The number of *used* channels being assigned to the CNT register broke PWM when <4 channels were in active use
* The setting of general PIN_CNF was only partially correct (it didn't capture that the pins could be in P1 instead of P2), and needless (as while PWM is active, the pins are driven immaterial of PIN_CNF)

They are grouped in one PR as they're in close proximity, and require the same documentation (<https://infocenter.nordicsemi.com/pdf/nRF52840_PS_v1.1.pdf#page=256>) to verify.

### Testing procedure

As they went unnoticed so far, the bugs can't easily be shown with the current code base; even https://github.com/RIOT-OS/RIOT/pull/15115 in its latest iterations uses all 4 channels and thus doesn't trigger the bug any more.

The easiest test is to take a board with PWM support (eg. nrf5240dongle when https://github.com/RIOT-OS/RIOT/pull/15115 is applied), run the `osci` command in tests/periph_pwm and see that things still work.

To show the original problem, you can replace one of the GPIOs in the board's periph_conf.h with `GPIO_UNINIT` (then, without this patch, PWM would not work at all on this device). For the removed code, I don't have any better testing other than "hey it still works"

### Issues/PRs references

These were discovered while looking through why an earlier version of https://github.com/RIOT-OS/RIOT/pull/15115 (that only assigned the RGB LED to channels) did not work.