### PR TITLE
cpu/stm32: add script to generate Kconfig.models and Kconfig.lines files

### DIFF
--- a/boards/weact-f411ce/Kconfig
+++ b/boards/weact-f411ce/Kconfig
@@ -11,7 +11,7 @@ config BOARD
 config BOARD_WEACT_F411CE
     bool
     default y
-    select CPU_MODEL_STM32F411CEU6
+    select CPU_MODEL_STM32F411CE
 
     # Put defined MCU peripherals here (in alphabetical order)
     select HAS_PERIPH_ADC

--- a/boards/weact-f411ce/Makefile.features
+++ b/boards/weact-f411ce/Makefile.features
@@ -1,5 +1,5 @@
 CPU = stm32
-CPU_MODEL = stm32f411ceu6
+CPU_MODEL = stm32f411ce
 
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc

--- a/cpu/stm32/dist/kconfig/Kconfig.lines.j2
+++ b/cpu/stm32/dist/kconfig/Kconfig.lines.j2
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
+# CPU lines
+{%- for line in lines %}
+config CPU_LINE_{{ line }}
+    bool
+    select CPU_FAM_{{ fam | upper }}
+{% endfor -%}

--- a/cpu/stm32/dist/kconfig/Kconfig.models.j2
+++ b/cpu/stm32/dist/kconfig/Kconfig.models.j2
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
+# CPU models
+{%- for item in models %}
+config CPU_MODEL_{{ item.model }}
+    bool
+    select {{ item.line | upper }}
+{% endfor %}
+
+# Configure CPU model
+config CPU_MODEL
+{%- for item in models %}
+    default "{{ item.model | lower }}" if CPU_MODEL_{{ item.model }}
+{%- endfor %}

--- a/cpu/stm32/dist/kconfig/README.md
+++ b/cpu/stm32/dist/kconfig/README.md
@@ -1,0 +1,78 @@
+## STM32 CPU lines and models Kconfig generator
+
+The script `gen_kconfig.py` can be used to automatically generate the Kconfig
+files describing CPU lines and models, per families (f0, f1, etc) and from
+the ProductsList.xlsx sheet that are downloadable on the ST website.
+
+### Prepare the data
+
+The sheet are available from
+https://www.st.com/en/microcontrollers-microprocessors/stm32-32-bit-arm-cortex-mcus.html.
+Just select a CPU series (e.g family in RIOT) in the menu on the left and go in
+the product selector tab, then click the `Export` button to download the Excel
+sheet (the default filename is `ProductsList.xlsx`).
+
+The available CPU lines are extracted from the
+`cpu/stm32/include/vendor/cmsis/<fam>/Include` directory. This means that the
+headers of a given family are already fetched here. This can be done with the
+following `make` commands:
+
+```
+$ cd $RIOTBASE
+$ RIOTBASE=$(pwd) RIOTTOOLS=$(pwd)/dist/tools CPU_FAM=<cpu_fam> make -C cpu/stm32/include/vendor
+```
+
+`<cpu_fam>` can be any family in `f0`, `f1`, etc
+
+
+### `gen_kconfig.py` dependencies
+
+The script depends on `jinja2` templating engine to generate the Kconfig files
+and `xlrd` to load and parse the Excel sheets. The dependencies can be
+installed with `pip`:
+
+```
+$ pip install -r ./cpu/stm32/dist/kconfig/requirements.txt
+```
+
+### `gen_kconfig.py` usage
+
+The script can be used to generate the `Kconfig.lines` and `Kconfig.models` of
+a given family as follows:
+
+```
+$ cd $RIOTBASE
+$ ./cpu/stm32/dist/kconfig/gen_kconfig.py <cpu_fam> --sheets <path-to-sheet>/ProductsList.xlsx
+```
+
+The `--sheets` option can take several files. This allows to handle the L4 case
+where the list of models is available in 2 separate sheets. So for L4 family,
+the command should be:
+
+```
+$ cd $RIOTBASE
+$ ./cpu/stm32/dist/kconfig/gen_kconfig.py l4 --sheets <path-to-sheet>/L4ProductsList.xlsx <path-to-sheet>/L4+ProductsList.xlsx
+```
+
+By default, if the `Kconfig.lines` and `Kconfig.models` files of a given family
+were not already created, they are created.
+If the `Kconfig.lines` and `Kconfig.models` files of a given family are already
+available in RIOT, by default the script will just dump the content to stdout.
+The files can still be overwritten by using the `--overwrite` flag.
+
+Print the detailed usage with `--help`:
+
+```
+$ ./cpu/stm32/dist/kconfig/gen_kconfig.py --help
+usage: gen_kconfig.py [-h] [--sheets SHEETS [SHEETS ...]] [--overwrite] [--quiet] cpu_fam
+
+positional arguments:
+  cpu_fam               STM32 CPU Family
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --sheets SHEETS [SHEETS ...], -s SHEETS [SHEETS ...]
+                        Excel sheet containing the list of products
+  --overwrite, -o       Overwrite any existing Kconfig file
+  --quiet, -q           Be quiet
+```

--- a/cpu/stm32/dist/kconfig/gen_kconfig.py
+++ b/cpu/stm32/dist/kconfig/gen_kconfig.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2020 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import argparse
+
+import xlrd
+from jinja2 import FileSystemLoader, Environment
+
+
+CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
+RIOTBASE = os.getenv(
+    "RIOTBASE", os.path.abspath(os.path.join(CURRENT_DIR, "../../../..")))
+STM32_KCONFIG_DIR = os.path.join(RIOTBASE, "cpu/stm32/kconfig")
+STM32_VENDOR_DIR = os.path.join(RIOTBASE, "cpu/stm32/include/vendor/cmsis")
+
+
+def parse_sheet(cpu_fam, sheets):
+    """Parse the Excel sheet and return a dict."""
+    models = []
+    for sheet in sheets:
+        # Load the content of the xlsx sheet
+        work_book = xlrd.open_workbook(sheet)
+        sheet = work_book.sheet_by_name('ProductsList')
+
+        # Extract models from sheet
+        for rownum in range(sheet.nrows):
+            row = sheet.row_values(rownum)
+            if not row[0].startswith("STM32"):
+                continue
+            models.append(row[0].replace("-", "_"))
+    return sorted(models)
+
+
+def parse_cpu_lines(cpu_fam):
+    """Return the list of available CPU lines."""
+    headers_dir = os.path.join(STM32_VENDOR_DIR, cpu_fam, "Include")
+    cpu_lines = [
+        header[:-2].upper() for header in os.listdir(headers_dir)
+        if (
+            header.startswith("stm32") and
+            header != "stm32{}xx.h".format(cpu_fam)
+        )
+    ]
+    return sorted(cpu_lines)
+
+
+def _match(model, line):
+    """Return True if a cpu model matches a cpu line, False otherwise."""
+    model = model.replace("_", "")
+    family_model = model[6:9]
+    family_model_letter1 = model[9]
+    family_model_letter2 = model[10] if len(model) >= 11 else None
+    family_model_letter3 = model[11] if len(model) == 12 else None
+
+    family_line = line[6:9]
+    family_line_letter1 = line[9]
+    family_line_letter2 = line[10] if len(line) >= 11 else None
+    family_line_letter3 = line[11] if len(line) == 12 else None
+
+    if family_line_letter1 == "X" and family_line_letter2 == "X":
+        letters_match = True
+    elif family_line_letter1 == "X":
+        if family_model_letter3 is not None or family_line_letter3 is not None:
+            letters_match = (
+                (family_line_letter2 == family_model_letter2) and
+                (family_line_letter3 == family_model_letter3)
+            )
+        else:
+            letters_match = family_line_letter2 == family_model_letter2
+    elif family_line_letter2 == "X":
+        letters_match = family_line_letter1 == family_model_letter1
+    else:
+        letters_match = False
+    return family_model == family_line and letters_match
+
+
+def get_context(cpu_fam, models, lines):
+    """Return a dict where keys are the models and values are the lines/fam."""
+    mapping = []
+    for model in models:
+        found_line = False
+        for line in lines:
+            if _match(model, line):
+                mapping.append(
+                    {"model": model, "line": "CPU_LINE_{}".format(line)}
+                )
+                found_line = True
+        # if a model has no matching line, just match it to the upper cpu
+        # fam level
+        if not found_line:
+            mapping.append(
+                {"model": model, "line": "CPU_FAM_{}".format(cpu_fam)}
+            )
+    return {"models": mapping, "lines": lines, "fam": cpu_fam}
+
+
+def generate_kconfig(kconfig, context, overwrite, verbose):
+    """Generic kconfig file generator."""
+    loader = FileSystemLoader(searchpath=CURRENT_DIR)
+    env = Environment(
+        loader=loader, trim_blocks=False, lstrip_blocks=True,
+        keep_trailing_newline=True
+    )
+    template_file = os.path.join("Kconfig.{}.j2".format(kconfig))
+    env.globals.update(zip=zip)
+    template = env.get_template(template_file)
+    render = template.render(**context)
+
+    kconfig_file = os.path.join(
+        STM32_KCONFIG_DIR, context["fam"], "Kconfig.{}".format(kconfig)
+    )
+
+    if (not os.path.exists(kconfig_file) or
+            (os.path.exists(kconfig_file) and
+             overwrite is True and
+             kconfig == "models")):
+        with open(kconfig_file, "w") as f_dest:
+            f_dest.write(render)
+    if verbose:
+        print("{}:".format(os.path.basename(kconfig_file)))
+        print("-" * (len(os.path.basename(kconfig_file)) + 1) + "\n")
+        print(render)
+
+
+def main(args):
+    """Main function."""
+    models = parse_sheet(args.cpu_fam, args.sheets)
+    lines = parse_cpu_lines(args.cpu_fam)
+    context = get_context(args.cpu_fam, models, lines)
+    if args.verbose:
+        print("Generated kconfig files:\n")
+    for kconfig in ["lines", "models"]:
+        generate_kconfig(kconfig, context, args.overwrite, args.verbose)
+
+
+PARSER = argparse.ArgumentParser()
+PARSER.add_argument("cpu_fam",
+                    help="STM32 CPU Family")
+PARSER.add_argument("--sheets", "-s", nargs='+',
+                    help="Excel sheet containing the list of products")
+PARSER.add_argument("--overwrite", "-o", action="store_true",
+                    help="Overwrite any existing Kconfig file")
+PARSER.add_argument("--verbose", "-v", action="store_true",
+                    help="Print generated file content")
+
+
+if __name__ == "__main__":
+    main(PARSER.parse_args())

--- a/cpu/stm32/dist/kconfig/requirements.txt
+++ b/cpu/stm32/dist/kconfig/requirements.txt
@@ -1,0 +1,2 @@
+xlrd
+jinja2

--- a/cpu/stm32/kconfig/f0/Kconfig.lines
+++ b/cpu/stm32/kconfig/f0/Kconfig.lines
@@ -5,7 +5,11 @@
 # directory for more details.
 #
 
-# CPU Lines
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
+# CPU lines
 config CPU_LINE_STM32F030X6
     bool
     select CPU_FAM_F0

--- a/cpu/stm32/kconfig/f0/Kconfig.models
+++ b/cpu/stm32/kconfig/f0/Kconfig.models
@@ -5,46 +5,376 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU models
+config CPU_MODEL_STM32F030C6
+    bool
+    select CPU_LINE_STM32F030X6
+
+config CPU_MODEL_STM32F030C8
+    bool
+    select CPU_LINE_STM32F030X8
+
+config CPU_MODEL_STM32F030CC
+    bool
+    select CPU_LINE_STM32F030XC
+
 config CPU_MODEL_STM32F030F4
     bool
     select CPU_FAM_F0
+
+config CPU_MODEL_STM32F030K6
+    bool
+    select CPU_LINE_STM32F030X6
 
 config CPU_MODEL_STM32F030R8
     bool
     select CPU_LINE_STM32F030X8
 
+config CPU_MODEL_STM32F030RC
+    bool
+    select CPU_LINE_STM32F030XC
+
+config CPU_MODEL_STM32F031C4
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F031C6
+    bool
+    select CPU_LINE_STM32F031X6
+
+config CPU_MODEL_STM32F031E6
+    bool
+    select CPU_LINE_STM32F031X6
+
+config CPU_MODEL_STM32F031F4
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F031F6
+    bool
+    select CPU_LINE_STM32F031X6
+
+config CPU_MODEL_STM32F031G4
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F031G6
+    bool
+    select CPU_LINE_STM32F031X6
+
+config CPU_MODEL_STM32F031K4
+    bool
+    select CPU_FAM_F0
+
 config CPU_MODEL_STM32F031K6
     bool
     select CPU_LINE_STM32F031X6
+
+config CPU_MODEL_STM32F038C6
+    bool
+    select CPU_LINE_STM32F038XX
+
+config CPU_MODEL_STM32F038E6
+    bool
+    select CPU_LINE_STM32F038XX
+
+config CPU_MODEL_STM32F038F6
+    bool
+    select CPU_LINE_STM32F038XX
+
+config CPU_MODEL_STM32F038G6
+    bool
+    select CPU_LINE_STM32F038XX
+
+config CPU_MODEL_STM32F038K6
+    bool
+    select CPU_LINE_STM32F038XX
+
+config CPU_MODEL_STM32F042C4
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F042C6
+    bool
+    select CPU_LINE_STM32F042X6
+
+config CPU_MODEL_STM32F042F4
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F042F6
+    bool
+    select CPU_LINE_STM32F042X6
+
+config CPU_MODEL_STM32F042G4
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F042G6
+    bool
+    select CPU_LINE_STM32F042X6
+
+config CPU_MODEL_STM32F042K4
+    bool
+    select CPU_FAM_F0
 
 config CPU_MODEL_STM32F042K6
     bool
     select CPU_LINE_STM32F042X6
 
+config CPU_MODEL_STM32F042T6
+    bool
+    select CPU_LINE_STM32F042X6
+
+config CPU_MODEL_STM32F048C6
+    bool
+    select CPU_LINE_STM32F048XX
+
+config CPU_MODEL_STM32F048G6
+    bool
+    select CPU_LINE_STM32F048XX
+
+config CPU_MODEL_STM32F048T6
+    bool
+    select CPU_LINE_STM32F048XX
+
+config CPU_MODEL_STM32F051C4
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F051C6
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F051C8
+    bool
+    select CPU_LINE_STM32F051X8
+
+config CPU_MODEL_STM32F051K4
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F051K6
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F051K8
+    bool
+    select CPU_LINE_STM32F051X8
+
+config CPU_MODEL_STM32F051R4
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F051R6
+    bool
+    select CPU_FAM_F0
+
 config CPU_MODEL_STM32F051R8
     bool
     select CPU_LINE_STM32F051X8
+
+config CPU_MODEL_STM32F051T8
+    bool
+    select CPU_LINE_STM32F051X8
+
+config CPU_MODEL_STM32F058C8
+    bool
+    select CPU_LINE_STM32F058XX
+
+config CPU_MODEL_STM32F058R8
+    bool
+    select CPU_LINE_STM32F058XX
+
+config CPU_MODEL_STM32F058T8
+    bool
+    select CPU_LINE_STM32F058XX
+
+config CPU_MODEL_STM32F070C6
+    bool
+    select CPU_LINE_STM32F070X6
+
+config CPU_MODEL_STM32F070CB
+    bool
+    select CPU_LINE_STM32F070XB
+
+config CPU_MODEL_STM32F070F6
+    bool
+    select CPU_LINE_STM32F070X6
 
 config CPU_MODEL_STM32F070RB
     bool
     select CPU_LINE_STM32F070XB
 
+config CPU_MODEL_STM32F071C8
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F071CB
+    bool
+    select CPU_LINE_STM32F071XB
+
+config CPU_MODEL_STM32F071RB
+    bool
+    select CPU_LINE_STM32F071XB
+
+config CPU_MODEL_STM32F071V8
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F071VB
+    bool
+    select CPU_LINE_STM32F071XB
+
+config CPU_MODEL_STM32F072C8
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F072CB
+    bool
+    select CPU_LINE_STM32F072XB
+
+config CPU_MODEL_STM32F072R8
+    bool
+    select CPU_FAM_F0
+
 config CPU_MODEL_STM32F072RB
     bool
     select CPU_LINE_STM32F072XB
+
+config CPU_MODEL_STM32F072V8
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F072VB
+    bool
+    select CPU_LINE_STM32F072XB
+
+config CPU_MODEL_STM32F078CB
+    bool
+    select CPU_LINE_STM32F078XX
+
+config CPU_MODEL_STM32F078RB
+    bool
+    select CPU_LINE_STM32F078XX
+
+config CPU_MODEL_STM32F078VB
+    bool
+    select CPU_LINE_STM32F078XX
+
+config CPU_MODEL_STM32F091CB
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F091CC
+    bool
+    select CPU_LINE_STM32F091XC
+
+config CPU_MODEL_STM32F091RB
+    bool
+    select CPU_FAM_F0
 
 config CPU_MODEL_STM32F091RC
     bool
     select CPU_LINE_STM32F091XC
 
+config CPU_MODEL_STM32F091VB
+    bool
+    select CPU_FAM_F0
+
+config CPU_MODEL_STM32F091VC
+    bool
+    select CPU_LINE_STM32F091XC
+
+config CPU_MODEL_STM32F098CC
+    bool
+    select CPU_LINE_STM32F098XX
+
+config CPU_MODEL_STM32F098RC
+    bool
+    select CPU_LINE_STM32F098XX
+
+config CPU_MODEL_STM32F098VC
+    bool
+    select CPU_LINE_STM32F098XX
+
+
 # Configure CPU model
 config CPU_MODEL
+    default "stm32f030c6" if CPU_MODEL_STM32F030C6
+    default "stm32f030c8" if CPU_MODEL_STM32F030C8
+    default "stm32f030cc" if CPU_MODEL_STM32F030CC
     default "stm32f030f4" if CPU_MODEL_STM32F030F4
+    default "stm32f030k6" if CPU_MODEL_STM32F030K6
     default "stm32f030r8" if CPU_MODEL_STM32F030R8
+    default "stm32f030rc" if CPU_MODEL_STM32F030RC
+    default "stm32f031c4" if CPU_MODEL_STM32F031C4
+    default "stm32f031c6" if CPU_MODEL_STM32F031C6
+    default "stm32f031e6" if CPU_MODEL_STM32F031E6
+    default "stm32f031f4" if CPU_MODEL_STM32F031F4
+    default "stm32f031f6" if CPU_MODEL_STM32F031F6
+    default "stm32f031g4" if CPU_MODEL_STM32F031G4
+    default "stm32f031g6" if CPU_MODEL_STM32F031G6
+    default "stm32f031k4" if CPU_MODEL_STM32F031K4
     default "stm32f031k6" if CPU_MODEL_STM32F031K6
+    default "stm32f038c6" if CPU_MODEL_STM32F038C6
+    default "stm32f038e6" if CPU_MODEL_STM32F038E6
+    default "stm32f038f6" if CPU_MODEL_STM32F038F6
+    default "stm32f038g6" if CPU_MODEL_STM32F038G6
+    default "stm32f038k6" if CPU_MODEL_STM32F038K6
+    default "stm32f042c4" if CPU_MODEL_STM32F042C4
+    default "stm32f042c6" if CPU_MODEL_STM32F042C6
+    default "stm32f042f4" if CPU_MODEL_STM32F042F4
+    default "stm32f042f6" if CPU_MODEL_STM32F042F6
+    default "stm32f042g4" if CPU_MODEL_STM32F042G4
+    default "stm32f042g6" if CPU_MODEL_STM32F042G6
+    default "stm32f042k4" if CPU_MODEL_STM32F042K4
     default "stm32f042k6" if CPU_MODEL_STM32F042K6
+    default "stm32f042t6" if CPU_MODEL_STM32F042T6
+    default "stm32f048c6" if CPU_MODEL_STM32F048C6
+    default "stm32f048g6" if CPU_MODEL_STM32F048G6
+    default "stm32f048t6" if CPU_MODEL_STM32F048T6
+    default "stm32f051c4" if CPU_MODEL_STM32F051C4
+    default "stm32f051c6" if CPU_MODEL_STM32F051C6
+    default "stm32f051c8" if CPU_MODEL_STM32F051C8
+    default "stm32f051k4" if CPU_MODEL_STM32F051K4
+    default "stm32f051k6" if CPU_MODEL_STM32F051K6
+    default "stm32f051k8" if CPU_MODEL_STM32F051K8
+    default "stm32f051r4" if CPU_MODEL_STM32F051R4
+    default "stm32f051r6" if CPU_MODEL_STM32F051R6
     default "stm32f051r8" if CPU_MODEL_STM32F051R8
+    default "stm32f051t8" if CPU_MODEL_STM32F051T8
+    default "stm32f058c8" if CPU_MODEL_STM32F058C8
+    default "stm32f058r8" if CPU_MODEL_STM32F058R8
+    default "stm32f058t8" if CPU_MODEL_STM32F058T8
+    default "stm32f070c6" if CPU_MODEL_STM32F070C6
+    default "stm32f070cb" if CPU_MODEL_STM32F070CB
+    default "stm32f070f6" if CPU_MODEL_STM32F070F6
     default "stm32f070rb" if CPU_MODEL_STM32F070RB
+    default "stm32f071c8" if CPU_MODEL_STM32F071C8
+    default "stm32f071cb" if CPU_MODEL_STM32F071CB
+    default "stm32f071rb" if CPU_MODEL_STM32F071RB
+    default "stm32f071v8" if CPU_MODEL_STM32F071V8
+    default "stm32f071vb" if CPU_MODEL_STM32F071VB
+    default "stm32f072c8" if CPU_MODEL_STM32F072C8
+    default "stm32f072cb" if CPU_MODEL_STM32F072CB
+    default "stm32f072r8" if CPU_MODEL_STM32F072R8
     default "stm32f072rb" if CPU_MODEL_STM32F072RB
+    default "stm32f072v8" if CPU_MODEL_STM32F072V8
+    default "stm32f072vb" if CPU_MODEL_STM32F072VB
+    default "stm32f078cb" if CPU_MODEL_STM32F078CB
+    default "stm32f078rb" if CPU_MODEL_STM32F078RB
+    default "stm32f078vb" if CPU_MODEL_STM32F078VB
+    default "stm32f091cb" if CPU_MODEL_STM32F091CB
+    default "stm32f091cc" if CPU_MODEL_STM32F091CC
+    default "stm32f091rb" if CPU_MODEL_STM32F091RB
     default "stm32f091rc" if CPU_MODEL_STM32F091RC
+    default "stm32f091vb" if CPU_MODEL_STM32F091VB
+    default "stm32f091vc" if CPU_MODEL_STM32F091VC
+    default "stm32f098cc" if CPU_MODEL_STM32F098CC
+    default "stm32f098rc" if CPU_MODEL_STM32F098RC
+    default "stm32f098vc" if CPU_MODEL_STM32F098VC

--- a/cpu/stm32/kconfig/f1/Kconfig.lines
+++ b/cpu/stm32/kconfig/f1/Kconfig.lines
@@ -5,6 +5,10 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU lines
 config CPU_LINE_STM32F100XB
     bool

