### PR TITLE
cpu/nrf5x_common: UART: add support for 1 MBaud

### DIFF
--- a/cpu/nrf5x_common/periph/uart.c
+++ b/cpu/nrf5x_common/periph/uart.c
@@ -194,6 +194,9 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
         case 921600:
             REG_BAUDRATE = UART_BAUDRATE_BAUDRATE_Baud921600;
             break;
+        case 1000000:
+            REG_BAUDRATE = UART_BAUDRATE_BAUDRATE_Baud1M;
+            break;
         default:
             return UART_NOBAUD;
     }


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`UART_BAUDRATE_BAUDRATE_Baud1M` is defined in the vendor files, so make it available to the user.

### Testing procedure

Run `tests/periph_uart`. You should now be able to use Baudrates of 1000000.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
