### PR TITLE
sys/net/ieee802154/radio: add IEEE802154_RADIO_INDICATION_TX_START

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf.c
+++ b/cpu/cc2538/radio/cc2538_rf.c
@@ -65,9 +65,11 @@ static const init_pair_t init_table[] = {
     {&RFCORE_XREG_FRMCTRL1,  0x00                     },
     {&RFCORE_XREG_SRCMATCH,  0x00                     },
     {&RFCORE_XREG_FIFOPCTRL, CC2538_RF_MAX_DATA_LEN   },
-    {&RFCORE_XREG_RFIRQM0,   FIFOP | RXPKTDONE        },
 #if IS_USED(MODULE_IEEE802154_RADIO_HAL)
-    {&RFCORE_XREG_RFIRQM1,   TXDONE | CSP_STOP        },
+    {&RFCORE_XREG_RFIRQM0,   FIFOP | RXPKTDONE | SFD  },
+    {&RFCORE_XREG_RFIRQM1,   TXDONE | CSP_STOP | TXACKDONE  },
+#else
+    {&RFCORE_XREG_RFIRQM0,   FIFOP | RXPKTDONE        },
 #endif
     {&RFCORE_XREG_RFERRM,    STROBE_ERR | TXUNDERF | TXOVERF | RXUNDERF | RXOVERF | NLOCK},
     {NULL, 0},

--- a/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
+++ b/cpu/nrf52/radio/nrf802154/nrf802154_radio.c
@@ -455,6 +455,16 @@ void isr_radio(void)
 {
     ieee802154_dev_t *dev = &nrf802154_hal_dev;
 
+    if (NRF_RADIO->EVENTS_FRAMESTART) {
+        NRF_RADIO->EVENTS_FRAMESTART = 0;
+        if (_state == STATE_TX) {
+            dev->cb(dev, IEEE802154_RADIO_INDICATION_TX_START);
+        }
+        else if (_state == STATE_RX) {
+            dev->cb(dev, IEEE802154_RADIO_INDICATION_RX_START);
+        }
+    }
+
     if (NRF_RADIO->EVENTS_CCAIDLE) {
         NRF_RADIO->EVENTS_CCAIDLE = 0;
         if (_state != STATE_TX) {
@@ -585,6 +595,7 @@ static int _request_on(ieee802154_dev_t *dev)
     /* enable interrupts */
     NVIC_EnableIRQ(RADIO_IRQn);
     NRF_RADIO->INTENSET = RADIO_INTENSET_END_Msk |
+                          RADIO_INTENSET_FRAMESTART_Msk |
                           RADIO_INTENSET_CCAIDLE_Msk |
                           RADIO_INTENSET_CCABUSY_Msk;
 
@@ -639,6 +650,8 @@ static bool _get_cap(ieee802154_dev_t *dev, ieee802154_rf_caps_t cap)
     (void) dev;
     switch (cap) {
     case IEEE802154_CAP_24_GHZ:
+    case IEEE802154_CAP_IRQ_RX_START:
+    case IEEE802154_CAP_IRQ_TX_START:
     case IEEE802154_CAP_IRQ_TX_DONE:
     case IEEE802154_CAP_IRQ_CCA_DONE:
         return true;

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -122,6 +122,10 @@ ifneq (,$(filter sntp,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter ieee802154_radio_hal,$(USEMODULE)))
+  USEMODULE += ieee802154
+endif
+
 ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
   USEMODULE += netdev_default
   USEMODULE += gnrc_netif

--- a/sys/include/net/ieee802154/radio.h
+++ b/sys/include/net/ieee802154/radio.h
@@ -101,6 +101,10 @@ typedef enum {
      */
     IEEE802154_CAP_IRQ_RX_START,
     /**
+     * @brief the device reports the start of a frame (SFD) was sent.
+     */
+    IEEE802154_CAP_IRQ_TX_START,
+    /**
      * @brief the device reports the end of the CCA procedure
      */
     IEEE802154_CAP_IRQ_CCA_DONE,
@@ -185,6 +189,15 @@ typedef enum {
      * This event is present if radio has @ref IEEE802154_CAP_IRQ_RX_START cap.
      */
     IEEE802154_RADIO_INDICATION_RX_START,
+
+    /**
+     * @brief the transceiver sent out a valid SFD
+     *
+     * This event is present if radio has @ref IEEE802154_CAP_IRQ_TX_START cap.
+     *
+     * @note The SFD of an outgoing ACK (AUTOACK) should not be indicated
+     */
+    IEEE802154_RADIO_INDICATION_TX_START,
 
     /**
      * @brief the transceiver received a frame and lies in the
@@ -1071,6 +1084,22 @@ static inline bool ieee802154_radio_has_irq_tx_done(ieee802154_dev_t *dev)
 static inline bool ieee802154_radio_has_irq_rx_start(ieee802154_dev_t *dev)
 {
     return dev->driver->get_cap(dev, IEEE802154_CAP_IRQ_RX_START);
+}
+
+/**
+ * @brief Check if the device supports TX start interrupt
+ *
+ * Internally this function calls ieee802154_radio_ops::get_cap with @ref
+ * IEEE802154_CAP_IRQ_TX_START.
+ *
+ * @param[in] dev IEEE802.15.4 device descriptor
+ *
+ * @return true if the device has support
+ * @return false otherwise
+ */
+static inline bool ieee802154_radio_has_irq_tx_start(ieee802154_dev_t *dev)
+{
+    return dev->driver->get_cap(dev, IEEE802154_CAP_IRQ_TX_START);
 }
 
 /**

--- a/tests/ieee802154_hal/main.c
+++ b/tests/ieee802154_hal/main.c
@@ -232,6 +232,9 @@ static int _init(void)
     ieee802154_phy_conf_t conf = {.channel=CONFIG_IEEE802154_DEFAULT_CHANNEL, .page=CONFIG_IEEE802154_DEFAULT_SUBGHZ_PAGE, .pow=CONFIG_IEEE802154_DEFAULT_TXPOWER};
 
     ieee802154_radio_config_phy(ieee802154_hal_test_get_dev(RADIO_DEFAULT_ID), &conf);
+
+    /* ieee802154_radio_set_cca_mode*/
+    ieee802154_radio_set_cca_mode(ieee802154_hal_test_get_dev(RADIO_DEFAULT_ID), IEEE802154_CCA_MODE_ED_THRESHOLD);
     ieee802154_radio_set_cca_threshold(ieee802154_hal_test_get_dev(RADIO_DEFAULT_ID), CONFIG_IEEE802154_CCA_THRESH_DEFAULT);
 
     /* Set the transceiver state to RX_ON in order to receive packets */


### PR DESCRIPTION
### Contribution description

This PR adds the TX_START event to the radio hal as well as the implementation for NRF52 and CC2538.

On cc2538 It also now disables while a frame has not yet been processed, that way an incoming frame can not override the already received frame.

### Testing procedure

Testing `tests/ieee802154_hal` should still work for nrf52840 or cc2538 based boards. You can see the events happening if enabling `LOG_DEBUG` in the test, better values if measuring with an osciloscope.

```
2020-10-02 10:01:39,064 # main(): This is RIOT! (Version: 2020.10-deve<DAPLink:Overflow>
2020-10-02 10:01:49,447 # EVT - RX_STARTED
2020-10-02 10:01:53,191 # EVT - RX_STARTED
2020-10-02 10:01:53,192 # EVT - RX_DONE
2020-10-02 10:01:53,194 # Packet received:
2020-10-02 10:01:53,200 # 61 dc 00 23 00 c5 2d 69 69 1c e5 e4 82 23 68 96 23 f6 31 96 36
2020-10-02 10:01:53,202 # LQI: 212, RSSI: 202
2020-10-02 10:01:53,202 #
txtsnd 369631f623966823 "hi openmote-b"
2020-10-02 10:02:01,961 # txtsnd 369631f623966823 "hi openmote-b"
2020-10-02 10:02:01,962 # EVT - TX_STARTED
2020-10-02 10:02:01,963 # EVT - TX_DONE
2020-10-02 10:02:01,966 # Transmission succeeded
2020-10-02 10:02:01,966 #
2020-10-02 10:02:01,966 #
```

```
> 2020-10-02 10:01:43,015 #  main(): This is RIOT! (Version: 2020.10-devel-1656-gc2998-pr_tx_start_radio_hal)
2020-10-02 10:01:43,016 # Initialization successful - starting the shell now
> txtsnd  82e4e51c69692dc5 "hi nrf52840-mdk"
2020-10-02 10:01:53,190 #  txtsnd  82e4e51c69692dc5 "hi nrf52840-mdk"
2020-10-02 10:01:53,191 # EVT - RX_STARTED
2020-10-02 10:01:53,205 # EVT - TX_DONE
2020-10-02 10:01:53,206 # Transmission succeeded
2020-10-02 10:01:53,206 #
2020-10-02 10:01:53,206 #
> 2020-10-02 10:02:01,989 #  EVT - TX_STARTED
2020-10-02 10:02:01,990 # EVT - RX_STARTED
2020-10-02 10:02:01,991 # EVT - RX_DONE
2020-10-02 10:02:01,992 # Packet received:
2020-10-02 10:02:01,995 # 61 dc 00 23 00 23 68 96 23 f6 31 96 36 c5 2d 69 69 1c e5 e4 82
2020-10-02 10:02:01,995 # LQI: 229, RSSI: 185
2020-10-02 10:02:01,996 #
```

### Issues/PRs references
