### PR TITLE
ieee802154_submac: use EUI provider

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -441,7 +441,6 @@ ifneq (,$(filter gnrc_pktdump,$(USEMODULE)))
 endif
 
 ifneq (,$(filter ieee802154_submac,$(USEMODULE)))
-  USEMODULE += luid
   USEMODULE += xtimer
 endif
 

--- a/sys/net/link_layer/ieee802154/submac.c
+++ b/sys/net/link_layer/ieee802154/submac.c
@@ -15,11 +15,12 @@
 
 #include <stdio.h>
 #include <string.h>
+#include "net/eui_provider.h"
 #include "net/ieee802154/submac.h"
 #include "net/ieee802154.h"
+#include "net/netdev/ieee802154_submac.h"
 #include "xtimer.h"
 #include "random.h"
-#include "luid.h"
 #include "kernel_defines.h"
 #include "errno.h"
 #include <assert.h>
@@ -277,6 +278,7 @@ int ieee802154_send(ieee802154_submac_t *submac, const iolist_t *iolist)
 
 int ieee802154_submac_init(ieee802154_submac_t *submac)
 {
+    netdev_ieee802154_submac_t *netdev = container_of(submac, netdev_ieee802154_submac_t, submac);
     ieee802154_dev_t *dev = submac->dev;
 
     submac->tx = false;
@@ -285,8 +287,8 @@ int ieee802154_submac_init(ieee802154_submac_t *submac)
     ieee802154_radio_request_on(dev);
 
     /* generate EUI-64 and short address */
-    luid_get_eui64(&submac->ext_addr);
-    luid_get_short(&submac->short_addr);
+    netdev_eui64_get(&netdev->dev.netdev, &submac->ext_addr);
+    eui_short_from_eui64(&submac->ext_addr, &submac->short_addr);
     submac->panid = CONFIG_IEEE802154_DEFAULT_PANID;
 
     submac->be.min = CONFIG_IEEE802154_DEFAULT_CSMA_CA_MIN_BE;


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Use the netdev ID to get a stable EUI-64 instead of relying on luid.

### Testing procedure

Add this to your `board.h`:

```C
#include "net/eui_provider.h"

static inline int _get_dummy_eui64(const void *arg, eui64_t *addr)
{
    (void) arg;

    for (unsigned i = 0; i < sizeof(*addr); ++i) {
        addr->uint8[i] = i;
    }

    return 0;
}

#define EUI64_PROVIDER_FUNC   _get_dummy_eui64
#define EUI64_PROVIDER_TYPE   NETDEV_ANY      
#define EUI64_PROVIDER_INDEX  0
```
 and flash `examples/gnrc_networking` with `USEMODULE=netdev_ieee802154_submac` on a board with a supported radio.

This gives

```
2020-10-01 12:01:25,522 # Iface  6  HWaddr: 06:07  Channel: 26  NID: 0x23 
2020-10-01 12:01:25,526 #           Long HWaddr: 00:01:02:03:04:05:06:07 
2020-10-01 12:01:25,528 #            State: IDLE 
2020-10-01 12:01:25,533 #           L2-PDU:102  MTU:1280  HL:64  RTR  
2020-10-01 12:01:25,535 #           RTR_ADV  6LO  IPHC  
2020-10-01 12:01:25,539 #           Source address length: 8
2020-10-01 12:01:25,541 #           Link type: wireless
2020-10-01 12:01:25,547 #           inet6 addr: fe80::201:203:405:607  scope: link  VAL
2020-10-01 12:01:25,553 #           inet6 addr: 2001:db8::201:203:405:607  scope: global  VAL
2020-10-01 12:01:25,555 #           inet6 group: ff02::2
2020-10-01 12:01:25,559 #           inet6 group: ff02::1
2020-10-01 12:01:25,562 #           inet6 group: ff02::1:ff05:607
2020-10-01 12:01:25,563 #           
2020-10-01 12:01:25,565 #           Statistics for Layer 2
2020-10-01 12:01:25,569 #             RX packets 5  bytes 380
2020-10-01 12:01:25,573 #             TX packets 2 (Multicast: 1)  bytes 0
2020-10-01 12:01:25,576 #             TX succeeded 2 errors 0
2020-10-01 12:01:25,579 #           Statistics for IPv6
2020-10-01 12:01:25,582 #             RX packets 3  bytes 368
2020-10-01 12:01:25,586 #             TX packets 2 (Multicast: 1)  bytes 160
2020-10-01 12:01:25,589 #             TX succeeded 2 errors 0
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
