### PR TITLE
cpu/cc26xx_cc13xx: enable periph clocks on sleep

### DIFF
--- a/cpu/cc26x0/include/cc26x0_prcm.h
+++ b/cpu/cc26x0/include/cc26x0_prcm.h
@@ -341,6 +341,14 @@ typedef struct {
 #define GPIOCLKGR_CLK_EN       0x1
 #define I2CCLKGR_CLK_EN        0x1
 #define UARTCLKGR_CLK_EN_UART0 0x1
+
+#define GPIOCLKGS_CLK_EN       0x1
+#define I2CCLKGS_CLK_EN        0x1
+#define UARTCLKGS_CLK_EN_UART0 0x1
+
+#define GPIOCLKGDS_CLK_EN       0x1
+#define I2CCLKGDS_CLK_EN        0x1
+#define UARTCLKGDS_CLK_EN_UART0 0x1
 /** @} */
 
 /** @ingroup cpu_specific_peripheral_memory_map

--- a/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
+++ b/cpu/cc26x2_cc13x2/include/cc26x2_cc13x2_prcm.h
@@ -354,10 +354,20 @@ typedef struct {
 #define PDSTAT1_RFC_ON      0x4
 #define PDSTAT1_VIMS_ON     0x8
 
-#define GPIOCLKGR_CLK_EN       0x1
-#define I2CCLKGR_CLK_EN        0x1
-#define UARTCLKGR_CLK_EN_UART0 0x1
-#define UARTCLKGR_CLK_EN_UART1 0x2
+#define GPIOCLKGR_CLK_EN        0x1
+#define I2CCLKGR_CLK_EN         0x1
+#define UARTCLKGR_CLK_EN_UART0  0x1
+#define UARTCLKGR_CLK_EN_UART1  0x2
+
+#define GPIOCLKGS_CLK_EN        0x1
+#define I2CCLKGS_CLK_EN         0x1
+#define UARTCLKGS_CLK_EN_UART0  0x1
+#define UARTCLKGS_CLK_EN_UART1  0x2
+
+#define GPIOCLKGDS_CLK_EN       0x1
+#define I2CCLKGDS_CLK_EN        0x1
+#define UARTCLKGDS_CLK_EN_UART0 0x1
+#define UARTCLKGDS_CLK_EN_UART1 0x2
 /** @} */
 
 /** @ingroup cpu_specific_peripheral_memory_map

--- a/cpu/cc26xx_cc13xx/power_arch.c
+++ b/cpu/cc26xx_cc13xx/power_arch.c
@@ -8,6 +8,7 @@
 
 /**
  * @ingroup     cpu_cc26xx_cc13xx
+ *
  * @{
  *
  * @file
@@ -95,31 +96,42 @@ void power_enable_domain(const power_domain_t domain)
 
 void power_clock_enable_gpio(void)
 {
-    PRCM->GPIOCLKGR = GPIOCLKGR_CLK_EN;
+    /* enable clock gates for GPIO peripheral, for run mode
+     * and sleep mode */
+    PRCM->GPIOCLKGR |= GPIOCLKGR_CLK_EN;
+    PRCM->GPIOCLKGS |= GPIOCLKGS_CLK_EN;
 
     prcm_commit();
 }
 
 void power_clock_enable_gpt(uint32_t tim)
 {
+    /* enable clock gates for GPT peripheral, for run mode and sleep mode */
     PRCM->GPTCLKGR |= (1 << tim);
+    PRCM->GPTCLKGS |= (1 << tim);
 
     prcm_commit();
 }
 void power_clock_enable_i2c(void) {
-    PRCM->I2CCLKGR = I2CCLKGR_CLK_EN;
+    /* I2C peripheral is only enabled for run mode as it isn't necessary to
+     * keep it running at sleep or deep sleep, as the I2C interrupt is mainly
+     * for the slave mode ;-) */
+    PRCM->I2CCLKGR |= I2CCLKGR_CLK_EN;
 
     prcm_commit();
 }
 
 void power_clock_enable_uart(uart_t uart)
 {
+    /* enable clock gates for UART peripheral, for run mode and sleep mode. */
     if (uart == 0) {
         PRCM->UARTCLKGR |= UARTCLKGR_CLK_EN_UART0;
+        PRCM->UARTCLKGS |= UARTCLKGS_CLK_EN_UART0;
     }
 #ifdef UARTCLKGR_CLK_EN_UART1
     else if (uart == 1) {
         PRCM->UARTCLKGR |= UARTCLKGR_CLK_EN_UART1;
+        PRCM->UARTCLKGS |= UARTCLKGS_CLK_EN_UART1;
     }
 #endif
 
@@ -128,12 +140,15 @@ void power_clock_enable_uart(uart_t uart)
 
 void power_clock_disable_uart(uart_t uart)
 {
+    /* disable clock gates for UART peripheral, for run and sleep mode */
     if (uart == 0) {
         PRCM->UARTCLKGR &= ~UARTCLKGR_CLK_EN_UART0;
+        PRCM->UARTCLKGS &= ~UARTCLKGS_CLK_EN_UART0;
     }
 #ifdef UARTCLKGR_CLK_EN_UART1
     else if (uart == 1) {
         PRCM->UARTCLKGR &= ~UARTCLKGR_CLK_EN_UART1;
+        PRCM->UARTCLKGS &= ~UARTCLKGS_CLK_EN_UART1;
     }
 #endif
 


### PR DESCRIPTION
### Contribution description

Fixes #15130 .

All registers for the peripherals that RIOT uses from `cc26xx_cc13xx` CPUs were gated only for run mode (normal mode), when entering idle mode the CPU  (`sched_arch_idle`), an interrupt (of the peripherals) would never fire because the peripherals weren't gated for "sleep"/"deepsleep".

### Testing procedure

- `make -C tests/shell flash term BOARD=cc1312-launchpad` and serial communication should work as usual.

### Issues/PRs references

#15130 
