### PR TITLE
boards/common/nrf52xxxdk: configure LEDs as PWM

### DIFF
--- a/boards/common/nrf52xxxdk/include/periph_conf_common.h
+++ b/boards/common/nrf52xxxdk/include/periph_conf_common.h
@@ -27,6 +27,8 @@
 #include "cfg_rtt_default.h"
 #include "cfg_timer_default.h"
 
+#include "board.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -36,7 +38,32 @@ extern "C" {
  * @{
  */
 static const pwm_conf_t pwm_config[] = {
-    { NRF_PWM0, { 28, 29, 30, 31 } }
+    { NRF_PWM0, {
+        /* configure LED0 as PWM */
+#ifdef LED0_PIN
+        LED0_PIN,
+#else
+        GPIO_UNDEF,
+#endif
+        /* configure LED1 as PWM */
+#ifdef LED1_PIN
+        LED1_PIN,
+#else
+        GPIO_UNDEF,
+#endif
+        /* configure LED2 as PWM */
+#ifdef LED2_PIN
+        LED2_PIN,
+#else
+        GPIO_UNDEF,
+#endif
+        /* configure LED3 as PWM */
+#ifdef LED3_PIN
+        LED3_PIN,
+#else
+        GPIO_UNDEF,
+#endif
+    } },
 };
 #define PWM_NUMOF           ARRAY_SIZE(pwm_config)
 /** @} */


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The 'common' pwm pins don't make sense for every board.
Use the LED pin defines instead as a sensible PWM default.


### Testing procedure

Flash e.g. `nrf52840dk` or `nrf52dk` with `tests/periph_pwm`.
Run the `osci` command.

You should now see the on-board LEDs flashing.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
