### PR TITLE
cpu/cc2538: reset rtt on init

### DIFF
--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -344,6 +344,10 @@ typedef gpio_t adc_conf_t;
 #define RTT_ISR             isr_sleepmode
 #define RTT_MAX_VALUE       (0xffffffff)
 #define RTT_FREQUENCY       (CLOCK_OSC32K)
+/* When setting a new compare value, the value must be at least 5 more
+   than the current sleep timer value. Otherwise, the timer compare
+   event may be lost. */
+#define RTT_MIN_OFFSET      (5U)
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

This PR clears the overflow and offset callback on init, it also checks if the callback is set before calling it. This avoid spurious callbacks being called on a software reset, or if the rtt is reset.

It also sets `RTT_MIN_OFFSET` according to the datasheet recommendation.

### Testing procedure

`tests/periph_rtt` should still work:

`BOARD=openmote-b make -C tests/periph_rtt flash test --no-print-directory`

```
main(): This is RIOT! (Version: 2020.10-devel-1649-g43648-pr_cc2538_rtt_init)

RIOT RTT low-level driver test
This test will display 'Hello' every 5 seconds

Initializing the RTT driver
RTT now: 103097
Setting initial alarm to now + 5 s (266937)
Done setting up the RTT, wait for many Hellos
Hello
Hello
Hello
Hello
Hello
```

### Issues/PRs references