--- a/cpu/stm32/kconfig/f1/Kconfig.models
+++ b/cpu/stm32/kconfig/f1/Kconfig.models
@@ -5,7 +5,243 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU models
+config CPU_MODEL_STM32F100C4
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F100C6
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F100C8
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F100CB
+    bool
+    select CPU_LINE_STM32F100XB
+
+config CPU_MODEL_STM32F100R4
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F100R6
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F100R8
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F100RB
+    bool
+    select CPU_LINE_STM32F100XB
+
+config CPU_MODEL_STM32F100RC
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F100RD
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F100RE
+    bool
+    select CPU_LINE_STM32F100XE
+
+config CPU_MODEL_STM32F100V8
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F100VB
+    bool
+    select CPU_LINE_STM32F100XB
+
+config CPU_MODEL_STM32F100VC
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F100VD
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F100VE
+    bool
+    select CPU_LINE_STM32F100XE
+
+config CPU_MODEL_STM32F100ZC
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F100ZD
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F100ZE
+    bool
+    select CPU_LINE_STM32F100XE
+
+config CPU_MODEL_STM32F101C4
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101C6
+    bool
+    select CPU_LINE_STM32F101X6
+
+config CPU_MODEL_STM32F101C8
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101CB
+    bool
+    select CPU_LINE_STM32F101XB
+
+config CPU_MODEL_STM32F101R4
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101R6
+    bool
+    select CPU_LINE_STM32F101X6
+
+config CPU_MODEL_STM32F101R8
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101RB
+    bool
+    select CPU_LINE_STM32F101XB
+
+config CPU_MODEL_STM32F101RC
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101RD
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101RE
+    bool
+    select CPU_LINE_STM32F101XE
+
+config CPU_MODEL_STM32F101RF
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101RG
+    bool
+    select CPU_LINE_STM32F101XG
+
+config CPU_MODEL_STM32F101T4
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101T6
+    bool
+    select CPU_LINE_STM32F101X6
+
+config CPU_MODEL_STM32F101T8
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101TB
+    bool
+    select CPU_LINE_STM32F101XB
+
+config CPU_MODEL_STM32F101V8
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101VB
+    bool
+    select CPU_LINE_STM32F101XB
+
+config CPU_MODEL_STM32F101VC
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101VD
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101VE
+    bool
+    select CPU_LINE_STM32F101XE
+
+config CPU_MODEL_STM32F101VF
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101VG
+    bool
+    select CPU_LINE_STM32F101XG
+
+config CPU_MODEL_STM32F101ZC
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101ZD
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101ZE
+    bool
+    select CPU_LINE_STM32F101XE
+
+config CPU_MODEL_STM32F101ZF
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F101ZG
+    bool
+    select CPU_LINE_STM32F101XG
+
+config CPU_MODEL_STM32F102C4
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F102C6
+    bool
+    select CPU_LINE_STM32F102X6
+
+config CPU_MODEL_STM32F102C8
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F102CB
+    bool
+    select CPU_LINE_STM32F102XB
+
+config CPU_MODEL_STM32F102R4
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F102R6
+    bool
+    select CPU_LINE_STM32F102X6
+
+config CPU_MODEL_STM32F102R8
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F102RB
+    bool
+    select CPU_LINE_STM32F102XB
+
+config CPU_MODEL_STM32F103C4
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103C6
+    bool
+    select CPU_LINE_STM32F103X6
+
 config CPU_MODEL_STM32F103C8
     bool
     select CPU_FAM_F1
@@ -14,17 +250,241 @@ config CPU_MODEL_STM32F103CB
     bool
     select CPU_LINE_STM32F103XB
 
+config CPU_MODEL_STM32F103R4
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103R6
+    bool
+    select CPU_LINE_STM32F103X6
+
+config CPU_MODEL_STM32F103R8
+    bool
+    select CPU_FAM_F1
+
 config CPU_MODEL_STM32F103RB
     bool
     select CPU_LINE_STM32F103XB
+
+config CPU_MODEL_STM32F103RC
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103RD
+    bool
+    select CPU_FAM_F1
 
 config CPU_MODEL_STM32F103RE
     bool
     select CPU_LINE_STM32F103XE
 
+config CPU_MODEL_STM32F103RF
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103RG
+    bool
+    select CPU_LINE_STM32F103XG
+
+config CPU_MODEL_STM32F103T4
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103T6
+    bool
+    select CPU_LINE_STM32F103X6
+
+config CPU_MODEL_STM32F103T8
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103TB
+    bool
+    select CPU_LINE_STM32F103XB
+
+config CPU_MODEL_STM32F103V8
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103VB
+    bool
+    select CPU_LINE_STM32F103XB
+
+config CPU_MODEL_STM32F103VC
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103VD
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103VE
+    bool
+    select CPU_LINE_STM32F103XE
+
+config CPU_MODEL_STM32F103VF
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103VG
+    bool
+    select CPU_LINE_STM32F103XG
+
+config CPU_MODEL_STM32F103ZC
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103ZD
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103ZE
+    bool
+    select CPU_LINE_STM32F103XE
+
+config CPU_MODEL_STM32F103ZF
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F103ZG
+    bool
+    select CPU_LINE_STM32F103XG
+
+config CPU_MODEL_STM32F105R8
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F105RB
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F105RC
+    bool
+    select CPU_LINE_STM32F105XC
+
+config CPU_MODEL_STM32F105V8
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F105VB
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F105VC
+    bool
+    select CPU_LINE_STM32F105XC
+
+config CPU_MODEL_STM32F107RB
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F107RC
+    bool
+    select CPU_LINE_STM32F107XC
+
+config CPU_MODEL_STM32F107VB
+    bool
+    select CPU_FAM_F1
+
+config CPU_MODEL_STM32F107VC
+    bool
+    select CPU_LINE_STM32F107XC
+
+
 # Configure CPU model
 config CPU_MODEL
+    default "stm32f100c4" if CPU_MODEL_STM32F100C4
+    default "stm32f100c6" if CPU_MODEL_STM32F100C6
+    default "stm32f100c8" if CPU_MODEL_STM32F100C8
+    default "stm32f100cb" if CPU_MODEL_STM32F100CB
+    default "stm32f100r4" if CPU_MODEL_STM32F100R4
+    default "stm32f100r6" if CPU_MODEL_STM32F100R6
+    default "stm32f100r8" if CPU_MODEL_STM32F100R8
+    default "stm32f100rb" if CPU_MODEL_STM32F100RB
+    default "stm32f100rc" if CPU_MODEL_STM32F100RC
+    default "stm32f100rd" if CPU_MODEL_STM32F100RD
+    default "stm32f100re" if CPU_MODEL_STM32F100RE
+    default "stm32f100v8" if CPU_MODEL_STM32F100V8
+    default "stm32f100vb" if CPU_MODEL_STM32F100VB
+    default "stm32f100vc" if CPU_MODEL_STM32F100VC
+    default "stm32f100vd" if CPU_MODEL_STM32F100VD
+    default "stm32f100ve" if CPU_MODEL_STM32F100VE
+    default "stm32f100zc" if CPU_MODEL_STM32F100ZC
+    default "stm32f100zd" if CPU_MODEL_STM32F100ZD
+    default "stm32f100ze" if CPU_MODEL_STM32F100ZE
+    default "stm32f101c4" if CPU_MODEL_STM32F101C4
+    default "stm32f101c6" if CPU_MODEL_STM32F101C6
+    default "stm32f101c8" if CPU_MODEL_STM32F101C8
+    default "stm32f101cb" if CPU_MODEL_STM32F101CB
+    default "stm32f101r4" if CPU_MODEL_STM32F101R4
+    default "stm32f101r6" if CPU_MODEL_STM32F101R6
+    default "stm32f101r8" if CPU_MODEL_STM32F101R8
+    default "stm32f101rb" if CPU_MODEL_STM32F101RB
+    default "stm32f101rc" if CPU_MODEL_STM32F101RC
+    default "stm32f101rd" if CPU_MODEL_STM32F101RD
+    default "stm32f101re" if CPU_MODEL_STM32F101RE
+    default "stm32f101rf" if CPU_MODEL_STM32F101RF
+    default "stm32f101rg" if CPU_MODEL_STM32F101RG
+    default "stm32f101t4" if CPU_MODEL_STM32F101T4
+    default "stm32f101t6" if CPU_MODEL_STM32F101T6
+    default "stm32f101t8" if CPU_MODEL_STM32F101T8
+    default "stm32f101tb" if CPU_MODEL_STM32F101TB
+    default "stm32f101v8" if CPU_MODEL_STM32F101V8
+    default "stm32f101vb" if CPU_MODEL_STM32F101VB
+    default "stm32f101vc" if CPU_MODEL_STM32F101VC
+    default "stm32f101vd" if CPU_MODEL_STM32F101VD
+    default "stm32f101ve" if CPU_MODEL_STM32F101VE
+    default "stm32f101vf" if CPU_MODEL_STM32F101VF
+    default "stm32f101vg" if CPU_MODEL_STM32F101VG
+    default "stm32f101zc" if CPU_MODEL_STM32F101ZC
+    default "stm32f101zd" if CPU_MODEL_STM32F101ZD
+    default "stm32f101ze" if CPU_MODEL_STM32F101ZE
+    default "stm32f101zf" if CPU_MODEL_STM32F101ZF
+    default "stm32f101zg" if CPU_MODEL_STM32F101ZG
+    default "stm32f102c4" if CPU_MODEL_STM32F102C4
+    default "stm32f102c6" if CPU_MODEL_STM32F102C6
+    default "stm32f102c8" if CPU_MODEL_STM32F102C8
+    default "stm32f102cb" if CPU_MODEL_STM32F102CB
+    default "stm32f102r4" if CPU_MODEL_STM32F102R4
+    default "stm32f102r6" if CPU_MODEL_STM32F102R6
+    default "stm32f102r8" if CPU_MODEL_STM32F102R8
+    default "stm32f102rb" if CPU_MODEL_STM32F102RB
+    default "stm32f103c4" if CPU_MODEL_STM32F103C4
+    default "stm32f103c6" if CPU_MODEL_STM32F103C6
     default "stm32f103c8" if CPU_MODEL_STM32F103C8
     default "stm32f103cb" if CPU_MODEL_STM32F103CB
+    default "stm32f103r4" if CPU_MODEL_STM32F103R4
+    default "stm32f103r6" if CPU_MODEL_STM32F103R6
+    default "stm32f103r8" if CPU_MODEL_STM32F103R8
     default "stm32f103rb" if CPU_MODEL_STM32F103RB
+    default "stm32f103rc" if CPU_MODEL_STM32F103RC
+    default "stm32f103rd" if CPU_MODEL_STM32F103RD
     default "stm32f103re" if CPU_MODEL_STM32F103RE
+    default "stm32f103rf" if CPU_MODEL_STM32F103RF
+    default "stm32f103rg" if CPU_MODEL_STM32F103RG
+    default "stm32f103t4" if CPU_MODEL_STM32F103T4
+    default "stm32f103t6" if CPU_MODEL_STM32F103T6
+    default "stm32f103t8" if CPU_MODEL_STM32F103T8
+    default "stm32f103tb" if CPU_MODEL_STM32F103TB
+    default "stm32f103v8" if CPU_MODEL_STM32F103V8
+    default "stm32f103vb" if CPU_MODEL_STM32F103VB
+    default "stm32f103vc" if CPU_MODEL_STM32F103VC
+    default "stm32f103vd" if CPU_MODEL_STM32F103VD
+    default "stm32f103ve" if CPU_MODEL_STM32F103VE
+    default "stm32f103vf" if CPU_MODEL_STM32F103VF
+    default "stm32f103vg" if CPU_MODEL_STM32F103VG
+    default "stm32f103zc" if CPU_MODEL_STM32F103ZC
+    default "stm32f103zd" if CPU_MODEL_STM32F103ZD
+    default "stm32f103ze" if CPU_MODEL_STM32F103ZE
+    default "stm32f103zf" if CPU_MODEL_STM32F103ZF
+    default "stm32f103zg" if CPU_MODEL_STM32F103ZG
+    default "stm32f105r8" if CPU_MODEL_STM32F105R8
+    default "stm32f105rb" if CPU_MODEL_STM32F105RB
+    default "stm32f105rc" if CPU_MODEL_STM32F105RC
+    default "stm32f105v8" if CPU_MODEL_STM32F105V8
+    default "stm32f105vb" if CPU_MODEL_STM32F105VB
+    default "stm32f105vc" if CPU_MODEL_STM32F105VC
+    default "stm32f107rb" if CPU_MODEL_STM32F107RB
+    default "stm32f107rc" if CPU_MODEL_STM32F107RC
+    default "stm32f107vb" if CPU_MODEL_STM32F107VB
+    default "stm32f107vc" if CPU_MODEL_STM32F107VC

--- a/cpu/stm32/kconfig/f2/Kconfig.lines
+++ b/cpu/stm32/kconfig/f2/Kconfig.lines
@@ -5,6 +5,10 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU lines
 config CPU_LINE_STM32F205XX
     bool

--- a/cpu/stm32/kconfig/f2/Kconfig.models
+++ b/cpu/stm32/kconfig/f2/Kconfig.models
@@ -5,11 +5,201 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU models
+config CPU_MODEL_STM32F205RB
+    bool
+    select CPU_LINE_STM32F205XX
+
+config CPU_MODEL_STM32F205RC
+    bool
+    select CPU_LINE_STM32F205XX
+
+config CPU_MODEL_STM32F205RE
+    bool
+    select CPU_LINE_STM32F205XX
+
+config CPU_MODEL_STM32F205RF
+    bool
+    select CPU_LINE_STM32F205XX
+
+config CPU_MODEL_STM32F205RG
+    bool
+    select CPU_LINE_STM32F205XX
+
+config CPU_MODEL_STM32F205VB
+    bool
+    select CPU_LINE_STM32F205XX
+
+config CPU_MODEL_STM32F205VC
+    bool
+    select CPU_LINE_STM32F205XX
+
+config CPU_MODEL_STM32F205VE
+    bool
+    select CPU_LINE_STM32F205XX
+
+config CPU_MODEL_STM32F205VF
+    bool
+    select CPU_LINE_STM32F205XX
+
+config CPU_MODEL_STM32F205VG
+    bool
+    select CPU_LINE_STM32F205XX
+
+config CPU_MODEL_STM32F205ZC
+    bool
+    select CPU_LINE_STM32F205XX
+
+config CPU_MODEL_STM32F205ZE
+    bool
+    select CPU_LINE_STM32F205XX
+
+config CPU_MODEL_STM32F205ZF
+    bool
+    select CPU_LINE_STM32F205XX
+
+config CPU_MODEL_STM32F205ZG
+    bool
+    select CPU_LINE_STM32F205XX
+
+config CPU_MODEL_STM32F207IC
+    bool
+    select CPU_LINE_STM32F207XX
+
+config CPU_MODEL_STM32F207IE
+    bool
+    select CPU_LINE_STM32F207XX
+
+config CPU_MODEL_STM32F207IF
+    bool
+    select CPU_LINE_STM32F207XX
+
+config CPU_MODEL_STM32F207IG
+    bool
+    select CPU_LINE_STM32F207XX
+
+config CPU_MODEL_STM32F207VC
+    bool
+    select CPU_LINE_STM32F207XX
+
+config CPU_MODEL_STM32F207VE
+    bool
+    select CPU_LINE_STM32F207XX
+
+config CPU_MODEL_STM32F207VF
+    bool
+    select CPU_LINE_STM32F207XX
+
+config CPU_MODEL_STM32F207VG
+    bool
+    select CPU_LINE_STM32F207XX
+
+config CPU_MODEL_STM32F207ZC
+    bool
+    select CPU_LINE_STM32F207XX
+
+config CPU_MODEL_STM32F207ZE
+    bool
+    select CPU_LINE_STM32F207XX
+
+config CPU_MODEL_STM32F207ZF
+    bool
+    select CPU_LINE_STM32F207XX
+
 config CPU_MODEL_STM32F207ZG
     bool
     select CPU_LINE_STM32F207XX
 
+config CPU_MODEL_STM32F215RE
+    bool
+    select CPU_LINE_STM32F215XX
+
+config CPU_MODEL_STM32F215RG
+    bool
+    select CPU_LINE_STM32F215XX
+
+config CPU_MODEL_STM32F215VE
+    bool
+    select CPU_LINE_STM32F215XX
+
+config CPU_MODEL_STM32F215VG
+    bool
+    select CPU_LINE_STM32F215XX
+
+config CPU_MODEL_STM32F215ZE
+    bool
+    select CPU_LINE_STM32F215XX
+
+config CPU_MODEL_STM32F215ZG
+    bool
+    select CPU_LINE_STM32F215XX
+
+config CPU_MODEL_STM32F217IE
+    bool
+    select CPU_LINE_STM32F217XX
+
+config CPU_MODEL_STM32F217IG
+    bool
+    select CPU_LINE_STM32F217XX
+
+config CPU_MODEL_STM32F217VE
+    bool
+    select CPU_LINE_STM32F217XX
+
+config CPU_MODEL_STM32F217VG
+    bool
+    select CPU_LINE_STM32F217XX
+
+config CPU_MODEL_STM32F217ZE
+    bool
+    select CPU_LINE_STM32F217XX
+
+config CPU_MODEL_STM32F217ZG
+    bool
+    select CPU_LINE_STM32F217XX
+
+
 # Configure CPU model
 config CPU_MODEL
+    default "stm32f205rb" if CPU_MODEL_STM32F205RB
+    default "stm32f205rc" if CPU_MODEL_STM32F205RC
+    default "stm32f205re" if CPU_MODEL_STM32F205RE
+    default "stm32f205rf" if CPU_MODEL_STM32F205RF
+    default "stm32f205rg" if CPU_MODEL_STM32F205RG
+    default "stm32f205vb" if CPU_MODEL_STM32F205VB
+    default "stm32f205vc" if CPU_MODEL_STM32F205VC
+    default "stm32f205ve" if CPU_MODEL_STM32F205VE
+    default "stm32f205vf" if CPU_MODEL_STM32F205VF
+    default "stm32f205vg" if CPU_MODEL_STM32F205VG
+    default "stm32f205zc" if CPU_MODEL_STM32F205ZC
+    default "stm32f205ze" if CPU_MODEL_STM32F205ZE
+    default "stm32f205zf" if CPU_MODEL_STM32F205ZF
+    default "stm32f205zg" if CPU_MODEL_STM32F205ZG
+    default "stm32f207ic" if CPU_MODEL_STM32F207IC
+    default "stm32f207ie" if CPU_MODEL_STM32F207IE
+    default "stm32f207if" if CPU_MODEL_STM32F207IF
+    default "stm32f207ig" if CPU_MODEL_STM32F207IG
+    default "stm32f207vc" if CPU_MODEL_STM32F207VC
+    default "stm32f207ve" if CPU_MODEL_STM32F207VE
+    default "stm32f207vf" if CPU_MODEL_STM32F207VF
+    default "stm32f207vg" if CPU_MODEL_STM32F207VG
+    default "stm32f207zc" if CPU_MODEL_STM32F207ZC
+    default "stm32f207ze" if CPU_MODEL_STM32F207ZE
+    default "stm32f207zf" if CPU_MODEL_STM32F207ZF
     default "stm32f207zg" if CPU_MODEL_STM32F207ZG
+    default "stm32f215re" if CPU_MODEL_STM32F215RE
+    default "stm32f215rg" if CPU_MODEL_STM32F215RG
+    default "stm32f215ve" if CPU_MODEL_STM32F215VE
+    default "stm32f215vg" if CPU_MODEL_STM32F215VG
+    default "stm32f215ze" if CPU_MODEL_STM32F215ZE
+    default "stm32f215zg" if CPU_MODEL_STM32F215ZG
+    default "stm32f217ie" if CPU_MODEL_STM32F217IE
+    default "stm32f217ig" if CPU_MODEL_STM32F217IG
+    default "stm32f217ve" if CPU_MODEL_STM32F217VE
+    default "stm32f217vg" if CPU_MODEL_STM32F217VG
+    default "stm32f217ze" if CPU_MODEL_STM32F217ZE
+    default "stm32f217zg" if CPU_MODEL_STM32F217ZG

--- a/cpu/stm32/kconfig/f3/Kconfig.lines
+++ b/cpu/stm32/kconfig/f3/Kconfig.lines
@@ -5,6 +5,10 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU lines
 config CPU_LINE_STM32F301X8
     bool
@@ -29,12 +33,10 @@ config CPU_LINE_STM32F303X8
 config CPU_LINE_STM32F303XC
     bool
     select CPU_FAM_F3
-    select HAS_CORTEXM_MPU
 
 config CPU_LINE_STM32F303XE
     bool
     select CPU_FAM_F3
-    select HAS_CORTEXM_MPU
 
 config CPU_LINE_STM32F318XX
     bool

--- a/cpu/stm32/kconfig/f3/Kconfig.lines
+++ b/cpu/stm32/kconfig/f3/Kconfig.lines
@@ -33,10 +33,12 @@ config CPU_LINE_STM32F303X8
 config CPU_LINE_STM32F303XC
     bool
     select CPU_FAM_F3
+    select HAS_CORTEXM_MPU
 
 config CPU_LINE_STM32F303XE
     bool
     select CPU_FAM_F3
+    select HAS_CORTEXM_MPU
 
 config CPU_LINE_STM32F318XX
     bool

--- a/cpu/stm32/kconfig/f3/Kconfig.models
+++ b/cpu/stm32/kconfig/f3/Kconfig.models
@@ -5,36 +5,356 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU models
+config CPU_MODEL_STM32F301C6
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F301C8
+    bool
+    select CPU_LINE_STM32F301X8
+
+config CPU_MODEL_STM32F301K6
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F301K8
+    bool
+    select CPU_LINE_STM32F301X8
+
+config CPU_MODEL_STM32F301R6
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F301R8
+    bool
+    select CPU_LINE_STM32F301X8
+
+config CPU_MODEL_STM32F302C6
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F302C8
+    bool
+    select CPU_LINE_STM32F302X8
+
+config CPU_MODEL_STM32F302CB
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F302CC
+    bool
+    select CPU_LINE_STM32F302XC
+
+config CPU_MODEL_STM32F302K6
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F302K8
+    bool
+    select CPU_LINE_STM32F302X8
+
+config CPU_MODEL_STM32F302R6
+    bool
+    select CPU_FAM_F3
+
 config CPU_MODEL_STM32F302R8
     bool
     select CPU_LINE_STM32F302X8
+
+config CPU_MODEL_STM32F302RB
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F302RC
+    bool
+    select CPU_LINE_STM32F302XC
+
+config CPU_MODEL_STM32F302RD
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F302RE
+    bool
+    select CPU_LINE_STM32F302XE
+
+config CPU_MODEL_STM32F302VB
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F302VC
+    bool
+    select CPU_LINE_STM32F302XC
+
+config CPU_MODEL_STM32F302VD
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F302VE
+    bool
+    select CPU_LINE_STM32F302XE
+
+config CPU_MODEL_STM32F302ZD
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F302ZE
+    bool
+    select CPU_LINE_STM32F302XE
+
+config CPU_MODEL_STM32F303C6
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F303C8
+    bool
+    select CPU_LINE_STM32F303X8
+
+config CPU_MODEL_STM32F303CB
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F303CC
+    bool
+    select CPU_LINE_STM32F303XC
+
+config CPU_MODEL_STM32F303K6
+    bool
+    select CPU_FAM_F3
 
 config CPU_MODEL_STM32F303K8
     bool
     select CPU_LINE_STM32F303X8
 
+config CPU_MODEL_STM32F303R6
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F303R8
+    bool
+    select CPU_LINE_STM32F303X8
+
+config CPU_MODEL_STM32F303RB
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F303RC
+    bool
+    select CPU_LINE_STM32F303XC
+
+config CPU_MODEL_STM32F303RD
+    bool
+    select CPU_FAM_F3
+
 config CPU_MODEL_STM32F303RE
     bool
     select CPU_LINE_STM32F303XE
