### PR TITLE
cpu/nrf52: nrf802154: default to netdev_ieee802154_submac

### DIFF
--- a/cpu/nrf52/Makefile.dep
+++ b/cpu/nrf52/Makefile.dep
@@ -5,6 +5,9 @@ ifneq (,$(filter nrf802154,$(USEMODULE)))
   FEATURES_REQUIRED += radio_nrf802154
   USEMODULE += luid
   USEMODULE += netdev_ieee802154
+  ifeq (,$(filter netdev_ieee802154_legacy,$(USEMODULE)))
+    USEMODULE += netdev_ieee802154_submac
+  endif
 endif
 
 # The nrf52832 requires gpio IRQ with SPI to work around errata 58

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -31,6 +31,9 @@ USEMODULE += netstats_l2
 USEMODULE += netstats_ipv6
 USEMODULE += netstats_rpl
 
+# Uncomment this to enable legacy support of netdev for IEEE 802.15.4 radios.
+# USEMODULE += netdev_ieee802154_legacy
+
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the
 # development process:

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -133,6 +133,7 @@ PSEUDOMODULES += ztimer%
 # ztimer's main module is called "ztimer_core"
 NO_PSEUDOMODULES += ztimer_core
 NO_PSEUDOMODULES += netdev_ieee802154_submac
+NO_PSEUDOMODULES += netdev_ieee802154_legacy
 
 # print ascii representation in function od_hex_dump()
 PSEUDOMODULES += od_string


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The basic nrf802154 driver lacks ACK handling and retransmissions, which degrades it's usefulness.

The 802.15.4 Sub-MAC fixes all those issues.

Enable it by default for this driver to make it better behaved.


### Testing procedure

Benefits are immediately noticeable with `ping`

#### master

```
> 2020-10-01 17:32:20,009 #  ping fe80::d068:7df5:3123:3a22
2020-10-01 17:32:20,023 # 12 bytes from fe80::d068:7df5:3123:3a22%6: icmp_seq=0 ttl=64 rssi=-45 dBm time=5.778 ms
2020-10-01 17:32:20,032 # 12 bytes from fe80::d068:7df5:3123:3a22%6: icmp_seq=0 ttl=64 rssi=-45 dBm time=13.576 ms (DUP!)
2020-10-01 17:32:20,042 # 12 bytes from fe80::d068:7df5:3123:3a22%6: icmp_seq=0 ttl=64 rssi=-45 dBm time=22.072 ms (DUP!)
2020-10-01 17:32:20,049 # 12 bytes from fe80::d068:7df5:3123:3a22%6: icmp_seq=0 ttl=64 rssi=-45 dBm time=30.569 ms (DUP!)
2020-10-01 17:32:21,024 # 12 bytes from fe80::d068:7df5:3123:3a22%6: icmp_seq=1 ttl=64 rssi=-44 dBm time=5.777 ms
2020-10-01 17:32:21,032 # 12 bytes from fe80::d068:7df5:3123:3a22%6: icmp_seq=1 ttl=64 rssi=-44 dBm time=13.579 ms (DUP!)
2020-10-01 17:32:21,040 # 12 bytes from fe80::d068:7df5:3123:3a22%6: icmp_seq=1 ttl=64 rssi=-44 dBm time=22.075 ms (DUP!)
2020-10-01 17:32:21,049 # 12 bytes from fe80::d068:7df5:3123:3a22%6: icmp_seq=1 ttl=64 rssi=-44 dBm time=30.572 ms (DUP!)
2020-10-01 17:32:22,024 # 12 bytes from fe80::d068:7df5:3123:3a22%6: icmp_seq=2 ttl=64 rssi=-45 dBm time=5.777 ms
2020-10-01 17:32:22,024 # 
2020-10-01 17:32:22,027 # --- fe80::d068:7df5:3123:3a22 PING statistics ---
2020-10-01 17:32:22,034 # 3 packets transmitted, 3 packets received, 6 duplicates, 0% packet loss
2020-10-01 17:32:22,038 # round-trip min/avg/max = 5.777/16.641/30.572 ms
```

#### sub-MAC

```
2020-10-01 17:31:32,322 #  ping fe80::d068:7df5:3123:3a22
2020-10-01 17:31:32,337 # 12 bytes from fe80::d068:7df5:3123:3a22%6: icmp_seq=0 ttl=64 rssi=178 dBm time=7.791 ms
2020-10-01 17:31:33,338 # 12 bytes from fe80::d068:7df5:3123:3a22%6: icmp_seq=1 ttl=64 rssi=178 dBm time=8.409 ms
2020-10-01 17:31:34,337 # 12 bytes from fe80::d068:7df5:3123:3a22%6: icmp_seq=2 ttl=64 rssi=178 dBm time=7.129 ms
2020-10-01 17:31:34,337 # 
2020-10-01 17:31:34,342 # --- fe80::d068:7df5:3123:3a22 PING statistics ---
2020-10-01 17:31:34,346 # 3 packets transmitted, 3 packets received, 0% packet loss
2020-10-01 17:31:34,350 # round-trip min/avg/max = 7.129/7.776/8.409 ms
```

This adds 2732 bytes of ROM and 256 bytes of RAM.

### Issues/PRs references

Should probably wait until after the hard feature freeze. 