### PR TITLE
tests: blacklist mtd using tests for esp32-wroom-32

### DIFF
--- a/tests/mtd_mapper/Makefile
+++ b/tests/mtd_mapper/Makefile
@@ -3,4 +3,7 @@ include ../Makefile.tests_common
 USEMODULE += mtd_mapper
 USEMODULE += embunit
 
+# disabling due to unknown failure. See #15123.
+TEST_ON_CI_BLACKLIST += esp32-wroom-32
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_littlefs/Makefile
+++ b/tests/pkg_littlefs/Makefile
@@ -3,4 +3,7 @@ include ../Makefile.tests_common
 USEMODULE += littlefs
 USEMODULE += embunit
 
+# disabling due to unknown failure. See #15123.
+TEST_ON_CI_BLACKLIST += esp32-wroom-32
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_littlefs2/Makefile
+++ b/tests/pkg_littlefs2/Makefile
@@ -3,4 +3,7 @@ include ../Makefile.tests_common
 USEPKG += littlefs2
 USEMODULE += embunit
 
+# disabling due to unknown failure. See #15123.
+TEST_ON_CI_BLACKLIST += esp32-wroom-32
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_spiffs/Makefile
+++ b/tests/pkg_spiffs/Makefile
@@ -3,4 +3,7 @@ include ../Makefile.tests_common
 USEMODULE += spiffs
 USEMODULE += embunit
 
+# disabling due to unknown failure. See #15123.
+TEST_ON_CI_BLACKLIST += esp32-wroom-32
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

These tests fail on CI. Blocklisting them for now so CI won't stumble all the time.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Corresponding issue: https://github.com/RIOT-OS/RIOT/issues/15123

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