+
+config CPU_MODEL_STM32F303VB
+    bool
+    select CPU_FAM_F3
 
 config CPU_MODEL_STM32F303VC
     bool
     select CPU_LINE_STM32F303XC
 
+config CPU_MODEL_STM32F303VD
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F303VE
+    bool
+    select CPU_LINE_STM32F303XE
+
+config CPU_MODEL_STM32F303ZD
+    bool
+    select CPU_FAM_F3
+
 config CPU_MODEL_STM32F303ZE
     bool
     select CPU_LINE_STM32F303XE
+
+config CPU_MODEL_STM32F318C8
+    bool
+    select CPU_LINE_STM32F318XX
+
+config CPU_MODEL_STM32F318K8
+    bool
+    select CPU_LINE_STM32F318XX
+
+config CPU_MODEL_STM32F328C8
+    bool
+    select CPU_LINE_STM32F328XX
+
+config CPU_MODEL_STM32F334C4
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F334C6
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F334C8
+    bool
+    select CPU_LINE_STM32F334X8
+
+config CPU_MODEL_STM32F334K4
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F334K6
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F334K8
+    bool
+    select CPU_LINE_STM32F334X8
+
+config CPU_MODEL_STM32F334R6
+    bool
+    select CPU_FAM_F3
 
 config CPU_MODEL_STM32F334R8
     bool
     select CPU_LINE_STM32F334X8
 
+config CPU_MODEL_STM32F358CC
+    bool
+    select CPU_LINE_STM32F358XX
+
+config CPU_MODEL_STM32F358RC
+    bool
+    select CPU_LINE_STM32F358XX
+
+config CPU_MODEL_STM32F358VC
+    bool
+    select CPU_LINE_STM32F358XX
+
+config CPU_MODEL_STM32F373C8
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F373CB
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F373CC
+    bool
+    select CPU_LINE_STM32F373XC
+
+config CPU_MODEL_STM32F373R8
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F373RB
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F373RC
+    bool
+    select CPU_LINE_STM32F373XC
+
+config CPU_MODEL_STM32F373V8
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F373VB
+    bool
+    select CPU_FAM_F3
+
+config CPU_MODEL_STM32F373VC
+    bool
+    select CPU_LINE_STM32F373XC
+
+config CPU_MODEL_STM32F378CC
+    bool
+    select CPU_LINE_STM32F378XX
+
+config CPU_MODEL_STM32F378RC
+    bool
+    select CPU_LINE_STM32F378XX
+
+config CPU_MODEL_STM32F378VC
+    bool
+    select CPU_LINE_STM32F378XX
+
+config CPU_MODEL_STM32F398VE
+    bool
+    select CPU_LINE_STM32F398XX
+
+
 # Configure CPU model
 config CPU_MODEL
+    default "stm32f301c6" if CPU_MODEL_STM32F301C6
+    default "stm32f301c8" if CPU_MODEL_STM32F301C8
+    default "stm32f301k6" if CPU_MODEL_STM32F301K6
+    default "stm32f301k8" if CPU_MODEL_STM32F301K8
+    default "stm32f301r6" if CPU_MODEL_STM32F301R6
+    default "stm32f301r8" if CPU_MODEL_STM32F301R8
+    default "stm32f302c6" if CPU_MODEL_STM32F302C6
+    default "stm32f302c8" if CPU_MODEL_STM32F302C8
+    default "stm32f302cb" if CPU_MODEL_STM32F302CB
+    default "stm32f302cc" if CPU_MODEL_STM32F302CC
+    default "stm32f302k6" if CPU_MODEL_STM32F302K6
+    default "stm32f302k8" if CPU_MODEL_STM32F302K8
+    default "stm32f302r6" if CPU_MODEL_STM32F302R6
     default "stm32f302r8" if CPU_MODEL_STM32F302R8
+    default "stm32f302rb" if CPU_MODEL_STM32F302RB
+    default "stm32f302rc" if CPU_MODEL_STM32F302RC
+    default "stm32f302rd" if CPU_MODEL_STM32F302RD
+    default "stm32f302re" if CPU_MODEL_STM32F302RE
+    default "stm32f302vb" if CPU_MODEL_STM32F302VB
+    default "stm32f302vc" if CPU_MODEL_STM32F302VC
+    default "stm32f302vd" if CPU_MODEL_STM32F302VD
+    default "stm32f302ve" if CPU_MODEL_STM32F302VE
+    default "stm32f302zd" if CPU_MODEL_STM32F302ZD
+    default "stm32f302ze" if CPU_MODEL_STM32F302ZE
+    default "stm32f303c6" if CPU_MODEL_STM32F303C6
+    default "stm32f303c8" if CPU_MODEL_STM32F303C8
+    default "stm32f303cb" if CPU_MODEL_STM32F303CB
+    default "stm32f303cc" if CPU_MODEL_STM32F303CC
+    default "stm32f303k6" if CPU_MODEL_STM32F303K6
     default "stm32f303k8" if CPU_MODEL_STM32F303K8
+    default "stm32f303r6" if CPU_MODEL_STM32F303R6
+    default "stm32f303r8" if CPU_MODEL_STM32F303R8
+    default "stm32f303rb" if CPU_MODEL_STM32F303RB
+    default "stm32f303rc" if CPU_MODEL_STM32F303RC
+    default "stm32f303rd" if CPU_MODEL_STM32F303RD
     default "stm32f303re" if CPU_MODEL_STM32F303RE
+    default "stm32f303vb" if CPU_MODEL_STM32F303VB
     default "stm32f303vc" if CPU_MODEL_STM32F303VC
+    default "stm32f303vd" if CPU_MODEL_STM32F303VD
+    default "stm32f303ve" if CPU_MODEL_STM32F303VE
+    default "stm32f303zd" if CPU_MODEL_STM32F303ZD
     default "stm32f303ze" if CPU_MODEL_STM32F303ZE
+    default "stm32f318c8" if CPU_MODEL_STM32F318C8
+    default "stm32f318k8" if CPU_MODEL_STM32F318K8
+    default "stm32f328c8" if CPU_MODEL_STM32F328C8
+    default "stm32f334c4" if CPU_MODEL_STM32F334C4
+    default "stm32f334c6" if CPU_MODEL_STM32F334C6
+    default "stm32f334c8" if CPU_MODEL_STM32F334C8
+    default "stm32f334k4" if CPU_MODEL_STM32F334K4
+    default "stm32f334k6" if CPU_MODEL_STM32F334K6
+    default "stm32f334k8" if CPU_MODEL_STM32F334K8
+    default "stm32f334r6" if CPU_MODEL_STM32F334R6
     default "stm32f334r8" if CPU_MODEL_STM32F334R8
+    default "stm32f358cc" if CPU_MODEL_STM32F358CC
+    default "stm32f358rc" if CPU_MODEL_STM32F358RC
+    default "stm32f358vc" if CPU_MODEL_STM32F358VC
+    default "stm32f373c8" if CPU_MODEL_STM32F373C8
+    default "stm32f373cb" if CPU_MODEL_STM32F373CB
+    default "stm32f373cc" if CPU_MODEL_STM32F373CC
+    default "stm32f373r8" if CPU_MODEL_STM32F373R8
+    default "stm32f373rb" if CPU_MODEL_STM32F373RB
+    default "stm32f373rc" if CPU_MODEL_STM32F373RC
+    default "stm32f373v8" if CPU_MODEL_STM32F373V8
+    default "stm32f373vb" if CPU_MODEL_STM32F373VB
+    default "stm32f373vc" if CPU_MODEL_STM32F373VC
+    default "stm32f378cc" if CPU_MODEL_STM32F378CC
+    default "stm32f378rc" if CPU_MODEL_STM32F378RC
+    default "stm32f378vc" if CPU_MODEL_STM32F378VC
+    default "stm32f398ve" if CPU_MODEL_STM32F398VE

--- a/cpu/stm32/kconfig/f4/Kconfig.lines
+++ b/cpu/stm32/kconfig/f4/Kconfig.lines
@@ -5,6 +5,10 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU lines
 config CPU_LINE_STM32F401XC
     bool
@@ -17,12 +21,10 @@ config CPU_LINE_STM32F401XE
 config CPU_LINE_STM32F405XX
     bool
     select CPU_FAM_F4
-    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F407XX
     bool
     select CPU_FAM_F4
-    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F410CX
     bool
@@ -31,7 +33,6 @@ config CPU_LINE_STM32F410CX
 config CPU_LINE_STM32F410RX
     bool
     select CPU_FAM_F4
-    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F410TX
     bool
@@ -56,17 +57,14 @@ config CPU_LINE_STM32F412VX
 config CPU_LINE_STM32F412ZX
     bool
     select CPU_FAM_F4
-    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F413XX
     bool
     select CPU_FAM_F4
-    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F415XX
     bool
     select CPU_FAM_F4
-    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F417XX
     bool
@@ -83,12 +81,10 @@ config CPU_LINE_STM32F427XX
 config CPU_LINE_STM32F429XX
     bool
     select CPU_FAM_F4
-    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F437XX
     bool
     select CPU_FAM_F4
-    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F439XX
     bool

--- a/cpu/stm32/kconfig/f4/Kconfig.lines
+++ b/cpu/stm32/kconfig/f4/Kconfig.lines
@@ -21,10 +21,12 @@ config CPU_LINE_STM32F401XE
 config CPU_LINE_STM32F405XX
     bool
     select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F407XX
     bool
     select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F410CX
     bool
@@ -33,6 +35,7 @@ config CPU_LINE_STM32F410CX
 config CPU_LINE_STM32F410RX
     bool
     select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F410TX
     bool
@@ -57,14 +60,17 @@ config CPU_LINE_STM32F412VX
 config CPU_LINE_STM32F412ZX
     bool
     select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F413XX
     bool
     select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F415XX
     bool
     select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F417XX
     bool
@@ -81,10 +87,12 @@ config CPU_LINE_STM32F427XX
 config CPU_LINE_STM32F429XX
     bool
     select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F437XX
     bool
     select CPU_FAM_F4
+    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32F439XX
     bool

--- a/cpu/stm32/kconfig/f4/Kconfig.models
+++ b/cpu/stm32/kconfig/f4/Kconfig.models
@@ -5,52 +5,480 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU models
+config CPU_MODEL_STM32F401CB
+    bool
+    select CPU_FAM_F4
+
+config CPU_MODEL_STM32F401CC
+    bool
+    select CPU_LINE_STM32F401XC
+
+config CPU_MODEL_STM32F401CD
+    bool
+    select CPU_FAM_F4
+
+config CPU_MODEL_STM32F401CE
+    bool
+    select CPU_LINE_STM32F401XE
+
+config CPU_MODEL_STM32F401RB
+    bool
+    select CPU_FAM_F4
+
+config CPU_MODEL_STM32F401RC
+    bool
+    select CPU_LINE_STM32F401XC
+
+config CPU_MODEL_STM32F401RD
+    bool
+    select CPU_FAM_F4
+
 config CPU_MODEL_STM32F401RE
     bool
     select CPU_LINE_STM32F401XE
+
+config CPU_MODEL_STM32F401VB
+    bool
+    select CPU_FAM_F4
+
+config CPU_MODEL_STM32F401VC
+    bool
+    select CPU_LINE_STM32F401XC
+
+config CPU_MODEL_STM32F401VD
+    bool
+    select CPU_FAM_F4
+
+config CPU_MODEL_STM32F401VE
+    bool
+    select CPU_LINE_STM32F401XE
+
+config CPU_MODEL_STM32F405OE
+    bool
+    select CPU_LINE_STM32F405XX
+
+config CPU_MODEL_STM32F405OG
+    bool
+    select CPU_LINE_STM32F405XX
 
 config CPU_MODEL_STM32F405RG
     bool
     select CPU_LINE_STM32F405XX
 
+config CPU_MODEL_STM32F405VG
+    bool
+    select CPU_LINE_STM32F405XX
+
+config CPU_MODEL_STM32F405ZG
+    bool
+    select CPU_LINE_STM32F405XX
+
+config CPU_MODEL_STM32F407IE
+    bool
+    select CPU_LINE_STM32F407XX
+
+config CPU_MODEL_STM32F407IG
+    bool
+    select CPU_LINE_STM32F407XX
+
+config CPU_MODEL_STM32F407VE
+    bool
+    select CPU_LINE_STM32F407XX
+
 config CPU_MODEL_STM32F407VG
     bool
     select CPU_LINE_STM32F407XX
+
+config CPU_MODEL_STM32F407ZE
+    bool
+    select CPU_LINE_STM32F407XX
+
+config CPU_MODEL_STM32F407ZG
+    bool
+    select CPU_LINE_STM32F407XX
+
+config CPU_MODEL_STM32F410C8
+    bool
+    select CPU_LINE_STM32F410CX
+
+config CPU_MODEL_STM32F410CB
+    bool
+    select CPU_LINE_STM32F410CX
+
+config CPU_MODEL_STM32F410R8
+    bool
+    select CPU_LINE_STM32F410RX
 
 config CPU_MODEL_STM32F410RB
     bool
     select CPU_LINE_STM32F410RX
 
+config CPU_MODEL_STM32F410T8
+    bool
+    select CPU_LINE_STM32F410TX
+
+config CPU_MODEL_STM32F410TB
+    bool
+    select CPU_LINE_STM32F410TX
+
+config CPU_MODEL_STM32F411CC
+    bool
+    select CPU_FAM_F4
+
+config CPU_MODEL_STM32F411CE
+    bool
+    select CPU_LINE_STM32F411XE
+
+config CPU_MODEL_STM32F411RC
+    bool
+    select CPU_FAM_F4
+
 config CPU_MODEL_STM32F411RE
     bool
     select CPU_LINE_STM32F411XE
 
-config CPU_MODEL_STM32F411CEU6
+config CPU_MODEL_STM32F411VC
+    bool
+    select CPU_FAM_F4
+
+config CPU_MODEL_STM32F411VE
     bool
     select CPU_LINE_STM32F411XE
+
+config CPU_MODEL_STM32F412CE
+    bool
+    select CPU_LINE_STM32F412CX
+
+config CPU_MODEL_STM32F412CG
+    bool
+    select CPU_LINE_STM32F412CX
+
+config CPU_MODEL_STM32F412RE
+    bool
+    select CPU_LINE_STM32F412RX
+
+config CPU_MODEL_STM32F412RG
+    bool
+    select CPU_LINE_STM32F412RX
+
+config CPU_MODEL_STM32F412VE
+    bool
+    select CPU_LINE_STM32F412VX
+
+config CPU_MODEL_STM32F412VG
+    bool
+    select CPU_LINE_STM32F412VX
+
+config CPU_MODEL_STM32F412ZE
+    bool
+    select CPU_LINE_STM32F412ZX
 
 config CPU_MODEL_STM32F412ZG
     bool
     select CPU_LINE_STM32F412ZX
 
+config CPU_MODEL_STM32F413CG
+    bool
+    select CPU_LINE_STM32F413XX
+
+config CPU_MODEL_STM32F413CH
+    bool
+    select CPU_LINE_STM32F413XX
+
+config CPU_MODEL_STM32F413MG
+    bool
+    select CPU_LINE_STM32F413XX
+
+config CPU_MODEL_STM32F413MH
+    bool
+    select CPU_LINE_STM32F413XX
+
+config CPU_MODEL_STM32F413RG
+    bool
+    select CPU_LINE_STM32F413XX
+
+config CPU_MODEL_STM32F413RH
+    bool
+    select CPU_LINE_STM32F413XX
+
+config CPU_MODEL_STM32F413VG
+    bool
+    select CPU_LINE_STM32F413XX
+
+config CPU_MODEL_STM32F413VH
+    bool
+    select CPU_LINE_STM32F413XX
+
+config CPU_MODEL_STM32F413ZG
+    bool
+    select CPU_LINE_STM32F413XX
+
 config CPU_MODEL_STM32F413ZH
     bool
     select CPU_LINE_STM32F413XX
+
+config CPU_MODEL_STM32F415OG
+    bool
+    select CPU_LINE_STM32F415XX
 
 config CPU_MODEL_STM32F415RG
     bool
     select CPU_LINE_STM32F415XX
 
+config CPU_MODEL_STM32F415VG
+    bool
+    select CPU_LINE_STM32F415XX
+
+config CPU_MODEL_STM32F415ZG
+    bool
+    select CPU_LINE_STM32F415XX
+
+config CPU_MODEL_STM32F417IE
+    bool
+    select CPU_LINE_STM32F417XX
+
+config CPU_MODEL_STM32F417IG
+    bool
+    select CPU_LINE_STM32F417XX
+
+config CPU_MODEL_STM32F417VE
+    bool
+    select CPU_LINE_STM32F417XX
+
+config CPU_MODEL_STM32F417VG
+    bool
+    select CPU_LINE_STM32F417XX
+
+config CPU_MODEL_STM32F417ZE
+    bool
+    select CPU_LINE_STM32F417XX
+
+config CPU_MODEL_STM32F417ZG
+    bool
+    select CPU_LINE_STM32F417XX
+
+config CPU_MODEL_STM32F423CH
+    bool
+    select CPU_LINE_STM32F423XX
+
+config CPU_MODEL_STM32F423MH
+    bool
+    select CPU_LINE_STM32F423XX
+
+config CPU_MODEL_STM32F423RH
+    bool
+    select CPU_LINE_STM32F423XX
+
+config CPU_MODEL_STM32F423VH
+    bool
+    select CPU_LINE_STM32F423XX
+
+config CPU_MODEL_STM32F423ZH
+    bool
+    select CPU_LINE_STM32F423XX
+
+config CPU_MODEL_STM32F427AG
+    bool
+    select CPU_LINE_STM32F427XX
+
+config CPU_MODEL_STM32F427AI
+    bool
+    select CPU_LINE_STM32F427XX
+
+config CPU_MODEL_STM32F427IG
+    bool
+    select CPU_LINE_STM32F427XX
+
+config CPU_MODEL_STM32F427II
+    bool
+    select CPU_LINE_STM32F427XX
+
+config CPU_MODEL_STM32F427VG
+    bool
+    select CPU_LINE_STM32F427XX
+
+config CPU_MODEL_STM32F427VI
+    bool
+    select CPU_LINE_STM32F427XX
+
+config CPU_MODEL_STM32F427ZG
+    bool
+    select CPU_LINE_STM32F427XX
+
+config CPU_MODEL_STM32F427ZI
+    bool
+    select CPU_LINE_STM32F427XX
+
+config CPU_MODEL_STM32F429AG
+    bool
+    select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F429AI
+    bool
+    select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F429BE
+    bool
+    select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F429BG
+    bool
+    select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F429BI
+    bool
+    select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F429IE
+    bool
+    select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F429IG
+    bool
+    select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F429II
+    bool
+    select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F429NE
+    bool
+    select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F429NG
+    bool
+    select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F429NI
+    bool
+    select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F429VE
+    bool
+    select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F429VG
+    bool
+    select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F429VI
+    bool
+    select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F429ZE
+    bool
+    select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F429ZG
+    bool
+    select CPU_LINE_STM32F429XX
+
 config CPU_MODEL_STM32F429ZI
     bool
     select CPU_LINE_STM32F429XX
+
+config CPU_MODEL_STM32F437AI
+    bool
+    select CPU_LINE_STM32F437XX
+
+config CPU_MODEL_STM32F437IG
+    bool
+    select CPU_LINE_STM32F437XX
+
+config CPU_MODEL_STM32F437II
+    bool
+    select CPU_LINE_STM32F437XX
 
 config CPU_MODEL_STM32F437VG
     bool
     select CPU_LINE_STM32F437XX
 
+config CPU_MODEL_STM32F437VI
+    bool
+    select CPU_LINE_STM32F437XX
+
+config CPU_MODEL_STM32F437ZG
+    bool
+    select CPU_LINE_STM32F437XX
+
+config CPU_MODEL_STM32F437ZI
+    bool
+    select CPU_LINE_STM32F437XX
+
+config CPU_MODEL_STM32F439AI
+    bool
+    select CPU_LINE_STM32F439XX
+
+config CPU_MODEL_STM32F439BG
+    bool
+    select CPU_LINE_STM32F439XX
+
+config CPU_MODEL_STM32F439BI
+    bool
+    select CPU_LINE_STM32F439XX
+
+config CPU_MODEL_STM32F439IG
+    bool
+    select CPU_LINE_STM32F439XX
+
+config CPU_MODEL_STM32F439II
+    bool
+    select CPU_LINE_STM32F439XX
+
+config CPU_MODEL_STM32F439NG
+    bool
+    select CPU_LINE_STM32F439XX
+
+config CPU_MODEL_STM32F439NI
+    bool
+    select CPU_LINE_STM32F439XX
+
+config CPU_MODEL_STM32F439VG
+    bool
+    select CPU_LINE_STM32F439XX
+
+config CPU_MODEL_STM32F439VI
+    bool
+    select CPU_LINE_STM32F439XX
+
+config CPU_MODEL_STM32F439ZG
+    bool
+    select CPU_LINE_STM32F439XX
+
+config CPU_MODEL_STM32F439ZI
+    bool
+    select CPU_LINE_STM32F439XX
+
+config CPU_MODEL_STM32F446MC
+    bool
+    select CPU_LINE_STM32F446XX
+
+config CPU_MODEL_STM32F446ME
+    bool
+    select CPU_LINE_STM32F446XX
+
+config CPU_MODEL_STM32F446RC
+    bool
+    select CPU_LINE_STM32F446XX
+
 config CPU_MODEL_STM32F446RE
+    bool
+    select CPU_LINE_STM32F446XX
+
+config CPU_MODEL_STM32F446VC
+    bool
+    select CPU_LINE_STM32F446XX
+
+config CPU_MODEL_STM32F446VE
+    bool
+    select CPU_LINE_STM32F446XX
+
+config CPU_MODEL_STM32F446ZC
     bool
     select CPU_LINE_STM32F446XX
 
@@ -58,18 +486,275 @@ config CPU_MODEL_STM32F446ZE
     bool
     select CPU_LINE_STM32F446XX
 
+config CPU_MODEL_STM32F469AE
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469AG
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469AI
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469BE
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469BG
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469BI
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469IE
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469IG
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469II
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469NE
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469NG
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469NI
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469VE
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469VG
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469VI
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469ZE
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469ZG
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F469ZI
+    bool
+    select CPU_LINE_STM32F469XX
+
+config CPU_MODEL_STM32F479AG
+    bool
+    select CPU_LINE_STM32F479XX
+
+config CPU_MODEL_STM32F479AI
+    bool
+    select CPU_LINE_STM32F479XX
+
+config CPU_MODEL_STM32F479BG
+    bool
+    select CPU_LINE_STM32F479XX
+
+config CPU_MODEL_STM32F479BI
+    bool
+    select CPU_LINE_STM32F479XX
+
+config CPU_MODEL_STM32F479IG
+    bool
+    select CPU_LINE_STM32F479XX
+
+config CPU_MODEL_STM32F479II
+    bool
+    select CPU_LINE_STM32F479XX
+
+config CPU_MODEL_STM32F479NG
+    bool
+    select CPU_LINE_STM32F479XX
+
+config CPU_MODEL_STM32F479NI
+    bool
+    select CPU_LINE_STM32F479XX
+
+config CPU_MODEL_STM32F479VG
+    bool
+    select CPU_LINE_STM32F479XX
+
+config CPU_MODEL_STM32F479VI
+    bool
+    select CPU_LINE_STM32F479XX
+
+config CPU_MODEL_STM32F479ZG
+    bool
+    select CPU_LINE_STM32F479XX
+
+config CPU_MODEL_STM32F479ZI
+    bool
+    select CPU_LINE_STM32F479XX
+
+
 # Configure CPU model
 config CPU_MODEL
