### PR TITLE
driver/at86rf215: add functions to configure trim & clock output at run-time

### DIFF
--- a/drivers/at86rf215/at86rf215.c
+++ b/drivers/at86rf215/at86rf215.c
@@ -125,7 +125,7 @@ if (!IS_ACTIVE(CONFIG_AT86RF215_USE_CLOCK_OUTPUT)){
 }
     /* allow to configure board-specific trim */
 #ifdef CONFIG_AT86RF215_TRIM_VAL
-    at86rf215_reg_write(dev, RG_RF_XOC, CONFIG_AT86RF215_TRIM_VAL | XOC_FS_MASK);
+    at86rf215_set_trim(dev, CONFIG_AT86RF215_TRIM_VAL);
 #endif
 
     /* enable TXFE & RXFE IRQ */

--- a/drivers/at86rf215/at86rf215_getset.c
+++ b/drivers/at86rf215/at86rf215_getset.c
@@ -89,6 +89,18 @@ uint8_t at86rf215_get_chan(const at86rf215_t *dev)
     return at86rf215_reg_read16(dev, dev->RF->RG_CNL);
 }
 
+void at86rf215_set_trim(at86rf215_t *dev, uint8_t trim)
+{
+    assert(trim <= 0xF);
+    at86rf215_reg_write(dev, RG_RF_XOC, trim | XOC_FS_MASK);
+}
+
+void at86rf215_set_clock_output(at86rf215_t *dev,
+                                at86rf215_clko_cur_t cur, at86rf215_clko_freq_t freq)
+{
+    at86rf215_reg_write(dev, RG_RF_CLKO, cur | freq);
+}
+
 void at86rf215_set_chan(at86rf215_t *dev, uint16_t channel)
 {
     at86rf215_await_state_end(dev, RF_STATE_TX);

--- a/drivers/include/at86rf215.h
+++ b/drivers/include/at86rf215.h
@@ -273,6 +273,33 @@ enum {
 };
 
 /**
+ * @name    Clock Output Driver Strength
+ * @{
+ */
+typedef enum {
+    AT86RF215_CLKO_2mA = 0 << 3,    /**< 2 mA */
+    AT86RF215_CLKO_4mA = 1 << 3,    /**< 4 mA */
+    AT86RF215_CLKO_6mA = 2 << 3,    /**< 6 mA */
+    AT86RF215_CLKO_8mA = 3 << 3,    /**< 8 mA */
+} at86rf215_clko_cur_t;
+/** @} */
+
+/**
+ * @name    Clock Output Frequency
+ * @{
+ */
+typedef enum {
+    AT86RF215_CLKO_OFF = 0,         /**< Clock Output Disabled  */
+    AT86RF215_CLKO_26_MHz,          /**< 26 MHz */
+    AT86RF215_CLKO_32_MHz,          /**< 32 MHz */
+    AT86RF215_CLKO_16_MHz,          /**< 16 MHz */
+    AT86RF215_CLKO_8_MHz,           /**<  8 MHz */
+    AT86RF215_CLKO_4_MHz,           /**<  4 MHz */
+    AT86RF215_CLKO_2_MHz,           /**<  2 MHz */
+    AT86RF215_CLKO_1_MHz,           /**<  1 MHz */
+} at86rf215_clko_freq_t;
+
+/**
  * @name    Internal device option flags
  * @{
  */
@@ -525,6 +552,42 @@ int8_t at86rf215_get_ed_level(at86rf215_t *dev);
  * @param[in] state         true for enable, false for disable
  */
 void at86rf215_set_option(at86rf215_t *dev, uint16_t option, bool state);
+
+/**
+ * @brief   Set crystal oscillator trim value.
+ *
+ *          An internal capacitance array is connected to the
+ *          crystal oscillator pins TCXO and XTAL2.
+ *
+ *          Each increment of the trim value adds 0.3pF capacitance
+ *          to the oscillator circuit.
+ *
+ *          To trim a board, enable the clock output with
+ *          @ref at86rf215_set_clock_output and connect a frequency
+ *          counter to the clock output pin.
+ *          Then adjust the trim value until it the measured frequency
+ *          closely matches the configured output frequency.
+ *
+ *          It is recommended to use a 26 MHz output frequency for the
+ *          test as this is the raw frequency of the external oscillator.
+ *
+ *          The resulting trim value must then be stored in a persistent
+ *          memory area of the board to be set via @ref CONFIG_AT86RF215_TRIM_VAL
+ *
+ * @param[in] dev           device to configure
+ * @param[in] trim          trim value
+ */
+void at86rf215_set_trim(at86rf215_t *dev, uint8_t trim);
+
+/**
+ * @brief   Configure the Clock Output pin
+ *
+ * @param[in] dev           device to configure
+ * @param[in] cur           Clock output current
+ * @param[in] freq          Clock output frequency
+ */
+void at86rf215_set_clock_output(at86rf215_t *dev,
+                                at86rf215_clko_cur_t cur, at86rf215_clko_freq_t freq);
 
 /**
  * @brief   Convenience function for simply sending data

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -292,6 +292,11 @@ typedef enum {
 /** @} */
 
 /**
+ * @brief   Will match any device index
+ */
+#define NETDEV_INDEX_ANY    (0xFF)
+
+/**
  * @brief Structure to hold driver state
  *
  * Supposed to be extended by driver implementations.

--- a/sys/include/net/eui_provider.h
+++ b/sys/include/net/eui_provider.h
@@ -104,11 +104,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Will match any device index
- */
-#define NETDEV_INDEX_ANY    (0xFF)
-
-/**
  * @brief   Function for providing a EUI-48 to a device
  *
  * @param[in]   arg     Optional argument provided by eui48_conf_t

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -566,6 +566,19 @@ int gnrc_netif_set_from_netdev(gnrc_netif_t *netif,
                                const gnrc_netapi_opt_t *opt);
 
 /**
+ * @brief Gets an interface by the netdev type (and index)
+ *
+ * @pre The netdev has been registered with @ref netdev_register
+ *
+ * @param[in]  type         driver type of the netdev, can be @ref NETDEV_ANY
+ * @param[in]  index        index of the netdev, can be @ref NETDEV_INDEX_ANY
+ *
+ * @return  The network interface that has a netdev of matching type and index
+ *          NULL if no matching interface could be found
+ */
+gnrc_netif_t *gnrc_netif_get_by_type(netdev_type_t type, uint8_t index);
+
+/**
  * @brief   Converts a hardware address to a human readable string.
  *
  * @note    Compatibility wrapper for @see netif_addr_to_str

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -117,6 +117,31 @@ gnrc_netif_t *gnrc_netif_iter(const gnrc_netif_t *prev)
     return (gnrc_netif_t*) netif_iter((netif_t*) prev);
 }
 
+gnrc_netif_t *gnrc_netif_get_by_type(netdev_type_t type, uint8_t index)
+{
+    gnrc_netif_t *netif = NULL;
+    while ((netif = gnrc_netif_iter(netif))) {
+
+#ifdef MODULE_NETDEV_REGISTER
+        if (netif->dev->type != type && type != NETDEV_ANY) {
+            continue;
+        }
+
+        if (netif->dev->index != index && index != NETDEV_INDEX_ANY) {
+            continue;
+        }
+#else
+        (void)type;
+        (void)index;
+        assert(index == 0);
+#endif
+
+        return netif;
+    }
+
+    return NULL;
+}
+
 int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
 {
     int res = -ENOTSUP;


### PR DESCRIPTION
### Contribution description

To calibrate the at86rf215 radio, trim value has to be set at run-time during board production.
Add two helper functions to control the trim value and clock output register.

This also adds a `gnrc_netif_get_netdev()` netdev function to get a pointer to a previously registered netdev from netif. 

### Testing procedure

`tests/driver_at86rf215` has gained three new functions:

 - `set_trim` set the trim value
 - `set_clko` enable clock output
 - `get_random` get numbers from the radio's random number generator (previously untested)

If you connect a frequency counter to the clock output pin, you should be able to measure the set frequency and see it change when adjusting the trim value.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
