### PR TITLE
cpu/cc26xx_cc13xx: use _rom_length symbol for CCFG origin

### DIFF
--- a/cpu/cc26x0/Makefile.include
+++ b/cpu/cc26x0/Makefile.include
@@ -3,7 +3,7 @@ CPU_VARIANT = x0
 ROM_START_ADDR ?= 0x00000000
 RAM_START_ADDR ?= 0x20000000
 
-ROM_LEN ?= 0x1FFA8 # 128K - 88 bytes
+ROM_LEN ?= 128K
 RAM_LEN ?= 20K
 
 include ${RIOTCPU}/cc26xx_cc13xx/Makefile.include

--- a/cpu/cc26x2_cc13x2/Makefile.include
+++ b/cpu/cc26x2_cc13x2/Makefile.include
@@ -2,7 +2,7 @@ CPU_VARIANT = x2
 
 ROM_START_ADDR ?= 0x00000000
 RAM_START_ADDR ?= 0x20000000
-ROM_LEN ?= 0x57FA8 # 352K - 88 config bytes
+ROM_LEN ?= 352K
 RAM_LEN ?= 80K
 
 include ${RIOTCPU}/cc26xx_cc13xx/Makefile.include

--- a/cpu/cc26xx_cc13xx/ldscripts/cc26xx_cc13xx.ld
+++ b/cpu/cc26xx_cc13xx/ldscripts/cc26xx_cc13xx.ld
@@ -22,7 +22,8 @@ INCLUDE cortexm_rom_offset.ld
 MEMORY
 {
     rom      (rx)   : ORIGIN = _rom_start_addr + _rom_offset, LENGTH = _fw_rom_length
-    ccfg     (rx)   : ORIGIN = 0x00057FA8,                    LENGTH = 88
+    /* CCFG starts at the end of ROM */
+    ccfg     (rx)   : ORIGIN = _rom_length - 88,              LENGTH = 88
     /* GPRAM is only available when cache is disabled. When GPRAM is enabled it
      * is used as a backup RAM at the expense of slower CPU execution time */
     gpram           : ORIGIN = 0x11000000,                    LENGTH = 8K

--- a/cpu/cc26xx_cc13xx/vectors.c
+++ b/cpu/cc26xx_cc13xx/vectors.c
@@ -158,12 +158,14 @@ ccfg_regs_t cc26xx_cc13xx_ccfg = {
                         & CCFG_SET_BITS(SET_MODE_CONF_1_TCXO_MAX_START,
                                         CCFG_MODE_CONF_1_TCXO_MAX_START_s,
                                         CCFG_MODE_CONF_1_TCXO_MAX_START_m)
-#else
-                        0
-#endif /* CPU_VARIANT_X2 */
                         & CCFG_SET_BITS(SET_MODE_CONF_1_ALT_DCDC_VMIN,
                                         CCFG_MODE_CONF_1_ALT_DCDC_VMIN_s,
                                         CCFG_MODE_CONF_1_ALT_DCDC_VMIN_m)
+#else
+                          CCFG_SET_BITS(SET_MODE_CONF_1_ALT_DCDC_VMIN,
+                                        CCFG_MODE_CONF_1_ALT_DCDC_VMIN_s,
+                                        CCFG_MODE_CONF_1_ALT_DCDC_VMIN_m)
+#endif /* CPU_VARIANT_X2 */
                         & CCFG_SET_BITS(SET_MODE_CONF_1_ALT_DCDC_DITHER_EN,
                                         CCFG_MODE_CONF_1_ALT_DCDC_DITHER_EN_s,
                                         CCFG_MODE_CONF_1_ALT_DCDC_DITHER_EN_m)


### PR DESCRIPTION
### Contribution description

Fixes the CCFG origin on cc26x0 CPUs, it should be at end of the ROM.

### Testing procedure

- `make -C examples/hello-world menuconfig BOARD=cc2650-launchpad && make && arm-none-eabi-readelf --hex-dump=.ccfg examples/hello-world/bin/cc2650-launchpad/hello-world.elf`
- Output should be:
```
jeandudey@jean ~/D/R/e/hello-world> arm-none-eabi-readelf --hex-dump=.ccfg /home/jeandudey/Dev/RIOT/examples/hello-world/bin/cc2650-launchpad/hello-world.elf

Hex dump of section '.ccfg':
  0x0001ffa8 00008001 100082ff fdff5800 3affaff1 ..........X.:...
  0x0001ffb8 ffffffff ffffffff ffffffff ffffffff ................
  0x0001ffc8 ffffffff ffffffff ffffffff ffffffff ................
  0x0001ffd8 ffffff00 00000000 00000000 00c5c5ff ................
  0x0001ffe8 00000000 00000000 ffffffff ffffffff ................
  0x0001fff8 ffffffff ffffffff                   ........
```

### Issues/PRs references

- #14219 