+    default "stm32f401cb" if CPU_MODEL_STM32F401CB
+    default "stm32f401cc" if CPU_MODEL_STM32F401CC
+    default "stm32f401cd" if CPU_MODEL_STM32F401CD
+    default "stm32f401ce" if CPU_MODEL_STM32F401CE
+    default "stm32f401rb" if CPU_MODEL_STM32F401RB
+    default "stm32f401rc" if CPU_MODEL_STM32F401RC
+    default "stm32f401rd" if CPU_MODEL_STM32F401RD
     default "stm32f401re" if CPU_MODEL_STM32F401RE
+    default "stm32f401vb" if CPU_MODEL_STM32F401VB
+    default "stm32f401vc" if CPU_MODEL_STM32F401VC
+    default "stm32f401vd" if CPU_MODEL_STM32F401VD
+    default "stm32f401ve" if CPU_MODEL_STM32F401VE
+    default "stm32f405oe" if CPU_MODEL_STM32F405OE
+    default "stm32f405og" if CPU_MODEL_STM32F405OG
     default "stm32f405rg" if CPU_MODEL_STM32F405RG
+    default "stm32f405vg" if CPU_MODEL_STM32F405VG
+    default "stm32f405zg" if CPU_MODEL_STM32F405ZG
+    default "stm32f407ie" if CPU_MODEL_STM32F407IE
+    default "stm32f407ig" if CPU_MODEL_STM32F407IG
+    default "stm32f407ve" if CPU_MODEL_STM32F407VE
     default "stm32f407vg" if CPU_MODEL_STM32F407VG
+    default "stm32f407ze" if CPU_MODEL_STM32F407ZE
+    default "stm32f407zg" if CPU_MODEL_STM32F407ZG
+    default "stm32f410c8" if CPU_MODEL_STM32F410C8
+    default "stm32f410cb" if CPU_MODEL_STM32F410CB
+    default "stm32f410r8" if CPU_MODEL_STM32F410R8
     default "stm32f410rb" if CPU_MODEL_STM32F410RB
+    default "stm32f410t8" if CPU_MODEL_STM32F410T8
+    default "stm32f410tb" if CPU_MODEL_STM32F410TB
+    default "stm32f411cc" if CPU_MODEL_STM32F411CC
+    default "stm32f411ce" if CPU_MODEL_STM32F411CE
+    default "stm32f411rc" if CPU_MODEL_STM32F411RC
     default "stm32f411re" if CPU_MODEL_STM32F411RE
-    default "stm32f411ceu6" if CPU_MODEL_STM32F411CEU6
+    default "stm32f411vc" if CPU_MODEL_STM32F411VC
+    default "stm32f411ve" if CPU_MODEL_STM32F411VE
+    default "stm32f412ce" if CPU_MODEL_STM32F412CE
+    default "stm32f412cg" if CPU_MODEL_STM32F412CG
+    default "stm32f412re" if CPU_MODEL_STM32F412RE
+    default "stm32f412rg" if CPU_MODEL_STM32F412RG
+    default "stm32f412ve" if CPU_MODEL_STM32F412VE
+    default "stm32f412vg" if CPU_MODEL_STM32F412VG
+    default "stm32f412ze" if CPU_MODEL_STM32F412ZE
     default "stm32f412zg" if CPU_MODEL_STM32F412ZG
+    default "stm32f413cg" if CPU_MODEL_STM32F413CG
+    default "stm32f413ch" if CPU_MODEL_STM32F413CH
+    default "stm32f413mg" if CPU_MODEL_STM32F413MG
+    default "stm32f413mh" if CPU_MODEL_STM32F413MH
+    default "stm32f413rg" if CPU_MODEL_STM32F413RG
+    default "stm32f413rh" if CPU_MODEL_STM32F413RH
+    default "stm32f413vg" if CPU_MODEL_STM32F413VG
+    default "stm32f413vh" if CPU_MODEL_STM32F413VH
+    default "stm32f413zg" if CPU_MODEL_STM32F413ZG
     default "stm32f413zh" if CPU_MODEL_STM32F413ZH
+    default "stm32f415og" if CPU_MODEL_STM32F415OG
     default "stm32f415rg" if CPU_MODEL_STM32F415RG
+    default "stm32f415vg" if CPU_MODEL_STM32F415VG
+    default "stm32f415zg" if CPU_MODEL_STM32F415ZG
+    default "stm32f417ie" if CPU_MODEL_STM32F417IE
+    default "stm32f417ig" if CPU_MODEL_STM32F417IG
+    default "stm32f417ve" if CPU_MODEL_STM32F417VE
+    default "stm32f417vg" if CPU_MODEL_STM32F417VG
+    default "stm32f417ze" if CPU_MODEL_STM32F417ZE
+    default "stm32f417zg" if CPU_MODEL_STM32F417ZG
+    default "stm32f423ch" if CPU_MODEL_STM32F423CH
+    default "stm32f423mh" if CPU_MODEL_STM32F423MH
+    default "stm32f423rh" if CPU_MODEL_STM32F423RH
+    default "stm32f423vh" if CPU_MODEL_STM32F423VH
+    default "stm32f423zh" if CPU_MODEL_STM32F423ZH
+    default "stm32f427ag" if CPU_MODEL_STM32F427AG
+    default "stm32f427ai" if CPU_MODEL_STM32F427AI
+    default "stm32f427ig" if CPU_MODEL_STM32F427IG
+    default "stm32f427ii" if CPU_MODEL_STM32F427II
+    default "stm32f427vg" if CPU_MODEL_STM32F427VG
+    default "stm32f427vi" if CPU_MODEL_STM32F427VI
+    default "stm32f427zg" if CPU_MODEL_STM32F427ZG
+    default "stm32f427zi" if CPU_MODEL_STM32F427ZI
+    default "stm32f429ag" if CPU_MODEL_STM32F429AG
+    default "stm32f429ai" if CPU_MODEL_STM32F429AI
+    default "stm32f429be" if CPU_MODEL_STM32F429BE
+    default "stm32f429bg" if CPU_MODEL_STM32F429BG
+    default "stm32f429bi" if CPU_MODEL_STM32F429BI
+    default "stm32f429ie" if CPU_MODEL_STM32F429IE
+    default "stm32f429ig" if CPU_MODEL_STM32F429IG
+    default "stm32f429ii" if CPU_MODEL_STM32F429II
+    default "stm32f429ne" if CPU_MODEL_STM32F429NE
+    default "stm32f429ng" if CPU_MODEL_STM32F429NG
+    default "stm32f429ni" if CPU_MODEL_STM32F429NI
+    default "stm32f429ve" if CPU_MODEL_STM32F429VE
+    default "stm32f429vg" if CPU_MODEL_STM32F429VG
+    default "stm32f429vi" if CPU_MODEL_STM32F429VI
+    default "stm32f429ze" if CPU_MODEL_STM32F429ZE
+    default "stm32f429zg" if CPU_MODEL_STM32F429ZG
     default "stm32f429zi" if CPU_MODEL_STM32F429ZI
+    default "stm32f437ai" if CPU_MODEL_STM32F437AI
+    default "stm32f437ig" if CPU_MODEL_STM32F437IG
+    default "stm32f437ii" if CPU_MODEL_STM32F437II
     default "stm32f437vg" if CPU_MODEL_STM32F437VG
+    default "stm32f437vi" if CPU_MODEL_STM32F437VI
+    default "stm32f437zg" if CPU_MODEL_STM32F437ZG
+    default "stm32f437zi" if CPU_MODEL_STM32F437ZI
+    default "stm32f439ai" if CPU_MODEL_STM32F439AI
+    default "stm32f439bg" if CPU_MODEL_STM32F439BG
+    default "stm32f439bi" if CPU_MODEL_STM32F439BI
+    default "stm32f439ig" if CPU_MODEL_STM32F439IG
+    default "stm32f439ii" if CPU_MODEL_STM32F439II
+    default "stm32f439ng" if CPU_MODEL_STM32F439NG
+    default "stm32f439ni" if CPU_MODEL_STM32F439NI
+    default "stm32f439vg" if CPU_MODEL_STM32F439VG
+    default "stm32f439vi" if CPU_MODEL_STM32F439VI
+    default "stm32f439zg" if CPU_MODEL_STM32F439ZG
+    default "stm32f439zi" if CPU_MODEL_STM32F439ZI
+    default "stm32f446mc" if CPU_MODEL_STM32F446MC
+    default "stm32f446me" if CPU_MODEL_STM32F446ME
+    default "stm32f446rc" if CPU_MODEL_STM32F446RC
     default "stm32f446re" if CPU_MODEL_STM32F446RE
+    default "stm32f446vc" if CPU_MODEL_STM32F446VC
+    default "stm32f446ve" if CPU_MODEL_STM32F446VE
+    default "stm32f446zc" if CPU_MODEL_STM32F446ZC
     default "stm32f446ze" if CPU_MODEL_STM32F446ZE
+    default "stm32f469ae" if CPU_MODEL_STM32F469AE
+    default "stm32f469ag" if CPU_MODEL_STM32F469AG
+    default "stm32f469ai" if CPU_MODEL_STM32F469AI
+    default "stm32f469be" if CPU_MODEL_STM32F469BE
+    default "stm32f469bg" if CPU_MODEL_STM32F469BG
+    default "stm32f469bi" if CPU_MODEL_STM32F469BI
+    default "stm32f469ie" if CPU_MODEL_STM32F469IE
+    default "stm32f469ig" if CPU_MODEL_STM32F469IG
+    default "stm32f469ii" if CPU_MODEL_STM32F469II
+    default "stm32f469ne" if CPU_MODEL_STM32F469NE
+    default "stm32f469ng" if CPU_MODEL_STM32F469NG
+    default "stm32f469ni" if CPU_MODEL_STM32F469NI
+    default "stm32f469ve" if CPU_MODEL_STM32F469VE
+    default "stm32f469vg" if CPU_MODEL_STM32F469VG
+    default "stm32f469vi" if CPU_MODEL_STM32F469VI
+    default "stm32f469ze" if CPU_MODEL_STM32F469ZE
+    default "stm32f469zg" if CPU_MODEL_STM32F469ZG
+    default "stm32f469zi" if CPU_MODEL_STM32F469ZI
+    default "stm32f479ag" if CPU_MODEL_STM32F479AG
+    default "stm32f479ai" if CPU_MODEL_STM32F479AI
+    default "stm32f479bg" if CPU_MODEL_STM32F479BG
+    default "stm32f479bi" if CPU_MODEL_STM32F479BI
+    default "stm32f479ig" if CPU_MODEL_STM32F479IG
+    default "stm32f479ii" if CPU_MODEL_STM32F479II
+    default "stm32f479ng" if CPU_MODEL_STM32F479NG
+    default "stm32f479ni" if CPU_MODEL_STM32F479NI
+    default "stm32f479vg" if CPU_MODEL_STM32F479VG
+    default "stm32f479vi" if CPU_MODEL_STM32F479VI
+    default "stm32f479zg" if CPU_MODEL_STM32F479ZG
+    default "stm32f479zi" if CPU_MODEL_STM32F479ZI

--- a/cpu/stm32/kconfig/f7/Kconfig.lines
+++ b/cpu/stm32/kconfig/f7/Kconfig.lines
@@ -5,6 +5,10 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU lines
 config CPU_LINE_STM32F722XX
     bool

--- a/cpu/stm32/kconfig/f7/Kconfig.models
+++ b/cpu/stm32/kconfig/f7/Kconfig.models
@@ -5,31 +5,441 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU models
+config CPU_MODEL_STM32F722IC
+    bool
+    select CPU_LINE_STM32F722XX
+
+config CPU_MODEL_STM32F722IE
+    bool
+    select CPU_LINE_STM32F722XX
+
+config CPU_MODEL_STM32F722RC
+    bool
+    select CPU_LINE_STM32F722XX
+
+config CPU_MODEL_STM32F722RE
+    bool
+    select CPU_LINE_STM32F722XX
+
+config CPU_MODEL_STM32F722VC
+    bool
+    select CPU_LINE_STM32F722XX
+
+config CPU_MODEL_STM32F722VE
+    bool
+    select CPU_LINE_STM32F722XX
+
+config CPU_MODEL_STM32F722ZC
+    bool
+    select CPU_LINE_STM32F722XX
+
 config CPU_MODEL_STM32F722ZE
     bool
     select CPU_LINE_STM32F722XX
+
+config CPU_MODEL_STM32F723IC
+    bool
+    select CPU_LINE_STM32F723XX
 
 config CPU_MODEL_STM32F723IE
     bool
     select CPU_LINE_STM32F723XX
 
+config CPU_MODEL_STM32F723VC
+    bool
+    select CPU_LINE_STM32F723XX
+
+config CPU_MODEL_STM32F723VE
+    bool
+    select CPU_LINE_STM32F723XX
+
+config CPU_MODEL_STM32F723ZC
+    bool
+    select CPU_LINE_STM32F723XX
+
+config CPU_MODEL_STM32F723ZE
+    bool
+    select CPU_LINE_STM32F723XX
+
+config CPU_MODEL_STM32F730I8
+    bool
+    select CPU_LINE_STM32F730XX
+
+config CPU_MODEL_STM32F730R8
+    bool
+    select CPU_LINE_STM32F730XX
+
+config CPU_MODEL_STM32F730V8
+    bool
+    select CPU_LINE_STM32F730XX
+
+config CPU_MODEL_STM32F730Z8
+    bool
+    select CPU_LINE_STM32F730XX
+
+config CPU_MODEL_STM32F732IE
+    bool
+    select CPU_LINE_STM32F732XX
+
+config CPU_MODEL_STM32F732RE
+    bool
+    select CPU_LINE_STM32F732XX
+
+config CPU_MODEL_STM32F732VE
+    bool
+    select CPU_LINE_STM32F732XX
+
+config CPU_MODEL_STM32F732ZE
+    bool
+    select CPU_LINE_STM32F732XX
+
+config CPU_MODEL_STM32F733IE
+    bool
+    select CPU_LINE_STM32F733XX
+
+config CPU_MODEL_STM32F733VE
+    bool
+    select CPU_LINE_STM32F733XX
+
+config CPU_MODEL_STM32F733ZE
+    bool
+    select CPU_LINE_STM32F733XX
+
+config CPU_MODEL_STM32F745IE
+    bool
+    select CPU_LINE_STM32F745XX
+
+config CPU_MODEL_STM32F745IG
+    bool
+    select CPU_LINE_STM32F745XX
+
+config CPU_MODEL_STM32F745VE
+    bool
+    select CPU_LINE_STM32F745XX
+
+config CPU_MODEL_STM32F745VG
+    bool
+    select CPU_LINE_STM32F745XX
+
+config CPU_MODEL_STM32F745ZE
+    bool
+    select CPU_LINE_STM32F745XX
+
+config CPU_MODEL_STM32F745ZG
+    bool
+    select CPU_LINE_STM32F745XX
+
+config CPU_MODEL_STM32F746BE
+    bool
+    select CPU_LINE_STM32F746XX
+
+config CPU_MODEL_STM32F746BG
+    bool
+    select CPU_LINE_STM32F746XX
+
+config CPU_MODEL_STM32F746IE
+    bool
+    select CPU_LINE_STM32F746XX
+
+config CPU_MODEL_STM32F746IG
+    bool
+    select CPU_LINE_STM32F746XX
+
+config CPU_MODEL_STM32F746NE
+    bool
+    select CPU_LINE_STM32F746XX
+
+config CPU_MODEL_STM32F746NG
+    bool
+    select CPU_LINE_STM32F746XX
+
+config CPU_MODEL_STM32F746VE
+    bool
+    select CPU_LINE_STM32F746XX
+
+config CPU_MODEL_STM32F746VG
+    bool
+    select CPU_LINE_STM32F746XX
+
+config CPU_MODEL_STM32F746ZE
+    bool
+    select CPU_LINE_STM32F746XX
+
 config CPU_MODEL_STM32F746ZG
     bool
     select CPU_LINE_STM32F746XX
+
+config CPU_MODEL_STM32F750N8
+    bool
+    select CPU_LINE_STM32F750XX
+
+config CPU_MODEL_STM32F750V8
+    bool
+    select CPU_LINE_STM32F750XX
+
+config CPU_MODEL_STM32F750Z8
+    bool
+    select CPU_LINE_STM32F750XX
+
+config CPU_MODEL_STM32F756BG
+    bool
+    select CPU_LINE_STM32F756XX
+
+config CPU_MODEL_STM32F756IG
+    bool
+    select CPU_LINE_STM32F756XX
+
+config CPU_MODEL_STM32F756NG
+    bool
+    select CPU_LINE_STM32F756XX
+
+config CPU_MODEL_STM32F756VG
+    bool
+    select CPU_LINE_STM32F756XX
+
+config CPU_MODEL_STM32F756ZG
+    bool
+    select CPU_LINE_STM32F756XX
+
+config CPU_MODEL_STM32F765BG
+    bool
+    select CPU_LINE_STM32F765XX
+
+config CPU_MODEL_STM32F765BI
+    bool
+    select CPU_LINE_STM32F765XX
+
+config CPU_MODEL_STM32F765IG
+    bool
+    select CPU_LINE_STM32F765XX
+
+config CPU_MODEL_STM32F765II
+    bool
+    select CPU_LINE_STM32F765XX
+
+config CPU_MODEL_STM32F765NG
+    bool
+    select CPU_LINE_STM32F765XX
+
+config CPU_MODEL_STM32F765NI
+    bool
+    select CPU_LINE_STM32F765XX
+
+config CPU_MODEL_STM32F765VG
+    bool
+    select CPU_LINE_STM32F765XX
+
+config CPU_MODEL_STM32F765VI
+    bool
+    select CPU_LINE_STM32F765XX
+
+config CPU_MODEL_STM32F765ZG
+    bool
+    select CPU_LINE_STM32F765XX
+
+config CPU_MODEL_STM32F765ZI
+    bool
+    select CPU_LINE_STM32F765XX
+
+config CPU_MODEL_STM32F767BG
+    bool
+    select CPU_LINE_STM32F767XX
+
+config CPU_MODEL_STM32F767BI
+    bool
+    select CPU_LINE_STM32F767XX
+
+config CPU_MODEL_STM32F767IG
+    bool
+    select CPU_LINE_STM32F767XX
+
+config CPU_MODEL_STM32F767II
+    bool
+    select CPU_LINE_STM32F767XX
+
+config CPU_MODEL_STM32F767NG
+    bool
+    select CPU_LINE_STM32F767XX
+
+config CPU_MODEL_STM32F767NI
+    bool
+    select CPU_LINE_STM32F767XX
+
+config CPU_MODEL_STM32F767VG
+    bool
+    select CPU_LINE_STM32F767XX
+
+config CPU_MODEL_STM32F767VI
+    bool
+    select CPU_LINE_STM32F767XX
+
+config CPU_MODEL_STM32F767ZG
+    bool
+    select CPU_LINE_STM32F767XX
 
 config CPU_MODEL_STM32F767ZI
     bool
     select CPU_LINE_STM32F767XX
 
+config CPU_MODEL_STM32F769AI
+    bool
+    select CPU_LINE_STM32F769XX
+
+config CPU_MODEL_STM32F769BG
+    bool
+    select CPU_LINE_STM32F769XX
+
+config CPU_MODEL_STM32F769BI
+    bool
+    select CPU_LINE_STM32F769XX
+
+config CPU_MODEL_STM32F769IG
+    bool
+    select CPU_LINE_STM32F769XX
+
+config CPU_MODEL_STM32F769II
+    bool
+    select CPU_LINE_STM32F769XX
+
+config CPU_MODEL_STM32F769NG
+    bool
+    select CPU_LINE_STM32F769XX
+
 config CPU_MODEL_STM32F769NI
     bool
     select CPU_LINE_STM32F769XX
 
+config CPU_MODEL_STM32F777BI
+    bool
+    select CPU_LINE_STM32F777XX
+
+config CPU_MODEL_STM32F777II
+    bool
+    select CPU_LINE_STM32F777XX
+
+config CPU_MODEL_STM32F777NI
+    bool
+    select CPU_LINE_STM32F777XX
+
+config CPU_MODEL_STM32F777VI
+    bool
+    select CPU_LINE_STM32F777XX
+
+config CPU_MODEL_STM32F777ZI
+    bool
+    select CPU_LINE_STM32F777XX
+
+config CPU_MODEL_STM32F778AI
+    bool
+    select CPU_FAM_F7
+
+config CPU_MODEL_STM32F779AI
+    bool
+    select CPU_LINE_STM32F779XX
+
+config CPU_MODEL_STM32F779BI
+    bool
+    select CPU_LINE_STM32F779XX
+
+config CPU_MODEL_STM32F779II
+    bool
+    select CPU_LINE_STM32F779XX
+
+config CPU_MODEL_STM32F779NI
+    bool
+    select CPU_LINE_STM32F779XX
+
+
 # Configure CPU model
 config CPU_MODEL
+    default "stm32f722ic" if CPU_MODEL_STM32F722IC
+    default "stm32f722ie" if CPU_MODEL_STM32F722IE
+    default "stm32f722rc" if CPU_MODEL_STM32F722RC
+    default "stm32f722re" if CPU_MODEL_STM32F722RE
+    default "stm32f722vc" if CPU_MODEL_STM32F722VC
+    default "stm32f722ve" if CPU_MODEL_STM32F722VE
+    default "stm32f722zc" if CPU_MODEL_STM32F722ZC
     default "stm32f722ze" if CPU_MODEL_STM32F722ZE
+    default "stm32f723ic" if CPU_MODEL_STM32F723IC
     default "stm32f723ie" if CPU_MODEL_STM32F723IE
+    default "stm32f723vc" if CPU_MODEL_STM32F723VC
+    default "stm32f723ve" if CPU_MODEL_STM32F723VE
+    default "stm32f723zc" if CPU_MODEL_STM32F723ZC
+    default "stm32f723ze" if CPU_MODEL_STM32F723ZE
+    default "stm32f730i8" if CPU_MODEL_STM32F730I8
+    default "stm32f730r8" if CPU_MODEL_STM32F730R8
+    default "stm32f730v8" if CPU_MODEL_STM32F730V8
+    default "stm32f730z8" if CPU_MODEL_STM32F730Z8
+    default "stm32f732ie" if CPU_MODEL_STM32F732IE
+    default "stm32f732re" if CPU_MODEL_STM32F732RE
+    default "stm32f732ve" if CPU_MODEL_STM32F732VE
+    default "stm32f732ze" if CPU_MODEL_STM32F732ZE
+    default "stm32f733ie" if CPU_MODEL_STM32F733IE
+    default "stm32f733ve" if CPU_MODEL_STM32F733VE
+    default "stm32f733ze" if CPU_MODEL_STM32F733ZE
+    default "stm32f745ie" if CPU_MODEL_STM32F745IE
+    default "stm32f745ig" if CPU_MODEL_STM32F745IG
+    default "stm32f745ve" if CPU_MODEL_STM32F745VE
+    default "stm32f745vg" if CPU_MODEL_STM32F745VG
+    default "stm32f745ze" if CPU_MODEL_STM32F745ZE
+    default "stm32f745zg" if CPU_MODEL_STM32F745ZG
+    default "stm32f746be" if CPU_MODEL_STM32F746BE
+    default "stm32f746bg" if CPU_MODEL_STM32F746BG
+    default "stm32f746ie" if CPU_MODEL_STM32F746IE
+    default "stm32f746ig" if CPU_MODEL_STM32F746IG
+    default "stm32f746ne" if CPU_MODEL_STM32F746NE
+    default "stm32f746ng" if CPU_MODEL_STM32F746NG
+    default "stm32f746ve" if CPU_MODEL_STM32F746VE
+    default "stm32f746vg" if CPU_MODEL_STM32F746VG
+    default "stm32f746ze" if CPU_MODEL_STM32F746ZE
     default "stm32f746zg" if CPU_MODEL_STM32F746ZG
