### PR TITLE
boards/c/particle-mesh: Enable PWM on the LED pins

### DIFF
--- a/boards/common/particle-mesh/Kconfig
+++ b/boards/common/particle-mesh/Kconfig
@@ -9,6 +9,7 @@ config BOARD_COMMON_PARTICLE_MESH
     select BOARD_COMMON_NRF52
     select CPU_MODEL_NRF52840XXAA
     select HAS_PERIPH_I2C
+    select HAS_PERIPH_PWM
     select HAS_PERIPH_SPI
     select HAS_PERIPH_UART
     select HAS_PERIPH_USBDEV

--- a/boards/common/particle-mesh/Makefile.features
+++ b/boards/common/particle-mesh/Makefile.features
@@ -2,6 +2,7 @@ CPU_MODEL = nrf52840xxaa
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev

--- a/boards/common/particle-mesh/include/periph_conf_common.h
+++ b/boards/common/particle-mesh/include/periph_conf_common.h
@@ -26,6 +26,8 @@
 #include "cfg_rtt_default.h"
 #include "cfg_timer_default.h"
 
+#include "board.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -44,6 +46,22 @@ static const spi_conf_t spi_config[] = {
 };
 
 #define SPI_NUMOF           ARRAY_SIZE(spi_config)
+/** @} */
+
+/**
+ * @name    PWM configuration
+ *
+ * A single PWM device is used to map the three channels of the on-board RGB
+ * LED
+ *
+ * @{
+ */
+
+static const pwm_conf_t pwm_config[] = {
+    { NRF_PWM0, { LED0_PIN, LED1_PIN, LED2_PIN, GPIO_UNDEF } }
+};
+#define PWM_NUMOF           ARRAY_SIZE(pwm_config)
+
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

On all particle-mesh boards (particle-xenon, particle-argon, particle-boron), this sets up the internal PWM0 peripheral as PWM_DEV(0), and assigns the three channels of the on-board LED to it.

### Testing procedure

(I actually tested it with my particle-xenon-native-bootloader2 branch merged and the respective flashing options, but that should be immaterial to the general case).

```
$ make -C tests/periph_pwm BOARD=particle-xenon all flash term
[...]
> osci
```

You'll see the RGB LED breathe as if it were a single white LED.

### Issues/PRs references

This is analogous to #15115 that did this for nrf52840dongle, and uses the method of #15122 (on the nrf52xxxdk group) of using the knowledge of the LED pin definitions. Unlike #15122, all boards sharing the particle-mesh commonalities have exactly one single RGB LED; they even share the pinout, but why hardcode it when it's already in board.h.