### PR TITLE
dist/codespell: update the list of ignored words and fix all typos

### DIFF
--- a/CODING_CONVENTIONS.md
+++ b/CODING_CONVENTIONS.md
@@ -58,7 +58,7 @@
         uint8_t b;
     } foobar_t;
 ```
-* Use of a seperate line typedef for structs is allowed for forward
+* Use of a separate line typedef for structs is allowed for forward
   declarations, e.g.,
 ```
     typedef struct mystruct mystruct_t;

--- a/LOSTANDFOUND.md
+++ b/LOSTANDFOUND.md
@@ -60,7 +60,7 @@ Reason for removal:
 - board cannot be automatically tested for lack of UART
 - board has many special cases, which hurt upgrade to msp430-elf-gcc 9.x
 - the onboard radio has been unsupported for a while
-- noone seems to use the board, noone seems to maintain it
+- no one seems to use the board, no one seems to maintain it
 
 ### sys/net/gnrc/application_layer/tftp [0e2a62078850e1ecc74db2db4d639cf2d8fb96d3]
 Author:

--- a/boards/dwm1001/doc.txt
+++ b/boards/dwm1001/doc.txt
@@ -9,7 +9,7 @@ The [Devawave DWM1001 development board](https://www.decawave.com/product/dwm100
 includes a DWM1001 module which is based on a Nordic nRF51832 microcontroller.
 This microcontroller is an ARM Cortex-M4 with 64KB of RAM and 512KB of flash
 memory. It also provides in integrated BLE radio.
-The DWM1001 module also contains an UWB tranceiver connected to the
+The DWM1001 module also contains an UWB transceiver connected to the
 microcontroller via SPI (not supported yet).
 
 ## Flash the board

--- a/boards/dwm1001/include/board.h
+++ b/boards/dwm1001/include/board.h
@@ -74,7 +74,7 @@ extern "C" {
 /** @} */
 
 /**
- * @name    DW1000 UWB tranceiver
+ * @name    DW1000 UWB transceiver
  * @{
  */
 #define DW1000_PARAM_SPI_DEV        SPI_DEV(1)

--- a/boards/dwm1001/include/periph_conf.h
+++ b/boards/dwm1001/include/periph_conf.h
@@ -50,7 +50,7 @@ static const spi_conf_t spi_config[] = {
         .miso = GPIO_PIN(0, 6),
         .ppi = 0,
     },
-    {   /* Connected to the DWM1001 UWB tranceiver */
+    {   /* Connected to the DWM1001 UWB transceiver */
         .dev  = NRF_SPIM1,
         .sclk = GPIO_PIN(0, 16),
         .mosi = GPIO_PIN(0, 20),

--- a/boards/limifrog-v1/doc.txt
+++ b/boards/limifrog-v1/doc.txt
@@ -34,7 +34,7 @@ features a variety of sensors as well as an OLED Display and a BLE
 | Reference Manual      | [Reference Manual](http://www.st.com/web/en/resource/technical/document/reference_manual/CD00240193.pdf) |
 | Programming Manual    | [Programming Manual](http://www.st.com/web/en/resource/technical/document/programming_manual/CD00228163.pdf) |
 
-## User Inferface
+## User Interface
 
 2 Buttons:
 

--- a/boards/nrf52dk/doc.txt
+++ b/boards/nrf52dk/doc.txt
@@ -6,7 +6,7 @@
 ## Overview:
 There are some nameless simple development Boards with an nRF52832 available.
 These boards providing access to most SoC ports. There are two buttons (RST,
-KEY), two LED’s (Pin 30, 31), a voltage regulator and a current messurment shunt
+KEY), two LED’s (Pin 30, 31), a voltage regulator and a current measurement shunt
 on board. A serial connection and flashing must be provided by external
 Hardware.
 

--- a/core/include/msg_bus.h
+++ b/core/include/msg_bus.h
@@ -55,10 +55,10 @@ typedef struct {
  *
  * Must be called by the owner of a ``msg_bus_t`` struct.
  *
- * Message busses are considered to be long-running and must be
+ * Message buses are considered to be long-running and must be
  * created before any threads can attach to them.
  *
- * There can be a maximum number of 2047 busses in total.
+ * There can be a maximum number of 2047 buses in total.
  */
 void msg_bus_init(msg_bus_t *bus);
 
@@ -80,7 +80,7 @@ static inline uint8_t msg_bus_get_type(const msg_t *msg)
 /**
  * @brief Check if a message originates from a certain bus
  *
- * If a thread is attached to multiple busses, this function can be used
+ * If a thread is attached to multiple buses, this function can be used
  * to determine if a message originated from a certain bus.
  *
  * @param[in] bus           The bus to check for
@@ -128,7 +128,7 @@ void msg_bus_detach(msg_bus_t *bus, msg_bus_entry_t *entry);
  * Traverse the message bus to find the subscriber entry for the
  * current thread.
  *
- * @param[in] bus           The message bus to seach
+ * @param[in] bus           The message bus to search
  *
  * @return                  The subscriber entry for the current thread.
  *                          NULL if the thread is not attached to @p bus.

--- a/cpu/cc26xx_cc13xx/include/cpu_conf_cc26xx_cc13xx.h
+++ b/cpu/cc26xx_cc13xx/include/cpu_conf_cc26xx_cc13xx.h
@@ -164,7 +164,7 @@ extern "C" {
  *
  * `EXT_LF_CLK.RTC_INCREMENT = 2^38/InputClockFrequency in Hertz`
  *
- * For exmaple:
+ * For example:
  *
  * `RTC_INCREMENT=0x800000` for `InputClockFrequency=32768 Hz`
  */

--- a/cpu/cortexm_common/include/cpu_conf_common.h
+++ b/cpu/cortexm_common/include/cpu_conf_common.h
@@ -79,7 +79,7 @@ extern "C" {
  *
  * Cortex-M CPUs allow interrupt priorities to be arranged in subgroups,
  * meaning that any interrupts on the same subgroup will not
- * pre-empt each other, but those on a lower sub-priority will run
+ * preempt each other, but those on a lower sub-priority will run
  * only once all on the higher sub-priorities have been completed.
  *
  * The usual practice on Cortex-M is to run the PendSV interrupt
@@ -119,10 +119,10 @@ extern "C" {
  * By default, RIOT runs PendSV on the same interrupt priority with all
  * other interrupts.
  *
- * For efficency (or other reasons), one may want to run the PendSV as
+ * For efficiency (or other reasons), one may want to run the PendSV as
  * the last one, just before returning to the (next) thread.  However,
  * since PendSV triggers the RIOT scheduler _without_ interrupts being
- * disabled, any interrupts that pre-empt the scheduler, including the
+ * disabled, any interrupts that preempt the scheduler, including the
  * timer interrupts, must not call anything that may affect the
  * scheduler, such as mutex or scheduler functions.  With the current
  * design of RIOT, writing interrupt handlers in such a manner is not

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -384,7 +384,7 @@ __attribute__((used)) void hard_fault_handler(uint32_t* sp, uint32_t corrupted, 
             /* Print the interrupt number, NMI being -14, hardfault is -13,
              * IRQ0 is 0 and so on */
             uint32_t psr = sp[7];  /* Program status register. */
-            printf("Hard fault occured in ISR number %d\n",
+            printf("Hard fault occurred in ISR number %d\n",
                    (int)(psr & 0xff) - 16);
         }
         puts("Attempting to reconstruct state for debugging...");

--- a/cpu/esp_common/include/esp_common.h
+++ b/cpu/esp_common/include/esp_common.h
@@ -51,7 +51,7 @@ extern "C" {
 #define RTC_DATA_ATTR __attribute__((section(".rtc.data")))
 #endif
 
-/** Print out a message that function is not yet implementd */
+/** Print out a message that function is not yet implemented */
 #define NOT_YET_IMPLEMENTED()     LOG_INFO("%s not yet implemented\n", __func__)
 /** Print out a message that function is not supported */
 #define NOT_SUPPORTED()           LOG_INFO("%s not supported\n", __func__)

--- a/cpu/fe310/periph/i2c.c
+++ b/cpu/fe310/periph/i2c.c
@@ -172,10 +172,10 @@ int i2c_write_bytes(i2c_t dev, uint16_t address, const void *data, size_t length
 static inline int _wait_busy(i2c_t dev, uint32_t max_timeout_counter)
 {
     uint32_t timeout_counter = 0;
-    DEBUG("[i2c] wait for transfert\n");
+    DEBUG("[i2c] wait for transfer\n");
     while (_REG32(i2c_config[dev].addr, I2C_STATUS) & I2C_STATUS_TIP) {
         if (++timeout_counter >= max_timeout_counter) {
-            DEBUG("[i2c] transfert timeout\n");
+            DEBUG("[i2c] transfer timeout\n");
             return -ETIMEDOUT;
         }
         else if ((_REG32(i2c_config[dev].addr, I2C_STATUS) & I2C_STATUS_ALOST) == I2C_STATUS_ALOST) {

--- a/cpu/native/include/async_read.h
+++ b/cpu/native/include/async_read.h
@@ -42,7 +42,7 @@ typedef void (*native_async_read_callback_t)(int fd, void *arg);
  */
 typedef struct {
     pid_t child_pid;                    /**< PID of the interrupt listener */
-    native_async_read_callback_t cb;    /**< Interrupt callback funtion */
+    native_async_read_callback_t cb;    /**< Interrupt callback function */
     void *arg;                          /**< Argument ptr for the callback */
     struct pollfd *fd;                  /**< sysfs gpio fd */
 } async_read_t;

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -589,7 +589,7 @@ static int _config_phy(ieee802154_dev_t *dev, const ieee802154_phy_conf_t *conf)
 
     /* The value of this register represents the frequency offset (in MHz) from
      * 2400 MHz.  Channel 11 (first 2.4 GHz band channel) starts at 2405 MHz
-     * and all channels have a bandwidth of 5 MHz. Thus, we substract 10 to the
+     * and all channels have a bandwidth of 5 MHz. Thus, we subtract 10 to the
      * channel number and multiply by 5 to calculate the offset.
      */
     NRF_RADIO->FREQUENCY = (((uint8_t) conf->channel) - 10) * 5;

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -40,7 +40,7 @@
  * ```
  *
  * This switches the GPIO reads to use the Cortex-M0+ single-cycle I/O port
- * instead of the regular APB acces. The single-cycle I/O port is always used
+ * instead of the regular APB access. The single-cycle I/O port is always used
  * for writes when it is available on the device.
  *
  * @}

--- a/cpu/sam0_common/periph/timer.c
+++ b/cpu/sam0_common/periph/timer.c
@@ -145,7 +145,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
         return -1;
     }
 
-    /* make sure the prescaler is withing range */
+    /* make sure the prescaler is within range */
     if (scale > TC_CTRLA_PRESCALER_DIV1024_Val) {
         DEBUG("[timer %d] scale %d is out of range\n", tim, scale);
         return -1;

--- a/dist/tools/codespell/ignored_words.txt
+++ b/dist/tools/codespell/ignored_words.txt
@@ -16,3 +16,88 @@ dout
 
 # ALS (Ambient Light Sensing) => ALSO
 als
+
+# Technik (From "Beuth Hochschule für Technik Berlin") => Technique
+technik
+
+# inout (Doxygen input/output param) => input, in out
+inout
+
+# OT (OpenThread) => TO, OF, OR
+ot
+
+# fo  (fragment offset) => of, for
+fo
+
+# AACK (802.15.4 Auto ACK) => ACK
+aack
+
+# pres (variable used for pressure measurement) => press
+pres
+
+# tHW (concatenation of \t and HW) => the, thaw
+thw
+
+# tThe (concatenation of \t and The) => the
+tthe
+
+# HSI (High Speed Internal oscillator) => HIS
+hsi
+
+# hart (RISC-V hart) => heart, harm
+hart
+
+# produkt (used in an url) => product
+produkt
+
+# BORD (a define in arm7_common) => BOARD, BORED, BORDER
+bord
+
+# PTD (a define in kinetis) => PDF
+ptd
+
+# THRE (a register of AVR UART peripheral) => THREE, THERE, THEIR, THE
+thre
+
+# UE (a register of AVR UART peripheral) => USE, DUE
+ue
+
+# BA (an hexadecimal value in tests-hashes-sha1.c) => BY, BE
+ba
+
+# doesnt (used in a test string in tests-crypto-modes-ccm.c) => doesn't, does not
+doesnt
+
+# creat (a POSIX fnctl function name) => create
+creat
+
+# Manal (firstname of a contributor) => Manual
+manal
+
+# ths (a variable name in thread_cooperation/main.c) => the, this
+ths
+
+# te, hel (partial words used in shell test script) => the, be, help, hell, heal
+te
+hel
+
+# GUAs (Global Unicast Address) => gauss
+guas
+
+# extint (variable for external interrupt) => extinct, extant
+extint
+
+# ser (variable name in espreset.py script) => set
+ser
+
+# keypair (function name used in qdsa test) => key pair
+keypair
+
+# comprE (RPL number of prefix octets) => compare, compère
+compre
+
+# files' (when files is the last word in string, between quotes) => file's
+files'
+
+# dedup (used in a GNRC header file name) => dedupe
+dedup

--- a/dist/tools/suit/suit-manifest-generator/suit_tool/argparser.py
+++ b/dist/tools/suit/suit-manifest-generator/suit_tool/argparser.py
@@ -54,7 +54,7 @@ class MainArgumentParser(object):
 
         # create_parser.add_argument('-v', '--manifest-version', choices=['1'], default='1')
         create_parser.add_argument('-i', '--input-file', metavar='FILE', type=argparse.FileType('r'),
-            help='An input file describing the update. The file must be formated as JSON. The overal structure is described in README.')
+            help='An input file describing the update. The file must be formatted as JSON. The overal structure is described in README.')
         create_parser.add_argument('-o', '--output-file', metavar='FILE', type=argparse.FileType('wb'), required=True)
         create_parser.add_argument('-f', '--format', metavar='FMT', choices=['suit', 'suit-debug', 'json'], default='suit')
         create_parser.add_argument('-s', '--severable', action='store_true', help='Convert large elements to severable fields.')

--- a/dist/tools/suit/suit-manifest-generator/suit_tool/compile.py
+++ b/dist/tools/suit/suit-manifest-generator/suit_tool/compile.py
@@ -373,7 +373,6 @@ def compile_manifest(options, m):
                 'command-arg' : None
             }))
         else:
-            te = []
             for c in bootable_components:
                 pass
                 # TODO: conditions

--- a/doc/doxygen/src/advanced-build-system-tricks.md
+++ b/doc/doxygen/src/advanced-build-system-tricks.md
@@ -177,7 +177,7 @@ Documentation:
 
 This is a simpler approach to the above mentioned issue. The solution here only
 uses a makefile script for selecting the debugger and serial port. No
-adminstrative privileges (e.g. to configure Udev) are required.
+administrative privileges (e.g. to configure Udev) are required.
 
 One of the limitations of the solution described here is that it currently
 doesn't work with multiple boards of the same type. This limitation is a

--- a/doc/doxygen/src/kconfig/kconfig.md
+++ b/doc/doxygen/src/kconfig/kconfig.md
@@ -100,7 +100,7 @@ The integration of Kconfig into the build system is mainly done in
 
 ## Steps during the build process                {#kconfig-steps-build-process}
 
-![Ouput of every step of the build process](kconfig_integration.svg)
+![Output of every step of the build process](kconfig_integration.svg)
 
 ### 0. Module dependency resolution
 Currently, the resolution of module dependencies is performed by the build

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -832,7 +832,7 @@ static void _isr(netdev_t *netdev)
  */
 #if AT86RF2XX_HAVE_RETRIES
 ISR(TRX24_TX_START_vect){
-    /* __enter_isr(); is not neccessary as there is nothing which causes a
+    /* __enter_isr(); is not necessary as there is nothing which causes a
      * thread_yield and the interrupt can not be interrupted by an other ISR */
 
     at86rf2xx_t *dev = (at86rf2xx_t *) at86rfmega_dev;

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -83,7 +83,7 @@
  * @brief  Maximum transmission time
  *
  * The time in us that is required to send an Ethernet frame of maximum length
- * (Preamle + SFD + 1518 byte) at 10 Mbps in full duplex mode with a guard
+ * (Preamble + SFD + 1518 byte) at 10 Mbps in full duplex mode with a guard
  * period of 9,6 us. This time is used as time out for send operations.
  */
 #define MAX_TX_TIME                 (1230U)

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -32,7 +32,7 @@
  * application. This allows to @ref at_add_urc "register" and
  * @ref at_remove_urc "de-register" URC strings to check. Later,
  * @ref at_process_urc can be called to check if any of the registered URCs have
- * been detected. If a registered URC has been detected the correspondant
+ * been detected. If a registered URC has been detected the correspondent
  * @ref at_urc_t::cb "callback function" is called. The mode of operation
  * requires that the user of the module processes periodically the URCs.
  *

--- a/drivers/include/ina3221.h
+++ b/drivers/include/ina3221.h
@@ -53,7 +53,7 @@
  *              low.
  *
  *              For all enabled channels (1 <= i <= INA3221_NUM_CH),
- *              the time to complete a full measurment cycle is:
+ *              the time to complete a full measurement cycle is:
  *
  *              num_samples * (shunt_conv_time_ch_i + bus_voltage_conv_time_ch_i)
  *
@@ -369,7 +369,7 @@ int _ina3221_enable_alert(ina3221_t *dev, ina3221_alert_t alert,
 
 /**
  * @brief   Wrapper around @see _ina3221_enable_alert, to
- *          enble warning alert
+ *          enable warning alert
  *
  * @param[in,out] dev       Device handle
  * @param[in] cb            Alert callback

--- a/drivers/include/lc709203f.h
+++ b/drivers/include/lc709203f.h
@@ -311,7 +311,7 @@ void lc709203f_set_rsoc_initial(const lc709203f_t *dev);
  * @param[in] *dev		pointer to lc709203f_t struct containing the i2c device and the address
  * @param[in] value		temp in 0.1K 0xAAC=0°C
  *
- * @return              LC709203F_CELL_TEMP_INVALID Invlid cell temp
+ * @return              LC709203F_CELL_TEMP_INVALID Invalid cell temp
 
  */
 int8_t lc709203f_set_cell_temp(const lc709203f_t *dev, const unsigned int value);

--- a/drivers/include/ltc4150.h
+++ b/drivers/include/ltc4150.h
@@ -153,7 +153,7 @@ typedef struct {
     /**
      * @brief Pin indicating (dis-)charging, labeled POL
      *
-     * Set this pin to `GPIO_UNDEF` to tread every pulse as discharging. This
+     * Set this pin to `GPIO_UNDEF` to treat every pulse as discharging. This
      * pin is pulled low by the LTC4150 in case the battery is discharging.
      */
     gpio_t polarity;

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -197,7 +197,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
 /**
  * @brief   Enable pin interrupt if configured as interrupt source
  *
- *          Interrupts that would have occured after @see gpio_irq_disable
+ *          Interrupts that would have occurred after @see gpio_irq_disable
  *          was called will be discarded.
  *
  * @note    You have to add the module `periph_gpio_irq` to your project to

--- a/drivers/include/pir.h
+++ b/drivers/include/pir.h
@@ -123,7 +123,7 @@ pir_event_t pir_get_status(const pir_t *dev);
 int pir_get_occupancy(pir_t *dev, int16_t *occup);
 
 /**
- * @brief   Register a thread for notification whan state changes on the
+ * @brief   Register a thread for notification when state changes on the
  *          motion sensor.
  *
  * @note

--- a/drivers/mtd_mci/mtd_mci.c
+++ b/drivers/mtd_mci/mtd_mci.c
@@ -31,7 +31,7 @@
 
 #define min(a, b) ((a) > (b) ? (b) : (a))
 
-/* MCI driver only suports whole page reads / writes */
+/* MCI driver only supports whole page reads / writes */
 static uint8_t _page_buffer[SD_HC_BLOCK_SIZE];
 
 static int mtd_mci_init(mtd_dev_t *dev)

--- a/pkg/nimble/netif/include/nimble_netif.h
+++ b/pkg/nimble/netif/include/nimble_netif.h
@@ -121,7 +121,7 @@ enum {
 typedef enum {
     NIMBLE_NETIF_ACCEPTING,         /**< accepting incoming connections */
     NIMBLE_NETIF_ACCEPT_STOP,       /**< stop accepting incoming connections */
-    NIMBLE_NETIF_INIT_MASTER,       /**< conn. procedure started (as mater) */
+    NIMBLE_NETIF_INIT_MASTER,       /**< conn. procedure started (as master) */
     NIMBLE_NETIF_INIT_SLAVE,        /**< conn. procedure started (as slave) */
     NIMBLE_NETIF_CONNECTED_MASTER,  /**< connection established as master */
     NIMBLE_NETIF_CONNECTED_SLAVE,   /**< connection established as slave */

--- a/pkg/nordic_softdevice_ble/README-BLE-6LoWPAN.md
+++ b/pkg/nordic_softdevice_ble/README-BLE-6LoWPAN.md
@@ -1,4 +1,4 @@
-This README contains information how to establish an IPv6 connecton between
+This README contains information how to establish an IPv6 connection between
 Linux BLE router and an IPSP enabled BLE device.
 
 Prerequisites

--- a/pkg/wakaama/include/lwm2m_client_config.h
+++ b/pkg/wakaama/include/lwm2m_client_config.h
@@ -183,7 +183,7 @@ extern "C" {
 #define CONFIG_LWM2M_DEVICE_BINDING_US
 
 /**
- * @brief UDP and SMS bindins with Queue mode
+ * @brief UDP and SMS bindings with Queue mode
  */
 #define CONFIG_LWM2M_DEVICE_BINDING_UQS
 #endif

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -1982,8 +1982,8 @@ API Changes
 - static inline int ipv6_addr_split_iface(char *addr_str)
 + static inline char *ipv6_addr_split_iface(char *addr_str)
 
-- int ipv6_addr_split(char *addr_str, char seperator, int _default);
-+ int ipv6_addr_split_int(char *addr_str, char seperator, int _default);
+- int ipv6_addr_split(char *addr_str, char separator, int _default);
++ int ipv6_addr_split_int(char *addr_str, char separator, int _default);
 + char *ipv6_addr_split_str(char *addr_str, char separator);
 
 /* change address getter and setter functions to avoid byte order confusion */
@@ -2857,7 +2857,7 @@ Networking
     * gnrc_ipv6_nib: add address from netif to address validation timer
     + netdev_ieee802154: add txpower and page
     + net/lorawan/hdr: add lorawan header helpers
-    + ble/nimble: add support for build-in IPSS service
+    + ble/nimble: add support for built-in IPSS service
     * pkg/semtech-loramac: rework interaction with the MAC
     * pkg/semtech-loramac: provide basic persistence for MAC state
     * RPL: API update suggestions
@@ -3082,7 +3082,7 @@ Networking related issues
 #11859: examples: dtls-echo fails silently when DTLS_ECC flag enabled
 #11519: shell/ping6: Incorrect handling of unexpected pongs
 #11405: nrfmin: communication not possible after multicast ping with no interval
-#11390: gnrc networking crashs on nRF51dk
+#11390: gnrc networking crashes on nRF51dk
 #11212: POSIX sockets + lwIP: bad file descriptor
 #11033: 6lo: RIOT does not receive packets from Linux when short_addr is set
 #10969: net: netdev_driver_t::send() doc unclear
@@ -4309,7 +4309,7 @@ Networking related issues
 #7474: 6lo: gnrc fragmentation expects driver to block on TX
 #7737: pkg: libcoap is partially broken and outdated
 #8086: gnrc_rpl_p2p: not compiling
-#8130: gcoap: can't build witth network stacks other than gnrc
+#8130: gcoap: can't build with network stacks other than gnrc
 #8172: gnrc_netif, gnrc_uhcpc: Replacing prefix on border router results in no
        configured prefix
 #8271: app/netdev: application stops working after receiving frames with
@@ -4401,7 +4401,7 @@ Fixed Issues from the last release (2018.07)
 #9573: pkg/lwip: assert on samr21-xpro
 #9584: drivers/cc2420: add netopt NETOPT_MAX_PACKET_SIZE
 #6437: periph/spi: Leftovers from SPI rework in #4780
-#6650: GPIO Port shift in cc2538 is unconsistent
+#6650: GPIO Port shift in cc2538 is inconsistent
 #6836: Issuing a reboot on ATmega328p makes the board loop-reboot
 #7846: stm32f1: I2C read functions return bogus values with unconnected devices
 #9616: at86rf2xx: can not correctly set channel after `NETOPT_STATE_RESET`
@@ -4602,7 +4602,7 @@ Networking related issues
 #7474: 6lo: gnrc fragmentation expects driver to block on TX
 #7737: pkg: libcoap is partially broken and outdated
 #8086: gnrc_rpl_p2p: not compiling
-#8130: gcoap: can't build witth network stacks other than gnrc
+#8130: gcoap: can't build with network stacks other than gnrc
 #8172: gnrc_netif, gnrc_uhcpc: Replacing prefix on border router results in no
        configured prefix
 #8271: app/netdev: application stops working after receiving frames with
@@ -4651,7 +4651,7 @@ Other platforms related issues
 #6437: periph/spi: Leftovers from SPI rework in #4780
 #6567: periph/spi: Switching between CPOL=0,1 problems on Kinetis with software
        CS
-#6650: GPIO Port shift in cc2538 is unconsistent
+#6650: GPIO Port shift in cc2538 is inconsistent
 #6838: Issuing a reboot on ATmega328p makes the board loop-reboot
 #6874: SAMD21: possible CMSIS bug
 #7020: isr_rfcoreerrors while pinging between CC2538DKs
@@ -5201,7 +5201,7 @@ Networking related issues
        network interfaces need to get unlocked in the current implementation to not get deadlocked.
        Recursive mutexes as provided in #5731 might help to solve this problem.
 #5748: gnrc: nodes crashing with too small packet buffer: A packet buffer of size ~512 B might lead
-       to crashes. The issue describes this for several hundret nodes, but agressive flooding with
+       to crashes. The issue describes this for several hundred nodes, but aggressive flooding with
        just two nodes was also shown to lead to this problem.
 #5858: gnrc: 6lo: potential problem with reassembly of fragments: If one frame gets lost the reassembly
        state machine might get out of sync
@@ -5258,7 +5258,7 @@ other platform related issues
        some pin configurations might get lost.
 #5009: RIOT is saw-toothing in energy consumption (even when idling)
 #5103: xtimer: weird behavior of tests/xtimer_drift: xtimer_drift randomly jumps a few seconds on nrf52
-#5405: Eratic timings on iotlab-m3 with compression context activated
+#5405: Erratic timings on iotlab-m3 with compression context activated
 #5486: at86rf2xx: lost interrupts
 #5678: at86rf2xx: failed assertion in _isr
 #5944: msp430: ipv6_hdr unittests fail
@@ -5689,7 +5689,7 @@ Drivers
 + SD Card driver (SPI)
 + NXP PN532 NFC driver
 + Initial (experimental) Microchip MRF24J40 radio driver
-+ JEDEC JC42.4 temperatur sensors
++ JEDEC JC42.4 temperature sensors
 + Bosch BME280 pressure, humidity and temperature sensor
 * NXP MMA8x5x accelerometer (previously MMA8652)
 * Unified STM32 RTC driver
@@ -5741,7 +5741,7 @@ Networking related issues
        network interfaces need to get unlocked in the current implementation to not get deadlocked.
        Recursive mutexes as provided in #5731 might help to solve this problem.
 #5748: gnrc: nodes crashing with too small packet buffer: A packet buffer of size ~512 B might lead
-       to crashes. The issue describes this for several hundret nodes, but agressive flooding with
+       to crashes. The issue describes this for several hundred nodes, but aggressive flooding with
        just two nodes was also shown to lead to this problem.
 #5858: gnrc: 6lo: potential problem with reassembly of fragments: If one frame gets lost the reassembly
        state machine might get out of sync
@@ -5808,7 +5808,7 @@ other platform related issues
 #5009: RIOT is saw-toothing in energy consumption (even when idling)
 #5103: xtimer: weird behavior of tests/xtimer_drift: xtimer_drift randomly jumps a few seconds on nrf52
 #5361: cpu/cc26x0: timer broken
-#5405: Eratic timings on iotlab-m3 with compression context activated
+#5405: Erratic timings on iotlab-m3 with compression context activated
 #5460: cpu/samd21: i2c timing with compiler optimization
 #5486: at86rf2xx: lost interrupts
 #5489: cpu/lpc11u34: ADC broken
@@ -6041,7 +6041,7 @@ Networking related issues
        provided in #5731 might help to solve this problem.
 #5748: gnrc: nodes crashing with too small packet buffer: A packet buffer of
        size ~512 B might lead to crashes. The issue describes this for several
-       hundret nodes, but agressive flooding with just two nodes was also
+       hundred nodes, but aggressive flooding with just two nodes was also
        shown to lead to this problem.
 #5858: gnrc: 6lo: potential problem with reassembly of fragments: If one frame
        gets lost the reassembly state machine might get out of sync
@@ -6091,7 +6091,7 @@ native related issues
 
 other platform related issues
 -----------------------------
-#1891: newlib-nano: Printf formatting does not work properly for some numberic
+#1891: newlib-nano: Printf formatting does not work properly for some numeric
        types: PRI[uxdi]64, PRI[uxdi]8 and float are not parsed in newlib-nano
 #2006: cpu/nrf51822: timer callback may be fired too early
 #2143: unittests: tests-core doesn't compile for all platforms: GCC build-ins
@@ -6113,7 +6113,7 @@ other platform related issues
 #5103: xtimer: weird behavior of tests/xtimer_drift: xtimer_drift randomly
        jumps a few seconds on nrf52
 #5361: cpu/cc26x0: timer broken
-#5405: Eratic timings on iotlab-m3 with compression context activated
+#5405: Erratic timings on iotlab-m3 with compression context activated
 #5460: cpu/samd21: i2c timing with compiler optimization
 #5486: at86rf2xx: lost interrupts
 #5489: cpu/lpc11u34: ADC broken
@@ -6489,7 +6489,7 @@ Drivers
 + AES encryption for xbee radio driver
 + added ADC mapping to SAUL
 
-Sytem libraries
+System libraries
 ---
 - vtimer support was dropped completely and removed
 
@@ -7337,7 +7337,7 @@ other issues:
 --------------
 #1449: a removed vtimer might still get called back by hwtimer
     The timer callback might still fire even after vtimer_remove() was called.
-#2175: valgrind registeres "Invalid write of size 4" in unittests for ubjson
+#2175: valgrind registers "Invalid write of size 4" in unittests for ubjson
      According to valgrind the stack gets corrupted in UBJSON.
 
 For all issues and open pull requests please check the RIOT issue tracker:

--- a/sys/arduino/include/wireport.hpp
+++ b/sys/arduino/include/wireport.hpp
@@ -75,7 +75,7 @@ class TwoWire
     static uint8_t rxBufferIndex;   /**< index for RX buffer read */
     static uint8_t rxBufferLength;  /**< number of bytes in RX buffer */
 
-    static uint8_t txAddress;       /**< adress for transfer */
+    static uint8_t txAddress;       /**< address for transfer */
     static uint8_t txBuffer[];      /**< TX buffer */
     static uint8_t txBufferIndex;   /**< index for TX buffer write */
     static uint8_t txBufferLength;  /**< number of bytes in TX buffer */

--- a/sys/can/device.c
+++ b/sys/can/device.c
@@ -503,7 +503,7 @@ int can_device_calc_bittiming(uint32_t clock, const struct can_bittiming_const *
          tseg >= timing_const->tseg1_min + timing_const->tseg2_min; tseg--) {
         uint32_t nbt = tseg + CAN_SYNC_SEG;
 
-        /* theoritical brp */
+        /* theoretical brp */
         uint32_t brp = clock / (timing->bitrate * nbt);
         /* brp according to brp_inc */
         brp = (brp / timing_const->brp_inc) * timing_const->brp_inc;

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -76,7 +76,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Per-Interface Event Message Busses
+ * @brief   Per-Interface Event Message Buses
  */
 typedef enum {
 #ifdef MODULE_GNRC_IPV6

--- a/sys/include/net/gnrc/netif/lorawan.h
+++ b/sys/include/net/gnrc/netif/lorawan.h
@@ -45,7 +45,7 @@ typedef struct {
     uint8_t datarate;                       /**< LoRaWAN datarate for the next transmission */
     uint8_t port;                           /**< LoRaWAN port for the next transmission */
     uint8_t ack_req;                        /**< Request ACK in the next transmission */
-    uint8_t otaa;                           /**< wether the next transmission is OTAA or not */
+    uint8_t otaa;                           /**< whether the next transmission is OTAA or not */
 } gnrc_netif_lorawan_t;
 
 #ifdef __cplusplus

--- a/sys/include/net/gnrc/tcp.h
+++ b/sys/include/net/gnrc/tcp.h
@@ -58,7 +58,7 @@ typedef struct {
  * @param[in]     addr        Address for endpoint.
  * @param[in]     addr_size   Size of @p addr.
  * @param[in]     port        Port number for endpoint.
- * @param[in]     netif       Network inferface to use.
+ * @param[in]     netif       Network interface to use.
  *
  * @return   0 on success.
  * @return   -EAFNOSUPPORT if @p address_family is not supported.

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -410,7 +410,7 @@ static inline bool xtimer_less64(xtimer_ticks64_t a, xtimer_ticks64_t b);
  * @param[in]    us     timeout in microseconds relative
  *
  * @return       0, when returned after mutex was locked
- * @return       -1, when the timeout occcured
+ * @return       -1, when the timeout occurred
  */
 int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us);
 
@@ -421,7 +421,7 @@ int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us);
  * @param[in]    us     timeout in microseconds relative
  *
  * @return       0, when returned after rmutex was locked
- * @return       -1, when the timeout occcured
+ * @return       -1, when the timeout occurred
  */
 int xtimer_rmutex_lock_timeout(rmutex_t *rmutex, uint64_t us);
 

--- a/sys/include/zptr.h
+++ b/sys/include/zptr.h
@@ -12,7 +12,7 @@
  * @brief       Provides 32bit -> 16bit pointer compression
  *
  * On many platforms, some pointers may have to be aligned, e.g., to 4 byte
- * bounderies.
+ * boundaries.
  * On 32bit platforms, that makes it possible to store all possible aligned
  * 32bit pointers in a 16bit value as long as the total memory is small (e.g.,
  * with 4 byte alignment, all pointers within 256kb RAM can be represented by a
@@ -83,7 +83,7 @@ typedef uint16_t zptr_t;
 #define ZPTR_MAX_ADDR   ((uintptr_t)ZPTR_BASE + (1 << 18))
 
 /**
- * @brief Determine if a pointer is compressable by zptrc()
+ * @brief Determine if a pointer is compressible by zptrc()
  * @param[in]   pointer     pointer to check
  * @returns     1 if pointer can be compressed, 0 if not
  */
@@ -98,7 +98,7 @@ static inline int zptr_check(void *pointer)
 /**
  * @brief Compress a pointer (if possible)
  *
- * Substracts ZPTR_BASE, then right-shifts @p pointer by two.
+ * Subtracts ZPTR_BASE, then right-shifts @p pointer by two.
  *
  * @param[in]   pointer     pointer to compress
  * @returns     compressed pointer

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -234,7 +234,7 @@ void _handle_snd_ns(_nib_onl_entry_t *nbr)
             /* intentionally falls through */
         case GNRC_IPV6_NIB_NC_INFO_NUD_STATE_UNREACHABLE:
             if (!IS_ACTIVE(CONFIG_GNRC_IPV6_NIB_6LR) ||
-                /* if neighbor is a 6LoWPAN node (i.e. address registartion
+                /* if neighbor is a 6LoWPAN node (i.e. address registration
                  * state is non-garbage-collectible), only probe if it is a
                  * router (where the solicited-nodes multicast address MUST
                  * be set; only MAY otherwise).

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -148,7 +148,7 @@ static uint16_t _send_1st_fragment(gnrc_netif_t *iface,
      * datagram_size: size of the uncompressed IPv6 packet */
     int payload_diff = _payload_diff(fbuf, payload_len);
     uint16_t local_offset;
-    /* virtually add payload_diff to flooring to account for offset (must be divisable by 8)
+    /* virtually add payload_diff to flooring to account for offset (must be dividable by 8)
      * in uncompressed datagram */
     uint16_t max_frag_size = _floor8(_max_frag_size(iface, fbuf) +
                                      payload_diff - sizeof(sixlowpan_frag_t)) -

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
@@ -306,7 +306,7 @@ static int _fsm_call_recv(gnrc_tcp_tcb_t *tcb, void *buf, size_t len)
     if (ringbuffer_get_free(&tcb->rcv_buf) >= CONFIG_GNRC_TCP_MSS) {
         tcb->rcv_wnd = ringbuffer_get_free(&(tcb->rcv_buf));
 
-        /* Send ACK to anounce window update */
+        /* Send ACK to announce window update */
         gnrc_pktsnip_t *out_pkt = NULL;
         uint16_t seq_con = 0;
         _pkt_build(tcb, &out_pkt, &seq_con, MSK_ACK, tcb->snd_nxt, tcb->rcv_nxt, NULL, 0);

--- a/sys/posix/pthread/pthread_tls.c
+++ b/sys/posix/pthread/pthread_tls.c
@@ -182,7 +182,7 @@ void __pthread_keys_exit(int self_id)
 {
     tls_data_t **tls = __pthread_get_tls_head(self_id);
 
-    /* Calling the dtor could cause another pthread_exit(), so we dehead and free defore calling it. */
+    /* Calling the dtor could cause another pthread_exit(), so we dehead and free before calling it. */
     mutex_lock(&tls_mutex);
     for (tls_data_t *specific; (specific = *tls); ) {
         *tls = specific->next;

--- a/sys/shell/commands/sc_sht1x.c
+++ b/sys/shell/commands/sc_sht1x.c
@@ -189,7 +189,7 @@ int _sht_config_handler(int argc, char **argv)
                "\n"
                "  -r l/h\n"
                "    Set resolution to low/high. Low resolution trades "
-               "presicion for speed\n"
+               "precision for speed\n"
                "\n"
                "  -H y/n\n"
                "    Turns heater on/off. Can increase temperature by up to "

--- a/sys/ztimer/core.c
+++ b/sys/ztimer/core.c
@@ -13,7 +13,7 @@
  * @{
  *
  * @file
- * @brief       ztimer core functinality
+ * @brief       ztimer core functionality
  *
  * This file contains ztimer's main API implementation and functionality
  * present in all ztimer clocks (most notably multiplexing ant extension).

--- a/tests/bench_xtimer/README.md
+++ b/tests/bench_xtimer/README.md
@@ -14,7 +14,7 @@ actually triggers.
 
 ### set() one
 
-This repeatedly sets one timer in an otherwise emtpy list.
+This repeatedly sets one timer in an otherwise empty list.
 All but the first iteration will cause xtimer to implicitly remove the timer
 first.
 All iterations will cause the underlying periph timer to be updated.

--- a/tests/driver_ina3221/main.c
+++ b/tests/driver_ina3221/main.c
@@ -27,7 +27,7 @@
 #include "ina3221_params.h"
 #include "ina3221.h"
 
-/* Issue critical alert if shunt voltage is above thist value */
+/* Issue critical alert if shunt voltage is above this value */
 #define CRIT_ALERT_LIM_UV      (2500)
 /* Issue warning alert if shunt voltage is above this value */
 #define WARN_ALERT_LIM_UV      (1600)

--- a/tests/gnrc_dhcpv6_client_6lbr/README.md
+++ b/tests/gnrc_dhcpv6_client_6lbr/README.md
@@ -22,7 +22,7 @@ frames to properly communicate over the TAP interface.
 
 The tests succeeds if you see the string `SUCCESS`.
 
-If any problems are encountered (i.e. if the test prints the sting `FAILED`),
+If any problems are encountered (i.e. if the test prints the string `FAILED`),
 set the echo parameter in the `run()` function at the bottom of the test script
 (tests/01-run.py) to `True`. The test script will then offer a more detailed
 output.

--- a/tests/gnrc_ipv6_ext/README.md
+++ b/tests/gnrc_ipv6_ext/README.md
@@ -24,7 +24,7 @@ frames to properly communicate over the TAP interface.
 
 The tests succeeds if you see the string `SUCCESS`.
 
-If any problems are encountered (i.e. if the test prints the sting `FAILED`),
+If any problems are encountered (i.e. if the test prints the string `FAILED`),
 set the echo parameter in the `run()` function at the bottom of the test script
 (tests/01-run.py) to `True`. The test script will then offer a more detailed
 output.

--- a/tests/gnrc_ipv6_ext_frag/README.md
+++ b/tests/gnrc_ipv6_ext_frag/README.md
@@ -24,7 +24,7 @@ frames to properly communicate over the TAP interface.
 
 The tests succeeds if you see the string `SUCCESS`.
 
-If any problems are encountered (i.e. if the test prints the sting `FAILED`),
+If any problems are encountered (i.e. if the test prints the string `FAILED`),
 set the echo parameter in the `run()` function at the bottom of the test script
 (tests/01-run.py) to `True`. The test script will then offer a more detailed
 output.

--- a/tests/gnrc_ipv6_ext_opt/README.md
+++ b/tests/gnrc_ipv6_ext_opt/README.md
@@ -25,7 +25,7 @@ frames to properly communicate over the TAP interface.
 
 The tests succeeds if you see the string `SUCCESS`.
 
-If any problems are encountered (i.e. if the test prints the sting `FAILED`),
+If any problems are encountered (i.e. if the test prints the string `FAILED`),
 set the echo parameter in the `run()` function at the bottom of the test script
 (tests/01-run.py) to `True`. The test script will then offer a more detailed
 output.

--- a/tests/gnrc_rpl_srh/README.md
+++ b/tests/gnrc_rpl_srh/README.md
@@ -22,7 +22,7 @@ frames to properly communicate over the TAP interface.
 
 The tests succeeds if you see the string `SUCCESS`.
 
-If any problems are encountered (i.e. if the test prints the sting `FAILED`),
+If any problems are encountered (i.e. if the test prints the string `FAILED`),
 set the echo parameter in the `run()` function at the bottom of the test script
 (tests/01-run.py) to `True`. The test script will then offer a more detailed
 output.

--- a/tests/od/main.c
+++ b/tests/od/main.c
@@ -29,7 +29,7 @@ static const char long_str[] = "\xff,a\xff.bcdefghijklmnop";
 
 int main(void)
 {
-    /* test data width vs. output width discrepency */
+    /* test data width vs. output width discrepancy */
     CALL(od_hex_dump(short_str, sizeof(short_str), OD_WIDTH_DEFAULT));
 
     /* Test different output width in default configuration*/

--- a/tests/periph_i2c/main.c
+++ b/tests/periph_i2c/main.c
@@ -42,7 +42,7 @@
 
 #define ARG_ERROR       (-1)
 
-/* i2c_buf is global to reduce stack memory consumtion */
+/* i2c_buf is global to reduce stack memory consumption */
 static uint8_t i2c_buf[BUFSIZE];
 
 static inline void _print_i2c_read(i2c_t dev, uint16_t *reg, uint8_t *buf,

--- a/tests/sys_crypto/tests-crypto-modes-ccm.c
+++ b/tests/sys_crypto/tests-crypto-modes-ccm.c
@@ -892,7 +892,7 @@ static const size_t TEST_WYCHEPROOF_28_EXPECTED_LEN = 63;
 
 
 /* Manually created test vectors */
-/* This is neccessary, because no test vectors are published with input length > 256 */
+/* This is necessary, because no test vectors are published with input length > 256 */
 /* Data has been verified against BouncyCastle (.NET Core) and pycryptodome */
 
 static const uint8_t TEST_MANUAL_01_KEY[] = {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR updates the codespell list of ignored words so all (current) false positives are removed. It also fixes all other real typos raised by the tool.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Run `./dist/tools/codespell/check.sh`. With this PR, you get an empty output (no typo found)

<details><summary>master</summary>

```
$ ./dist/tools/codespell/check.sh
There are typos in the following files:

CODING_CONVENTIONS.md:61: seperate ==> separate
LOSTANDFOUND.md:63: noone ==> no one
LOSTANDFOUND.md:63: noone ==> no one
boards/common/stm32/include/f0/cfg_clock_default.h:34: HSI ==> HIS
boards/common/stm32/include/f0/cfg_clock_default.h:63: HSI ==> HIS
boards/common/stm32/include/f0/cfg_clock_default.h:88: HSI ==> HIS
boards/common/stm32/include/f0/cfg_clock_default.h:115: HSI ==> HIS
boards/common/stm32/include/f1f3/cfg_clock_default.h:39: HSI ==> HIS
boards/common/stm32/include/f1f3/cfg_clock_default.h:68: HSI ==> HIS
boards/common/stm32/include/f1f3/cfg_clock_default.h:94: HSI ==> HIS
boards/common/stm32/include/f1f3/cfg_clock_default.h:125: HSI ==> HIS
boards/common/stm32/include/g0/cfg_clock_default.h:17: HSI ==> HIS
boards/common/stm32/include/g0/cfg_clock_default.h:37: HSI ==> HIS
boards/common/stm32/include/g0/cfg_clock_default.h:66: HSI ==> HIS
boards/common/stm32/include/g0/cfg_clock_default.h:104: HSI ==> HIS
boards/common/stm32/include/g4/cfg_clock_default.h:60: HSI ==> HIS
boards/common/stm32/include/l0l1/cfg_clock_default.h:32: HSI ==> HIS
boards/common/stm32/include/l0l1/cfg_clock_default.h:75: HSI ==> HIS
boards/common/stm32/include/l0l1/cfg_clock_default.h:104: HSI ==> HIS
boards/common/stm32/include/l0l1/cfg_clock_default.h:137: HSI ==> HIS
boards/common/stm32/include/l4/cfg_clock_default.h:76: HSI ==> HIS
boards/derfmega128/doc.txt:13: produkt ==> product
boards/derfmega128/doc.txt:16: produkt ==> product
boards/derfmega128/doc.txt:19: produkt ==> product
boards/derfmega128/doc.txt:22: produkt ==> product
boards/derfmega128/doc.txt:25: produkt ==> product
boards/derfmega128/doc.txt:28: produkt ==> product
boards/derfmega256/doc.txt:11: produkt ==> product
boards/derfmega256/doc.txt:12: produkt ==> product
boards/derfmega256/doc.txt:12: produkt ==> product
boards/dwm1001/doc.txt:12: tranceiver ==> transceiver
boards/dwm1001/include/board.h:77: tranceiver ==> transceiver
boards/dwm1001/include/periph_conf.h:53: tranceiver ==> transceiver
boards/limifrog-v1/doc.txt:37: Inferface ==> Interface
boards/mcb2388/board_init.c:2: Technik ==> Technique
boards/mcb2388/include/adc_params.h:2: Technik ==> Technique
boards/mcb2388/include/board.h:2: Technik ==> Technique
boards/mcb2388/include/gpio_params.h:2: Technik ==> Technique
boards/mcb2388/include/periph_conf.h:2: Technik ==> Technique
boards/nrf52dk/doc.txt:9: messurment ==> measurement
core/include/clist.h:18: circularly ==> circular
core/include/msg_bus.h:58: busses ==> buses
core/include/msg_bus.h:61: busses ==> buses
core/include/msg_bus.h:83: busses ==> buses
core/include/msg_bus.h:131: seach ==> search
core/lifo.c:47: tThe ==> the
cpu/arm7_common/include/arm7_common.h:72: BORD ==> BOARD, BORED, BORDER
cpu/cc26xx_cc13xx/include/cpu_conf_cc26xx_cc13xx.h:167: exmaple ==> example
cpu/cortexm_common/include/cpu_conf_common.h:82: pre-empt ==> preempt
cpu/cortexm_common/include/cpu_conf_common.h:122: efficency ==> efficiency
cpu/cortexm_common/include/cpu_conf_common.h:125: pre-empt ==> preempt
cpu/cortexm_common/vectors_cortexm.c:387: occured ==> occurred
cpu/esp_common/include/esp_common.h:54: implementd ==> implemented
cpu/fe310/include/cpucycle.h:31: hart ==> heart, harm
cpu/fe310/periph/i2c.c:175: transfert ==> transfer, transferred
cpu/fe310/periph/i2c.c:178: transfert ==> transfer, transferred
cpu/kinetis/include/cpu_conf_kinetis.h:108: PTD ==> PDF
cpu/kinetis/periph/ics.c:106: PRES ==> PRESS
cpu/kinetis/periph/rtc.c:40: inout ==> input, in out
cpu/lpc1768/periph/uart.c:117: THRE ==> THREE, THERE, THEIR, THE
cpu/lpc23xx/periph/adc.c:2: Technik ==> Technique
cpu/lpc23xx/periph/dac.c:2: Technik ==> Technique
cpu/lpc23xx/periph/i2c.c:2: Technik ==> Technique
cpu/lpc23xx/periph/pm.c:2: Technik ==> Technique
cpu/native/include/async_read.h:45: funtion ==> function
cpu/native/syscalls.c:463: creat ==> create
cpu/nrf52/radio/nrf802154/nrf802154_radio.c:592: substract ==> subtract
cpu/sam0_common/periph/dac.c:2: Technik ==> Technique
cpu/sam0_common/periph/gpio.c:43: acces ==> access
cpu/sam0_common/periph/timer.c:148: withing ==> within
cpu/stm32/dist/clk_conf/clk_conf.c:186: HSI ==> HIS
cpu/stm32/dist/clk_conf/clk_conf.c:250: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.c:251: HSI ==> HIS
cpu/stm32/dist/clk_conf/clk_conf.c:303: HSI ==> HIS
cpu/stm32/dist/clk_conf/clk_conf.h:171: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:171: HSI ==> HIS
cpu/stm32/dist/clk_conf/clk_conf.h:181: HSI ==> HIS
cpu/stm32/dist/clk_conf/clk_conf.h:316: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:344: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:372: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:400: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:413: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:441: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:455: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:469: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:483: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:497: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:512: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:526: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:541: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:556: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:571: hsi ==> his
cpu/stm32/dist/clk_conf/clk_conf.h:586: hsi ==> his
cpu/stm32/doc.txt:16: HSI ==> HIS
cpu/stm32/doc.txt:31: HSI ==> HIS
cpu/stm32/doc.txt:32: HSI ==> HIS
cpu/stm32/doc.txt:33: HSI ==> HIS
cpu/stm32/include/periph_cpu.h:367: ot ==> to, of, or
cpu/stm32/include/periph_cpu.h:367: ot ==> to, of, or
cpu/stm32/include/stmclk.h:34: HSI ==> HIS
cpu/stm32/include/stmclk.h:35: HSI ==> HIS
cpu/stm32/include/stmclk.h:40: HSI ==> HIS
cpu/stm32/include/stmclk.h:47: HSI ==> HIS
cpu/stm32/include/stmclk.h:52: HSI ==> HIS
cpu/stm32/include/stmclk.h:54: HSI ==> HIS
cpu/stm32/periph/adc_l1.c:61: HSI ==> HIS
cpu/stm32/periph/adc_l1.c:64: HSI ==> HIS
cpu/stm32/periph/flashpage.c:91: HSI ==> HIS
cpu/stm32/periph/flashpage.c:146: HSI ==> HIS
cpu/stm32/periph/flashpage.c:182: HSI ==> HIS
cpu/stm32/periph/flashpage.c:221: HSI ==> HIS
cpu/stm32/periph/uart.c:320: HSI ==> HIS
cpu/stm32/periph/uart.c:433: UE ==> USE, DUE
cpu/stm32/periph/uart.c:434: UE ==> USE, DUE
cpu/stm32/periph/uart.c:445: UE ==> USE, DUE
cpu/stm32/stmclk/stmclk_common.c:67: HSI ==> HIS
cpu/stm32/stmclk/stmclk_f0f1f3.c:33: HSI ==> HIS
cpu/stm32/stmclk/stmclk_f0f1f3.c:120: HSI ==> HIS
cpu/stm32/stmclk/stmclk_f0f1f3.c:121: HSI ==> HIS
cpu/stm32/stmclk/stmclk_f0f1f3.c:122: HSI ==> HIS
cpu/stm32/stmclk/stmclk_f0f1f3.c:146: HSI ==> HIS
cpu/stm32/stmclk/stmclk_f0f1f3.c:149: HSI ==> HIS
cpu/stm32/stmclk/stmclk_f0f1f3.c:161: HSI ==> HIS
cpu/stm32/stmclk/stmclk_f0f1f3.c:198: HSI ==> HIS
cpu/stm32/stmclk/stmclk_f2f4f7.c:135: HSI ==> HIS
cpu/stm32/stmclk/stmclk_f2f4f7.c:138: HSI ==> HIS
cpu/stm32/stmclk/stmclk_f2f4f7.c:147: HSI ==> HIS
cpu/stm32/stmclk/stmclk_gx.c:167: HSI ==> HIS
cpu/stm32/stmclk/stmclk_gx.c:172: HSI ==> HIS
cpu/stm32/stmclk/stmclk_gx.c:191: HSI ==> HIS
cpu/stm32/stmclk/stmclk_l0l1.c:67: HSI ==> HIS
cpu/stm32/stmclk/stmclk_l0l1.c:143: HSI ==> HIS
cpu/stm32/stmclk/stmclk_l0l1.c:144: HSI ==> HIS
cpu/stm32/stmclk/stmclk_l0l1.c:145: HSI ==> HIS
cpu/stm32/stmclk/stmclk_l0l1.c:178: HSI ==> HIS
cpu/stm32/stmclk/stmclk_l0l1.c:185: HSI ==> HIS
cpu/stm32/stmclk/stmclk_l0l1.c:226: HSI ==> HIS
cpu/stm32/stmclk/stmclk_l0l1.c:249: HSI ==> HIS
cpu/stm32/stmclk/stmclk_l4wb.c:194: HSI ==> HIS
cpu/stm32/stmclk/stmclk_l4wb.c:197: HSI ==> HIS
cpu/stm32/stmclk/stmclk_l4wb.c:212: HSI ==> HIS
cpu/stm32/stmclk/stmclk_l4wb.c:291: HSI ==> HIS
dist/tools/buildsystem_sanity_check/check.sh:76: files' ==> file's
dist/tools/esptool/espreset.py:62: ser ==> set
dist/tools/esptool/espreset.py:63: ser ==> set
dist/tools/esptool/espreset.py:65: ser ==> set
dist/tools/esptool/espreset.py:66: ser ==> set
dist/tools/esptool/espreset.py:70: ser ==> set
dist/tools/esptool/espreset.py:71: ser ==> set
dist/tools/esptool/esptool.py:2604: files' ==> file's
dist/tools/mcuboot/imgtool.md:20: keypair ==> key pair
dist/tools/suit/suit-manifest-generator/README.md:183: fo ==> of, for
dist/tools/suit/suit-manifest-generator/README.md:215: keypair ==> key pair
dist/tools/suit/suit-manifest-generator/suit_tool/argparser.py:57: formated ==> formatted
dist/tools/suit/suit-manifest-generator/suit_tool/compile.py:376: te ==> the, be
doc/doxygen/src/advanced-build-system-tricks.md:180: adminstrative ==> administrative
doc/doxygen/src/kconfig/kconfig.md:103: Ouput ==> Output
drivers/at86rf215/at86rf215.c:207: AACK ==> ACK
drivers/at86rf215/at86rf215_netdev.c:706: AACK ==> ACK
drivers/at86rf215/at86rf215_netdev.c:995: tHW ==> the, thaw
drivers/at86rf2xx/at86rf2xx_netdev.c:835: neccessary ==> necessary
drivers/enc28j60/enc28j60.c:86: Preamle ==> Preamble
drivers/include/at.h:35: correspondant ==> correspondent
drivers/include/ina3221.h:56: measurment ==> measurement
drivers/include/ina3221.h:372: enble ==> enable
drivers/include/lc709203f.h:314: Invlid ==> Invalid
drivers/include/lpsxxx.h:139: pres ==> press
drivers/include/lpsxxx.h:144: pres ==> press
drivers/include/ltc4150.h:156: tread ==> thread, treat
drivers/include/mhz19.h:34: Manal ==> Manual
drivers/include/mhz19.h:34: manal ==> manual
drivers/include/mpl3115a2.h:164: pres ==> press
drivers/include/mpl3115a2.h:170: pres ==> press
drivers/include/periph/gpio.h:200: occured ==> occurred
drivers/include/pir.h:126: whan ==> want, when
drivers/include/stmpe811.h:95: inout ==> input, in out
drivers/lpsxxx/lpsxxx.c:157: pres ==> press
drivers/lpsxxx/lpsxxx.c:195: pres ==> press
drivers/mhz19/include/mhz19_params.h:18: Manal ==> Manual
drivers/mhz19/include/mhz19_params.h:18: manal ==> manual
drivers/mhz19/mhz19_pwm.c:18: Manal ==> Manual
drivers/mhz19/mhz19_pwm.c:18: manal ==> manual
drivers/mhz19/mhz19_uart.c:19: Manal ==> Manual
drivers/mhz19/mhz19_uart.c:19: manal ==> manual
drivers/mpl3115a2/mpl3115a2.c:155: pres ==> press
drivers/mpl3115a2/mpl3115a2.c:168: pres ==> press
drivers/mpl3115a2/mpl3115a2.c:169: pres ==> press
drivers/mpl3115a2/mpl3115a2.c:169: pres ==> press
drivers/mtd_mci/mtd_mci.c:2: Technik ==> Technique
drivers/mtd_mci/mtd_mci.c:34: suports ==> supports
drivers/sdp3x/sdp3x_saul.c:40: pres ==> press
drivers/sdp3x/sdp3x_saul.c:44: pres ==> press
drivers/w5100/w5100.c:105: extint ==> extinct, extant
drivers/w5100/w5100.c:124: extint ==> extinct, extant
examples/openthread/main.c:18: ot ==> to, of, or
examples/wakaama/main.c:17: Manal ==> Manual
examples/wakaama/main.c:17: manal ==> manual
pkg/nimble/netif/include/nimble_netif.h:124: mater ==> matter, master, mother
pkg/nordic_softdevice_ble/README-BLE-6LoWPAN.md:1: connecton ==> connection, connector
pkg/openthread/contrib/netdev/openthread_netdev.c:31: ot ==> to, of, or
pkg/openthread/contrib/openthread.c:23: ot ==> to, of, or
pkg/openthread/contrib/platform_alarm.c:23: ot ==> to, of, or
pkg/openthread/contrib/platform_functions_wrapper.c:13: OT ==> TO, OF, OR
pkg/openthread/contrib/platform_functions_wrapper.c:13: OT ==> TO, OF, OR
pkg/openthread/contrib/platform_functions_wrapper.c:27: ot ==> to, of, or
pkg/openthread/contrib/platform_functions_wrapper.c:222: OT ==> TO, OF, OR
pkg/openthread/contrib/platform_misc.c:22: ot ==> to, of, or
pkg/openthread/contrib/platform_radio.c:32: ot ==> to, of, or
pkg/openthread/contrib/platform_uart.c:27: ot ==> to, of, or
pkg/openthread/include/ot.h:170: OT ==> TO, OF, OR
pkg/wakaama/contrib/lwm2m_client.c:17: Manal ==> Manual
pkg/wakaama/contrib/lwm2m_client.c:17: manal ==> manual
pkg/wakaama/contrib/lwm2m_client_connection.c:16: Manal ==> Manual
pkg/wakaama/contrib/lwm2m_client_connection.c:36: Manal ==> Manual
pkg/wakaama/contrib/lwm2m_client_connection.c:36: manal ==> manual
pkg/wakaama/contrib/lwm2m_platform.c:15: Manal ==> Manual
pkg/wakaama/contrib/lwm2m_platform.c:26: Manal ==> Manual
pkg/wakaama/contrib/lwm2m_platform.c:26: manal ==> manual
pkg/wakaama/contrib/objects/device.c:15: Manal ==> Manual
pkg/wakaama/contrib/objects/device.c:15: manal ==> manual
pkg/wakaama/include/lwm2m_client_config.h:22: Manal ==> Manual
pkg/wakaama/include/lwm2m_client_config.h:22: manal ==> manual
pkg/wakaama/include/lwm2m_client_config.h:186: bindins ==> bindings
pkg/wakaama/include/lwm2m_client_connection.h:16: Manal ==> Manual
pkg/wakaama/include/lwm2m_client_connection.h:36: Manal ==> Manual
pkg/wakaama/include/lwm2m_client_connection.h:36: manal ==> manual
release-notes.txt:1985: seperator ==> separator
release-notes.txt:1986: seperator ==> separator
release-notes.txt:2860: build-in ==> built-in
release-notes.txt:3085: crashs ==> crashes
release-notes.txt:4312: witth ==> with
release-notes.txt:4404: unconsistent ==> inconsistent
release-notes.txt:4605: witth ==> with
release-notes.txt:4654: unconsistent ==> inconsistent
release-notes.txt:5204: hundret ==> hundred, hundreds
release-notes.txt:5204: agressive ==> aggressive
release-notes.txt:5217: GUAs ==> gauss
release-notes.txt:5261: Eratic ==> Erratic
release-notes.txt:5692: temperatur ==> temperature
release-notes.txt:5744: hundret ==> hundred, hundreds
release-notes.txt:5744: agressive ==> aggressive
release-notes.txt:5755: GUAs ==> gauss
release-notes.txt:5811: Eratic ==> Erratic
release-notes.txt:6044: hundret ==> hundred, hundreds
release-notes.txt:6044: agressive ==> aggressive
release-notes.txt:6054: GUAs ==> gauss
release-notes.txt:6094: numberic ==> numeric
release-notes.txt:6116: Eratic ==> Erratic
release-notes.txt:6309: GUAs ==> gauss
release-notes.txt:6492: Sytem ==> System
release-notes.txt:6534: GUAs ==> gauss
release-notes.txt:7340: registeres ==> registers
sys/arduino/include/spiport.hpp:169: inout ==> input, in out
sys/arduino/include/wireport.hpp:78: adress ==> address
sys/can/device.c:506: theoritical ==> theoretical
sys/cpp11-compat/include/riot/mutex.hpp:305: inout ==> input, in out
sys/cpp11-compat/include/riot/mutex.hpp:306: inout ==> input, in out
sys/cpp11-compat/include/riot/thread.hpp:271: inout ==> input, in out
sys/cpp11-compat/include/riot/thread.hpp:319: inout ==> input, in out
sys/cpp11-compat/include/riot/thread.hpp:320: inout ==> input, in out
sys/include/can/conn/isotp.h:94: inout ==> input, in out
sys/include/can/conn/isotp.h:127: inout ==> input, in out
sys/include/can/conn/isotp.h:139: inout ==> input, in out
sys/include/can/conn/raw.h:69: inout ==> input, in out
sys/include/fmt.h:514: inout ==> input, in out
sys/include/matstat.h:107: inout ==> input, in out
sys/include/net/gnrc/netif.h:53: dedup ==> dedupe
sys/include/net/gnrc/netif.h:79: Busses ==> Buses
sys/include/net/gnrc/netif/lorawan.h:48: wether ==> weather, whether
sys/include/net/gnrc/rpl/srh.h:47: comprE ==> compare, compère
sys/include/net/gnrc/tcp.h:61: inferface ==> interface
sys/include/net/ipv4/hdr.h:169: fo ==> of, for
sys/include/net/ipv4/hdr.h:171: fo ==> of, for
sys/include/net/ipv4/hdr.h:174: fo ==> of, for
sys/include/net/ipv4/hdr.h:175: fo ==> of, for
sys/include/xtimer.h:413: occcured ==> occurred
sys/include/xtimer.h:424: occcured ==> occurred
sys/include/zptr.h:15: bounderies ==> boundaries
sys/include/zptr.h:86: compressable ==> compressible
sys/include/zptr.h:101: Substracts ==> Subtracts
sys/include/ztimer/periodic.h:101: inout ==> input, in out
sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c:237: registartion ==> registration
sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c:151: divisable ==> divisible
sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c:309: anounce ==> announce
sys/posix/include/fcntl.h:59: creat ==> create
sys/posix/pthread/pthread_tls.c:185: defore ==> before
sys/random/fortuna/fortuna.c:261: inout ==> input, in out
sys/random/fortuna/fortuna.c:268: inout ==> input, in out
sys/random/fortuna/fortuna.c:275: inout ==> input, in out
sys/random/fortuna/fortuna.h:160: inout ==> input, in out
sys/random/fortuna/fortuna.h:171: inout ==> input, in out
sys/random/fortuna/fortuna.h:186: inout ==> input, in out
sys/random/fortuna/fortuna.h:206: inout ==> input, in out
sys/random/fortuna/fortuna.h:220: inout ==> input, in out
sys/random/fortuna/fortuna.h:221: inout ==> input, in out
sys/random/fortuna/fortuna.h:225: inout ==> input, in out
sys/shell/commands/sc_cryptoauthlib.c:131: UE ==> USE, DUE
sys/shell/commands/sc_sht1x.c:192: presicion ==> precision
sys/ztimer/core.c:16: functinality ==> functionality
tests/bench_timers/print_results.c:111: pres ==> press
tests/bench_timers/print_results.h:57: pres ==> press
tests/bench_xtimer/README.md:17: emtpy ==> empty
tests/driver_ina3221/main.c:30: thist ==> this
tests/driver_lpsxxx/main.c:40: pres ==> press
tests/driver_lpsxxx/main.c:47: pres ==> press
tests/driver_lpsxxx/main.c:54: pres ==> press
tests/driver_mhz19/main.c:19: Manal ==> Manual
tests/driver_mhz19/main.c:19: manal ==> manual
tests/gnrc_dhcpv6_client_6lbr/README.md:25: sting ==> string
tests/gnrc_ipv6_ext/README.md:27: sting ==> string
tests/gnrc_ipv6_ext_frag/README.md:27: sting ==> string
tests/gnrc_ipv6_ext_opt/README.md:28: sting ==> string
tests/gnrc_rpl_srh/README.md:25: sting ==> string
tests/ieee802154_hal/main.c:637: AACK ==> ACK
tests/od/main.c:32: discrepency ==> discrepancy
tests/periph_i2c/main.c:45: consumtion ==> consumption
tests/periph_timer_periodic/main.c:2: Technik ==> Technique
tests/pkg_c25519/main.c:44: keypair ==> key pair
tests/pkg_hacl/main.c:52: keypair ==> key pair
tests/pkg_hacl/main.c:55: keypair ==> key pair
tests/pkg_monocypher/main.c:42: keypair ==> key pair
tests/pkg_openwsn/README.md:211: BA ==> BY, BE
tests/pkg_openwsn/README.md:254: BA ==> BY, BE
tests/pkg_qdsa/main.c:51: keypair ==> key pair
tests/pkg_tweetnacl/main.c:63: keypair ==> key pair
tests/pkg_tweetnacl/main.c:66: keypair ==> key pair
tests/pkg_tweetnacl/main.c:97: keypair ==> key pair
tests/pthread_cooperation/main.c:28: ths ==> the, this
tests/pthread_cooperation/main.c:61: ths ==> the, this
tests/pthread_cooperation/main.c:66: ths ==> the, this
tests/shell/tests/01-run.py:79: te ==> the, be
tests/shell/tests/01-run.py:83: hel ==> help, hell, heal
tests/sys_crypto/tests-crypto-modes-ccm.c:895: neccessary ==> necessary
tests/thread_cooperation/main.c:64: ths ==> the, this
tests/thread_cooperation/main.c:73: ths ==> the, this
tests/thread_cooperation/main.c:78: ths ==> the, this
tests/thread_cooperation/main.c:83: ths ==> the, this
tests/thread_cooperation/main.c:85: ths ==> the, this
tests/unittests/tests-hashes/tests-hashes-sha1.c:54: BA ==> BY, BE
tests/unittests/tests-hashes/tests-hashes-sha1.c:55: BA ==> BY, BE
tests/unittests/tests-hashes/tests-hashes-sha1.c:107: BA ==> BY, BE
tests/unittests/tests-sock_util/tests-sock_util.c:52: doesnt ==> doesn't, does not
tests/unittests/tests-sock_util/tests-sock_util.c:55: doesnt ==> doesn't, does not
```

</details>

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