+    default "stm32f750n8" if CPU_MODEL_STM32F750N8
+    default "stm32f750v8" if CPU_MODEL_STM32F750V8
+    default "stm32f750z8" if CPU_MODEL_STM32F750Z8
+    default "stm32f756bg" if CPU_MODEL_STM32F756BG
+    default "stm32f756ig" if CPU_MODEL_STM32F756IG
+    default "stm32f756ng" if CPU_MODEL_STM32F756NG
+    default "stm32f756vg" if CPU_MODEL_STM32F756VG
+    default "stm32f756zg" if CPU_MODEL_STM32F756ZG
+    default "stm32f765bg" if CPU_MODEL_STM32F765BG
+    default "stm32f765bi" if CPU_MODEL_STM32F765BI
+    default "stm32f765ig" if CPU_MODEL_STM32F765IG
+    default "stm32f765ii" if CPU_MODEL_STM32F765II
+    default "stm32f765ng" if CPU_MODEL_STM32F765NG
+    default "stm32f765ni" if CPU_MODEL_STM32F765NI
+    default "stm32f765vg" if CPU_MODEL_STM32F765VG
+    default "stm32f765vi" if CPU_MODEL_STM32F765VI
+    default "stm32f765zg" if CPU_MODEL_STM32F765ZG
+    default "stm32f765zi" if CPU_MODEL_STM32F765ZI
+    default "stm32f767bg" if CPU_MODEL_STM32F767BG
+    default "stm32f767bi" if CPU_MODEL_STM32F767BI
+    default "stm32f767ig" if CPU_MODEL_STM32F767IG
+    default "stm32f767ii" if CPU_MODEL_STM32F767II
+    default "stm32f767ng" if CPU_MODEL_STM32F767NG
+    default "stm32f767ni" if CPU_MODEL_STM32F767NI
+    default "stm32f767vg" if CPU_MODEL_STM32F767VG
+    default "stm32f767vi" if CPU_MODEL_STM32F767VI
+    default "stm32f767zg" if CPU_MODEL_STM32F767ZG
     default "stm32f767zi" if CPU_MODEL_STM32F767ZI
+    default "stm32f769ai" if CPU_MODEL_STM32F769AI
+    default "stm32f769bg" if CPU_MODEL_STM32F769BG
+    default "stm32f769bi" if CPU_MODEL_STM32F769BI
+    default "stm32f769ig" if CPU_MODEL_STM32F769IG
+    default "stm32f769ii" if CPU_MODEL_STM32F769II
+    default "stm32f769ng" if CPU_MODEL_STM32F769NG
     default "stm32f769ni" if CPU_MODEL_STM32F769NI
+    default "stm32f777bi" if CPU_MODEL_STM32F777BI
+    default "stm32f777ii" if CPU_MODEL_STM32F777II
+    default "stm32f777ni" if CPU_MODEL_STM32F777NI
+    default "stm32f777vi" if CPU_MODEL_STM32F777VI
+    default "stm32f777zi" if CPU_MODEL_STM32F777ZI
+    default "stm32f778ai" if CPU_MODEL_STM32F778AI
+    default "stm32f779ai" if CPU_MODEL_STM32F779AI
+    default "stm32f779bi" if CPU_MODEL_STM32F779BI
+    default "stm32f779ii" if CPU_MODEL_STM32F779II
+    default "stm32f779ni" if CPU_MODEL_STM32F779NI

--- a/cpu/stm32/kconfig/g0/Kconfig.lines
+++ b/cpu/stm32/kconfig/g0/Kconfig.lines
@@ -5,19 +5,11 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU lines
-config CPU_LINE_STM32G0B0XX
-    bool
-    select CPU_FAM_G0
-
-config CPU_LINE_STM32G0B1XX
-    bool
-    select CPU_FAM_G0
-
-config CPU_LINE_STM32G0C1XX
-    bool
-    select CPU_FAM_G0
-
 config CPU_LINE_STM32G030XX
     bool
     select CPU_FAM_G0
@@ -39,5 +31,17 @@ config CPU_LINE_STM32G071XX
     select CPU_FAM_G0
 
 config CPU_LINE_STM32G081XX
+    bool
+    select CPU_FAM_G0
+
+config CPU_LINE_STM32G0B0XX
+    bool
+    select CPU_FAM_G0
+
+config CPU_LINE_STM32G0B1XX
+    bool
+    select CPU_FAM_G0
+
+config CPU_LINE_STM32G0C1XX
     bool
     select CPU_FAM_G0

--- a/cpu/stm32/kconfig/g0/Kconfig.models
+++ b/cpu/stm32/kconfig/g0/Kconfig.models
@@ -5,16 +5,251 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU models
+config CPU_MODEL_STM32G030C6
+    bool
+    select CPU_LINE_STM32G030XX
+
+config CPU_MODEL_STM32G030C8
+    bool
+    select CPU_LINE_STM32G030XX
+
+config CPU_MODEL_STM32G030F6
+    bool
+    select CPU_LINE_STM32G030XX
+
+config CPU_MODEL_STM32G030J6
+    bool
+    select CPU_LINE_STM32G030XX
+
+config CPU_MODEL_STM32G030K6
+    bool
+    select CPU_LINE_STM32G030XX
+
+config CPU_MODEL_STM32G030K8
+    bool
+    select CPU_LINE_STM32G030XX
+
+config CPU_MODEL_STM32G031C4
+    bool
+    select CPU_LINE_STM32G031XX
+
+config CPU_MODEL_STM32G031C6
+    bool
+    select CPU_LINE_STM32G031XX
+
+config CPU_MODEL_STM32G031C8
+    bool
+    select CPU_LINE_STM32G031XX
+
+config CPU_MODEL_STM32G031F4
+    bool
+    select CPU_LINE_STM32G031XX
+
+config CPU_MODEL_STM32G031F6
+    bool
+    select CPU_LINE_STM32G031XX
+
+config CPU_MODEL_STM32G031F8
+    bool
+    select CPU_LINE_STM32G031XX
+
+config CPU_MODEL_STM32G031G4
+    bool
+    select CPU_LINE_STM32G031XX
+
+config CPU_MODEL_STM32G031G6
+    bool
+    select CPU_LINE_STM32G031XX
+
+config CPU_MODEL_STM32G031G8
+    bool
+    select CPU_LINE_STM32G031XX
+
+config CPU_MODEL_STM32G031J4
+    bool
+    select CPU_LINE_STM32G031XX
+
+config CPU_MODEL_STM32G031J6
+    bool
+    select CPU_LINE_STM32G031XX
+
+config CPU_MODEL_STM32G031K4
+    bool
+    select CPU_LINE_STM32G031XX
+
+config CPU_MODEL_STM32G031K6
+    bool
+    select CPU_LINE_STM32G031XX
+
+config CPU_MODEL_STM32G031K8
+    bool
+    select CPU_LINE_STM32G031XX
+
+config CPU_MODEL_STM32G031Y8
+    bool
+    select CPU_LINE_STM32G031XX
+
+config CPU_MODEL_STM32G041C6
+    bool
+    select CPU_LINE_STM32G041XX
+
+config CPU_MODEL_STM32G041C8
+    bool
+    select CPU_LINE_STM32G041XX
+
+config CPU_MODEL_STM32G041F6
+    bool
+    select CPU_LINE_STM32G041XX
+
+config CPU_MODEL_STM32G041F8
+    bool
+    select CPU_LINE_STM32G041XX
+
+config CPU_MODEL_STM32G041G6
+    bool
+    select CPU_LINE_STM32G041XX
+
+config CPU_MODEL_STM32G041G8
+    bool
+    select CPU_LINE_STM32G041XX
+
+config CPU_MODEL_STM32G041J6
+    bool
+    select CPU_LINE_STM32G041XX
+
+config CPU_MODEL_STM32G041K6
+    bool
+    select CPU_LINE_STM32G041XX
+
+config CPU_MODEL_STM32G041K8
+    bool
+    select CPU_LINE_STM32G041XX
+
+config CPU_MODEL_STM32G041Y8
+    bool
+    select CPU_LINE_STM32G041XX
+
+config CPU_MODEL_STM32G070CB
+    bool
+    select CPU_LINE_STM32G070XX
+
+config CPU_MODEL_STM32G070KB
+    bool
+    select CPU_LINE_STM32G070XX
+
 config CPU_MODEL_STM32G070RB
     bool
     select CPU_LINE_STM32G070XX
+
+config CPU_MODEL_STM32G071C8
+    bool
+    select CPU_LINE_STM32G071XX
+
+config CPU_MODEL_STM32G071CB
+    bool
+    select CPU_LINE_STM32G071XX
+
+config CPU_MODEL_STM32G071EB
+    bool
+    select CPU_LINE_STM32G071XX
+
+config CPU_MODEL_STM32G071G8
+    bool
+    select CPU_LINE_STM32G071XX
+
+config CPU_MODEL_STM32G071GB
+    bool
+    select CPU_LINE_STM32G071XX
+
+config CPU_MODEL_STM32G071K8
+    bool
+    select CPU_LINE_STM32G071XX
+
+config CPU_MODEL_STM32G071KB
+    bool
+    select CPU_LINE_STM32G071XX
+
+config CPU_MODEL_STM32G071R8
+    bool
+    select CPU_LINE_STM32G071XX
 
 config CPU_MODEL_STM32G071RB
     bool
     select CPU_LINE_STM32G071XX
 
+config CPU_MODEL_STM32G081CB
+    bool
+    select CPU_LINE_STM32G081XX
+
+config CPU_MODEL_STM32G081EB
+    bool
+    select CPU_LINE_STM32G081XX
+
+config CPU_MODEL_STM32G081GB
+    bool
+    select CPU_LINE_STM32G081XX
+
+config CPU_MODEL_STM32G081KB
+    bool
+    select CPU_LINE_STM32G081XX
+
+config CPU_MODEL_STM32G081RB
+    bool
+    select CPU_LINE_STM32G081XX
+
+
 # Configure CPU model
 config CPU_MODEL
+    default "stm32g030c6" if CPU_MODEL_STM32G030C6
+    default "stm32g030c8" if CPU_MODEL_STM32G030C8
+    default "stm32g030f6" if CPU_MODEL_STM32G030F6
+    default "stm32g030j6" if CPU_MODEL_STM32G030J6
+    default "stm32g030k6" if CPU_MODEL_STM32G030K6
+    default "stm32g030k8" if CPU_MODEL_STM32G030K8
+    default "stm32g031c4" if CPU_MODEL_STM32G031C4
+    default "stm32g031c6" if CPU_MODEL_STM32G031C6
+    default "stm32g031c8" if CPU_MODEL_STM32G031C8
+    default "stm32g031f4" if CPU_MODEL_STM32G031F4
+    default "stm32g031f6" if CPU_MODEL_STM32G031F6
+    default "stm32g031f8" if CPU_MODEL_STM32G031F8
+    default "stm32g031g4" if CPU_MODEL_STM32G031G4
+    default "stm32g031g6" if CPU_MODEL_STM32G031G6
+    default "stm32g031g8" if CPU_MODEL_STM32G031G8
+    default "stm32g031j4" if CPU_MODEL_STM32G031J4
+    default "stm32g031j6" if CPU_MODEL_STM32G031J6
+    default "stm32g031k4" if CPU_MODEL_STM32G031K4
+    default "stm32g031k6" if CPU_MODEL_STM32G031K6
+    default "stm32g031k8" if CPU_MODEL_STM32G031K8
+    default "stm32g031y8" if CPU_MODEL_STM32G031Y8
+    default "stm32g041c6" if CPU_MODEL_STM32G041C6
+    default "stm32g041c8" if CPU_MODEL_STM32G041C8
+    default "stm32g041f6" if CPU_MODEL_STM32G041F6
+    default "stm32g041f8" if CPU_MODEL_STM32G041F8
+    default "stm32g041g6" if CPU_MODEL_STM32G041G6
+    default "stm32g041g8" if CPU_MODEL_STM32G041G8
+    default "stm32g041j6" if CPU_MODEL_STM32G041J6
+    default "stm32g041k6" if CPU_MODEL_STM32G041K6
+    default "stm32g041k8" if CPU_MODEL_STM32G041K8
+    default "stm32g041y8" if CPU_MODEL_STM32G041Y8
+    default "stm32g070cb" if CPU_MODEL_STM32G070CB
+    default "stm32g070kb" if CPU_MODEL_STM32G070KB
     default "stm32g070rb" if CPU_MODEL_STM32G070RB
+    default "stm32g071c8" if CPU_MODEL_STM32G071C8
+    default "stm32g071cb" if CPU_MODEL_STM32G071CB
+    default "stm32g071eb" if CPU_MODEL_STM32G071EB
+    default "stm32g071g8" if CPU_MODEL_STM32G071G8
+    default "stm32g071gb" if CPU_MODEL_STM32G071GB
+    default "stm32g071k8" if CPU_MODEL_STM32G071K8
+    default "stm32g071kb" if CPU_MODEL_STM32G071KB
+    default "stm32g071r8" if CPU_MODEL_STM32G071R8
     default "stm32g071rb" if CPU_MODEL_STM32G071RB
+    default "stm32g081cb" if CPU_MODEL_STM32G081CB
+    default "stm32g081eb" if CPU_MODEL_STM32G081EB
+    default "stm32g081gb" if CPU_MODEL_STM32G081GB
+    default "stm32g081kb" if CPU_MODEL_STM32G081KB
+    default "stm32g081rb" if CPU_MODEL_STM32G081RB

--- a/cpu/stm32/kconfig/g4/Kconfig.lines
+++ b/cpu/stm32/kconfig/g4/Kconfig.lines
@@ -5,12 +5,16 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU lines
 config CPU_LINE_STM32G431XX
     bool
     select CPU_FAM_G4
 
-config CPU_LINE_STM32G441X
+config CPU_LINE_STM32G441XX
     bool
     select CPU_FAM_G4
 

--- a/cpu/stm32/kconfig/g4/Kconfig.models
+++ b/cpu/stm32/kconfig/g4/Kconfig.models
@@ -5,16 +5,311 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU models
+config CPU_MODEL_STM32G431C6
+    bool
+    select CPU_LINE_STM32G431XX
+
+config CPU_MODEL_STM32G431C8
+    bool
+    select CPU_LINE_STM32G431XX
+
+config CPU_MODEL_STM32G431CB
+    bool
+    select CPU_LINE_STM32G431XX
+
+config CPU_MODEL_STM32G431K6
+    bool
+    select CPU_LINE_STM32G431XX
+
+config CPU_MODEL_STM32G431K8
+    bool
+    select CPU_LINE_STM32G431XX
+
+config CPU_MODEL_STM32G431KB
+    bool
+    select CPU_LINE_STM32G431XX
+
+config CPU_MODEL_STM32G431M6
+    bool
+    select CPU_LINE_STM32G431XX
+
+config CPU_MODEL_STM32G431M8
+    bool
+    select CPU_LINE_STM32G431XX
+
+config CPU_MODEL_STM32G431MB
+    bool
+    select CPU_LINE_STM32G431XX
+
+config CPU_MODEL_STM32G431R6
+    bool
+    select CPU_LINE_STM32G431XX
+
+config CPU_MODEL_STM32G431R8
+    bool
+    select CPU_LINE_STM32G431XX
+
 config CPU_MODEL_STM32G431RB
     bool
     select CPU_LINE_STM32G431XX
+
+config CPU_MODEL_STM32G431V6
+    bool
+    select CPU_LINE_STM32G431XX
+
+config CPU_MODEL_STM32G431V8
+    bool
+    select CPU_LINE_STM32G431XX
+
+config CPU_MODEL_STM32G431VB
+    bool
+    select CPU_LINE_STM32G431XX
+
+config CPU_MODEL_STM32G441CB
+    bool
+    select CPU_LINE_STM32G441XX
+
+config CPU_MODEL_STM32G441KB
+    bool
+    select CPU_LINE_STM32G441XX
+
+config CPU_MODEL_STM32G441MB
+    bool
+    select CPU_LINE_STM32G441XX
+
+config CPU_MODEL_STM32G441RB
+    bool
+    select CPU_LINE_STM32G441XX
+
+config CPU_MODEL_STM32G441VB
+    bool
+    select CPU_LINE_STM32G441XX
+
+config CPU_MODEL_STM32G473CB
+    bool
+    select CPU_LINE_STM32G473XX
+
+config CPU_MODEL_STM32G473CC
+    bool
+    select CPU_LINE_STM32G473XX
+
+config CPU_MODEL_STM32G473CE
+    bool
+    select CPU_LINE_STM32G473XX
+
+config CPU_MODEL_STM32G473MB
+    bool
+    select CPU_LINE_STM32G473XX
+
+config CPU_MODEL_STM32G473MC
+    bool
+    select CPU_LINE_STM32G473XX
+
+config CPU_MODEL_STM32G473ME
+    bool
+    select CPU_LINE_STM32G473XX
+
+config CPU_MODEL_STM32G473QB
+    bool
+    select CPU_LINE_STM32G473XX
+
+config CPU_MODEL_STM32G473QC
+    bool
+    select CPU_LINE_STM32G473XX
+
+config CPU_MODEL_STM32G473QE
+    bool
+    select CPU_LINE_STM32G473XX
+
+config CPU_MODEL_STM32G473RB
+    bool
+    select CPU_LINE_STM32G473XX
+
+config CPU_MODEL_STM32G473RC
+    bool
+    select CPU_LINE_STM32G473XX
+
+config CPU_MODEL_STM32G473RE
+    bool
+    select CPU_LINE_STM32G473XX
+
+config CPU_MODEL_STM32G473VB
+    bool
+    select CPU_LINE_STM32G473XX
+
+config CPU_MODEL_STM32G473VC
+    bool
+    select CPU_LINE_STM32G473XX
+
+config CPU_MODEL_STM32G473VE
+    bool
+    select CPU_LINE_STM32G473XX
+
+config CPU_MODEL_STM32G474CB
+    bool
+    select CPU_LINE_STM32G474XX
+
+config CPU_MODEL_STM32G474CC
+    bool
+    select CPU_LINE_STM32G474XX
+
+config CPU_MODEL_STM32G474CE
+    bool
+    select CPU_LINE_STM32G474XX
+
+config CPU_MODEL_STM32G474MB
+    bool
+    select CPU_LINE_STM32G474XX
+
+config CPU_MODEL_STM32G474MC
+    bool
+    select CPU_LINE_STM32G474XX
+
+config CPU_MODEL_STM32G474ME
+    bool
+    select CPU_LINE_STM32G474XX
+
+config CPU_MODEL_STM32G474QB
+    bool
+    select CPU_LINE_STM32G474XX
+
+config CPU_MODEL_STM32G474QC
+    bool
+    select CPU_LINE_STM32G474XX
+
+config CPU_MODEL_STM32G474QE
+    bool
+    select CPU_LINE_STM32G474XX
+
+config CPU_MODEL_STM32G474RB
+    bool
+    select CPU_LINE_STM32G474XX
+
+config CPU_MODEL_STM32G474RC
+    bool
+    select CPU_LINE_STM32G474XX
 
 config CPU_MODEL_STM32G474RE
     bool
     select CPU_LINE_STM32G474XX
 
+config CPU_MODEL_STM32G474VB
+    bool
+    select CPU_LINE_STM32G474XX
+
+config CPU_MODEL_STM32G474VC
+    bool
+    select CPU_LINE_STM32G474XX
+
+config CPU_MODEL_STM32G474VE
+    bool
+    select CPU_LINE_STM32G474XX
+
+config CPU_MODEL_STM32G483CE
+    bool
+    select CPU_LINE_STM32G483XX
+
+config CPU_MODEL_STM32G483ME
+    bool
+    select CPU_LINE_STM32G483XX
+
+config CPU_MODEL_STM32G483QE
+    bool
+    select CPU_LINE_STM32G483XX
+
+config CPU_MODEL_STM32G483RE
+    bool
+    select CPU_LINE_STM32G483XX
+
+config CPU_MODEL_STM32G483VE
+    bool
+    select CPU_LINE_STM32G483XX
+
+config CPU_MODEL_STM32G484CE
+    bool
+    select CPU_LINE_STM32G484XX
+
+config CPU_MODEL_STM32G484ME
+    bool
+    select CPU_LINE_STM32G484XX
+
+config CPU_MODEL_STM32G484QE
+    bool
+    select CPU_LINE_STM32G484XX
+
+config CPU_MODEL_STM32G484RE
+    bool
+    select CPU_LINE_STM32G484XX
+
+config CPU_MODEL_STM32G484VE
+    bool
+    select CPU_LINE_STM32G484XX
+
+
 # Configure CPU model
 config CPU_MODEL
+    default "stm32g431c6" if CPU_MODEL_STM32G431C6
+    default "stm32g431c8" if CPU_MODEL_STM32G431C8
+    default "stm32g431cb" if CPU_MODEL_STM32G431CB
+    default "stm32g431k6" if CPU_MODEL_STM32G431K6
+    default "stm32g431k8" if CPU_MODEL_STM32G431K8
+    default "stm32g431kb" if CPU_MODEL_STM32G431KB
+    default "stm32g431m6" if CPU_MODEL_STM32G431M6
+    default "stm32g431m8" if CPU_MODEL_STM32G431M8
+    default "stm32g431mb" if CPU_MODEL_STM32G431MB
+    default "stm32g431r6" if CPU_MODEL_STM32G431R6
+    default "stm32g431r8" if CPU_MODEL_STM32G431R8
     default "stm32g431rb" if CPU_MODEL_STM32G431RB
+    default "stm32g431v6" if CPU_MODEL_STM32G431V6
+    default "stm32g431v8" if CPU_MODEL_STM32G431V8
+    default "stm32g431vb" if CPU_MODEL_STM32G431VB
+    default "stm32g441cb" if CPU_MODEL_STM32G441CB
+    default "stm32g441kb" if CPU_MODEL_STM32G441KB
+    default "stm32g441mb" if CPU_MODEL_STM32G441MB
+    default "stm32g441rb" if CPU_MODEL_STM32G441RB
+    default "stm32g441vb" if CPU_MODEL_STM32G441VB
+    default "stm32g473cb" if CPU_MODEL_STM32G473CB
+    default "stm32g473cc" if CPU_MODEL_STM32G473CC
+    default "stm32g473ce" if CPU_MODEL_STM32G473CE
+    default "stm32g473mb" if CPU_MODEL_STM32G473MB
+    default "stm32g473mc" if CPU_MODEL_STM32G473MC
+    default "stm32g473me" if CPU_MODEL_STM32G473ME
+    default "stm32g473qb" if CPU_MODEL_STM32G473QB
+    default "stm32g473qc" if CPU_MODEL_STM32G473QC
+    default "stm32g473qe" if CPU_MODEL_STM32G473QE
+    default "stm32g473rb" if CPU_MODEL_STM32G473RB
+    default "stm32g473rc" if CPU_MODEL_STM32G473RC
+    default "stm32g473re" if CPU_MODEL_STM32G473RE
+    default "stm32g473vb" if CPU_MODEL_STM32G473VB
+    default "stm32g473vc" if CPU_MODEL_STM32G473VC
+    default "stm32g473ve" if CPU_MODEL_STM32G473VE
+    default "stm32g474cb" if CPU_MODEL_STM32G474CB
+    default "stm32g474cc" if CPU_MODEL_STM32G474CC
+    default "stm32g474ce" if CPU_MODEL_STM32G474CE
+    default "stm32g474mb" if CPU_MODEL_STM32G474MB
+    default "stm32g474mc" if CPU_MODEL_STM32G474MC
+    default "stm32g474me" if CPU_MODEL_STM32G474ME
+    default "stm32g474qb" if CPU_MODEL_STM32G474QB
+    default "stm32g474qc" if CPU_MODEL_STM32G474QC
+    default "stm32g474qe" if CPU_MODEL_STM32G474QE
+    default "stm32g474rb" if CPU_MODEL_STM32G474RB
+    default "stm32g474rc" if CPU_MODEL_STM32G474RC
     default "stm32g474re" if CPU_MODEL_STM32G474RE
+    default "stm32g474vb" if CPU_MODEL_STM32G474VB
+    default "stm32g474vc" if CPU_MODEL_STM32G474VC
+    default "stm32g474ve" if CPU_MODEL_STM32G474VE
+    default "stm32g483ce" if CPU_MODEL_STM32G483CE
+    default "stm32g483me" if CPU_MODEL_STM32G483ME
+    default "stm32g483qe" if CPU_MODEL_STM32G483QE
+    default "stm32g483re" if CPU_MODEL_STM32G483RE
+    default "stm32g483ve" if CPU_MODEL_STM32G483VE
+    default "stm32g484ce" if CPU_MODEL_STM32G484CE
+    default "stm32g484me" if CPU_MODEL_STM32G484ME
+    default "stm32g484qe" if CPU_MODEL_STM32G484QE
+    default "stm32g484re" if CPU_MODEL_STM32G484RE
+    default "stm32g484ve" if CPU_MODEL_STM32G484VE

--- a/cpu/stm32/kconfig/l0/Kconfig.lines
+++ b/cpu/stm32/kconfig/l0/Kconfig.lines
@@ -5,6 +5,10 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU lines
 config CPU_LINE_STM32L010X4
     bool
@@ -45,12 +49,10 @@ config CPU_LINE_STM32L051XX
 config CPU_LINE_STM32L052XX
     bool
     select CPU_FAM_L0
-    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32L053XX
     bool
     select CPU_FAM_L0
-    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32L061XX
     bool
@@ -71,12 +73,10 @@ config CPU_LINE_STM32L071XX
 config CPU_LINE_STM32L072XX
     bool
     select CPU_FAM_L0
-    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32L073XX
     bool
     select CPU_FAM_L0
-    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32L081XX
     bool

--- a/cpu/stm32/kconfig/l0/Kconfig.lines
+++ b/cpu/stm32/kconfig/l0/Kconfig.lines
@@ -49,10 +49,12 @@ config CPU_LINE_STM32L051XX
 config CPU_LINE_STM32L052XX
     bool
     select CPU_FAM_L0
+    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32L053XX
     bool
     select CPU_FAM_L0
+    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32L061XX
     bool
@@ -73,10 +75,12 @@ config CPU_LINE_STM32L071XX
 config CPU_LINE_STM32L072XX
     bool
     select CPU_FAM_L0
+    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32L073XX
     bool
     select CPU_FAM_L0
+    select HAS_PERIPH_HWRNG
 
 config CPU_LINE_STM32L081XX
     bool

--- a/cpu/stm32/kconfig/l0/Kconfig.models
+++ b/cpu/stm32/kconfig/l0/Kconfig.models
@@ -5,16 +5,216 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU models
+config CPU_MODEL_STM32L010C6
+    bool
+    select CPU_LINE_STM32L010X6
+
+config CPU_MODEL_STM32L010F4
+    bool
+    select CPU_LINE_STM32L010X4
+
+config CPU_MODEL_STM32L010K4
+    bool
+    select CPU_LINE_STM32L010X4
+
+config CPU_MODEL_STM32L010K8
+    bool
+    select CPU_LINE_STM32L010X8
+
+config CPU_MODEL_STM32L010R8
+    bool
+    select CPU_LINE_STM32L010X8
+
+config CPU_MODEL_STM32L010RB
+    bool
+    select CPU_LINE_STM32L010XB
+
+config CPU_MODEL_STM32L011D3
+    bool
+    select CPU_LINE_STM32L011XX
+
+config CPU_MODEL_STM32L011D4
+    bool
+    select CPU_LINE_STM32L011XX
+
+config CPU_MODEL_STM32L011E3
+    bool
+    select CPU_LINE_STM32L011XX
+
+config CPU_MODEL_STM32L011E4
+    bool
+    select CPU_LINE_STM32L011XX
+
+config CPU_MODEL_STM32L011F3
+    bool
+    select CPU_LINE_STM32L011XX
+
+config CPU_MODEL_STM32L011F4
+    bool
+    select CPU_LINE_STM32L011XX
+
+config CPU_MODEL_STM32L011G3
+    bool
+    select CPU_LINE_STM32L011XX
+
+config CPU_MODEL_STM32L011G4
+    bool
+    select CPU_LINE_STM32L011XX
+
+config CPU_MODEL_STM32L011K3
+    bool
+    select CPU_LINE_STM32L011XX
+
+config CPU_MODEL_STM32L011K4
+    bool
+    select CPU_LINE_STM32L011XX
+
+config CPU_MODEL_STM32L021D4
+    bool
+    select CPU_LINE_STM32L021XX
+
+config CPU_MODEL_STM32L021F4
+    bool
+    select CPU_LINE_STM32L021XX
+
+config CPU_MODEL_STM32L021G4
+    bool
+    select CPU_LINE_STM32L021XX
+
+config CPU_MODEL_STM32L021K4
+    bool
+    select CPU_LINE_STM32L021XX
+
+config CPU_MODEL_STM32L031C4
+    bool
+    select CPU_LINE_STM32L031XX
+
+config CPU_MODEL_STM32L031C6
+    bool
+    select CPU_LINE_STM32L031XX
+
+config CPU_MODEL_STM32L031E4
+    bool
+    select CPU_LINE_STM32L031XX
+
+config CPU_MODEL_STM32L031E6
+    bool
+    select CPU_LINE_STM32L031XX
+
+config CPU_MODEL_STM32L031F4
+    bool
+    select CPU_LINE_STM32L031XX
+
+config CPU_MODEL_STM32L031F6
+    bool
+    select CPU_LINE_STM32L031XX
+
+config CPU_MODEL_STM32L031G4
+    bool
+    select CPU_LINE_STM32L031XX
+
+config CPU_MODEL_STM32L031G6
+    bool
+    select CPU_LINE_STM32L031XX
+
+config CPU_MODEL_STM32L031K4
+    bool
+    select CPU_LINE_STM32L031XX
+
 config CPU_MODEL_STM32L031K6
     bool
     select CPU_LINE_STM32L031XX
+
+config CPU_MODEL_STM32L041C6
+    bool
+    select CPU_LINE_STM32L041XX
+
+config CPU_MODEL_STM32L041E6
+    bool
+    select CPU_LINE_STM32L041XX
+
+config CPU_MODEL_STM32L041F6
+    bool
+    select CPU_LINE_STM32L041XX
+
+config CPU_MODEL_STM32L041G6
+    bool
+    select CPU_LINE_STM32L041XX
+
+config CPU_MODEL_STM32L041K6
+    bool
+    select CPU_LINE_STM32L041XX
+
+config CPU_MODEL_STM32L051C6
+    bool
+    select CPU_LINE_STM32L051XX
+
+config CPU_MODEL_STM32L051C8
+    bool
+    select CPU_LINE_STM32L051XX
+
+config CPU_MODEL_STM32L051K6
+    bool
+    select CPU_LINE_STM32L051XX
+
+config CPU_MODEL_STM32L051K8
+    bool
+    select CPU_LINE_STM32L051XX
+
+config CPU_MODEL_STM32L051R6
+    bool
+    select CPU_LINE_STM32L051XX
+
+config CPU_MODEL_STM32L051R8
+    bool
+    select CPU_LINE_STM32L051XX
+
+config CPU_MODEL_STM32L051T6
+    bool
+    select CPU_LINE_STM32L051XX
+
+config CPU_MODEL_STM32L051T8
+    bool
+    select CPU_LINE_STM32L051XX
+
+config CPU_MODEL_STM32L052C6
+    bool
+    select CPU_LINE_STM32L052XX
+
+config CPU_MODEL_STM32L052C8
+    bool
+    select CPU_LINE_STM32L052XX
+
+config CPU_MODEL_STM32L052K6
+    bool
+    select CPU_LINE_STM32L052XX
+
+config CPU_MODEL_STM32L052K8
+    bool
+    select CPU_LINE_STM32L052XX
+
+config CPU_MODEL_STM32L052R6
+    bool
+    select CPU_LINE_STM32L052XX
+
+config CPU_MODEL_STM32L052R8
+    bool
+    select CPU_LINE_STM32L052XX
+
+config CPU_MODEL_STM32L052T6
+    bool
+    select CPU_LINE_STM32L052XX
 
 config CPU_MODEL_STM32L052T8
     bool
     select CPU_LINE_STM32L052XX
 
-config CPU_MODEL_STM32L053R8
+config CPU_MODEL_STM32L053C6
     bool
     select CPU_LINE_STM32L053XX
 
@@ -22,19 +222,289 @@ config CPU_MODEL_STM32L053C8
     bool
     select CPU_LINE_STM32L053XX
 
+config CPU_MODEL_STM32L053R6
+    bool
+    select CPU_LINE_STM32L053XX
+
+config CPU_MODEL_STM32L053R8
+    bool
+    select CPU_LINE_STM32L053XX
+
+config CPU_MODEL_STM32L062C8
+    bool
+    select CPU_LINE_STM32L062XX
+
+config CPU_MODEL_STM32L062K8
+    bool
+    select CPU_LINE_STM32L062XX
+
+config CPU_MODEL_STM32L063C8
+    bool
+    select CPU_LINE_STM32L063XX
+
+config CPU_MODEL_STM32L063R8
+    bool
+    select CPU_LINE_STM32L063XX
+
+config CPU_MODEL_STM32L071C8
+    bool
+    select CPU_LINE_STM32L071XX
+
+config CPU_MODEL_STM32L071CB
+    bool
+    select CPU_LINE_STM32L071XX
+
+config CPU_MODEL_STM32L071CZ
+    bool
+    select CPU_LINE_STM32L071XX
+
+config CPU_MODEL_STM32L071K8
+    bool
+    select CPU_LINE_STM32L071XX
+
+config CPU_MODEL_STM32L071KB
+    bool
+    select CPU_LINE_STM32L071XX
+
+config CPU_MODEL_STM32L071KZ
+    bool
+    select CPU_LINE_STM32L071XX
+
+config CPU_MODEL_STM32L071RB
+    bool
+    select CPU_LINE_STM32L071XX
+
+config CPU_MODEL_STM32L071RZ
+    bool
+    select CPU_LINE_STM32L071XX
+
+config CPU_MODEL_STM32L071V8
+    bool
+    select CPU_LINE_STM32L071XX
+
+config CPU_MODEL_STM32L071VB
+    bool
+    select CPU_LINE_STM32L071XX
+
+config CPU_MODEL_STM32L071VZ
+    bool
+    select CPU_LINE_STM32L071XX
+
+config CPU_MODEL_STM32L072CB
+    bool
+    select CPU_LINE_STM32L072XX
+
 config CPU_MODEL_STM32L072CZ
     bool
     select CPU_LINE_STM32L072XX
+
+config CPU_MODEL_STM32L072KB
+    bool
+    select CPU_LINE_STM32L072XX
+
+config CPU_MODEL_STM32L072KZ
+    bool
+    select CPU_LINE_STM32L072XX
+
+config CPU_MODEL_STM32L072RB
+    bool
+    select CPU_LINE_STM32L072XX
+
+config CPU_MODEL_STM32L072RZ
+    bool
+    select CPU_LINE_STM32L072XX
+
+config CPU_MODEL_STM32L072V8
+    bool
+    select CPU_LINE_STM32L072XX
+
+config CPU_MODEL_STM32L072VB
+    bool
+    select CPU_LINE_STM32L072XX
+
+config CPU_MODEL_STM32L072VZ
+    bool
+    select CPU_LINE_STM32L072XX
+
+config CPU_MODEL_STM32L073CB
+    bool
+    select CPU_LINE_STM32L073XX
+
+config CPU_MODEL_STM32L073CZ
+    bool
+    select CPU_LINE_STM32L073XX
+
+config CPU_MODEL_STM32L073RB
+    bool
+    select CPU_LINE_STM32L073XX
 
 config CPU_MODEL_STM32L073RZ
     bool
     select CPU_LINE_STM32L073XX
 
+config CPU_MODEL_STM32L073V8
+    bool
+    select CPU_LINE_STM32L073XX
+
+config CPU_MODEL_STM32L073VB
+    bool
+    select CPU_LINE_STM32L073XX
+
+config CPU_MODEL_STM32L073VZ
+    bool
+    select CPU_LINE_STM32L073XX
+
+config CPU_MODEL_STM32L081CB
+    bool
+    select CPU_LINE_STM32L081XX
+
+config CPU_MODEL_STM32L081CZ
+    bool
+    select CPU_LINE_STM32L081XX
+
+config CPU_MODEL_STM32L081KZ
+    bool
+    select CPU_LINE_STM32L081XX
+
+config CPU_MODEL_STM32L082CZ
+    bool
+    select CPU_LINE_STM32L082XX
+
+config CPU_MODEL_STM32L082KB
+    bool
+    select CPU_LINE_STM32L082XX
+
+config CPU_MODEL_STM32L082KZ
+    bool
+    select CPU_LINE_STM32L082XX
+
+config CPU_MODEL_STM32L083CB
+    bool
+    select CPU_LINE_STM32L083XX
+
+config CPU_MODEL_STM32L083CZ
+    bool
+    select CPU_LINE_STM32L083XX
+
+config CPU_MODEL_STM32L083RB
+    bool
+    select CPU_LINE_STM32L083XX
+
+config CPU_MODEL_STM32L083RZ
+    bool
+    select CPU_LINE_STM32L083XX
+
+config CPU_MODEL_STM32L083V8
+    bool
+    select CPU_LINE_STM32L083XX
+
+config CPU_MODEL_STM32L083VB
+    bool
+    select CPU_LINE_STM32L083XX
+
+config CPU_MODEL_STM32L083VZ
+    bool
+    select CPU_LINE_STM32L083XX
+
+
 # Configure CPU model
 config CPU_MODEL
+    default "stm32l010c6" if CPU_MODEL_STM32L010C6
+    default "stm32l010f4" if CPU_MODEL_STM32L010F4
+    default "stm32l010k4" if CPU_MODEL_STM32L010K4
+    default "stm32l010k8" if CPU_MODEL_STM32L010K8
+    default "stm32l010r8" if CPU_MODEL_STM32L010R8
+    default "stm32l010rb" if CPU_MODEL_STM32L010RB
+    default "stm32l011d3" if CPU_MODEL_STM32L011D3
+    default "stm32l011d4" if CPU_MODEL_STM32L011D4
+    default "stm32l011e3" if CPU_MODEL_STM32L011E3
+    default "stm32l011e4" if CPU_MODEL_STM32L011E4
+    default "stm32l011f3" if CPU_MODEL_STM32L011F3
+    default "stm32l011f4" if CPU_MODEL_STM32L011F4
+    default "stm32l011g3" if CPU_MODEL_STM32L011G3
+    default "stm32l011g4" if CPU_MODEL_STM32L011G4
+    default "stm32l011k3" if CPU_MODEL_STM32L011K3
+    default "stm32l011k4" if CPU_MODEL_STM32L011K4
+    default "stm32l021d4" if CPU_MODEL_STM32L021D4
+    default "stm32l021f4" if CPU_MODEL_STM32L021F4
+    default "stm32l021g4" if CPU_MODEL_STM32L021G4
+    default "stm32l021k4" if CPU_MODEL_STM32L021K4
+    default "stm32l031c4" if CPU_MODEL_STM32L031C4
+    default "stm32l031c6" if CPU_MODEL_STM32L031C6
+    default "stm32l031e4" if CPU_MODEL_STM32L031E4
+    default "stm32l031e6" if CPU_MODEL_STM32L031E6
+    default "stm32l031f4" if CPU_MODEL_STM32L031F4
+    default "stm32l031f6" if CPU_MODEL_STM32L031F6
+    default "stm32l031g4" if CPU_MODEL_STM32L031G4
+    default "stm32l031g6" if CPU_MODEL_STM32L031G6
+    default "stm32l031k4" if CPU_MODEL_STM32L031K4
     default "stm32l031k6" if CPU_MODEL_STM32L031K6
+    default "stm32l041c6" if CPU_MODEL_STM32L041C6
+    default "stm32l041e6" if CPU_MODEL_STM32L041E6
+    default "stm32l041f6" if CPU_MODEL_STM32L041F6
+    default "stm32l041g6" if CPU_MODEL_STM32L041G6
+    default "stm32l041k6" if CPU_MODEL_STM32L041K6
+    default "stm32l051c6" if CPU_MODEL_STM32L051C6
+    default "stm32l051c8" if CPU_MODEL_STM32L051C8
+    default "stm32l051k6" if CPU_MODEL_STM32L051K6
+    default "stm32l051k8" if CPU_MODEL_STM32L051K8
+    default "stm32l051r6" if CPU_MODEL_STM32L051R6
+    default "stm32l051r8" if CPU_MODEL_STM32L051R8
+    default "stm32l051t6" if CPU_MODEL_STM32L051T6
+    default "stm32l051t8" if CPU_MODEL_STM32L051T8
+    default "stm32l052c6" if CPU_MODEL_STM32L052C6
+    default "stm32l052c8" if CPU_MODEL_STM32L052C8
+    default "stm32l052k6" if CPU_MODEL_STM32L052K6
+    default "stm32l052k8" if CPU_MODEL_STM32L052K8
+    default "stm32l052r6" if CPU_MODEL_STM32L052R6
+    default "stm32l052r8" if CPU_MODEL_STM32L052R8
+    default "stm32l052t6" if CPU_MODEL_STM32L052T6
     default "stm32l052t8" if CPU_MODEL_STM32L052T8
-    default "stm32l053r8" if CPU_MODEL_STM32L053R8
+    default "stm32l053c6" if CPU_MODEL_STM32L053C6
     default "stm32l053c8" if CPU_MODEL_STM32L053C8
+    default "stm32l053r6" if CPU_MODEL_STM32L053R6
+    default "stm32l053r8" if CPU_MODEL_STM32L053R8
+    default "stm32l062c8" if CPU_MODEL_STM32L062C8
+    default "stm32l062k8" if CPU_MODEL_STM32L062K8
+    default "stm32l063c8" if CPU_MODEL_STM32L063C8
+    default "stm32l063r8" if CPU_MODEL_STM32L063R8
+    default "stm32l071c8" if CPU_MODEL_STM32L071C8
+    default "stm32l071cb" if CPU_MODEL_STM32L071CB
+    default "stm32l071cz" if CPU_MODEL_STM32L071CZ
+    default "stm32l071k8" if CPU_MODEL_STM32L071K8
+    default "stm32l071kb" if CPU_MODEL_STM32L071KB
+    default "stm32l071kz" if CPU_MODEL_STM32L071KZ
+    default "stm32l071rb" if CPU_MODEL_STM32L071RB
+    default "stm32l071rz" if CPU_MODEL_STM32L071RZ
+    default "stm32l071v8" if CPU_MODEL_STM32L071V8
+    default "stm32l071vb" if CPU_MODEL_STM32L071VB
+    default "stm32l071vz" if CPU_MODEL_STM32L071VZ
+    default "stm32l072cb" if CPU_MODEL_STM32L072CB
     default "stm32l072cz" if CPU_MODEL_STM32L072CZ
+    default "stm32l072kb" if CPU_MODEL_STM32L072KB
+    default "stm32l072kz" if CPU_MODEL_STM32L072KZ
+    default "stm32l072rb" if CPU_MODEL_STM32L072RB
+    default "stm32l072rz" if CPU_MODEL_STM32L072RZ
+    default "stm32l072v8" if CPU_MODEL_STM32L072V8
+    default "stm32l072vb" if CPU_MODEL_STM32L072VB
+    default "stm32l072vz" if CPU_MODEL_STM32L072VZ
+    default "stm32l073cb" if CPU_MODEL_STM32L073CB
+    default "stm32l073cz" if CPU_MODEL_STM32L073CZ
+    default "stm32l073rb" if CPU_MODEL_STM32L073RB
     default "stm32l073rz" if CPU_MODEL_STM32L073RZ
+    default "stm32l073v8" if CPU_MODEL_STM32L073V8
+    default "stm32l073vb" if CPU_MODEL_STM32L073VB
+    default "stm32l073vz" if CPU_MODEL_STM32L073VZ
+    default "stm32l081cb" if CPU_MODEL_STM32L081CB
+    default "stm32l081cz" if CPU_MODEL_STM32L081CZ
+    default "stm32l081kz" if CPU_MODEL_STM32L081KZ
+    default "stm32l082cz" if CPU_MODEL_STM32L082CZ
+    default "stm32l082kb" if CPU_MODEL_STM32L082KB
+    default "stm32l082kz" if CPU_MODEL_STM32L082KZ
+    default "stm32l083cb" if CPU_MODEL_STM32L083CB
+    default "stm32l083cz" if CPU_MODEL_STM32L083CZ
+    default "stm32l083rb" if CPU_MODEL_STM32L083RB
+    default "stm32l083rz" if CPU_MODEL_STM32L083RZ
+    default "stm32l083v8" if CPU_MODEL_STM32L083V8
+    default "stm32l083vb" if CPU_MODEL_STM32L083VB
+    default "stm32l083vz" if CPU_MODEL_STM32L083VZ

--- a/cpu/stm32/kconfig/l1/Kconfig.lines
+++ b/cpu/stm32/kconfig/l1/Kconfig.lines
@@ -5,6 +5,10 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU lines
 config CPU_LINE_STM32L100XB
     bool

--- a/cpu/stm32/kconfig/l1/Kconfig.models
+++ b/cpu/stm32/kconfig/l1/Kconfig.models
@@ -5,7 +5,55 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU models
+config CPU_MODEL_STM32L100C6
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L100C6_A
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L100R8
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L100R8_A
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L100RB
+    bool
+    select CPU_LINE_STM32L100XB
+
+config CPU_MODEL_STM32L100RB_A
+    bool
+    select CPU_LINE_STM32L100XBA
+
+config CPU_MODEL_STM32L100RC
+    bool
+    select CPU_LINE_STM32L100XC
+
+config CPU_MODEL_STM32L151C6
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L151C6_A
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L151C8
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L151C8_A
+    bool
+    select CPU_FAM_L1
+
 config CPU_MODEL_STM32L151CB
     bool
     select CPU_LINE_STM32L151XB
@@ -14,17 +62,389 @@ config CPU_MODEL_STM32L151CB_A
     bool
     select CPU_LINE_STM32L151XBA
 
+config CPU_MODEL_STM32L151CC
+    bool
+    select CPU_LINE_STM32L151XC
+
+config CPU_MODEL_STM32L151QC
+    bool
+    select CPU_LINE_STM32L151XC
+
+config CPU_MODEL_STM32L151QD
+    bool
+    select CPU_LINE_STM32L151XD
+
+config CPU_MODEL_STM32L151QE
+    bool
+    select CPU_LINE_STM32L151XE
+
+config CPU_MODEL_STM32L151R6
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L151R6_A
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L151R8
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L151R8_A
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L151RB
+    bool
+    select CPU_LINE_STM32L151XB
+
+config CPU_MODEL_STM32L151RB_A
+    bool
+    select CPU_LINE_STM32L151XBA
+
 config CPU_MODEL_STM32L151RC
     bool
     select CPU_LINE_STM32L151XC
+
+config CPU_MODEL_STM32L151RC_A
+    bool
+    select CPU_LINE_STM32L151XCA
+
+config CPU_MODEL_STM32L151RD
+    bool
+    select CPU_LINE_STM32L151XD
+
+config CPU_MODEL_STM32L151RE
+    bool
+    select CPU_LINE_STM32L151XE
+
+config CPU_MODEL_STM32L151UC
+    bool
+    select CPU_LINE_STM32L151XC
+
+config CPU_MODEL_STM32L151V8
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L151V8_A
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L151VB
+    bool
+    select CPU_LINE_STM32L151XB
+
+config CPU_MODEL_STM32L151VB_A
+    bool
+    select CPU_LINE_STM32L151XBA
+
+config CPU_MODEL_STM32L151VC
+    bool
+    select CPU_LINE_STM32L151XC
+
+config CPU_MODEL_STM32L151VC_A
+    bool
+    select CPU_LINE_STM32L151XCA
+
+config CPU_MODEL_STM32L151VD
+    bool
+    select CPU_LINE_STM32L151XD
+
+config CPU_MODEL_STM32L151VD_X
+    bool
+    select CPU_LINE_STM32L151XDX
+
+config CPU_MODEL_STM32L151VE
+    bool
+    select CPU_LINE_STM32L151XE
+
+config CPU_MODEL_STM32L151ZC
+    bool
+    select CPU_LINE_STM32L151XC
+
+config CPU_MODEL_STM32L151ZD
+    bool
+    select CPU_LINE_STM32L151XD
+
+config CPU_MODEL_STM32L151ZE
+    bool
+    select CPU_LINE_STM32L151XE
+
+config CPU_MODEL_STM32L152C6
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L152C6_A
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L152C8
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L152C8_A
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L152CB
+    bool
+    select CPU_LINE_STM32L152XB
+
+config CPU_MODEL_STM32L152CB_A
+    bool
+    select CPU_LINE_STM32L152XBA
+
+config CPU_MODEL_STM32L152CC
+    bool
+    select CPU_LINE_STM32L152XC
+
+config CPU_MODEL_STM32L152QC
+    bool
+    select CPU_LINE_STM32L152XC
+
+config CPU_MODEL_STM32L152QD
+    bool
+    select CPU_LINE_STM32L152XD
+
+config CPU_MODEL_STM32L152QE
+    bool
+    select CPU_LINE_STM32L152XE
+
+config CPU_MODEL_STM32L152R6
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L152R6_A
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L152R8
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L152R8_A
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L152RB
+    bool
+    select CPU_LINE_STM32L152XB
+
+config CPU_MODEL_STM32L152RB_A
+    bool
+    select CPU_LINE_STM32L152XBA
+
+config CPU_MODEL_STM32L152RC
+    bool
+    select CPU_LINE_STM32L152XC
+
+config CPU_MODEL_STM32L152RC_A
+    bool
+    select CPU_LINE_STM32L152XCA
+
+config CPU_MODEL_STM32L152RD
+    bool
+    select CPU_LINE_STM32L152XD
 
 config CPU_MODEL_STM32L152RE
     bool
     select CPU_LINE_STM32L152XE
 
+config CPU_MODEL_STM32L152UC
+    bool
+    select CPU_LINE_STM32L152XC
+
+config CPU_MODEL_STM32L152V8
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L152V8_A
+    bool
+    select CPU_FAM_L1
+
+config CPU_MODEL_STM32L152VB
+    bool
+    select CPU_LINE_STM32L152XB
+
+config CPU_MODEL_STM32L152VB_A
+    bool
+    select CPU_LINE_STM32L152XBA
+
+config CPU_MODEL_STM32L152VC
+    bool
+    select CPU_LINE_STM32L152XC
+
+config CPU_MODEL_STM32L152VC_A
+    bool
+    select CPU_LINE_STM32L152XCA
+
+config CPU_MODEL_STM32L152VD
+    bool
+    select CPU_LINE_STM32L152XD
+
+config CPU_MODEL_STM32L152VD_X
+    bool
+    select CPU_LINE_STM32L152XDX
+
+config CPU_MODEL_STM32L152VE
+    bool
+    select CPU_LINE_STM32L152XE
+
+config CPU_MODEL_STM32L152ZC
+    bool
+    select CPU_LINE_STM32L152XC
+
+config CPU_MODEL_STM32L152ZD
+    bool
+    select CPU_LINE_STM32L152XD
+
+config CPU_MODEL_STM32L152ZE
+    bool
+    select CPU_LINE_STM32L152XE
+
+config CPU_MODEL_STM32L162QC
+    bool
+    select CPU_LINE_STM32L162XC
+
+config CPU_MODEL_STM32L162QD
+    bool
+    select CPU_LINE_STM32L162XD
+
+config CPU_MODEL_STM32L162RC
+    bool
+    select CPU_LINE_STM32L162XC
+
+config CPU_MODEL_STM32L162RC_A
+    bool
+    select CPU_LINE_STM32L162XCA
+
+config CPU_MODEL_STM32L162RD
+    bool
+    select CPU_LINE_STM32L162XD
+
+config CPU_MODEL_STM32L162RE
+    bool
+    select CPU_LINE_STM32L162XE
+
+config CPU_MODEL_STM32L162VC
+    bool
+    select CPU_LINE_STM32L162XC
+
+config CPU_MODEL_STM32L162VC_A
+    bool
+    select CPU_LINE_STM32L162XCA
+
+config CPU_MODEL_STM32L162VD
+    bool
+    select CPU_LINE_STM32L162XD
+
+config CPU_MODEL_STM32L162VD_X
+    bool
+    select CPU_LINE_STM32L162XDX
+
+config CPU_MODEL_STM32L162VE
+    bool
+    select CPU_LINE_STM32L162XE
+
+config CPU_MODEL_STM32L162ZC
+    bool
+    select CPU_LINE_STM32L162XC
+
+config CPU_MODEL_STM32L162ZD
+    bool
+    select CPU_LINE_STM32L162XD
+
+config CPU_MODEL_STM32L162ZE
+    bool
+    select CPU_LINE_STM32L162XE
+
+
 # Configure CPU model
 config CPU_MODEL
+    default "stm32l100c6" if CPU_MODEL_STM32L100C6
+    default "stm32l100c6_a" if CPU_MODEL_STM32L100C6_A
+    default "stm32l100r8" if CPU_MODEL_STM32L100R8
+    default "stm32l100r8_a" if CPU_MODEL_STM32L100R8_A
+    default "stm32l100rb" if CPU_MODEL_STM32L100RB
+    default "stm32l100rb_a" if CPU_MODEL_STM32L100RB_A
+    default "stm32l100rc" if CPU_MODEL_STM32L100RC
+    default "stm32l151c6" if CPU_MODEL_STM32L151C6
+    default "stm32l151c6_a" if CPU_MODEL_STM32L151C6_A
+    default "stm32l151c8" if CPU_MODEL_STM32L151C8
+    default "stm32l151c8_a" if CPU_MODEL_STM32L151C8_A
     default "stm32l151cb" if CPU_MODEL_STM32L151CB
     default "stm32l151cb_a" if CPU_MODEL_STM32L151CB_A
+    default "stm32l151cc" if CPU_MODEL_STM32L151CC
+    default "stm32l151qc" if CPU_MODEL_STM32L151QC
+    default "stm32l151qd" if CPU_MODEL_STM32L151QD
+    default "stm32l151qe" if CPU_MODEL_STM32L151QE
+    default "stm32l151r6" if CPU_MODEL_STM32L151R6
+    default "stm32l151r6_a" if CPU_MODEL_STM32L151R6_A
+    default "stm32l151r8" if CPU_MODEL_STM32L151R8
+    default "stm32l151r8_a" if CPU_MODEL_STM32L151R8_A
+    default "stm32l151rb" if CPU_MODEL_STM32L151RB
+    default "stm32l151rb_a" if CPU_MODEL_STM32L151RB_A
     default "stm32l151rc" if CPU_MODEL_STM32L151RC
+    default "stm32l151rc_a" if CPU_MODEL_STM32L151RC_A
+    default "stm32l151rd" if CPU_MODEL_STM32L151RD
+    default "stm32l151re" if CPU_MODEL_STM32L151RE
+    default "stm32l151uc" if CPU_MODEL_STM32L151UC
+    default "stm32l151v8" if CPU_MODEL_STM32L151V8
+    default "stm32l151v8_a" if CPU_MODEL_STM32L151V8_A
+    default "stm32l151vb" if CPU_MODEL_STM32L151VB
+    default "stm32l151vb_a" if CPU_MODEL_STM32L151VB_A
+    default "stm32l151vc" if CPU_MODEL_STM32L151VC
+    default "stm32l151vc_a" if CPU_MODEL_STM32L151VC_A
+    default "stm32l151vd" if CPU_MODEL_STM32L151VD
+    default "stm32l151vd_x" if CPU_MODEL_STM32L151VD_X
+    default "stm32l151ve" if CPU_MODEL_STM32L151VE
+    default "stm32l151zc" if CPU_MODEL_STM32L151ZC
+    default "stm32l151zd" if CPU_MODEL_STM32L151ZD
+    default "stm32l151ze" if CPU_MODEL_STM32L151ZE
+    default "stm32l152c6" if CPU_MODEL_STM32L152C6
+    default "stm32l152c6_a" if CPU_MODEL_STM32L152C6_A
+    default "stm32l152c8" if CPU_MODEL_STM32L152C8
+    default "stm32l152c8_a" if CPU_MODEL_STM32L152C8_A
+    default "stm32l152cb" if CPU_MODEL_STM32L152CB
+    default "stm32l152cb_a" if CPU_MODEL_STM32L152CB_A
+    default "stm32l152cc" if CPU_MODEL_STM32L152CC
+    default "stm32l152qc" if CPU_MODEL_STM32L152QC
+    default "stm32l152qd" if CPU_MODEL_STM32L152QD
+    default "stm32l152qe" if CPU_MODEL_STM32L152QE
+    default "stm32l152r6" if CPU_MODEL_STM32L152R6
+    default "stm32l152r6_a" if CPU_MODEL_STM32L152R6_A
+    default "stm32l152r8" if CPU_MODEL_STM32L152R8
+    default "stm32l152r8_a" if CPU_MODEL_STM32L152R8_A
+    default "stm32l152rb" if CPU_MODEL_STM32L152RB
+    default "stm32l152rb_a" if CPU_MODEL_STM32L152RB_A
+    default "stm32l152rc" if CPU_MODEL_STM32L152RC
+    default "stm32l152rc_a" if CPU_MODEL_STM32L152RC_A
+    default "stm32l152rd" if CPU_MODEL_STM32L152RD
     default "stm32l152re" if CPU_MODEL_STM32L152RE
+    default "stm32l152uc" if CPU_MODEL_STM32L152UC
+    default "stm32l152v8" if CPU_MODEL_STM32L152V8
+    default "stm32l152v8_a" if CPU_MODEL_STM32L152V8_A
+    default "stm32l152vb" if CPU_MODEL_STM32L152VB
+    default "stm32l152vb_a" if CPU_MODEL_STM32L152VB_A
+    default "stm32l152vc" if CPU_MODEL_STM32L152VC
+    default "stm32l152vc_a" if CPU_MODEL_STM32L152VC_A
+    default "stm32l152vd" if CPU_MODEL_STM32L152VD
+    default "stm32l152vd_x" if CPU_MODEL_STM32L152VD_X
+    default "stm32l152ve" if CPU_MODEL_STM32L152VE
+    default "stm32l152zc" if CPU_MODEL_STM32L152ZC
+    default "stm32l152zd" if CPU_MODEL_STM32L152ZD
+    default "stm32l152ze" if CPU_MODEL_STM32L152ZE
+    default "stm32l162qc" if CPU_MODEL_STM32L162QC
+    default "stm32l162qd" if CPU_MODEL_STM32L162QD
+    default "stm32l162rc" if CPU_MODEL_STM32L162RC
+    default "stm32l162rc_a" if CPU_MODEL_STM32L162RC_A
+    default "stm32l162rd" if CPU_MODEL_STM32L162RD
+    default "stm32l162re" if CPU_MODEL_STM32L162RE
+    default "stm32l162vc" if CPU_MODEL_STM32L162VC
+    default "stm32l162vc_a" if CPU_MODEL_STM32L162VC_A
+    default "stm32l162vd" if CPU_MODEL_STM32L162VD
+    default "stm32l162vd_x" if CPU_MODEL_STM32L162VD_X
+    default "stm32l162ve" if CPU_MODEL_STM32L162VE
+    default "stm32l162zc" if CPU_MODEL_STM32L162ZC
+    default "stm32l162zd" if CPU_MODEL_STM32L162ZD
+    default "stm32l162ze" if CPU_MODEL_STM32L162ZE

--- a/cpu/stm32/kconfig/l4/Kconfig.lines
+++ b/cpu/stm32/kconfig/l4/Kconfig.lines
@@ -5,43 +5,11 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU lines
-config CPU_LINE_STM32L4A6XX
-    bool
-    select CPU_FAM_L4
-
-config CPU_LINE_STM32L4P5XX
-    bool
-    select CPU_FAM_L4
-
-config CPU_LINE_STM32L4Q5XX
-    bool
-    select CPU_FAM_L4
-
-config CPU_LINE_STM32L4R5XX
-    bool
-    select CPU_FAM_L4
-
-config CPU_LINE_STM32L4R7XX
-    bool
-    select CPU_FAM_L4
-
-config CPU_LINE_STM32L4R9XX
-    bool
-    select CPU_FAM_L4
-
-config CPU_LINE_STM32L4S5XX
-    bool
-    select CPU_FAM_L4
-
-config CPU_LINE_STM32L4S7XX
-    bool
-    select CPU_FAM_L4
-
-config CPU_LINE_STM32L4S9XX
-    bool
-    select CPU_FAM_L4
-
 config CPU_LINE_STM32L412XX
     bool
     select CPU_FAM_L4
@@ -103,5 +71,41 @@ config CPU_LINE_STM32L486XX
     select CPU_FAM_L4
 
 config CPU_LINE_STM32L496XX
+    bool
+    select CPU_FAM_L4
+
+config CPU_LINE_STM32L4A6XX
+    bool
+    select CPU_FAM_L4
+
+config CPU_LINE_STM32L4P5XX
+    bool
+    select CPU_FAM_L4
+
+config CPU_LINE_STM32L4Q5XX
+    bool
+    select CPU_FAM_L4
+
+config CPU_LINE_STM32L4R5XX
+    bool
+    select CPU_FAM_L4
+
+config CPU_LINE_STM32L4R7XX
+    bool
+    select CPU_FAM_L4
+
+config CPU_LINE_STM32L4R9XX
+    bool
+    select CPU_FAM_L4
+
+config CPU_LINE_STM32L4S5XX
+    bool
+    select CPU_FAM_L4
+
+config CPU_LINE_STM32L4S7XX
+    bool
+    select CPU_FAM_L4
+
+config CPU_LINE_STM32L4S9XX
     bool
     select CPU_FAM_L4

--- a/cpu/stm32/kconfig/l4/Kconfig.models
+++ b/cpu/stm32/kconfig/l4/Kconfig.models
@@ -5,28 +5,288 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU models
+config CPU_MODEL_STM32L412C8
+    bool
+    select CPU_LINE_STM32L412XX
+
+config CPU_MODEL_STM32L412CB
+    bool
+    select CPU_LINE_STM32L412XX
+
+config CPU_MODEL_STM32L412K8
+    bool
+    select CPU_LINE_STM32L412XX
+
 config CPU_MODEL_STM32L412KB
     bool
     select CPU_LINE_STM32L412XX
+
+config CPU_MODEL_STM32L412R8
+    bool
+    select CPU_LINE_STM32L412XX
+
+config CPU_MODEL_STM32L412RB
+    bool
+    select CPU_LINE_STM32L412XX
+
+config CPU_MODEL_STM32L412T8
+    bool
+    select CPU_LINE_STM32L412XX
+
+config CPU_MODEL_STM32L412TB
+    bool
+    select CPU_LINE_STM32L412XX
+
+config CPU_MODEL_STM32L422CB
+    bool
+    select CPU_LINE_STM32L422XX
+
+config CPU_MODEL_STM32L422KB
+    bool
+    select CPU_LINE_STM32L422XX
+
+config CPU_MODEL_STM32L422RB
+    bool
+    select CPU_LINE_STM32L422XX
+
+config CPU_MODEL_STM32L422TB
+    bool
+    select CPU_LINE_STM32L422XX
+
+config CPU_MODEL_STM32L431CB
+    bool
+    select CPU_LINE_STM32L431XX
+
+config CPU_MODEL_STM32L431CC
+    bool
+    select CPU_LINE_STM32L431XX
+
+config CPU_MODEL_STM32L431KB
+    bool
+    select CPU_LINE_STM32L431XX
+
+config CPU_MODEL_STM32L431KC
+    bool
+    select CPU_LINE_STM32L431XX
+
+config CPU_MODEL_STM32L431RB
+    bool
+    select CPU_LINE_STM32L431XX
+
+config CPU_MODEL_STM32L431RC
+    bool
+    select CPU_LINE_STM32L431XX
+
+config CPU_MODEL_STM32L431VC
+    bool
+    select CPU_LINE_STM32L431XX
+
+config CPU_MODEL_STM32L432KB
+    bool
+    select CPU_LINE_STM32L432XX
 
 config CPU_MODEL_STM32L432KC
     bool
     select CPU_LINE_STM32L432XX
 
+config CPU_MODEL_STM32L433CB
+    bool
+    select CPU_LINE_STM32L433XX
+
+config CPU_MODEL_STM32L433CC
+    bool
+    select CPU_LINE_STM32L433XX
+
+config CPU_MODEL_STM32L433RB
+    bool
+    select CPU_LINE_STM32L433XX
+
 config CPU_MODEL_STM32L433RC
     bool
     select CPU_LINE_STM32L433XX
+
+config CPU_MODEL_STM32L433VC
+    bool
+    select CPU_LINE_STM32L433XX
+
+config CPU_MODEL_STM32L442KC
+    bool
+    select CPU_LINE_STM32L442XX
+
+config CPU_MODEL_STM32L443CC
+    bool
+    select CPU_LINE_STM32L443XX
+
+config CPU_MODEL_STM32L443RC
+    bool
+    select CPU_LINE_STM32L443XX
+
+config CPU_MODEL_STM32L443VC
+    bool
+    select CPU_LINE_STM32L443XX
+
+config CPU_MODEL_STM32L451CC
+    bool
+    select CPU_LINE_STM32L451XX
+
+config CPU_MODEL_STM32L451CE
+    bool
+    select CPU_LINE_STM32L451XX
+
+config CPU_MODEL_STM32L451RC
+    bool
+    select CPU_LINE_STM32L451XX
+
+config CPU_MODEL_STM32L451RE
+    bool
+    select CPU_LINE_STM32L451XX
+
+config CPU_MODEL_STM32L451VC
+    bool
+    select CPU_LINE_STM32L451XX
+
+config CPU_MODEL_STM32L451VE
+    bool
+    select CPU_LINE_STM32L451XX
+
+config CPU_MODEL_STM32L452CC
+    bool
+    select CPU_LINE_STM32L452XX
+
+config CPU_MODEL_STM32L452CE
+    bool
+    select CPU_LINE_STM32L452XX
+
+config CPU_MODEL_STM32L452RC
+    bool
+    select CPU_LINE_STM32L452XX
 
 config CPU_MODEL_STM32L452RE
     bool
     select CPU_LINE_STM32L452XX
 
+config CPU_MODEL_STM32L452VC
+    bool
+    select CPU_LINE_STM32L452XX
+
+config CPU_MODEL_STM32L452VE
+    bool
+    select CPU_LINE_STM32L452XX
+
+config CPU_MODEL_STM32L462CE
+    bool
+    select CPU_LINE_STM32L462XX
+
+config CPU_MODEL_STM32L462RE
+    bool
+    select CPU_LINE_STM32L462XX
+
+config CPU_MODEL_STM32L462VE
+    bool
+    select CPU_LINE_STM32L462XX
+
+config CPU_MODEL_STM32L471QE
+    bool
+    select CPU_LINE_STM32L471XX
+
+config CPU_MODEL_STM32L471QG
+    bool
+    select CPU_LINE_STM32L471XX
+
+config CPU_MODEL_STM32L471RE
+    bool
+    select CPU_LINE_STM32L471XX
+
+config CPU_MODEL_STM32L471RG
+    bool
+    select CPU_LINE_STM32L471XX
+
+config CPU_MODEL_STM32L471VE
+    bool
+    select CPU_LINE_STM32L471XX
+
+config CPU_MODEL_STM32L471VG
+    bool
+    select CPU_LINE_STM32L471XX
+
+config CPU_MODEL_STM32L471ZE
+    bool
+    select CPU_LINE_STM32L471XX
+
+config CPU_MODEL_STM32L471ZG
+    bool
+    select CPU_LINE_STM32L471XX
+
+config CPU_MODEL_STM32L475RC
+    bool
+    select CPU_LINE_STM32L475XX
+
+config CPU_MODEL_STM32L475RE
+    bool
+    select CPU_LINE_STM32L475XX
+
+config CPU_MODEL_STM32L475RG
+    bool
+    select CPU_LINE_STM32L475XX
+
+config CPU_MODEL_STM32L475VC
+    bool
+    select CPU_LINE_STM32L475XX
+
+config CPU_MODEL_STM32L475VE
+    bool
+    select CPU_LINE_STM32L475XX
+
 config CPU_MODEL_STM32L475VG
     bool
     select CPU_LINE_STM32L475XX
 
+config CPU_MODEL_STM32L476JE
+    bool
+    select CPU_LINE_STM32L476XX
+
+config CPU_MODEL_STM32L476JG
+    bool
+    select CPU_LINE_STM32L476XX
+
+config CPU_MODEL_STM32L476ME
+    bool
+    select CPU_LINE_STM32L476XX
+
+config CPU_MODEL_STM32L476MG
+    bool
+    select CPU_LINE_STM32L476XX
+
+config CPU_MODEL_STM32L476QE
+    bool
+    select CPU_LINE_STM32L476XX
+
+config CPU_MODEL_STM32L476QG
+    bool
+    select CPU_LINE_STM32L476XX
+
+config CPU_MODEL_STM32L476RC
+    bool
+    select CPU_LINE_STM32L476XX
+
+config CPU_MODEL_STM32L476RE
+    bool
+    select CPU_LINE_STM32L476XX
+
 config CPU_MODEL_STM32L476RG
+    bool
+    select CPU_LINE_STM32L476XX
+
+config CPU_MODEL_STM32L476VC
+    bool
+    select CPU_LINE_STM32L476XX
+
+config CPU_MODEL_STM32L476VE
     bool
     select CPU_LINE_STM32L476XX
 
@@ -34,7 +294,67 @@ config CPU_MODEL_STM32L476VG
     bool
     select CPU_LINE_STM32L476XX
 
+config CPU_MODEL_STM32L476ZE
+    bool
+    select CPU_LINE_STM32L476XX
+
+config CPU_MODEL_STM32L476ZG
+    bool
+    select CPU_LINE_STM32L476XX
+
+config CPU_MODEL_STM32L486JG
+    bool
+    select CPU_LINE_STM32L486XX
+
+config CPU_MODEL_STM32L486QG
+    bool
+    select CPU_LINE_STM32L486XX
+
+config CPU_MODEL_STM32L486RG
+    bool
+    select CPU_LINE_STM32L486XX
+
+config CPU_MODEL_STM32L486VG
+    bool
+    select CPU_LINE_STM32L486XX
+
+config CPU_MODEL_STM32L486ZG
+    bool
+    select CPU_LINE_STM32L486XX
+
+config CPU_MODEL_STM32L496AE
+    bool
+    select CPU_LINE_STM32L496XX
+
 config CPU_MODEL_STM32L496AG
+    bool
+    select CPU_LINE_STM32L496XX
+
+config CPU_MODEL_STM32L496QE
+    bool
+    select CPU_LINE_STM32L496XX
+
+config CPU_MODEL_STM32L496QG
+    bool
+    select CPU_LINE_STM32L496XX
+
+config CPU_MODEL_STM32L496RE
+    bool
+    select CPU_LINE_STM32L496XX
+
+config CPU_MODEL_STM32L496RG
+    bool
+    select CPU_LINE_STM32L496XX
+
+config CPU_MODEL_STM32L496VE
+    bool
+    select CPU_LINE_STM32L496XX
+
+config CPU_MODEL_STM32L496VG
+    bool
+    select CPU_LINE_STM32L496XX
+
+config CPU_MODEL_STM32L496ZE
     bool
     select CPU_LINE_STM32L496XX
 
@@ -42,19 +362,344 @@ config CPU_MODEL_STM32L496ZG
     bool
     select CPU_LINE_STM32L496XX
 
+config CPU_MODEL_STM32L4A6AG
+    bool
+    select CPU_LINE_STM32L4A6XX
+
+config CPU_MODEL_STM32L4A6QG
+    bool
+    select CPU_LINE_STM32L4A6XX
+
+config CPU_MODEL_STM32L4A6RG
+    bool
+    select CPU_LINE_STM32L4A6XX
+
+config CPU_MODEL_STM32L4A6VG
+    bool
+    select CPU_LINE_STM32L4A6XX
+
+config CPU_MODEL_STM32L4A6ZG
+    bool
+    select CPU_LINE_STM32L4A6XX
+
+config CPU_MODEL_STM32L4P5AE
+    bool
+    select CPU_LINE_STM32L4P5XX
+
+config CPU_MODEL_STM32L4P5AG
+    bool
+    select CPU_LINE_STM32L4P5XX
+
+config CPU_MODEL_STM32L4P5CE
+    bool
+    select CPU_LINE_STM32L4P5XX
+
+config CPU_MODEL_STM32L4P5CG
+    bool
+    select CPU_LINE_STM32L4P5XX
+
+config CPU_MODEL_STM32L4P5QE
+    bool
+    select CPU_LINE_STM32L4P5XX
+
+config CPU_MODEL_STM32L4P5QG
+    bool
+    select CPU_LINE_STM32L4P5XX
+
+config CPU_MODEL_STM32L4P5RE
+    bool
+    select CPU_LINE_STM32L4P5XX
+
+config CPU_MODEL_STM32L4P5RG
+    bool
+    select CPU_LINE_STM32L4P5XX
+
+config CPU_MODEL_STM32L4P5VE
+    bool
+    select CPU_LINE_STM32L4P5XX
+
+config CPU_MODEL_STM32L4P5VG
+    bool
+    select CPU_LINE_STM32L4P5XX
+
+config CPU_MODEL_STM32L4P5ZE
+    bool
+    select CPU_LINE_STM32L4P5XX
+
+config CPU_MODEL_STM32L4P5ZG
+    bool
+    select CPU_LINE_STM32L4P5XX
+
+config CPU_MODEL_STM32L4Q5AG
+    bool
+    select CPU_LINE_STM32L4Q5XX
+
+config CPU_MODEL_STM32L4Q5CG
+    bool
+    select CPU_LINE_STM32L4Q5XX
+
+config CPU_MODEL_STM32L4Q5QG
+    bool
+    select CPU_LINE_STM32L4Q5XX
+
+config CPU_MODEL_STM32L4Q5RG
+    bool
+    select CPU_LINE_STM32L4Q5XX
+
+config CPU_MODEL_STM32L4Q5VG
+    bool
+    select CPU_LINE_STM32L4Q5XX
+
+config CPU_MODEL_STM32L4Q5ZG
+    bool
+    select CPU_LINE_STM32L4Q5XX
+
+config CPU_MODEL_STM32L4R5AG
+    bool
+    select CPU_LINE_STM32L4R5XX
+
+config CPU_MODEL_STM32L4R5AI
+    bool
+    select CPU_LINE_STM32L4R5XX
+
+config CPU_MODEL_STM32L4R5QG
+    bool
+    select CPU_LINE_STM32L4R5XX
+
+config CPU_MODEL_STM32L4R5QI
+    bool
+    select CPU_LINE_STM32L4R5XX
+
+config CPU_MODEL_STM32L4R5VG
+    bool
+    select CPU_LINE_STM32L4R5XX
+
+config CPU_MODEL_STM32L4R5VI
+    bool
+    select CPU_LINE_STM32L4R5XX
+
+config CPU_MODEL_STM32L4R5ZG
+    bool
+    select CPU_LINE_STM32L4R5XX
+
 config CPU_MODEL_STM32L4R5ZI
     bool
     select CPU_LINE_STM32L4R5XX
 
+config CPU_MODEL_STM32L4R7AI
+    bool
+    select CPU_LINE_STM32L4R7XX
+
+config CPU_MODEL_STM32L4R7VI
+    bool
+    select CPU_LINE_STM32L4R7XX
+
+config CPU_MODEL_STM32L4R7ZI
+    bool
+    select CPU_LINE_STM32L4R7XX
+
+config CPU_MODEL_STM32L4R9AG
+    bool
+    select CPU_LINE_STM32L4R9XX
+
+config CPU_MODEL_STM32L4R9AI
+    bool
+    select CPU_LINE_STM32L4R9XX
+
+config CPU_MODEL_STM32L4R9VG
+    bool
+    select CPU_LINE_STM32L4R9XX
+
+config CPU_MODEL_STM32L4R9VI
+    bool
+    select CPU_LINE_STM32L4R9XX
+
+config CPU_MODEL_STM32L4R9ZG
+    bool
+    select CPU_LINE_STM32L4R9XX
+
+config CPU_MODEL_STM32L4R9ZI
+    bool
+    select CPU_LINE_STM32L4R9XX
+
+config CPU_MODEL_STM32L4S5AI
+    bool
+    select CPU_LINE_STM32L4S5XX
+
+config CPU_MODEL_STM32L4S5QI
+    bool
+    select CPU_LINE_STM32L4S5XX
+
+config CPU_MODEL_STM32L4S5VI
+    bool
+    select CPU_LINE_STM32L4S5XX
+
+config CPU_MODEL_STM32L4S5ZI
+    bool
+    select CPU_LINE_STM32L4S5XX
+
+config CPU_MODEL_STM32L4S7AI
+    bool
+    select CPU_LINE_STM32L4S7XX
+
+config CPU_MODEL_STM32L4S7VI
+    bool
+    select CPU_LINE_STM32L4S7XX
+
+config CPU_MODEL_STM32L4S7ZI
+    bool
+    select CPU_LINE_STM32L4S7XX
+
+config CPU_MODEL_STM32L4S9AI
+    bool
+    select CPU_LINE_STM32L4S9XX
+
+config CPU_MODEL_STM32L4S9VI
+    bool
+    select CPU_LINE_STM32L4S9XX
+
+config CPU_MODEL_STM32L4S9ZI
+    bool
+    select CPU_LINE_STM32L4S9XX
+
+
 # Configure CPU model
 config CPU_MODEL
+    default "stm32l412c8" if CPU_MODEL_STM32L412C8
+    default "stm32l412cb" if CPU_MODEL_STM32L412CB
+    default "stm32l412k8" if CPU_MODEL_STM32L412K8
     default "stm32l412kb" if CPU_MODEL_STM32L412KB
+    default "stm32l412r8" if CPU_MODEL_STM32L412R8
+    default "stm32l412rb" if CPU_MODEL_STM32L412RB
+    default "stm32l412t8" if CPU_MODEL_STM32L412T8
+    default "stm32l412tb" if CPU_MODEL_STM32L412TB
+    default "stm32l422cb" if CPU_MODEL_STM32L422CB
+    default "stm32l422kb" if CPU_MODEL_STM32L422KB
+    default "stm32l422rb" if CPU_MODEL_STM32L422RB
+    default "stm32l422tb" if CPU_MODEL_STM32L422TB
+    default "stm32l431cb" if CPU_MODEL_STM32L431CB
+    default "stm32l431cc" if CPU_MODEL_STM32L431CC
+    default "stm32l431kb" if CPU_MODEL_STM32L431KB
+    default "stm32l431kc" if CPU_MODEL_STM32L431KC
+    default "stm32l431rb" if CPU_MODEL_STM32L431RB
+    default "stm32l431rc" if CPU_MODEL_STM32L431RC
+    default "stm32l431vc" if CPU_MODEL_STM32L431VC
+    default "stm32l432kb" if CPU_MODEL_STM32L432KB
     default "stm32l432kc" if CPU_MODEL_STM32L432KC
+    default "stm32l433cb" if CPU_MODEL_STM32L433CB
+    default "stm32l433cc" if CPU_MODEL_STM32L433CC
+    default "stm32l433rb" if CPU_MODEL_STM32L433RB
     default "stm32l433rc" if CPU_MODEL_STM32L433RC
+    default "stm32l433vc" if CPU_MODEL_STM32L433VC
+    default "stm32l442kc" if CPU_MODEL_STM32L442KC
+    default "stm32l443cc" if CPU_MODEL_STM32L443CC
+    default "stm32l443rc" if CPU_MODEL_STM32L443RC
+    default "stm32l443vc" if CPU_MODEL_STM32L443VC
+    default "stm32l451cc" if CPU_MODEL_STM32L451CC
+    default "stm32l451ce" if CPU_MODEL_STM32L451CE
+    default "stm32l451rc" if CPU_MODEL_STM32L451RC
+    default "stm32l451re" if CPU_MODEL_STM32L451RE
+    default "stm32l451vc" if CPU_MODEL_STM32L451VC
+    default "stm32l451ve" if CPU_MODEL_STM32L451VE
+    default "stm32l452cc" if CPU_MODEL_STM32L452CC
+    default "stm32l452ce" if CPU_MODEL_STM32L452CE
+    default "stm32l452rc" if CPU_MODEL_STM32L452RC
     default "stm32l452re" if CPU_MODEL_STM32L452RE
+    default "stm32l452vc" if CPU_MODEL_STM32L452VC
+    default "stm32l452ve" if CPU_MODEL_STM32L452VE
+    default "stm32l462ce" if CPU_MODEL_STM32L462CE
+    default "stm32l462re" if CPU_MODEL_STM32L462RE
+    default "stm32l462ve" if CPU_MODEL_STM32L462VE
+    default "stm32l471qe" if CPU_MODEL_STM32L471QE
+    default "stm32l471qg" if CPU_MODEL_STM32L471QG
+    default "stm32l471re" if CPU_MODEL_STM32L471RE
+    default "stm32l471rg" if CPU_MODEL_STM32L471RG
+    default "stm32l471ve" if CPU_MODEL_STM32L471VE
+    default "stm32l471vg" if CPU_MODEL_STM32L471VG
+    default "stm32l471ze" if CPU_MODEL_STM32L471ZE
+    default "stm32l471zg" if CPU_MODEL_STM32L471ZG
+    default "stm32l475rc" if CPU_MODEL_STM32L475RC
+    default "stm32l475re" if CPU_MODEL_STM32L475RE
+    default "stm32l475rg" if CPU_MODEL_STM32L475RG
+    default "stm32l475vc" if CPU_MODEL_STM32L475VC
+    default "stm32l475ve" if CPU_MODEL_STM32L475VE
     default "stm32l475vg" if CPU_MODEL_STM32L475VG
+    default "stm32l476je" if CPU_MODEL_STM32L476JE
+    default "stm32l476jg" if CPU_MODEL_STM32L476JG
+    default "stm32l476me" if CPU_MODEL_STM32L476ME
+    default "stm32l476mg" if CPU_MODEL_STM32L476MG
+    default "stm32l476qe" if CPU_MODEL_STM32L476QE
+    default "stm32l476qg" if CPU_MODEL_STM32L476QG
+    default "stm32l476rc" if CPU_MODEL_STM32L476RC
+    default "stm32l476re" if CPU_MODEL_STM32L476RE
     default "stm32l476rg" if CPU_MODEL_STM32L476RG
+    default "stm32l476vc" if CPU_MODEL_STM32L476VC
+    default "stm32l476ve" if CPU_MODEL_STM32L476VE
     default "stm32l476vg" if CPU_MODEL_STM32L476VG
+    default "stm32l476ze" if CPU_MODEL_STM32L476ZE
+    default "stm32l476zg" if CPU_MODEL_STM32L476ZG
+    default "stm32l486jg" if CPU_MODEL_STM32L486JG
+    default "stm32l486qg" if CPU_MODEL_STM32L486QG
+    default "stm32l486rg" if CPU_MODEL_STM32L486RG
+    default "stm32l486vg" if CPU_MODEL_STM32L486VG
+    default "stm32l486zg" if CPU_MODEL_STM32L486ZG
+    default "stm32l496ae" if CPU_MODEL_STM32L496AE
     default "stm32l496ag" if CPU_MODEL_STM32L496AG
+    default "stm32l496qe" if CPU_MODEL_STM32L496QE
+    default "stm32l496qg" if CPU_MODEL_STM32L496QG
+    default "stm32l496re" if CPU_MODEL_STM32L496RE
+    default "stm32l496rg" if CPU_MODEL_STM32L496RG
+    default "stm32l496ve" if CPU_MODEL_STM32L496VE
+    default "stm32l496vg" if CPU_MODEL_STM32L496VG
+    default "stm32l496ze" if CPU_MODEL_STM32L496ZE
     default "stm32l496zg" if CPU_MODEL_STM32L496ZG
+    default "stm32l4a6ag" if CPU_MODEL_STM32L4A6AG
+    default "stm32l4a6qg" if CPU_MODEL_STM32L4A6QG
+    default "stm32l4a6rg" if CPU_MODEL_STM32L4A6RG
+    default "stm32l4a6vg" if CPU_MODEL_STM32L4A6VG
+    default "stm32l4a6zg" if CPU_MODEL_STM32L4A6ZG
+    default "stm32l4p5ae" if CPU_MODEL_STM32L4P5AE
+    default "stm32l4p5ag" if CPU_MODEL_STM32L4P5AG
+    default "stm32l4p5ce" if CPU_MODEL_STM32L4P5CE
+    default "stm32l4p5cg" if CPU_MODEL_STM32L4P5CG
+    default "stm32l4p5qe" if CPU_MODEL_STM32L4P5QE
+    default "stm32l4p5qg" if CPU_MODEL_STM32L4P5QG
+    default "stm32l4p5re" if CPU_MODEL_STM32L4P5RE
+    default "stm32l4p5rg" if CPU_MODEL_STM32L4P5RG
+    default "stm32l4p5ve" if CPU_MODEL_STM32L4P5VE
+    default "stm32l4p5vg" if CPU_MODEL_STM32L4P5VG
+    default "stm32l4p5ze" if CPU_MODEL_STM32L4P5ZE
+    default "stm32l4p5zg" if CPU_MODEL_STM32L4P5ZG
+    default "stm32l4q5ag" if CPU_MODEL_STM32L4Q5AG
+    default "stm32l4q5cg" if CPU_MODEL_STM32L4Q5CG
+    default "stm32l4q5qg" if CPU_MODEL_STM32L4Q5QG
+    default "stm32l4q5rg" if CPU_MODEL_STM32L4Q5RG
+    default "stm32l4q5vg" if CPU_MODEL_STM32L4Q5VG
+    default "stm32l4q5zg" if CPU_MODEL_STM32L4Q5ZG
+    default "stm32l4r5ag" if CPU_MODEL_STM32L4R5AG
+    default "stm32l4r5ai" if CPU_MODEL_STM32L4R5AI
+    default "stm32l4r5qg" if CPU_MODEL_STM32L4R5QG
+    default "stm32l4r5qi" if CPU_MODEL_STM32L4R5QI
+    default "stm32l4r5vg" if CPU_MODEL_STM32L4R5VG
+    default "stm32l4r5vi" if CPU_MODEL_STM32L4R5VI
+    default "stm32l4r5zg" if CPU_MODEL_STM32L4R5ZG
     default "stm32l4r5zi" if CPU_MODEL_STM32L4R5ZI
+    default "stm32l4r7ai" if CPU_MODEL_STM32L4R7AI
+    default "stm32l4r7vi" if CPU_MODEL_STM32L4R7VI
+    default "stm32l4r7zi" if CPU_MODEL_STM32L4R7ZI
+    default "stm32l4r9ag" if CPU_MODEL_STM32L4R9AG
+    default "stm32l4r9ai" if CPU_MODEL_STM32L4R9AI
+    default "stm32l4r9vg" if CPU_MODEL_STM32L4R9VG
+    default "stm32l4r9vi" if CPU_MODEL_STM32L4R9VI
+    default "stm32l4r9zg" if CPU_MODEL_STM32L4R9ZG
+    default "stm32l4r9zi" if CPU_MODEL_STM32L4R9ZI
+    default "stm32l4s5ai" if CPU_MODEL_STM32L4S5AI
+    default "stm32l4s5qi" if CPU_MODEL_STM32L4S5QI
+    default "stm32l4s5vi" if CPU_MODEL_STM32L4S5VI
+    default "stm32l4s5zi" if CPU_MODEL_STM32L4S5ZI
+    default "stm32l4s7ai" if CPU_MODEL_STM32L4S7AI
+    default "stm32l4s7vi" if CPU_MODEL_STM32L4S7VI
+    default "stm32l4s7zi" if CPU_MODEL_STM32L4S7ZI
+    default "stm32l4s9ai" if CPU_MODEL_STM32L4S9AI
+    default "stm32l4s9vi" if CPU_MODEL_STM32L4S9VI
+    default "stm32l4s9zi" if CPU_MODEL_STM32L4S9ZI

--- a/cpu/stm32/kconfig/wb/Kconfig.lines
+++ b/cpu/stm32/kconfig/wb/Kconfig.lines
@@ -5,11 +5,11 @@
 # directory for more details.
 #
 
-# CPU lines
-config CPU_LINE_STM32WB5MXX
-    bool
-    select CPU_FAM_WB
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
 
+# CPU lines
 config CPU_LINE_STM32WB30XX
     bool
     select CPU_FAM_WB
@@ -23,5 +23,9 @@ config CPU_LINE_STM32WB50XX
     select CPU_FAM_WB
 
 config CPU_LINE_STM32WB55XX
+    bool
+    select CPU_FAM_WB
+
+config CPU_LINE_STM32WB5MXX
     bool
     select CPU_FAM_WB

--- a/cpu/stm32/kconfig/wb/Kconfig.models
+++ b/cpu/stm32/kconfig/wb/Kconfig.models
@@ -5,11 +5,81 @@
 # directory for more details.
 #
 
+# This file was auto-generated from ST ProductsList.xlsx sheet using the
+# script in cpu/stm32/dist/kconfig/gen_kconfig.py
+# See cpu/stm32/dist/kconfig/README.md for details
+
 # CPU models
+config CPU_MODEL_STM32WB30CE
+    bool
+    select CPU_LINE_STM32WB30XX
+
+config CPU_MODEL_STM32WB35CC
+    bool
+    select CPU_LINE_STM32WB35XX
+
+config CPU_MODEL_STM32WB35CE
+    bool
+    select CPU_LINE_STM32WB35XX
+
+config CPU_MODEL_STM32WB50CG
+    bool
+    select CPU_LINE_STM32WB50XX
+
+config CPU_MODEL_STM32WB55CC
+    bool
+    select CPU_LINE_STM32WB55XX
+
+config CPU_MODEL_STM32WB55CE
+    bool
+    select CPU_LINE_STM32WB55XX
+
+config CPU_MODEL_STM32WB55CG
+    bool
+    select CPU_LINE_STM32WB55XX
+
+config CPU_MODEL_STM32WB55RC
+    bool
+    select CPU_LINE_STM32WB55XX
+
+config CPU_MODEL_STM32WB55RE
+    bool
+    select CPU_LINE_STM32WB55XX
+
 config CPU_MODEL_STM32WB55RG
     bool
     select CPU_LINE_STM32WB55XX
 
+config CPU_MODEL_STM32WB55VC
+    bool
+    select CPU_LINE_STM32WB55XX
+
+config CPU_MODEL_STM32WB55VE
+    bool
+    select CPU_LINE_STM32WB55XX
+
+config CPU_MODEL_STM32WB55VG
+    bool
+    select CPU_LINE_STM32WB55XX
+
+config CPU_MODEL_STM32WB55VY
+    bool
+    select CPU_LINE_STM32WB55XX
+
+
 # Configure CPU model
 config CPU_MODEL
+    default "stm32wb30ce" if CPU_MODEL_STM32WB30CE
+    default "stm32wb35cc" if CPU_MODEL_STM32WB35CC
+    default "stm32wb35ce" if CPU_MODEL_STM32WB35CE
+    default "stm32wb50cg" if CPU_MODEL_STM32WB50CG
+    default "stm32wb55cc" if CPU_MODEL_STM32WB55CC
+    default "stm32wb55ce" if CPU_MODEL_STM32WB55CE
+    default "stm32wb55cg" if CPU_MODEL_STM32WB55CG
+    default "stm32wb55rc" if CPU_MODEL_STM32WB55RC
+    default "stm32wb55re" if CPU_MODEL_STM32WB55RE
     default "stm32wb55rg" if CPU_MODEL_STM32WB55RG
+    default "stm32wb55vc" if CPU_MODEL_STM32WB55VC
+    default "stm32wb55ve" if CPU_MODEL_STM32WB55VE
+    default "stm32wb55vg" if CPU_MODEL_STM32WB55VG
+    default "stm32wb55vy" if CPU_MODEL_STM32WB55VY


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This POC PR adds a script that can be used to generate Kconfig.models and Kconfig.lines files of a given STM32 family.
The script uses the cmsis headers directory to get the list of available CPU lines and takes as input one (or several) ST Excel sheets which contains all available CPU models of a given family.

The sheets can be downloaded from [ST website](https://www.st.com/en/microcontrollers-microprocessors/stm32-32-bit-arm-cortex-mcus.html). So this step is kept manual but that's the only one and this something that should be done very rarely.

The script also tries to match all CPU models to existing CPU lines and if it can't find one (that happens unfortunately), the CPU models is directly linked to the CPU family (in Kconfig).

The Python script uses the Jinja2 templating engine to generate the Kconfig file and xlrd to parse the Excel sheets. A documentation is provided in a README.md as well.

All Kconfig files from already supported STM32 families are updated with the script. The CPU model declared for `weact-f411ce` had to be changed from `stm32f411ceu6` to `stm32f411ce` to match the generated files.

Note that there's room to even more increase the level of support thanks to the Excel sheets: available RAM and ROM are also given in the sheet so it could be used to completely replace the Make logic that determine this information when we completely switch to Kconfig.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- A green Murdock

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #14998 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
